### PR TITLE
Move all enumerations into the libMesh namespace

### DIFF
--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -247,7 +247,7 @@ int main (int argc, char** argv)
       mesh.print_info();
 
       // Read in the solution stored in "saved_solution.xda"
-      equation_systems.read("saved_solution.xda", libMeshEnums::READ);
+      equation_systems.read("saved_solution.xda", READ);
 
       // Get a reference to the system so that we can call update() on it
       TransientLinearImplicitSystem & system =
@@ -445,7 +445,7 @@ int main (int argc, char** argv)
       std::cout << "Final H1 norm = " << H1norm << std::endl << std::endl;
 
       mesh.write("saved_mesh.xda");
-      equation_systems.write("saved_solution.xda", libMeshEnums::WRITE);
+      equation_systems.write("saved_solution.xda", WRITE);
       GMVIO(mesh).write_equation_systems ("saved_solution.gmv",
                                           equation_systems);
     }

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -265,7 +265,7 @@ int main (int argc, char** argv)
       mesh.print_info();
 
       // Read in the solution stored in "saved_solution.xda"
-      equation_systems.read("saved_solution.xdr", libMeshEnums::DECODE);
+      equation_systems.read("saved_solution.xdr", DECODE);
     }
 
   // Get a reference to the system so that we can attach things to it
@@ -516,7 +516,7 @@ int main (int argc, char** argv)
       std::cout << "Final H1 norm = " << H1norm << std::endl << std::endl;
 
       mesh.write("saved_mesh.xdr");
-      equation_systems.write("saved_solution.xdr", libMeshEnums::ENCODE);
+      equation_systems.write("saved_solution.xdr", ENCODE);
 #ifdef LIBMESH_HAVE_GMV
       GMVIO(mesh).write_equation_systems ("saved_solution.gmv",
                                           equation_systems);

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -182,14 +182,14 @@ void write_output(EquationSystems &es,
     {
       mesh.write(numbered_filename(t_step, a_step, solution_type, "mesh", "xda", param));
       es.write(numbered_filename(t_step, a_step, solution_type, "soln", "xda", param),
-               libMeshEnums::WRITE, EquationSystems::WRITE_DATA |
+               WRITE, EquationSystems::WRITE_DATA |
                EquationSystems::WRITE_ADDITIONAL_DATA);
     }
   if (param.output_xdr)
     {
       mesh.write(numbered_filename(t_step, a_step, solution_type, "mesh", "xdr", param));
       es.write(numbered_filename(t_step, a_step, solution_type, "soln", "xdr", param),
-               libMeshEnums::WRITE, EquationSystems::WRITE_DATA |
+               WRITE, EquationSystems::WRITE_DATA |
                EquationSystems::WRITE_ADDITIONAL_DATA);
     }
 }
