### PR TITLE
Clang 3.3 complained this line was ambiguous --with-dof-id-bytes=8.

### DIFF
--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1250,8 +1250,8 @@ void XdrIO::read_serialized_connectivity (Xdr &io, const dof_id_type n_elem, std
        last_elem<n_elem; blk++)
     {
       first_elem = cast_int<dof_id_type>(blk*io_blksize);
-      last_elem  = cast_int<dof_id_type>(std::min((blk+1)*io_blksize,
-                            cast_int<std::size_t>(n_elem)));
+      last_elem  = cast_int<dof_id_type>(std::min(cast_int<std::size_t>((blk+1)*io_blksize),
+                                                  cast_int<std::size_t>(n_elem)));
 
       conn.clear();
 


### PR DESCRIPTION
Presumably this is because calling std::min() with mixed types is ambiguous,
but I'm not sure what the compiler thought the two types were supposed to be.
Explicitly casting them both to size_t resolves the issue.
