### PR TITLE
Clearer defaults from configure --help

### DIFF
--- a/configure
+++ b/configure
@@ -1800,15 +1800,15 @@ Optional Features:
   --disable-maintainer-mode
                           disable make rules and dependencies not useful (and
                           sometimes confusing) to the casual installer
-  --enable-mpi            build with MPI message passing support
+  --disable-mpi           build without MPI message passing support
   --enable-dependency-tracking
                           do not reject slow dependency extractors
   --disable-dependency-tracking
                           speeds up one-time build
-  --enable-fortran        build with Fortran language support
-  --enable-glibcxx-debugging
-                          add -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC to
-                          CXXFLAGS_DBG (yes by default)
+  --disable-fortran       build without Fortran language support
+  --disable-glibcxx-debugging
+                          omit -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC even
+                          in dbg mode
   --enable-coverage       configure code coverage analysis tools
   --enable-static[=PKGS]  build static libraries [default=no]
   --enable-shared[=PKGS]  build shared libraries [default=yes]
@@ -1822,12 +1822,13 @@ Optional Features:
                           Use triple-precision scalars
   --enable-quadrupleprecision
                           Use quadruple-precision scalars
-  --enable-getpwuid       allow calls to getpwuid
-  --enable-exceptions     throw exceptions on unexpected errors
-  --enable-unordered-containers
-                          Use unordered_map/unordered_set if available
-  --enable-openmp         Build with OpenMP Support
-  --enable-warnings       Warn when using deprecated, experimental, or
+  --disable-getpwuid      do not make calls to getpwuid
+  --disable-exceptions    exit rather than throw exceptions on unexpected
+                          errors
+  --disable-unordered-containers
+                          Use map/set instead of unordered_map/unordered_set
+  --disable-openmp        Build without OpenMP Support
+  --disable-warnings      Do not warn about deprecated, experimental, or
                           questionable code
   --enable-blocked-storage
                           Support for blocked matrix/vector storage
@@ -1838,73 +1839,75 @@ Optional Features:
                           #include "libmesh/header.h"
   --enable-legacy-using-namespace
                           add "using namespace libMesh" to libMesh headers
-  --enable-everything     treat all applicable options as enabled
+  --enable-everything     enable all non-conflicting options
   --enable-unique-id      build with unique id suppport
   --enable-tracefiles     write stack trace files on unexpected errors
-  --enable-amr            build with adaptive mesh refinement (AMR) suppport
-  --enable-vsmoother      build with variational smoother suppport
-  --enable-periodic       build with periodic boundary condition suppport
-  --enable-dirichlet      build with Dirichlet boundary constraint support
+  --disable-amr           build without adaptive mesh refinement (AMR)
+                          suppport
+  --disable-vsmoother     build without variational smoother suppport
+  --disable-periodic      build without periodic boundary condition suppport
+  --disable-dirichlet     build without Dirichlet boundary constraint support
   --enable-nodeconstraint build with node constraints suppport
-  --enable-parmesh        Use experimental ParallelMesh as Mesh
-  --enable-ghosted        Use ghosted local vectors when available
-  --enable-node-valence   Compute and store node valence values
+  --enable-parmesh        Use distributed ParallelMesh as Mesh
+  --disable-ghosted       Use dense instead of sparse/ghosted local vectors
+  --disable-node-valence  Do not compute and store node valence values
   --enable-1D-only        build with support for 1D meshes only
   --enable-2D-only        build with support for 1D and 2D meshes only
-  --enable-pfem           build with support for higher order p-FEM shapes
+  --disable-pfem          build without support for higher p order FEM shapes
   --enable-ifem           build with infinite elements
-  --enable-second         build with second derivatives
-  --enable-xdr            enable XDR platform-independent binary I/O
-  --enable-complex        build with complex number support
-  --enable-reference-counting
-                          build with reference counting suppport
+  --disable-second        build without second derivatives support
+  --disable-xdr           build without XDR platform-independent binary I/O
+  --enable-complex        build to support complex-number solutions
+  --disable-reference-counting
+                          build without reference counting support
   --enable-perflog        build with performance logging turned on
-  --enable-examples       support compilation, installation, & running example
-                          suite
-  --enable-optional       en/disable optional external libraries
+  --disable-examples      Do not compile, install, or test with example suite
+  --disable-optional      build without most optional external libraries
   --enable-strict-lgpl    Compile libmesh with LGPL-compatible contrib
                           libraries only
