### PR TITLE
Added N^2 node search option back into SerialMesh::stitch_meshes.

### DIFF
--- a/include/mesh/serial_mesh.h
+++ b/include/mesh/serial_mesh.h
@@ -173,6 +173,12 @@ class SerialMesh : public UnstructuredMesh
    * being stitched) to determine whether or not nodes are overlapping.
    * If \p clear_stitched_boundary_ids==true, this function clears boundary_info IDs in this
    * mesh associated \p this_mesh_boundary and \p other_mesh_boundary.
+   * If \p use_binary_search is true, we use an optimized "sort then binary search" algorithm
+   * for finding matching nodes. Otherwise we use a N^2 algorithm (which can be more reliable
+   * at dealing with slightly misaligned meshes).
+   * If enforce_all_nodes_match_on_boundaries is true, we throw an error if the number of
+   * nodes on the specified boundaries don't match the number of nodes that were merged.
+   * This is a helpful error check in some cases.
    */
   void stitch_meshes (SerialMesh& other_mesh,
                       boundary_id_type this_mesh_boundary,
@@ -180,7 +186,8 @@ class SerialMesh : public UnstructuredMesh
                       Real tol=TOLERANCE,
                       bool clear_stitched_boundary_ids=false,
                       bool verbose=true,
-                      bool use_binary_search=true);
+                      bool use_binary_search=true,
+                      bool enforce_all_nodes_match_on_boundaries=false);
 
   /**
    * Similar to stitch_meshes, except that we stitch two adjacent surfaces within this mesh.
@@ -190,7 +197,8 @@ class SerialMesh : public UnstructuredMesh
                         Real tol=TOLERANCE,
                         bool clear_stitched_boundary_ids=false,
                         bool verbose=true,
-                        bool use_binary_search=true);
+                        bool use_binary_search=true,
+                        bool enforce_all_nodes_match_on_boundaries=false);
 
 public:
   /**
@@ -389,7 +397,8 @@ private:
                          Real tol,
                          bool clear_stitched_boundary_ids,
                          bool verbose,
-                         bool use_binary_search);
+                         bool use_binary_search,
+                         bool enforce_all_nodes_match_on_boundaries);
 
   /**
    * Typedefs for the container implementation.  In this case,

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -741,7 +741,8 @@ void SerialMesh::stitch_meshes (SerialMesh& other_mesh,
                                 Real tol,
                                 bool clear_stitched_boundary_ids,
                                 bool verbose,
-                                bool use_binary_search)
+                                bool use_binary_search,
+                                bool enforce_all_nodes_match_on_boundaries)
 {
   stitching_helper(&other_mesh,
                    this_mesh_boundary_id,
@@ -749,7 +750,8 @@ void SerialMesh::stitch_meshes (SerialMesh& other_mesh,
                    tol,
                    clear_stitched_boundary_ids,
                    verbose,
-                   use_binary_search);
+                   use_binary_search,
+                   enforce_all_nodes_match_on_boundaries);
 }
 
 void SerialMesh::stitch_surfaces (boundary_id_type boundary_id_1,
@@ -757,7 +759,8 @@ void SerialMesh::stitch_surfaces (boundary_id_type boundary_id_1,
                                   Real tol,
                                   bool clear_stitched_boundary_ids,
                                   bool verbose,
-                                  bool use_binary_search)
+                                  bool use_binary_search,
+                                  bool enforce_all_nodes_match_on_boundaries)
 {
   stitching_helper(NULL,
                    boundary_id_1,
@@ -765,7 +768,8 @@ void SerialMesh::stitch_surfaces (boundary_id_type boundary_id_1,
                    tol,
                    clear_stitched_boundary_ids,
                    verbose,
-                   use_binary_search);
+                   use_binary_search,
+                   enforce_all_nodes_match_on_boundaries);
 }
 
 void SerialMesh::stitching_helper (SerialMesh* other_mesh,
@@ -774,7 +778,8 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                                    Real tol,
                                    bool clear_stitched_boundary_ids,
                                    bool verbose,
-                                   bool use_binary_search)
+                                   bool use_binary_search,
+                                   bool enforce_all_nodes_match_on_boundaries)
 {
   std::map<dof_id_type, dof_id_type> node_to_node_map, other_to_this_node_map; // The second is the inverse map of the first
   std::map<dof_id_type, std::vector<dof_id_type> > node_to_elems_map;
@@ -994,6 +999,20 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                    << "Found " << node_to_node_map.size()
                    << " matching nodes.\n"
                    << std::endl;
+    }
+    
+    if(enforce_all_nodes_match_on_boundaries)
+    {
+      unsigned int n_matching_nodes = node_to_node_map.size();
+      unsigned int this_mesh_n_nodes = this_boundary_node_ids.size();
+      unsigned int other_mesh_n_nodes = other_boundary_node_ids.size();
+      if( (n_matching_nodes != this_mesh_n_nodes) ||
+          (n_matching_nodes != other_mesh_n_nodes) )
+      {
+        libMesh::out << "Error: We expected the number of nodes to match."
+                     << std::endl;
+        libmesh_error();
+      }
     }
   }
   else


### PR DESCRIPTION
This option is more robust in the case that we have tolerance issues that lead to less accurate alignment of the nodes that are to be stitched.

The N^2 search was the initial implementation, but was replaced by @jwpeterson due to its slowness. But it now avoids the expensive loop over other_mesh (using the reverse node map introduced by @jwpeterson), so it's not so slow anymore (I haven't done detailed comparisons yet though).
