### PR TITLE
some methods in rb_theta_expansion need to be virtual

### DIFF
--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -62,21 +62,21 @@ public:
    * if the theta functions need to be treated differently
    * in subclasses.
    */
-  Number eval_A_theta(unsigned int q,
-                      const RBParameters& mu);
+  virtual Number eval_A_theta(unsigned int q,
+                              const RBParameters& mu);
 
   /**
    * Evaluate theta_q_f at the current parameter.
    */
-  Number eval_F_theta(unsigned int q,
-                      const RBParameters& mu);
+  virtual Number eval_F_theta(unsigned int q,
+                              const RBParameters& mu);
 
   /**
    * Evaluate theta_q_l at the current parameter.
    */
-  Number eval_output_theta(unsigned int output_index,
-                           unsigned int q_l,
-                           const RBParameters& mu);
+  virtual Number eval_output_theta(unsigned int output_index,
+                                   unsigned int q_l,
+                                   const RBParameters& mu);
 
   /**
    * Get Q_a, the number of terms in the affine


### PR DESCRIPTION
Child classes of rb_theta_expansion (such as transient_rb_theta_expansion) should have the ability to override these methods.