### PR TITLE
Use static_assert to get a slightly better error message.

### DIFF
--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -295,6 +295,23 @@ protected:
 
 
 //-------------------------------------------------------------------
+
+#ifdef LIBMESH_HAVE_CXX11
+// A C++03-compatible replacement for std::false_type
+struct false_type
+{
+  static const bool value = false;
+  typedef bool value_type;
+  typedef false_type type;
+  operator value_type() const { return value; }
+};
+
+// Templated helper class to be used with static_assert.
+template<typename T>
+struct dependent_false : false_type
+{};
+#endif
+
 /**
  * Templated class to provide the appropriate MPI datatype
  * for use with built-in C types or simple C++ constructions.
@@ -305,6 +322,12 @@ protected:
 template <typename T>
 class StandardType : public DataType
 {
+#ifdef LIBMESH_HAVE_CXX11
+  // Get a slightly better compiler diagnostic if we have C++11
+  static_assert(dependent_false<T>::value,
+                "Only specializations of StandardType may be used, did you forget to include a header file (e.g. parallel_algebra.h)?");
+#endif
+
   /*
    * The unspecialized class is useless, so we make its constructor
    * private to catch mistakes at compile-time rather than link-time.


### PR DESCRIPTION
This branch prints out a more helpful error message when your compiler supports `static_assert`.  When it doesn't, you get the old error message about calling a private constructor.  @roystgnr 
