### PR TITLE
NumericVector::get refactoring

### DIFF
--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -344,12 +344,20 @@ public:
   virtual T el(const numeric_index_type i) const { return (*this)(i); }
 
   /**
+   * Access multiple components at once.  \p values will *not* be
+   * reallocated; it should already have enough space.  The default
+   * implementation calls \p operator() for each index, but some
+   * implementations may supply faster methods here.
+   */
+  virtual void get(const std::vector<numeric_index_type>& index, T* values) const;
+
+  /**
    * Access multiple components at once.  \p values will be resized,
    * if necessary, and filled.  The default implementation calls \p
    * operator() for each index, but some implementations may supply
    * faster methods here.
    */
-  virtual void get(const std::vector<numeric_index_type>& index, std::vector<T>& values) const;
+  void get(const std::vector<numeric_index_type>& index, std::vector<T>& values) const;
 
   /**
    * Addition operator.
@@ -764,14 +772,27 @@ void NumericVector<T>::clear ()
 
 template <typename T>
 inline
-void NumericVector<T>::get(const std::vector<numeric_index_type>& index, std::vector<T>& values) const
+void NumericVector<T>::get(const std::vector<numeric_index_type>& index, T* values) const
 {
   const std::size_t num = index.size();
-  values.resize(num);
   for(std::size_t i=0; i<num; i++)
     {
       values[i] = (*this)(index[i]);
     }
+}
+
+
+
+template <typename T>
+inline
+void NumericVector<T>::get(const std::vector<numeric_index_type>& index, std::vector<T>& values) const
+{
+  const std::size_t num = index.size();
+  values.resize(num);
+  if (!num)
+    return;
+
+  this->get(index, &values[0]);
 }
 
 

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -298,11 +298,12 @@ public:
   T operator() (const numeric_index_type i) const;
 
   /**
-   * Access multiple components at once.  Overloaded method that
-   * should be faster (probably much faster) than calling \p
-   * operator() individually for each index.
+   * Access multiple components at once.  \p values will *not* be
+   * reallocated; it should already have enough space.  Overloaded
+   * method that should be faster (probably much faster) than calling
+   * \p operator() individually for each index.
    */
-  virtual void get(const std::vector<numeric_index_type>& index, std::vector<T>& values) const;
+  virtual void get(const std::vector<numeric_index_type>& index, T* values) const;
 
   /**
    * Addition operator.
@@ -1247,12 +1248,11 @@ T PetscVector<T>::operator() (const numeric_index_type i) const
 
 template <typename T>
 inline
-void PetscVector<T>::get(const std::vector<numeric_index_type>& index, std::vector<T>& values) const
+void PetscVector<T>::get(const std::vector<numeric_index_type>& index, T* values) const
 {
   this->_get_array();
 
   const std::size_t num = index.size();
-  values.resize(num);
 
   for(std::size_t i=0; i<num; i++)
     {


### PR DESCRIPTION
Added an API for get(T*), and refactored the get(vector<T>) API to be
an inline wrapper for it.
