### PR TITLE
AC_HELP_STRING -> AS_HELP_STRING

### DIFF
--- a/m4/all_static.m4
+++ b/m4/all_static.m4
@@ -6,7 +6,7 @@
 AC_DEFUN([AX_ALL_STATIC],
 [
   AC_ARG_ENABLE(all-static,
-                [AC_HELP_STRING([--enable-all-static],[Pass -all-static to libtool's link mode])],
+                [AS_HELP_STRING([--enable-all-static],[Pass -all-static to libtool's link mode])],
                 enableallstatic=$enableval,
                 enableallstatic=no)
 

--- a/m4/blas.m4
+++ b/m4/blas.m4
@@ -40,7 +40,7 @@ acx_blas_ok=no
 acx_blas_save_LIBS="$LIBS"
 
 AC_ARG_WITH(blas,
-            AC_HELP_STRING([--with-blas=<lib>], [use BLAS library <lib>]))
+            AS_HELP_STRING([--with-blas=<lib>], [use BLAS library <lib>]))
 case $with_blas in
 	yes | "") ;;
 	no) acx_blas_ok=disable ;;

--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -5,7 +5,7 @@
 AC_DEFUN([CONFIGURE_BOOST],
 [
   AC_ARG_ENABLE(boost,
-                AC_HELP_STRING([--disable-boost],
+                AS_HELP_STRING([--disable-boost],
                                [build without either external or built-in BOOST support]),
    	        [case "${enableval}" in
   	      	  yes)  enableboost=yes ;;

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -11,7 +11,7 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
      #                             smart about which compilers to look for
      # -------------------------------------------------------------------
      AC_ARG_ENABLE(mpi,
-                   AC_HELP_STRING([--disable-mpi],
+                   AS_HELP_STRING([--disable-mpi],
                                   [build without MPI message passing support]),
    		   [case "${enableval}" in
    		     yes)  enablempi=yes ;;
@@ -27,7 +27,7 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
   fi
 
   AC_ARG_WITH([cxx],
-  	    AC_HELP_STRING([--with-cxx=CXX],
+  	    AS_HELP_STRING([--with-cxx=CXX],
                              [C++ compiler to use]),
   	    [CXX="$withval"],
   	    [])
@@ -57,7 +57,7 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
     CC_TRY_LIST="mpicc $CC_TRY_LIST"
   fi
   AC_ARG_WITH([cc],
-  	    AC_HELP_STRING([--with-cc=CC],
+  	    AS_HELP_STRING([--with-cc=CC],
                              [C compiler to use]),
   	    [CC="$withval"],
   	    [])
@@ -83,7 +83,7 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
   # --disable-fortran
   # --------------------------------------------------------------
   AC_ARG_ENABLE(fortran,
-                AC_HELP_STRING([--disable-fortran],
+                AS_HELP_STRING([--disable-fortran],
                                [build without Fortran language support]),
 		[case "${enableval}" in
 		  yes)  enablefortran=yes ;;
@@ -101,7 +101,7 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
       FC_TRY_LIST="mpif90 $FC_TRY_LIST"
     fi
     AC_ARG_WITH([fc],
-    	    AC_HELP_STRING([--with-fc=FC],
+    	    AS_HELP_STRING([--with-fc=FC],
                                [Fortran compiler to use]),
     	    [FC="$withval"],
     	    [])
@@ -127,7 +127,7 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
       F77_TRY_LIST="mpif77 $F77_TRY_LIST"
     fi
     AC_ARG_WITH([f77],
-    	    AC_HELP_STRING([--with-f77=F77],
+    	    AS_HELP_STRING([--with-f77=F77],
                                [Fortran compiler to use]),
     	    [F77="$withval"],
     	    [])
@@ -529,7 +529,7 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
   # in the case blocks below we may add GLIBCXX-specific pedantic debugging preprocessor
   # definitions. however, allow the knowing user to preclude that if they need to.
   AC_ARG_ENABLE(glibcxx-debugging,
-	 [AC_HELP_STRING([--disable-glibcxx-debugging],
+	 [AS_HELP_STRING([--disable-glibcxx-debugging],
 	                 [omit -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC even in dbg mode])],
 	 [case "${enableval}" in
 	   yes)  enableglibcxxdebugging=yes ;;

--- a/m4/coverage.m4
+++ b/m4/coverage.m4
@@ -25,7 +25,7 @@
 AC_DEFUN([AX_CODE_COVERAGE],
 [
 
-AC_ARG_ENABLE(coverage, AC_HELP_STRING([--enable-coverage],[configure code coverage analysis tools]))
+AC_ARG_ENABLE(coverage, AS_HELP_STRING([--enable-coverage],[configure code coverage analysis tools]))
 
 HAVE_GCOV_TOOLS=0
 

--- a/m4/eigen.m4
+++ b/m4/eigen.m4
@@ -22,7 +22,7 @@
 AC_DEFUN([CONFIGURE_EIGEN],
 [
   AC_ARG_ENABLE(eigen,
-                AC_HELP_STRING([--disable-eigen],
+                AS_HELP_STRING([--disable-eigen],
                                [build without Eigen linear algebra support]),
 		[case "${enableval}" in
 		  yes)  enableeigen=yes ;;
@@ -41,7 +41,7 @@ AC_DEFUN([CONFIGURE_EIGEN],
 
     # User-specific include path
     AC_ARG_WITH(eigen-include,
-                AC_HELP_STRING([--with-eigen-include=PATH],[Specify the path for EIGEN header files]),
+                AS_HELP_STRING([--with-eigen-include=PATH],[Specify the path for EIGEN header files]),
                 witheigeninc=$withval,
                 witheigeninc=no)
 

--- a/m4/exodus.m4
+++ b/m4/exodus.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_EXODUS],
 [
   AC_ARG_ENABLE(exodus,
-                AC_HELP_STRING([--disable-exodus],
+                AS_HELP_STRING([--disable-exodus],
                                [build without ExodusII API support]),
 		[case "${enableval}" in
 		  yes|new|v522)  enableexodus=yes; exodusversion="v5.22" ;;
@@ -44,7 +44,7 @@ AC_DEFUN([CONFIGURE_EXODUS],
 	  AC_DEFINE(HAVE_EXODUS_API, 1, [Flag indicating whether the library will be compiled with Exodus support])
 	  AC_MSG_RESULT(<<< Configuring library with Exodus version $exodusversion support >>>)
 	  AC_ARG_ENABLE(exodus-fortran,
-	                AC_HELP_STRING([--enable-exodus-fortran],
+	                AS_HELP_STRING([--enable-exodus-fortran],
 			               [build with ExodusII Fortran API support]),
 			[case "${enableval}" in
 			    yes)  enableexodusfortran=yes; ;;

--- a/m4/fparser.m4
+++ b/m4/fparser.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([CONFIGURE_FPARSER],
 [
   AC_ARG_ENABLE([fparser],
-                AC_HELP_STRING([--disable-fparser],
+                AS_HELP_STRING([--disable-fparser],
                                [build without C++ function parser support]),
 		[case "${enableval}" in
 		  yes)  enablefparser=yes ;;
@@ -14,7 +14,7 @@ AC_DEFUN([CONFIGURE_FPARSER],
 		 [enablefparser=$enableoptional])
 
   AC_ARG_WITH([fparser],
-	       AC_HELP_STRING([--with-fparser=<release|none|devel>],
+	       AS_HELP_STRING([--with-fparser=<release|none|devel>],
                               [Determine which version of the C++ function parser to use]),
 	      [case "${withval}" in
 		  release)  enablefparserdevel=no  ;;
@@ -29,7 +29,7 @@ AC_DEFUN([CONFIGURE_FPARSER],
 
 
     AC_ARG_ENABLE(fparser-debugging,
-                  AC_HELP_STRING([--enable-fparser-debugging],
+                  AS_HELP_STRING([--enable-fparser-debugging],
                                  [Build fparser with bytecode debugging functions]),
 		[case "${enableval}" in
 		  yes)  enablefparserdebugging=yes ;;
@@ -39,7 +39,7 @@ AC_DEFUN([CONFIGURE_FPARSER],
                  [enablefparserdebugging=no])
 
     AC_ARG_ENABLE(fparser-optimizer,
-                  AC_HELP_STRING([--disable-fparser-optimizer],
+                  AS_HELP_STRING([--disable-fparser-optimizer],
                                  [do not optimize parsed functions]),
 		[case "${enableval}" in
 		  yes)  enablefparseroptimizer=yes ;;

--- a/m4/glpk.m4
+++ b/m4/glpk.m4
@@ -10,7 +10,7 @@
 AC_DEFUN([CONFIGURE_GLPK],
 [
   AC_ARG_ENABLE(glpk,
-                AC_HELP_STRING([--disable-glpk],
+                AS_HELP_STRING([--disable-glpk],
                                [build without GLPK support]),
 		[case "${enableval}" in
 		  yes)  enableglpk=yes ;;
@@ -24,13 +24,13 @@ AC_DEFUN([CONFIGURE_GLPK],
 
     # User-specific include path
     AC_ARG_WITH(glpk-include,
-                AC_HELP_STRING([--with-glpk-include=PATH],[Specify the path for GLPK header files]),
+                AS_HELP_STRING([--with-glpk-include=PATH],[Specify the path for GLPK header files]),
                 withglpkinc=$withval,
                 withglpkinc=no)
 
     # User-specific library path
     AC_ARG_WITH(glpk-lib,
-                AC_HELP_STRING([--with-glpk-lib=PATH],[Specify the path for GLPK libs]),
+                AS_HELP_STRING([--with-glpk-lib=PATH],[Specify the path for GLPK libs]),
                 withglpklib=$withval,
                 withglpklib=no)
 

--- a/m4/gmv.m4
+++ b/m4/gmv.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_GMV],
 [
   AC_ARG_ENABLE(gmv,
-                AC_HELP_STRING([--disable-gmv],
+                AS_HELP_STRING([--disable-gmv],
                                [build without GMV file I/O support]),
 		[case "${enableval}" in
 		  yes)  enablegmv=yes ;;

--- a/m4/gz.m4
+++ b/m4/gz.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([CONFIGURE_GZ],
 [
   AC_ARG_ENABLE(gzstreams,
-                AC_HELP_STRING([--disable-gzstreams],
+                AS_HELP_STRING([--disable-gzstreams],
                                [build without gzstreams compressed I/O suppport]),
 		[case "${enableval}" in
 		  yes)  enablegz=yes ;;

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([CONFIGURE_HDF5],
 [
   AC_ARG_ENABLE(hdf5,
-                AC_HELP_STRING([--disable-hdf5],
+                AS_HELP_STRING([--disable-hdf5],
                                [build without HDF5 support]),
 		[case "${enableval}" in
 		  yes)  enablehdf5=yes ;;

--- a/m4/lapack.m4
+++ b/m4/lapack.m4
@@ -36,7 +36,7 @@ AC_REQUIRE([ACX_BLAS])
 acx_lapack_ok=no
 
 AC_ARG_WITH(lapack,
-            AC_HELP_STRING([--with-lapack=<lib>], [use LAPACK library <lib>]))
+            AS_HELP_STRING([--with-lapack=<lib>], [use LAPACK library <lib>]))
 case $with_lapack in
         yes | "") ;;
         no) acx_lapack_ok=disable ;;

--- a/m4/laspack.m4
+++ b/m4/laspack.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_LASPACK],
 [
   AC_ARG_ENABLE(laspack,
-                AC_HELP_STRING([--disable-laspack],
+                AS_HELP_STRING([--disable-laspack],
                                [build without LASPACK iterative solver suppport]),
 		[case "${enableval}" in
 		  yes)  enablelaspack=yes ;;

--- a/m4/libhilbert.m4
+++ b/m4/libhilbert.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_LIBHILBERT],
 [
   AC_ARG_ENABLE(libHilbert,
-                AC_HELP_STRING([--disable-libHilbert],
+                AS_HELP_STRING([--disable-libHilbert],
                                [build without Chris Hamilton's libHilbert]),
 		[case "${enableval}" in
 		  yes)  enablelibhilbert=yes ;;

--- a/m4/libmesh_compiler_features.m4
+++ b/m4/libmesh_compiler_features.m4
@@ -65,7 +65,7 @@ AC_C_RESTRICT
 # --disable-getpwuid.
 # --------------------------------------------------------------
 AC_ARG_ENABLE(getpwuid,
-              AC_HELP_STRING([--disable-getpwuid],
+              AS_HELP_STRING([--disable-getpwuid],
                              [do not make calls to getpwuid]),
               enablegetpwuid=$enableval,
               enablegetpwuid=yes)
@@ -83,7 +83,7 @@ fi
 # C++ exceptions - enabled by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(exceptions,
-              AC_HELP_STRING([--disable-exceptions],
+              AS_HELP_STRING([--disable-exceptions],
                              [exit rather than throw exceptions on unexpected errors]),
               enableexceptions=$enableval,
               enableexceptions=yes)
@@ -139,7 +139,7 @@ AC_CHECK_HEADERS(xmmintrin.h)
 AC_HAVE_FEEXCEPT
 
 AC_ARG_ENABLE(unordered-containers,
-              AC_HELP_STRING([--disable-unordered-containers],
+              AS_HELP_STRING([--disable-unordered-containers],
                              [Use map/set instead of unordered_map/unordered_set]),
               enableunorderedcontainers=$enableval,
               enableunorderedcontainers=yes)
@@ -166,7 +166,7 @@ AX_CXX_GLIBC_BACKTRACE
 # OpenMP Support  -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(openmp,
-             AC_HELP_STRING([--disable-openmp],
+             AS_HELP_STRING([--disable-openmp],
                             [Build without OpenMP Support]),
              enableopenmp=$enableval,
              enableopenmp=yes)

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -11,7 +11,7 @@ AC_MSG_RESULT(---------------------------------------------)
 # library warnings - enable by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(warnings,
-              [AC_HELP_STRING([--disable-warnings],[Do not warn about deprecated, experimental, or questionable code])],
+              [AS_HELP_STRING([--disable-warnings],[Do not warn about deprecated, experimental, or questionable code])],
               enablewarnings=$enableval,
               enablewarnings=yes)
 
@@ -32,7 +32,7 @@ fi
 #   See http://sourceforge.net/mailarchive/forum.php?thread_name=B4613A7D-0033-43C7-A9DF-5A801217A097%40nasa.gov&forum_name=libmesh-devel
 # --------------------------------------------------------------
 AC_ARG_ENABLE(blocked-storage,
-              [AC_HELP_STRING([--enable-blocked-storage],[Support for blocked matrix/vector storage])],
+              [AS_HELP_STRING([--enable-blocked-storage],[Support for blocked matrix/vector storage])],
               enableblockedstorage=$enableval,
               enableblockedstorage=no)
 
@@ -48,7 +48,7 @@ fi
 # default comm_world - now disabled by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(default-comm-world,
-              [AC_HELP_STRING([--enable-default-comm-world],[Provide global libMesh::CommWorld])],
+              [AS_HELP_STRING([--enable-default-comm-world],[Provide global libMesh::CommWorld])],
               enabledefaultcommworld=$enableval,
               enabledefaultcommworld=no)
 
@@ -68,7 +68,7 @@ fi
 # legacy include paths - disabled by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(legacy-include-paths,
-              [AC_HELP_STRING([--enable-legacy-include-paths],[allow for e.g. #include "header.h" instead of #include "libmesh/header.h"])],
+              [AS_HELP_STRING([--enable-legacy-include-paths],[allow for e.g. #include "header.h" instead of #include "libmesh/header.h"])],
               enablelegacyincludepaths=$enableval,
               enablelegacyincludepaths=no)
 
@@ -86,7 +86,7 @@ fi
 # legacy "using namespace libMesh" - disabled by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(legacy-using-namespace,
-              [AC_HELP_STRING([--enable-legacy-using-namespace],[add "using namespace libMesh" to libMesh headers])],
+              [AS_HELP_STRING([--enable-legacy-using-namespace],[add "using namespace libMesh" to libMesh headers])],
               enablelegacyusingnamespace=$enableval,
               enablelegacyusingnamespace=no)
 
@@ -106,7 +106,7 @@ fi
 # size of boundary_id_type -- default 2 bytes
 # -------------------------------------------------------------
 AC_ARG_WITH([boundary_id_bytes],
-	    AC_HELP_STRING([--with-boundary-id-bytes=<1|2|4|8>],
+	    AS_HELP_STRING([--with-boundary-id-bytes=<1|2|4|8>],
                            [bytes used per boundary side per boundary_id [2]]),
 	    [boundary_bytes="$withval"],
 	    [boundary_bytes=2])
@@ -139,7 +139,7 @@ AC_MSG_RESULT([configuring size of boundary_id... $boundary_bytes])
 # size of dof_id_type -- default 4 bytes
 # -------------------------------------------------------------
 AC_ARG_WITH([dof_id_bytes],
-	    AC_HELP_STRING([--with-dof-id-bytes=<1|2|4|8>],
+	    AS_HELP_STRING([--with-dof-id-bytes=<1|2|4|8>],
                            [bytes used per dof object id, dof index [4]]),
 	    [dof_bytes="$withval"],
 	    [dof_bytes=4])
@@ -172,7 +172,7 @@ AC_MSG_RESULT([configuring size of dof_id... $dof_bytes])
 # size of processor_id_type -- default 4 bytes
 # -------------------------------------------------------------
 AC_ARG_WITH([processor_id_bytes],
-	    AC_HELP_STRING([--with-processor-id-bytes=<1|2|4|8>],
+	    AS_HELP_STRING([--with-processor-id-bytes=<1|2|4|8>],
                            [bytes used for processor id [4]]),
 	    [processor_bytes="$withval"],
 	    [processor_bytes=2])
@@ -205,7 +205,7 @@ AC_MSG_RESULT([configuring size of processor_id... $processor_bytes])
 # size of subdomain_id_type -- default 2 bytes
 # -------------------------------------------------------------
 AC_ARG_WITH([subdomain_id_bytes],
-	    AC_HELP_STRING([--with-subdomain-id-bytes=<1|2|4|8>],
+	    AS_HELP_STRING([--with-subdomain-id-bytes=<1|2|4|8>],
                            [bytes of storage per element used to store the subdomain_id [2]]),
 	    [subdomain_bytes="$withval"],
 	    [subdomain_bytes=2])
@@ -248,7 +248,7 @@ AC_MSG_RESULT([configuring size of subdomain_id... $subdomain_bytes])
 #
 # -------------------------------------------------------------
 AC_ARG_ENABLE(everything,
-              AC_HELP_STRING([--enable-everything],
+              AS_HELP_STRING([--enable-everything],
                              [enable all non-conflicting options]),
               enableeverything=$enableval,
               enableeverything=no)
@@ -259,7 +259,7 @@ AC_ARG_ENABLE(everything,
 # unique_id -- disable by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(unique-id,
-              AC_HELP_STRING([--enable-unique-id],
+              AS_HELP_STRING([--enable-unique-id],
                              [build with unique id suppport]),
 	      [case "${enableval}" in
 	          yes)  enableuniqueid=yes ;;
@@ -281,7 +281,7 @@ fi
 # size of unique_id_type -- default 8 bytes
 # -------------------------------------------------------------
 AC_ARG_WITH([unique_id_bytes],
-	    AC_HELP_STRING([--with-unique-id-bytes=<1|2|4|8>],
+	    AS_HELP_STRING([--with-unique-id-bytes=<1|2|4|8>],
                            [bytes used per unique id [4]]),
 	    [unique_bytes="$withval"],
 	    [unique_bytes=8])
@@ -317,7 +317,7 @@ fi
 # Write stack trace output files on error() - disabled by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(tracefiles,
-              AC_HELP_STRING([--enable-tracefiles],
+              AS_HELP_STRING([--enable-tracefiles],
                              [write stack trace files on unexpected errors]),
               enabletracefiles=$enableval,
               enabletracefiles=$enableeverything)
@@ -334,7 +334,7 @@ fi
 # AMR -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(amr,
-              AC_HELP_STRING([--disable-amr],
+              AS_HELP_STRING([--disable-amr],
                              [build without adaptive mesh refinement (AMR) suppport]),
               enableamr=$enableval,
               enableamr=yes)
@@ -352,7 +352,7 @@ fi
 # Variational smoother -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(vsmoother,
-              AC_HELP_STRING([--disable-vsmoother],
+              AS_HELP_STRING([--disable-vsmoother],
                              [build without variational smoother suppport]),
               enablevsmoother=$enableval,
               enablevsmoother=yes)
@@ -370,7 +370,7 @@ fi
 # Periodic BCs -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(periodic,
-              AC_HELP_STRING([--disable-periodic],
+              AS_HELP_STRING([--disable-periodic],
                              [build without periodic boundary condition suppport]),
               enableperiodic=$enableval,
               enableperiodic=yes)
@@ -388,7 +388,7 @@ fi
 # Dirichlet BC constraints -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(dirichlet,
-              AC_HELP_STRING([--disable-dirichlet],
+              AS_HELP_STRING([--disable-dirichlet],
                              [build without Dirichlet boundary constraint support]),
               enabledirichlet=$enableval,
               enabledirichlet=yes)
@@ -406,7 +406,7 @@ fi
 # NodeConstraints -- disabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(nodeconstraint,
-              AC_HELP_STRING([--enable-nodeconstraint],
+              AS_HELP_STRING([--enable-nodeconstraint],
                              [build with node constraints suppport]),
               enablenodeconstraint=$enableval,
               enablenodeconstraint=$enableeverything)
@@ -424,7 +424,7 @@ fi
 # Mesh == ParallelMesh -- disabled by default for max compatibility
 # -------------------------------------------------------------
 AC_ARG_ENABLE(parmesh,
-              AC_HELP_STRING([--enable-parmesh],
+              AS_HELP_STRING([--enable-parmesh],
                              [Use distributed ParallelMesh as Mesh]),
               enableparmesh=$enableval,
               enableparmesh=no)
@@ -443,7 +443,7 @@ fi
 # Ghosted instead of Serial local vectors -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(ghosted,
-              AC_HELP_STRING([--disable-ghosted],
+              AS_HELP_STRING([--disable-ghosted],
                              [Use dense instead of sparse/ghosted local vectors]),
               enableghosted=$enableval,
               enableghosted=yes)
@@ -462,7 +462,7 @@ fi
 #  elements -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(node-valence,
-              AC_HELP_STRING([--disable-node-valence],
+              AS_HELP_STRING([--disable-node-valence],
                              [Do not compute and store node valence values]),
               enablenodevalence=$enableval,
               enablenodevalence=yes)
@@ -480,13 +480,13 @@ fi
 # 1D or 1D/2D only -- disabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(1D-only,
-              AC_HELP_STRING([--enable-1D-only],
+              AS_HELP_STRING([--enable-1D-only],
                              [build with support for 1D meshes only]),
               enable1D=$enableval,
               enable1D=no)
 
 AC_ARG_ENABLE(2D-only,
-              AC_HELP_STRING([--enable-2D-only],
+              AS_HELP_STRING([--enable-2D-only],
                              [build with support for 1D and 2D meshes only]),
               enable2D=$enableval,
               enable2D=no)
@@ -511,7 +511,7 @@ fi
 # higher order shapes -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(pfem,
-              AC_HELP_STRING([--disable-pfem],
+              AS_HELP_STRING([--disable-pfem],
                              [build without support for higher p order FEM shapes]),
               enablepfem=$enableval,
               enablepfem=yes)
@@ -529,7 +529,7 @@ fi
 # Infinite Elements  -- disabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(ifem,
-              AC_HELP_STRING([--enable-ifem],
+              AS_HELP_STRING([--enable-ifem],
                              [build with infinite elements]),
               enableifem=$enableval,
               enableifem=$enableeverything)
@@ -550,7 +550,7 @@ AM_CONDITIONAL(LIBMESH_ENABLE_INFINITE_ELEMENTS, test x$enableifem != no )
 # Second Derivative Calculations -- disabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(second,
-              AC_HELP_STRING([--disable-second],
+              AS_HELP_STRING([--disable-second],
                              [build without second derivatives support]),
               enablesecond=$enableval,
               enablesecond=yes)
@@ -568,7 +568,7 @@ fi
 # XDR binary IO support - enabled by default
 # --------------------------------------------------------------
 AC_ARG_ENABLE(xdr,
-              AC_HELP_STRING([--disable-xdr],
+              AS_HELP_STRING([--disable-xdr],
                              [build without XDR platform-independent binary I/O]),
               enablexdr=$enableval,
               enablexdr=yes)
@@ -606,7 +606,7 @@ fi
 # complex numbers -- disabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(complex,
-              AC_HELP_STRING([--enable-complex],
+              AS_HELP_STRING([--enable-complex],
                              [build to support complex-number solutions]),
  	      [case "${enableval}" in
 	          yes)  enablecomplex=yes ;;
@@ -635,7 +635,7 @@ AM_CONDITIONAL(LIBMESH_ENABLE_COMPLEX, test x$enablecomplex = xyes)
 # Reference Counting -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(reference-counting,
-              AC_HELP_STRING([--disable-reference-counting],
+              AS_HELP_STRING([--disable-reference-counting],
                              [build without reference counting support]),
               enablerefct=$enableval,
               enablerefct=yes)
@@ -657,7 +657,7 @@ fi
 # Performance Logging -- disabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(perflog,
-              AC_HELP_STRING([--enable-perflog],
+              AS_HELP_STRING([--enable-perflog],
                              [build with performance logging turned on]),
               enableperflog=$enableval,
               enableperflog=$enableeverything)
@@ -675,7 +675,7 @@ fi
 # Examples - enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(examples,
-              AC_HELP_STRING([--disable-examples],
+              AS_HELP_STRING([--disable-examples],
                              [Do not compile, install, or test with example suite]),
  	      [case "${enableval}" in
 	          yes)  enableexamples=yes ;;

--- a/m4/libmesh_method.m4
+++ b/m4/libmesh_method.m4
@@ -12,7 +12,7 @@
 #  # accept --with-method=METHOD.  but default to $METHOD, which is either set
 #  # by the user already or defaulted to opt above
 #  AC_ARG_WITH(method,
-#              AC_HELP_STRING([--with-method=METHOD],
+#              AS_HELP_STRING([--with-method=METHOD],
 #                             [method used to build libMesh (opt,dbg,devel,oprofile)]),
 #              [case "${withval}" in
 #                   opt)   METHOD=opt   ;;
@@ -97,7 +97,7 @@ AC_DEFUN([LIBMESH_SET_METHODS],
  # accept --with-methods=METHODS.  but default to $METHODS, which is either set
  # by the user already or defaulted above
  AC_ARG_WITH(methods,
-             AC_HELP_STRING([--with-methods=METHODS],
+             AS_HELP_STRING([--with-methods=METHODS],
                             [methods used to build libMesh (opt,dbg,devel,prof,oprof)]),
              [for method in ${withval} ; do
                 # make sure each method specified makes sense

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -35,7 +35,7 @@ libmesh_installed_LIBS=""
 # Allow for disable-optional
 # --------------------------------------------------------------
 AC_ARG_ENABLE(optional,
-              AC_HELP_STRING([--disable-optional],
+              AS_HELP_STRING([--disable-optional],
                              [build without most optional external libraries]),
 	      [case "${enableval}" in
 	      	  yes) enableoptional=yes ;;
@@ -62,7 +62,7 @@ fi
 # support.
 # --------------------------------------------------------------
 AC_ARG_ENABLE(strict-lgpl,
-              AC_HELP_STRING([--disable-strict-lgpl],
+              AS_HELP_STRING([--disable-strict-lgpl],
                              [Compile libmesh with even non-LGPL-compatible contrib libraries]),
               [case "${enableval}" in
                   yes) enablestrictlgpl=yes ;;
@@ -76,7 +76,7 @@ AC_ARG_ENABLE(strict-lgpl,
 # Allow for disable-nested
 # --------------------------------------------------------------
 AC_ARG_ENABLE(nested,
-              AC_HELP_STRING([--disable-nested],
+              AS_HELP_STRING([--disable-nested],
                              [Do not use nested autoconf subpackages]),
 	      [case "${enableval}" in
 	      	  yes) enablenested=yes ;;
@@ -151,7 +151,7 @@ fi
 # Pthread support -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(pthreads,
-              AC_HELP_STRING([--disable-pthreads],
+              AS_HELP_STRING([--disable-pthreads],
                              [build without POSIX threading (pthreads) support]),
 		[case "${enableval}" in
 		  yes)  enablepthreads=yes ;;
@@ -180,7 +180,7 @@ fi
 # C++ Thread Support  -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(cppthreads,
-             AC_HELP_STRING([--disable-cppthreads],
+             AS_HELP_STRING([--disable-cppthreads],
                             [Build without C++ std::thread support]),
              enablecppthreads=$enableval,
              enablecppthreads=yes)
@@ -249,7 +249,7 @@ AC_CONFIG_FILES([contrib/gzstream/Makefile])
 # Compressed Files with bzip2
 # -------------------------------------------------------------
 AC_ARG_ENABLE(bzip2,
-              AC_HELP_STRING([--disable-bzip2],
+              AS_HELP_STRING([--disable-bzip2],
                              [build without bzip2 compressed I/O suppport]),
               enablebz2=$enableval,
               enablebz2=$enableoptional)
@@ -273,7 +273,7 @@ fi
 # Compressed Files with xz
 # -------------------------------------------------------------
 AC_ARG_ENABLE(xz,
-              AC_HELP_STRING([--disable-xz],
+              AS_HELP_STRING([--disable-xz],
                              [build without xz compressed I/O suppport]),
               enablexz=$enableval,
               enablexz=$enableoptional)
@@ -563,7 +563,7 @@ AC_CONFIG_FILES([contrib/fparser/extrasrc/Makefile])
 # cppunit C++ unit testing -- enabled by default
 # -------------------------------------------------------------
 AC_ARG_ENABLE(cppunit,
-             AC_HELP_STRING([--disable-cppunit],
+             AS_HELP_STRING([--disable-cppunit],
                             [Build without cppunit C++ unit testing support]),
 		[case "${enableval}" in
 		  yes)  enablecppunit=yes ;;

--- a/m4/metis.m4
+++ b/m4/metis.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_METIS],
 [
   AC_ARG_ENABLE(metis,
-                AC_HELP_STRING([--disable-metis],
+                AS_HELP_STRING([--disable-metis],
                                [build without Metis graph partitioning suppport]),
 		[case "${enableval}" in
 		  yes)  enablemetis=yes ;;
@@ -14,7 +14,7 @@ AC_DEFUN([CONFIGURE_METIS],
 		 [enablemetis=$enableoptional])
 
  AC_ARG_WITH(metis,
-             AC_HELP_STRING([--with-metis=<internal,PETSc>],
+             AS_HELP_STRING([--with-metis=<internal,PETSc>],
                             [metis to use.
 			      interal: build from contrib.
 			      PETSc: rely on PETSc]),

--- a/m4/mpi.m4
+++ b/m4/mpi.m4
@@ -9,7 +9,7 @@ if (test "x$MPIHOME" = x) ; then
 fi
 
 AC_ARG_WITH([mpi],
-	    AC_HELP_STRING([--with-mpi=PATH],
+	    AS_HELP_STRING([--with-mpi=PATH],
                            [Prefix where MPI is installed (MPIHOME)]),
 	    [MPI="$withval"],
 	    [
@@ -94,7 +94,7 @@ if (test -e $MPI_LIBS_PATH/libmpich.a || test -e $MPI_LIBS_PATH/libmpich.so) ; t
             GMHOME="/usr"
           fi
           AC_ARG_WITH([gm],
-	              AC_HELP_STRING([--with-gm=PATH],
+	              AS_HELP_STRING([--with-gm=PATH],
                                      [Prefix where GM is installed (GMHOME)]),
 		      [GM="$withval"],
 		      [

--- a/m4/nanoflann.m4
+++ b/m4/nanoflann.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([CONFIGURE_NANOFLANN],
 [
   AC_ARG_ENABLE(nanoflann,
-                AC_HELP_STRING([--disable-nanoflann],
+                AS_HELP_STRING([--disable-nanoflann],
                                [build without nanoflann KD-tree suppport]),
 		[case "${enableval}" in
 		  yes)  enablenanoflann=yes ;;

--- a/m4/nemesis.m4
+++ b/m4/nemesis.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_NEMESIS],
 [
   AC_ARG_ENABLE(nemesis,
-                AC_HELP_STRING([--disable-nemesis],
+                AS_HELP_STRING([--disable-nemesis],
                                [build without NemesisII API support]),
 		[case "${enableval}" in
 		  yes|new|v522) enablenemesis=yes ; nemesisversion="v5.22" ;;

--- a/m4/netcdf.m4
+++ b/m4/netcdf.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_NETCDF],
 [
   AC_ARG_ENABLE(netcdf,
-                AC_HELP_STRING([--disable-netcdf],
+                AS_HELP_STRING([--disable-netcdf],
                                [build without netCDF binary I/O]),
 		[case "${enableval}" in
                   yes|new|v4) enablenetcdf=yes; netcdfversion=4  ;;

--- a/m4/parmetis.m4
+++ b/m4/parmetis.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_PARMETIS],
 [
   AC_ARG_ENABLE(parmetis,
-                AC_HELP_STRING([--disable-parmetis],
+                AS_HELP_STRING([--disable-parmetis],
                                [build without Parmetis parallel graph partitioning suppport]),
 		[case "${enableval}" in
 		  yes)  enableparmetis=yes ;;

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([CONFIGURE_PETSC],
 [
   AC_ARG_ENABLE(petsc,
-                AC_HELP_STRING([--disable-petsc],
+                AS_HELP_STRING([--disable-petsc],
                                [build without PETSc iterative solver suppport]),
 		[case "${enableval}" in
 		  yes)  enablepetsc=yes ;;

--- a/m4/precision.m4
+++ b/m4/precision.m4
@@ -5,19 +5,19 @@ dnl ----------------------------------------------------------------------------
 AC_DEFUN([ACX_CHOOSE_PRECISION],
 [
 AC_ARG_ENABLE(singleprecision,
-              AC_HELP_STRING([--enable-singleprecision],
+              AS_HELP_STRING([--enable-singleprecision],
                              [Use single-precision scalars]),
               enablesingleprecision=$enableval,
               enablesingleprecision=no)
 
 AC_ARG_ENABLE(tripleprecision,
-              AC_HELP_STRING([--enable-tripleprecision],
+              AS_HELP_STRING([--enable-tripleprecision],
                              [Use triple-precision scalars]),
               enabletripleprecision=$enableval,
               enabletripleprecision=no)
 
 AC_ARG_ENABLE(quadrupleprecision,
-              AC_HELP_STRING([--enable-quadrupleprecision],
+              AS_HELP_STRING([--enable-quadrupleprecision],
                              [Use quadruple-precision scalars]),
               enablequadrupleprecision=$enableval,
               enablequadrupleprecision=no)

--- a/m4/qhull.m4
+++ b/m4/qhull.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([CONFIGURE_QHULL],
 [
   AC_ARG_ENABLE(qhull,
-                AC_HELP_STRING([--enable-qhull],
+                AS_HELP_STRING([--enable-qhull],
                                [build with Qhull API support]),
 		[case "${enableval}" in
 		  yes)  enableqhull=yes;;

--- a/m4/sfc.m4
+++ b/m4/sfc.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_SFC],
 [
   AC_ARG_ENABLE(sfc,
-                AC_HELP_STRING([--disable-sfc],
+                AS_HELP_STRING([--disable-sfc],
                                [build without space-filling curves suppport]),
 		[case "${enableval}" in
 		  yes)  enablesfc=yes ;;

--- a/m4/slepc.m4
+++ b/m4/slepc.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([CONFIGURE_SLEPC],
 [
   AC_ARG_ENABLE(slepc,
-                AC_HELP_STRING([--disable-slepc],
+                AS_HELP_STRING([--disable-slepc],
                                [build without SLEPc eigen solver support]),
 		[case "${enableval}" in
 		  yes)  enableslepc=yes ;;

--- a/m4/tbb.m4
+++ b/m4/tbb.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TBB],
 [
   AC_ARG_ENABLE(tbb,
-                AC_HELP_STRING([--disable-tbb],
+                AS_HELP_STRING([--disable-tbb],
                                [build without threading support via Threading Building Blocks]),
 		[case "${enableval}" in
 		  yes)  enabletbb=yes ;;
@@ -17,12 +17,12 @@ AC_DEFUN([CONFIGURE_TBB],
   if (test $enabletbb = yes); then
 
     AC_ARG_WITH(tbb,
-                AC_HELP_STRING([--with-tbb=PATH],[Specify the path where Threading Building Blocks is installed]),
+                AS_HELP_STRING([--with-tbb=PATH],[Specify the path where Threading Building Blocks is installed]),
                 withtbb=$withval,
                 withtbb=$TBB_DIR)
 
     AC_ARG_WITH(tbb-lib,
-                AC_HELP_STRING([--with-tbb-lib=PATH],[Specify the path to Threading Building Blocks libraries]),
+                AS_HELP_STRING([--with-tbb-lib=PATH],[Specify the path to Threading Building Blocks libraries]),
                 withtbblib=$withval,
                 withtbblib=$TBB_LIB_PATH)
 

--- a/m4/tecio.m4
+++ b/m4/tecio.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TECIO],
 [
   AC_ARG_ENABLE(tecio,
-                AC_HELP_STRING([--disable-tecio],
+                AS_HELP_STRING([--disable-tecio],
                                [build without Tecplot TecIO API support (from source)]),
 		[case "${enableval}" in
 		  yes)  enabletecio=yes ;;
@@ -14,7 +14,7 @@ AC_DEFUN([CONFIGURE_TECIO],
 		 [enabletecio=$enableoptional])
 
   AC_ARG_WITH(tecio-x11-include,
-              AC_HELP_STRING([--with-tecio-x11-include=PATH],
+              AS_HELP_STRING([--with-tecio-x11-include=PATH],
                              [Path to X11 header files. E.g. /usr/include but _not_ /usr/include/X11]),
               withteciox11inc=$withval,
               withteciox11inc=no)

--- a/m4/tecplot.m4
+++ b/m4/tecplot.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([CONFIGURE_TECPLOT],
 [
   AC_ARG_ENABLE(tecplot,
-                AC_HELP_STRING([--enable-tecplot],
+                AS_HELP_STRING([--enable-tecplot],
                                [build with Tecplot binary file I/O support (using distributed libraries)]),
 		[case "${enableval}" in
 		  yes)  enabletecplot=yes ;;

--- a/m4/tetgen.m4
+++ b/m4/tetgen.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TETGEN],
 [
   AC_ARG_ENABLE(tetgen,
-                AC_HELP_STRING([--disable-tetgen],
+                AS_HELP_STRING([--disable-tetgen],
                                [build without TetGen tetrahedrization library support]),
 		[case "${enableval}" in
 		  yes)  enabletetgen=yes ;;

--- a/m4/triangle.m4
+++ b/m4/triangle.m4
@@ -4,7 +4,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TRIANGLE],
 [
   AC_ARG_ENABLE(triangle,
-                AC_HELP_STRING([--disable-triangle],
+                AS_HELP_STRING([--disable-triangle],
                                [build without Triangle Delaunay triangulation library support]),
 		[case "${enableval}" in
 		  yes)  enabletriangle=yes ;;

--- a/m4/trilinos.m4
+++ b/m4/trilinos.m4
@@ -13,7 +13,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_10],
   fi
 
   AC_ARG_WITH(trilinos,
-              AC_HELP_STRING([--with-trilinos=PATH],[Specify the path to Trilinos installation]),
+              AS_HELP_STRING([--with-trilinos=PATH],[Specify the path to Trilinos installation]),
               withtrilinosdir=$withval,
               withtrilinosdir=$TRILINOS_DIR)
 
@@ -185,7 +185,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_9],
   fi
 
   AC_ARG_WITH(trilinos,
-              AC_HELP_STRING([--with-trilinos=PATH],[Specify the path to Trilinos installation]),
+              AS_HELP_STRING([--with-trilinos=PATH],[Specify the path to Trilinos installation]),
               withtrilinosdir=$withval,
               withtrilinosdir=$TRILINOS_DIR)
 
@@ -213,7 +213,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_9],
 
   dnl Nox
   AC_ARG_WITH(nox,
-              AC_HELP_STRING([--with-nox=PATH],[Specify the path to Nox installation]),
+              AS_HELP_STRING([--with-nox=PATH],[Specify the path to Nox installation]),
               withnoxdir=$withval,
               withnoxdir=$TRILINOS_DIR)
 
@@ -240,7 +240,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_9],
 
   dnl ML
   AC_ARG_WITH(ml,
-              AC_HELP_STRING([--with-ml=PATH],[Specify the path to ML installation]),
+              AS_HELP_STRING([--with-ml=PATH],[Specify the path to ML installation]),
               withmldir=$withval,
               withmldir=$TRILINOS_DIR)
 
@@ -265,7 +265,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_9],
 
   dnl Tpetra
   AC_ARG_WITH(tpetra,
-              AC_HELP_STRING([--with-tpetra=PATH],[Specify the path to Tpetra installation]),
+              AS_HELP_STRING([--with-tpetra=PATH],[Specify the path to Tpetra installation]),
               withtpetradir=$withval,
               withtpetradir=$TRILINOS_DIR)
 
@@ -292,7 +292,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_9],
 
   dnl DTK
   AC_ARG_WITH(dtk,
-              AC_HELP_STRING([--with-dtk=PATH],[Specify the path to Dtk installation]),
+              AS_HELP_STRING([--with-dtk=PATH],[Specify the path to Dtk installation]),
               withdtkdir=$withval,
               withdtkdir=$TRILINOS_DIR)
 
@@ -449,7 +449,7 @@ dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TRILINOS],
 [
   AC_ARG_ENABLE(trilinos,
-                AC_HELP_STRING([--disable-trilinos],
+                AS_HELP_STRING([--disable-trilinos],
                                [build without Trilinos support]),
 		[case "${enableval}" in
 		  yes)  enabletrilinos=yes ;;

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -7,7 +7,7 @@ AC_DEFUN([CONFIGURE_VTK],
   AC_ARG_VAR([VTK_DIR],     [path to VTK installation])
 
   AC_ARG_ENABLE(vtk,
-                AC_HELP_STRING([--disable-vtk],
+                AS_HELP_STRING([--disable-vtk],
                                [build without VTK file I/O support]),
 		[case "${enableval}" in
 		  yes)  enablevtk=yes ;;
@@ -50,13 +50,13 @@ AC_DEFUN([CONFIGURE_VTK],
 
     dnl User-specific include path
     AC_ARG_WITH(vtk-include,
-                AC_HELP_STRING([--with-vtk-include=PATH],[Specify the path for VTK header files]),
+                AS_HELP_STRING([--with-vtk-include=PATH],[Specify the path for VTK header files]),
                 withvtkinc=$withval,
                 withvtkinc=no)
 
     dnl User-specific library path
     AC_ARG_WITH(vtk-lib,
-                AC_HELP_STRING([--with-vtk-lib=PATH],[Specify the path for VTK libs]),
+                AS_HELP_STRING([--with-vtk-lib=PATH],[Specify the path for VTK libs]),
                 withvtklib=$withval,
                 withvtklib=no)
 


### PR DESCRIPTION
AS_HELP_STRING seems to have been in autoconf since 2004.

AC_HELP_STRING is officially obsolete, and apparently some autoconf
versions complain about it.

My version of autoconf thinks they're functionally exactly equivalent,
but since googling AS_HELP_STRING takes you to the correct manual page
and AC_HELP_STRING doesn't, we might as well use the former.
