### PR TITLE
"make doc" from best examples METHOD available

### DIFF
--- a/examples/Make.common
+++ b/examples/Make.common
@@ -65,6 +65,36 @@ if LIBMESH_OPROF_MODE
   example_oprof_LDADD    = $(top_builddir)/libmesh_oprof.la
 endif
 
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+if LIBMESH_OPT_MODE
+  DOC_PROGRAM = example-opt
+  DOC_METHOD=opt
+else
+if LIBMESH_OPROF_MODE
+  DOC_PROGRAM = example-oprof
+  DOC_METHOD=oprof
+else
+if LIBMESH_PROF_MODE
+  DOC_PROGRAM = example-prof
+  DOC_METHOD=prof
+else
+if LIBMESH_DEVEL_MODE
+  DOC_PROGRAM = example-devel
+  DOC_METHOD=devel
+else
+if LIBMESH_DBG_MODE
+  DOC_PROGRAM = example-dbg
+  DOC_METHOD=dbg
+endif
+endif
+endif
+endif
+endif
+
 ######################################################################
 #
 # Running the tests
@@ -86,10 +116,10 @@ run: $(check_PROGRAMS)
 CLEANFILES += $(example_name).php stdout.log
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adaptivity/adaptivity_ex1/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex1/Makefile.in
@@ -595,6 +595,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1115,10 +1130,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adaptivity/adaptivity_ex2/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex2/Makefile.in
@@ -612,6 +612,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1217,10 +1232,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adaptivity/adaptivity_ex3/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex3/Makefile.in
@@ -604,6 +604,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1133,10 +1148,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adaptivity/adaptivity_ex4/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex4/Makefile.in
@@ -600,6 +600,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1120,10 +1135,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adaptivity/adaptivity_ex5/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex5/Makefile.in
@@ -609,6 +609,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1211,10 +1226,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adjoints/adjoints_ex1/Makefile.in
+++ b/examples/adjoints/adjoints_ex1/Makefile.in
@@ -662,6 +662,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1641,10 +1656,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adjoints/adjoints_ex2/Makefile.in
+++ b/examples/adjoints/adjoints_ex2/Makefile.in
@@ -650,6 +650,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1405,10 +1420,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adjoints/adjoints_ex3/Makefile.in
+++ b/examples/adjoints/adjoints_ex3/Makefile.in
@@ -688,6 +688,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1666,10 +1681,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adjoints/adjoints_ex4/Makefile.in
+++ b/examples/adjoints/adjoints_ex4/Makefile.in
@@ -662,6 +662,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1640,10 +1655,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/adjoints/adjoints_ex5/Makefile.in
+++ b/examples/adjoints/adjoints_ex5/Makefile.in
@@ -661,6 +661,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1639,10 +1654,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/eigenproblems/eigenproblems_ex1/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex1/Makefile.in
@@ -596,6 +596,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1116,10 +1131,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/eigenproblems/eigenproblems_ex2/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex2/Makefile.in
@@ -596,6 +596,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1116,10 +1131,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/eigenproblems/eigenproblems_ex3/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex3/Makefile.in
@@ -606,6 +606,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1134,10 +1149,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/fem_system/fem_system_ex1/Makefile.in
+++ b/examples/fem_system/fem_system_ex1/Makefile.in
@@ -626,6 +626,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1229,10 +1244,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/fem_system/fem_system_ex2/Makefile.in
+++ b/examples/fem_system/fem_system_ex2/Makefile.in
@@ -636,6 +636,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1313,10 +1328,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/introduction/introduction_ex1/Makefile.in
+++ b/examples/introduction/introduction_ex1/Makefile.in
@@ -594,6 +594,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1114,10 +1129,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/introduction/introduction_ex2/Makefile.in
+++ b/examples/introduction/introduction_ex2/Makefile.in
@@ -594,6 +594,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1114,10 +1129,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/introduction/introduction_ex3/Makefile.in
+++ b/examples/introduction/introduction_ex3/Makefile.in
@@ -604,6 +604,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1199,10 +1214,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/introduction/introduction_ex4/Makefile.in
+++ b/examples/introduction/introduction_ex4/Makefile.in
@@ -607,6 +607,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1209,10 +1224,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/introduction/introduction_ex5/Makefile.in
+++ b/examples/introduction/introduction_ex5/Makefile.in
@@ -606,6 +606,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1208,10 +1223,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/miscellaneous/miscellaneous_ex1/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex1/Makefile.in
@@ -597,6 +597,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1117,10 +1132,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/miscellaneous/miscellaneous_ex2/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex2/Makefile.in
@@ -601,6 +601,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1121,10 +1136,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/miscellaneous/miscellaneous_ex3/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex3/Makefile.in
@@ -602,6 +602,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1128,10 +1143,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/miscellaneous/miscellaneous_ex4/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex4/Makefile.in
@@ -594,6 +594,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1114,10 +1129,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/miscellaneous/miscellaneous_ex5/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex5/Makefile.in
@@ -612,6 +612,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1142,10 +1157,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/miscellaneous/miscellaneous_ex6/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex6/Makefile.in
@@ -595,6 +595,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1115,10 +1130,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/miscellaneous/miscellaneous_ex7/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex7/Makefile.in
@@ -627,6 +627,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1297,10 +1312,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/miscellaneous/miscellaneous_ex8/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex8/Makefile.in
@@ -629,6 +629,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1157,10 +1172,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/reduced_basis/reduced_basis_ex1/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex1/Makefile.in
@@ -644,6 +644,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1174,10 +1189,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/reduced_basis/reduced_basis_ex2/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex2/Makefile.in
@@ -624,6 +624,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1154,10 +1169,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/reduced_basis/reduced_basis_ex3/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex3/Makefile.in
@@ -624,6 +624,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1154,10 +1169,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/reduced_basis/reduced_basis_ex4/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex4/Makefile.in
@@ -659,6 +659,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1191,10 +1206,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/reduced_basis/reduced_basis_ex5/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex5/Makefile.in
@@ -627,6 +627,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1232,10 +1247,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/reduced_basis/reduced_basis_ex6/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex6/Makefile.in
@@ -645,6 +645,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1177,10 +1192,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/reduced_basis/reduced_basis_ex7/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex7/Makefile.in
@@ -621,6 +621,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1152,10 +1167,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/solution_transfer/solution_transfer_ex1/Makefile.in
+++ b/examples/solution_transfer/solution_transfer_ex1/Makefile.in
@@ -594,6 +594,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1114,10 +1129,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/subdomains/subdomains_ex1/Makefile.in
+++ b/examples/subdomains/subdomains_ex1/Makefile.in
@@ -607,6 +607,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1209,10 +1224,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/subdomains/subdomains_ex2/Makefile.in
+++ b/examples/subdomains/subdomains_ex2/Makefile.in
@@ -606,6 +606,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1208,10 +1223,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/systems_of_equations/systems_of_equations_ex1/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex1/Makefile.in
@@ -594,6 +594,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1114,10 +1129,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/systems_of_equations/systems_of_equations_ex2/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex2/Makefile.in
@@ -599,6 +599,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1119,10 +1134,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/systems_of_equations/systems_of_equations_ex3/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex3/Makefile.in
@@ -594,6 +594,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1114,10 +1129,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/systems_of_equations/systems_of_equations_ex4/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex4/Makefile.in
@@ -594,6 +594,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1114,10 +1129,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/systems_of_equations/systems_of_equations_ex5/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex5/Makefile.in
@@ -594,6 +594,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1114,10 +1129,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/systems_of_equations/systems_of_equations_ex6/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex6/Makefile.in
@@ -594,6 +594,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1114,10 +1129,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/transient/transient_ex1/Makefile.in
+++ b/examples/transient/transient_ex1/Makefile.in
@@ -606,6 +606,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1209,10 +1224,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/transient/transient_ex2/Makefile.in
+++ b/examples/transient/transient_ex2/Makefile.in
@@ -597,6 +597,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1124,10 +1139,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/vector_fe/vector_fe_ex1/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex1/Makefile.in
@@ -602,6 +602,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1197,10 +1212,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/vector_fe/vector_fe_ex2/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex2/Makefile.in
@@ -632,6 +632,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1234,10 +1249,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 

