### PR TITLE
Fix FParser AD compilation with --disable-threads

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -443,7 +443,7 @@ void FunctionParserADBase<Value_t>::Commit(const DiffProgramFragment & diff)
   }
 
 #ifndef FP_USE_THREAD_SAFE_EVAL
-  mData->mStack.resize(mData->stackSize);
+  mData->mStack.resize(mData->mStackSize);
 #endif
 }
 


### PR DESCRIPTION
Is this the right fix?  I'm still running "make check" to see if this works at all at runtime.