-  --enable-nested         en/disable nested autoconf subpackages
-  --enable-boost          build with either external or built-in BOOST support
-  --enable-petsc          build with PETSc iterative solver suppport
-  --enable-slepc          build with SLEPc eigen solver support
-  --enable-trilinos       build with Trilinos support
-  --enable-tbb            build with threading support via Threading Building
-                          Blocks
-  --enable-pthreads       build with threading support via POSIX threads
-                          (pthreads)
-  --enable-cppthreads     Build with C++ std::thread support
-  --enable-laspack        build with LASPACK iterative solver suppport
-  --enable-sfc            build with space-filling curves suppport
-  --enable-gzstreams      build with gzstreams compressed I/O suppport
-  --enable-bzip2          build with bzip2 compressed I/O suppport
-  --enable-xz             build with xz compressed I/O suppport
-  --enable-tecio          build with Tecplot TecIO API support (from source)
+  --disable-nested        Do not use nested autoconf subpackages
+  --disable-boost         build without either external or built-in BOOST
+                          support
+  --disable-petsc         build without PETSc iterative solver suppport
+  --disable-slepc         build without SLEPc eigen solver support
+  --disable-trilinos      build without Trilinos support
+  --disable-tbb           build without threading support via Threading
+                          Building Blocks
+  --disable-pthreads      build without POSIX threading (pthreads) support
+  --disable-cppthreads    Build without C++ std::thread support
+  --disable-laspack       build without LASPACK iterative solver suppport
+  --disable-sfc           build without space-filling curves suppport
+  --disable-gzstreams     build without gzstreams compressed I/O suppport
+  --disable-bzip2         build without bzip2 compressed I/O suppport
+  --disable-xz            build without xz compressed I/O suppport
+  --disable-tecio         build without Tecplot TecIO API support (from
+                          source)
   --enable-tecplot        build with Tecplot binary file I/O support (using
                           distributed libraries)
-  --enable-metis          build with Metis graph partitioning suppport
-  --enable-parmetis       build with Parmetis parallel graph partitioning
+  --disable-metis         build without Metis graph partitioning suppport
+  --disable-parmetis      build without Parmetis parallel graph partitioning
                           suppport
-  --enable-tetgen         build with TetGen tetrahedrization library support
-  --enable-triangle       build with Triangle Delaunay triangulation library
+  --disable-tetgen        build without TetGen tetrahedrization library
                           support
-  --enable-gmv            build with GMV file I/O support
-  --enable-vtk            build with VTK file I/O support
-  --enable-eigen          build with Eigen linear algebra support
-  --enable-glpk           build with GLPK support
-  --enable-hdf5           build with HDF5 support
-  --enable-netcdf         build with netCDF binary I/O
-  --enable-exodus         build with ExodusII API support
+  --disable-triangle      build without Triangle Delaunay triangulation
+                          library support
+  --disable-gmv           build without GMV file I/O support
+  --disable-vtk           build without VTK file I/O support
+  --disable-eigen         build without Eigen linear algebra support
+  --disable-glpk          build without GLPK support
+  --disable-hdf5          build without HDF5 support
+  --disable-netcdf        build without netCDF binary I/O
+  --disable-exodus        build without ExodusII API support
   --enable-exodus-fortran build with ExodusII Fortran API support
