### PR TITLE
Stitch mesh

### DIFF
--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -35,7 +35,12 @@ namespace
   // of the point
   class FuzzyPointCompare
   {
-   public:
+  private:
+    Real _tol;
+
+  public:
+    // Constructor takes the tolerance to be used in fuzzy comparisons
+    FuzzyPointCompare(Real tol) : _tol(tol) {}
 
     // This is inspired directly by Point::operator<
     bool operator()(const Point& lhs, const Point& rhs)
@@ -62,8 +67,8 @@ namespace
             rel_size = 1.;
 
           // Don't attempt the comparison if lhs(i) and rhs(i) are too close
-          // together.  Again, here you could use some other custom tolerance.
-          if ( std::abs(lhs(i) - rhs(i)) / rel_size < TOLERANCE)
+          // together.
+          if ( std::abs(lhs(i) - rhs(i)) / rel_size < _tol)
             continue;
 
           if (lhs(i) < rhs(i))
@@ -91,14 +96,15 @@ namespace
 
   PointVector::iterator fuzzy_binary_find(PointVector::iterator first,
                                           PointVector::iterator last,
-                                          Point val)
+                                          Point val,
+                                          Real tol)
   {
     PointVector::iterator it;
     std::iterator_traits<PointVector::iterator>::difference_type count, step;
     count = std::distance(first, last);
 
     // Object we'll use to make comparisons
-    FuzzyPointCompare comp;
+    FuzzyPointCompare comp(tol);
 
     while (count>0)
       {
@@ -110,7 +116,7 @@ namespace
         Point p = it->first;
 
         // If p relative_fuzzy_equals val, return 'it'
-        if (p.relative_fuzzy_equals(val))
+        if (p.relative_fuzzy_equals(val, tol))
           return it;
 
         // Otherwise, continue binary searching
@@ -837,7 +843,7 @@ void SerialMesh::stitch_meshes (SerialMesh& other_mesh,
             }
 
           // Sort the vectors based on the FuzzyPointCompare struct op()
-          std::sort(vec_array[i]->begin(), vec_array[i]->end(), FuzzyPointCompare());
+          std::sort(vec_array[i]->begin(), vec_array[i]->end(), FuzzyPointCompare(tol));
         }
     }
 
@@ -853,7 +859,8 @@ void SerialMesh::stitch_meshes (SerialMesh& other_mesh,
         // slight differences between the list of nodes on each mesh.
         PointVector::iterator other_iter = fuzzy_binary_find(other_sorted_bndry_nodes.begin(),
                                                              other_sorted_bndry_nodes.end(),
-                                                             this_point);
+                                                             this_point,
+                                                             tol);
 
         if (other_iter == other_sorted_bndry_nodes.end())
           {


### PR DESCRIPTION
This is a series of improvements to SerialMesh::stitch_meshes().  On a 3D mesh with ~3000 total nodes to stitch together it was taking _minutes_, it now takes < 3 seconds.  The main improvements are to not loop over the mesh once per stitched node, and to not call elem->contains_point().
