### PR TITLE
Allow VariableGroup to group scalar variables together

### DIFF
--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -235,8 +235,6 @@ public:
   unsigned int first_scalar_number(unsigned int v) const
   {
     libmesh_assert_less (v, this->n_variables());
-    if ((this->type().family == SCALAR) &&
-	(this->n_variables() > 1)) libmesh_error(); // [BSK] I am not yet sure what this means!
     return _first_scalar_number+v;
   }
 


### PR DESCRIPTION
In our setup we might be using multiple scalar variables (for example for ODEs - each variable for different equation). It seems that VariableGroup does not allow grouping these variables together (not quite sure why). This patch removes this limitation.

Verified against INL's test suite.
