### PR TITLE
Fixed bug in ExodusII_IO_Helper for discontinuous plots.

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -242,36 +242,20 @@ public:
   virtual void create(std::string filename);
 
   /**
-   * Initializes the Exodus file
+   * Initializes the Exodus file.
    */
-  virtual void initialize(std::string title, const MeshBase & mesh);
-
-  /**
-   * Initializes the Exodus file
-   */
-  void initialize_discontinuous(std::string title, const MeshBase & mesh);
+  virtual void initialize(std::string title, const MeshBase & mesh, bool use_discontinuous=false);
 
   /**
    * Writes the nodal coordinates contained in "mesh"
    */
-  virtual void write_nodal_coordinates(const MeshBase & mesh);
-
-  /**
-   * Writes the nodal coordinates contained in "mesh"
-   */
-  void write_nodal_coordinates_discontinuous(const MeshBase & mesh);
+  virtual void write_nodal_coordinates(const MeshBase & mesh, bool use_discontinuous=false);
 
   /**
    * Writes the elements contained in "mesh". FIXME: This only works
    * for Meshes having a single type of element!
    */
-  virtual void write_elements(const MeshBase & mesh);
-
-  /**
-   * Writes the elements contained in "mesh". FIXME: This only works
-   * for Meshes having a single type of element!
-   */
-  void write_elements_discontinuous(const MeshBase & mesh);
+  virtual void write_elements(const MeshBase & mesh, bool use_discontinuous=false);
 
   /**
    * Writes the sidesets contained in "mesh"

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -892,15 +892,15 @@ void ExodusII_IO::write_nodal_data_common(std::string fname,
 
           if (continuous)
             {
-              exio_helper->initialize(fname,mesh);
-              exio_helper->write_nodal_coordinates(mesh);
-              exio_helper->write_elements(mesh);
+              exio_helper->initialize(fname, mesh, /*use_discontinuous=*/ false);
+              exio_helper->write_nodal_coordinates(mesh, /*use_discontinuous=*/ false);
+              exio_helper->write_elements(mesh, /*use_discontinuous=*/ false);
             }
           else
             {
-              exio_helper->initialize_discontinuous(fname,mesh);
-              exio_helper->write_nodal_coordinates_discontinuous(mesh);
-              exio_helper->write_elements_discontinuous(mesh);
+              exio_helper->initialize(fname, mesh, /*use_discontinuous=*/ true);
+              exio_helper->write_nodal_coordinates(mesh, /*use_discontinuous=*/ true);
+              exio_helper->write_elements(mesh, /*use_discontinuous=*/ true);
             }
           exio_helper->write_sidesets(mesh);
           exio_helper->write_nodesets(mesh);


### PR DESCRIPTION
The bug was due to an indexing error in the case of multiple subdomains.

Also, DRY'd out the discontinuous vs. continuous code in ExodusII_IO_Helper.
