### PR TITLE
Updated threads.h to trigger thread safe useage of fparser

### DIFF
--- a/contrib/fparser/fparser.cc
+++ b/contrib/fparser/fparser.cc
@@ -10,6 +10,7 @@
 
 #include "fpconfig.hh"
 #include "fparser.hh"
+#include "libmesh/threads.h"
 
 #include <set>
 #include <cstdlib>

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -75,6 +75,11 @@
 // Helper macro for knowing whether or not threaded regions are enabled
 #define LIBMESH_USING_THREADS defined(LIBMESH_HAVE_PTHREAD) || defined(LIBMESH_HAVE_TBB_API)
 
+// Communicate to fparser that threads are being utilized
+#ifdef LIBMESH_USING_THREADS
+#  define FP_USE_THREAD_SAFE_EVAL
+#endif
+
 namespace libMesh
 {
 


### PR DESCRIPTION
The tread safe #define FP_USE_THREAD_SAFE_EVAL is now defined in threads.h, which is now included in fparser.cc. This was done to fix problems with threading in MOOSE that existed with periodic boundaries.
