### PR TITLE
Modifications have been made to correct behavior of h-adaptivity with hi...

### DIFF
--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -431,6 +431,23 @@ namespace libMesh
   template <> bool FE<2,BERNSTEIN>::is_hierarchic() const { return false; }
   template <> bool FE<3,BERNSTEIN>::is_hierarchic() const { return false; }
 
+#ifdef LIBMESH_ENABLE_AMR
+  // compute_constraints() specializations are only needed for 2 and 3D
+  template <>
+  void FE<2,BERNSTEIN>::compute_constraints (DofConstraints &constraints,
+					      DofMap &dof_map,
+					      const unsigned int variable_number,
+					      const Elem* elem)
+  { compute_proj_constraints(constraints, dof_map, variable_number, elem); }
+
+  template <>
+  void FE<3,BERNSTEIN>::compute_constraints (DofConstraints &constraints,
+					      DofMap &dof_map,
+					      const unsigned int variable_number,
+					      const Elem* elem)
+  { compute_proj_constraints(constraints, dof_map, variable_number, elem); }
+#endif // #ifdef LIBMESH_ENABLE_AMR
+
   // Bernstein shapes need reinit only for approximation orders >= 3,
   // but we might reach that with p refinement
   template <> bool FE<0,BERNSTEIN>::shapes_need_reinit() const { return true; }

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -882,7 +882,21 @@ void FEInterface::compute_constraints (DofConstraints &constraints,
 						     variable_number,
 						     elem); return;
 
+        
+#ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
+	  case SZABAB:
+	    FE<2,SZABAB>::compute_constraints (constraints,
+					       dof_map,
+					       variable_number,
+					       elem); return;
 
+	  case BERNSTEIN:
+	    FE<2,BERNSTEIN>::compute_constraints (constraints,
+						  dof_map,
+						  variable_number,
+						  elem); return;
+
+#endif
 	  default:
 	    return;
 	  }
@@ -922,6 +936,20 @@ void FEInterface::compute_constraints (DofConstraints &constraints,
 						     dof_map,
 						     variable_number,
 						     elem); return;
+#ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
+	  case SZABAB:
+	    FE<3,SZABAB>::compute_constraints (constraints,
+					       dof_map,
+					       variable_number,
+					       elem); return;
+
+	  case BERNSTEIN:
+	    FE<3,BERNSTEIN>::compute_constraints (constraints,
+						  dof_map,
+						  variable_number,
+						  elem); return;
+
+#endif
 	  default:
 	    return;
 	  }
@@ -1296,10 +1324,6 @@ bool FEInterface::extra_hanging_dofs(const FEType& fe_t)
     case L2_LAGRANGE:
     case MONOMIAL:
     case L2_HIERARCHIC:
-#ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
-    case BERNSTEIN:
-    case SZABAB:
-#endif
     case XYZ:
     case LAGRANGE_VEC:
     case NEDELEC_ONE:
@@ -1307,6 +1331,10 @@ bool FEInterface::extra_hanging_dofs(const FEType& fe_t)
     case CLOUGH:
     case HERMITE:
     case HIERARCHIC:
+#ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
+    case BERNSTEIN:
+    case SZABAB:
+#endif
     default:
       return true;
     }

--- a/src/fe/fe_szabab.C
+++ b/src/fe/fe_szabab.C
@@ -1261,10 +1261,27 @@ namespace libMesh
   template <> FEContinuity FE<3,SZABAB>::get_continuity() const { return C_ZERO; }
 
   // Szabab FEMs are not hierarchic
-  template <> bool FE<0,SZABAB>::is_hierarchic() const { return false; }
-  template <> bool FE<1,SZABAB>::is_hierarchic() const { return false; }
-  template <> bool FE<2,SZABAB>::is_hierarchic() const { return false; }
-  template <> bool FE<3,SZABAB>::is_hierarchic() const { return false; }
+  template <> bool FE<0,SZABAB>::is_hierarchic() const { return true; }
+  template <> bool FE<1,SZABAB>::is_hierarchic() const { return true; }
+  template <> bool FE<2,SZABAB>::is_hierarchic() const { return true; }
+  template <> bool FE<3,SZABAB>::is_hierarchic() const { return true; }
+
+#ifdef LIBMESH_ENABLE_AMR
+  // compute_constraints() specializations are only needed for 2 and 3D
+  template <>
+  void FE<2,SZABAB>::compute_constraints (DofConstraints &constraints,
+					      DofMap &dof_map,
+					      const unsigned int variable_number,
+					      const Elem* elem)
+  { compute_proj_constraints(constraints, dof_map, variable_number, elem); }
+
+  template <>
+  void FE<3,SZABAB>::compute_constraints (DofConstraints &constraints,
+					      DofMap &dof_map,
+					      const unsigned int variable_number,
+					      const Elem* elem)
+  { compute_proj_constraints(constraints, dof_map, variable_number, elem); }
+#endif // #ifdef LIBMESH_ENABLE_AMR
 
   // Szabab shapes need reinit only for approximation orders >= 3,
   // but we might reach that with p refinement


### PR DESCRIPTION
...gher order SZABAB and BERNSTEIN:

--  defined SZABAB to be hierarchic

-- defined compute_constraints function for SZABAB and BERNSTEIN

-- defined extra_hanging_dofs for SZABAB and BERNSTEIN to be true

-- FEInterface::compute_constraints for SZABAB and BERNSTEIN now call the compute constraint functions for the respective elements.
