### PR TITLE
Patch based on Manav Bhatia's for type-mixing methods

### DIFF
--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -149,14 +149,14 @@ public:
    * complex conjugate of vec.
    */
   template <typename T2>
-  Number dot (const DenseVector<T2> &vec) const;
+  typename CompareTypes<T, T2>::supertype dot (const DenseVector<T2> &vec) const;
 
   /**
    * Evaluate dot product with \p vec. In the complex-valued case, do not
    * use the complex conjugate of vec.
    */
   template <typename T2>
-  Number indefinite_dot (const DenseVector<T2> &vec) const;
+    typename CompareTypes<T, T2>::supertype indefinite_dot (const DenseVector<T2> &vec) const;
 
   /**
    * Tests if \p vec is exactly equal to this vector.
@@ -397,11 +397,11 @@ DenseVector<T>::add (const T2 factor,
 template<typename T>
 template<typename T2>
 inline
-Number DenseVector<T>::dot (const DenseVector<T2>& vec) const
+  typename CompareTypes<T, T2>::supertype DenseVector<T>::dot (const DenseVector<T2>& vec) const
 {
   libmesh_assert_equal_to (this->size(), vec.size());
 
-  Number val = 0.;
+  typename CompareTypes<T, T2>::supertype val = 0.;
 
   for (unsigned int i=0; i<this->size(); i++)
     val += (*this)(i)*libmesh_conj(vec(i));
@@ -412,11 +412,11 @@ Number DenseVector<T>::dot (const DenseVector<T2>& vec) const
 template<typename T>
 template<typename T2>
 inline
-Number DenseVector<T>::indefinite_dot (const DenseVector<T2>& vec) const
+  typename CompareTypes<T, T2>::supertype DenseVector<T>::indefinite_dot (const DenseVector<T2>& vec) const
 {
   libmesh_assert_equal_to (this->size(), vec.size());
 
-  Number val = 0.;
+  typename CompareTypes<T, T2>::supertype val = 0.;
 
   for (unsigned int i=0; i<this->size(); i++)
     val += (*this)(i)*(vec(i));


### PR DESCRIPTION
scale_column is a generally useful method; the rest of these should make it easier to mix DenseVector/DenseMatirx objects of real and complex (or of float and double, etc) data types.
