### PR TITLE
Print traces on all processors if requested

### DIFF
--- a/src/base/libmesh_common.C
+++ b/src/base/libmesh_common.C
@@ -17,6 +17,7 @@
 
 
 // libmesh includes
+#include "libmesh/libmesh.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/print_trace.h"
 
@@ -62,7 +63,9 @@ void stop(const char* file, int line, const char* date, const char* time)
 
 void report_error(const char* file, int line, const char* date, const char* time)
 {
-  if (libMesh::global_n_processors() == 1)
+  if (libMesh::global_n_processors() == 1 ||
+      libMesh::on_command_line("--print_trace") ||
+      libMesh::on_command_line("--print-trace"))
     libMesh::print_trace();
   else
     libMesh::write_traceout();


### PR DESCRIPTION
This was useful when trying to debug some segfaults on stampede; it might be more useful in other situations where queuing systems (or file permissions or something I haven't thought of) make it less likely that trace files will be cleanly written.
