### PR TITLE
Remove global functions and data associated with a default COMM_WORLD

### DIFF
--- a/include/base/libmesh_base.h
+++ b/include/base/libmesh_base.h
@@ -24,6 +24,7 @@
 
 namespace libMesh {
 
+#ifndef LIBMESH_DISABLE_COMMWORLD
   /**
    * @returns the number of processors used in the current simulation.
    */
@@ -33,6 +34,18 @@ namespace libMesh {
    * @returns the index of the local processor.
    */
   processor_id_type processor_id();
+#endif
+
+  /**
+   * @returns the number of processors libMesh was initialized with.
+   */
+  processor_id_type global_n_processors();
+
+  /**
+   * @returns the index of the local processor with respect to the
+   * original MPI pool libMesh was initialized with.
+   */
+  processor_id_type global_processor_id();
 
   /**
    * @returns the maximum number of threads used in the simulation.
@@ -70,8 +83,25 @@ namespace libMesh {
 
 // ------------------------------------------------------------
 // libMesh inline member functions
+#ifndef LIBMESH_DISABLE_COMMWORLD
 inline
 libMesh::processor_id_type libMesh::n_processors()
+{
+  return libMesh::global_n_processors();
+}
+
+
+
+inline
+libMesh::processor_id_type libMesh::processor_id()
+{
+  return libMesh::global_processor_id();
+}
+#endif // LIBMESH_DISABLE_COMMWORLD
+
+
+inline
+libMesh::processor_id_type libMesh::global_n_processors()
 {
 #ifdef LIBMESH_HAVE_MPI
   return libMeshPrivateData::_n_processors;
@@ -80,10 +110,8 @@ libMesh::processor_id_type libMesh::n_processors()
 #endif
 }
 
-
-
 inline
-libMesh::processor_id_type libMesh::processor_id()
+libMesh::processor_id_type libMesh::global_processor_id()
 {
 #ifdef LIBMESH_HAVE_MPI
   return libMeshPrivateData::_processor_id;
@@ -91,8 +119,6 @@ libMesh::processor_id_type libMesh::processor_id()
   return 0;
 #endif
 }
-
-
 
 
 inline

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -178,16 +178,31 @@ typedef float ErrorVectorReal;
 
 
 #ifdef LIBMESH_HAVE_MPI
+  #ifndef LIBMESH_DISABLE_COMMWORLD
+    /**
+     * MPI Communicator to be used in the library.
+     */
+    extern MPI_Comm COMM_WORLD;
+  #endif
+
   /**
-   * MPI Communicator to be used in the library.
+   * MPI Communicator used to initialize libMesh.
    */
-  extern MPI_Comm COMM_WORLD;
+  extern MPI_Comm GLOBAL_COMM_WORLD;
 #else
-  /**
+  #ifndef LIBMESH_DISABLE_COMMWORLD
+    /**
+     * Something to use with CHKERRABORT if we're just using PETSc's MPI
+     * "uni" stub.
+     */
+    extern int COMM_WORLD;
+  #endif
+
+/**
    * Something to use with CHKERRABORT if we're just using PETSc's MPI
    * "uni" stub.
    */
-  extern int COMM_WORLD;
+  extern int GLOBAL_COMM_WORLD;
 #endif
 
 // Let's define a couple output streams - these will default

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2127,7 +2127,7 @@ public:
   {
     // libmesh_assert_greater_equal (*(_buf_begin+5), 0);
     libmesh_assert_less (static_cast<unsigned int>(*(_buf_begin+5)),
-                   libMesh::n_processors() ||
+                         libMesh::global_n_processors() ||
                    static_cast<processor_id_type>(*(_buf_begin+5)) == DofObject::invalid_processor_id);
     return static_cast<processor_id_type>(*(_buf_begin+5));
   }

--- a/src/base/libmesh_common.C
+++ b/src/base/libmesh_common.C
@@ -34,7 +34,7 @@ namespace MacroFunctions
 {
   void here(const char* file, int line, const char* date, const char* time)
   {
-    libMesh::err << "[" << static_cast<std::size_t>(libMesh::processor_id()) << "] "
+    libMesh::err << "[" << static_cast<std::size_t>(libMesh::global_processor_id()) << "] "
                  << file
                  << ", line " << line
                  << ", compiled " << date
@@ -46,7 +46,7 @@ namespace MacroFunctions
 
   void stop(const char* file, int line, const char* date, const char* time)
   {
-    if (libMesh::n_processors() == 1)
+    if (libMesh::global_n_processors() == 1)
       {
         libMesh::MacroFunctions::here(file, line, date, time);
 #ifdef LIBMESH_HAVE_CSIGNAL
@@ -62,7 +62,7 @@ namespace MacroFunctions
 
   void report_error(const char* file, int line, const char* date, const char* time)
   {
-    if (libMesh::n_processors() == 1)
+    if (libMesh::global_n_processors() == 1)
       libMesh::print_trace();
     else
       libMesh::write_traceout();

--- a/src/geom/node.C
+++ b/src/geom/node.C
@@ -139,7 +139,7 @@ void Node::PackedNode::unpack (std::vector<largest_id_type>::const_iterator star
 {
   processor_id_type processor_id = static_cast<processor_id_type>(*start++);
   libmesh_assert(processor_id == DofObject::invalid_processor_id ||
-                 processor_id < libMesh::n_processors());
+                 processor_id < libMesh::global_n_processors());
 
   dof_id_type id = static_cast<dof_id_type>(*start++);
 

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -420,7 +420,7 @@ Elem* ParallelMesh::add_elem (Elem *e)
     _n_elem++;
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-  if (!e->valid_unique_id() && libMesh::processor_id() == e->processor_id())
+  if (!e->valid_unique_id() && processor_id() == e->processor_id())
     {
       e->set_unique_id() = _next_unique_id;
       _next_unique_id += this->n_processors();
@@ -584,7 +584,7 @@ Node* ParallelMesh::add_node (Node *n)
     _n_nodes++;
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-  if (!n->valid_unique_id() && libMesh::processor_id() == n->processor_id())
+  if (!n->valid_unique_id() && processor_id() == n->processor_id())
     {
       n->set_unique_id() = _next_unique_id;
       _next_unique_id += this->n_processors();
@@ -1328,7 +1328,7 @@ void ParallelMesh::assign_unique_ids()
     const elem_iterator_imp end = _elements.end();
 
     for (; it != end; ++it)
-      if ((*it) && ! (*it)->valid_unique_id() && libMesh::processor_id() == (*it)->processor_id())
+      if ((*it) && ! (*it)->valid_unique_id() && processor_id() == (*it)->processor_id())
       {
         (*it)->set_unique_id() = _next_unique_id;
         _next_unique_id += this->n_processors();
@@ -1340,7 +1340,7 @@ void ParallelMesh::assign_unique_ids()
     node_iterator_imp end = _nodes.end();
 
     for (; it != end; ++it)
-      if ((*it) && ! (*it)->valid_unique_id() && libMesh::processor_id() == (*it)->processor_id())
+      if ((*it) && ! (*it)->valid_unique_id() && processor_id() == (*it)->processor_id())
       {
         (*it)->set_unique_id() = _next_unique_id;
         _next_unique_id += this->n_processors();

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -373,7 +373,7 @@ void RBEIMEvaluation::write_out_interpolation_points_elem(const std::string dire
     {
       old_elem = extra_interpolation_point_elem;
     }
-    
+
     for(unsigned int n=0; n<old_elem->n_nodes(); n++)
     {
       Node* node_ptr = old_elem->get_node(n);
@@ -385,9 +385,9 @@ void RBEIMEvaluation::write_out_interpolation_points_elem(const std::string dire
       {
         node_ids.insert(old_node_id);
         _interpolation_points_mesh.add_point(*node_ptr, new_node_id, /* proc_id */ 0);
-        
+
         node_id_map[old_node_id] = new_node_id;
-        
+
         new_node_id++;
       }
     }
@@ -409,16 +409,16 @@ void RBEIMEvaluation::write_out_interpolation_points_elem(const std::string dire
     {
       old_elem = extra_interpolation_point_elem;
     }
-    
+
     dof_id_type old_elem_id = old_elem->id();
-    
+
     // Only insert the element into the mesh if it hasn't already been inserted
     std::map<dof_id_type,dof_id_type>::iterator id_it = elem_id_map.find(old_elem_id);
     if(id_it == elem_id_map.end())
     {
       Elem* new_elem = Elem::build(old_elem->type(), /*parent*/ NULL).release();
       new_elem->subdomain_id() = old_elem->subdomain_id();
-    
+
       // Assign all the nodes
       for(unsigned int n=0; n<new_elem->n_nodes(); n++)
       {
@@ -436,7 +436,7 @@ void RBEIMEvaluation::write_out_interpolation_points_elem(const std::string dire
       new_elem->set_id(new_elem_id);
       interpolation_elem_ids[i] = new_elem->id();
       elem_id_map[old_elem_id] = new_elem->id();
-      
+
       new_elem_id++;
     }
     else
@@ -453,7 +453,7 @@ void RBEIMEvaluation::write_out_interpolation_points_elem(const std::string dire
   // Also, write out the vector that tells us which element each entry
   // of interpolation_points_elem corresponds to. This allows us to handle
   // the case in which elements are repeated in interpolation_points_elem.
-  if(libMesh::processor_id() == 0)
+  if(processor_id() == 0)
   {
     // These are just integers, so no need for a binary format here
     std::ofstream interpolation_elem_ids_out

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -61,19 +61,19 @@ __libmesh_petsc_diff_solver_monitor (SNES snes, PetscInt its,
 
     Vec petsc_delta_u;
     ierr = SNESGetSolutionUpdate(snes, &petsc_delta_u);
-    CHKERRABORT(libMesh::COMM_WORLD, ierr);
+    CHKERRABORT(solver.comm().get(), ierr);
     PetscVector<Number> delta_u(petsc_delta_u, solver.comm());
     delta_u.close();
 
     Vec petsc_u;
     ierr = SNESGetSolution(snes, &petsc_u);
-    CHKERRABORT(libMesh::COMM_WORLD, ierr);
+    CHKERRABORT(solver.comm().get(), ierr);
     PetscVector<Number> u(petsc_u, solver.comm());
     u.close();
 
     Vec petsc_res;
     ierr = SNESGetFunction(snes, &petsc_res, NULL, NULL);
-    CHKERRABORT(libMesh::COMM_WORLD, ierr);
+    CHKERRABORT(solver.comm().get(), ierr);
     PetscVector<Number> res(petsc_res, solver.comm());
     res.close();
 

--- a/src/solvers/petsc_dm_nonlinear_solver.C
+++ b/src/solvers/petsc_dm_nonlinear_solver.C
@@ -55,9 +55,9 @@ namespace libMesh {
 
     PetscErrorCode ierr;
 #if PETSC_RELEASE_LESS_THAN(3,4,0)
-    ierr = DMRegister(DMLIBMESH, PETSC_NULL, "DMCreate_libMesh", DMCreate_libMesh); CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    ierr = DMRegister(DMLIBMESH, PETSC_NULL, "DMCreate_libMesh", DMCreate_libMesh); CHKERRABORT(libMesh::GLOBAL_COMM_WORLD,ierr);
 #else
-    ierr = DMRegister(DMLIBMESH, DMCreate_libMesh); CHKERRABORT(libMesh::COMM_WORLD,ierr);
+    ierr = DMRegister(DMLIBMESH, DMCreate_libMesh); CHKERRABORT(libMesh::GLOBAL_COMM_WORLD,ierr);
 #endif
     PetscDMRegistered = PETSC_TRUE;
   }

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -146,10 +146,10 @@ std::string PerfLog::get_info_header() const
       v.push_back(&user_stream);
 
       // Fill string stream objects
-      if (libMesh::n_processors() > 1)
+      if (libMesh::global_n_processors() > 1)
 	{
-	  pid_stream     << "| Processor id:   " << libMesh::processor_id();
-	  nprocs_stream  << "| Num Processors: " << libMesh::n_processors();
+	  pid_stream     << "| Processor id:   " << libMesh::global_processor_id();
+	  nprocs_stream  << "| Num Processors: " << libMesh::global_n_processors();
 	}
 
       time_stream    << "| Time:           " << date                   ;


### PR DESCRIPTION
This removes:

libMesh::COMM_WORLD
libMesh::Parallel::n_processors()
libMesh::Parallel::processor_id()

when the default COMM is disabled.  This is extremely helpful when trying to track down places in application code that need to be updated.

I also added a different version of all of these called

libMesh::GLOBAL_COMM_WORLD
libMesh::Parallel::global_n_processors()
libMesh::Parallel::global_processor_id()

That always uses the communicator libMesh was initialized with.  This is handy for when you truly do need "global" MPI information.
