### PR TITLE
AdjointRefinement fixes

### DIFF
--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -126,6 +126,29 @@ void AdjointRefinementEstimator::estimate_error (const System& _system,
       system.update();
     }
 
+  // Loop over all the adjoint problems and, if any have heterogenous
+  // Dirichlet conditions, get the corresponding coarse lift
+  // function(s)
+  for (unsigned int j=0; j != system.qoi.size(); j++)
+    {
+      // Skip this QoI if it is not in the QoI Set or if there are no
+      // heterogeneous Dirichlet boundaries for it
+      if (_qoi_set.has_index(j) &&
+          system.get_dof_map().has_adjoint_dirichlet_boundaries(j))
+	{
+          std::ostringstream liftfunc_name;
+          liftfunc_name << "adjoint_lift_function" << j;
+          NumericVector<Number> &liftvec =
+            system.add_vector(liftfunc_name.str());
+
+          system.get_dof_map().enforce_constraints_exactly
+            (system, &liftvec, true);
+        }
+    }
+
+
+
+
 #ifndef NDEBUG
   // n_coarse_elem is only used in an assertion later so
   // avoid declaring it unless asserts are active.
@@ -164,8 +187,8 @@ void AdjointRefinementEstimator::estimate_error (const System& _system,
   NumericVector<Number> & projected_residual = (dynamic_cast<ExplicitSystem&>(system)).get_vector("RHS Vector");
   projected_residual.close();
 
-  // Solve the adjoint problem on the refined FE space
-  system.adjoint_solve();
+  // Solve the adjoint problem(s) on the refined FE space
+  system.adjoint_solve(_qoi_set);
 
   // Now that we have the refined adjoint solution and the projected primal solution,
   // we first compute the global QoI error estimate
@@ -183,11 +206,14 @@ void AdjointRefinementEstimator::estimate_error (const System& _system,
 	{
           // If the adjoint solution has heterogeneous dirichlet
           // values, then to get a proper error estimate here we need
-          // to subtract off a lift function.  We do so by enforcing
-          // *homogeneous* constraints on the adjoint solutions
+          // to subtract off a lift function.  We won't need the lift
+          // function afterward.
+          std::ostringstream liftfunc_name;
+          liftfunc_name << "adjoint_lift_function" << j;
+          system.get_adjoint_solution(j) -=
+            system.get_vector(liftfunc_name.str());
 
-          system.get_dof_map().enforce_constraints_exactly
-            (system, &system.get_adjoint_solution(j), true);
+          system.remove_vector(liftfunc_name.str());
 
           computed_global_QoI_errors[j] = projected_residual.dot(system.get_adjoint_solution(j));
         }


### PR DESCRIPTION
In the general case, we only need to compute requested adjoints, not
every adjoint.

In the heterogeneous BCs case, we may need to subtract off the coarse
grid lift function rather than the fine grid lift.

Vikram's tested this and saw good results, so I'll commit in a day or so unless someone speaks up.
