### PR TITLE
allow installcheck targets to do some parallel forking

### DIFF
--- a/contrib/bin/test_installed_examples.sh
+++ b/contrib/bin/test_installed_examples.sh
@@ -2,7 +2,12 @@
 #set -e
 #env
 
-n_concurrent=5
+# Respect the JOBS environment variable, if it is set
+if [ -n "$JOBS" ]; then
+    n_concurrent=$JOBS
+else
+    n_concurrent=5
+fi
 
 # Terminal commands to goto specific columns
 rescol=65;

--- a/contrib/bin/test_installed_headers.sh
+++ b/contrib/bin/test_installed_headers.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 #set -e
 
-n_concurrent=20
+# Respect the JOBS environment variable, if it is set
+if [ -n "$JOBS" ]; then
+    n_concurrent=$JOBS
+else
+    n_concurrent=20
+fi
 
 #echo MAKEFLAGS=$MAKEFLAGS
 


### PR DESCRIPTION
@jwpeterson, what do you think?  This implements what we just discussed.  

ATM n_concurrent is hardcoded as the number of compiles to execute in parallel, but that could be improved.
