### PR TITLE
Disable xdr when we don't support xdr

### DIFF
--- a/examples/introduction/introduction_ex1/introduction_ex1.C
+++ b/examples/introduction/introduction_ex1/introduction_ex1.C
@@ -68,6 +68,12 @@ int main (int argc, char** argv)
   // default MPI communicator.
   Mesh mesh(init.comm());
 
+  // We may need XDR support compiled in to read binary .xdr files
+  std::string input_filename = argv[3];
+  libmesh_example_assert(LIBMESH_HAVE_XDR ||
+                         input_filename.rfind(".xdr") >=
+                         input_filename.size(), "XDR support");
+
   // Read the input mesh.
   mesh.read (argv[3]);
 
@@ -77,7 +83,15 @@ int main (int argc, char** argv)
   // Write the output mesh if the user specified an
   // output file name.
   if (argc >= 6 && std::string("-o") == argv[4])
-    mesh.write (argv[5]);
+    {
+      // We may need XDR support compiled in to read binary .xdr files
+      std::string output_filename = argv[5];
+      libmesh_example_assert(LIBMESH_HAVE_XDR ||
+                             output_filename.rfind(".xdr") >=
+                             output_filename.size(), "XDR support");
+
+      mesh.write (argv[5]);
+    }
 
   // All done.  libMesh objects are destroyed here.  Because the
   // LibMeshInit object was created first, its destruction occurs


### PR DESCRIPTION
This should fix a regression in the BuildBot Barebones tests
