### PR TITLE
miscellaneous_ex10 should be faster

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex10/run.sh
+++ b/examples/miscellaneous/miscellaneous_ex10/run.sh
@@ -6,6 +6,6 @@ source $LIBMESH_DIR/examples/run_common.sh
 
 example_name=miscellaneous_ex10
 
-options="-n 4"
+options="-n 2"
 
 run_example "$example_name" "$options"


### PR DESCRIPTION
With METHOD=dbg it can take forever for miscellaneous_ex10 to get through METIS; using tiny meshes fixes that.

I'm going to also increase BuildBot's allotted runtime to get rid of the current occasional "tests didn't finish in time" false positive error reports, but there's really no reason we should be spending ten minutes on a single example case.

This probably isn't METIS' fault either; they may just be heavily relying on one of the STL containers whose asymptotic cost gets changed by our dbg-mode flags.
