### PR TITLE
Use nemesis=old whenever we only have exodus=old

### DIFF
--- a/configure
+++ b/configure
@@ -34694,9 +34694,14 @@ if test "${enable_nemesis+set}" = set; then :
  		             *) as_fn_error $? "bad value ${enableval} for --enable-nemesis" "$LINENO" 5 ;;
 		 esac
 else
-  enablenemesis=$enableexodus ; nemesisversion="v5.22"
+  enablenemesis=$enableexodus ; # if unspecified, depend on exodus
+                 if (test "x$exodusversion" = "xv5.22"); then
+                   nemesisversion="v5.22"
+                 else
+                   nemesisversion="v3.09"
+                 fi
 fi
- # if unspecified, depend on exodus
+
 
 
   # Trump --enable-nemesis with --disable-mpi

--- a/m4/nemesis.m4
+++ b/m4/nemesis.m4
@@ -12,7 +12,12 @@ AC_DEFUN([CONFIGURE_NEMESIS],
 		            no) enablenemesis=no  ; nemesisversion=no ;;
  		             *) AC_MSG_ERROR(bad value ${enableval} for --enable-nemesis) ;;
 		 esac],
-		 [enablenemesis=$enableexodus ; nemesisversion="v5.22"]) # if unspecified, depend on exodus
+                [enablenemesis=$enableexodus ; # if unspecified, depend on exodus 
+                 if (test "x$exodusversion" = "xv5.22"); then
+                   nemesisversion="v5.22"
+                 else
+                   nemesisversion="v3.09"
+                 fi])
 
 
   # Trump --enable-nemesis with --disable-mpi


### PR DESCRIPTION
this fixes compile-time failures when Nemesis 5.22 source files don't
recognize identifiers which would have been defined in Exodus 5.22
