### PR TITLE
Use contrib/ eigen when 3rd party eigen is bad

### DIFF
--- a/configure
+++ b/configure
@@ -32780,6 +32780,48 @@ fi
 done
 
 
+    # Check to make sure the external header files are sufficiently up
+    # to date - this fixes our Eigen detection on Scientific Linux 6
+    if (test x$externaleigenincFound = xyes); then
+        ac_eigen_save_CPPFLAGS="$CPPFLAGS"
+	CPPFLAGS="-I${EIGEN_INC} ${CPPFLAGS}"
+
+	for ac_header in Eigen/Dense
+do :
+  ac_fn_cxx_check_header_mongrel "$LINENO" "Eigen/Dense" "ac_cv_header_Eigen_Dense" "$ac_includes_default"
+if test "x$ac_cv_header_Eigen_Dense" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EIGEN_DENSE 1
+_ACEOF
+
+else
+  enableeigenincFound=no
+fi
+
+done
+
+
+        if (test x$enableeigensparse = xyes); then
+	    for ac_header in Eigen/Sparse
+do :
+  ac_fn_cxx_check_header_mongrel "$LINENO" "Eigen/Sparse" "ac_cv_header_Eigen_Sparse" "$ac_includes_default"
+if test "x$ac_cv_header_Eigen_Sparse" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EIGEN_SPARSE 1
+_ACEOF
+
+else
+  enableeigenincFound=no
+fi
+
+done
+
+        fi
+
+	CPPFLAGS="${ac_eigen_save_CPPFLAGS}"
+    fi
+
+
     if (test x$externaleigenincFound = xyes); then
         EIGEN_INCLUDE="-I$EIGEN_INC"
     elif (test -d $top_srcdir/contrib/eigen/eigen); then

--- a/m4/eigen.m4
+++ b/m4/eigen.m4
@@ -78,6 +78,22 @@ AC_DEFUN([CONFIGURE_EIGEN],
     externaleigenincFound=no;
     AC_CHECK_HEADERS($EIGEN_INC/Eigen/Eigen, externaleigenincFound=yes)
 
+    # Check to make sure the external header files are sufficiently up
+    # to date - this fixes our Eigen detection on Scientific Linux 6
+    if (test x$externaleigenincFound = xyes); then
+        ac_eigen_save_CPPFLAGS="$CPPFLAGS"
+	CPPFLAGS="-I${EIGEN_INC} ${CPPFLAGS}"
+
+	AC_CHECK_HEADERS([Eigen/Dense],[],[enableeigenincFound=no])
+
+        if (test x$enableeigensparse = xyes); then
+	    AC_CHECK_HEADERS([Eigen/Sparse],[],[enableeigenincFound=no])
+        fi
+
+	CPPFLAGS="${ac_eigen_save_CPPFLAGS}"
+    fi
+
+
     if (test x$externaleigenincFound = xyes); then
         EIGEN_INCLUDE="-I$EIGEN_INC"
     elif (test -d $top_srcdir/contrib/eigen/eigen); then


### PR DESCRIPTION
Currently if we detect 3rd party Eigen installations but have trouble
compiling Eigen headers (e.g. with old versions of Eigen/Sparse) we
disable eigen entirely.  We should fall back on the contrib/ Eigen
instead.

This fixes Eigen detection on ScientificLinux 6 for me.  If we ever bump up our Eigen version requirements, though, we'll need a more extensive fix.
