### PR TITLE
Fix "foo << unsigned char" instances

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -345,9 +345,9 @@ void ExodusII_IO::read (const std::string& fname)
 #if LIBMESH_DIM < 3
   if (mesh.mesh_dimension() > LIBMESH_DIM)
     libmesh_error_msg("Cannot open dimension "        \
-                      << mesh.mesh_dimension()            \
+                      << +mesh.mesh_dimension()            \
                       << " mesh file when configured without "        \
-                      << mesh.mesh_dimension()                        \
+                      << +mesh.mesh_dimension()                        \
                       << "D support.");
 #endif
 }

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -586,8 +586,8 @@ void GmshIO::read_mesh(std::istream& in)
                   }
 
               // Debugging:
-              // libMesh::out << "max_elem_dimension_seen=" << max_elem_dimension_seen << std::endl;
-              // libMesh::out << "min_elem_dimension_seen=" << min_elem_dimension_seen << std::endl;
+              // libMesh::out << "max_elem_dimension_seen=" << +max_elem_dimension_seen << std::endl;
+              // libMesh::out << "min_elem_dimension_seen=" << +min_elem_dimension_seen << std::endl;
 
               // If the difference between the max and min element dimension seen is larger than
               // 1, (e.g. the file has 1D and 3D elements only) we don't handle this case.

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -931,7 +931,7 @@ void GMVIO::write_ascii_old_impl (const std::string& fname,
         }
 
       default:
-        libmesh_error_msg("Unsupported mesh dimension: " << mesh.mesh_dimension());
+        libmesh_error_msg("Unsupported mesh dimension: " << +mesh.mesh_dimension());
       }
 
     out_stream << '\n';
@@ -1333,7 +1333,7 @@ void GMVIO::write_binary (const std::string& fname,
           }
         break;
       default:
-        libmesh_error_msg("Unsupported mesh dimension: " << mesh.mesh_dimension());
+        libmesh_error_msg("Unsupported mesh dimension: " << +mesh.mesh_dimension());
 
       }
   }
@@ -1817,7 +1817,7 @@ void GMVIO::write_discontinuous_gmv (const std::string& name,
         }
 
       default:
-        libmesh_error_msg("Unsupported mesh dimension: " << mesh.mesh_dimension());
+        libmesh_error_msg("Unsupported mesh dimension: " << +mesh.mesh_dimension());
       }
 
     out_stream << std::endl;
@@ -2097,9 +2097,9 @@ void GMVIO::read (const std::string& name)
 #if LIBMESH_DIM < 3
   if (mesh.mesh_dimension() > LIBMESH_DIM)
     libmesh_error_msg("Cannot open dimension " \
-                      << mesh.mesh_dimension()            \
+                      << +mesh.mesh_dimension()            \
                       << " mesh file when configured without "        \
-                      << mesh.mesh_dimension()                        \
+                      << +mesh.mesh_dimension()                        \
                       << "D support.");
 #endif
 

--- a/src/mesh/legacy_xdr_io.C
+++ b/src/mesh/legacy_xdr_io.C
@@ -614,9 +614,9 @@ void LegacyXdrIO::read_mesh (const std::string& name,
 #if LIBMESH_DIM < 3
   if (mesh.mesh_dimension() > LIBMESH_DIM)
     libmesh_error_msg("Cannot open dimension "              \
-                      << mesh.mesh_dimension()                          \
+                      << +mesh.mesh_dimension()                          \
                       << " mesh file when configured without "          \
-                      << mesh.mesh_dimension()                          \
+                      << +mesh.mesh_dimension()                          \
                       << "D support." );
 #endif
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -308,8 +308,8 @@ std::string MeshBase::get_info() const
   std::ostringstream oss;
 
   oss << " Mesh Information:"                                  << '\n'
-      << "  mesh_dimension()="    << this->mesh_dimension()    << '\n'
-      << "  spatial_dimension()=" << this->spatial_dimension() << '\n'
+      << "  mesh_dimension()="    << +this->mesh_dimension()   << '\n'
+      << "  spatial_dimension()=" << +this->spatial_dimension()<< '\n'
       << "  n_nodes()="           << this->n_nodes()           << '\n'
       << "    n_local_nodes()="   << this->n_local_nodes()     << '\n'
       << "  n_elem()="            << this->n_elem()            << '\n'

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1411,7 +1411,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh& mesh,
       } // end case dim==3
 
     default:
-      libmesh_error_msg("Unknown dimension " << mesh.mesh_dimension());
+      libmesh_error_msg("Unknown dimension " << +mesh.mesh_dimension());
     }
 
   STOP_LOG("build_cube()", "MeshTools::Generation");
