### PR TITLE
Added build_active_side list method

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -392,6 +392,12 @@ public:
   void build_side_list (std::vector<dof_id_type>&        element_id_list,
                         std::vector<unsigned short int>& side_list,
                         std::vector<boundary_id_type>&   bc_id_list) const;
+  /**
+   * Creates a list of active element numbers, sides, and  and ids for those sides.
+   */
+  void build_active_side_list (std::vector<dof_id_type>&        element_id_list,
+                               std::vector<unsigned short int>& side_list,
+                               std::vector<boundary_id_type>&   bc_id_list) const;
 
   /**
    * @returns the user-specified boundary ids.


### PR DESCRIPTION
`BoundaryInfo::build_side_list` only reports level zero elements, we need a list that returns active elements regardless of level.
