### PR TITLE
add switch to enable debugging functions in fparser

### DIFF
--- a/configure
+++ b/configure
@@ -661,6 +661,8 @@ CPPUNIT_CFLAGS
 CPPUNIT_CONFIG
 LIBMESH_ENABLE_FPARSER_FALSE
 LIBMESH_ENABLE_FPARSER_TRUE
+FPARSER_SUPPORT_DEBUGGING_FALSE
+FPARSER_SUPPORT_DEBUGGING_TRUE
 FPARSER_SUPPORT_OPTIMIZER_FALSE
 FPARSER_SUPPORT_OPTIMIZER_TRUE
 FPARSER_NO_SUPPORT_OPTIMIZER_FALSE
@@ -1137,6 +1139,7 @@ enable_nemesis
 enable_libHilbert
 enable_fparser
 with_fparser
+enable_fparser_debugging
 enable_fparser_optimizer
 enable_cppunit
 with_cppunit_prefix
@@ -1896,6 +1899,8 @@ Optional Features:
   --enable-nemesis        build with NemesisII API support
   --enable-libHilbert     build with libHilbert, from Chris Hamilton
   --enable-fparser        build with C++ function parser support
+  --enable-fparser-debugging
+                          enable fparser debugging functions
   --enable-fparser-optimizer
                           use fparser optimization where possible
   --enable-cppunit        Build with cppunit C++ unit testing support
@@ -33520,13 +33525,25 @@ fi
   if (test x$enablefparser = xyes); then
 
 
+    # Check whether --enable-fparser-debugging was given.
+if test "${enable_fparser_debugging+set}" = set; then :
+  enableval=$enable_fparser_debugging; case "${enableval}" in
+		  yes)  enablefparserdebugging=yes ;;
+		   no)  enablefparserdebugging=no ;;
+		    *)  as_fn_error $? "bad value ${enableval} for --enable-fparser-debugging" "$LINENO" 5 ;;
+		 esac
+else
+  enablefparserdebugging=yes
+fi
+
+
     # Check whether --enable-fparser-optimizer was given.
 if test "${enable_fparser_optimizer+set}" = set; then :
   enableval=$enable_fparser_optimizer; case "${enableval}" in
-  		  yes)  enablefparseroptimizer=yes ;;
-  		   no)  enablefparseroptimizer=no ;;
-   		    *)  as_fn_error $? "bad value ${enableval} for --enable-fparser-optimizer" "$LINENO" 5 ;;
-  		 esac
+		  yes)  enablefparseroptimizer=yes ;;
+		   no)  enablefparseroptimizer=no ;;
+		    *)  as_fn_error $? "bad value ${enableval} for --enable-fparser-optimizer" "$LINENO" 5 ;;
+		 esac
 else
   enablefparseroptimizer=yes
 fi
@@ -33679,6 +33696,15 @@ $as_echo "#define HAVE_FPARSER_DEVEL 0" >>confdefs.h
 $as_echo "<<< Configuring library with fparser support (release version) >>>" >&6; }
       fi
 
+      # This define in libmesh_config.h is used internally in fparser.hh and various source files
+      if (test $enablefparserdebugging = yes); then
+
+$as_echo "#define FPARSER_SUPPORT_DEBUGGING 1" >>confdefs.h
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with fparser debugging functions >>>" >&5
+$as_echo "<<< Configuring library with fparser debugging functions >>>" >&6; }
+      fi
+
   else
      FPARSER_INCLUDE=""
      FPARSER_LIBRARY=""
@@ -33718,6 +33744,14 @@ fi
 else
   FPARSER_SUPPORT_OPTIMIZER_TRUE='#'
   FPARSER_SUPPORT_OPTIMIZER_FALSE=
+fi
+
+   if test x$enablefparserdebugging = xyes; then
+  FPARSER_SUPPORT_DEBUGGING_TRUE=
+  FPARSER_SUPPORT_DEBUGGING_FALSE='#'
+else
+  FPARSER_SUPPORT_DEBUGGING_TRUE='#'
+  FPARSER_SUPPORT_DEBUGGING_FALSE=
 fi
 
 
@@ -34453,6 +34487,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${FPARSER_SUPPORT_OPTIMIZER_TRUE}" && test -z "${FPARSER_SUPPORT_OPTIMIZER_FALSE}"; then
   as_fn_error $? "conditional \"FPARSER_SUPPORT_OPTIMIZER\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${FPARSER_SUPPORT_DEBUGGING_TRUE}" && test -z "${FPARSER_SUPPORT_DEBUGGING_FALSE}"; then