@@ -377,7 +377,7 @@ void read_output(EquationSystems &es,
   mesh.read(file_name_mesh);
 
   // And the stored solution
-  es.read(file_name_soln, libMeshEnums::READ,
+  es.read(file_name_soln, READ,
           EquationSystems::READ_HEADER |
           EquationSystems::READ_DATA |
           EquationSystems::READ_ADDITIONAL_DATA);
@@ -584,8 +584,8 @@ AutoPtr<ErrorEstimator>
 build_error_estimator_component_wise
   (FEMParameters &param,
    std::vector<std::vector<Real> > &term_weights,
-   std::vector<libMeshEnums::FEMNormType> &primal_error_norm_type,
-   std::vector<libMeshEnums::FEMNormType> &dual_error_norm_type)
+   std::vector<FEMNormType> &primal_error_norm_type,
+   std::vector<FEMNormType> &dual_error_norm_type)
 {
   AutoPtr<ErrorEstimator> error_estimator;
 
@@ -639,8 +639,8 @@ AutoPtr<ErrorEstimator>
 build_weighted_error_estimator_component_wise
   (FEMParameters &param,
    std::vector<std::vector<Real> > &term_weights,
-   std::vector<libMeshEnums::FEMNormType> &primal_error_norm_type,
-   std::vector<libMeshEnums::FEMNormType> &dual_error_norm_type,
+   std::vector<FEMNormType> &primal_error_norm_type,
+   std::vector<FEMNormType> &dual_error_norm_type,
    std::vector<FEMFunctionBase<Number>*> coupled_system_weight_functions)
 {
   AutoPtr<ErrorEstimator> error_estimator;
@@ -867,14 +867,14 @@ int main (int argc, char** argv)
           // First we build the norm_type_vector_non_pressure vectors and
           // weights_matrix_non_pressure matrix for the non-pressure term
           // error contributions
-          std::vector<libMeshEnums::FEMNormType>
+          std::vector<FEMNormType>
             primal_norm_type_vector_non_pressure;
           primal_norm_type_vector_non_pressure.push_back(H1_SEMINORM);
           primal_norm_type_vector_non_pressure.push_back(H1_SEMINORM);
           primal_norm_type_vector_non_pressure.push_back(L2);
           primal_norm_type_vector_non_pressure.push_back(H1_SEMINORM);
 
-          std::vector<libMeshEnums::FEMNormType>
+          std::vector<FEMNormType>
             dual_norm_type_vector_non_pressure;
           dual_norm_type_vector_non_pressure.push_back(H1_SEMINORM);
           dual_norm_type_vector_non_pressure.push_back(H1_SEMINORM);
@@ -909,14 +909,14 @@ int main (int argc, char** argv)
 	  // Next we build the norm_type_vector_with_pressure vectors and
           // weights_matrix_with_pressure matrix for the pressure term
           // error contributions
-          std::vector<libMeshEnums::FEMNormType>
+          std::vector<FEMNormType>
             primal_norm_type_vector_with_pressure;
           primal_norm_type_vector_with_pressure.push_back(H1_X_SEMINORM);
           primal_norm_type_vector_with_pressure.push_back(H1_Y_SEMINORM);
           primal_norm_type_vector_with_pressure.push_back(L2);
           primal_norm_type_vector_with_pressure.push_back(L2);
 
-          std::vector<libMeshEnums::FEMNormType>
+          std::vector<FEMNormType>
             dual_norm_type_vector_with_pressure;
           dual_norm_type_vector_with_pressure.push_back(H1_X_SEMINORM);
           dual_norm_type_vector_with_pressure.push_back(H1_Y_SEMINORM);
@@ -953,14 +953,14 @@ int main (int argc, char** argv)
           ErrorVector error_convection_diffusion_x;
 
           // The norm type vectors and weights matrix for the convection_diffusion_x errors
-          std::vector<libMeshEnums::FEMNormType>
+          std::vector<FEMNormType>
             primal_norm_type_vector_convection_diffusion_x;
           primal_norm_type_vector_convection_diffusion_x.push_back(L2);
           primal_norm_type_vector_convection_diffusion_x.push_back(L2);
           primal_norm_type_vector_convection_diffusion_x.push_back(L2);
           primal_norm_type_vector_convection_diffusion_x.push_back(H1_X_SEMINORM);
 
-          std::vector<libMeshEnums::FEMNormType>
+          std::vector<FEMNormType>
             dual_norm_type_vector_convection_diffusion_x;
           dual_norm_type_vector_convection_diffusion_x.push_back(L2);
           dual_norm_type_vector_convection_diffusion_x.push_back(L2);
@@ -1016,14 +1016,14 @@ int main (int argc, char** argv)
           ErrorVector error_convection_diffusion_y;
 
           // The norm type vectors and weights matrix for the convection_diffusion_x errors
-          std::vector<libMeshEnums::FEMNormType>
+          std::vector<FEMNormType>
             primal_norm_type_vector_convection_diffusion_y;
           primal_norm_type_vector_convection_diffusion_y.push_back(L2);
           primal_norm_type_vector_convection_diffusion_y.push_back(L2);
           primal_norm_type_vector_convection_diffusion_y.push_back(L2);
           primal_norm_type_vector_convection_diffusion_y.push_back(H1_Y_SEMINORM);
 
-          std::vector<libMeshEnums::FEMNormType>
+          std::vector<FEMNormType>
             dual_norm_type_vector_convection_diffusion_y;
           dual_norm_type_vector_convection_diffusion_y.push_back(L2);
           dual_norm_type_vector_convection_diffusion_y.push_back(L2);

--- a/examples/introduction/introduction_ex2/introduction_ex2.C
+++ b/examples/introduction/introduction_ex2/introduction_ex2.C
@@ -139,9 +139,9 @@ int main (int argc, char** argv)
 
   // Write the equation system if the user specified an
   // output file name.  Note that there are two possible
-  // formats to write to.  Specifying libMeshEnums::WRITE will
+  // formats to write to.  Specifying WRITE will
   // create a formatted ASCII file.  Optionally, you can specify
-  // libMeshEnums::ENCODE and get an XDR-encoded binary file.
+  // ENCODE and get an XDR-encoded binary file.
   //
   // We will write the data, clear the object, and read the file
   // we just wrote.  This is simply to demonstrate capability.
@@ -155,7 +155,7 @@ int main (int argc, char** argv)
                   << std::endl;
 
         // Write the system.
-        equation_systems.write (argv[1], libMeshEnums::WRITE);
+        equation_systems.write (argv[1], WRITE);
 
         // Clear the equation systems data structure.
         equation_systems.clear ();
@@ -165,7 +165,7 @@ int main (int argc, char** argv)
 
         // Read the file we just wrote.  This better
         // work!
-        equation_systems.read (argv[1], libMeshEnums::READ);
+        equation_systems.read (argv[1], READ);
 
         // Print the information again.
         equation_systems.print_info();

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -202,7 +202,7 @@ int main (int argc, char** argv)
   // use the FEInterface::compute_data() methods to
   // determine physically correct results within an
   // infinite element.
-  equation_systems.write ("eqn_sys.dat", libMeshEnums::WRITE);
+  equation_systems.write ("eqn_sys.dat", WRITE);
 
   // All done.
   return 0;

--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -264,7 +264,7 @@ int main (int argc, char** argv)
   // written to disk.  By default, the additional vectors are also
   // saved.
 
-  equation_systems.write ("eqn_sys.dat", libMeshEnums::WRITE);
+  equation_systems.write ("eqn_sys.dat", WRITE);
 
   // All done.
   return 0;

--- a/include/enums/enum_eigen_solver_type.h
+++ b/include/enums/enum_eigen_solver_type.h
@@ -20,14 +20,9 @@
 #ifndef LIBMESH_ENUM_EIGENSOLVER_TYPE_H
 #define LIBMESH_ENUM_EIGENSOLVER_TYPE_H
 
-/*
- * The \p libMeshEnums namespace is the namespace all \p enum definitions
- * should be put into.
- */
-
 // ------------------------------------------------------------
 // enum SolverType definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
    * Defines an \p enum for iterative eigenproblem solver types
@@ -74,7 +69,5 @@ namespace libMeshEnums {
 
                            INVALID_Postion_of_Spectrum};
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_EIGENSOLVER_TYPE_H

--- a/include/enums/enum_elem_quality.h
+++ b/include/enums/enum_elem_quality.h
@@ -22,7 +22,7 @@
 
 // ------------------------------------------------------------
 // enum ElemType definition
-namespace libMeshEnums
+namespace libMesh
 {
   /**
    * Defines an \p enum for element quality metrics.
@@ -44,8 +44,5 @@ namespace libMeshEnums
                     SIZE,
                     JACOBIAN};
 }
-
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_ELEM_QUALITY_H

--- a/include/enums/enum_elem_type.h
+++ b/include/enums/enum_elem_type.h
@@ -20,14 +20,9 @@
 #ifndef LIBMESH_ENUM_ELEM_TYPE_H
 #define LIBMESH_ENUM_ELEM_TYPE_H
 
-/**
- * The \p libMeshEnums namespace is the namespace all \p enum definitions
- * should be put into.
- */
-
 // ------------------------------------------------------------
 // enum ElemType definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
    * Defines an \p enum for geometric element types.
@@ -75,7 +70,5 @@ namespace libMeshEnums {
 
                  INVALID_ELEM};  // 28 - should always be last
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_ELEM_TYPE_H

--- a/include/enums/enum_fe_family.h
+++ b/include/enums/enum_fe_family.h
@@ -22,10 +22,10 @@
 
 // ------------------------------------------------------------
 // enum FEFamily definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
-   * \enum libMeshEnums::FEFamily defines an \p enum for finite
+   * \enum libMesh::FEFamily defines an \p enum for finite
    * element families.
    */
                  // vanilla C0
@@ -65,7 +65,7 @@ namespace libMeshEnums {
                  INVALID_FE   = 99};
 
   /**
-   * \enum libMeshEnums::FEContinuity defines an \p enum for finite element
+   * \enum libMesh::FEContinuity defines an \p enum for finite element
    * types to libmesh_assert a certain level (or type? Hcurl?) of continuity.
    */
   enum FEContinuity {DISCONTINUOUS,
@@ -74,14 +74,12 @@ namespace libMeshEnums {
                      H_CURL};
 
   /**
-   * \enum libMeshEnums::FEFieldType defines an \p enum for finite element
+   * \enum libMesh::FEFieldType defines an \p enum for finite element
    * field types - i.e. is it a scalar element, vector, tensor, etc.
    */
   enum FEFieldType {TYPE_SCALAR = 0,
                     TYPE_VECTOR};
 
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_FE_FAMILY_H

--- a/include/enums/enum_inf_map_type.h
+++ b/include/enums/enum_inf_map_type.h
@@ -20,17 +20,12 @@
 #ifndef LIBMESH_ENUM_INF_MAP_TYPE_H
 #define LIBMESH_ENUM_INF_MAP_TYPE_H
 
-/**
- * The \p libMeshEnums namespace is the namespace all \p enum definitions
- * should be put into.
- */
-
 // ------------------------------------------------------------
 // enum Order definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
-   * \enum libMeshEnums::InfMapType defines an \p enum for the
+   * \enum libMesh::InfMapType defines an \p enum for the
    * types of coordinate mappings available in infinite elements.
    */
   enum InfMapType {CARTESIAN=0,
@@ -39,7 +34,5 @@ namespace libMeshEnums {
                    INVALID_INF_MAP};
 
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_INF_MAP_TYPE_H

--- a/include/enums/enum_io_package.h
+++ b/include/enums/enum_io_package.h
@@ -20,14 +20,10 @@
 #ifndef LIBMESH_ENUM_IO_PACKAGE_H
 #define LIBMESH_ENUM_IO_PACKAGE_H
 
-/*
- * The \p libMeshEnums namespace is the namespace all \p enum definitions
- * should be put into.
- */
 
 // ------------------------------------------------------------
 // enum IOPackage definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
    * libMesh interfaces with several different software packages
@@ -48,7 +44,5 @@ namespace libMeshEnums {
       INVALID_IO_PACKAGE
     };
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_IO_PACKAGE_H

--- a/include/enums/enum_norm_type.h
+++ b/include/enums/enum_norm_type.h
@@ -22,10 +22,10 @@
 
 // ------------------------------------------------------------
 // enum FEMNormType definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
-   * \enum libMeshEnums::FEMNormType defines an \p enum for norms
+   * \enum libMesh::FEMNormType defines an \p enum for norms
    * defined on vectors of finite element coefficients
    */
   // Hilbert norms and seminorms in FE space
@@ -62,7 +62,5 @@ namespace libMeshEnums {
 
                     INVALID_NORM    = 42};
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_NORM_TYPE_H

--- a/include/enums/enum_order.h
+++ b/include/enums/enum_order.h
@@ -22,10 +22,10 @@
 
 // ------------------------------------------------------------
 // enum Order definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
-   * \enum libMeshEnums::Order defines an \p enum for polynomial orders.
+   * \enum libMesh::Order defines an \p enum for polynomial orders.
    * Fixing each label to a specific int, since \p InfFE and p refinement
    * may cast between them
    */
@@ -81,7 +81,5 @@ namespace libMeshEnums {
               INVALID_ORDER};
 
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_ORDER_H

--- a/include/enums/enum_parallel_type.h
+++ b/include/enums/enum_parallel_type.h
@@ -20,14 +20,9 @@
 #ifndef LIBMESH_ENUM_PARALLEL_TYPE_H
 #define LIBMESH_ENUM_PARALLEL_TYPE_H
 
-/*
- * The \p libMeshEnums namespace is the namespace all \p enum definitions
- * should be put into.
- */
-
 // ------------------------------------------------------------
 // enum SolverType definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
    * Defines an \p enum for parallel data structure types
@@ -39,9 +34,5 @@ namespace libMeshEnums {
 
                      INVALID_PARALLELIZATION};
 }
-
-using namespace libMeshEnums;
-
-
 
 #endif // LIBMESH_ENUM_PARALLEL_TYPE_H

--- a/include/enums/enum_point_locator_type.h
+++ b/include/enums/enum_point_locator_type.h
@@ -22,10 +22,10 @@
 
 // ------------------------------------------------------------
 // enum PointLocatorType definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
-   * \enum MeshEnums::PointLocatorType defines an \p enum for the types
+   * \enum PointLocatorType defines an \p enum for the types
    * of point locators (given a point with global coordinates,
    * locate the corresponding element in space) available in libMesh.
    */
@@ -33,7 +33,5 @@ namespace libMeshEnums {
                          LIST,
                          INVALID_LOCATOR};
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_POINT_LOCATOR_TYPE_H

--- a/include/enums/enum_preconditioner_type.h
+++ b/include/enums/enum_preconditioner_type.h
@@ -20,14 +20,9 @@
 #ifndef LIBMESH_ENUM_PRECONDITIONER_TYPE_H
 #define LIBMESH_ENUM_PRECONDITIONER_TYPE_H
 
-/*
- * The \p libMeshEnums namespace is the namespace all \p enum definitions
- * should be put into.
- */
-
 // ------------------------------------------------------------
 // enum PreconditionerType definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
    * Defines an \p enum for preconditioner types
@@ -49,7 +44,5 @@ namespace libMeshEnums {
 
                            INVALID_PRECONDITIONER};
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_PRECONDITIONER_TYPE_H

--- a/include/enums/enum_quadrature_type.h
+++ b/include/enums/enum_quadrature_type.h
@@ -22,7 +22,7 @@
 
 // ------------------------------------------------------------
 // enum QuadratureType definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
    * Defines an \p enum for currently available quadrature rules.
@@ -43,7 +43,5 @@ namespace libMeshEnums {
 
                        INVALID_Q_RULE    = 127};
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_QUADRATURE_TYPE_H

--- a/include/enums/enum_solver_package.h
+++ b/include/enums/enum_solver_package.h
@@ -20,14 +20,9 @@
 #ifndef LIBMESH_ENUM_SOLVER_PACKAGE_H
 #define LIBMESH_ENUM_SOLVER_PACKAGE_H
 
-/*
- * The \p libMeshEnums namespace is the namespace all \p enum definitions
- * should be put into.
- */
-
 // ------------------------------------------------------------
 // enum SolverType definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
    * Defines an \p enum for various linear solver packages.
@@ -45,8 +40,5 @@ namespace libMeshEnums {
       INVALID_SOLVER_PACKAGE
     };
 }
-
-using namespace libMeshEnums;
-
 
 #endif // LIBMESH_ENUM_SOLVER_PACKAGE_H

--- a/include/enums/enum_solver_type.h
+++ b/include/enums/enum_solver_type.h
@@ -20,14 +20,9 @@
 #ifndef LIBMESH_ENUM_SOLVER_TYPE_H
 #define LIBMESH_ENUM_SOLVER_TYPE_H
 
-/*
- * The \p libMeshEnums namespace is the namespace all \p enum definitions
- * should be put into.
- */
-
 // ------------------------------------------------------------
 // enum SolverType definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
    * Defines an \p enum for iterative solver types
@@ -53,9 +48,5 @@ namespace libMeshEnums {
 
                    INVALID_SOLVER};
 }
-
-using namespace libMeshEnums;
-
-
 
 #endif // LIBMESH_ENUM_SOLVER_TYPE_H

--- a/include/enums/enum_subset_solve_mode.h
+++ b/include/enums/enum_subset_solve_mode.h
@@ -22,10 +22,10 @@
 
 // ------------------------------------------------------------
 // enum SubsetSolveMode definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
-   * \enum libMeshEnums::SubsetSolveMode defines an \p enum for the
+   * \enum SubsetSolveMode defines an \p enum for the
    * question what happens to the dofs outside the given subset when a
    * system is solved on a subset.
    */
@@ -36,7 +36,5 @@ namespace libMeshEnums {
   };
 
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_SUBSET_SOLVE_MODE_H

--- a/include/enums/enum_xdr_mode.h
+++ b/include/enums/enum_xdr_mode.h
@@ -20,14 +20,9 @@
 #ifndef LIBMESH_ENUM_XDR_MODE_H
 #define LIBMESH_ENUM_XDR_MODE_H
 
-/*
- * The \p libMeshEnums namespace is the namespace all \p enum definitions
- * should be put into.
- */
-
 // ------------------------------------------------------------
 // enum XdrMode definition
-namespace libMeshEnums {
+namespace libMesh {
 
   /**
    * Defines an \p enum for read/write mode in Xdr format.
@@ -39,7 +34,5 @@ namespace libMeshEnums {
       UNKNOWN = -1, ENCODE=0, DECODE, WRITE, READ
     };
 }
-
-using namespace libMeshEnums;
 
 #endif // LIBMESH_ENUM_XDR_MODE_H

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -325,12 +325,12 @@ public:
    */
     template <typename InValType>
   void read (const std::string& name,
-             const libMeshEnums::XdrMODE,
+             const XdrMODE,
              const unsigned int read_flags=(READ_HEADER | READ_DATA),
              bool partition_agnostic = true);
 
   void read (const std::string& name,
-             const libMeshEnums::XdrMODE mode,
+             const XdrMODE mode,
              const unsigned int read_flags=(READ_HEADER | READ_DATA),
              bool partition_agnostic = true)
     { read<Number>(name, mode, read_flags, partition_agnostic); }
@@ -368,7 +368,7 @@ public:
    * that have two nodes in exactly the same position!
    */
   void write (const std::string& name,
-              const libMeshEnums::XdrMODE,
+              const XdrMODE,
               const unsigned int write_flags=(WRITE_DATA),
               bool partition_agnostic = true) const;
 
@@ -485,7 +485,7 @@ private:
    */
     template <typename InValType>
   void _read_impl (const std::string& name,
-                   const libMeshEnums::XdrMODE,
+                   const XdrMODE,
                    const unsigned int read_flags,
                    bool partition_agnostic = true);
 

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -76,7 +76,7 @@ public:
    * Constructor.  Takes the filename and the mode.
    * Valid modes are ENCODE, DECODE, READ, and WRITE.
    */
-  Xdr (const std::string& name="", const libMeshEnums::XdrMODE m=UNKNOWN);
+  Xdr (const std::string& name="", const XdrMODE m=UNKNOWN);
 
   /**
    * Destructor.  Closes the file if it is open.

--- a/src/apps/compare.C
+++ b/src/apps/compare.C
@@ -100,7 +100,7 @@ void process_cmd_line(int argc, char **argv,
                       std::vector<std::string>& names,
                       unsigned int& dim,
                       double& threshold,
-                      libMeshEnums::XdrMODE& format,
+                      XdrMODE& format,
                       bool& verbose,
                       bool& quiet)
 {
@@ -204,7 +204,7 @@ void process_cmd_line(int argc, char **argv,
               }
             else
               {
-                format = libMeshEnums::READ;
+                format = READ;
                 format_set = true;
               }
             break;
@@ -223,7 +223,7 @@ void process_cmd_line(int argc, char **argv,
               }
             else
               {
-                format = libMeshEnums::DECODE;
+                format = DECODE;
                 format_set = true;
               }
             break;
@@ -318,7 +318,7 @@ int main (int argc, char** argv)
   std::vector<std::string> names;
   unsigned int dim                = static_cast<unsigned int>(-1);
   double threshold                = TOLERANCE;
-  libMeshEnums::XdrMODE format    = libMeshEnums::READ;
+  XdrMODE format                  = READ;
   bool verbose                    = false;
 
   // get commands

--- a/src/apps/projection.C
+++ b/src/apps/projection.C
@@ -140,7 +140,7 @@ int main(int argc, char** argv)
   EquationSystems old_es(old_mesh);
   EquationSystems new_es(new_mesh);
 
-  libMeshEnums::XdrMODE read_mode;
+  XdrMODE read_mode;
 
   if (solnname.rfind(".xdr") < solnname.size())
     read_mode = DECODE;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -46,7 +46,7 @@ namespace
 {
   // Define equivalence classes of Cubit/Exodus element types that map to
   // libmesh ElemTypes
-  std::map<std::string, libMeshEnums::ElemType> element_equivalence_map;
+  std::map<std::string, ElemType> element_equivalence_map;
 
   // This function initializes the element_equivalence_map the first time it
   // is called, and returns early all other times.
@@ -1954,7 +1954,7 @@ ExodusII_IO_Helper::Conversion ExodusII_IO_Helper::ElementMaps::assign_conversio
   // Do only upper-case comparisons
   std::transform(type_str.begin(), type_str.end(), type_str.begin(), ::toupper);
 
-  std::map<std::string, libMeshEnums::ElemType>::iterator it =
+  std::map<std::string, ElemType>::iterator it =
     element_equivalence_map.find(type_str);
 
   if (it != element_equivalence_map.end())

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -795,8 +795,8 @@ void MeshTools::find_hanging_nodes_and_parents(const MeshBase& mesh, std::map<do
     const Elem* elem = (*it);
 
     //Right now this only works for quad4's
-    //libmesh_assert_equal_to (elem->type(), libMeshEnums::QUAD4);
-    if(elem->type() == libMeshEnums::QUAD4)
+    //libmesh_assert_equal_to (elem->type(), QUAD4);
+    if(elem->type() == QUAD4)
     {
       //Loop over the sides looking for sides that have hanging nodes
       //This code is inspired by compute_proj_constraints()

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -572,7 +572,7 @@ void RBConstruction::allocate_data_structures()
   {
     // Initialize the memory for the vectors
     Fq_vector[q] = NumericVector<Number>::build(this->comm()).release();
-    Fq_vector[q]->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+    Fq_vector[q]->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
   }
 
   // We also need to initialize a second set of non-Dirichlet operators
@@ -583,7 +583,7 @@ void RBConstruction::allocate_data_structures()
     {
       // Initialize the memory for the vectors
       non_dirichlet_Fq_vector[q] = NumericVector<Number>::build(this->comm()).release();
-      non_dirichlet_Fq_vector[q]->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+      non_dirichlet_Fq_vector[q]->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
     }
   }
 
@@ -592,7 +592,7 @@ void RBConstruction::allocate_data_structures()
     {
       // Initialize the memory for the truth output vectors
       outputs_vector[n][q_l] = (NumericVector<Number>::build(this->comm()).release());
-      outputs_vector[n][q_l]->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+      outputs_vector[n][q_l]->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
     }
 
   if(store_non_dirichlet_operators)
@@ -605,7 +605,7 @@ void RBConstruction::allocate_data_structures()
       {
         // Initialize the memory for the truth output vectors
         non_dirichlet_outputs_vector[n][q_l] = (NumericVector<Number>::build(this->comm()).release());
-        non_dirichlet_outputs_vector[n][q_l]->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+        non_dirichlet_outputs_vector[n][q_l]->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
       }
     }
   }
@@ -848,7 +848,7 @@ void RBConstruction::truth_assembly()
     }
 
     AutoPtr< NumericVector<Number> > temp_vec = NumericVector<Number>::build(this->comm());
-    temp_vec->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+    temp_vec->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
     for(unsigned int q_f=0; q_f<get_rb_theta_expansion().get_n_F_terms(); q_f++)
     {
       *temp_vec = *get_Fq(q_f);
@@ -1275,7 +1275,7 @@ void RBConstruction::enrich_RB_space()
   START_LOG("enrich_RB_space()", "RBConstruction");
 
   NumericVector<Number>* new_bf = NumericVector<Number>::build(this->comm()).release();
-  new_bf->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+  new_bf->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
   *new_bf = *solution;
 
   for(unsigned int index=0; index<get_rb_evaluation().get_n_basis_functions(); index++)
@@ -1446,7 +1446,7 @@ void RBConstruction::update_RB_system_matrices()
   unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
 
   AutoPtr< NumericVector<Number> > temp = NumericVector<Number>::build(this->comm());
-  temp->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+  temp->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
   for(unsigned int q_f=0; q_f<get_rb_theta_expansion().get_n_F_terms(); q_f++)
   {
@@ -1537,7 +1537,7 @@ void RBConstruction::update_residual_terms(bool compute_inner_products)
       if(!get_rb_evaluation().Aq_representor[q_a][i])
       {
         get_rb_evaluation().Aq_representor[q_a][i] = (NumericVector<Number>::build(this->comm()).release());
-        get_rb_evaluation().Aq_representor[q_a][i]->init(this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+        get_rb_evaluation().Aq_representor[q_a][i]->init(this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
       }
 
       libmesh_assert(get_rb_evaluation().Aq_representor[q_a][i]->size()       == this->n_dofs()       &&
@@ -1685,7 +1685,7 @@ void RBConstruction::compute_output_dual_innerprods()
     for(unsigned int q=0; q<max_Q_l; q++)
     {
       L_q_representor[q] = (NumericVector<Number>::build(this->comm()).release());
-      L_q_representor[q]->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+      L_q_representor[q]->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
     }
 
     if(reuse_preconditioner)
@@ -1831,7 +1831,7 @@ void RBConstruction::compute_Fq_representor_innerprods(bool compute_inner_produc
       if(!Fq_representor[q_f])
       {
         Fq_representor[q_f] = (NumericVector<Number>::build(this->comm()).release());
-        Fq_representor[q_f]->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+        Fq_representor[q_f]->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
       }
 
       libmesh_assert(Fq_representor[q_f]->size()       == this->n_dofs()       &&
@@ -1949,10 +1949,10 @@ void RBConstruction::load_rb_solution()
 //   // have a different parameter value during the Greedy training.
 //
 //   AutoPtr< NumericVector<Number> > RB_sol = NumericVector<Number>::build();
-//   RB_sol->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+//   RB_sol->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 //
 //   AutoPtr< NumericVector<Number> > temp = NumericVector<Number>::build();
-//   temp->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+//   temp->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 //
 //   for(unsigned int i=0; i<N; i++)
 //   {
@@ -2262,7 +2262,7 @@ void RBConstruction::read_riesz_representors_from_files(const std::string& riesz
     read_serialized_data(fqr_data, false);
 
     Fq_representor[i] = NumericVector<Number>::build(this->comm()).release();
-    Fq_representor[i]->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+    Fq_representor[i]->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
     // No need to copy, just swap
     // *Fq_representor[i] = *solution;
@@ -2316,7 +2316,7 @@ void RBConstruction::read_riesz_representors_from_files(const std::string& riesz
 
       get_rb_evaluation().Aq_representor[i][j] = NumericVector<Number>::build(this->comm()).release();
       get_rb_evaluation().Aq_representor[i][j]->init (n_dofs(), n_local_dofs(),
-                                            false, libMeshEnums::PARALLEL);
+                                            false, PARALLEL);
 
       // No need to copy, just swap
       //*Aq_representor[i][j] = *solution;

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -93,7 +93,7 @@ void RBConstructionBase<Base>::init_data ()
   // Initialize the inner product storage vector, which is useful for
   // storing intermediate results when evaluating inner products
   inner_product_storage_vector = NumericVector<Number>::build(this->comm());
-  inner_product_storage_vector->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+  inner_product_storage_vector->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 }
 
 template <class Base>
@@ -298,7 +298,7 @@ void RBConstructionBase<Base>::load_training_set(std::map< std::string, std::vec
   for( ; it != it_end; ++it)
   {
     it->second = NumericVector<Number>::build(this->comm()).release();
-    it->second->init(n_global_training_samples, n_local_training_samples, false, libMeshEnums::PARALLEL);
+    it->second->init(n_global_training_samples, n_local_training_samples, false, PARALLEL);
   }
 
   it = training_parameters.begin();
@@ -403,11 +403,11 @@ void RBConstructionBase<Base>::generate_training_parameters_random(const Paralle
         else
           n_local_training_samples = quotient;
 
-        training_parameters_in[param_name]->init(n_training_samples_in, n_local_training_samples, false, libMeshEnums::PARALLEL);
+        training_parameters_in[param_name]->init(n_training_samples_in, n_local_training_samples, false, PARALLEL);
       }
       else
       {
-        training_parameters_in[param_name]->init(n_training_samples_in, false, libMeshEnums::SERIAL);
+        training_parameters_in[param_name]->init(n_training_samples_in, false, SERIAL);
       }
     }
   }
@@ -536,11 +536,11 @@ void RBConstructionBase<Base>::generate_training_parameters_partially_random(con
         else
           n_local_training_samples = quotient;
 
-        training_parameters_in[param_name]->init(n_training_samples_in, n_local_training_samples, false, libMeshEnums::PARALLEL);
+        training_parameters_in[param_name]->init(n_training_samples_in, n_local_training_samples, false, PARALLEL);
       }
       else
       {
-        training_parameters_in[param_name]->init(n_training_samples_in, false, libMeshEnums::SERIAL);
+        training_parameters_in[param_name]->init(n_training_samples_in, false, SERIAL);
       }
     }
   }
@@ -692,11 +692,11 @@ void RBConstructionBase<Base>::generate_training_parameters_deterministic(const 
         else
           n_local_training_samples = quotient;
 
-        training_parameters_in[param_name]->init(n_training_samples_in, n_local_training_samples, false, libMeshEnums::PARALLEL);
+        training_parameters_in[param_name]->init(n_training_samples_in, n_local_training_samples, false, PARALLEL);
       }
       else
       {
-        training_parameters_in[param_name]->init(n_training_samples_in, false, libMeshEnums::SERIAL);
+        training_parameters_in[param_name]->init(n_training_samples_in, false, SERIAL);
       }
     }
   }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -357,7 +357,7 @@ void RBEIMConstruction::enrich_RB_space()
     eim_eval.interpolation_points_elem.push_back( elem_ptr );
 
     NumericVector<Number>* new_bf = NumericVector<Number>::build(this->comm()).release();
-    new_bf->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+    new_bf->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
     *new_bf = *solution;
     get_rb_evaluation().basis_functions.push_back( new_bf );
   }

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -1066,7 +1066,7 @@ void RBEvaluation::read_in_vectors(System& sys,
           sys.read_serialized_data(vector_data, false);
 
           vectors[i] = NumericVector<Number>::build(sys.comm()).release();
-          vectors[i]->init (sys.n_dofs(), sys.n_local_dofs(), false, libMeshEnums::PARALLEL);
+          vectors[i]->init (sys.n_dofs(), sys.n_local_dofs(), false, PARALLEL);
 
           // No need to copy, just swap
           // *vectors[i] = *solution;
@@ -1082,7 +1082,7 @@ void RBEvaluation::read_in_vectors(System& sys,
       for(unsigned int i=0; i<vectors.size(); i++)
         {
           vectors[i] = NumericVector<Number>::build(sys.comm()).release();
-          vectors[i]->init (sys.n_dofs(), sys.n_local_dofs(), false, libMeshEnums::PARALLEL);
+          vectors[i]->init (sys.n_dofs(), sys.n_local_dofs(), false, PARALLEL);
         }
 
       file_name.str("");

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -261,7 +261,7 @@ void TransientRBConstruction::allocate_data_structures()
   for(unsigned int i=0; i<n_time_levels; i++)
   {
     temporal_data[i] = (NumericVector<Number>::build(this->comm()).release());
-    temporal_data[i]->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+    temporal_data[i]->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
   }
 
   // and the truth output vectors
@@ -293,7 +293,7 @@ void TransientRBConstruction::assemble_affine_expansion()
     initialize_truth();
 
     AutoPtr< NumericVector<Number> > temp1 = NumericVector<Number>::build(this->comm());
-    temp1->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+    temp1->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
     // First compute the right-hand side vector for the L2 projection
     L2_matrix->vector_mult(*temp1, *solution);
@@ -398,7 +398,7 @@ void TransientRBConstruction::mass_matrix_scaled_matvec(Number scalar,
   const unsigned int Q_m = trans_theta_expansion.get_n_M_terms();
 
   AutoPtr< NumericVector<Number> > temp_vec = NumericVector<Number>::build(this->comm());
-  temp_vec->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+  temp_vec->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
   for(unsigned int q=0; q<Q_m; q++)
   {
@@ -438,7 +438,7 @@ void TransientRBConstruction::truth_assembly()
     mass_matrix_scaled_matvec(1./dt, *rhs, *current_local_solution);
 
     AutoPtr< NumericVector<Number> > temp_vec = NumericVector<Number>::build(this->comm());
-    temp_vec->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+    temp_vec->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
     for(unsigned int q_a=0; q_a<Q_a; q_a++)
     {
@@ -548,7 +548,7 @@ Real TransientRBConstruction::truth_solve(int write_interval)
 
 //   // NumericVector for computing true L2 error
 //   AutoPtr< NumericVector<Number> > temp = NumericVector<Number>::build();
-//   temp->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+//   temp->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
   // Apply initial condition again.
   initialize_truth();
@@ -685,7 +685,7 @@ Number TransientRBConstruction::set_error_temporal_data()
     unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
 
     AutoPtr< NumericVector<Number> > temp = NumericVector<Number>::build(this->comm());
-    temp->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+    temp->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
     // First compute the right-hand side vector for the projection
     inner_product_matrix->vector_mult(*temp, *solution);
@@ -787,7 +787,7 @@ void TransientRBConstruction::add_IC_to_RB_space()
   // load the new basis function into the basis_functions vector.
   get_rb_evaluation().basis_functions.push_back( NumericVector<Number>::build(this->comm()).release() );
   NumericVector<Number>& current_bf = get_rb_evaluation().get_basis_function(get_rb_evaluation().get_n_basis_functions()-1);
-  current_bf.init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+  current_bf.init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
   current_bf = *solution;
 
   // We can just set the norm to 1.
@@ -911,7 +911,7 @@ void TransientRBConstruction::enrich_RB_space()
       // load the new basis function into the basis_functions vector.
       get_rb_evaluation().basis_functions.push_back( NumericVector<Number>::build(this->comm()).release() );
       NumericVector<Number>& current_bf = get_rb_evaluation().get_basis_function(get_rb_evaluation().get_n_basis_functions()-1);
-      current_bf.init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+      current_bf.init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
       current_bf.zero();
 
       // Perform the matrix multiplication of temporal data with
@@ -1042,7 +1042,7 @@ void TransientRBConstruction::update_RB_system_matrices()
   unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
 
   AutoPtr< NumericVector<Number> > temp = NumericVector<Number>::build(this->comm());
-  temp->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+  temp->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
   for(unsigned int i=(RB_size-delta_N); i<RB_size; i++)
   {
@@ -1129,7 +1129,7 @@ void TransientRBConstruction::update_residual_terms(bool compute_inner_products)
       if(!trans_rb_eval.M_q_representor[q_m][i])
       {
         trans_rb_eval.M_q_representor[q_m][i] = (NumericVector<Number>::build(this->comm()).release());
-        trans_rb_eval.M_q_representor[q_m][i]->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+        trans_rb_eval.M_q_representor[q_m][i]->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
       }
 
       libmesh_assert(trans_rb_eval.M_q_representor[q_m][i]->size()       == this->n_dofs()       &&
@@ -1273,10 +1273,10 @@ void TransientRBConstruction::update_RB_initial_condition_all_N()
   initialize_truth();
 
   AutoPtr< NumericVector<Number> > temp1 = NumericVector<Number>::build(this->comm());
-  temp1->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+  temp1->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
   AutoPtr< NumericVector<Number> > temp2 = NumericVector<Number>::build(this->comm());
-  temp2->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+  temp2->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 
 
   unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
@@ -1343,7 +1343,7 @@ void TransientRBConstruction::update_RB_initial_condition_all_N()
 //   // Assemble the right-hand side to find the Reisz representor
 //   // of the residual in the X norm
 //   AutoPtr< NumericVector<Number> > RB_sol = NumericVector<Number>::build();
-//   RB_sol->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+//   RB_sol->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 //   RB_sol->zero();
 //
 //   AutoPtr< NumericVector<Number> > ghosted_temp = NumericVector<Number>::build();
@@ -1352,7 +1352,7 @@ void TransientRBConstruction::update_RB_initial_condition_all_N()
 //                       GHOSTED);
 //
 //   AutoPtr< NumericVector<Number> > parallel_temp = NumericVector<Number>::build();
-//   parallel_temp->init (this->n_dofs(), this->n_local_dofs(), false, libMeshEnums::PARALLEL);
+//   parallel_temp->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
 //
 //   // Store current_local_solution, since we don't want to corrupt it
 //   *ghosted_temp = *current_local_solution;
@@ -1519,7 +1519,7 @@ void TransientRBConstruction::read_riesz_representors_from_files(const std::stri
 
         trans_rb_eval.M_q_representor[i][j] = NumericVector<Number>::build(this->comm()).release();
         trans_rb_eval.M_q_representor[i][j]->init (n_dofs(), n_local_dofs(),
-                                                   false, libMeshEnums::PARALLEL);
+                                                   false, PARALLEL);
 
         // No need to copy, just swap
         //*M_q_representor[i][j] = *solution;

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -197,7 +197,7 @@ std::pair<Real, Real> CondensedEigenSystem::get_eigenpair(unsigned int i)
   unsigned int n       = n_local;
   this->comm().sum(n);
 
-  temp->init (n, n_local, false, libMeshEnums::PARALLEL);
+  temp->init (n, n_local, false, PARALLEL);
 
   std::pair<Real, Real> eval = eigen_solver->get_eigenpair (i, *temp);
 

--- a/src/systems/equation_systems_io.C
+++ b/src/systems/equation_systems_io.C
@@ -75,7 +75,7 @@ void EquationSystems::read (const std::string& name,
                             const unsigned int read_flags,
                             bool partition_agnostic)
 {
-  libMeshEnums::XdrMODE mode = READ;
+  XdrMODE mode = READ;
   if (name.find(".xdr") != std::string::npos)
     mode = DECODE;
   this->read(name, mode, read_flags, partition_agnostic);
@@ -90,7 +90,7 @@ void EquationSystems::read (const std::string& name,
 
 template <typename InValType>
 void EquationSystems::read (const std::string& name,
-                            const libMeshEnums::XdrMODE mode,
+                            const XdrMODE mode,
                             const unsigned int read_flags,
                             bool partition_agnostic)
 {
@@ -152,7 +152,7 @@ void EquationSystems::read (const std::string& name,
 
     template <typename InValType>
 void EquationSystems::_read_impl (const std::string& name,
-                                  const libMeshEnums::XdrMODE mode,
+                                  const XdrMODE mode,
                                   const unsigned int read_flags,
                                   bool partition_agnostic)
 {
@@ -378,7 +378,7 @@ void EquationSystems::write(const std::string& name,
                             const unsigned int write_flags,
                             bool partition_agnostic) const
 {
-  libMeshEnums::XdrMODE mode = WRITE;
+  XdrMODE mode = WRITE;
   if (name.find(".xdr") != std::string::npos)
     mode = ENCODE;
   this->write(name, mode, write_flags, partition_agnostic);
@@ -387,7 +387,7 @@ void EquationSystems::write(const std::string& name,
 
 
 void EquationSystems::write(const std::string& name,
-                            const libMeshEnums::XdrMODE mode,
+                            const XdrMODE mode,
                             const unsigned int write_flags,
                             bool partition_agnostic) const
 {
@@ -583,12 +583,12 @@ void EquationSystems::write(const std::string& name,
 // template specialization
 
 template void EquationSystems::read<Number> (const std::string& name, const unsigned int read_flags, bool partition_agnostic);
-template void EquationSystems::read<Number> (const std::string& name, const libMeshEnums::XdrMODE mode, const unsigned int read_flags, bool partition_agnostic);
-template void EquationSystems::_read_impl<Number> (const std::string& name, const libMeshEnums::XdrMODE mode, const unsigned int read_flags, bool partition_agnostic);
+template void EquationSystems::read<Number> (const std::string& name, const XdrMODE mode, const unsigned int read_flags, bool partition_agnostic);
+template void EquationSystems::_read_impl<Number> (const std::string& name, const XdrMODE mode, const unsigned int read_flags, bool partition_agnostic);
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
 template void EquationSystems::read<Real> (const std::string& name, const unsigned int read_flags, bool partition_agnostic);
-template void EquationSystems::read<Real> (const std::string& name, const libMeshEnums::XdrMODE mode, const unsigned int read_flags, bool partition_agnostic);
-template void EquationSystems::_read_impl<Real> (const std::string& name, const libMeshEnums::XdrMODE mode, const unsigned int read_flags, bool partition_agnostic);
+template void EquationSystems::read<Real> (const std::string& name, const XdrMODE mode, const unsigned int read_flags, bool partition_agnostic);
+template void EquationSystems::_read_impl<Real> (const std::string& name, const XdrMODE mode, const unsigned int read_flags, bool partition_agnostic);
 #endif
 
 } // namespace libMesh


### PR DESCRIPTION
We've been doing something kind of bad for a while now: all of our enumeration header files had

```
using namespace libMeshEnums;
```

in them, violating the general rule of not putting `using` declarations in headers.  We actually ran into a namespace collision while trying to create a class called "VTK", which collided with one of the IOPackage enumerations.

This patch moves the enumerations into the libMesh namespace and cleanses the rest of the library of the libMeshEnums namespace.  It's possible that this change will affect applications, but the fix is trivial: just remove `libMeshEnums::` wherever it appears in your code.

This was actually Roy's idea so I've discussed it with him already, but I wanted to give others the chance to comment... for example, does anyone know why we had this separate namespace in the first place?
