### PR TITLE
Fix FEMFunction projection bug reported by Manav Bhatia.

### DIFF
--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -2128,8 +2128,6 @@ void ProjectFEMSolution::operator()(const ConstElemRange &range) const
           // In 3D, project any edge values next
           if (dim > 2 && cont != DISCONTINUOUS)
 	    {
-	      const QBase& qedgerule = context.get_edge_qrule();
-	      const unsigned int n_qp = qedgerule.n_points();
 	      const std::vector<Point>& xyz_values = edge_fe->get_xyz();
 	      const std::vector<Real>& JxW = edge_fe->get_JxW();
 
@@ -2142,6 +2140,9 @@ void ProjectFEMSolution::operator()(const ConstElemRange &range) const
 		{
 		  context.edge = e;
 		  context.edge_fe_reinit();
+
+                  const QBase& qedgerule = context.get_edge_qrule();
+                  const unsigned int n_qp = qedgerule.n_points();
 
 		  FEInterface::dofs_on_edge(elem, dim, fe_type, e,
 					    side_dofs);
@@ -2235,8 +2236,6 @@ void ProjectFEMSolution::operator()(const ConstElemRange &range) const
 	  // Project any side values (edges in 2D, faces in 3D)
           if (dim > 1 && cont != DISCONTINUOUS)
 	    {
-	      const QBase& qsiderule = context.get_side_qrule();
-	      const unsigned int n_qp = qsiderule.n_points();
 	      const std::vector<Point>& xyz_values = side_fe->get_xyz();
 	      const std::vector<Real>& JxW = side_fe->get_JxW();
 
@@ -2268,6 +2267,9 @@ void ProjectFEMSolution::operator()(const ConstElemRange &range) const
 
 		  context.side = s;
 		  context.side_fe_reinit();
+
+                  const QBase& qsiderule = context.get_side_qrule();
+                  const unsigned int n_qp = qsiderule.n_points();
 
 		  // Loop over the quadrature points
 		  for (unsigned int qp=0; qp<n_qp; qp++)


### PR DESCRIPTION
Discussed in [this](http://sourceforge.net/p/libmesh/mailman/message/31428231/) thread. To summarize, need to get quadrature rule info after reinit elements. This only broke on 3D faces because QGauss init's automatically for 1D rules. Example code provided by Manav Bhatia now runs successfully. Also tested in GRINS to be double sure.