+  as_fn_error $? "conditional \"FPARSER_SUPPORT_DEBUGGING\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${LIBMESH_ENABLE_FPARSER_TRUE}" && test -z "${LIBMESH_ENABLE_FPARSER_FALSE}"; then

--- a/contrib/fparser/fparser.hh
+++ b/contrib/fparser/fparser.hh
@@ -14,6 +14,14 @@
 #include <string>
 #include <vector>
 
+#include "libmesh_config.h"
+// Debugging support was enabled at compile time
+#ifdef LIBMESH_FPARSER_SUPPORT_DEBUGGING
+#  ifndef FUNCTIONPARSER_SUPPORT_DEBUGGING
+#    define FUNCTIONPARSER_SUPPORT_DEBUGGING
+#  endif
+#endif
+
 #ifdef FUNCTIONPARSER_SUPPORT_DEBUGGING
 #include <iostream>
 #endif

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -158,6 +158,9 @@
 /* Flag indicating if the library should have warnings enabled */
 #undef ENABLE_WARNINGS
 
+/* Enable fparser debugging functions */
+#undef FPARSER_SUPPORT_DEBUGGING
+
 /* Flag indicating whether the library shall be compiled to use the Trilinos
    solver collection */
 #undef HAVE_AZTECOO

--- a/m4/fparser.m4
+++ b/m4/fparser.m4
@@ -28,15 +28,25 @@ AC_DEFUN([CONFIGURE_FPARSER],
   if (test x$enablefparser = xyes); then
 
 
+    AC_ARG_ENABLE(fparser-debugging,
+                  AC_HELP_STRING([--enable-fparser-debugging],
+                                 [enable fparser debugging functions]),
+		[case "${enableval}" in
+		  yes)  enablefparserdebugging=yes ;;
+		   no)  enablefparserdebugging=no ;;
+		    *)  AC_MSG_ERROR(bad value ${enableval} for --enable-fparser-debugging) ;;
+		 esac],
+		 [enablefparserdebugging=yes])
+
     AC_ARG_ENABLE(fparser-optimizer,
                   AC_HELP_STRING([--enable-fparser-optimizer],
                                  [use fparser optimization where possible]),
-  		[case "${enableval}" in
-  		  yes)  enablefparseroptimizer=yes ;;
-  		   no)  enablefparseroptimizer=no ;;
-   		    *)  AC_MSG_ERROR(bad value ${enableval} for --enable-fparser-optimizer) ;;
-  		 esac],
-  		 [enablefparseroptimizer=yes])
+		[case "${enableval}" in
+		  yes)  enablefparseroptimizer=yes ;;
+		   no)  enablefparseroptimizer=no ;;
+		    *)  AC_MSG_ERROR(bad value ${enableval} for --enable-fparser-optimizer) ;;
+		 esac],
+		 [enablefparseroptimizer=yes])
 
     # note - fparser optimization may fail on cygwin (please test), so disable it regardless
     case "${host_os}" in
@@ -66,6 +76,12 @@ AC_DEFUN([CONFIGURE_FPARSER],
         AC_MSG_RESULT(<<< Configuring library with fparser support (release version) >>>)
       fi
 
+      # This define in libmesh_config.h is used internally in fparser.hh and various source files
+      if (test $enablefparserdebugging = yes); then
+        AC_DEFINE(FPARSER_SUPPORT_DEBUGGING, 1, [Enable fparser debugging functions])
+        AC_MSG_RESULT(<<< Configuring library with fparser debugging functions >>>)
+      fi
+
   else
      FPARSER_INCLUDE=""
      FPARSER_LIBRARY=""
@@ -79,4 +95,5 @@ AC_DEFUN([CONFIGURE_FPARSER],
   AM_CONDITIONAL(FPARSER_DEVEL,                test x$enablefparserdevel = xyes)
   AM_CONDITIONAL(FPARSER_NO_SUPPORT_OPTIMIZER, test x$enablefparseroptimizer = xno)
   AM_CONDITIONAL(FPARSER_SUPPORT_OPTIMIZER,    test x$enablefparseroptimizer = xyes)
+  AM_CONDITIONAL(FPARSER_SUPPORT_DEBUGGING,    test x$enablefparserdebugging = xyes)
 ])


### PR DESCRIPTION
This patch enables some debugging capabilities built into FParser. Most importantly the `PrintByteCode(..)` method  is made available which provides a human readable dump of a function's byte code (indispensable for analyzing the results of the optimizer and the automatic differentiation).
