### PR TITLE
PETSc 3.5.0 Fixes

### DIFF
--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -562,9 +562,15 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T>&  jac_in,  // System Jacobian Ma
   ierr = SNESGetLinearSolveIterations(_snes, &_n_linear_iterations);
   LIBMESH_CHKERRABORT(ierr);
 
+#endif
+
+# if PETSC_VERSION_LESS_THAN(3,5,0)
+  // SNESGetFunctionNorm was removed in PETSc 3.5.0
   ierr = SNESGetFunctionNorm(_snes,&final_residual_norm);
   LIBMESH_CHKERRABORT(ierr);
-
+#else
+  ierr = VecNorm(r->vec(),NORM_2,&final_residual_norm);
+  LIBMESH_CHKERRABORT(ierr);
 #endif
 
   // Get and store the reason for convergence


### PR DESCRIPTION
SNESGetFunctionNorm is now removed from PETSc as of 3.5.0. This PR addresses the two spots where that was a problem. I'm less confident about what's going on in the DM nonlinear solver bit (who wrote that code?, doesn't look like there's an example that uses it), but I manually ran the Laplace-Young example to double check the final residual is giving the correct answer.
