### PR TITLE
Added System::reinit_constraints().

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -248,6 +248,11 @@ public:
   virtual void reinit ();
 
   /**
+   * Reinitializes the constraints for this system.
+   */
+  virtual void reinit_constraints ();
+
+  /**
    * Update the local values to reflect the solution
    * on neighboring processors.
    */

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -408,6 +408,14 @@ void System::reinit ()
 }
 
 
+void System::reinit_constraints()
+{
+  get_dof_map().create_dof_constraints(_mesh, this->time);
+  user_constrain();
+  get_dof_map().process_constraints(_mesh);
+  get_dof_map().prepare_send_list();
+}
+
 
 void System::update ()
 {


### PR DESCRIPTION
This allows us to update constraints with less overhead than by calling EquationSystems::reinit().
This new method can be used in the case that the mesh hasn't changed.