### PR TITLE
Make Elem::nullify_neighbors() public

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1189,12 +1189,16 @@ protected:
 
 
 
+ public:
+
   /**
    * Replaces this element with \p NULL for all of
    * its neighbors.  This is useful when deleting an
    * element.
    */
   void nullify_neighbors ();
+
+ protected:
 
   /**
    * Pointers to the nodes we are connected to.
@@ -1256,7 +1260,7 @@ protected:
    * It would seem that we are just getting around it
    * by using friends!
    */
-  friend class MeshRefinement;    // (Elem::nullify_neighbors)
+  friend class MeshRefinement;
 };
 
 // ------------------------------------------------------------


### PR DESCRIPTION
I'm adding and deleting elements to implement Heaviside-enriched XFEM using the phantom node method.  I have this up and running in MOOSE, but to accomplish this, I've had to make a few changes (OK, really ugly hacks) to libmesh because it appears that libmesh does not really support adding and deleting elements outside of adaptivity.  I'd like to resolve those issues to enable adding and deleting elements during a transient analysis outside the adaptivity system.  This would also be useful for other purposes, such as an element death capability.

I need to call nullify_neighbors() on elements that I've deleted, but I can't because it's protected, so I've made it public in this commit.  It looks like the intent was originally to only permit MeshRefinement to call many of these methods by making them protected and making MeshRefinement a friend of Elem.  There are some comments at the end of the Elem class definition that indicate that MeshRefinement is a friend to enable it to call the build methods, but in the current version, those methods are actually all public, so those comment must be out of date.  Maybe it's time for Elem to unfriend MeshRefinement.

FYI, the other place I've hit trouble in adding and deleting elements is in EquationSystems::reinit(), where it's calling System::prolong_vectors(), which calls System::restrict_vectors().  The code chokes on the calls to System::project_vector() because my newly created elements and nodes are missing old dof indices.  I also hit trouble in the call to system->localize_solution() because the size of the solution vector changed.  I've been able to run my models by commenting out the problematic code in System::restrict_vectors().  It seems like these are things we ought to be able to work out.
