### PR TITLE
PointLocatorTree could print out a lot of noise when it fell back on linear search.

### DIFF
--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -129,6 +129,11 @@ public:
    */
   virtual void unset_close_to_point_tol();
 
+  /**
+   * Boolean flag to indicate whether to print out extra info.
+   */
+  bool _verbose;
+
 protected:
   /**
    * Const pointer to our master, initialized to \p NULL if none

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -35,6 +35,7 @@ namespace libMesh
 // PointLocatorBase methods
 PointLocatorBase::PointLocatorBase (const MeshBase& mesh,
                                     const PointLocatorBase* master) :
+  _verbose                 (false),
   _master                  (master),
   _mesh                    (mesh),
   _initialized             (false),

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -227,9 +227,12 @@ const Elem* PointLocatorTree::operator() (const Point& p, const std::set<subdoma
           // specified tolerance).
           if( _use_close_to_point_tol )
             {
-              libMesh::out << "Performing linear search using close-to-point tolerance "
-                           << _close_to_point_tol
-                           << std::endl;
+              if(_verbose)
+                {
+                  libMesh::out << "Performing linear search using close-to-point tolerance "
+                               << _close_to_point_tol
+                               << std::endl;
+                }
 
               this->_element =
                 this->perform_linear_search(p,


### PR DESCRIPTION
Added a _verbose flag (defaults to false) to optionally turn this noise off.