-  --enable-nemesis        build with NemesisII API support
-  --enable-libHilbert     build with libHilbert, from Chris Hamilton
-  --enable-fparser        build with C++ function parser support
-  --enable-fparser-debugging
-                          enable fparser debugging functions
-  --enable-fparser-optimizer
-                          use fparser optimization where possible
-  --enable-cppunit        Build with cppunit C++ unit testing support
-  --enable-nanoflann      build with space-filling curves suppport
+  --disable-nemesis       build without NemesisII API support
+  --disable-libHilbert    build without Chris Hamilton's libHilbert
+  --disable-fparser       build without C++ function parser support
+  --disable-fparser-debugging
+                          do not provide fparser debugging functions
+  --disable-fparser-optimizer
+                          do not optimize parsed functions
+  --disable-cppunit       Build without cppunit C++ unit testing support
+  --disable-nanoflann     build without nanoflann KD-tree suppport
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -1921,16 +1924,16 @@ Optional Packages:
   --with-sysroot=DIR Search for dependent libraries within DIR
                         (or the compiler's sysroot if not specified).
   --with-boundary-id-bytes=<1|2|4|8>
-                          bytes used per boundary side per boundary_id
+                          bytes used per boundary side per boundary_id [2]
   --with-dof-id-bytes=<1|2|4|8>
-                          bytes used per dof object id, dof index
+                          bytes used per dof object id, dof index [4]
   --with-processor-id-bytes=<1|2|4|8>
-                          bytes used for processor id
+                          bytes used for processor id [4]
   --with-subdomain-id-bytes=<1|2|4|8>
                           bytes of storage per element used to store the
-                          subdomain_id
+                          subdomain_id [2]
   --with-unique-id-bytes=<1|2|4|8>
-                          bytes used per unique id
+                          bytes used per unique id [4]
   --with-boost[=ARG]      use Boost library from a standard location
                           (ARG=yes), from the specified location (ARG=<path>),
                           or disable it (ARG=no) [ARG=yes]
@@ -26484,7 +26487,7 @@ fi
 
 
 # --------------------------------------------------------------
-# default comm_world - enabled by default
+# default comm_world - now disabled by default
 # --------------------------------------------------------------
 # Check whether --enable-default-comm-world was given.
 if test "${enable_default_comm_world+set}" = set; then :
@@ -26985,7 +26988,7 @@ fi
 
 
 # -------------------------------------------------------------
-# Mesh == ParallelMesh -- disabled until it's debugged/finished
+# Mesh == ParallelMesh -- disabled by default for max compatibility
 # -------------------------------------------------------------
 # Check whether --enable-parmesh was given.
 if test "${enable_parmesh+set}" = set; then :

--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -5,8 +5,8 @@
 AC_DEFUN([CONFIGURE_BOOST],
 [
   AC_ARG_ENABLE(boost,
-                AC_HELP_STRING([--enable-boost],
-                               [build with either external or built-in BOOST support]),
+                AC_HELP_STRING([--disable-boost],
+                               [build without either external or built-in BOOST support]),
    	        [case "${enableval}" in
   	      	  yes)  enableboost=yes ;;
   		   no)  enableboost=no ;;

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -11,8 +11,8 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
      #                             smart about which compilers to look for
      # -------------------------------------------------------------------
      AC_ARG_ENABLE(mpi,
-                   AC_HELP_STRING([--enable-mpi],
-                                  [build with MPI message passing support]),
+                   AC_HELP_STRING([--disable-mpi],
+                                  [build without MPI message passing support]),
    		   [case "${enableval}" in
    		     yes)  enablempi=yes ;;
    		      no)  enablempi=no ;;
@@ -83,8 +83,8 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
   # --disable-fortran
   # --------------------------------------------------------------
   AC_ARG_ENABLE(fortran,
-                AC_HELP_STRING([--enable-fortran],
-                               [build with Fortran language support]),
+                AC_HELP_STRING([--disable-fortran],
+                               [build without Fortran language support]),
 		[case "${enableval}" in
 		  yes)  enablefortran=yes ;;
 		   no)  enablefortran=no ;;
@@ -529,8 +529,8 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
   # in the case blocks below we may add GLIBCXX-specific pedantic debugging preprocessor
   # definitions. however, allow the knowing user to preclude that if they need to.
   AC_ARG_ENABLE(glibcxx-debugging,
-	 [AC_HELP_STRING([--enable-glibcxx-debugging],
-	                 [add -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC to CXXFLAGS_DBG (yes by default)])],
+	 [AC_HELP_STRING([--disable-glibcxx-debugging],
+	                 [omit -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC even in dbg mode])],
 	 [case "${enableval}" in
 	   yes)  enableglibcxxdebugging=yes ;;
 	    no)  enableglibcxxdebugging=no ;;

--- a/m4/eigen.m4
+++ b/m4/eigen.m4
@@ -22,8 +22,8 @@
 AC_DEFUN([CONFIGURE_EIGEN],
 [
   AC_ARG_ENABLE(eigen,
-                AC_HELP_STRING([--enable-eigen],
-                               [build with Eigen linear algebra support]),
+                AC_HELP_STRING([--disable-eigen],
+                               [build without Eigen linear algebra support]),
 		[case "${enableval}" in
 		  yes)  enableeigen=yes ;;
 		   no)  enableeigen=no ;;

--- a/m4/exodus.m4
+++ b/m4/exodus.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_EXODUS],
 [
   AC_ARG_ENABLE(exodus,
-                AC_HELP_STRING([--enable-exodus],
-                               [build with ExodusII API support]),
+                AC_HELP_STRING([--disable-exodus],
+                               [build without ExodusII API support]),
 		[case "${enableval}" in
 		  yes|new|v522)  enableexodus=yes; exodusversion="v5.22" ;;
 		      old|v509)  enableexodus=yes; exodusversion="v5.09" ;;

--- a/m4/fparser.m4
+++ b/m4/fparser.m4
@@ -4,8 +4,8 @@
 AC_DEFUN([CONFIGURE_FPARSER],
 [
   AC_ARG_ENABLE([fparser],
-                AC_HELP_STRING([--enable-fparser],
-                               [build with C++ function parser support]),
+                AC_HELP_STRING([--disable-fparser],
+                               [build without C++ function parser support]),
 		[case "${enableval}" in
 		  yes)  enablefparser=yes ;;
 		   no)  enablefparser=no ;;
@@ -29,8 +29,8 @@ AC_DEFUN([CONFIGURE_FPARSER],
 
 
     AC_ARG_ENABLE(fparser-debugging,
-                  AC_HELP_STRING([--enable-fparser-debugging],
-                                 [enable fparser debugging functions]),
+                  AC_HELP_STRING([--disable-fparser-debugging],
+                                 [do not provide fparser debugging functions]),
 		[case "${enableval}" in
 		  yes)  enablefparserdebugging=yes ;;
 		   no)  enablefparserdebugging=no ;;
@@ -39,8 +39,8 @@ AC_DEFUN([CONFIGURE_FPARSER],
 		 [enablefparserdebugging=yes])
 
     AC_ARG_ENABLE(fparser-optimizer,
-                  AC_HELP_STRING([--enable-fparser-optimizer],
-                                 [use fparser optimization where possible]),
+                  AC_HELP_STRING([--disable-fparser-optimizer],
+                                 [do not optimize parsed functions]),
 		[case "${enableval}" in
 		  yes)  enablefparseroptimizer=yes ;;
 		   no)  enablefparseroptimizer=no ;;

--- a/m4/glpk.m4
+++ b/m4/glpk.m4
@@ -10,8 +10,8 @@
 AC_DEFUN([CONFIGURE_GLPK],
 [
   AC_ARG_ENABLE(glpk,
-                AC_HELP_STRING([--enable-glpk],
-                               [build with GLPK support]),
+                AC_HELP_STRING([--disable-glpk],
+                               [build without GLPK support]),
 		[case "${enableval}" in
 		  yes)  enableglpk=yes ;;
 		   no)  enableglpk=no ;;

--- a/m4/gmv.m4
+++ b/m4/gmv.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_GMV],
 [
   AC_ARG_ENABLE(gmv,
-                AC_HELP_STRING([--enable-gmv],
-                               [build with GMV file I/O support]),
+                AC_HELP_STRING([--disable-gmv],
+                               [build without GMV file I/O support]),
 		[case "${enableval}" in
 		  yes)  enablegmv=yes ;;
 		   no)  enablegmv=no ;;

--- a/m4/gz.m4
+++ b/m4/gz.m4
@@ -4,8 +4,8 @@
 AC_DEFUN([CONFIGURE_GZ],
 [
   AC_ARG_ENABLE(gzstreams,
-                AC_HELP_STRING([--enable-gzstreams],
-                               [build with gzstreams compressed I/O suppport]),
+                AC_HELP_STRING([--disable-gzstreams],
+                               [build without gzstreams compressed I/O suppport]),
 		[case "${enableval}" in
 		  yes)  enablegz=yes ;;
 		   no)  enablegz=no ;;

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -4,8 +4,8 @@
 AC_DEFUN([CONFIGURE_HDF5],
 [
   AC_ARG_ENABLE(hdf5,
-                AC_HELP_STRING([--enable-hdf5],
-                               [build with HDF5 support]),
+                AC_HELP_STRING([--disable-hdf5],
+                               [build without HDF5 support]),
 		[case "${enableval}" in
 		  yes)  enablehdf5=yes ;;
 		   no)  enablehdf5=no ;;

--- a/m4/laspack.m4
+++ b/m4/laspack.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_LASPACK],
 [
   AC_ARG_ENABLE(laspack,
-                AC_HELP_STRING([--enable-laspack],
-                               [build with LASPACK iterative solver suppport]),
+                AC_HELP_STRING([--disable-laspack],
+                               [build without LASPACK iterative solver suppport]),
 		[case "${enableval}" in
 		  yes)  enablelaspack=yes ;;
 		   no)  enablelaspack=no ;;

--- a/m4/libhilbert.m4
+++ b/m4/libhilbert.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_LIBHILBERT],
 [
   AC_ARG_ENABLE(libHilbert,
-                AC_HELP_STRING([--enable-libHilbert],
-                               [build with libHilbert, from Chris Hamilton]),
+                AC_HELP_STRING([--disable-libHilbert],
+                               [build without Chris Hamilton's libHilbert]),
 		[case "${enableval}" in
 		  yes)  enablelibhilbert=yes ;;
 		   no)  enablelibhilbert=no ;;

--- a/m4/libmesh_compiler_features.m4
+++ b/m4/libmesh_compiler_features.m4
@@ -65,8 +65,8 @@ AC_C_RESTRICT
 # --disable-getpwuid.
 # --------------------------------------------------------------
 AC_ARG_ENABLE(getpwuid,
-              AC_HELP_STRING([--enable-getpwuid],
-                             [allow calls to getpwuid]),
+              AC_HELP_STRING([--disable-getpwuid],
+                             [do not make calls to getpwuid]),
               enablegetpwuid=$enableval,
               enablegetpwuid=yes)
 
@@ -83,8 +83,8 @@ fi
 # C++ exceptions - enabled by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(exceptions,
-              AC_HELP_STRING([--enable-exceptions],
-                             [throw exceptions on unexpected errors]),
+              AC_HELP_STRING([--disable-exceptions],
+                             [exit rather than throw exceptions on unexpected errors]),
               enableexceptions=$enableval,
               enableexceptions=yes)
 
@@ -139,8 +139,8 @@ AC_CHECK_HEADERS(xmmintrin.h)
 AC_HAVE_FEEXCEPT
 
 AC_ARG_ENABLE(unordered-containers,
-              AC_HELP_STRING([--enable-unordered-containers],
-                             [Use unordered_map/unordered_set if available]),
+              AC_HELP_STRING([--disable-unordered-containers],
+                             [Use map/set instead of unordered_map/unordered_set]),
               enableunorderedcontainers=$enableval,
               enableunorderedcontainers=yes)
 
@@ -166,8 +166,8 @@ AX_CXX_GLIBC_BACKTRACE
 # OpenMP Support  -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(openmp,
-             AC_HELP_STRING([--enable-openmp],
-                            [Build with OpenMP Support]),
+             AC_HELP_STRING([--disable-openmp],
+                            [Build without OpenMP Support]),
              enableopenmp=$enableval,
              enableopenmp=yes)
 if (test "$enableopenmp" != no) ; then

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -11,7 +11,7 @@ AC_MSG_RESULT(---------------------------------------------)
 # library warnings - enable by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(warnings,
-              [AC_HELP_STRING([--enable-warnings],[Warn when using deprecated, experimental, or questionable code])],
+              [AC_HELP_STRING([--disable-warnings],[Do not warn about deprecated, experimental, or questionable code])],
               enablewarnings=$enableval,
               enablewarnings=yes)
 
@@ -45,7 +45,7 @@ fi
 
 
 # --------------------------------------------------------------
-# default comm_world - enabled by default
+# default comm_world - now disabled by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(default-comm-world,
               [AC_HELP_STRING([--enable-default-comm-world],[Provide global libMesh::CommWorld])],
@@ -107,7 +107,7 @@ fi
 # -------------------------------------------------------------
 AC_ARG_WITH([boundary_id_bytes],
 	    AC_HELP_STRING([--with-boundary-id-bytes=<1|2|4|8>],
-                           [bytes used per boundary side per boundary_id]),
+                           [bytes used per boundary side per boundary_id [2]]),
 	    [boundary_bytes="$withval"],
 	    [boundary_bytes=2])
 
@@ -140,7 +140,7 @@ AC_MSG_RESULT([configuring size of boundary_id... $boundary_bytes])
 # -------------------------------------------------------------
 AC_ARG_WITH([dof_id_bytes],
 	    AC_HELP_STRING([--with-dof-id-bytes=<1|2|4|8>],
-                           [bytes used per dof object id, dof index]),
+                           [bytes used per dof object id, dof index [4]]),
 	    [dof_bytes="$withval"],
 	    [dof_bytes=4])
 
@@ -173,7 +173,7 @@ AC_MSG_RESULT([configuring size of dof_id... $dof_bytes])
 # -------------------------------------------------------------
 AC_ARG_WITH([processor_id_bytes],
 	    AC_HELP_STRING([--with-processor-id-bytes=<1|2|4|8>],
-                           [bytes used for processor id]),
+                           [bytes used for processor id [4]]),
 	    [processor_bytes="$withval"],
 	    [processor_bytes=2])
 
@@ -206,7 +206,7 @@ AC_MSG_RESULT([configuring size of processor_id... $processor_bytes])
 # -------------------------------------------------------------
 AC_ARG_WITH([subdomain_id_bytes],
 	    AC_HELP_STRING([--with-subdomain-id-bytes=<1|2|4|8>],
-                           [bytes of storage per element used to store the subdomain_id]),
+                           [bytes of storage per element used to store the subdomain_id [2]]),
 	    [subdomain_bytes="$withval"],
 	    [subdomain_bytes=2])
 
@@ -249,7 +249,7 @@ AC_MSG_RESULT([configuring size of subdomain_id... $subdomain_bytes])
 # -------------------------------------------------------------
 AC_ARG_ENABLE(everything,
               AC_HELP_STRING([--enable-everything],
-                             [treat all applicable options as enabled]),
+                             [enable all non-conflicting options]),
               enableeverything=$enableval,
               enableeverything=no)
 
@@ -282,7 +282,7 @@ fi
 # -------------------------------------------------------------
 AC_ARG_WITH([unique_id_bytes],
 	    AC_HELP_STRING([--with-unique-id-bytes=<1|2|4|8>],
-                           [bytes used per unique id]),
+                           [bytes used per unique id [4]]),
 	    [unique_bytes="$withval"],
 	    [unique_bytes=8])
 
@@ -334,8 +334,8 @@ fi
 # AMR -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(amr,
-              AC_HELP_STRING([--enable-amr],
-                             [build with adaptive mesh refinement (AMR) suppport]),
+              AC_HELP_STRING([--disable-amr],
+                             [build without adaptive mesh refinement (AMR) suppport]),
               enableamr=$enableval,
               enableamr=yes)
 
@@ -352,8 +352,8 @@ fi
 # Variational smoother -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(vsmoother,
-              AC_HELP_STRING([--enable-vsmoother],
-                             [build with variational smoother suppport]),
+              AC_HELP_STRING([--disable-vsmoother],
+                             [build without variational smoother suppport]),
               enablevsmoother=$enableval,
               enablevsmoother=yes)
 
@@ -370,8 +370,8 @@ fi
 # Periodic BCs -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(periodic,
-              AC_HELP_STRING([--enable-periodic],
-                             [build with periodic boundary condition suppport]),
+              AC_HELP_STRING([--disable-periodic],
+                             [build without periodic boundary condition suppport]),
               enableperiodic=$enableval,
               enableperiodic=yes)
 
@@ -388,8 +388,8 @@ fi
 # Dirichlet BC constraints -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(dirichlet,
-              AC_HELP_STRING([--enable-dirichlet],
-                             [build with Dirichlet boundary constraint support]),
+              AC_HELP_STRING([--disable-dirichlet],
+                             [build without Dirichlet boundary constraint support]),
               enabledirichlet=$enableval,
               enabledirichlet=yes)
 
@@ -421,11 +421,11 @@ fi
 
 
 # -------------------------------------------------------------
-# Mesh == ParallelMesh -- disabled until it's debugged/finished
+# Mesh == ParallelMesh -- disabled by default for max compatibility
 # -------------------------------------------------------------
 AC_ARG_ENABLE(parmesh,
               AC_HELP_STRING([--enable-parmesh],
-                             [Use experimental ParallelMesh as Mesh]),
+                             [Use distributed ParallelMesh as Mesh]),
               enableparmesh=$enableval,
               enableparmesh=no)
 
@@ -443,8 +443,8 @@ fi
 # Ghosted instead of Serial local vectors -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(ghosted,
-              AC_HELP_STRING([--enable-ghosted],
-                             [Use ghosted local vectors when available]),
+              AC_HELP_STRING([--disable-ghosted],
+                             [Use dense instead of sparse/ghosted local vectors]),
               enableghosted=$enableval,
               enableghosted=yes)
 
@@ -462,8 +462,8 @@ fi
 #  elements -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(node-valence,
-              AC_HELP_STRING([--enable-node-valence],
-                             [Compute and store node valence values]),
+              AC_HELP_STRING([--disable-node-valence],
+                             [Do not compute and store node valence values]),
               enablenodevalence=$enableval,
               enablenodevalence=yes)
 
