### PR TITLE
Subtract off a coarse adjoint in ARefEE

### DIFF
--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -197,7 +197,8 @@ void AdjointRefinementEstimator::estimate_error (const System& _system,
             NumericVector<Number>::build(mesh.comm()).release();
 
           // Can do "fast" init since we're overwriting this in a sec
-          coarse_adjoint->init(system.solution->size(), true);
+          coarse_adjoint->init(system.solution->size(), true,
+                               system.get_adjoint_solution(j).type());
 
           *coarse_adjoint = system.get_adjoint_solution(j);
 


### PR DESCRIPTION
This shouldn't change the global error estimate, but should hopefully
give us a more suitable local indicator for adaptive refinement.

@coreymbryant, let me know if the results here are at all improved?

If so (and if this doesn't regress any of my tests) then we'll merge; based on the discussion today this ought to be a very general improvement.
