### PR TITLE
Remove unnecessary null pointer checks.

### DIFF
--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -130,13 +130,8 @@ DofObject& DofObject::operator= (const DofObject& dof_obj)
 
 void  DofObject::clear_old_dof_object ()
 {
-  // If we have been called before...
-  // prevent a memory leak
-  if (old_dof_object != NULL)
-    {
-      delete this->old_dof_object;
-      this->old_dof_object = NULL;
-    }
+  delete this->old_dof_object;
+  this->old_dof_object = NULL;
 }
 
 

--- a/src/base/libmesh_singleton.C
+++ b/src/base/libmesh_singleton.C
@@ -102,7 +102,6 @@ namespace libMesh
     for (SingletonList::reverse_iterator it = singleton_cache.rbegin();
 	 it!=singleton_cache.rend(); ++it)
       {
-	libmesh_assert (*it != NULL);
 	delete *it;
 	*it = NULL;
       }

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -162,8 +162,8 @@ void InfFE<Dim,T_radial,T_base>::init_face_shape_functions(const std::vector<Poi
     libmesh_assert_equal_to (Dim, 3);
 
     AutoPtr<FEBase> ap_fb(FEBase::build(Dim-2, this->fe_type));
-    if (base_fe != NULL)
-      delete base_fe;
+
+    delete base_fe;
     base_fe = ap_fb.release();
     base_fe->attach_quadrature_rule(base_qrule);
   }

--- a/src/geom/elem_refinement.C
+++ b/src/geom/elem_refinement.C
@@ -218,11 +218,9 @@ void Elem::contract()
   libmesh_assert (this->active());
 
   // Active contracted elements no longer can have children
-  if (_children)
-    {
-      delete [] _children;
-      _children = NULL;
-    }
+  delete [] _children;
+  _children = NULL;
+
   if (this->refinement_flag() == Elem::JUST_COARSENED)
     this->set_refinement_flag(Elem::DO_NOTHING);
 }

