### PR TITLE
Allow the user to limit point locator searches to subsets of the mesh.

### DIFF
--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -91,9 +91,10 @@ public:
 
   /**
    * Locates the element in which the point with global coordinates
-   * \p p is located.  Pure virtual.
+   * \p p is located.  Pure virtual. Optionally allows the user to restrict
+   * the subdomains searched.
    */
-  virtual const Elem* operator() (const Point& p) const = 0;
+  virtual const Elem* operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const = 0;
 
   /**
    * @returns \p true when this object is properly initialized

--- a/include/utils/point_locator_list.h
+++ b/include/utils/point_locator_list.h
@@ -98,9 +98,10 @@ public:
 
   /**
    * Locates the element in which the point with global coordinates
-   * \p p is located.  Overloaded from base class.
+   * \p p is located, optionally restricted to a set of allowed subdomains.
+   * Overloaded from base class.
    */
-  virtual const Elem* operator() (const Point& p) const;
+  virtual const Elem* operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
 
   /**
    * Enables out-of-mesh mode.  In this mode, if asked to find a point

--- a/include/utils/point_locator_tree.h
+++ b/include/utils/point_locator_tree.h
@@ -100,11 +100,12 @@ public:
 
   /**
    * Locates the element in which the point with global coordinates
-   * \p p is located.  The mutable _element member is used to cache
+   * \p p is located, optionally restricted to a set of allowed subdomains.
+   * The mutable _element member is used to cache
    * the result and allow it to be used during the next call to
    * operator().
    */
-  virtual const Elem* operator() (const Point& p) const;
+  virtual const Elem* operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
 
   /**
    * As a fallback option, it's helpful to be able to do a linear
@@ -116,6 +117,7 @@ public:
    */
   const Elem* perform_linear_search(
     const Point& p,
+    const std::set<subdomain_id_type> *allowed_subdomains,
     bool use_close_to_point,
     Real close_to_point_tolerance=TOLERANCE) const;
 

--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -75,14 +75,16 @@ public:
   unsigned int n_active_bins() const { return root.n_active_bins(); }
 
   /**
-   * @returns a pointer to the element containing point p.
+   * @returns a pointer to the element containing point p,
+   * optionally restricted to a set of allowed subdomains.
    */
-  const Elem* find_element(const Point& p) const;
+  const Elem* find_element(const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
 
   /**
-   * @returns a pointer to the element containing point p.
+   * @returns a pointer to the element containing point p,
+   * optionally restricted to a set of allowed subdomains.
    */
-  const Elem* operator() (const Point& p) const;
+  const Elem* operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
 
 
 private:

--- a/include/utils/tree_base.h
+++ b/include/utils/tree_base.h
@@ -24,6 +24,7 @@
 #include "libmesh/reference_counted_object.h"
 
 // C++ includes
+#include <set>
 
 namespace libMesh
 {
@@ -88,9 +89,10 @@ public:
   virtual unsigned int n_active_bins() const = 0;
 
   /**
-   * @returns a pointer to the element containing point p.
+   * @returns a pointer to the element containing point p,
+   * optionally restricted to a set of allowed subdomains.
    */
-  virtual const Elem* find_element(const Point& p) const = 0;
+  virtual const Elem* find_element(const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const = 0;
 
 protected:
 

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -27,6 +27,7 @@
 // C++ includes
 #include <cstddef>
 #include <vector>
+#include <set>
 
 namespace libMesh
 {
@@ -136,16 +137,18 @@ public:
   unsigned int n_active_bins() const;
 
   /**
-   * @returns an element containing point p.
+   * @returns an element containing point p,
+   * optionally restricted to a set of allowed subdomains.
    */
-  const Elem* find_element (const Point& p) const;
+  const Elem* find_element (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
 
 
 private:
   /**
-   * Look for point \p p in our children.
+   * Look for point \p p in our children,
+   * optionally restricted to a set of allowed subdomains.
    */
-  const Elem* find_element_in_children (const Point& p) const;
+  const Elem* find_element_in_children (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains) const;
 
   /**
    * Constructs the bounding box for child \p c.

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -126,17 +126,17 @@ void Tree<N>::print_elements(std::ostream& my_out) const
 
 
 template <unsigned int N>
-const Elem* Tree<N>::find_element(const Point& p) const
+const Elem* Tree<N>::find_element(const Point& p, const std::set<subdomain_id_type> *allowed_subdomains) const
 {
-  return root.find_element(p);
+  return root.find_element(p,allowed_subdomains);
 }
 
 
 
 template <unsigned int N>
-const Elem* Tree<N>::operator() (const Point& p) const
+const Elem* Tree<N>::operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains) const
 {
-  return this->find_element(p);
+  return this->find_element(p,allowed_subdomains);
 }
 
 


### PR DESCRIPTION
We have an application where a requested point lives on the interface between subdomains, and it is desirable to restrict which subdomain the returned element belongs to. This commit implements this feature, with backwards compatibility through the API using default function arguments.
