### PR TITLE
Switch some cout/cerr uses to libMesh::out/err

### DIFF
--- a/include/mesh/mesh_data.h
+++ b/include/mesh/mesh_data.h
@@ -880,7 +880,7 @@ const std::vector<Number>& MeshData::get_data (const Node* node) const
 #ifdef DEBUG
   if (pos == _node_data.end())
     {
-      std::cerr << "ERROR: No data for this node.  Use has_data() first!" << std::endl;
+      libMesh::err << "ERROR: No data for this node.  Use has_data() first!" << std::endl;
       libmesh_error();
     }
 #endif

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -202,7 +202,7 @@ public:
 
       if (it == _additional_vars.end())
       {
-        std::cerr << "ERROR: Requested variable not found in parsed function\n" << std::endl;
+        libMesh::err << "ERROR: Requested variable not found in parsed function\n" << std::endl;
         libmesh_error();
       }
 

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -1171,7 +1171,7 @@ numeric_index_type PetscVector<T>::map_global_to_local_index (const numeric_inde
           error_message << "}\n";
         }
 
-      std::cerr << error_message.str();
+      libMesh::err << error_message.str();
 
       libmesh_error();
     }

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -393,13 +393,13 @@ void PerfLog::pop (const std::string &libmesh_dbg_var(label),
       PerfData *perf_data = &(log[std::make_pair(header,label)]);
       if (perf_data != log_stack.top())
         {
-          std::cerr << "PerfLog can't pop (" << header << ',' << label << ')' << std::endl;
-          std::cerr << "From top of stack of running logs:" << std::endl;
+          libMesh::err << "PerfLog can't pop (" << header << ',' << label << ')' << std::endl;
+          libMesh::err << "From top of stack of running logs:" << std::endl;
           std::map<std::pair<std::string, std::string>, PerfData>::iterator
             i = log.begin(), endi = log.end();
           for (; i != endi; ++i)
             if (&(i->second) == log_stack.top())
-              std::cerr << '(' << i->first.first << ',' << i->first.second << ')' << std::endl;
+              libMesh::err << '(' << i->first.first << ',' << i->first.second << ')' << std::endl;
 
           libmesh_assert_equal_to (perf_data, log_stack.top());
         }

--- a/src/apps/amr.C
+++ b/src/apps/amr.C
@@ -48,7 +48,7 @@ int main (int argc, char** argv)
   LibMeshInit init(argc, argv);
 
   if (argc < 4)
-    std::cout << "Usage: ./prog -d DIM filename" << std::endl;
+    libMesh::out << "Usage: ./prog -d DIM filename" << std::endl;
 
   // Variables to get us started
   const unsigned int dim = atoi(argv[2]);
@@ -259,8 +259,8 @@ void assemble(EquationSystems& es,
       system.matrix->add_matrix(Kvv, dof_indices_V);
     }
 
-  std::cout << "Vol="  << vol << std::endl;
+  libMesh::out << "Vol="  << vol << std::endl;
 
   if (dim == 3)
-    std::cout << "Area=" << area << std::endl;
+    libMesh::out << "Area=" << area << std::endl;
 }

