### PR TITLE
Clear EvalError when using JIT compile Parsers

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -997,6 +997,9 @@ bool FunctionParserADBase<Value_t>::JITCompileHelper(const std::string & Value_t
     return false;
   }
 
+  // clear evalerror (this will not get set again by the JIT code)
+  mData->mEvalErrorType = 0;
+
   // rename successfully compiled obj to cache file
   if (cacheFunction && (mkdir(jitdir.c_str(), 0700) == 0 || errno == EEXIST)) {
     // the directory was either successfuly created, or it already exists


### PR DESCRIPTION
The FParser EvalError status is not cleared when using the JIT compiled function for evaluation. This could get you in a situation where the last evaluation of a parser object before JIT compilation threw an error, which will then stick for all further (JIT) evaluations.
