### PR TITLE
NewtonSolver: Check for result of linear solve

### DIFF
--- a/include/solvers/diff_solver.h
+++ b/include/solvers/diff_solver.h
@@ -271,7 +271,13 @@ public:
      * The DiffSolver failed to find a descent direction
      * by backtracking (See newton_solver.C)
      */
-    DIVERGED_BACKTRACKING_FAILURE = 128
+    DIVERGED_BACKTRACKING_FAILURE = 128,
+
+    /**
+     * The linear solver used by the DiffSolver failed to
+     * find a solution.
+     */
+    DIVERGED_LINEAR_SOLVER_FAILURE = 256
   };
 
   /**

--- a/include/solvers/newton_solver.h
+++ b/include/solvers/newton_solver.h
@@ -112,6 +112,15 @@ public:
   bool brent_line_search;
 
   /**
+   * If set to true, check for convergence of the linear solve. If no
+   * convergence is acquired during the linear solve, the nonlinear solve
+   * fails with DiffSolver::DIVERGED_LINEAR_SOLVER_FAILURE.
+   * Enabled by default as nonlinear convergence is very difficult, if the
+   * linear solver is not converged.
+   */
+  bool track_linear_convergence;
+
+  /**
    * If the quasi-Newton step length must be reduced to below this
    * factor to give a residual reduction, then the Newton solver
    * dies with an error message.

--- a/src/solvers/newton_solver.C
+++ b/src/solvers/newton_solver.C
@@ -234,6 +234,7 @@ NewtonSolver::NewtonSolver (sys_type& s)
     require_residual_reduction(true),
     require_finite_residual(true),
     brent_line_search(true),
+    track_linear_convergence(true),
     minsteplength(1e-5),
     linear_tolerance_multiplier(1e-3),
     linear_solver(LinearSolver<Number>::build(s.comm()))
@@ -364,6 +365,22 @@ unsigned int NewtonSolver::solve()
         linear_solver->solve (matrix, _system.request_matrix("Preconditioner"),
                               linear_solution, rhs, current_linear_tolerance,
                               max_linear_iterations);
+
+      if (track_linear_convergence)
+        {
+        LinearConvergenceReason linear_c_reason = linear_solver->get_converged_reason();
+
+        // Check if something went wrong during the linear solve
+        if (linear_c_reason < 0)
+          {
+            // The linear solver failed somehow
+            _solve_result |= DiffSolver::DIVERGED_LINEAR_SOLVER_FAILURE;
+            // Print a message
+            libMesh::out << "Linear solver failed during Newton step, dropping out."
+                         << std::endl;
+            break;
+          }
+        }
 
       // We may need to localize a parallel solution
       _system.update ();


### PR DESCRIPTION
The newton solver does not converge if the linear solver has not finished successfully. This patch checks for the result of the linear solve and exits the newton solver with a corresponding message, if there was an error.
The check is enabled by default, but can be disabled by a flag in NewtonSolver.
It has passed a "make check" on my machine
