### PR TITLE
Avoid false positive SLEPc detection

### DIFF
--- a/configure
+++ b/configure
@@ -29473,21 +29473,27 @@ getSLEPC_LIBS:
 	echo \$(SLEPC_LIB) \$(ARPACK_LIB)
 EOF
 	SLEPC_LIBS=`make -s -f Makefile_config_slepc getSLEPC_LIBS`
-	rm -f Makefile_config_slepc
+        if (test x$? = x0); then
+	  rm -f Makefile_config_slepc
 
-	#echo " "
-	#echo "SLEPC_INCLUDE=$SLEPC_INCLUDE"
-	#echo "SLEPC_LIBS=$SLEPC_LIBS"
-	#echo " "
+	  #echo " "
+	  #echo "SLEPC_INCLUDE=$SLEPC_INCLUDE"
+	  #echo "SLEPC_LIBS=$SLEPC_LIBS"
+	  #echo " "
 
 
 $as_echo "#define HAVE_SLEPC 1" >>confdefs.h
 
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with SLEPc version $slepcversion support >>>" >&5
+	  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with SLEPc version $slepcversion support >>>" >&5
 $as_echo "<<< Configuring library with SLEPc version $slepcversion support >>>" >&6; }
 
 
 
+        else
+          enableslepc=no
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< SLEPc configuration query failed. SLEPc disabled. >>>" >&5
+$as_echo "<<< SLEPc configuration query failed. SLEPc disabled. >>>" >&6; }
+        fi
       fi
     fi
   fi

--- a/m4/slepc.m4
+++ b/m4/slepc.m4
@@ -97,19 +97,24 @@ getSLEPC_LIBS:
 	echo \$(SLEPC_LIB) \$(ARPACK_LIB)
 EOF
 	SLEPC_LIBS=`make -s -f Makefile_config_slepc getSLEPC_LIBS`
-	rm -f Makefile_config_slepc
+        if (test x$? = x0); then
+	  rm -f Makefile_config_slepc
 
-	#echo " "
-	#echo "SLEPC_INCLUDE=$SLEPC_INCLUDE"
-	#echo "SLEPC_LIBS=$SLEPC_LIBS"
-	#echo " "
+	  #echo " "
+	  #echo "SLEPC_INCLUDE=$SLEPC_INCLUDE"
+	  #echo "SLEPC_LIBS=$SLEPC_LIBS"
+	  #echo " "
 
-	AC_DEFINE(HAVE_SLEPC, 1,
-                 [Flag indicating whether or not SLEPc is available])
-	AC_MSG_RESULT(<<< Configuring library with SLEPc version $slepcversion support >>>)
+	  AC_DEFINE(HAVE_SLEPC, 1,
+                   [Flag indicating whether or not SLEPc is available])
+	  AC_MSG_RESULT(<<< Configuring library with SLEPc version $slepcversion support >>>)
 
-	AC_SUBST(SLEPC_INCLUDE)
-	AC_SUBST(SLEPC_LIBS)
+	  AC_SUBST(SLEPC_INCLUDE)
+	  AC_SUBST(SLEPC_LIBS)
+        else
+          enableslepc=no
+          AC_MSG_RESULT(<<< SLEPc configuration query failed. SLEPc disabled. >>>)
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
If we seem to have SLEPc, but there's some reason we can't scarf build
configuration from SLEPc, then we really don't have SLEPc.

I got caught by this when trying a new PETSC_ARCH for which I hadn't
yet built SLEPc.