--- a/src/geom/reference_elem.C
+++ b/src/geom/reference_elem.C
@@ -59,7 +59,6 @@ namespace
     ~SingletonCache()
     {
       for (unsigned int e=0; e<elem_list.size(); e++)
-	if (elem_list[e])
 	  {
 	    delete elem_list[e];
 	    elem_list[e] = NULL;
@@ -68,7 +67,6 @@ namespace
       elem_list.clear();
 
       for (unsigned int n=0; n<node_list.size(); n++)
-	if (node_list[n])
 	  {
 	    delete node_list[n];
 	    node_list[n] = NULL;

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -87,7 +87,7 @@ MeshFunction::MeshFunction (const EquationSystems& eqn_systems,
 MeshFunction::~MeshFunction ()
 {
   // only delete the point locator when we are the master
-  if ((this->_point_locator != NULL) && (this->_master == NULL))
+  if (this->_master == NULL)
     delete this->_point_locator;
 }
 

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -76,11 +76,8 @@ void RBConstructionBase<Base>::clear ()
   for( ; it != it_end; ++it)
   {
     NumericVector<Number>* training_vector = it->second;
-    if(training_vector)
-    {
-      delete training_vector;
-      training_vector = NULL;
-    }
+
+    delete training_vector;
   }
   training_parameters.clear();
 }
@@ -282,11 +279,8 @@ void RBConstructionBase<Base>::load_training_set(std::map< std::string, std::vec
   for( ; it != it_end; ++it)
   {
     NumericVector<Number>* training_vector = it->second;
-    if(training_vector)
-    {
-      delete training_vector;
-      training_vector = NULL;
-    }
+
+    delete training_vector;
   }
 
   // Get the number of local and global training parameters
@@ -338,11 +332,8 @@ void RBConstructionBase<Base>::generate_training_parameters_random(const Paralle
     for( ; it != it_end; ++it)
     {
       NumericVector<Number>* training_vector = it->second;
-      if(training_vector)
-      {
-        delete training_vector;
-        training_vector = NULL;
-      }
+
+      delete training_vector;
     }
     training_parameters_in.clear();
   }
@@ -470,11 +461,8 @@ void RBConstructionBase<Base>::generate_training_parameters_partially_random(con
     for( ; it != it_end; ++it)
     {
       NumericVector<Number>* training_vector = it->second;
-      if(training_vector)
-      {
-        delete training_vector;
-        training_vector = NULL;
-      }
+
+      delete training_vector;
     }
     training_parameters_in.clear();
   }
@@ -664,11 +652,8 @@ void RBConstructionBase<Base>::generate_training_parameters_deterministic(const 
     for( ; it != it_end; ++it)
     {
       NumericVector<Number>* training_vector = it->second;
-      if(training_vector)
-      {
-        delete training_vector;
-        training_vector = NULL;
-      }
+
+      delete training_vector;
     }
   }
 

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -63,21 +63,15 @@ RBEIMAssembly::~RBEIMAssembly()
 {
   for(unsigned int var=0; var<_fe_var.size(); var++)
   {
-    if(_fe_var[var])
-    {
-      delete _fe_var[var];
-      _fe_var[var] = NULL;
-    }
+    delete _fe_var[var];
+    _fe_var[var] = NULL;
   }
   _fe_var.clear();
 
   for(unsigned int var=0; var<_fe_qrule.size(); var++)
   {
-    if(_fe_qrule[var])
-    {
-      delete _fe_qrule[var];
-      _fe_qrule[var] = NULL;
-    }
+    delete _fe_qrule[var];
+    _fe_qrule[var] = NULL;
   }
   _fe_qrule.clear();
 }
@@ -102,10 +96,7 @@ void RBEIMAssembly::evaluate_basis_function(unsigned int var,
   if(!repeated_qrule)
   {
     // First, possibly delete the old qrule
-    if(_fe_qrule[var] != NULL)
-    {
-      delete _fe_qrule[var];
-    }
+    delete _fe_qrule[var];
 
     _fe_qrule[var] =
       QBase::build(element_qrule.type(),

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -430,11 +430,8 @@ void RBEvaluation::clear_riesz_representors()
   {
     for(unsigned int i=0; i<Aq_representor[q_a].size(); i++)
     {
-      if(Aq_representor[q_a][i])
-      {
-        delete Aq_representor[q_a][i];
-        Aq_representor[q_a][i] = NULL;
-      }
+      delete Aq_representor[q_a][i];
+      Aq_representor[q_a][i] = NULL;
     }
   }
 

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -93,22 +93,16 @@ void TransientRBConstruction::clear()
   // clear the mass matrices
   for(unsigned int q=0; q<M_q_vector.size(); q++)
   {
-    if(M_q_vector[q])
-    {
-      delete M_q_vector[q];
-      M_q_vector[q] = NULL;
-    }
+    delete M_q_vector[q];
+    M_q_vector[q] = NULL;
   }
 
   if(store_non_dirichlet_operators)
   {
     for(unsigned int q=0; q<non_dirichlet_M_q_vector.size(); q++)
     {
-      if(non_dirichlet_M_q_vector[q])
-      {
-        delete non_dirichlet_M_q_vector[q];
-        non_dirichlet_M_q_vector[q] = NULL;
-      }
+      delete non_dirichlet_M_q_vector[q];
+      non_dirichlet_M_q_vector[q] = NULL;
     }
   }
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -134,8 +134,7 @@ FEMContext::~FEMContext()
   delete side_qrule;
   side_qrule = NULL;
 
-  if (edge_qrule)
-    delete edge_qrule;
+  delete edge_qrule;
   side_qrule = NULL;
 }
 


### PR DESCRIPTION
Explicit null pointer checks are performed at some source code places before pointers are passed to the C++ delete operator. This is unnecessary because [the delete operator will care for such parameter validation already](http://www.parashift.com/c++-faq/delete-handles-null.html).

This is a follow-up to [a previous update suggestion](https://github.com/libMesh/libmesh/issues/169).
