### PR TITLE
allow access to PerfData objects

### DIFF
--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -227,6 +227,15 @@ class PerfLog
    */
   double get_elapsed_time() const;
 
+  /**
+   * @returns the active time
+   */
+  double get_active_time() const;
+
+  /**
+   * Return the PerfData object associated with a label and header.
+   */
+  PerfData get_perf_data(const std::string &label, const std::string &header="");
 
  private:
 
@@ -419,6 +428,11 @@ double PerfLog::get_elapsed_time () const
   return elapsed_time;
 }
 
+inline
+double PerfLog::get_active_time() const
+{
+  return total_time;
+}
 
 } // namespace libMesh
 

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -591,7 +591,10 @@ void PerfLog::print_log() const
     }
 }
 
-
+PerfData PerfLog::get_perf_data(const std::string &label, const std::string &header)
+{
+  return log[std::make_pair(header, label)];
+}
 
 void PerfLog::start_event(const std::string &label,
 			  const std::string &header)
@@ -664,6 +667,5 @@ void PerfLog::split_on_whitespace(const std::string& input, std::vector<std::str
         }
     }
 }
-
 
 } // namespace libMesh


### PR DESCRIPTION
Add accessors to PerfLog so we can get at the raw data if we want.  I put this up for a pull request just in case you guys didn't want raw access to PerfData objects (I don't see a problem with it, but whatever)...
