### PR TITLE
Added the option to set a close_to_point tolerance in PointLocatorTree

### DIFF
--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -204,6 +204,19 @@ public:
    */
   void disable_out_of_mesh_mode(void);
 
+  /**
+   * We may want to specify a tolerance for the PointLocator to use,
+   * since in some cases the point we want to evaluate at might be
+   * slightly outside the mesh (due to numerical rounding issues,
+   * for example).
+   */
+  void set_point_locator_tolerance(Real tol);
+
+  /**
+   * Turn off the user-specified PointLocator tolerance.
+   */
+  void unset_point_locator_tolerance();
+
 protected:
 
 

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -116,6 +116,18 @@ public:
    */
   virtual void disable_out_of_mesh_mode () = 0;
 
+  /**
+   * Set a tolerance to use when determining
+   * if a point is contained within the mesh.
+   */
+  virtual void set_close_to_point_tol(Real close_to_point_tol);
+
+  /**
+   * Specify that we do not want to use a user-specified tolerance to
+   * determine if a point is contained within the mesh.
+   */
+  virtual void unset_close_to_point_tol();
+
 protected:
   /**
    * Const pointer to our master, initialized to \p NULL if none
@@ -133,6 +145,17 @@ protected:
    * \p true when properly initialized, \p false otherwise.
    */
   bool _initialized;
+
+  /**
+   * \p true if we will use a user-specified tolerance for locating
+   * the element.
+   */
+  bool _use_close_to_point_tol;
+
+  /**
+   * The tolerance to use.
+   */
+  Real _close_to_point_tol;
 };
 
 } // namespace libMesh

--- a/include/utils/point_locator_list.h
+++ b/include/utils/point_locator_list.h
@@ -117,6 +117,18 @@ public:
    */
   virtual void disable_out_of_mesh_mode ();
 
+  /**
+   * Set a tolerance to use when determining
+   * if a point is contained within the mesh.
+   */
+  virtual void set_close_to_point_tol(Real close_to_point_tol);
+
+  /**
+   * Specify that we do not want to use a user-specified tolerance to
+   * determine if a point is contained within the mesh.
+   */
+  virtual void unset_close_to_point_tol();
+
 protected:
   /**
    * Pointer to the list of element centroids.  Only the

--- a/include/utils/point_locator_tree.h
+++ b/include/utils/point_locator_tree.h
@@ -107,6 +107,19 @@ public:
   virtual const Elem* operator() (const Point& p) const;
 
   /**
+   * As a fallback option, it's helpful to be able to do a linear
+   * search over the entire mesh. This can be used if operator()
+   * fails to find an element that contains \p p, for example.
+   * Optionally specify a "close to point" tolerance to use in
+   * the linear search.
+   * Return NULL if no element is found.
+   */
+  const Elem* perform_linear_search(
+    const Point& p,
+    bool use_close_to_point,
+    Real close_to_point_tolerance=TOLERANCE) const;
+
+  /**
    * Enables out-of-mesh mode.  In this mode, if asked to find a point
    * that is contained in no mesh at all, the point locator will
    * return a NULL pointer instead of crashing.  Per default, this

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -582,4 +582,19 @@ void MeshFunction::disable_out_of_mesh_mode(void)
   _out_of_mesh_mode = false;
 }
 
+void MeshFunction::set_point_locator_tolerance(Real tol)
+{
+  // We need to enable out_of_mesh mode in the point_locator
+  // in order for the point locator tolerance to be used.
+  _point_locator->enable_out_of_mesh_mode();
+
+  // Set the tolerance
+  _point_locator->set_close_to_point_tol(tol);
+}
+
+void MeshFunction::unset_point_locator_tolerance()
+{
+  _point_locator->unset_close_to_point_tol();
+}
+
 } // namespace libMesh

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -37,7 +37,9 @@ PointLocatorBase::PointLocatorBase (const MeshBase& mesh,
                                     const PointLocatorBase* master) :
   _master                  (master),
   _mesh                    (mesh),
-  _initialized             (false)
+  _initialized             (false),
+  _use_close_to_point_tol  (false),
+  _close_to_point_tol      (TOLERANCE)
 {
 }
 
@@ -95,6 +97,19 @@ AutoPtr<PointLocatorBase> PointLocatorBase::build (PointLocatorType t,
   libmesh_error_msg("We'll never get here!");
   AutoPtr<PointLocatorBase> ap(NULL);
   return ap;
+}
+
+void PointLocatorBase::set_close_to_point_tol (Real close_to_point_tol)
+{
+  _use_close_to_point_tol = true;
+  _close_to_point_tol = close_to_point_tol;
+}
+
+
+void PointLocatorBase::unset_close_to_point_tol ()
+{
+  _use_close_to_point_tol = false;
+  _close_to_point_tol = TOLERANCE;
 }
 
 } // namespace libMesh

--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -202,4 +202,18 @@ void PointLocatorList::disable_out_of_mesh_mode ()
   libmesh_not_implemented();
 }
 
+
+void PointLocatorList::set_close_to_point_tol (Real close_to_point_tol)
+{
+  /* This functionality is not yet implemented for PointLocatorList.  */
+  libmesh_not_implemented();
+}
+
+
+void PointLocatorList::unset_close_to_point_tol ()
+{
+  /* This functionality is not yet implemented for PointLocatorList.  */
+  libmesh_not_implemented();
+}
+
 } // namespace libMesh


### PR DESCRIPTION
Added the option to set a close_to_point tolerance in PointLocatorTree and MeshFunction, as a fallback option.

This is helpful when we have numerical tolerance issues which can lead to points being outside a mesh within
some tolerance. Note that we use a linear search with close_to_point, so it's slow, but at least it's a robust
backup.
