### PR TITLE
icc 13.1 doesn't like C++ code included in C files

### DIFF
--- a/contrib/qhull/2012.1/src/libqhull/qhull_a.h
+++ b/contrib/qhull/2012.1/src/libqhull/qhull_a.h
@@ -102,13 +102,13 @@
 #elif defined(__MWERKS__) && defined(__INTEL__)
 #   define QHULL_OS_WIN
 #endif
-#if defined(__INTEL_COMPILER) && !defined(QHULL_OS_WIN)
-template <typename T>
-inline void qhullUnused(T &x) { (void)x; }
-#  define QHULL_UNUSED(x) qhullUnused(x);
-#else
+//#if defined(__INTEL_COMPILER) && !defined(QHULL_OS_WIN)
+//template <typename T>
+//inline void qhullUnused(T &x) { (void)x; }
+//#  define QHULL_UNUSED(x) qhullUnused(x);
+//#else
 #  define QHULL_UNUSED(x) (void)x;
-#endif
+//#endif
 
 /***** -libqhull.c prototypes (alphabetical after qhull) ********************/
 


### PR DESCRIPTION
But it does like the non-intel workaround just fine, so let's just use
that regardless.
