### PR TITLE
Added options for triangle in TriangleInterface

### DIFF
--- a/include/mesh/mesh_triangle_interface.h
+++ b/include/mesh/mesh_triangle_interface.h
@@ -115,9 +115,21 @@ namespace libMesh
     ElemType& elem_type() {return _elem_type;}
 
     /**
-     * Sets and/or gets the desired triangle area.
+     * Sets and/or gets the desired triangle area. Set to zero to disable
+     * area constraint.
      */
     Real& desired_area() {return _desired_area;}
+
+    /**
+     * Sets and/or gets the minimum angle. Set to zero to disable area
+     * constraint.
+     */
+    Real& minimum_angle() {return _minimum_angle;}
+
+    /**
+     * Sets and/or gets additional flags to be passed to triangle
+     */
+    std::string& extra_flags() {return _extra_flags;}
 
     /**
      * Sets and/or gets the desired triangulation type.
@@ -176,6 +188,16 @@ namespace libMesh
      * The desired area for the elements in the resulting mesh.
      */
     Real _desired_area;
+
+    /**
+     * Minimum angle in triangles
+     */
+    Real _minimum_angle;
+
+    /**
+     * Additional flags to be passed to triangle
+     */
+    std::string _extra_flags;
 
     /**
      * The type of triangulation to perform: choices are:

--- a/src/mesh/mesh_triangle_interface.C
+++ b/src/mesh/mesh_triangle_interface.C
@@ -45,6 +45,8 @@ namespace libMesh
       _holes(NULL),
       _elem_type(TRI3),
       _desired_area(0.1),
+      _minimum_angle(20.0),
+      _extra_flags(""),
       _triangulation_type(GENERATE_CONVEX_HULL),
       _insert_extra_points(false),
       _smooth_after_generating(true),
@@ -255,7 +257,7 @@ namespace libMesh
     std::ostringstream flags;
 
     // Default flags always used
-    flags << "zBPQq";
+    flags << "zBPQ";
 
     // Flags which are specific to the type of triangulation
     switch (_triangulation_type)
@@ -314,7 +316,16 @@ namespace libMesh
       flags << "p";
 
     // Finally, add the area constraint
-    flags << "a" << std::fixed << _desired_area;
+    if (_desired_area > TOLERANCE)
+      flags << "a" << std::fixed << _desired_area;
+
+    // add minimum angle constraint
+    if (_minimum_angle > TOLERANCE)
+      flags << "q" << std::fixed << _minimum_angle;
+
+    // add user provided extra flags
+    if (_extra_flags.size() > 0)
+      flags << _extra_flags;
 
     // Refine the initial output to conform to the area constraint
     TriangleWrapper::triangulate(const_cast<char*>(flags.str().c_str()),


### PR DESCRIPTION
Changes are backwards compatible and should not change anything in existing code. It passes miscellaneous_ex6 (Only example which tests TriangleInterface) on my machine.
My motivation for this change is to have a triangulation of existing point without any additional points. Triangle might inserts additional points to meet the area or angle constraints.