@@ -511,8 +511,8 @@ fi
 # higher order shapes -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(pfem,
-              AC_HELP_STRING([--enable-pfem],
-                             [build with support for higher order p-FEM shapes]),
+              AC_HELP_STRING([--disable-pfem],
+                             [build without support for higher p order FEM shapes]),
               enablepfem=$enableval,
               enablepfem=yes)
 
@@ -550,8 +550,8 @@ AM_CONDITIONAL(LIBMESH_ENABLE_INFINITE_ELEMENTS, test x$enableifem != no )
 # Second Derivative Calculations -- disabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(second,
-              AC_HELP_STRING([--enable-second],
-                             [build with second derivatives]),
+              AC_HELP_STRING([--disable-second],
+                             [build without second derivatives support]),
               enablesecond=$enableval,
               enablesecond=yes)
 
@@ -568,8 +568,8 @@ fi
 # XDR binary IO support - enabled by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(xdr,
-              AC_HELP_STRING([--enable-xdr],
-                             [enable XDR platform-independent binary I/O]),
+              AC_HELP_STRING([--disable-xdr],
+                             [build without XDR platform-independent binary I/O]),
               enablexdr=$enableval,
               enablexdr=yes)
 
@@ -607,7 +607,7 @@ fi
 # -------------------------------------------------------------
 AC_ARG_ENABLE(complex,
               AC_HELP_STRING([--enable-complex],
-                             [build with complex number support]),
+                             [build to support complex-number solutions]),
  	      [case "${enableval}" in
 	          yes)  enablecomplex=yes ;;
 		   no)  enablecomplex=no ;;
