### PR TITLE
extend Dereks idea to initialization as well

### DIFF
--- a/include/base/libmesh_singleton.h
+++ b/include/base/libmesh_singleton.h
@@ -44,6 +44,37 @@ namespace libMesh {
   public:
 
     /**
+     * Abstract base class for runtime singleton setup.
+     * This will be called from the \p LibMeshInit constructor.
+     */
+    class Setup
+    {
+    protected:
+      /**
+       * Constructor.  Adds the derived object to the setup cache list.
+       */
+      Setup ();
+      
+    public:
+      /**
+       * Destructor.
+       */
+      virtual ~Setup() {};
+
+      /**
+       * Setup method.  Importantly, this is called *after main()* from the
+       * \p LibMeshInit constructor.
+       */
+      virtual void setup () = 0;
+    };
+
+    /**
+     * Setup function.  Initializes any derived \p Singleton::Setup objects.
+     * objects.
+     */
+    static void setup();
+
+    /**
      * Cleanup function.  Removes all dynamically created \p Singleton
      * objects.
      */

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -22,7 +22,6 @@
 #include "libmesh/getpot.h"
 #include "libmesh/parallel.h"
 #include "libmesh/reference_counter.h"
-#include "libmesh/remote_elem.h"
 #include "libmesh/libmesh_singleton.h"
 #include "libmesh/threads.h"
 
@@ -345,9 +344,7 @@ void _init (int argc, const char* const* argv,
 
   // Construct singletons who may be at risk of the
   // "static initialization order fiasco"
-  //
-  // RemoteElem depends on static reference counting data
-  RemoteElem::create();
+  Singleton::setup();
 
 #if defined(LIBMESH_HAVE_MPI)
 

--- a/src/geom/remote_elem.C
+++ b/src/geom/remote_elem.C
@@ -19,6 +19,7 @@
 
 // Local includes
 #include "libmesh/remote_elem.h"
+#include "libmesh/libmesh_singleton.h"
 #include "libmesh/threads.h"
 
 
@@ -29,6 +30,21 @@ namespace
 
   typedef Threads::spin_mutex RemoteElemMutex;
   RemoteElemMutex remote_elem_mtx;
+
+
+  // Class to be dispatched by Singleton::setup() 
+  // to create the \p RemoteElem singleton.
+  // While this actual object has file-level static
+  // scope and will be initialized before main(),
+  // importantly the setup() method will not be invoked
+  // until after main().
+  class RemoteElemSetup : public Singleton::Setup
+  {
+    void setup ()
+    {
+      RemoteElem::create();
+    }
+  } remote_elem_setup;
 }
 
 


### PR DESCRIPTION
This extends Derek's idea to singleton creation as well.  Consider in remote_elem.C:

``` c++
namespace
{
  // Class to be dispatched by Singleton::setup() 
  // to create the \p RemoteElem singleton.
  // While this actual object has file-level static
  // scope and will be initialized before main(),
  // importantly the setup() method will not be invoked
  // until after main().
  class RemoteElemSetup : public Singleton::Setup
  {
    void setup ()
    {
      RemoteElem::create();
    }
  } remote_elem_setup;
}
```

The Singleton now holds a list of such objects which are dynamically initialized from LibMeshInit by  calling

``` c++
Singleton::setup();
```
