### PR TITLE
Bugfix for mismatched id sizes when reading xdr

### DIFF
--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1301,7 +1301,7 @@ void XdrIO::read_serialized_connectivity (Xdr &io, const dof_id_type n_elem, std
 #endif
             ++it;
           }
-          const dof_id_type parent_id     = *it; ++it;
+          const T parent_id     = *it; ++it;
 	  const processor_id_type processor_id = *it; ++it;
 	  const subdomain_id_type subdomain_id = *it; ++it;
 #ifdef LIBMESH_ENABLE_AMR
@@ -1310,7 +1310,7 @@ void XdrIO::read_serialized_connectivity (Xdr &io, const dof_id_type n_elem, std
 	  ++it;
 
 	  Elem *parent =
-            (parent_id == static_cast<dof_id_type>(-1)) ? NULL : mesh.elem(parent_id);
+            (parent_id == static_cast<T>(-1)) ? NULL : mesh.elem(parent_id);
 
 	  Elem *elem = Elem::build (elem_type, parent).release();
 


### PR DESCRIPTION
This fixes a regression in our BuildBot "BigIDs" tests.  When
sizeof(T) is different than sizeof(dof_id_type) (as happened when an
8-byte-dof_id libMesh reads a file written with a 4-byte-dof_id
libMesh), we need to use the former rather than the latter to decide
what the code is for "no parent element".