@@ -635,8 +635,8 @@ AM_CONDITIONAL(LIBMESH_ENABLE_COMPLEX, test x$enablecomplex = xyes)
 # Reference Counting -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(reference-counting,
-              AC_HELP_STRING([--enable-reference-counting],
-                             [build with reference counting suppport]),
+              AC_HELP_STRING([--disable-reference-counting],
+                             [build without reference counting support]),
               enablerefct=$enableval,
               enablerefct=yes)
 
@@ -675,8 +675,8 @@ fi
 # Examples - enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(examples,
-              AC_HELP_STRING([--enable-examples],
-                             [support compilation, installation, & running example suite]),
+              AC_HELP_STRING([--disable-examples],
+                             [Do not compile, install, or test with example suite]),
  	      [case "${enableval}" in
 	          yes)  enableexamples=yes ;;
 		   no)  enableexamples=no ;;

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -35,8 +35,8 @@ libmesh_installed_LIBS=""
 # Allow for disable-optional
 # --------------------------------------------------------------
 AC_ARG_ENABLE(optional,
-              AC_HELP_STRING([--enable-optional],
-                             [en/disable optional external libraries]),
+              AC_HELP_STRING([--disable-optional],
+                             [build without most optional external libraries]),
 	      [case "${enableval}" in
 	      	  yes) enableoptional=yes ;;
 		   no) enableoptional=no ;;
