### PR TITLE
Enable ability to have _output_variables empty in ExodusII_IO

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -169,6 +169,12 @@ class ExodusII_IO : public MeshInput<MeshBase>,
   void set_output_variables(const std::vector<std::string> & output_variables);
 
   /**
+   * If true, this will override the default behavior of outputing all variables if _output_variables
+   * is an empty. Thus, this allows the possibility for writting output files without nodal variables
+   */
+  void allow_empty_output_variables(bool tf_value);
+  
+  /**
    * In the general case, meshes containing 2D elements can be
    * manifolds living in 3D space, thus by default we write all
    * meshes with the Exodus dimension set to LIBMESH_DIM =
@@ -234,6 +240,14 @@ class ExodusII_IO : public MeshInput<MeshBase>,
   void write_nodal_data_common(std::string fname,
                                const std::vector<std::string>& names,
                                bool continuous=true);
+
+  /**
+   * By default this flag is false, which will populate the _output_variables
+   * list to all possible variables if it is empty. True will allow this list
+   * of variables to remain empty.
+   */ 
+  bool _allow_empty_output;
+  
 };
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -46,8 +46,9 @@ ExodusII_IO::ExodusII_IO (MeshBase& mesh) :
 #endif
   _timestep(1),
   _verbose(false),
-  _append(false)
-{
+  _append(false),
+  _allow_empty_output(false)
+{  
 }
 
 
@@ -58,12 +59,18 @@ void ExodusII_IO::set_output_variables(const std::vector<std::string> & output_v
 
 
 
+void ExodusII_IO::allow_empty_output_variables(bool tf_value)
+{
+  _allow_empty_output = tf_value;
+}
+
+
+
 void ExodusII_IO::copy_nodal_solution(System& system, std::string var_name, unsigned int timestep)
 {
   libmesh_deprecated();
   copy_nodal_solution(system, var_name, var_name, timestep);
 }
-
 
 
 void ExodusII_IO::write_discontinuous_exodusII(const std::string& name, const EquationSystems& es)
@@ -549,7 +556,9 @@ void ExodusII_IO::write_nodal_data (const std::string& fname,
   // The names of the variables to be output
   std::vector<std::string> output_names;
 
-  if(_output_variables.size())
+  // If _allow_empty_output = true, then _output_names may be empty, otherwise
+  // if it is empty it will be populated with all possible variables
+  if(_allow_empty_output || !_output_variables.empty())
     output_names = _output_variables;
   else
     output_names = names;


### PR DESCRIPTION
We are working on creating a new output system for MOOSE. This change will give us more control over the Exodus output.
