### PR TITLE
More tests when constructing Parsed*Function

### DIFF
--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -119,7 +119,9 @@ public:
                             std::string::npos : end - nextstart);
 
         // fparser can crash on empty expressions
-        libmesh_assert(!subexpression.empty());
+        if (subexpression.empty())
+          libmesh_error_msg("ERROR: FunctionParser is unable to parse empty expression.\n");
+
 
 #ifdef LIBMESH_HAVE_FPARSER
         // Parse (and optimize if possible) the subexpression.

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -110,7 +110,8 @@ public:
                             std::string::npos : end - nextstart);
 
         // fparser can crash on empty expressions
-        libmesh_assert(!subexpression.empty());
+        if (subexpression.empty())
+          libmesh_error_msg("ERROR: FunctionParser is unable to parse empty expression.\n");
 
         // Parse (and optimize if possible) the subexpression.
         // Add some basic constants, to Real precision.


### PR DESCRIPTION
The whole point of parsed functions is to allow users to change the string contents at run time, so there's no way for us to guarantee that those strings will be valid; we should be making those tests even in opt mode.

This should fix #393