@@ -76,8 +76,8 @@ AC_ARG_ENABLE(strict-lgpl,
 # Allow for disable-nested
 # --------------------------------------------------------------
 AC_ARG_ENABLE(nested,
-              AC_HELP_STRING([--enable-nested],
-                             [en/disable nested autoconf subpackages]),
+              AC_HELP_STRING([--disable-nested],
+                             [Do not use nested autoconf subpackages]),
 	      [case "${enableval}" in
 	      	  yes) enablenested=yes ;;
 		   no) enablenested=no ;;
@@ -151,8 +151,8 @@ fi
 # Pthread support -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(pthreads,
-              AC_HELP_STRING([--enable-pthreads],
-                             [build with threading support via POSIX threads (pthreads)]),
+              AC_HELP_STRING([--disable-pthreads],
+                             [build without POSIX threading (pthreads) support]),
 		[case "${enableval}" in
 		  yes)  enablepthreads=yes ;;
 		   no)  enablepthreads=no ;;
@@ -180,8 +180,8 @@ fi
 # C++ Thread Support  -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(cppthreads,
-             AC_HELP_STRING([--enable-cppthreads],
-                            [Build with C++ std::thread support]),
+             AC_HELP_STRING([--disable-cppthreads],
+                            [Build without C++ std::thread support]),
              enablecppthreads=$enableval,
              enablecppthreads=yes)
 if (test "$enablecppthreads" != no) ; then
