### PR TITLE
Fix off-by-one error when trying to remove delimiter from section name

### DIFF
--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -1407,7 +1407,7 @@ GetPot::_process_section_label(const std::string& Section,
           if (sname[i] == '/')
             {
               section_stack.push_back(sname.substr(0,i));
-              if (i+1 < sname.length()-1)
+              if (i+1 < sname.length())
                 sname = sname.substr(i+1);
               i = 0;
             }


### PR DESCRIPTION
A MOOSE user reported that they couldn't create section names in a getpot file like this 

`[./Somename/a]`

While the second slash is not prohibited in the example above, the logic in `GetPot::_process_section_name` incorrectly subtracts from the length of the string when doing an "in-bounds" comparison creating an infinite loop and chewing up memory.
