### PR TITLE
just pass vectors through to the PETSc interface

### DIFF
--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -212,8 +212,14 @@ void PetscVector<T>::add_vector (const std::vector<T>& v,
   this->_restore_array();
   libmesh_assert_equal_to (v.size(), dof_indices.size());
 
-  for (unsigned int i=0; i<v.size(); i++)
-    this->add (dof_indices[i], v[i]);
+  PetscErrorCode ierr=0;
+  const PetscInt * i_val = reinterpret_cast<const PetscInt*>(&dof_indices[0]);
+  const PetscScalar * petsc_value = static_cast<const PetscScalar*>(&v[0]);
+
+  ierr = VecSetValues (_vec, v.size(), i_val, petsc_value, ADD_VALUES);
+         LIBMESH_CHKERRABORT(ierr);
+
+  this->_is_closed = false;
 }
 
 


### PR DESCRIPTION
Is there a reason we haven't always done it this way?

I've done this because that for loop was showing up in my timing - and even though this may just push that for loop down into PETSc... it at least makes me feel better ;-)