@@ -249,8 +249,8 @@ AC_CONFIG_FILES([contrib/gzstream/Makefile])
 # Compressed Files with bzip2
 # -------------------------------------------------------------
 AC_ARG_ENABLE(bzip2,
-              AC_HELP_STRING([--enable-bzip2],
-                             [build with bzip2 compressed I/O suppport]),
+              AC_HELP_STRING([--disable-bzip2],
+                             [build without bzip2 compressed I/O suppport]),
               enablebz2=$enableval,
               enablebz2=$enableoptional)
 
@@ -273,8 +273,8 @@ fi
 # Compressed Files with xz
 # -------------------------------------------------------------
 AC_ARG_ENABLE(xz,
-              AC_HELP_STRING([--enable-xz],
-                             [build with xz compressed I/O suppport]),
+              AC_HELP_STRING([--disable-xz],
+                             [build without xz compressed I/O suppport]),
               enablexz=$enableval,
               enablexz=$enableoptional)
 
@@ -550,8 +550,8 @@ AC_CONFIG_FILES([contrib/fparser/extrasrc/Makefile])
 # cppunit C++ unit testing -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(cppunit,
-             AC_HELP_STRING([--enable-cppunit],
-                            [Build with cppunit C++ unit testing support]),
+             AC_HELP_STRING([--disable-cppunit],
+                            [Build without cppunit C++ unit testing support]),
 		[case "${enableval}" in
 		  yes)  enablecppunit=yes ;;
 		   no)  enablecppunit=no ;;

