### PR TITLE
Adding simple support for copying elemental solutions from exodus files

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -105,6 +105,12 @@ class ExodusII_IO : public MeshInput<MeshBase>,
   void copy_nodal_solution(System& es, std::string system_var_name, std::string exodus_var_name, unsigned int timestep=1);
 
   /**
+   * If we read in a elemental solution while reading in a mesh, we can attempt
+   * to copy that elemental solution into an EquationSystems object.
+   */
+  void copy_elemental_solution(System& es, std::string system_var_name, std::string exodus_var_name, unsigned int timestep=1);
+
+  /**
    * Writes a exodusII file with discontinuous data
    */
   void write_discontinuous_exodusII (const std::string& name,

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -469,6 +469,17 @@ public:
    */
   const std::vector<Real>& get_nodal_var_values(std::string nodal_var_name, int time_step);
 
+  /*
+   * Returns an array containing the elemental var names in the file
+   */
+  const std::vector<std::string>& get_elemental_var_names();
+
+  /*
+   * Returns an array containing the elemental variable values
+   * at the specified time
+   */
+  const std::vector<Real>& get_elemental_var_values(std::string elemental_var_name, int time_step);
+
   // For Writing Solutions
   /**
    * Opens an \p ExodusII mesh
@@ -692,6 +703,8 @@ public:
   std::vector<Real> nodal_var_values;
 
   int num_elem_vars;
+  std::vector<std::string> elem_var_names;
+  std::vector<Real> elem_var_values;
 
   // A pair of containers used to emulate a char** data
   // structure without having to worry about dynamic memory

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -371,6 +371,63 @@ void ExodusII_IO::copy_nodal_solution(System& system, std::string system_var_nam
 #endif
 
 
+#ifndef LIBMESH_HAVE_EXODUS_API
+
+void ExodusII_IO::copy_elemental_solution(System&, std::string, std::string, unsigned int)
+{
+
+  libMesh::err <<  "ERROR, ExodusII API is not defined.\n"
+            << std::endl;
+  libmesh_error();
+}
+
+#else
+
+void ExodusII_IO::copy_elemental_solution(System& system, std::string system_var_name, std::string exodus_var_name, unsigned int timestep)
+{
+  if (!exio_helper->created())
+    {
+      libMesh::err << "ERROR, ExodusII file must be opened "
+                   << "before copying elemental solutions.\n"
+                   << std::endl;
+      libmesh_error();
+    }
+
+  // FIXME: Do we need to call get_time_steps() at all?
+  /*const std::vector<double>& time_steps = */
+  exio_helper->get_time_steps();
+
+  const std::vector<Real> & elemental_values = exio_helper->get_elemental_var_values(exodus_var_name, timestep);
+
+  const unsigned int var_num = system.variable_number(system_var_name);
+  if (system.variable_type(var_num) != FEType(CONSTANT, MONOMIAL))
+  {
+    libMesh::err << "Error! Trying to copy elemental solution into a variable that is not of CONSTANT MONOMIAL type. " << std::endl;
+    libmesh_error();
+  }
+
+  for (unsigned int i=0; i<elemental_values.size(); ++i)
+    {
+      const Elem * elem = MeshInput<MeshBase>::mesh().elem(i);
+
+      if (!elem)
+        {
+          libMesh::err << "Error! Mesh returned NULL pointer for elem " << i << std::endl;
+          libmesh_error();
+        }
+
+      dof_id_type dof_index = elem->dof_number(system.number(), var_num, 0);
+
+      // If the dof_index is local to this processor, set the value
+      if ((dof_index >= system.solution->first_local_index()) && (dof_index < system.solution->last_local_index()))
+    system.solution->set (dof_index, elemental_values[i]);
+    }
+
+  system.solution->close();
+  system.update();
+}
+
+#endif
 
 
 #ifndef LIBMESH_HAVE_EXODUS_API


### PR DESCRIPTION
This adds really simple and very stupid support for copying elemental solutions from exodus files. I tested it on a very simple mesh with one block and that's working.  If the mesh has more blocks and element numbering gets funky, this will probably not work. However I have no idea how to deal with such a situation.  This patch should help MOOSE to load simple solutions into elemental fields (that's the motivation here). 
