### PR TITLE
NumericVector::add_vector refactoring

### DIFF
--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -314,21 +314,10 @@ public:
   void add (const T a, const NumericVector<T>& v);
 
   /**
-   * \f$U+=v\f$ where v is a \p std::vector<T>
-   * and you
-   * want to specify WHERE to add it
+   * We override one NumericVector<T>::add_vector() method but don't
+   * want to hide the other defaults.
    */
-  void add_vector (const std::vector<T>& v,
-                   const std::vector<numeric_index_type>& dof_indices);
-
-  /**
-   * \f$U+=V\f$ where U and V are type
-   * \p NumericVector<T> and you
-   * want to specify WHERE to add
-   * the \p NumericVector<T> V
-   */
-  void add_vector (const NumericVector<T>& V,
-                   const std::vector<numeric_index_type>& dof_indices);
+  using NumericVector<T>::add_vector;
 
   /**
    * \f$U+=A*V\f$.
@@ -339,15 +328,6 @@ public:
   void add_vector (const NumericVector<T>&,
                    const SparseMatrix<T>&)
   { libmesh_not_implemented(); }
-
-  /**
-   * \f$U+=V\f$ where U and V are type
-   * \p DenseVector<T> and you
-   * want to specify WHERE to add
-   * the \p DenseVector<T> V
-   */
-  void add_vector (const DenseVector<T>& V,
-                   const std::vector<numeric_index_type>& dof_indices);
 
   /**
    * \f$U+=A^T*V\f$.

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -324,21 +324,10 @@ public:
   void add (const T a, const NumericVector<T>& v);
 
   /**
-   * \f$ U+=v \f$ where v is a \p std::vector<T>
-   * and you
-   * want to specify WHERE to add it
+   * We override one NumericVector<T>::add_vector() method but don't
+   * want to hide the other defaults.
    */
-  void add_vector (const std::vector<T>& v,
-                   const std::vector<numeric_index_type>& dof_indices);
-
-  /**
-   * \f$ U+=V \f$ where U and V are type
-   * NumericVector<T> and you
-   * want to specify WHERE to add
-   * the NumericVector<T> V
-   */
-  void add_vector (const NumericVector<T>& V,
-                   const std::vector<numeric_index_type>& dof_indices);
+  using NumericVector<T>::add_vector;
 
   /**
    * \f$U+=A*V\f$, add the product of a \p SparseMatrix \p A
@@ -346,15 +335,6 @@ public:
    */
   void add_vector (const NumericVector<T> &,
                    const SparseMatrix<T> &);
-
-  /**
-   * \f$U+=V \f$ where U and V are type
-   * DenseVector<T> and you
-   * want to specify WHERE to add
-   * the DenseVector<T> V
-   */
-  void add_vector (const DenseVector<T>& V,
-                   const std::vector<numeric_index_type>& dof_indices);
 
   /**
    * \f$U+=A^T*V\f$, add the product of the transpose of a \p SparseMatrix \p A_trans

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -320,21 +320,10 @@ public:
   void add (const T a, const NumericVector<T>& v);
 
   /**
-   * \f$ U+=v \f$ where v is a \p std::vector<T>
-   * and you
-   * want to specify WHERE to add it
+   * We override one NumericVector<T>::add_vector() method but don't
+   * want to hide the other defaults.
    */
-  void add_vector (const std::vector<T>& v,
-                   const std::vector<numeric_index_type>& dof_indices);
-
-  /**
-   * \f$ U+=V \f$ where U and V are type
-   * NumericVector<T> and you
-   * want to specify WHERE to add
-   * the NumericVector<T> V
-   */
-  void add_vector (const NumericVector<T>& V,
-                   const std::vector<numeric_index_type>& dof_indices);
+  using NumericVector<T>::add_vector;
 
   /**
    * \f$U+=A*V\f$, add the product of a \p SparseMatrix \p A
@@ -342,15 +331,6 @@ public:
    */
   void add_vector (const NumericVector<T> &,
                    const SparseMatrix<T> &);
