### PR TITLE
libMeshEnums namespace for backward compatibility

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -552,4 +552,9 @@ inline Tnew libmesh_cast_int (Told oldvar)
 } // namespace libMesh
 
 
+// Backwards compatibility
+namespace libMeshEnums {
+  using namespace libMesh;
+}
+
 #endif // LIBMESH_LIBMESH_COMMON_H


### PR DESCRIPTION
This lets us keep libMeshEnums::foo in some user code (extending compatibility with old libMesh) without breaking compatibility with new libMesh.

If everyone approves, this needs to go in 0.9.4 as well.
