### PR TITLE
Making residual/jacobian zero-outing configurable

### DIFF
--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -126,12 +126,16 @@ public:
   virtual unsigned get_current_nonlinear_iteration_number() const { return _current_nonlinear_iteration_number; }
 
   /**
-   * This public setter is necessary since the value is computed in the
-   * __libmesh_petsc_snes_residual()/jacobian() function and must be stored
-   * somehow.
+   * Set if the residual should be zeroed out in the callback
    */
-  void set_current_nonlinear_iteration_number(unsigned num) { _current_nonlinear_iteration_number = num; }
+  void set_residual_zero_out(bool state) { _zero_out_residual = state; }
 
+  /**
+   * Set if the jacobian should be zeroed out in the callback
+   */
+  void set_jacobian_zero_out(bool state) { _zero_out_jacobian = state; }
+
+protected:
   /**
    * Nonlinear solver context
    */
@@ -172,6 +176,9 @@ public:
                             void (*)(std::vector<NumericVector<Number>*>&, sys_type&),
                             MatNullSpace*);
 #endif
+
+  friend PetscErrorCode __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void *ctx);
+  friend PetscErrorCode __libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat *jac, Mat *pc, MatStructure *msflag, void *ctx);
 };
 
 

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -95,7 +95,7 @@ extern "C"
       PetscInt n_iterations = 0;
       ierr = SNESGetIterationNumber(snes, &n_iterations);
       CHKERRABORT(solver->comm().get(),ierr);
-      solver->set_current_nonlinear_iteration_number( static_cast<unsigned>(n_iterations) );
+      solver->_current_nonlinear_iteration_number = static_cast<unsigned>(n_iterations);
     }
 
     NonlinearImplicitSystem &sys = solver->system();
@@ -172,7 +172,7 @@ extern "C"
       PetscInt n_iterations = 0;
       ierr = SNESGetIterationNumber(snes, &n_iterations);
       CHKERRABORT(solver->comm().get(),ierr);
-      solver->set_current_nonlinear_iteration_number( static_cast<unsigned>(n_iterations) );
+      solver->_current_nonlinear_iteration_number = static_cast<unsigned>(n_iterations);
     }
 
     NonlinearImplicitSystem &sys = solver->system();


### PR DESCRIPTION
The motivation behind this patch is the following.  In one of our setups, the jacobian is constant over the whole simulation (it is a mass matrix in an explicit scheme). In order to save the computation time of re-evaluating the jacobian, we want to compute it only once and reuse it, thus we need a way how to tell libmesh not to zero it out. This simple patch does it.

In order to maintain symmetry, this patch does the above for the residual as well, even though I am not quite sure, if it is even helpful/usable in any scenario.
