### PR TITLE
Generalizing all_tri to handle 3D, adding support for PRISMs

### DIFF
--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -40,6 +40,22 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/unstructured_mesh.h"
 
+namespace
+{
+  bool split_first_diagonal(const Elem* elem,
+                            unsigned int diag_1_node_1,
+                            unsigned int diag_1_node_2,
+                            unsigned int diag_2_node_1,
+                            unsigned int diag_2_node_2)
+    {
+      return ((elem->node(diag_1_node_1) > elem->node(diag_2_node_1) &&
+               elem->node(diag_1_node_1) > elem->node(diag_2_node_2)) ||
+              (elem->node(diag_1_node_2) > elem->node(diag_2_node_1) &&
+               elem->node(diag_1_node_2) > elem->node(diag_2_node_2)));
+    }
+
+}
+
 namespace libMesh
 {
 
@@ -922,27 +938,34 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
 
           case PRISM6:
             {
+              // Prisms all split into three tetrahedra
               subelem[0] = new Tet4;
               subelem[1] = new Tet4;
               subelem[2] = new Tet4;
 
+              // Triangular faces are not split.
+
+              // On quad faces, we choose the node with the highest
+              // global id, and we split on the diagonal which
+              // includes that node.  This ensures that (even in
+              // parallel, even on distributed meshes) the same
+              // diagonal split will be chosen for elements on either
+              // side of the same quad face.  It also ensures that we
+              // always have a mix of "clockwise" and
+              // "counterclockwise" split faces (two of one and one
+              // of the other on each prism; this is useful since the
+              // alternative all-clockwise or all-counterclockwise
+              // face splittings can't be turned into tets without
+              // adding more nodes
+
               // Split on 0-4 diagonal
-              if ((elem->node(0) > elem->node(1) &&
-                   elem->node(0) > elem->node(3)) ||
-                  (elem->node(4) > elem->node(1) &&
-                   elem->node(4) > elem->node(3)))
+              if (split_first_diagonal(elem, 0,4, 1,3))
                 {
                   // Split on 0-5 diagonal
-                  if ((elem->node(0) > elem->node(2) &&
-                       elem->node(0) > elem->node(3)) ||
-                      (elem->node(5) > elem->node(2) &&
-                       elem->node(5) > elem->node(3)))
+                  if (split_first_diagonal(elem, 0,5, 2,3))
                     {
                       // Split on 1-5 diagonal
-                      if ((elem->node(1) > elem->node(2) &&
-                           elem->node(1) > elem->node(4)) ||
-                          (elem->node(5) > elem->node(2) &&
-                           elem->node(5) > elem->node(4)))
+                      if (split_first_diagonal(elem, 1,5, 2,4))
                         {
                           subelem[0]->set_node(0) = elem->get_node(0);
                           subelem[0]->set_node(1) = elem->get_node(4);
@@ -961,6 +984,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                         }
                       else // Split on 2-4 diagonal
                         {
+                          libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
+
                           subelem[0]->set_node(0) = elem->get_node(0);
                           subelem[0]->set_node(1) = elem->get_node(4);
                           subelem[0]->set_node(2) = elem->get_node(5);
@@ -979,7 +1004,11 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                     }
                   else // Split on 2-3 diagonal
                     {
+                      libmesh_assert (split_first_diagonal(elem, 2,3, 0,5));
+
                       // 0-4 and 2-3 split implies 2-4 split
+                      libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
+
                       subelem[0]->set_node(0) = elem->get_node(0);
                       subelem[0]->set_node(1) = elem->get_node(4);
                       subelem[0]->set_node(2) = elem->get_node(2);
@@ -998,13 +1027,14 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                 }
               else // Split on 1-3 diagonal
                 {
+                  libmesh_assert (split_first_diagonal(elem, 1,3, 0,4));
+
                   // Split on 0-5 diagonal
-                  if ((elem->node(0) > elem->node(2) &&
-                       elem->node(0) > elem->node(3)) ||
-                      (elem->node(5) > elem->node(2) &&
-                       elem->node(5) > elem->node(3)))
+                  if (split_first_diagonal(elem, 0,5, 2,3))
                     {
                       // 1-3 and 0-5 split implies 1-5 split
+                      libmesh_assert (split_first_diagonal(elem, 1,5, 2,4));
+
                       subelem[0]->set_node(0) = elem->get_node(1);
                       subelem[0]->set_node(1) = elem->get_node(3);
                       subelem[0]->set_node(2) = elem->get_node(4);
@@ -1022,11 +1052,10 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                     }
                   else // Split on 2-3 diagonal
                     {
+                      libmesh_assert (split_first_diagonal(elem, 2,3, 0,5));
+
                       // Split on 1-5 diagonal
-                      if ((elem->node(1) > elem->node(2) &&
-                           elem->node(1) > elem->node(4)) ||
-                          (elem->node(5) > elem->node(2) &&
-                           elem->node(5) > elem->node(4)))
+                      if (split_first_diagonal(elem, 1,5, 2,4))
                         {
                           subelem[0]->set_node(0) = elem->get_node(0);
                           subelem[0]->set_node(1) = elem->get_node(1);
@@ -1045,6 +1074,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                         }
                       else // Split on 2-4 diagonal
                         {
+                          libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
+
                           subelem[0]->set_node(0) = elem->get_node(0);
                           subelem[0]->set_node(1) = elem->get_node(1);
                           subelem[0]->set_node(2) = elem->get_node(2);
@@ -1073,22 +1104,13 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               subelem[2] = new Tet10;
 
               // Split on 0-4 diagonal
-              if ((elem->node(0) > elem->node(1) &&
-                   elem->node(0) > elem->node(3)) ||
-                  (elem->node(4) > elem->node(1) &&
-                   elem->node(4) > elem->node(3)))
+              if (split_first_diagonal(elem, 0,4, 1,3))
                 {
                   // Split on 0-5 diagonal
-                  if ((elem->node(0) > elem->node(2) &&
-                       elem->node(0) > elem->node(3)) ||
-                      (elem->node(5) > elem->node(2) &&
-                       elem->node(5) > elem->node(3)))
+                  if (split_first_diagonal(elem, 0,5, 2,3))
                     {
                       // Split on 1-5 diagonal
-                      if ((elem->node(1) > elem->node(2) &&
-                           elem->node(1) > elem->node(4)) ||
-                          (elem->node(5) > elem->node(2) &&
-                           elem->node(5) > elem->node(4)))
+                      if (split_first_diagonal(elem, 1,5, 2,4))
                         {
                           subelem[0]->set_node(0) = elem->get_node(0);
                           subelem[0]->set_node(1) = elem->get_node(4);
@@ -1128,6 +1150,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                         }
                       else // Split on 2-4 diagonal
                         {
+                          libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
+
                           subelem[0]->set_node(0) = elem->get_node(0);
                           subelem[0]->set_node(1) = elem->get_node(4);
                           subelem[0]->set_node(2) = elem->get_node(5);
@@ -1167,7 +1191,11 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                     }
                   else // Split on 2-3 diagonal
                     {
+                      libmesh_assert (split_first_diagonal(elem, 2,3, 0,5));
+
                       // 0-4 and 2-3 split implies 2-4 split
+                      libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
+
                       subelem[0]->set_node(0) = elem->get_node(0);
                       subelem[0]->set_node(1) = elem->get_node(4);
                       subelem[0]->set_node(2) = elem->get_node(2);
@@ -1207,13 +1235,14 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                 }
               else // Split on 1-3 diagonal
                 {
+                  libmesh_assert (split_first_diagonal(elem, 1,3, 0,4));
+
                   // Split on 0-5 diagonal
-                  if ((elem->node(0) > elem->node(2) &&
-                       elem->node(0) > elem->node(3)) ||
-                      (elem->node(5) > elem->node(2) &&
-                       elem->node(5) > elem->node(3)))
+                  if (split_first_diagonal(elem, 0,5, 2,3))
                     {
                       // 1-3 and 0-5 split implies 1-5 split
+                      libmesh_assert (split_first_diagonal(elem, 1,5, 2,4));
+
                       subelem[0]->set_node(0) = elem->get_node(1);
                       subelem[0]->set_node(1) = elem->get_node(3);
                       subelem[0]->set_node(2) = elem->get_node(4);
@@ -1252,11 +1281,10 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                     }
                   else // Split on 2-3 diagonal
                     {
+                      libmesh_assert (split_first_diagonal(elem, 2,3, 0,5));
+
                       // Split on 1-5 diagonal
-                      if ((elem->node(1) > elem->node(2) &&
-                           elem->node(1) > elem->node(4)) ||
-                          (elem->node(5) > elem->node(2) &&
-                           elem->node(5) > elem->node(4)))
+                      if (split_first_diagonal(elem, 1,5, 2,4))
                         {
                           subelem[0]->set_node(0) = elem->get_node(0);
                           subelem[0]->set_node(1) = elem->get_node(1);
@@ -1296,6 +1324,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                         }
                       else // Split on 2-4 diagonal
                         {
+                          libmesh_assert (split_first_diagonal(elem, 2,4, 1,5));
+
                           subelem[0]->set_node(0) = elem->get_node(0);
                           subelem[0]->set_node(1) = elem->get_node(1);
                           subelem[0]->set_node(2) = elem->get_node(2);

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -848,10 +848,11 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               subelem[0] = new Tri6;
               subelem[1] = new Tri6;
 
-              Node * new_node = mesh.add_point((mesh.node(elem->node(0)) +
-                                                mesh.node(elem->node(1)) +
-                                                mesh.node(elem->node(2)) +
-                                                mesh.node(elem->node(3)) / 4),
+              // Add a new node at the center (vertex average) of the element.
+              Node * new_node = mesh.add_point(.25 * (mesh.node(elem->node(0)) +
+                                                      mesh.node(elem->node(1)) +
+                                                      mesh.node(elem->node(2)) +
+                                                      mesh.node(elem->node(3))),
                                                DofObject::invalid_id,
                                                elem->processor_id());
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1465,7 +1465,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               } // end for loop over sides
 
             // Remove the original element from the BoundaryInfo structure.
-            mesh.boundary_info->remove(elem);
+            mesh.get_boundary_info().remove(elem);
 
           } // end if (mesh_has_boundary_data)
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -42,7 +42,7 @@
 
 namespace
 {
-  bool split_first_diagonal(const Elem* elem,
+  bool split_first_diagonal(const libMesh::Elem * elem,
                             unsigned int diag_1_node_1,
                             unsigned int diag_1_node_2,
                             unsigned int diag_2_node_1,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,6 +17,7 @@ unit_tests_sources = \
 	geom/node_test.C \
 	geom/point_test.C \
 	geom/point_test.h \
+	mesh/all_tri.C \
 	mesh/boundary_mesh.C \
 	mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -169,7 +169,7 @@ PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -192,6 +192,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	base/unit_tests_dbg-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_dbg-node_test.$(OBJEXT) \
 	geom/unit_tests_dbg-point_test.$(OBJEXT) \
+	mesh/unit_tests_dbg-all_tri.$(OBJEXT) \
 	mesh/unit_tests_dbg-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_dbg-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT) \
@@ -230,7 +231,7 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -252,6 +253,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	base/unit_tests_devel-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_devel-node_test.$(OBJEXT) \
 	geom/unit_tests_devel-point_test.$(OBJEXT) \
+	mesh/unit_tests_devel-all_tri.$(OBJEXT) \
 	mesh/unit_tests_devel-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_devel-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT) \
@@ -288,7 +290,7 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -310,6 +312,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	base/unit_tests_oprof-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_oprof-node_test.$(OBJEXT) \
 	geom/unit_tests_oprof-point_test.$(OBJEXT) \
+	mesh/unit_tests_oprof-all_tri.$(OBJEXT) \
 	mesh/unit_tests_oprof-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_oprof-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT) \
@@ -346,7 +349,7 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -368,6 +371,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	base/unit_tests_opt-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_opt-node_test.$(OBJEXT) \
 	geom/unit_tests_opt-point_test.$(OBJEXT) \
+	mesh/unit_tests_opt-all_tri.$(OBJEXT) \
 	mesh/unit_tests_opt-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_opt-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT) \
@@ -402,7 +406,7 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -424,6 +428,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	base/unit_tests_prof-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_prof-node_test.$(OBJEXT) \
 	geom/unit_tests_prof-point_test.$(OBJEXT) \
+	mesh/unit_tests_prof-all_tri.$(OBJEXT) \
 	mesh/unit_tests_prof-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_prof-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT) \
@@ -875,10 +880,10 @@ AM_CPPFLAGS = $(libmesh_optional_INCLUDES) -I$(top_builddir)/include \
 AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h mesh/boundary_mesh.C \
-	mesh/boundary_info.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	numerics/composite_function_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -997,6 +1002,8 @@ mesh/$(am__dirstamp):
 mesh/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) mesh/$(DEPDIR)
 	@: > mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1094,6 +1101,8 @@ geom/unit_tests_devel-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1155,6 +1164,8 @@ geom/unit_tests_oprof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_oprof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1216,6 +1227,8 @@ geom/unit_tests_opt-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1277,6 +1290,8 @@ geom/unit_tests_prof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_prof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1376,26 +1391,31 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@
@@ -1585,6 +1605,20 @@ geom/unit_tests_dbg-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/point_test.C' object='geom/unit_tests_dbg-point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
+
+mesh/unit_tests_dbg-all_tri.o: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Tpo -c -o mesh/unit_tests_dbg-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_dbg-all_tri.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+
+mesh/unit_tests_dbg-all_tri.obj: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-all_tri.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Tpo -c -o mesh/unit_tests_dbg-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_dbg-all_tri.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
 
 mesh/unit_tests_dbg-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-boundary_mesh.Tpo -c -o mesh/unit_tests_dbg-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C
@@ -1992,6 +2026,20 @@ geom/unit_tests_devel-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
 
+mesh/unit_tests_devel-all_tri.o: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-all_tri.Tpo -c -o mesh/unit_tests_devel-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_devel-all_tri.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+
+mesh/unit_tests_devel-all_tri.obj: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-all_tri.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-all_tri.Tpo -c -o mesh/unit_tests_devel-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_devel-all_tri.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+
 mesh/unit_tests_devel-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Tpo -c -o mesh/unit_tests_devel-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Tpo mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Po
@@ -2397,6 +2445,20 @@ geom/unit_tests_oprof-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/point_test.C' object='geom/unit_tests_oprof-point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
+
+mesh/unit_tests_oprof-all_tri.o: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Tpo -c -o mesh/unit_tests_oprof-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_oprof-all_tri.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+
+mesh/unit_tests_oprof-all_tri.obj: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-all_tri.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Tpo -c -o mesh/unit_tests_oprof-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_oprof-all_tri.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
 
 mesh/unit_tests_oprof-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-boundary_mesh.Tpo -c -o mesh/unit_tests_oprof-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C
@@ -2804,6 +2866,20 @@ geom/unit_tests_opt-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
 
+mesh/unit_tests_opt-all_tri.o: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-all_tri.Tpo -c -o mesh/unit_tests_opt-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_opt-all_tri.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+
+mesh/unit_tests_opt-all_tri.obj: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-all_tri.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-all_tri.Tpo -c -o mesh/unit_tests_opt-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_opt-all_tri.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+
 mesh/unit_tests_opt-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Tpo -c -o mesh/unit_tests_opt-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Tpo mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Po
@@ -3209,6 +3285,20 @@ geom/unit_tests_prof-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/point_test.C' object='geom/unit_tests_prof-point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
+
+mesh/unit_tests_prof-all_tri.o: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-all_tri.Tpo -c -o mesh/unit_tests_prof-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_prof-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_prof-all_tri.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
+
+mesh/unit_tests_prof-all_tri.obj: mesh/all_tri.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-all_tri.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-all_tri.Tpo -c -o mesh/unit_tests_prof-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_prof-all_tri.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_prof-all_tri.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
 
 mesh/unit_tests_prof-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-boundary_mesh.Tpo -c -o mesh/unit_tests_prof-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C

--- a/tests/mesh/all_tri.C
+++ b/tests/mesh/all_tri.C
@@ -1,0 +1,115 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/libmesh.h>
+#include <libmesh/serial_mesh.h>
+#include <libmesh/elem.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/mesh_modification.h>
+
+#include "test_comm.h"
+
+using namespace libMesh;
+
+class AllTriTest : public CppUnit::TestCase
+{
+  /**
+   * The goal of this test is to verify proper operation of the Mesh Extruder
+   * with the optional object callback for setting custom subdomain IDs.
+   * We pass a custom object for generating subdomains based on the old element
+   * ID and the current layer and assert the proper values.
+   */
+public:
+  CPPUNIT_TEST_SUITE( AllTriTest );
+
+  // 2D tests
+  CPPUNIT_TEST( testAllTriTri );
+  CPPUNIT_TEST( testAllTriQuad );
+  CPPUNIT_TEST( testAllTriQuad8 );
+  CPPUNIT_TEST( testAllTriQuad9 );
+
+  // 3D tests
+  CPPUNIT_TEST( testAllTriPrism6 );
+  CPPUNIT_TEST( testAllTriPrism18 );
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+  // Helper function called by the test implementations, saves a few lines of code.
+  void test_helper_2D(ElemType elem_type,
+                      dof_id_type n_elem_expected,
+                      std::size_t n_boundary_conds_expected)
+  {
+    SerialMesh mesh(*TestCommWorld, /*dim=*/2);
+
+    // Build a 2x1 TRI3 mesh and ask to split it into triangles.
+    // Should be a no-op
+    MeshTools::Generation::build_square(mesh,
+                                        /*nx=*/2, /*ny=*/1,
+                                        /*xmin=*/0., /*xmax=*/1.,
+                                        /*ymin=*/0., /*ymax=*/1.,
+                                        elem_type);
+
+    MeshTools::Modification::all_tri(mesh);
+
+    // Make sure that the expected number of elements is found.
+    CPPUNIT_ASSERT_EQUAL(n_elem_expected, mesh.n_elem());
+
+    // Make sure the expected number of BCs is found.
+    CPPUNIT_ASSERT_EQUAL(n_boundary_conds_expected, mesh.get_boundary_info().n_boundary_conds());
+  }
+
+  // Helper function called by the test implementations in 3D, saves a few lines of code.
+  void test_helper_3D(ElemType elem_type,
+                      dof_id_type n_elem_expected,
+                      std::size_t n_boundary_conds_expected)
+  {
+    SerialMesh mesh(*TestCommWorld, /*dim=*/3);
+
+    // Build a 2x1 TRI3 mesh and ask to split it into triangles.
+    // Should be a no-op
+    MeshTools::Generation::build_cube(mesh,
+                                      /*nx=*/1, /*ny=*/1, /*nz=*/1,
+                                      /*xmin=*/0., /*xmax=*/1.,
+                                      /*ymin=*/0., /*ymax=*/1.,
+                                      /*zmin=*/0., /*zmax=*/1.,
+                                      elem_type);
+
+    MeshTools::Modification::all_tri(mesh);
+
+    // Make sure that the expected number of elements is found.
+    CPPUNIT_ASSERT_EQUAL(n_elem_expected, mesh.n_elem());
+
+    // Make sure the expected number of BCs is found.
+    CPPUNIT_ASSERT_EQUAL(n_boundary_conds_expected, mesh.get_boundary_info().n_boundary_conds());
+  }
+
+public:
+  void setUp() {}
+
+  void tearDown() {}
+
+  // 4 TRIs no-op
+  void testAllTriTri() { test_helper_2D(TRI3, /*nelem=*/4, /*nbcs=*/6); }
+
+  // 2 quads split into 4 TRIs.
+  void testAllTriQuad() { test_helper_2D(QUAD4, /*nelem=*/4, /*nbcs=*/6); }
+
+  // 2 QUAD8s split into 4 TRIs.
+  void testAllTriQuad8() { test_helper_2D(QUAD8, /*nelem=*/4, /*nbcs=*/6); }
+
+  // 2 QUAD9s split into 4 TRIs.
+  void testAllTriQuad9() { test_helper_2D(QUAD9, /*nelem=*/4, /*nbcs=*/6); }
+
+  // 2 PRISM6s split into 6 TETs with 2 boundary faces per side.
+  void testAllTriPrism6() { test_helper_3D(PRISM6, /*nelem=*/6, /*nbcs=*/12); }
+
+  // 2 PRISM6s split into 6 TETs with 2 boundary faces per side.
+  void testAllTriPrism18() { test_helper_3D(PRISM18, /*nelem=*/6, /*nbcs=*/12); }
+};
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION( AllTriTest );


### PR DESCRIPTION
Roy's comments:
```
In theory this branch adds the ability to split prisms into tets (and makes it easier to add
a future capability to split pyramids and hexes into tets).

In practice the refactoring here may have even broken the ability to split quads into tris, 
and the whole thing needs more testing before merge.
```