### PR TITLE
Detect cJump opcodes in FParser AutoDiff

### DIFF
--- a/contrib/fparser/examples/autodiff.cc
+++ b/contrib/fparser/examples/autodiff.cc
@@ -30,7 +30,8 @@ int main()
 
   //std::string func = "sin(x^2)";
   //std::string func = "sin(3*x)+x*5*sin(3*x)+x^2*(3+sin(3*x))";
-  std::string func = "x^(-1/2)";
+  std::string func = "if(x<x*x,x^(-1/2),5)";
+//std::string func = "5+if(x<x*x,1,3)*6+x";
 
 
   // Parse the input expression into bytecode
@@ -49,7 +50,7 @@ int main()
   FunctionParserAD fparser2(fparser);
 
   // Generate derivative with respect to x
-  fparser.AutoDiff("x");
+  std::cout << "AutoDiff returned " << fparser.AutoDiff("x") << std::endl;
   std::cout << "Unsimplified derivative:\n";
   fparser.PrintByteCode(std::cout);
   std::cout << std::endl;

--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -511,6 +511,8 @@ int FunctionParserADBase<Value_t>::AutoDiff(const std::string& var)
         Interval arg = GetArgument(orig);
         orig.insert(orig.end(), arg.first, arg.second);
       }
+      else if (op == cJump)
+        throw UnsupportedOpcodeException;
       else if (op == cFetch)
       {
         // get index and advance instruction counter
@@ -522,7 +524,7 @@ int FunctionParserADBase<Value_t>::AutoDiff(const std::string& var)
       }
       else if (op == cSinCos)
       {
-        // this instructuon puts two values on the stack!
+        // this instruction puts two values on the stack!
         Interval arg = GetArgument(orig);
         DiffProgramFragment sub(arg.first, arg.second);
         orig.push_back(OpcodeDataPair(cSin, 0.0));


### PR DESCRIPTION
The AutoDiff code silently ignored the unsupported use of an `if()` statement and dis not throw an error like it was supposed to. This is a quick fix, but I will have to sit down and figure out why this is not working as intended. 

Without this fix invalid bytecode will be generated by AutoDiff in certain cases. Eval'ing it will result in a segfault. This error has existed for quite a while, but I only uncovered it now, as I test more thoroughly for unsupported derivatives and proper error status return :-/

I'll work on this a bit more tomorrow.
