### PR TITLE
Fixing scalable_allocator declaration.

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -95,7 +95,7 @@ typedef std::map<dof_id_type, Real,
 class DofConstraints : public std::map<dof_id_type,
                                        DofConstraintRow,
                                        std::less<dof_id_type>,
-                                       Threads::scalable_allocator<std::pair<const dof_id_type, Number> > >
+                                       Threads::scalable_allocator<std::pair<const dof_id_type, DofConstraintRow> > >
 {
 };
 


### PR DESCRIPTION
This doesn't fix the valgrind errors we see, but still seems like it was wrong.  Not even sure how this compiled before...
