### PR TITLE
Bugfix for mismatched id sizes when reading xdr

### DIFF
--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1328,7 +1328,7 @@ void XdrIO::read_serialized_connectivity (Xdr &io, const dof_id_type n_elem, std
 #endif
               ++it;
             }
-          const dof_id_type parent_id =
+          const T parent_id =
             (*it == static_cast<T>(-1)) ?
             DofObject::invalid_id :
             cast_int<dof_id_type>(*it);
@@ -1346,7 +1346,7 @@ void XdrIO::read_serialized_connectivity (Xdr &io, const dof_id_type n_elem, std
           ++it;
 
           Elem *parent =
-            (parent_id == DofObject::invalid_id) ? NULL : mesh.elem(parent_id);
+            (parent_id == static_cast<T>(-1)) ? NULL : mesh.elem(parent_id);
 
           Elem *elem = Elem::build (elem_type, parent).release();
 


### PR DESCRIPTION
This branch is originally from Nov 2013!  I didn't want it to get lost forever, so I rebased it and made a PR.  @roystgnr, I know buildbot is giving you headaches right now, so can you let us know the configure options you use in your "BigIDs" tests?

This fixes a regression in our BuildBot "BigIDs" tests.  When
sizeof(T) is different than sizeof(dof_id_type) (as happened when an
8-byte-dof_id libMesh reads a file written with a 4-byte-dof_id
libMesh), we need to use the former rather than the latter to decide
what the code is for "no parent element".