-
-  /**
-   * \f$U+=V \f$ where U and V are type
-   * DenseVector<T> and you
-   * want to specify WHERE to add
-   * the DenseVector<T> V
-   */
-  void add_vector (const DenseVector<T>& V,
-                   const std::vector<numeric_index_type>& dof_indices);
 
   /**
    * \f$U+=A^T*V\f$, add the product of the transpose of a \p SparseMatrix \p A_trans

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -431,21 +431,34 @@ public:
   virtual void add (const T a, const NumericVector<T>& v) = 0;
 
   /**
-   * \f$ U+=v \f$ where v is a \p std::vector<T>
-   * and you
-   * want to specify WHERE to add it
+   * \f$ U+=v \f$ where v is a pointer and each \p dof_indices[i]
+   * specifies where to add value \p v[i]
+   *
+   * This should be overridden in subclasses for efficiency
    */
-  virtual void add_vector (const std::vector<T>& v,
-                           const std::vector<numeric_index_type>& dof_indices) = 0;
+  virtual void add_vector (const T* v,
+                           const std::vector<numeric_index_type>& dof_indices);
 
   /**
-   * \f$U+=V\f$, where U and V are type
-   * NumericVector<T> and you
-   * want to specify WHERE to add
-   * the NumericVector<T> V
+   * \f$ U+=v \f$ where v is a std::vector and each \p dof_indices[i]
+   * specifies where to add value \p v[i]
+   */
+  void add_vector (const std::vector<T>& v,
+                   const std::vector<numeric_index_type>& dof_indices);
+
+  /**
+   * \f$ U+=v \f$ where v is a NumericVector and each \p dof_indices[i]
+   * specifies where to add value \p v(i)
    */
   virtual void add_vector (const NumericVector<T>& V,
-                           const std::vector<numeric_index_type>& dof_indices) = 0;
+                           const std::vector<numeric_index_type>& dof_indices);
+
+  /**
+   * \f$ U+=v \f$ where v is a DenseVector and each \p dof_indices[i]
+   * specifies where to add value \p v(i)
+   */
+  void add_vector (const DenseVector<T>& V,
+                   const std::vector<numeric_index_type>& dof_indices);
 
   /**
    * \f$U+=A*V\f$, add the product of a \p SparseMatrix \p A
@@ -460,15 +473,6 @@ public:
    */
   void add_vector (const NumericVector<T>& v,
                    const ShellMatrix<T>& a);
-
-  /**
-   * \f$ U+=V \f$ where U and V are type
-   * DenseVector<T> and you
-   * want to specify WHERE to add
-   * the DenseVector<T> V
-   */
-  virtual void add_vector (const DenseVector<T>& V,
-                           const std::vector<numeric_index_type>& dof_indices) = 0;
 
   /**
    * \f$U+=A^T*V\f$, add the product of the transpose of a \p SparseMatrix \p A_trans
@@ -793,6 +797,32 @@ void NumericVector<T>::get(const std::vector<numeric_index_type>& index, std::ve
     return;
 
   this->get(index, &values[0]);
+}
+
+
+
+template <typename T>
+inline
+void NumericVector<T>::add_vector 
+  (const std::vector<T>& v,
+   const std::vector<numeric_index_type>& dof_indices)
+{
+  libmesh_assert(v.size() == dof_indices.size());
+  if (!v.empty())
+    this->add_vector(&v[0], dof_indices);
+}
+
+
+
+template <typename T>
+inline
+void NumericVector<T>::add_vector 
+  (const DenseVector<T>& v,
+   const std::vector<numeric_index_type>& dof_indices)
+{
+  libmesh_assert(v.size() == dof_indices.size());
+  if (!v.empty())
+    this->add_vector(&v(0), dof_indices);
 }
 
 

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -360,22 +360,17 @@ public:
   void add (const T a, const NumericVector<T>& v);
 
   /**
-   * \f$ U+=v \f$ where \p v is a std::vector<T>
-   * and you
-   * want to specify WHERE to add it
+   * We override two NumericVector<T>::add_vector() methods but don't
+   * want to hide the other defaults.
    */
-  void add_vector (const std::vector<T>& v,
-                   const std::vector<numeric_index_type>& dof_indices);
+  using NumericVector<T>::add_vector;
 
   /**
-   * \f$ U+=V \f$ where U and V are type
-   * \p NumericVector<T> and you
-   * want to specify WHERE to add
-   * the \p NumericVector<T> V
+   * \f$ U+=v \f$ where v is a pointer and each \p dof_indices[i]
+   * specifies where to add value \p v[i]
    */
