### PR TITLE
Fix for -Wliteral-suffix C++11 warning

### DIFF
--- a/configure
+++ b/configure
@@ -34500,7 +34500,7 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
-$as_echo "#define BUILD_DATE __DATE__\" \"__TIME__" >>confdefs.h
+$as_echo "#define BUILD_DATE __DATE__ \" \" __TIME__" >>confdefs.h
 
 
 

--- a/m4/config_environment.m4
+++ b/m4/config_environment.m4
@@ -65,7 +65,7 @@ AC_DEFINE_UNQUOTED([BUILD_ARCH],     "${BUILD_ARCH}",     [Architecture of the b
 AC_DEFINE_UNQUOTED([BUILD_HOST],     "${BUILD_HOST}",     [Build host name])
 AC_DEFINE_UNQUOTED([BUILD_VERSION],  "${BUILD_VERSION}",  [SVN revision])
 AC_DEFINE_UNQUOTED([BUILD_DEVSTATUS],"${BUILD_DEVSTATUS}",[Dev/Release build])
-AC_DEFINE(         [BUILD_DATE],     __DATE__" "__TIME__, [Build date])
+AC_DEFINE(         [BUILD_DATE],     __DATE__ " " __TIME__, [Build date])
 
 AC_SUBST(BUILD_USER)
 AC_SUBST(BUILD_ARCH)


### PR DESCRIPTION
In C++11, concatenation of literal and preprocessor strings requires
an intervening space so as to avoid conflicting with the new string
suffix syntax.  g++ seems to be only warning about this for now, but
let's fix it before they turn it into an error.
