### PR TITLE
Interpolation points mesh getter in RBEIMEvaluation

### DIFF
--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -95,6 +95,11 @@ public:
   unsigned int get_n_parametrized_functions() const;
 
   /**
+   * Get a writable reference to the interpolation points mesh.
+   */
+  SerialMesh& get_interpolation_points_mesh();
+  
+  /**
    * @return the value of the parametrized function that is being
    * approximated at the point \p p.
    * \p var_index specifies the

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -101,6 +101,11 @@ unsigned int RBEIMEvaluation::get_n_parametrized_functions() const
     (_parametrized_functions.size());
 }
 
+SerialMesh& RBEIMEvaluation::get_interpolation_points_mesh()
+{
+  return _interpolation_points_mesh;
+}
+
 Number RBEIMEvaluation::evaluate_parametrized_function(unsigned int var_index,
                                                        const Point& p,
                                                        const Elem& elem)


### PR DESCRIPTION
This getter is needed when manually reconstructing an instance of RBEIMEvaluation without using the inherited read_offline_data_from_files() method to load offline data.
