### PR TITLE
Tone down AutoDiff error reporting and make it switch-offable

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -9,14 +9,16 @@ using namespace FUNCTIONPARSERTYPES;
 template<typename Value_t>
 FunctionParserADBase<Value_t>::FunctionParserADBase() :
     FunctionParserBase<Value_t>(),
-    mData(this->getParserData())
+    mData(this->getParserData()),
+    mSilenceErrors(false)
 {
 }
 
 template<typename Value_t>
 FunctionParserADBase<Value_t>::FunctionParserADBase(const FunctionParserADBase& cpy) :
     FunctionParserBase<Value_t>(cpy),
-    mData(this->getParserData())
+    mData(this->getParserData()),
+    mSilenceErrors(cpy.mSilenceErrors)
 {
 }
 
@@ -554,7 +556,12 @@ int FunctionParserADBase<Value_t>::AutoDiff(const std::string& var)
   }
   catch(std::exception &e)
   {
-    std::cerr << "AutoDiff exception: " << e.what() << std::endl;
+    static bool printed_error = false;
+    if (!printed_error && !mSilenceErrors)
+    {
+      std::cerr << "AutoDiff exception: " << e.what() << " (this message will only be shown once per process)"<< std::endl;
+      printed_error = true;
+    }
     setZero();
     return 0;
   }

--- a/contrib/fparser/fparser_ad.hh
+++ b/contrib/fparser/fparser_ad.hh
@@ -30,6 +30,11 @@ public:
    */
   void setZero();
 
+  /**
+   * Do not report any error messages to the console
+   */
+  void silenceAutoDiffErrors(bool _silence = true) { mSilenceErrors = _silence; }
+
 protected:
   /**
    * A list of opcodes and immediate values
@@ -65,8 +70,14 @@ private:
   /// variable to diff for
   unsigned mVarOp;
 
-  // write the DiffProgramFragement into the internal bytecode storage
+  /// write the DiffProgramFragement into the internal bytecode storage
   void Commit(const DiffProgramFragment & code);
+
+  /**
+   * In certain applications derivatives are built proactively and may never be used.
+   * We silence all AutoDiff exceptions in that case to avoid confusing the user.
+   */
+  bool mSilenceErrors;
 
   // Exceptions
   class UnsupportedOpcode : public std::exception {

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -121,6 +121,10 @@ public:
         if (fp.Parse(subexpression, variables) != -1) // -1 for success
           libmesh_error_msg("ERROR: FunctionParser is unable to parse expression: " << subexpression << '\n' << fp.ErrorMsg());
 
+        // use of derivatives is optional. suppress error output on the console
+        // use the has_derivatives() method to check if AutoDiff was successful.
+        fp.silenceAutoDiffErrors();
+
         // generate derivatives through automatic differentiation
         FunctionParserADBase<Output> dx_fp(fp);
         if (dx_fp.AutoDiff("x") != -1) // -1 for success


### PR DESCRIPTION
In certain applications, such as ParsedFunction, derivatives are build proactively and may never be used. We silence all AutoDiff exceptions in that case to avoid confusing the user. 
It is up to the user to verify that the derivatives of a ParsedFunction were build successfully.
This adresses #269 