@@ -1834,7 +1834,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh& mesh,
       } // end case 3
 
     default:
-      libmesh_error_msg("Unknown dimension " << mesh.mesh_dimension());
+      libmesh_error_msg("Unknown dimension " << +mesh.mesh_dimension());
 
 
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -517,7 +517,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
 
     default:
       // Hm?
-      libmesh_error_msg("Unknown mesh dimension " << this->mesh_dimension());
+      libmesh_error_msg("Unknown mesh dimension " << +this->mesh_dimension());
     }
 
 

--- a/src/mesh/mesh_smoother_laplace.C
+++ b/src/mesh/mesh_smoother_laplace.C
@@ -254,7 +254,8 @@ void LaplaceMeshSmoother::init()
       } // case 3
 
     default:
-      libmesh_error_msg("At this time it is not possible to smooth a dimension " << _mesh.mesh_dimension() << "mesh.  Aborting...");
+      libmesh_error_msg("At this time it is not possible to smooth a dimension " <<
+                        +_mesh.mesh_dimension() << "mesh.  Aborting...");
     }
 
   // Done building graph from local elements.  Let's now allgather the

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -899,9 +899,9 @@ void Nemesis_IO::read (const std::string& base_filename)
 #if LIBMESH_DIM < 3
   if (mesh.mesh_dimension() > LIBMESH_DIM)
     libmesh_error_msg("Cannot open dimension "   \
-                      << mesh.mesh_dimension()                          \
+                      << +mesh.mesh_dimension()                          \
                       << " mesh file when configured without "          \
-                      << mesh.mesh_dimension()                          \
+                      << +mesh.mesh_dimension()                          \
                       << "D support." );
 #endif
 

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -211,9 +211,9 @@ void UCDIO::read_implementation (std::istream& in)
 #if LIBMESH_DIM < 3
     if (mesh.mesh_dimension() > LIBMESH_DIM)
       libmesh_error_msg("Cannot open dimension " \
-                        << mesh.mesh_dimension() \
+                        << +mesh.mesh_dimension() \
                         << " mesh file when configured without " \
-                        << mesh.mesh_dimension() \
+                        << +mesh.mesh_dimension() \
                         << "D support.");
 #endif
   }
@@ -231,7 +231,7 @@ void UCDIO::write_implementation (std::ostream& out_stream)
   libmesh_assert_not_equal_to (mesh.mesh_dimension(), 1);
   if(mesh.mesh_dimension() != 3)
     libmesh_error_msg("Error: Can't write boundary elements for meshes of dimension less than 3. " \
-                      << "Mesh dimension = " << mesh.mesh_dimension());
+                      << "Mesh dimension = " << +mesh.mesh_dimension());
 
   // Write header
   this->write_header(out_stream,mesh,mesh.n_elem(),0);

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -231,9 +231,9 @@ void UNVIO::read_implementation (std::istream& in_stream)
 #if LIBMESH_DIM < 3
     if (MeshInput<MeshBase>::mesh().mesh_dimension() > LIBMESH_DIM)
       libmesh_error_msg("Cannot open dimension "                        \
-                        << MeshInput<MeshBase>::mesh().mesh_dimension() \
+                        << +MeshInput<MeshBase>::mesh().mesh_dimension() \
                         << " mesh file when configured without "        \
-                        << MeshInput<MeshBase>::mesh().mesh_dimension() \
+                        << +MeshInput<MeshBase>::mesh().mesh_dimension() \
                         << "D support." );
 #endif
 

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -542,9 +542,9 @@ void VTKIO::read (const std::string& name)
 #if LIBMESH_DIM < 3
   if (mesh.mesh_dimension() > LIBMESH_DIM)
     libmesh_error_msg("Cannot open dimension "  \
-                      << mesh.mesh_dimension()              \
+                      << +mesh.mesh_dimension()              \
                       << " mesh file when configured without "  \
-                      << mesh.mesh_dimension()                  \
+                      << +mesh.mesh_dimension()                  \
                       << "D support.");
 #endif
 

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1389,9 +1389,9 @@ void XdrIO::read_serialized_connectivity (Xdr &io, const dof_id_type n_elem, std
 #if LIBMESH_DIM < 3
   if (mesh.mesh_dimension() > LIBMESH_DIM)
     libmesh_error_msg("Cannot open dimension "              \
-                      << mesh.mesh_dimension()                          \
+                      << +mesh.mesh_dimension()                          \
                       << " mesh file when configured without "          \
-                      << mesh.mesh_dimension()                          \
+                      << +mesh.mesh_dimension()                          \
                       << "D support.");
 #endif
 }


### PR DESCRIPTION
Hopefully this catches all the places where the type change in
mesh dimension could corrupt our text output.
