### PR TITLE
API changes for PETSc compatibility since release-3.3.0

### DIFF
--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -707,17 +707,28 @@ PetscVector<T>::PetscVector (Vec v)
     {
       const numeric_index_type my_local_size = static_cast<numeric_index_type>(petsc_local_size);
       const numeric_index_type ghost_begin = static_cast<numeric_index_type>(petsc_local_size);
+#if PETSC_VERSION_RELEASE && PETSC_VERSION_LESS_THAN(3,4,0)
       const numeric_index_type ghost_end = static_cast<numeric_index_type>(mapping->n);
+#else
+      PetscInt n;
+      ierr = ISLocalToGlobalMappingGetSize(mapping,&n);
+      CHKERRABORT(libMesh::COMM_WORLD,ierr);
+      const numeric_index_type ghost_end = static_cast<numeric_index_type>(n);
+#endif
 #if PETSC_VERSION_RELEASE && PETSC_VERSION_LESS_THAN(3,1,1)
       const PetscInt *indices = mapping->indices;
 #else
-      const PetscInt *indices = mapping->indices;
+      const PetscInt *indices;
       ierr = ISLocalToGlobalMappingGetIndices(mapping,&indices);
       CHKERRABORT(libMesh::COMM_WORLD,ierr);
-#endif
+#endif 
       for(numeric_index_type i=ghost_begin; i<ghost_end; i++)
         _global_to_local_map[indices[i]] = i-my_local_size;
       this->_type = GHOSTED;
+#if !PETSC_VERSION_RELEASE || !PETSC_VERSION_LESS_THAN(3,1,1)
+      ierr = ISLocalToGlobalMappingRestoreIndices(mapping,&indices);
+      CHKERRABORT(libMesh::COMM_WORLD,ierr);
+#endif
     }
     else
       this->_type = PARALLEL;

