### PR TITLE
Complex-valued and single-precision data output in ExodusII/Nemesis format

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
+++ b/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
@@ -170,7 +170,14 @@ int main (int argc, char** argv)
       // Plot the solution
       rb_con.load_rb_solution();
 
+      //Output the variable in GMV format
       GMVIO(mesh).write_equation_systems ("RB_sol.gmv",equation_systems);
+      
+      //Output the variable in ExodusII format
+      ExodusII_IO(mesh).write_equation_systems ("RB_sol_double.exo", equation_systems);
+      
+      //Output the variable in ExodusII format (single precision)
+      ExodusII_IO(mesh, /*single_precision=*/true).write_equation_systems ("RB_sol_float.exo", equation_systems);
     }
 
     // Now do a sweep over frequencies and write out the reflection coefficient for each frequency

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -60,7 +60,7 @@ class ExodusII_IO : public MeshInput<MeshBase>,
    * This is the constructor required to read a mesh.
    */
   explicit
-  ExodusII_IO (MeshBase& mesh);
+  ExodusII_IO (MeshBase& mesh, bool single_precision=false);
 
   /**
    * Destructor.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -71,7 +71,8 @@ public:
    */
   ExodusII_IO_Helper(const ParallelObject &parent,
                      bool v=false,
-                     bool run_only_on_proc0=true);
+                     bool run_only_on_proc0=true,
+                     bool single_precision=false);
   /**
    * Destructor.
    */
@@ -297,13 +298,13 @@ public:
   /**
    * Writes the vector of values to the element variables.
    */
-  void write_element_values(const MeshBase & mesh, const std::vector<Number> & values, int timestep);
-
+  void write_element_values(const MeshBase & mesh, const std::vector<Real> & values, int timestep);
+  
   /**
    * Writes the vector of values to a nodal variable.
    */
-  void write_nodal_values(int var_id, const std::vector<Number> & values, int timestep);
-
+  void write_nodal_values(int var_id, const std::vector<Real> & values, int timestep);
+  
   /**
    * Writes the vector of information records.
    */
@@ -312,7 +313,7 @@ public:
   /**
    * Writes the vector of global variables.
    */
-  void write_global_values(const std::vector<Number> & values, int timestep);
+  void write_global_values(const std::vector<Real> & values, int timestep);
 
   /**
    * Sets the underlying value of the boolean flag
@@ -330,6 +331,12 @@ public:
    */
   void set_coordinate_offset(Point p);
 
+  /**
+   * Returns a vector with three copies of each element in the provided name vector,
+   * starting with r_, i_ and a_ respectively.
+   */ 
+  std::vector<std::string> get_complex_names(const std::vector<std::string>& names) const;
+  
   /**
    * This is the \p ExodusII_IO_Helper Conversion class.  It provides
    * a data structure which contains \p ExodusII node/edge maps and
@@ -544,6 +551,9 @@ protected:
 
   // On output, shift every point by _coordinate_offset
   Point _coordinate_offset;
+  
+  // If true, forces single precision I/O
+  bool _single_precision;
 
 private:
   /**

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -62,7 +62,7 @@ class Nemesis_IO_Helper;
    * This is the constructor required to read a mesh.
    */
   explicit
-  Nemesis_IO (MeshBase& mesh);
+  Nemesis_IO (MeshBase& mesh, bool single_precision=false);
 
   /**
    * Destructor.

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -65,7 +65,7 @@ public:
    */
   explicit
   Nemesis_IO_Helper(const ParallelObject &parent,
-		    bool verbose=false);
+		    bool verbose=false, bool single_precision=false);
 
   /**
    * Destructor.


### PR DESCRIPTION
This commit implements correct complex-valued output to ExodusII and Nemesis formats. In addition, a flag is added to the ExodusII_IO constructor to force single-precision output.

Both features have been tested with nodal data in ExodusII format with the reduced_basis_ex7 example (Nemesis and elemental data not tested yet).
