### PR TITLE
Partially fix compilation problem on Mac OSX and gcc/4.10.0 #322

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -27,7 +27,6 @@
 // C++ includes
 #include <vector>
 #include <algorithm>
-#include <cstring> // std::memset
 
 namespace libMesh
 {
@@ -719,13 +718,7 @@ void DenseMatrix<T>::zero()
 {
   _decomposition_type = NONE;
 
-  // Just doing this ifdef to be completely safe
-#ifndef LIBMESH_USE_COMPLEX_NUMBERS
-  if(_val.size())
-    std::memset(&_val[0], 0, sizeof(T) * _val.size());
-#else
-  std::fill (_val.begin(), _val.end(), 0.);
-#endif
+  std::fill (_val.begin(), _val.end(), static_cast<T>(0));
 }
 
 


### PR DESCRIPTION
This fixes the issue referenced in Issue #322. However, now compilation of libmesh with g++-4.10.0 fails with the following error message:

```
src/mesh/gmsh_io.C:1097:1: internal compiler error: in insn_default_length, at config/i386/i386.md:1787

src/mesh/gmsh_io.C:1097:1: internal compiler error: Abort trap: 6
g++: internal compiler error: Abort trap: 6 (program cc1plus)
```

However, this is a [known issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61387), so presumably we can just wait for this problem to fix itself.