--- a/src/solvers/petsc_dm_nonlinear_solver.C
+++ b/src/solvers/petsc_dm_nonlinear_solver.C
@@ -124,8 +124,8 @@ namespace libMesh {
     int ierr=0;
     int n_iterations =0;
 
-    // Should actually be a PetscReal, but I don't know which version of PETSc first introduced PetscReal
-    Real final_residual_norm=0.;
+
+    PetscReal final_residual_norm=0.;
 
     if (this->user_presolve)
       this->user_presolve(this->system());

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -351,7 +351,7 @@ void PetscLinearSolver<T>::init ( PetscMatrix<T>* matrix )
       // Have the Krylov subspace method use our good initial guess
       // rather than 0, unless the user requested a KSPType of
       // preonly, which complains if asked to use initial guesses.
-#if PETSC_VERSION_LESS_THAN(3,0,0)
+#if PETSC_VERSION_LESS_THAN(3,0,0) || !PETSC_VERSION_LESS_THAN(3,4,0) || !PETSC_VERSION_RELEASE
       KSPType ksp_type;
 #else
       const KSPType ksp_type;

--- a/src/solvers/petscdmlibmesh.C
+++ b/src/solvers/petscdmlibmesh.C
@@ -279,7 +279,11 @@ static PetscErrorCode  DMCreateFieldDecomposition_libMesh(DM dm, PetscInt *len, 
       ierr = ISCreateGeneral(((PetscObject)dm)->comm, dindices.size(),darray, PETSC_OWN_POINTER, &dis); CHKERRQ(ierr);
       if(dlm->embedding) {
 	/* Create a relative embedding into the parent's index space. */
+#if PETSC_VERSION_LE(3,3,0) && PETSC_VERSION_RELEASE
 	ierr = ISMapFactorRight(dis,dlm->embedding, PETSC_TRUE, &emb); CHKERRQ(ierr);
+#else
+	ierr = ISEmbed(dis,dlm->embedding, PETSC_TRUE, &emb); CHKERRQ(ierr);
+#endif
 	PetscInt elen, dlen;
 	ierr = ISGetLocalSize(emb, &elen); CHKERRQ(ierr);
 	ierr = ISGetLocalSize(dis, &dlen); CHKERRQ(ierr);
@@ -379,7 +383,11 @@ static PetscErrorCode  DMCreateDomainDecomposition_libMesh(DM dm, PetscInt *len,
       ierr = ISCreateGeneral(((PetscObject)dm)->comm, dindices.size(),darray, PETSC_OWN_POINTER, &dis); CHKERRQ(ierr);
       if(dlm->embedding) {
 	/* Create a relative embedding into the parent's index space. */
+#if PETSC_VERSION_LE(3,3,0) && PETSC_VERSION_RELEASE
 	ierr = ISMapFactorRight(dis,dlm->embedding, PETSC_TRUE, &emb); CHKERRQ(ierr);
+#else
+	ierr = ISEmbed(dis,dlm->embedding, PETSC_TRUE, &emb); CHKERRQ(ierr);
+#endif
 	PetscInt elen, dlen;
 	ierr = ISGetLocalSize(emb, &elen); CHKERRQ(ierr);
 	ierr = ISGetLocalSize(dis, &dlen);  CHKERRQ(ierr);
@@ -699,8 +707,8 @@ static PetscErrorCode  DMCreateDomainDecompositionDM_libMesh(DM dm, const char* 
 }
 
 #undef __FUNCT__
-#define __FUNCT__ "DMFunction_libMesh"
-static PetscErrorCode DMFunction_libMesh(DM dm, Vec x, Vec r)
+#define __FUNCT__ "DMlibMeshFunction"
+static PetscErrorCode DMlibMeshFunction(DM dm, Vec x, Vec r)
 {
   PetscErrorCode ierr;
   PetscFunctionBegin;
@@ -760,12 +768,23 @@ static PetscErrorCode DMFunction_libMesh(DM dm, Vec x, Vec r)
   PetscFunctionReturn(0);
 }
 
-
+#if !PETSC_VERSION_LE(3,3,0) || !PETSC_VERSION_RELEASE
+#undef __FUNCT__
+#define __FUNCT__ "SNESFunction_DMlibMesh"
+static PetscErrorCode SNESFunction_DMlibMesh(SNES, Vec x, Vec r, void *ctx)
+{
+  DM dm = (DM)ctx;
+  PetscErrorCode ierr;
+  PetscFunctionBegin;
+  ierr = DMlibMeshFunction(dm,x,r);CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+#endif
 
 
 #undef __FUNCT__
-#define __FUNCT__ "DMJacobian_libMesh"
-static PetscErrorCode DMJacobian_libMesh(DM dm, Vec x, Mat jac, Mat pc, MatStructure *msflag)
+#define __FUNCT__ "DMlibMeshJacobian"
+static PetscErrorCode DMlibMeshJacobian(DM dm, Vec x, Mat jac, Mat pc, MatStructure *msflag)
 {
   PetscErrorCode ierr;
   PetscFunctionBegin;
@@ -832,6 +851,18 @@ static PetscErrorCode DMJacobian_libMesh(DM dm, Vec x, Mat jac, Mat pc, MatStruc
   PetscFunctionReturn(0);
 }
 
+#if !PETSC_VERSION_LE(3,3,0) || !PETSC_VERSION_RELEASE
+#undef  __FUNCT__
+#define __FUNCT__ "SNESJacobian_DMlibMesh"
+static PetscErrorCode SNESJacobian_DMlibMesh(SNES,Vec x,Mat *jac,Mat *pc, MatStructure* flag, void* ctx) 
+{
+  DM dm = (DM)ctx;
+  PetscErrorCode ierr;
+  PetscFunctionBegin;
+  ierr = DMlibMeshJacobian(dm,x,*jac,*pc,flag); CHKERRQ(ierr);
+  PetscFunctionReturn(0);
+}
+#endif
 
 #undef __FUNCT__
 #define __FUNCT__ "DMVariableBounds_libMesh"
@@ -1001,11 +1032,15 @@ static PetscErrorCode  DMSetUp_libMesh(DM dm)
      Do not evaluate function, Jacobian or bounds for an embedded DM -- the subproblem might not have enough information for that. 
   */
   if(!dlm->embedding) {
-    ierr = DMSetFunction(dm, DMFunction_libMesh); CHKERRQ(ierr);
-    ierr = DMSetJacobian(dm, DMJacobian_libMesh); CHKERRQ(ierr);
+#if PETSC_VERSION_LE(3,3,0) && PETSC_VERSION_RELEASE
+    ierr = DMSetFunction(dm, DMlibMeshFunction); CHKERRQ(ierr);
+    ierr = DMSetJacobian(dm, DMlibMeshJacobian); CHKERRQ(ierr);
+#else
+    ierr = DMSNESSetFunction(dm, SNESFunction_DMlibMesh, (void*)dm); CHKERRQ(ierr);
+    ierr = DMSNESSetJacobian(dm, SNESJacobian_DMlibMesh, (void*)dm); CHKERRQ(ierr);    
+#endif
     if (dlm->sys->nonlinear_solver->bounds || dlm->sys->nonlinear_solver->bounds_object)
       ierr = DMSetVariableBounds(dm, DMVariableBounds_libMesh); CHKERRQ(ierr);
-    
   }
   else {
     /* 
@@ -1084,9 +1119,11 @@ PetscErrorCode  DMCreate_libMesh(DM dm)
   dm->ops->getinjection       = 0; // DMGetInjection_libMesh;
   dm->ops->getaggregates      = 0; // DMGetAggregates_libMesh;
   
+#if PETSC_VERSION_LE(3,3,0) && PETSC_VERSION_RELEASE
   dm->ops->createfielddecompositiondm  = DMCreateFieldDecompositionDM_libMesh;
-  dm->ops->createfielddecomposition    = DMCreateFieldDecomposition_libMesh;
   dm->ops->createdomaindecompositiondm = DMCreateDomainDecompositionDM_libMesh;
+#endif
+  dm->ops->createfielddecomposition    = DMCreateFieldDecomposition_libMesh;
   dm->ops->createdomaindecomposition   = DMCreateDomainDecomposition_libMesh;
 
   dm->ops->destroy            = DMDestroy_libMesh;


### PR DESCRIPTION
Guys, take a look at this patch, which restores compatibility with PETSc since release-3.3.0 in preparation for release-3.4.0, hopefully, in a backward-compatible way. I did some limited testing by building against petsc-3.3 and petsc-3.2 and running miscellaneous/ex7, which exercises DMlibMesh to serve up vector bounds to a VI solver (there may be some regression on the PETSc side there, but the libMesh code seems to be fine).

There will probably be at least one more such pull request before petsc-3.4.0 release.
That patch will fix DMlibMeshCreateXXXDecomposition() for better interaction with PC(G)ASM and PCFIELDSPLIT -- those are effectively turned off at the moment and I want to do some substantial refactoring there before another commit.
