### PR TITLE
Added access to variable names in ExodusII reader

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -209,6 +209,16 @@ public:
    */
   void append(bool val);
 
+  /**
+   * Return list of the elemental variable names
+   */
+  const std::vector<std::string> & get_elem_var_names();
+
+  /**
+   * Return list of the nodal variable names
+   */
+  const std::vector<std::string> & get_nodal_var_names();
+
 private:
   /**
    * Only attempt to instantiate an ExodusII helper class

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -522,6 +522,17 @@ public:
   // different ExodusII_IO object for each one.
   std::string current_filename;
 
+  /**
+   * Wraps calls to exII::ex_get_var_names() and exII::ex_get_var_param().
+   * The enumeration controls whether nodal, elemental, or global
+   * variable names are read and which class members are filled in.
+   * NODAL:     num_nodal_vars  nodal_var_names
+   * ELEMENTAL: num_elem_vars   elem_var_names
+   * GLOBAL:    num_global_vars global_var_names
+   */
+  enum ExodusVarType {NODAL=0, ELEMENTAL=1, GLOBAL=2};
+  void read_var_names(ExodusVarType type);
+
 protected:
   // If true, whenever there is an I/O operation, only perform if if we are on processor 0.
   bool _run_only_on_proc0;
@@ -547,16 +558,6 @@ protected:
   bool _single_precision;
 
 private:
-  /**
-   * Wraps calls to exII::ex_get_var_names() and exII::ex_get_var_param().
-   * The enumeration controls whether nodal, elemental, or global
-   * variable names are read and which class members are filled in.
-   * NODAL:     num_nodal_vars  nodal_var_names
-   * ELEMENTAL: num_elem_vars   elem_var_names
-   * GLOBAL:    num_global_vars global_var_names
-   */
-  enum ExodusVarType {NODAL=0, ELEMENTAL=1, GLOBAL=2};
-  void read_var_names(ExodusVarType type);
 
   /**
    * Wraps calls to exII::ex_put_var_names() and exII::ex_put_var_param().

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -891,6 +891,17 @@ void ExodusII_IO::write_nodal_data_common(std::string fname,
     }
 }
 
+const std::vector<std::string> & ExodusII_IO::get_nodal_var_names()
+{
+  exio_helper->read_var_names(ExodusII_IO_Helper::NODAL);
+  return exio_helper->nodal_var_names;
+}
+
+const std::vector<std::string> & ExodusII_IO::get_elem_var_names()
+{
+  exio_helper->read_var_names(ExodusII_IO_Helper::ELEMENTAL);
+  return exio_helper->elem_var_names;
+}
 
 
 // LIBMESH_HAVE_EXODUS_API is not defined, declare error() versions of functions...
@@ -1019,6 +1030,17 @@ void ExodusII_IO::write_nodal_data_discontinuous (const std::string&, const std:
 void ExodusII_IO::write_nodal_data_common(std::string,
                                           const std::vector<std::string>&,
                                           bool)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+
+const std::vector<std::string> & ExodusII_IO::elem_var_names()
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+const std::vector<std::string> & ExodusII_IO::nodal_var_names()
 {
   libmesh_error_msg("ERROR, ExodusII API is not defined.");
 }


### PR DESCRIPTION
This was added to allow for more control over system creation from a file within MOOSE.
