### PR TITLE
Bugfix: make old_dof_indices ordering consistent

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2160,7 +2160,7 @@ void DofMap::old_dof_indices (const Elem* const elem,
           {
             // We asked for this variable, so add it to the vector.
             std::vector<dof_id_type> di_new;
-            this->SCALAR_dof_indices(di_new,*it,true);
+            this->SCALAR_dof_indices(di_new,v,true);
             di.insert( di.end(), di_new.begin(), di_new.end());
           }
         else


### PR DESCRIPTION
We moved the SCALAR dofs to their variable number position in
dof_indices, but didn't make the same update to old_dof_indices
