### PR TITLE
vector_as_adjoint changes

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -871,7 +871,7 @@ public:
    * vec_name represents a solution from an adjoint (non-negative) or
    * the primal (-1) space.
    */
-  int vector_as_adjoint (const std::string &vec_name) const;
+  int vector_is_adjoint (const std::string &vec_name) const;
 
  /**
    * Allows one to set the boolean controlling whether the vector

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -325,7 +325,9 @@ void System::restrict_vectors ()
       NumericVector<Number>* v = pos->second;
 
       if (_vector_projections[pos->first])
-        this->project_vector (*v, _vector_is_adjoint[pos->first]);
+        {
+          this->project_vector (*v, this->vector_is_adjoint(pos->first));
+        }
       else
         {
           ParallelType type = _vector_types[pos->first];
@@ -687,6 +689,9 @@ NumericVector<Number> & System::add_vector (const std::string& vec_name,
 
   _vector_types.insert (std::make_pair (vec_name, type));
 
+  // Vectors are primal by default
+  _vector_is_adjoint.insert (std::make_pair (vec_name, -1));
+
   // Initialize it if necessary
   if (!_can_add_vectors)
     {
@@ -903,7 +908,7 @@ void System::set_vector_as_adjoint (const std::string &vec_name,
 
 
 
-int System::vector_as_adjoint (const std::string &vec_name) const
+int System::vector_is_adjoint (const std::string &vec_name) const
 {
   libmesh_assert(_vector_is_adjoint.find(vec_name) !=
                  _vector_is_adjoint.end());


### PR DESCRIPTION
Change name to vector_is_adjoint; anybody using this API probably
should be paying attention to this commit anyways.

Fix default vector behavior: handle projections with primal rather
than adjoint BCs.  I'm not sure why this took so long to trigger a
regression anywhere; are we doing a redundant constraint application
with the correct rhs after projections?
