### PR TITLE
Adding missing boost header necessary for "shared_ptr" support on older ...

### DIFF
--- a/contrib/boost/include/Makefile.am
+++ b/contrib/boost/include/Makefile.am
@@ -25,6 +25,7 @@ if LIBMESH_INSTALL_INTERNAL_BOOST
         boost/memory_order.hpp \
         boost/shared_ptr.hpp \
         boost/smart_ptr/shared_ptr.hpp \
+        boost/utility/addressof.hpp \
         boost/config/no_tr1/memory.hpp \
         boost/throw_exception.hpp \
         boost/exception/detail/attribute_noreturn.hpp \

--- a/contrib/boost/include/Makefile.in
+++ b/contrib/boost/include/Makefile.in
@@ -132,8 +132,8 @@ am__nobase_include_HEADERS_DIST = boost/assert.hpp boost/config.hpp \
 	boost/config/posix_features.hpp boost/config/suffix.hpp \
 	boost/current_function.hpp boost/checked_delete.hpp \
 	boost/memory_order.hpp boost/shared_ptr.hpp \
-	boost/smart_ptr/shared_ptr.hpp boost/config/no_tr1/memory.hpp \
-	boost/throw_exception.hpp \
+	boost/smart_ptr/shared_ptr.hpp boost/utility/addressof.hpp \
+	boost/config/no_tr1/memory.hpp boost/throw_exception.hpp \
 	boost/exception/detail/attribute_noreturn.hpp \
 	boost/detail/workaround.hpp boost/exception/exception.hpp \
 	boost/smart_ptr/detail/shared_count.hpp \
@@ -617,6 +617,7 @@ vtkversion = @vtkversion@
 @LIBMESH_INSTALL_INTERNAL_BOOST_TRUE@        boost/memory_order.hpp \
 @LIBMESH_INSTALL_INTERNAL_BOOST_TRUE@        boost/shared_ptr.hpp \
 @LIBMESH_INSTALL_INTERNAL_BOOST_TRUE@        boost/smart_ptr/shared_ptr.hpp \
+@LIBMESH_INSTALL_INTERNAL_BOOST_TRUE@        boost/utility/addressof.hpp \
 @LIBMESH_INSTALL_INTERNAL_BOOST_TRUE@        boost/config/no_tr1/memory.hpp \
 @LIBMESH_INSTALL_INTERNAL_BOOST_TRUE@        boost/throw_exception.hpp \
 @LIBMESH_INSTALL_INTERNAL_BOOST_TRUE@        boost/exception/detail/attribute_noreturn.hpp \

--- a/contrib/boost/include/boost/utility/addressof.hpp
+++ b/contrib/boost/include/boost/utility/addressof.hpp
@@ -1,0 +1,102 @@
+// Copyright (C) 2002 Brad King (brad.king@kitware.com)
+//                    Douglas Gregor (gregod@cs.rpi.edu)
+//
+// Copyright (C) 2002, 2008 Peter Dimov
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// For more information, see http://www.boost.org
+
+#ifndef BOOST_UTILITY_ADDRESSOF_HPP
+# define BOOST_UTILITY_ADDRESSOF_HPP
+
+# include <boost/config.hpp>
+# include <boost/detail/workaround.hpp>
+
+namespace boost
+{
+
+namespace detail
+{
+
+template<class T> struct addr_impl_ref
+{
+    T & v_;
+
+    inline addr_impl_ref( T & v ): v_( v ) {}
+    inline operator T& () const { return v_; }
+
+private:
+    addr_impl_ref & operator=(const addr_impl_ref &);
+};
+
+template<class T> struct addressof_impl
+{
+    static inline T * f( T & v, long )
+    {
+        return reinterpret_cast<T*>(
+            &const_cast<char&>(reinterpret_cast<const volatile char &>(v)));
+    }
+
+    static inline T * f( T * v, int )
+    {
+        return v;
+    }
+};
+
+} // namespace detail
+
+template<class T> T * addressof( T & v )
+{
+#if (defined( __BORLANDC__ ) && BOOST_WORKAROUND( __BORLANDC__, BOOST_TESTED_AT( 0x610 ) ) ) || defined( __SUNPRO_CC )
+
+    return boost::detail::addressof_impl<T>::f( v, 0 );
+
+#else
+
+    return boost::detail::addressof_impl<T>::f( boost::detail::addr_impl_ref<T>( v ), 0 );
+
+#endif
+}
+
+#if defined( __SUNPRO_CC ) && BOOST_WORKAROUND( __SUNPRO_CC, BOOST_TESTED_AT( 0x590 ) )
+
+namespace detail
+{
+
+template<class T> struct addressof_addp
+{
+    typedef T * type;
+};
+
+} // namespace detail
+
+template< class T, std::size_t N >
+typename detail::addressof_addp< T[N] >::type addressof( T (&t)[N] )
+{
+    return &t;
+}
+
+#endif
+
+// Borland doesn't like casting an array reference to a char reference
+// but these overloads work around the problem.
+#if defined( __BORLANDC__ ) && BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+template<typename T,std::size_t N>
+T (*addressof(T (&t)[N]))[N]
+{
+   return reinterpret_cast<T(*)[N]>(&t);
+}
+
+template<typename T,std::size_t N>
+const T (*addressof(const T (&t)[N]))[N]
+{
+   return reinterpret_cast<const T(*)[N]>(&t);
+}
+#endif
+
+} // namespace boost
+
+#endif // BOOST_UTILITY_ADDRESSOF_HPP


### PR DESCRIPTION
...compilers
