### PR TITLE
GDB backtrace

### DIFF
--- a/include/base/print_trace.h
+++ b/include/base/print_trace.h
@@ -27,12 +27,12 @@
 namespace libMesh
 {
 
-/*
+/**
  * Print a stack trace (for code compiled with gcc)
  */
 void print_trace(std::ostream &out_stream = std::cerr);
 
-/*
+/**
  * Mostly system independent demangler
  */
 std::string demangle(const char *name);


### PR DESCRIPTION
This branch improves `print_trace()` by using GDB when it's available, and falling back to the current implementation when it's not.  GDB print traces are better because they provide more information, in particular, line numbers!  I found this to be really useful while working on #343.

I've tested this and it works on both a Linux system (where gdb is available) and an OSX system (in fallback mode) which doesn't have GDB.  I'm still investigating the possibility of calling lldb in a similar manner, but I'm not sure if it supports a "batch" mode yet.  The branch also makes the `#ifdefs` in print_trace.C a little more fine-grained, so it would be great if somebody could double-check that as well.

Here's an example:

Old backtrace:

```
Stack frames: 7
0: 0   libmesh_dbg.0.dylib                 0x0000000111b49816 libMesh::print_trace(std::ostream&) + 70
1: 1   print_trace_test-dbg                0x000000010e9fbf47 f3() + 343
2: 2   print_trace_test-dbg                0x000000010e9fbde3 f2() + 51
3: 3   print_trace_test-dbg                0x000000010e9fbda3 f1() + 51
4: 4   print_trace_test-dbg                0x000000010e9fbd2a main + 74
5: 5   libdyld.dylib                       0x00007fff923015fd start + 1
6: 6   ???                                 0x0000000000000001 0x0 + 1
```

GDB backtrace with line numbers:

```
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
0x00007fe436060c8e in __libc_waitpid (pid=<optimized out>, stat_loc=0x7fff67c044f0, options=0) at ../sysdeps/unix/sysv/linux/waitpid.c:32
#0  0x00007fe436060c8e in __libc_waitpid (pid=<optimized out>, stat_loc=0x7fff67c044f0, options=0) at ../sysdeps/unix/sysv/linux/waitpid.c:32
#1  0x00007fe435fe629e in do_system (line=0x183abb8 "gdb -p 30622 -batch -ex bt 2>/dev/null 1>temp_print_trace.KEcpFH") at ../sysdeps/posix/system.c:149
#2  0x00007fe43719e766 in (anonymous namespace)::gdb_backtrace (out_stream=...) at ../src/base/print_trace.C:132
#3  0x00007fe43719e8c8 in libMesh::print_trace (out_stream=...) at ../src/base/print_trace.C:165
#4  0x00000000004149cd in f3 () at print_trace_test.cc:52
#5  0x00000000004148c4 in f2 () at print_trace_test.cc:37
#6  0x000000000041489d in f1 () at print_trace_test.cc:29
#7  0x0000000000414841 in main (argc=1, argv=0x7fff67c04fe8) at print_trace_test.cc:19
```
