### PR TITLE
Allow user to install their own PETSc monitors

### DIFF
--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -135,6 +135,11 @@ public:
    */
   void set_jacobian_zero_out(bool state) { _zero_out_jacobian = state; }
 
+  /**
+   * Set to true to use the libMeash's default monitor, set to false to use your own
+   */
+  void use_default_monitor(bool state) { _default_monitor = state; }
+
 protected:
   /**
    * Nonlinear solver context
@@ -169,6 +174,11 @@ protected:
    * true to zero out jacobian before going into application level call-back, otherwise false
    */
   bool _zero_out_jacobian;
+
+  /**
+   * true if we want the default monitor to be set, false for no monitor (i.e. user code can use their own)
+   */
+  bool _default_monitor;
 
  private:
 #if !PETSC_VERSION_LESS_THAN(3,3,0)

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -247,7 +247,8 @@ PetscNonlinearSolver<T>::PetscNonlinearSolver (sys_type& system_in) :
     _n_linear_iterations(0),
     _current_nonlinear_iteration_number(0),
     _zero_out_residual(true),
-    _zero_out_jacobian(true)
+    _zero_out_jacobian(true),
+    _default_monitor(true)
 {
 }
 
@@ -306,16 +307,18 @@ void PetscNonlinearSolver<T>::init ()
 
 #endif
 
-
+      if (_default_monitor)
+      {
 #if PETSC_VERSION_LESS_THAN(2,3,3)
-      ierr = SNESSetMonitor (_snes, __libmesh_petsc_snes_monitor,
-			     this, PETSC_NULL);
+        ierr = SNESSetMonitor (_snes, __libmesh_petsc_snes_monitor,
+			       this, PETSC_NULL);
 #else
-      // API name change in PETSc 2.3.3
-      ierr = SNESMonitorSet (_snes, __libmesh_petsc_snes_monitor,
-			     this, PETSC_NULL);
+        // API name change in PETSc 2.3.3
+        ierr = SNESMonitorSet (_snes, __libmesh_petsc_snes_monitor,
+			       this, PETSC_NULL);
 #endif
-      LIBMESH_CHKERRABORT(ierr);
+        LIBMESH_CHKERRABORT(ierr);
+      }
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
       // Cannot call SNESSetOptions before SNESSetFunction when using


### PR DESCRIPTION
In MOOSE, we want to install our own monitor(s) and do not want to call PETSc directly to handle everything correctly.  Thus, I added this small interface that can turn on and off the default libMesh monitor callback.
