### PR TITLE
initial infrastructure for user-specified element refinement selection

### DIFF
--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -83,7 +83,7 @@ public:
    * augment traditional error indicator based refinement.
    * This simply provides a base class that can be derived
    * from and then passed to the 
-   * \p flag_elements_by_user_selection() method.
+   * \p flag_elements_by () method.
    */
   class ElementFlagging
   {
@@ -198,12 +198,10 @@ public:
 				     const unsigned int max_level = libMesh::invalid_uint);
 
   /**
-   * Flag elements based on direct user selection.  The class \p ElementFlagging
-   * defines a mechanism for the user to direcly mark the refinement flags for
-   * specific elements.
+   * Flag elements based on a function object.  The class \p ElementFlagging
+   * defines a mechanism for implementing refinement strategies.
    */
-  void flag_elements_by_user_selection (ElementFlagging &element_flagging);
-    
+  void flag_elements_by (ElementFlagging &element_flagging);    
     
   /**
    * Takes a mesh whose elements are flagged for h refinement and coarsening,

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -652,10 +652,9 @@ void MeshRefinement::flag_elements_by_mean_stddev (const ErrorVector& error_per_
 
 
 
-void MeshRefinement::flag_elements_by_user_selection (ElementFlagging &element_flagging)
+void MeshRefinement::flag_elements_by (ElementFlagging &element_flagging)
 {
   element_flagging.flag_elements();
-  this->make_flags_parallel_consistent();
 }
 
 


### PR DESCRIPTION
Sometimes it would be useful for the user to mark elements directly for refinement & coarsening.  This provides a mechanism for that functionality.  Any user class that derives from MeshRefinement::ElementFlagging and then implements the flag_elements() member can then use the new

``` c++
MeshRefinement::flag_elements_by_user_selection (ElementFlagging &element_flagging) 
```

member function to directly mark what elements they would like refined.

This can be done in leu of or to augment traditional error indicator based flagging.

Attached is an image from an application code where I can use this new functionality to manually perform physics-based feature adaption.

Besides the academic impurity, any objections for libmesh/master?

![Screenshot-Untitled Window](https://f.cloud.github.com/assets/2366572/287781/35d5c652-9260-11e2-8f15-5d30d81cd827.png)