--- a/src/apps/compare.C
+++ b/src/apps/compare.C
@@ -130,8 +130,8 @@ void process_cmd_line(int argc, char **argv,
               names.push_back(optarg);
             else
               {
-                std::cout << "ERROR: Mesh file name must preceed left file name!"
-                          << std::endl;
+                libMesh::out << "ERROR: Mesh file name must preceed left file name!"
+                             << std::endl;
                 exit(1);
               }
             break;
@@ -158,8 +158,8 @@ void process_cmd_line(int argc, char **argv,
               }
             else
               {
-                std::cout << "ERROR: Mesh file name must preceed right file name!"
-                          << std::endl;
+                libMesh::out << "ERROR: Mesh file name must preceed right file name!"
+                             << std::endl;
                 exit(1);
               }
             break;
@@ -174,9 +174,9 @@ void process_cmd_line(int argc, char **argv,
               names.push_back(optarg);
             else
               {
-                std::cout << "ERROR: Mesh file name and left file name must preceed "
-                          << "right file name!"
-                          << std::endl;
+                libMesh::out << "ERROR: Mesh file name and left file name must preceed "
+                             << "right file name!"
+                             << std::endl;
                 exit(1);
               }
             break;
@@ -198,8 +198,8 @@ void process_cmd_line(int argc, char **argv,
           {
             if (format_set)
               {
-                std::cout << "ERROR: Equation system file format already set!"
-                          << std::endl;
+                libMesh::out << "ERROR: Equation system file format already set!"
+                             << std::endl;
                 exit(1);
               }
             else
@@ -217,8 +217,8 @@ void process_cmd_line(int argc, char **argv,
           {
             if (format_set)
               {
-                std::cout << "ERROR: Equation system file format already set!"
-                          << std::endl;
+                libMesh::out << "ERROR: Equation system file format already set!"
+                             << std::endl;
                 exit(1);
               }
             else
@@ -276,11 +276,11 @@ bool do_compare (EquationSystems& les,
 
   if (verbose)
     {
-      std::cout        << "*********   LEFT SYSTEM    *********" << std::endl;
+      libMesh::out        << "*********   LEFT SYSTEM    *********" << std::endl;
       les.print_info  ();
-      std::cout << "*********   RIGHT SYSTEM   *********" << std::endl;
+      libMesh::out << "*********   RIGHT SYSTEM   *********" << std::endl;
       res.print_info ();
-      std::cout << "********* COMPARISON PHASE *********" << std::endl
+      libMesh::out << "********* COMPARISON PHASE *********" << std::endl
                 << std::endl;
     }
 
@@ -290,7 +290,7 @@ bool do_compare (EquationSystems& les,
   bool result = les.compare(res, threshold, verbose);
   if (verbose)
     {
-      std::cout        << "*********     FINISHED     *********" << std::endl;
+      libMesh::out        << "*********     FINISHED     *********" << std::endl;
     }
   return result;
 }
@@ -333,7 +333,7 @@ int main (int argc, char** argv)
 
   if (dim == static_cast<unsigned int>(-1))
     {
-      std::cout << "ERROR:  you must specify the dimension on "
+      libMesh::out << "ERROR:  you must specify the dimension on "
                 << "the command line!\n\n"
                 << argv[0] << " -d 3 ... for example\n\n";
       libmesh_error();
@@ -344,14 +344,14 @@ int main (int argc, char** argv)
 
   if (verbose)
     {
-        std::cout << "Settings:" << std::endl
-                  << " dimensionality = " << dim << std::endl
-                  << " mesh           = " << names[0] << std::endl
-                  << " left system    = " << names[1] << std::endl
-                  << " right system   = " << names[2] << std::endl
-                  << " threshold      = " << threshold << std::endl
-                  << " read format    = " << format << std::endl
-                  << std::endl;
+        libMesh::out << "Settings:" << std::endl
+                     << " dimensionality = " << dim << std::endl
+                     << " mesh           = " << names[0] << std::endl
+                     << " left system    = " << names[1] << std::endl
+                     << " right system   = " << names[2] << std::endl
+                     << " threshold      = " << threshold << std::endl
+                     << " read format    = " << format << std::endl
+                     << std::endl;
     }
 
 
@@ -372,7 +372,7 @@ int main (int argc, char** argv)
     }
   else
     {
-      std::cout << "No input specified." << std::endl;
+      libMesh::out << "No input specified." << std::endl;
       return 1;
     }
 
@@ -390,7 +390,7 @@ int main (int argc, char** argv)
     }
   else
     {
-      std::cout << "Bad input specified." << std::endl;
+      libMesh::out << "Bad input specified." << std::endl;
       libmesh_error();
     }
 
@@ -405,21 +405,21 @@ int main (int argc, char** argv)
   if (are_equal)
     {
       if (!quiet)
-          std::cout << std::endl
-                    << " Congrat's, up to the defined threshold, the two"
-                    << std::endl
-                    << " are identical."
-                    << std::endl;
+          libMesh::out << std::endl
+                       << " Congrat's, up to the defined threshold, the two"
+                       << std::endl
+                       << " are identical."
+                       << std::endl;
       our_result=0;
     }
   else
     {
       if (!quiet)
-          std::cout << std::endl
-                    << " Oops, differences occured!"
-                    << std::endl
-                    << " Use -v to obtain more information where differences occured."
-                    << std::endl;
+          libMesh::out << std::endl
+                       << " Oops, differences occured!"
+                       << std::endl
+                       << " Use -v to obtain more information where differences occured."
+                       << std::endl;
       our_result=1;
     }
 

--- a/src/apps/grid2grid.C
+++ b/src/apps/grid2grid.C
@@ -47,9 +47,9 @@ int main (int argc, char** argv)
 
   if (argc < 6)
     {
-      std::cerr << "Usage: " << argv[0]
-                << " ivar m0.mesh m1.mesh s0.soln s1.soln"
-                << std::endl;
+      libMesh::err << "Usage: " << argv[0]
+                   << " ivar m0.mesh m1.mesh s0.soln s1.soln"
+                   << std::endl;
 
       libmesh_error();
     }
@@ -59,16 +59,16 @@ int main (int argc, char** argv)
   Mesh mesh_fine(init.comm(), dim);
 
   // Read the coarse mesh
-  std::cout << "Reading Mesh " << argv[2] << std::endl;
+  libMesh::out << "Reading Mesh " << argv[2] << std::endl;
   mesh_coarse.read(argv[2]);
   mesh_coarse.print_info();
-  std::cout << std::endl;
+  libMesh::out << std::endl;
 
   // Read the fine mesh
-  std::cout << "Reading Mesh " << argv[3] << std::endl;
+  libMesh::out << "Reading Mesh " << argv[3] << std::endl;
   mesh_fine.read(argv[3]);
   mesh_fine.print_info();
-  std::cout << std::endl;
+  libMesh::out << std::endl;
 
 
   std::vector<Number> coarse_solution;
@@ -77,13 +77,13 @@ int main (int argc, char** argv)
   std::vector<std::string> fine_var_names;
 
   // Read the coarse solution
-  std::cout << "Reading Soln " << argv[4] << std::endl;
+  libMesh::out << "Reading Soln " << argv[4] << std::endl;
   LegacyXdrIO(mesh_coarse,true).read_mgf_soln(std::string(argv[4]),
                                               coarse_solution,
                                               coarse_var_names);
 
   // Read the fine solution
-  std::cout << "Reading Soln " << argv[5] << std::endl;
+  libMesh::out << "Reading Soln " << argv[5] << std::endl;
   LegacyXdrIO(mesh_fine,true).read_mgf_soln(std::string(argv[5]),
                                             fine_solution,
                                             fine_var_names);
@@ -98,21 +98,21 @@ int main (int argc, char** argv)
   Trees::OctTree octree_coarse(mesh_coarse,100);
   perf_log.stop_event("octree build");
 
-  std::cout << "n_active_bins() = " << octree_coarse.n_active_bins() << std::endl;
+  libMesh::out << "n_active_bins() = " << octree_coarse.n_active_bins() << std::endl;
 
   // sanity check.  Make sure that we can find all the element
   // centroids and all the mesh nodes!
   /*
     for (unsigned int e=0; e<mesh_coarse.n_elem(); e++)
     {
-    std::cout << "looking for centroid of element " << e << std::endl;
+    libMesh::out << "looking for centroid of element " << e << std::endl;
     const Elem* elem = octree_coarse.find_element(mesh_coarse.elem(e)->centroid(mesh_coarse));
 
     libmesh_assert(elem);
     }
     for (unsigned int n=0; n<mesh_coarse.n_nodes(); n++)
     {
-    std::cout << "looking for node " << n << std::endl;
+    libMesh::out << "looking for node " << n << std::endl;
     const Elem* elem = octree_coarse.find_element(mesh_coarse.vertex(n));
 
     libmesh_assert(elem);
@@ -222,8 +222,8 @@ int main (int argc, char** argv)
 
     error = sqrt(error);
 
-    std::cout << "Computed error=" << error
-              << std::endl;
+    libMesh::out << "Computed error=" << error
+                 << std::endl;
 
     // Now lets compute the error at each node in the fine mesh and plot it out.
     {

--- a/src/apps/meshbcid.C
+++ b/src/apps/meshbcid.C
@@ -37,9 +37,9 @@ using namespace libMesh;
 
 void usage_error(const char *progname)
 {
-  std::cout << "Usage: " << progname
-            << " --dim d --input inputmesh --output outputmesh --newbcid idnum --tests --moretests"
-            << std::endl;
+  libMesh::out << "Usage: " << progname
+               << " --dim d --input inputmesh --output outputmesh --newbcid idnum --tests --moretests"
+               << std::endl;
 
   exit(1);
 }
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
   int dim = -1;
   if (!cl.search("--dim"))
     {
-      std::cerr << "No --dim argument found!" << std::endl;
+      libMesh::err << "No --dim argument found!" << std::endl;
       usage_error(argv[0]);
     }
   dim = cl.next(dim);
@@ -62,17 +62,17 @@ int main(int argc, char** argv)
 
   if(!cl.search("--input"))
     {
-      std::cerr << "No --input argument found!" << std::endl;
+      libMesh::err << "No --input argument found!" << std::endl;
       usage_error(argv[0]);
     }
   const char* meshname = cl.next("mesh.xda");
 
   mesh.read(meshname);
-  std::cout << "Loaded mesh " << meshname << std::endl;
+  libMesh::out << "Loaded mesh " << meshname << std::endl;
 
   if(!cl.search("--newbcid"))
     {
-      std::cerr << "No --bcid argument found!" << std::endl;
+      libMesh::err << "No --bcid argument found!" << std::endl;
       usage_error(argv[0]);
     }
   boundary_id_type bcid = 0;
@@ -119,10 +119,10 @@ int main(int argc, char** argv)
   if (cl.search("--maxpointz"))
     maxpoint(2) = cl.next(maxpoint(2));
 
-std::cout << "min point = " << minpoint << std::endl;
-std::cout << "max point = " << maxpoint << std::endl;
-std::cout << "min normal = " << minnormal << std::endl;
-std::cout << "max normal = " << maxnormal << std::endl;
+libMesh::out << "min point = " << minpoint << std::endl;
+libMesh::out << "max point = " << maxpoint << std::endl;
+libMesh::out << "min normal = " << minnormal << std::endl;
+libMesh::out << "max normal = " << maxnormal << std::endl;
 
   bool matcholdbcid = false;
   boundary_id_type oldbcid = 0;
@@ -155,10 +155,10 @@ std::cout << "max normal = " << maxnormal << std::endl;
           const Point &p = face_points[0];
           const Point &n = face_normals[0];
 
-//std::cout << "elem = " << elem->id() << std::endl;
-//std::cout << "centroid = " << elem->centroid() << std::endl;
-//std::cout << "p = " << p << std::endl;
-//std::cout << "n = " << n << std::endl;
+//libMesh::out << "elem = " << elem->id() << std::endl;
+//libMesh::out << "centroid = " << elem->centroid() << std::endl;
+//libMesh::out << "p = " << p << std::endl;
+//libMesh::out << "n = " << n << std::endl;
 
           if (p(0) > minpoint(0) && p(0) < maxpoint(0) &&
               p(1) > minpoint(1) && p(1) < maxpoint(1) &&
@@ -172,8 +172,8 @@ std::cout << "max normal = " << maxnormal << std::endl;
                 continue;
               mesh.boundary_info->remove_side(elem, s);
               mesh.boundary_info->add_side(elem, s, bcid);
-//std::cout << "Set element " << elem->id() << " side " << s <<
-//             " to boundary " << bcid << std::endl;
+//libMesh::out << "Set element " << elem->id() << " side " << s <<
+//                " to boundary " << bcid << std::endl;
             }
         }
     }
@@ -191,7 +191,7 @@ std::cout << "max normal = " << maxnormal << std::endl;
 
 
   mesh.write(outputname.c_str());
-  std::cout << "Wrote mesh " << outputname << std::endl;
+  libMesh::out << "Wrote mesh " << outputname << std::endl;
 
   return 0;
 }

--- a/src/apps/meshdiff.C
+++ b/src/apps/meshdiff.C
@@ -37,17 +37,17 @@ int main(int argc, char** argv)
   Mesh mesh1(dim, init.comm()), mesh2(dim, init.comm());
   EquationSystems es1(mesh1), es2(mesh2);
 
-  std::cout << "Usage: " << argv[0]
-            << " coarsemesh coarsesolution finemesh finesolution" << std::endl;
+  libMesh::out << "Usage: " << argv[0]
+               << " coarsemesh coarsesolution finemesh finesolution" << std::endl;
 
   mesh1.read(argv[1]);
-  std::cout << "Loaded coarse mesh " << argv[1] << std::endl;
+  libMesh::out << "Loaded coarse mesh " << argv[1] << std::endl;
   es1.read(argv[2]);
-  std::cout << "Loaded coarse solution " << argv[2] << std::endl;
+  libMesh::out << "Loaded coarse solution " << argv[2] << std::endl;
   mesh2.read(argv[3]);
-  std::cout << "Loaded fine mesh " << argv[3] << std::endl;
+  libMesh::out << "Loaded fine mesh " << argv[3] << std::endl;
   es2.read(argv[4]);
-  std::cout << "Loaded fine solution " << argv[4] << std::endl;
+  libMesh::out << "Loaded fine solution " << argv[4] << std::endl;
 
   ExactSolution exact_sol(es1);
   exact_sol.attach_reference_solution(&es2);
@@ -59,19 +59,19 @@ int main(int argc, char** argv)
     if (es2.has_system(es1.get_system(i).name()))
       sysnames.push_back(es1.get_system(i).name());
     else
-      std::cout << "Coarse solution system "
-                << es1.get_system(i).name()
-		<< " not found in fine solution!" << std::endl;
+      libMesh::out << "Coarse solution system "
+                   << es1.get_system(i).name()
+		   << " not found in fine solution!" << std::endl;
 
   for (unsigned int i = 0; i != es2.n_systems(); ++i)
     if (!es1.has_system(es2.get_system(i).name()))
-      std::cout << "Fine solution system "
-                << es2.get_system(i).name()
-		<< " not found in coarse solution!" << std::endl;
+      libMesh::out << "Fine solution system "
+                   << es2.get_system(i).name()
+		   << " not found in coarse solution!" << std::endl;
 
   if (!es1.n_systems() && !es2.n_systems())
-    std::cout << "No systems found in fine or coarse solution!"
-              << std::endl;
+    libMesh::out << "No systems found in fine or coarse solution!"
+                 << std::endl;
 
   for (unsigned int i = 0; i != sysnames.size(); ++i)
     {
@@ -85,25 +85,25 @@ int main(int argc, char** argv)
 
           if (!sys2.has_variable(varname))
             {
-              std::cout << "Fine solution system " << sysname
-                        << " variable " << varname
-		        << " not found in coarse solution!" << std::endl;
+              libMesh::out << "Fine solution system " << sysname
+                           << " variable " << varname
+		           << " not found in coarse solution!" << std::endl;
               continue;
             }
           const unsigned int j2 = sys2.variable_number(varname);
 
           exact_sol.compute_error(sysname, varname);
 
-          std::cout << "Errors in system " << sysname << ", variable " << varname << ":" << std::endl;
-          std::cout << "L2 error: " << exact_sol.l2_error(sysname, varname)
-                    << ", fine norm: " << sys1.calculate_norm(*sys1.solution, j, L2)
-                    << ", coarse norm: " << sys2.calculate_norm(*sys2.solution, j2, L2) << std::endl;
-          std::cout << "H1 error: " << exact_sol.h1_error(sysname, varname)
-                    << ", fine norm: " << sys1.calculate_norm(*sys1.solution, j, H1)
-                    << ", coarse norm: " << sys2.calculate_norm(*sys2.solution, j2, H1) << std::endl;
-          std::cout << "H2 error: " << exact_sol.h2_error(sysname, varname)
-                    << ", fine norm: " << sys1.calculate_norm(*sys1.solution, j, H2)
-                    << ", coarse norm: " << sys2.calculate_norm(*sys2.solution, j2, H2) << std::endl;
+          libMesh::out << "Errors in system " << sysname << ", variable " << varname << ":" << std::endl;
+          libMesh::out << "L2 error: " << exact_sol.l2_error(sysname, varname)
+                       << ", fine norm: " << sys1.calculate_norm(*sys1.solution, j, L2)
+                       << ", coarse norm: " << sys2.calculate_norm(*sys2.solution, j2, L2) << std::endl;
+          libMesh::out << "H1 error: " << exact_sol.h1_error(sysname, varname)
+                       << ", fine norm: " << sys1.calculate_norm(*sys1.solution, j, H1)
+                       << ", coarse norm: " << sys2.calculate_norm(*sys2.solution, j2, H1) << std::endl;
+          libMesh::out << "H2 error: " << exact_sol.h2_error(sysname, varname)
+                       << ", fine norm: " << sys1.calculate_norm(*sys1.solution, j, H2)
+                       << ", coarse norm: " << sys2.calculate_norm(*sys2.solution, j2, H2) << std::endl;
         }
 
       for (unsigned int j = 0; j != sys2.n_vars(); ++j)
@@ -112,16 +112,16 @@ int main(int argc, char** argv)
 
           if (!sys1.has_variable(varname))
             {
-              std::cout << "Coarse solution system " << sysname
-                        << " variable " << varname
-		        << " not found in fine solution!" << std::endl;
+              libMesh::out << "Coarse solution system " << sysname
+                           << " variable " << varname
+		           << " not found in fine solution!" << std::endl;
               continue;
             }
         }
 
       if (!sys1.n_vars() && !sys2.n_vars())
-        std::cout << "No variables found in fine or coarse solution system "
-                  << sysname << '!' << std::endl;
+        libMesh::out << "No variables found in fine or coarse solution system "
+                     << sysname << '!' << std::endl;
     }
 
   return 0;

--- a/src/apps/meshnorm.C
+++ b/src/apps/meshnorm.C
@@ -12,21 +12,21 @@ void output_norms(const System &sys, const NumericVector<Number>&vec, const std:
 {
   for (unsigned int k = 0; k != sys.n_vars(); ++k)
     {
-      std::cout << "Norms in system " << sys.name() <<
+      libMesh::out << "Norms in system " << sys.name() <<
                    ", vector " << vecname <<
                    ", variable " << sys.variable_name(k) << ":" << std::endl;
       Real l1_vecnorm = sys.calculate_norm(vec, k, DISCRETE_L1);
-      std::cout << "l1     norm: " << l1_vecnorm << std::endl;
+      libMesh::out << "l1     norm: " << l1_vecnorm << std::endl;
       if (l1_vecnorm)
         {
-          std::cout << "l2     norm: " << sys.calculate_norm(vec, k, DISCRETE_L2) << std::endl;
-          std::cout << "linf   norm: " << sys.calculate_norm(vec, k, DISCRETE_L_INF) << std::endl;
-          std::cout << "H1     norm: " << sys.calculate_norm(vec, k, H1) << std::endl;
-          std::cout << "L1     norm: " << sys.calculate_norm(vec, k, L1) << std::endl;
-          std::cout << "L2     norm: " << sys.calculate_norm(vec, k, L2) << std::endl;
-          std::cout << "Linf   norm: " << sys.calculate_norm(vec, k, L_INF) << std::endl;
-          std::cout << "H1 seminorm: " << sys.calculate_norm(vec, k, H1_SEMINORM) << std::endl;
-          std::cout << "H1     norm: " << sys.calculate_norm(vec, k, H1) << std::endl;
+          libMesh::out << "l2     norm: " << sys.calculate_norm(vec, k, DISCRETE_L2) << std::endl;
+          libMesh::out << "linf   norm: " << sys.calculate_norm(vec, k, DISCRETE_L_INF) << std::endl;
+          libMesh::out << "H1     norm: " << sys.calculate_norm(vec, k, H1) << std::endl;
+          libMesh::out << "L1     norm: " << sys.calculate_norm(vec, k, L1) << std::endl;
+          libMesh::out << "L2     norm: " << sys.calculate_norm(vec, k, L2) << std::endl;
+          libMesh::out << "Linf   norm: " << sys.calculate_norm(vec, k, L_INF) << std::endl;
+          libMesh::out << "H1 seminorm: " << sys.calculate_norm(vec, k, H1_SEMINORM) << std::endl;
+          libMesh::out << "H1     norm: " << sys.calculate_norm(vec, k, H1) << std::endl;
         }
     }
 }
@@ -38,23 +38,23 @@ int main(int argc, char** argv)
   Mesh mesh(init.comm());
   EquationSystems es(mesh);
 
-  std::cout << "Usage: " << argv[0]
-            << " mesh solution" << std::endl;
+  libMesh::out << "Usage: " << argv[0]
+               << " mesh solution" << std::endl;
 
-  std::cout << "Loading..." << std::endl;
+  libMesh::out << "Loading..." << std::endl;
 
   mesh.read(argv[1]);
-  std::cout << "Loaded mesh " << argv[1] << std::endl;
+  libMesh::out << "Loaded mesh " << argv[1] << std::endl;
   mesh.print_info();
 
   es.read(argv[2], EquationSystems::READ_HEADER |
                    EquationSystems::READ_DATA |
                    EquationSystems::READ_ADDITIONAL_DATA |
                    EquationSystems::READ_BASIC_ONLY);
-  std::cout << "Loaded solution " << argv[2] << std::endl;
+  libMesh::out << "Loaded solution " << argv[2] << std::endl;
   es.print_info();
 
-  std::cout.precision(16);
+  libMesh::out.precision(16);
 
   for (unsigned int i = 0; i != es.n_systems(); ++i)
     {

--- a/src/apps/meshplot.C
+++ b/src/apps/meshplot.C
@@ -24,12 +24,12 @@ int main(int argc, char** argv)
   Mesh mesh(init.comm());
   EquationSystems es(mesh);
 
-  std::cout << "Usage: " << argv[0]
+  libMesh::out << "Usage: " << argv[0]
             << " inputmesh inputsolution outputplot" << std::endl;
 
   START_LOG("mesh.read()", "main");
   mesh.read(argv[1]);
-  std::cout << "Loaded mesh " << argv[1] << std::endl;
+  libMesh::out << "Loaded mesh " << argv[1] << std::endl;
   STOP_LOG("mesh.read()", "main");
 
   START_LOG("es.read()", "main");
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
           EquationSystems::READ_DATA |
           EquationSystems::READ_ADDITIONAL_DATA |
           EquationSystems::READ_BASIC_ONLY);
-  std::cout << "Loaded solution " << argv[2] << std::endl;
+  libMesh::out << "Loaded solution " << argv[2] << std::endl;
   STOP_LOG("es.read()", "main");
 
   START_LOG("write_equation_systems()", "main");
@@ -64,5 +64,5 @@ int main(int argc, char** argv)
     Nemesis_IO(mesh).write_equation_systems (outputname, es);
 
   STOP_LOG("write_equation_systems()", "main");
-  std::cout << "Wrote output " << argv[3] << std::endl;
+  libMesh::out << "Wrote output " << argv[3] << std::endl;
 }

--- a/src/apps/meshtool.C
+++ b/src/apps/meshtool.C
@@ -253,8 +253,8 @@ void process_cmd_line(int argc, char **argv,
               names.push_back(optarg);
             else
               {
-                std::cout << "ERROR: Input name must preceed output name!"
-                          << std::endl;
+                libMesh::out << "ERROR: Input name must preceed output name!"
+                             << std::endl;
                 exit(1);
               }
             break;
@@ -269,8 +269,8 @@ void process_cmd_line(int argc, char **argv,
               names.push_back(optarg);
             else
               {
-                std::cout << "ERROR: Input name must preceed output name!"
-                          << std::endl;
+                libMesh::out << "ERROR: Input name must preceed output name!"
+                             << std::endl;
                 exit(1);
               }
             break;
@@ -285,8 +285,8 @@ void process_cmd_line(int argc, char **argv,
               names.push_back(optarg);
             else
               {
-                std::cout << "ERROR: Input and output names must preceed solution name!"
-                          << std::endl;
+                libMesh::out << "ERROR: Input and output names must preceed solution name!"
+                             << std::endl;
                 exit(1);
               }
             break;
@@ -354,8 +354,8 @@ void process_cmd_line(int argc, char **argv,
           {
             if (b_mesh_B_given)
               {
-                std::cout << "ERROR: Do not use -b and -B concurrently!"
-                          << std::endl;
+                libMesh::out << "ERROR: Do not use -b and -B concurrently!"
+                             << std::endl;
                 exit(1);
               }
 
@@ -372,8 +372,8 @@ void process_cmd_line(int argc, char **argv,
           {
             if (b_mesh_b_given)
               {
-                std::cout << "ERROR: Do not use -b and -B concurrently!"
-                          << std::endl;
+                libMesh::out << "ERROR: Do not use -b and -B concurrently!"
+                             << std::endl;
                 exit(1);
               }
 
@@ -580,7 +580,7 @@ int main (int argc, char** argv)
 
   else
     {
-      std::cout << "No input specified." << std::endl;
+      libMesh::out << "No input specified." << std::endl;
       return 1;
     }
 
@@ -592,15 +592,15 @@ int main (int argc, char** argv)
     {
       if (names.size() == 3)
         {
-          std::cout << "ERROR: Invalid combination: Building infinite elements " << std::endl
-                    << "not compatible with solution import." << std::endl;
+          libMesh::out << "ERROR: Invalid combination: Building infinite elements " << std::endl
+                       << "not compatible with solution import." << std::endl;
           exit(1);
         }
 
       if (write_bndry != BM_DISABLED)
         {
-          std::cout << "ERROR: Invalid combination: Building infinite elements " << std::endl
-                    << "not compatible with writing boundary conditions." << std::endl;
+          libMesh::out << "ERROR: Invalid combination: Building infinite elements " << std::endl
+                       << "not compatible with writing boundary conditions." << std::endl;
           exit(1);
         }
 
@@ -612,9 +612,9 @@ int main (int argc, char** argv)
           (y_sym && !origin_y.first) ||     // the same for y
           (z_sym && !origin_z.first))       // the same for z
         {
-          std::cout << "ERROR: When x-symmetry is requested using -X, then" << std::endl
-                    << "the option -x <coord> also has to be given." << std::endl
-                    << "This holds obviously for y and z, too." << std::endl;
+          libMesh::out << "ERROR: When x-symmetry is requested using -X, then" << std::endl
+                       << "the option -x <coord> also has to be given." << std::endl
+                       << "This holds obviously for y and z, too." << std::endl;
           exit(1);
         }
 
@@ -637,8 +637,8 @@ int main (int argc, char** argv)
   else if((origin_x.first ||  origin_y.first || origin_z.first) ||
           (x_sym          ||  y_sym          || z_sym))
     {
-      std::cout << "ERROR:  -x/-y/-z/-X/-Y/-Z is only to be used when" << std::endl
-                << "the option -a is also specified!" << std::endl;
+      libMesh::out << "ERROR:  -x/-y/-z/-X/-Y/-Z is only to be used when" << std::endl
+                   << "the option -a is also specified!" << std::endl;
       exit(1);
     }
 
@@ -661,7 +661,8 @@ int main (int argc, char** argv)
 //  if (dim == 2 && triangulate)
   if (triangulate)
     {
-      if (verbose) std::cout << "...Converting to all simplices...\n";
+      if (verbose)
+	 libMesh::out << "...Converting to all simplices...\n";
 
       MeshTools::Modification::all_tri(mesh);
     }
@@ -678,13 +679,13 @@ int main (int argc, char** argv)
 
       const ElemQuality q = DIAGONAL;
 
-      std::cout << "Quality type is: " << Quality::name(q) << std::endl;
+      libMesh::out << "Quality type is: " << Quality::name(q) << std::endl;
 
       // What are the quality bounds for this element?
       std::pair<Real, Real> bounds = mesh.elem(0)->qual_bounds(q);
-      std::cout << "Quality bounds for this element type are: (" << bounds.first
-                << ", " << bounds.second << ") "
-                << std::endl;
+      libMesh::out << "Quality bounds for this element type are: (" << bounds.first
+                   << ", " << bounds.second << ") "
+                   << std::endl;
 
       for (unsigned int e=0; e<mesh.n_elem(); e++)
         {
@@ -692,19 +693,19 @@ int main (int argc, char** argv)
         }
 
       const unsigned int n_bins = 10;
-      std::cout << "Avg. shape quality: " << sv.mean() << std::endl;
+      libMesh::out << "Avg. shape quality: " << sv.mean() << std::endl;
 
       // Find element indices below the specified cutoff.
       // These might be considered "bad" elements which need refinement.
       std::vector<dof_id_type> bad_elts  = sv.cut_below(0.8);
-      std::cout << "Found " << bad_elts.size()
-                << " of " << mesh.n_elem()
-                << " elements below the cutoff." << std::endl;
+      libMesh::out << "Found " << bad_elts.size()
+                   << " of " << mesh.n_elem()
+                   << " elements below the cutoff." << std::endl;
 
       /*
       for (unsigned int i=0; i<bad_elts.size(); i++)
-        std::cout << bad_elts[i] << " ";
-      std::cout << std::endl;
+        libMesh::out << bad_elts[i] << " ";
+      libMesh::out << std::endl;
       */
 
       // Compute the histogram for this distribution
@@ -778,7 +779,7 @@ int main (int argc, char** argv)
           libmesh_error();
 
       if (verbose)
-        std::cout << message << std::endl;
+        libMesh::out << message << std::endl;
 
       mesh.all_second_order(second_order_mode);
 
@@ -798,9 +799,9 @@ int main (int argc, char** argv)
   if (n_rsteps > 0)
     {
       if (verbose)
-        std::cout << "Refining the mesh "
-                  << n_rsteps << " times"
-                  << std::endl;
+        libMesh::out << "Refining the mesh "
+                     << n_rsteps << " times"
+                     << std::endl;
 
       MeshRefinement mesh_refinement (mesh);
       mesh_refinement.uniformly_refine(n_rsteps);
@@ -818,9 +819,9 @@ int main (int argc, char** argv)
    */
   if (dist_fact > 0.)
     {
-      std::cout << "Distoring the mesh by a factor of "
-                << dist_fact
-                << std::endl;
+      libMesh::out << "Distoring the mesh by a factor of "
+                   << dist_fact
+                   << std::endl;
 
       MeshTools::Modification::distort(mesh,dist_fact);
     };
@@ -901,7 +902,7 @@ int main (int argc, char** argv)
         if (n_rsteps > 0)
           {
             if (verbose)
-                std::cout << " Mesh got refined, will write only _active_ elements." << std::endl;
+                libMesh::out << " Mesh got refined, will write only _active_ elements." << std::endl;
 
             Mesh new_mesh (init.comm(), mesh.mesh_dimension());
 
@@ -957,7 +958,7 @@ int main (int argc, char** argv)
   };
 
   /*
-  std::cout << "Infinite loop, look at memory footprint" << std::endl;
+  libMesh::out << "Infinite loop, look at memory footprint" << std::endl;
   for (;;)
     ;
   */

--- a/src/apps/projection.C
+++ b/src/apps/projection.C
@@ -40,7 +40,7 @@ using namespace libMesh;
 // If there's a missing input argument, then print a help message
 void usage_error(const char *progname)
 {
-  std::cout << "Options: " << progname << '\n'
+  libMesh::out << "Options: " << progname << '\n'
   << " --dim d               mesh dimension           [default: autodetect]\n"
   << " --inmesh filename     input mesh file\n"
   << " --insoln filename     input solution file\n"
@@ -60,7 +60,7 @@ T assert_argument (GetPot &cl,
 {
   if(!cl.search(argname))
     {
-      std::cerr << ("No " + argname + " argument found!") << std::endl;
+      libMesh::err << ("No " + argname + " argument found!") << std::endl;
       usage_error(progname);
     }
   return cl.next(defaultarg);
@@ -148,7 +148,7 @@ int main(int argc, char** argv)
     read_mode = READ;
   else
     {
-      std::cerr << "Unrecognized file extension on " << solnname << std::endl;
+      libMesh::err << "Unrecognized file extension on " << solnname << std::endl;
       libmesh_error();
     }
 
@@ -174,7 +174,7 @@ int main(int argc, char** argv)
       System &old_sys = old_es.get_system(i);
       current_sys_name = old_sys.name();
 
-      std::cout << "Projecting system " << current_sys_name << std::endl;
+      libMesh::out << "Projecting system " << current_sys_name << std::endl;
 
       libmesh_assert (new_es.has_system(current_sys_name));
 
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
       // variable's value
       for (unsigned int j = 0; j != n_vars; ++j)
         {
-          std::cout << " with variable " << old_sys.variable_name(j) << std::endl;
+          libMesh::out << " with variable " << old_sys.variable_name(j) << std::endl;
 
           MeshFunction *mesh_func =
             new MeshFunction(old_es, *comparison_soln,
@@ -216,7 +216,7 @@ int main(int argc, char** argv)
   new_es.write(outsolnname.c_str(),
                EquationSystems::WRITE_DATA |
                EquationSystems::WRITE_ADDITIONAL_DATA);
-  std::cout << "Wrote solution " << outsolnname << std::endl;
+  libMesh::out << "Wrote solution " << outsolnname << std::endl;
 
   return 0;
 }

--- a/src/apps/solution_components.C
+++ b/src/apps/solution_components.C
@@ -37,8 +37,8 @@ int main(int argc, char** argv)
   Mesh mesh1(init.comm(), dim);
   EquationSystems es1(mesh1);
 
-  std::cout << "Usage: " << argv[0]
-            << " mesh oldsolution newsolution system1 variable1 [sys2 var2...]" << std::endl;
+  libMesh::out << "Usage: " << argv[0]
+               << " mesh oldsolution newsolution system1 variable1 [sys2 var2...]" << std::endl;
 
   // We should have one system name for each variable name, and those
   // get preceded by an even number of arguments.
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
   libmesh_assert_greater_equal (argc, 6);
 
   mesh1.read(argv[1]);
-  std::cout << "Loaded mesh " << argv[1] << std::endl;
+  libMesh::out << "Loaded mesh " << argv[1] << std::endl;
   Mesh mesh2(mesh1);
   EquationSystems es2(mesh2);
 
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
            EquationSystems::READ_DATA |
            EquationSystems::READ_ADDITIONAL_DATA |
            EquationSystems::READ_BASIC_ONLY);
-  std::cout << "Loaded solution " << argv[2] << std::endl;
+  libMesh::out << "Loaded solution " << argv[2] << std::endl;
 
   std::vector<unsigned int> old_sys_num((argc-4)/2),
                             new_sys_num((argc-4)/2),

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -629,11 +629,11 @@ void DofMap::reinit(MeshBase& mesh)
 		      node->set_vg_dof_base(sys_num, vg,
 					    vertex_dofs);
 
-		      // std::cout << "sys_num,vg,old_node_dofs,vertex_dofs="
-		      // 		<< sys_num << ","
-		      // 		<< vg << ","
-		      // 		<< old_node_dofs << ","
-		      // 		<< vertex_dofs << '\n',
+		      // libMesh::out << "sys_num,vg,old_node_dofs,vertex_dofs="
+		      // 	      << sys_num << ","
+		      // 	      << vg << ","
+		      // 	      << old_node_dofs << ","
+		      // 	      << vertex_dofs << '\n',
 		      // 	node->debug_buffer();
 
 		      // libmesh_assert_equal_to (vertex_dofs, node->n_comp(sys_num, vg));
@@ -682,12 +682,12 @@ void DofMap::reinit(MeshBase& mesh)
 	        {
 		  libmesh_assert_greater_equal (old_node_dofs, vertex_dofs);
 		  // //if (vertex_dofs < new_node_dofs)
-		  //   std::cout << "sys_num,vg,old_node_dofs,vertex_dofs,new_node_dofs="
-		  // 	      << sys_num << ","
-		  // 	      << vg << ","
-		  // 	      << old_node_dofs << ","
-		  // 	      << vertex_dofs << ","
-		  // 	      << new_node_dofs << '\n',
+		  //   libMesh::out << "sys_num,vg,old_node_dofs,vertex_dofs,new_node_dofs="
+		  //                << sys_num << ","
+		  //                << vg << ","
+		  //                << old_node_dofs << ","
+		  //                << vertex_dofs << ","
+		  //                << new_node_dofs << '\n',
 		  //     node->debug_buffer();
 
 		  libmesh_assert_greater_equal (vertex_dofs,   new_node_dofs);
@@ -1105,7 +1105,7 @@ void DofMap::distribute_local_dofs_node_major(dof_id_type &next_free_dof,
 
 #ifdef DEBUG
   {
-    // std::cout << "next_free_dof=" << next_free_dof << std::endl
+    // libMesh::out << "next_free_dof=" << next_free_dof << std::endl
     // 	      << "_n_SCALAR_dofs=" << _n_SCALAR_dofs << std::endl;
 
     // Make sure we didn't miss any nodes
@@ -1328,7 +1328,7 @@ void DofMap::add_neighbors_to_send_list(MeshBase& mesh)
 		    {
 		      _send_list.push_back(dof_index);
 		      // libmesh_here();
-		      // std::cout << "sys_num,v,c,dof_index="
+		      // libMesh::out << "sys_num,v,c,dof_index="
 		      // 		<< sys_num << ", "
 		      // 		<< v << ", "
 		      // 		<< c << ", "

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -304,10 +304,10 @@ void DofObject::set_n_vars_per_group(const unsigned int s,
 
 #ifdef DEBUG
 
-  // std::cout << " [ ";
+  // libMesh::out << " [ ";
   // for (unsigned int i=0; i<_idx_buf.size(); i++)
-  //   std::cout << _idx_buf[i] << " ";
-  // std::cout << "]\n";
+  //   libMesh::out << _idx_buf[i] << " ";
+  // libMesh::out << "]\n";
 
   libmesh_assert_equal_to (this->n_var_groups(s), nvpg.size());
 
@@ -371,7 +371,7 @@ void DofObject::set_n_comp_group(const unsigned int s,
   libmesh_assert_less ((base_offset + 1), _idx_buf.size());
 
   // if (ncomp)
-  //   std::cout << "s,vg,ncomp="
+  //   libMesh::out << "s,vg,ncomp="
   // 	      << s  << ","
   // 	      << vg << ","
   // 	      << ncomp << '\n';
@@ -385,7 +385,7 @@ void DofObject::set_n_comp_group(const unsigned int s,
   _idx_buf[base_offset + 1] = (ncomp == 0) ? invalid_id - 1 : invalid_id;
 
   // this->debug_buffer();
-  // std::cout << "s,vg = " << s << "," << vg << '\n'
+  // libMesh::out << "s,vg = " << s << "," << vg << '\n'
   // 	    << "base_offset=" << base_offset << '\n'
   // 	    << "this->n_comp(s,vg)=" << this->n_comp(s,vg) << '\n'
   // 	    << "this->n_comp_group(s,vg)=" << this->n_comp_group(s,vg) << '\n'
@@ -426,10 +426,10 @@ void DofObject::set_dof_number(const unsigned int s,
     base_idx = dn;
 
 // #ifdef DEBUG
-//   std::cout << " [ ";
+//   libMesh::out << " [ ";
 //   for (unsigned int i=0; i<_idx_buf.size(); i++)
-//     std::cout << _idx_buf[i] << " ";
-//   std::cout << "]\n";
+//     libMesh::out << _idx_buf[i] << " ";
+//   libMesh::out << "]\n";
 // #endif
 
   libmesh_assert_equal_to (this->dof_number(s, var, comp), dn);
@@ -533,10 +533,10 @@ void DofObject::pack_indexing(std::back_insert_iterator<std::vector<int> > targe
 
 void DofObject::debug_buffer () const
 {
-  std::cout << " [ ";
+  libMesh::out << " [ ";
   for (unsigned int i=0; i<_idx_buf.size(); i++)
-    std::cout << _idx_buf[i] << " ";
-  std::cout << "]\n";
+    libMesh::out << _idx_buf[i] << " ";
+  libMesh::out << "]\n";
 }
 
 

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -100,28 +100,28 @@ namespace {
    */
   void libmesh_handleFPE(int /*signo*/, siginfo_t *info, void * /*context*/)
   {
-    std::cout << std::endl;
-    std::cout << "Floating point exception signaled (";
+    libMesh::err << std::endl;
+    libMesh::err << "Floating point exception signaled (";
     switch (info->si_code)
       {
-      case FPE_INTDIV: std::cerr << "integer divide by zero"; break;
-      case FPE_INTOVF: std::cerr << "integer overflow"; break;
-      case FPE_FLTDIV: std::cerr << "floating point divide by zero"; break;
-      case FPE_FLTOVF: std::cerr << "floating point overflow"; break;
-      case FPE_FLTUND: std::cerr << "floating point underflow"; break;
-      case FPE_FLTRES: std::cerr << "floating point inexact result"; break;
-      case FPE_FLTINV: std::cerr << "invalid floating point operation"; break;
-      case FPE_FLTSUB: std::cerr << "subscript out of range"; break;
-      default:         std::cerr << "unrecognized"; break;
+      case FPE_INTDIV: libMesh::err << "integer divide by zero"; break;
+      case FPE_INTOVF: libMesh::err << "integer overflow"; break;
+      case FPE_FLTDIV: libMesh::err << "floating point divide by zero"; break;
+      case FPE_FLTOVF: libMesh::err << "floating point overflow"; break;
+      case FPE_FLTUND: libMesh::err << "floating point underflow"; break;
+      case FPE_FLTRES: libMesh::err << "floating point inexact result"; break;
+      case FPE_FLTINV: libMesh::err << "invalid floating point operation"; break;
+      case FPE_FLTSUB: libMesh::err << "subscript out of range"; break;
+      default:         libMesh::err << "unrecognized"; break;
       }
-    std::cout << ")!" << std::endl;
+    libMesh::err << ")!" << std::endl;
 
-    std::cout << std::endl;
-    std::cout << "To track this down, compile debug version, start debugger, set breakpoint for 'libmesh_handleFPE' and run" << std::endl;
-    std::cout << "In gdb do:" << std::endl;
-    std::cout << "  break libmesh_handleFPE" << std::endl;
-    std::cout << "  run ..." << std::endl;
-    std::cout << "  bt" << std::endl;
+    libMesh::err << std::endl;
+    libMesh::err << "To track this down, compile debug version, start debugger, set breakpoint for 'libmesh_handleFPE' and run" << std::endl;
+    libMesh::err << "In gdb do:" << std::endl;
+    libMesh::err << "  break libmesh_handleFPE" << std::endl;
+    libMesh::err << "  run ..." << std::endl;
+    libMesh::err << "  bt" << std::endl;
 
     libmesh_error();
   }

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -783,7 +783,7 @@ namespace libMesh
 	_in >> c >> side_id;
 
 	// Debugging: print status
-	// std::cout << "Read elem_id=" << elem_id << ", side_id=" << side_id << std::endl;
+	// libMesh::out << "Read elem_id=" << elem_id << ", side_id=" << side_id << std::endl;
 
 	// Store this pair of data in the vector
 	id_storage.push_back( std::make_pair(elem_id, side_id) );

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -533,9 +533,9 @@ void GmshIO::read_mesh(std::istream& in)
                   static bool seen_high_dim_element = false;
                   if (!seen_high_dim_element)
                     {
-                      std::cerr << "Warning: can't load an element of dimension "
-                                << eletype.dim << " into a mesh of dimension "
-                                << dim << std::endl;
+                      libMesh::err << "Warning: can't load an element of dimension "
+                                   << eletype.dim << " into a mesh of dimension "
+                                   << dim << std::endl;
                       seen_high_dim_element = true;
                     }
                   int nod = 0;

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -224,16 +224,16 @@ void MeshCommunication::assign_global_indices (MeshBase& mesh) const
             {
               if (node_keys[i] == node_keys[j])
                 {
-		  std::cerr << "Error: nodes with duplicate Hilbert keys!" <<
+		  libMesh::err << "Error: nodes with duplicate Hilbert keys!" <<
                     std::endl;
                   CFixBitVec icoords[3], jcoords[3];
                   get_hilbert_coords(**nodej, bbox, jcoords);
-		  std::cerr <<
+		  libMesh::err <<
 		    "node " << (*nodej)->id() << ", " <<
 		    *(Point*)(*nodej) << " has HilbertIndices " <<
 		    node_keys[j] << std::endl;
                   get_hilbert_coords(**nodei, bbox, icoords);
-		  std::cerr <<
+		  libMesh::err <<
 		    "node " << (*nodei)->id() << ", " <<
 		    *(Point*)(*nodei) << " has HilbertIndices " <<
 		    node_keys[i] << std::endl;
@@ -264,18 +264,18 @@ void MeshCommunication::assign_global_indices (MeshBase& mesh) const
               if ((elem_keys[i] == elem_keys[j]) &&
                   ((*elemi)->level() == (*elemj)->level()))
                 {
-		  std::cerr <<
+		  libMesh::err <<
                     "Error: level " << (*elemi)->level() <<
                     " elements with duplicate Hilbert keys!" <<
                     std::endl;
-		  std::cerr <<
+		  libMesh::err <<
 		    "level " << (*elemj)->level() << " elem\n" <<
                     (**elemj) << " centroid " <<
 		    (*elemj)->centroid() << " has HilbertIndices " <<
 		    elem_keys[j] << " or " <<
 		    get_hilbert_index((*elemj)->centroid(), bbox) <<
                     std::endl;
-		  std::cerr <<
+		  libMesh::err <<
 		    "level " << (*elemi)->level() << " elem\n" <<
                     (**elemi) << " centroid " <<
 		    (*elemi)->centroid() << " has HilbertIndices " <<

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -222,9 +222,9 @@ namespace libMesh
 		sequential_index = std::distance(_sequential_to_libmesh_node_map.begin(), node_iter);
 
 	      // Debugging:
-	      //	    std::cout << "libmesh_node_id=" << libmesh_node_id
-	      //		      << ", sequential_index=" << sequential_index
-	      //		      << std::endl;
+	      //	    libMesh::out << "libmesh_node_id=" << libmesh_node_id
+	      //		         << ", sequential_index=" << sequential_index
+	      //		         << std::endl;
 
 	      tetgen_wrapper.set_vertex(insertnum, // facet number
 					0,         // polygon (always 0)
@@ -276,8 +276,8 @@ namespace libMesh
     const unsigned int num_nodes = tetgen_wrapper.get_numberofpoints();
 
     // Debugging:
-    // std::cout << "Original mesh had " << old_nodesnum << " nodes." << std::endl;
-    // std::cout << "Reserving space for " << num_nodes << " total nodes." << std::endl;
+    // libMesh::out << "Original mesh had " << old_nodesnum << " nodes." << std::endl;
+    // libMesh::out << "Reserving space for " << num_nodes << " total nodes." << std::endl;
 
     // Reserve space for additional nodes in the node map
     _sequential_to_libmesh_node_map.reserve(num_nodes);
@@ -377,7 +377,7 @@ namespace libMesh
 
 	if (current_node == NULL)
 	  {
-	    std::cerr << "Error! Mesh returned NULL node pointer!" << std::endl;
+	    libMesh::err << "Error! Mesh returned NULL node pointer!" << std::endl;
 	    libmesh_error();
 	  }
 

--- a/src/mesh/mesh_tetgen_wrapper.C
+++ b/src/mesh/mesh_tetgen_wrapper.C
@@ -82,12 +82,12 @@ namespace libMesh
     // Bounds checking...
     if (i >= static_cast<unsigned>(tetgen_output->numberofpoints))
       {
-	std::cerr << "Error, requested point "
-		  << i
-		  << ", but there are only "
-		  << tetgen_output->numberofpoints
-		  << " points available."
-		  << std::endl;
+	libMesh::err << "Error, requested point "
+		     << i
+		     << ", but there are only "
+		     << tetgen_output->numberofpoints
+		     << " points available."
+		     << std::endl;
 	libmesh_error();
       }
 

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1082,7 +1082,7 @@ void Nemesis_IO_Helper::compute_node_communication_maps()
 	// Get reference to the set of IDs to be packed into the vector.
 	std::set<unsigned>& node_set = (*it).second;
 
-	//std::cout << "[" << this->processor_id() << "] node_set.size()=" << node_set.size() << std::endl;
+	//libMesh::out << "[" << this->processor_id() << "] node_set.size()=" << node_set.size() << std::endl;
 
 	// Resize the vectors to receive their payload
 	this->node_cmap_node_ids[cnt].resize(node_set.size());

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -790,9 +790,9 @@ int EpetraVector<T>::inputNonlocalValues(int GID, int numValues,
     //  put value in nonlocalCoefs_[offset][0]
 
     if (numValues != nonlocalElementSize_[offset]) {
-      cerr << "Epetra_FEVector ERROR: block-size for GID " << GID << " is "
-	   << numValues<<" which doesn't match previously set block-size of "
-	   << nonlocalElementSize_[offset] << endl;
+      libMesh::err << "Epetra_FEVector ERROR: block-size for GID " << GID << " is "
+	           << numValues<<" which doesn't match previously set block-size of "
+	           << nonlocalElementSize_[offset] << endl;
       return(-1);
     }
 

--- a/src/solution_transfer/dtk_adapter.C
+++ b/src/solution_transfer/dtk_adapter.C
@@ -105,48 +105,48 @@ DTKAdapter::DTKAdapter(Teuchos::RCP<const Teuchos::Comm<int> > in_comm, Equation
   if(this->processor_id() == 1)
     sleep(1);
 
-  std::cout<<"n_nodes_per_elem: "<<n_nodes_per_elem<<std::endl;
+  libMesh::out<<"n_nodes_per_elem: "<<n_nodes_per_elem<<std::endl;
 
-  std::cout<<"Dim: "<<dim<<std::endl;
+  libMesh::out<<"Dim: "<<dim<<std::endl;
 
-  std::cerr<<"Vertices size: "<<vertices.size()<<std::endl;
+  libMesh::err<<"Vertices size: "<<vertices.size()<<std::endl;
   {
-    std::cerr<<this->processor_id()<<" Vertices: ";
+    libMesh::err<<this->processor_id()<<" Vertices: ";
 
     for(unsigned int i=0; i<vertices.size(); i++)
-      std::cerr<<vertices[i]<<" ";
+      libMesh::err<<vertices[i]<<" ";
 
-    std::cerr<<std::endl;
+    libMesh::err<<std::endl;
   }
 
-  std::cerr<<"Coordinates size: "<<coordinates.size()<<std::endl;
+  libMesh::err<<"Coordinates size: "<<coordinates.size()<<std::endl;
   {
-    std::cerr<<this->processor_id()<<" Coordinates: ";
+    libMesh::err<<this->processor_id()<<" Coordinates: ";
 
     for(unsigned int i=0; i<coordinates.size(); i++)
-      std::cerr<<coordinates[i]<<" ";
+      libMesh::err<<coordinates[i]<<" ";
 
-    std::cerr<<std::endl;
+    libMesh::err<<std::endl;
   }
 
-  std::cerr<<"Connectivity size: "<<connectivity.size()<<std::endl;
+  libMesh::err<<"Connectivity size: "<<connectivity.size()<<std::endl;
   {
-    std::cerr<<this->processor_id()<<" Connectivity: ";
+    libMesh::err<<this->processor_id()<<" Connectivity: ";
 
     for(unsigned int i=0; i<connectivity.size(); i++)
-      std::cerr<<connectivity[i]<<" ";
+      libMesh::err<<connectivity[i]<<" ";
 
-    std::cerr<<std::endl;
+    libMesh::err<<std::endl;
   }
 
-  std::cerr<<"Permutation_List size: "<<permutation_list.size()<<std::endl;
+  libMesh::err<<"Permutation_List size: "<<permutation_list.size()<<std::endl;
   {
-    std::cerr<<this->processor_id()<<" Permutation_List: ";
+    libMesh::err<<this->processor_id()<<" Permutation_List: ";
 
     for(unsigned int i=0; i<permutation_list.size(); i++)
-      std::cerr<<permutation_list[i]<<" ";
+      libMesh::err<<permutation_list[i]<<" ";
 
-    std::cerr<<std::endl;
+    libMesh::err<<std::endl;
   }
 
   */

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -329,16 +329,16 @@ namespace libMesh
 
 	  this->interpolate (tgt, ret_index, ret_dist_sqr, out_it);
 
-	  // std::cout << "knnSearch(): num_results=" << num_results << "\n";
+	  // libMesh::out << "knnSearch(): num_results=" << num_results << "\n";
 	  // for (size_t i=0;i<num_results;i++)
-	  //   std::cout << "idx[" << i << "]="
+	  //   libMesh::out << "idx[" << i << "]="
 	  // 	      << std::setw(6) << ret_index[i]
 	  // 	      << "\t dist["<< i << "]=" << ret_dist_sqr[i]
 	  // 	      << "\t val[" << std::setw(6) << ret_index[i] << "]=" << _src_vals[ret_index[i]]
 	  // 	      << std::endl;
-	  // std::cout << "\n";
+	  // libMesh::out << "\n";
 
-	  // std::cout << "ival=" << _vals[0] << '\n';
+	  // libMesh::out << "ival=" << _vals[0] << '\n';
 	}
     }
 #else

--- a/src/solution_transfer/radial_basis_interpolation.C
+++ b/src/solution_transfer/radial_basis_interpolation.C
@@ -81,9 +81,9 @@ namespace libMesh
 	}
     }
 
-    std::cout << "bounding box is \n"
-	      << _src_bbox.min() << '\n'
-	      << _src_bbox.max() << std::endl;
+    libMesh::out << "bounding box is \n"
+	         << _src_bbox.min() << '\n'
+	         << _src_bbox.max() << std::endl;
 
 
     // Construct the Radial Basis Function, giving it the size of the domain
@@ -94,11 +94,11 @@ namespace libMesh
 
     RBF rbf(_r_bbox);
 
-    std::cout << "bounding box is \n"
-	      << _src_bbox.min() << '\n'
-	      << _src_bbox.max() << '\n'
-	      << "r_bbox = " << _r_bbox << '\n'
-	      << "rbf(r_bbox/2) = " << rbf(_r_bbox/2) << std::endl;
+    libMesh::out << "bounding box is \n"
+	         << _src_bbox.min() << '\n'
+	         << _src_bbox.max() << '\n'
+	         << "r_bbox = " << _r_bbox << '\n'
+	         << "rbf(r_bbox/2) = " << rbf(_r_bbox/2) << std::endl;
 
 
     // Construct the projection Matrix

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -92,8 +92,8 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> &matrix_in,
 	solver.setMaxIterations(m_its);
 	solver.setTolerance(tol);
 	solution._vec = solver.solveWithGuess(rhs._vec,solution._vec);
-	std::cout << "#iterations: " << solver.iterations() << std::endl;
-	std::cout << "estimated error: " << solver.error() << std::endl;
+	libMesh::out << "#iterations: " << solver.iterations() << std::endl;
+	libMesh::out << "estimated error: " << solver.error() << std::endl;
 	retval = std::make_pair(solver.iterations(), solver.error());
   	break;
       }
@@ -105,8 +105,8 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> &matrix_in,
 	solver.setMaxIterations(m_its);
 	solver.setTolerance(tol);
 	solution._vec = solver.solveWithGuess(rhs._vec,solution._vec);
-	std::cout << "#iterations: " << solver.iterations() << std::endl;
-	std::cout << "estimated error: " << solver.error() << std::endl;
+	libMesh::out << "#iterations: " << solver.iterations() << std::endl;
+	libMesh::out << "estimated error: " << solver.error() << std::endl;
 	retval = std::make_pair(solver.iterations(), solver.error());
   	break;
       }

--- a/src/solvers/memory_solution_history.C
+++ b/src/solvers/memory_solution_history.C
@@ -145,7 +145,7 @@ namespace libMesh
     Real recovery_time = stored_sols->first;
 
     // Print out what time we are recovering vectors at
-//    std::cout << "Recovering solution vectors at time: " <<
+//    libMesh::out << "Recovering solution vectors at time: " <<
 //                 recovery_time << std::endl;
 
     // Do we not have a solution for this time?  Then
@@ -153,7 +153,7 @@ namespace libMesh
     if(stored_sols == stored_solutions.end() ||
        std::abs(recovery_time - _system.time) > TOLERANCE)
       {
-//	std::cout << "No more solutions to recover ! We are at time t = " <<
+//	libMesh::out << "No more solutions to recover ! We are at time t = " <<
 //                     _system.time << std::endl;
         return;
       }

--- a/src/solvers/trilinos_nox_nonlinear_solver.C
+++ b/src/solvers/trilinos_nox_nonlinear_solver.C
@@ -194,7 +194,7 @@ bool Problem_Interface::computeJacobian(const Epetra_Vector & x,
 
 bool Problem_Interface::computePrecMatrix(const Epetra_Vector & /*x*/, Epetra_RowMatrix & /*M*/)
 {
-//   cout << "ERROR: Problem_Interface::preconditionVector() - Use Explicit Jacobian only for this test problem!" << endl;
+//   libMesh::out << "ERROR: Problem_Interface::preconditionVector() - Use Explicit Jacobian only for this test problem!" << endl;
    throw 1;
 }
 

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -569,7 +569,7 @@ void EquationSystems::build_variable_names (std::vector<std::string>& var_names,
 		    var_names[var_num++] = var_name+"_z";
 		    break;
 		  default:
-		    std::cerr << "Invalid dim in build_variable_names" << std::endl;
+		    libMesh::err << "Invalid dim in build_variable_names" << std::endl;
 		    libmesh_error();
 		  }
 	      }

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -697,7 +697,7 @@ NumericVector<Number> & System::add_vector (const std::string& vec_name,
                  _dof_map->get_send_list(), false,
                  GHOSTED);
 #else
-      std::cerr << "Cannot initialize ghosted vectors when they are not enabled." << std::endl;
+      libMesh::err << "Cannot initialize ghosted vectors when they are not enabled." << std::endl;
       libmesh_error();
 #endif
     }

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -698,7 +698,7 @@ void System::read_parallel_data (Xdr &io,
   //   dt   = pl.get_elapsed_time(),
   //   rate = total_read_size*sizeof(Number)/dt;
 
-  // std::cerr << "Read " << total_read_size << " \"Number\" values\n"
+  // libMesh::err << "Read " << total_read_size << " \"Number\" values\n"
   // 	    << " Elapsed time = " << dt << '\n'
   // 	    << " Rate = " << rate/1.e6 << "(MB/sec)\n\n";
 
@@ -762,7 +762,7 @@ void System::read_serialized_data (Xdr& io,
   //   dt   = pl.get_elapsed_time(),
   //   rate = total_read_size*sizeof(Number)/dt;
 
-  // std::cout << "Read " << total_read_size << " \"Number\" values\n"
+  // libMesh::out << "Read " << total_read_size << " \"Number\" values\n"
   // 	    << " Elapsed time = " << dt << '\n'
   // 	    << " Rate = " << rate/1.e6 << "(MB/sec)\n\n";
 
@@ -1028,7 +1028,7 @@ dof_id_type System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
 		  for (unsigned int val=0; val<n_vals_tot_allvecs; val++, ++in_vals)
 		    {
 		      libmesh_assert (in_vals != input_vals.end());
-		      //std::cout << "*in_vals=" << *in_vals << '\n';
+		      //libMesh::out << "*in_vals=" << *in_vals << '\n';
 		      vals.push_back(*in_vals);
 		    }
 		}
@@ -1069,7 +1069,7 @@ dof_id_type System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
 			  libmesh_assert (val_it != vals.end());
 			  libmesh_assert_greater_equal (dof_index, vec.first_local_index());
 			  libmesh_assert_less (dof_index, vec.last_local_index());
-			  //std::cout << "dof_index, *val_it = \t" << dof_index << ", " << *val_it << '\n';
+			  //libMesh::out << "dof_index, *val_it = \t" << dof_index << ", " << *val_it << '\n';
 			  vec.set (dof_index, *val_it);
 			}
 		    }
@@ -1660,7 +1660,7 @@ void System::write_parallel_data (Xdr &io,
   //   dt   = pl.get_elapsed_time(),
   //   rate = total_written_size*sizeof(Number)/dt;
 
-  // std::cerr << "Write " << total_written_size << " \"Number\" values\n"
+  // libMesh::err << "Write " << total_written_size << " \"Number\" values\n"
   // 	    << " Elapsed time = " << dt << '\n'
   // 	    << " Rate = " << rate/1.e6 << "(MB/sec)\n\n";
 
@@ -1733,7 +1733,7 @@ void System::write_serialized_data (Xdr& io,
   //   dt   = pl.get_elapsed_time(),
   //   rate = total_written_size*sizeof(Number)/dt;
 
-  // std::cout << "Write " << total_written_size << " \"Number\" values\n"
+  // libMesh::out << "Write " << total_written_size << " \"Number\" values\n"
   // 	    << " Elapsed time = " << dt << '\n'
   // 	    << " Rate = " << rate/1.e6 << "(MB/sec)\n\n";
 
@@ -1770,7 +1770,7 @@ void System::write_serialized_data (Xdr& io,
   //     dt2   = pl.get_elapsed_time(),
   //     rate2 = total_written_size*sizeof(Number)/(dt2-dt);
 
-  //   std::cout << "Write (new) " << total_written_size << " \"Number\" values\n"
+  //   libMesh::out << "Write (new) " << total_written_size << " \"Number\" values\n"
   // 	      << " Elapsed time = " << (dt2-dt) << '\n'
   // 	      << " Rate = " << rate2/1.e6 << "(MB/sec)\n\n";
 
@@ -1822,7 +1822,7 @@ dof_id_type System::write_serialized_blocked_dof_objects (const std::vector<cons
     num_vecs   = libmesh_cast_int<unsigned int>(vecs.size()),
     num_blks   = std::ceil(static_cast<double>(n_objs)/static_cast<double>(io_blksize));
 
-  // std::cout << "io_blksize = "    << io_blksize
+  // libMesh::out << "io_blksize = "    << io_blksize
   // 	    << ", num_objects = " << n_objs
   // 	    << ", num_blks = "    << num_blks
   // 	    << std::endl;


### PR DESCRIPTION
Mentioning the --redirect-stdout flag on the mailing list today got me wondering whether we were still always using the redirected objects.  It turns out we weren't.  This should fix that.  It passes my tests but it's a relatively voluminous change so I figured I'd put it up for a day's review before committing.