--- a/examples/vector_fe/vector_fe_ex3/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex3/Makefile.in
@@ -632,6 +632,21 @@ data_DATA = $(data) $(top_builddir)/contrib/utils/Makefile
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_OPROF_MODE_TRUE@example_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_PROGRAM = example-devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_PROGRAM = example-prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_PROGRAM = example-oprof
+
+######################################################################
+#
+# Choose a flavor to run when making documentation
+#
+@LIBMESH_OPT_MODE_TRUE@DOC_PROGRAM = example-opt
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_DEVEL_MODE_FALSE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_FALSE@DOC_METHOD = devel
+@LIBMESH_OPROF_MODE_FALSE@@LIBMESH_OPT_MODE_FALSE@@LIBMESH_PROF_MODE_TRUE@DOC_METHOD = prof
+@LIBMESH_OPROF_MODE_TRUE@@LIBMESH_OPT_MODE_FALSE@DOC_METHOD = oprof
+@LIBMESH_OPT_MODE_TRUE@DOC_METHOD = opt
 
 ######################################################################
 #
@@ -1233,10 +1248,10 @@ run: $(check_PROGRAMS)
 	LIBMESH_DIR=$(abs_top_srcdir) METHODS="$(METHODS)" $(srcdir)/$(check_SCRIPTS)
 doc: $(example_name).php
 html: $(example_name).php
-$(example_name).php: example-opt example-dbg example-devel \
+$(example_name).php: $(DOC_PROGRAM) \
                         $(top_srcdir)/contrib/bin/ex2html.sh \
                        Makefile
-	$(MAKE) -s run > stdout.log
+	$(MAKE) METHODS=$(DOC_METHOD) -s run > stdout.log
 	$(AM_V_GEN) PATH=$(abs_top_srcdir)/contrib/bin:$(PATH) \
 	  ex2html.sh $(example_name) $(abs_srcdir)
 


### PR DESCRIPTION
Previously "make doc" was breaking for me on a build that didn't
include opt in METHODS

It looks like we had the .php file depending on (and running??) all of opt, dbg, and devel?

Now we look for the fastest method available and run the examples for that method alone when doing "make doc".

There's still work to be done here (out-of-source build docs currently have to be stitched together from build dir and source dir outputs by hand?) but this ought to be a step forward.
