### PR TITLE
Allow ExodusII_IO to have empty variable list

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -164,9 +164,12 @@ class ExodusII_IO : public MeshInput<MeshBase>,
   /**
    * Sets the list of variable names to be included in the output.
    * This is _optional_.  If this is never called then all variables
-   * will be present.
+   * will be present. If this is called and an empty vector is supplied
+   * no variables will be output. Setting the allow_empty = false will
+   * result in empty vectors supplied here to also be populated with all
+   * variables.
    */
-  void set_output_variables(const std::vector<std::string> & output_variables);
+  void set_output_variables(const std::vector<std::string> & output_variables, bool allow_empty = true);
 
   /**
    * In the general case, meshes containing 2D elements can be
@@ -234,6 +237,14 @@ class ExodusII_IO : public MeshInput<MeshBase>,
   void write_nodal_data_common(std::string fname,
                                const std::vector<std::string>& names,
                                bool continuous=true);
+
+  /**
+   * If true, _output_variables is allowed to remain empty.
+   * If false, if _output_variables is empty it will be populated with a complete list of all variables
+   * By default, calling set_output_variables() sets this flag to true, but it provides an override.
+   */
+  bool _allow_empty_variables;
+  
 };
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -46,14 +46,16 @@ ExodusII_IO::ExodusII_IO (MeshBase& mesh) :
 #endif
   _timestep(1),
   _verbose(false),
-  _append(false)
+  _append(false),
+  _allow_empty_variables(false)
 {
 }
 
 
-void ExodusII_IO::set_output_variables(const std::vector<std::string> & output_variables)
+void ExodusII_IO::set_output_variables(const std::vector<std::string> & output_variables, bool allow_empty)
 {
   _output_variables = output_variables;
+  _allow_empty_variables = allow_empty;
 }
 
 
@@ -549,7 +551,7 @@ void ExodusII_IO::write_nodal_data (const std::string& fname,
   // The names of the variables to be output
   std::vector<std::string> output_names;
 
-  if(_output_variables.size())
+  if(_allow_empty_variables || !_output_variables.empty())
     output_names = _output_variables;
   else
     output_names = names;


### PR DESCRIPTION
An improved method for allowing _output_variables to remain empty.