-  void add_vector (const NumericVector<T>& V,
+  void add_vector (const T* v,
                    const std::vector<numeric_index_type>& dof_indices);
-
 
   /**
    * \f$U+=A*V\f$, add the product of a \p SparseMatrix \p A
@@ -383,15 +378,6 @@ public:
    */
   void add_vector (const NumericVector<T> &V,
                    const SparseMatrix<T> &A);
-
-  /**
-   * \f$U+=V \f$ where U and V are type
-   * DenseVector<T> and you
-   * want to specify WHERE to add
-   * the DenseVector<T> V
-   */
-  void add_vector (const DenseVector<T>& V,
-                   const std::vector<numeric_index_type>& dof_indices);
 
   /**
    * \f$U+=A^T*V\f$, add the product of the transpose

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -347,22 +347,17 @@ public:
   void add (const T a, const NumericVector<T>& v);
 
   /**
-   * \f$ U+=v \f$ where \p v is a \p std::vector<T>
-   * and you
-   * want to specify WHERE to add it
+   * We override two NumericVector<T>::add_vector() methods but don't
+   * want to hide the other defaults.
    */
-  void add_vector (const std::vector<T>& v,
-                   const std::vector<numeric_index_type>& dof_indices);
+  using NumericVector<T>::add_vector;
 
   /**
-   * \f$ U+=V \f$ where U and V are type
-   * \p NumericVector<T> and you
-   * want to specify WHERE to add
-   * the \p NumericVector<T> V
+   * \f$ U+=v \f$ where v is a pointer and each \p dof_indices[i]
+   * specifies where to add value \p v[i]
    */
-  void add_vector (const NumericVector<T>& V,
+  void add_vector (const T* v,
                    const std::vector<numeric_index_type>& dof_indices);
-
 
   /**
    * \f$U+=A*V\f$, add the product of a \p SparseMatrix \p A
@@ -370,15 +365,6 @@ public:
    */
   void add_vector (const NumericVector<T> &V,
                    const SparseMatrix<T> &A);
-
-  /**
-   * \f$U+=V \f$ where U and V are type
-   * DenseVector<T> and you
-   * want to specify WHERE to add
-   * the DenseVector<T> V
-   */
-  void add_vector (const DenseVector<T>& V,
-                   const std::vector<numeric_index_type>& dof_indices);
 
   /**
    * \f$U+=A*V\f$, add the product of the transpose of a \p SparseMatrix \p A_trans

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -179,53 +179,6 @@ NumericVector<T> & DistributedVector<T>::operator /= (NumericVector<T> & v)
 
 
 template <typename T>
-void DistributedVector<T>::add_vector (const std::vector<T>& v,
-                                       const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert (!v.empty());
-  libmesh_assert_equal_to (v.size(), dof_indices.size());
-  libmesh_assert (this->initialized());
-  libmesh_assert_equal_to (_values.size(), _local_size);
-  libmesh_assert_equal_to ((_last_local_index - _first_local_index), _local_size);
-
-  for (std::size_t i=0; i<v.size(); i++)
-    add (dof_indices[i], v[i]);
-}
-
-
-
-template <typename T>
-void DistributedVector<T>::add_vector (const NumericVector<T>& V,
-                                       const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V.size(), dof_indices.size());
-  libmesh_assert (this->initialized());
-  libmesh_assert_equal_to (_values.size(), _local_size);
-  libmesh_assert_equal_to ((_last_local_index - _first_local_index), _local_size);
-
-  for (numeric_index_type i=0; i<V.size(); i++)
-    add (dof_indices[i], V(i));
-}
-
-
-
-template <typename T>
-void DistributedVector<T>::add_vector (const DenseVector<T>& V,
-                                       const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V.size(), dof_indices.size());
-  libmesh_assert (this->initialized());
-  libmesh_assert_equal_to (_values.size(), _local_size);
-  libmesh_assert_equal_to ((_last_local_index - _first_local_index), _local_size);
-
-  for (unsigned int i=0; i<V.size(); i++)
-    add (dof_indices[i], V(i));
-}
-
-
-
-
-template <typename T>
 void DistributedVector<T>::reciprocal()
 {
   for (numeric_index_type i=0; i<local_size(); i++)

--- a/src/numerics/eigen_sparse_vector.C
+++ b/src/numerics/eigen_sparse_vector.C
@@ -184,43 +184,6 @@ void EigenSparseVector<T>::add (const T a, const NumericVector<T>& v_in)
 
 
 template <typename T>
-void EigenSparseVector<T>::add_vector (const std::vector<T>& v,
-                                       const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert (!v.empty());
-  libmesh_assert_equal_to (v.size(), dof_indices.size());
-
-  for (numeric_index_type i=0; i<v.size(); i++)
-    this->add (dof_indices[i], v[i]);
-}
-
-
-
-template <typename T>
-void EigenSparseVector<T>::add_vector (const NumericVector<T>& V,
-                                       const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V.size(), dof_indices.size());
-
-  for (numeric_index_type i=0; i<V.size(); i++)
-    this->add (dof_indices[i], V(i));
-}
-
-
-
-template <typename T>
-void EigenSparseVector<T>::add_vector (const DenseVector<T>& V,
-                                       const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V.size(), dof_indices.size());
-
-  for (unsigned int i=0; i<V.size(); i++)
-    this->add (dof_indices[i], V(i));
-}
-
-
-
-template <typename T>
 void EigenSparseVector<T>::add_vector (const NumericVector<T> &vec_in,
                                        const SparseMatrix<T>  &mat_in)
 {

--- a/src/numerics/laspack_vector.C
+++ b/src/numerics/laspack_vector.C
@@ -200,43 +200,6 @@ void LaspackVector<T>::add (const T a, const NumericVector<T>& v_in)
 
 
 template <typename T>
-void LaspackVector<T>::add_vector (const std::vector<T>& v,
-                                   const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert (!v.empty());
-  libmesh_assert_equal_to (v.size(), dof_indices.size());
-
-  for (numeric_index_type i=0; i<v.size(); i++)
-    this->add (dof_indices[i], v[i]);
-}
-
-
-
-template <typename T>
-void LaspackVector<T>::add_vector (const NumericVector<T>& V,
-                                   const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V.size(), dof_indices.size());
-
-  for (numeric_index_type i=0; i<V.size(); i++)
-    this->add (dof_indices[i], V(i));
-}
-
-
-
-template <typename T>
-void LaspackVector<T>::add_vector (const DenseVector<T>& V,
-                                   const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V.size(), dof_indices.size());
-
-  for (unsigned int i=0; i<V.size(); i++)
-    this->add (dof_indices[i], V(i));
-}
-
-
-
-template <typename T>
 void LaspackVector<T>::add_vector (const NumericVector<T> &vec_in,
                                    const SparseMatrix<T> &mat_in)
 {

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -400,6 +400,29 @@ Real NumericVector<T>::subset_linfty_norm (const std::set<numeric_index_type> & 
 
 
 template <typename T>
+void NumericVector<T>::add_vector (const T* v,
+                                   const std::vector<numeric_index_type>& dof_indices)
+{
+  int n = dof_indices.size();
+  for (int i=0; i<n; i++)
+    this->add (dof_indices[i], v[i]);
+}
+
+
+
+template <typename T>
+void NumericVector<T>::add_vector (const NumericVector<T>& v,
+                                   const std::vector<numeric_index_type>& dof_indices)
+{
+  int n = dof_indices.size();
+  libmesh_assert_equal_to(v.size(), n);
+  for (int i=0; i<n; i++)
+    this->add (dof_indices[i], v(i));
+}
+
+
+
+template <typename T>
 void NumericVector<T>::add_vector (const NumericVector<T>& v,
                                    const ShellMatrix<T>& a)
 {

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -197,37 +197,24 @@ void PetscVector<T>::add (const numeric_index_type i, const T value)
 
 
 template <typename T>
-void PetscVector<T>::add_vector (const std::vector<T>& v,
+void PetscVector<T>::add_vector (const T* v,
                                  const std::vector<numeric_index_type>& dof_indices)
 {
   // If we aren't adding anything just return
-  if(v.empty() || dof_indices.empty())
+  if(dof_indices.empty())
     return;
 
   this->_restore_array();
-  libmesh_assert_equal_to (v.size(), dof_indices.size());
 
   PetscErrorCode ierr=0;
   const PetscInt * i_val = reinterpret_cast<const PetscInt*>(&dof_indices[0]);
-  const PetscScalar * petsc_value = static_cast<const PetscScalar*>(&v[0]);
+  const PetscScalar * petsc_value = static_cast<const PetscScalar*>(v);
 
-  ierr = VecSetValues (_vec, cast_int<PetscInt>(v.size()), i_val,
-                       petsc_value, ADD_VALUES);
+  ierr = VecSetValues (_vec, cast_int<PetscInt>(dof_indices.size()),
+                       i_val, petsc_value, ADD_VALUES);
   LIBMESH_CHKERRABORT(ierr);
 
   this->_is_closed = false;
-}
-
-
-
-template <typename T>
-void PetscVector<T>::add_vector (const NumericVector<T>& V,
-                                 const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V.size(), dof_indices.size());
-
-  for (unsigned int i=0; i<V.size(); i++)
-    this->add (dof_indices[i], V(i));
 }
 
 
@@ -251,17 +238,6 @@ void PetscVector<T>::add_vector (const NumericVector<T>& V_in,
   LIBMESH_CHKERRABORT(ierr);
 }
 
-
-
-template <typename T>
-void PetscVector<T>::add_vector (const DenseVector<T>& V,
-                                 const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V.size(), dof_indices.size());
-
-  for (unsigned int i=0; i<V.size(); i++)
-    this->add (dof_indices[i], V(i));
-}
 
 
 template <typename T>

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -206,27 +206,14 @@ void EpetraVector<T>::add (const numeric_index_type i_in, const T value_in)
 
 
 template <typename T>
-void EpetraVector<T>::add_vector (const std::vector<T>& v,
+void EpetraVector<T>::add_vector (const T* v,
                                   const std::vector<numeric_index_type>& dof_indices)
 {
-  libmesh_assert_equal_to (v.size(), dof_indices.size());
   libmesh_assert_equal_to (sizeof(numeric_index_type), sizeof(int));
 
-  SumIntoGlobalValues (v.size(),
+  SumIntoGlobalValues (dof_indices.size(),
                        (int*) &dof_indices[0],
-                       const_cast<T*>(&v[0]));
-}
-
-
-
-template <typename T>
-void EpetraVector<T>::add_vector (const NumericVector<T>& V,
-                                  const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V.size(), dof_indices.size());
-
-  for (unsigned int i=0; i<V.size(); i++)
-    this->add (dof_indices[i], V(i));
+                       const_cast<T*>(v));
 }
 
 
@@ -246,19 +233,6 @@ void EpetraVector<T>::add_vector (const NumericVector<T>& V_in,
   *this += *temp;
 }
 
-
-
-template <typename T>
-void EpetraVector<T>::add_vector (const DenseVector<T>& V_in,
-                                  const std::vector<numeric_index_type>& dof_indices)
-{
-  libmesh_assert_equal_to (V_in.size(), dof_indices.size());
-  libmesh_assert_equal_to (sizeof(numeric_index_type), sizeof(int));
-
-  SumIntoGlobalValues(dof_indices.size(),
-                      (int *)&dof_indices[0],
-                      &const_cast<DenseVector<T> *>(&V_in)->get_values()[0]);
-}
 
 
 // TODO: fill this in after creating an EpetraMatrix


### PR DESCRIPTION
Similar to #411 and #413

This was originally intended to be just another additional T\* API plus
a refactoring; however, the new PetscVector::add_vector(DenseVector)
code path should be a performance improvement as well.

MooseBuild and BuildBot have both been happy with the prior refactorings, so I'm feeling confident.  If MooseBuild likes this I'll merge to master this afternoon, and if Buildbot is then happy too then I'll merge to 0.9.4.

These seem to be all the new APIs that https://github.com/roystgnr/moose/tree/optimizations needs, so we ought to be ready to release 0.9.4 this weekend.
