### PR TITLE
Rebuilding Fpoptimizer

### DIFF
--- a/contrib/fparser/Makefile.orig
+++ b/contrib/fparser/Makefile.orig
@@ -7,7 +7,7 @@
 # The optimizer code generator requires bison.
 #===========================================================================
 
-RELEASE_VERSION=4.5
+RELEASE_VERSION=4.5.1
 
 # The FP_FEATURE_FLAGS is set by run_full_release_testing.sh, but can be
 # used otherwise as well.
@@ -28,13 +28,16 @@ FEATURE_FLAGS += -DFP_SUPPORT_COMPLEX_DOUBLE_TYPE
 FEATURE_FLAGS += -DFP_SUPPORT_COMPLEX_FLOAT_TYPE
 FEATURE_FLAGS += -DFP_SUPPORT_COMPLEX_LONG_DOUBLE_TYPE
 FEATURE_FLAGS += -DFP_USE_STRTOLD
+#FEATURE_FLAGS += -DFP_SUPPORT_CPLUSPLUS11_MATH_FUNCS
 else
 FEATURE_FLAGS = $(FP_FEATURE_FLAGS)
 endif
 
-OPTIMIZATION=-O3 -ffast-math -march=native -fexpensive-optimizations \
-	-fvpt -fomit-frame-pointer -ffunction-cse
+OPTIMIZATION=-O3 -ffast-math -march=native
 #       -ffunction-sections -fdata-sections
+
+# For GCC (not clang):
+OPTIMIZATION += -fexpensive-optimizations -fvpt -fomit-frame-pointer -ffunction-cse
 
 #OPTIMIZATION+=-g
 #OPTIMIZATION=-g -O0 -fno-inline
@@ -44,9 +47,12 @@ OPTIMIZATION=-O3 -ffast-math -march=native -fexpensive-optimizations \
 #OPTIMIZATION=-g -pg
 
 CXX=g++
+#CXX=clang++
 # -m32 -mfpmath=sse
 # -m32 -mfpmath=387
+
 LD=g++
+#LD=clang++
 #LD=g++ -g
 # -m32 -mfpmath=sse
 # -m32 -mfpmath=387
@@ -66,7 +72,7 @@ FEATURE_FLAGS += -DFUNCTIONPARSER_SUPPORT_DEBUGGING
 
 #LD +=  -fprofile -fprofile-values -fprofile-generate -ftest-coverage 
 
-CPPFLAGS=$(FEATURE_FLAGS)
+CPPFLAGS=$(FEATURE_FLAGS) -I../../installed/include/libmesh/
 CXXFLAGS=-Wall -W -pedantic -ansi $(OPTIMIZATION)
 #CXXFLAGS += -Wunreachable-code
 #CXXFLAGS += -std=c++0x
@@ -92,6 +98,10 @@ else
 ifneq (,$(findstring -DFP_USE_THREAD_SAFE_EVAL_WITH_ALLOCA,$(FEATURE_FLAGS)))
 BOOST_THREAD_LIB = -lboost_thread-mt
 endif
+endif
+
+ifneq (,$(findstring -DFP_SUPPORT_CPLUSPLUS11_MATH_FUNCS,$(FEATURE_FLAGS)))
+CXXFLAGS += -std=c++0x
 endif
 
 #LD += -Xlinker --gc-sections

--- a/contrib/fparser/README.rebuild_fpoptimizer
+++ b/contrib/fparser/README.rebuild_fpoptimizer
@@ -1,0 +1,6 @@
+User the upstream Makefile to rebuild the fpoptimizer.cc file (only necessary after changes to source files in the ./fpoptimizer directory)
+
+> rm .dep fpoptimizer.cc
+> make -f Makefile.orig fpoptimizer.cc
+
+Note that the upstream Makefile is patched to add the include path necessary to find libmesh_config.h


### PR DESCRIPTION
The fpoptimizer.cc file is a mushed-together macro compressed file that contains all the stuff from the fpoptimizer directory. This patch adds instructions for rebuilding this file (seldomly needed).