--- a/m4/metis.m4
+++ b/m4/metis.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_METIS],
 [
   AC_ARG_ENABLE(metis,
-                AC_HELP_STRING([--enable-metis],
-                               [build with Metis graph partitioning suppport]),
+                AC_HELP_STRING([--disable-metis],
+                               [build without Metis graph partitioning suppport]),
 		[case "${enableval}" in
 		  yes)  enablemetis=yes ;;
 		   no)  enablemetis=no ;;

--- a/m4/nanoflann.m4
+++ b/m4/nanoflann.m4
@@ -4,8 +4,8 @@
 AC_DEFUN([CONFIGURE_NANOFLANN],
 [
   AC_ARG_ENABLE(nanoflann,
-                AC_HELP_STRING([--enable-nanoflann],
-                               [build with space-filling curves suppport]),
+                AC_HELP_STRING([--disable-nanoflann],
+                               [build without nanoflann KD-tree suppport]),
 		[case "${enableval}" in
 		  yes)  enablenanoflann=yes ;;
 		   no)  enablenanoflann=no ;;

--- a/m4/nemesis.m4
+++ b/m4/nemesis.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_NEMESIS],
 [
   AC_ARG_ENABLE(nemesis,
-                AC_HELP_STRING([--enable-nemesis],
-                               [build with NemesisII API support]),
+                AC_HELP_STRING([--disable-nemesis],
+                               [build without NemesisII API support]),
 		[case "${enableval}" in
 		  yes|new|v522) enablenemesis=yes ; nemesisversion="v5.22" ;;
 		      old|v309) enablenemesis=yes ; nemesisversion="v3.09" ;;

--- a/m4/netcdf.m4
+++ b/m4/netcdf.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_NETCDF],
 [
   AC_ARG_ENABLE(netcdf,
-                AC_HELP_STRING([--enable-netcdf],
-                               [build with netCDF binary I/O]),
+                AC_HELP_STRING([--disable-netcdf],
+                               [build without netCDF binary I/O]),
 		[case "${enableval}" in
                   yes|new|v4) enablenetcdf=yes; netcdfversion=4  ;;
 		      old|v3) enablenetcdf=yes; netcdfversion=3  ;;

--- a/m4/parmetis.m4
+++ b/m4/parmetis.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_PARMETIS],
 [
   AC_ARG_ENABLE(parmetis,
-                AC_HELP_STRING([--enable-parmetis],
-                               [build with Parmetis parallel graph partitioning suppport]),
+                AC_HELP_STRING([--disable-parmetis],
+                               [build without Parmetis parallel graph partitioning suppport]),
 		[case "${enableval}" in
 		  yes)  enableparmetis=yes ;;
 		   no)  enableparmetis=no ;;

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -4,8 +4,8 @@
 AC_DEFUN([CONFIGURE_PETSC],
 [
   AC_ARG_ENABLE(petsc,
-                AC_HELP_STRING([--enable-petsc],
-                               [build with PETSc iterative solver suppport]),
+                AC_HELP_STRING([--disable-petsc],
+                               [build without PETSc iterative solver suppport]),
 		[case "${enableval}" in
 		  yes)  enablepetsc=yes ;;
 		   no)  enablepetsc=no ;;

--- a/m4/sfc.m4
+++ b/m4/sfc.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_SFC],
 [
   AC_ARG_ENABLE(sfc,
-                AC_HELP_STRING([--enable-sfc],
-                               [build with space-filling curves suppport]),
+                AC_HELP_STRING([--disable-sfc],
+                               [build without space-filling curves suppport]),
 		[case "${enableval}" in
 		  yes)  enablesfc=yes ;;
 		   no)  enablesfc=no ;;

--- a/m4/slepc.m4
+++ b/m4/slepc.m4
@@ -4,8 +4,8 @@
 AC_DEFUN([CONFIGURE_SLEPC],
 [
   AC_ARG_ENABLE(slepc,
-                AC_HELP_STRING([--enable-slepc],
-                               [build with SLEPc eigen solver support]),
+                AC_HELP_STRING([--disable-slepc],
+                               [build without SLEPc eigen solver support]),
 		[case "${enableval}" in
 		  yes)  enableslepc=yes ;;
 		   no)  enableslepc=no ;;

--- a/m4/tbb.m4
+++ b/m4/tbb.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TBB],
 [
   AC_ARG_ENABLE(tbb,
-                AC_HELP_STRING([--enable-tbb],
-                               [build with threading support via Threading Building Blocks]),
+                AC_HELP_STRING([--disable-tbb],
+                               [build without threading support via Threading Building Blocks]),
 		[case "${enableval}" in
 		  yes)  enabletbb=yes ;;
 		   no)  enabletbb=no ;;

--- a/m4/tecio.m4
+++ b/m4/tecio.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TECIO],
 [
   AC_ARG_ENABLE(tecio,
-                AC_HELP_STRING([--enable-tecio],
-                               [build with Tecplot TecIO API support (from source)]),
+                AC_HELP_STRING([--disable-tecio],
+                               [build without Tecplot TecIO API support (from source)]),
 		[case "${enableval}" in
 		  yes)  enabletecio=yes ;;
 		   no)  enabletecio=no ;;

--- a/m4/tetgen.m4
+++ b/m4/tetgen.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TETGEN],
 [
   AC_ARG_ENABLE(tetgen,
-                AC_HELP_STRING([--enable-tetgen],
-                               [build with TetGen tetrahedrization library support]),
+                AC_HELP_STRING([--disable-tetgen],
+                               [build without TetGen tetrahedrization library support]),
 		[case "${enableval}" in
 		  yes)  enabletetgen=yes ;;
 		   no)  enabletetgen=no ;;

--- a/m4/triangle.m4
+++ b/m4/triangle.m4
@@ -4,8 +4,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TRIANGLE],
 [
   AC_ARG_ENABLE(triangle,
-                AC_HELP_STRING([--enable-triangle],
-                               [build with Triangle Delaunay triangulation library support]),
+                AC_HELP_STRING([--disable-triangle],
+                               [build without Triangle Delaunay triangulation library support]),
 		[case "${enableval}" in
 		  yes)  enabletriangle=yes ;;
 		   no)  enabletriangle=no ;;

--- a/m4/trilinos.m4
+++ b/m4/trilinos.m4
@@ -449,8 +449,8 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TRILINOS],
 [
   AC_ARG_ENABLE(trilinos,
-                AC_HELP_STRING([--enable-trilinos],
-                               [build with Trilinos support]),
+                AC_HELP_STRING([--disable-trilinos],
+                               [build without Trilinos support]),
 		[case "${enableval}" in
 		  yes)  enabletrilinos=yes ;;
 		   no)  enabletrilinos=no ;;

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -7,8 +7,8 @@ AC_DEFUN([CONFIGURE_VTK],
   AC_ARG_VAR([VTK_DIR],     [path to VTK installation])
 
   AC_ARG_ENABLE(vtk,
-                AC_HELP_STRING([--enable-vtk],
-                               [build with VTK file I/O support]),
+                AC_HELP_STRING([--disable-vtk],
+                               [build without VTK file I/O support]),
 		[case "${enableval}" in
 		  yes)  enablevtk=yes ;;
 		   no)  enablevtk=no ;;


### PR DESCRIPTION
This should solve Issue #249

Most of these changes turn the help message from "--enable-foo" to
"--disable-foo" for values of foo that are on by default.  A few
changes add the default argument in brackets to the help message.
