### PR TITLE
Workaround for GCC 4.6 internal compiler error

### DIFF
--- a/contrib/fparser/fpoptimizer.cc
+++ b/contrib/fparser/fpoptimizer.cc
@@ -11771,30 +11771,30 @@ namespace
     template<typename Value_t>
     const Value_t RootPowerTable<Value_t>::RootPowers[(1+4)*(1+3)] =
     {
-        // (sqrt^n(x))
+        // (sqrt^n(x)) // Workaround for gcc-4.6 bug by RHS
         Value_t(1),
-        Value_t(1) / Value_t(2),
-        Value_t(1) / Value_t(2*2),
-        Value_t(1) / Value_t(2*2*2),
-        Value_t(1) / Value_t(2*2*2*2),
+        Value_t(1.L/2.L),
+        Value_t(1.L/ (2.L*2.L)),
+        Value_t(1.L/ (2.L*2.L*2.L)),
+        Value_t(1.L/ (2.L*2.L*2.L*2.L)),
         // cbrt^1(sqrt^n(x))
-        Value_t(1) / Value_t(3),
-        Value_t(1) / Value_t(3*2),
-        Value_t(1) / Value_t(3*2*2),
-        Value_t(1) / Value_t(3*2*2*2),
-        Value_t(1) / Value_t(3*2*2*2*2),
+        Value_t(1.L/ (3.L)),
+        Value_t(1.L/ (3.L*2.L)),
+        Value_t(1.L/ (3.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*2.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*2.L*2.L*2.L*2.L)),
         // cbrt^2(sqrt^n(x))
-        Value_t(1) / Value_t(3*3),
-        Value_t(1) / Value_t(3*3*2),
-        Value_t(1) / Value_t(3*3*2*2),
-        Value_t(1) / Value_t(3*3*2*2*2),
-        Value_t(1) / Value_t(3*3*2*2*2*2),
+        Value_t(1.L/ (3.L*3.L)),
+        Value_t(1.L/ (3.L*3.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*2.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*2.L*2.L*2.L*2.L)),
         // cbrt^3(sqrt^n(x))
-        Value_t(1) / Value_t(3*3*3),
-        Value_t(1) / Value_t(3*3*3*2),
-        Value_t(1) / Value_t(3*3*3*2*2),
-        Value_t(1) / Value_t(3*3*3*2*2*2),
-        Value_t(1) / Value_t(3*3*3*2*2*2*2)
+        Value_t(1.L/ (3.L*3.L*3.L)),
+        Value_t(1.L/ (3.L*3.L*3.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*3.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*3.L*2.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*3.L*2.L*2.L*2.L*2.L))
     };
 
     struct PowiResolver

--- a/contrib/fparser/fpoptimizer/transformations.cc
+++ b/contrib/fparser/fpoptimizer/transformations.cc
@@ -89,30 +89,30 @@ namespace
     template<typename Value_t>
     const Value_t RootPowerTable<Value_t>::RootPowers[(1+4)*(1+3)] =
     {
-        // (sqrt^n(x))
+        // (sqrt^n(x)) // Workaround for gcc-4.6 bug by RHS
         Value_t(1),
-        Value_t(1) / Value_t(2),
-        Value_t(1) / Value_t(2*2),
-        Value_t(1) / Value_t(2*2*2),
-        Value_t(1) / Value_t(2*2*2*2),
+        Value_t(1.L/2.L),
+        Value_t(1.L/ (2.L*2.L)),
+        Value_t(1.L/ (2.L*2.L*2.L)),
+        Value_t(1.L/ (2.L*2.L*2.L*2.L)),
         // cbrt^1(sqrt^n(x))
-        Value_t(1) / Value_t(3),
-        Value_t(1) / Value_t(3*2),
-        Value_t(1) / Value_t(3*2*2),
-        Value_t(1) / Value_t(3*2*2*2),
-        Value_t(1) / Value_t(3*2*2*2*2),
+        Value_t(1.L/ (3.L)),
+        Value_t(1.L/ (3.L*2.L)),
+        Value_t(1.L/ (3.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*2.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*2.L*2.L*2.L*2.L)),
         // cbrt^2(sqrt^n(x))
-        Value_t(1) / Value_t(3*3),
-        Value_t(1) / Value_t(3*3*2),
-        Value_t(1) / Value_t(3*3*2*2),
-        Value_t(1) / Value_t(3*3*2*2*2),
-        Value_t(1) / Value_t(3*3*2*2*2*2),
+        Value_t(1.L/ (3.L*3.L)),
+        Value_t(1.L/ (3.L*3.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*2.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*2.L*2.L*2.L*2.L)),
         // cbrt^3(sqrt^n(x))
-        Value_t(1) / Value_t(3*3*3),
-        Value_t(1) / Value_t(3*3*3*2),
-        Value_t(1) / Value_t(3*3*3*2*2),
-        Value_t(1) / Value_t(3*3*3*2*2*2),
-        Value_t(1) / Value_t(3*3*3*2*2*2*2)
+        Value_t(1.L/ (3.L*3.L*3.L)),
+        Value_t(1.L/ (3.L*3.L*3.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*3.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*3.L*2.L*2.L*2.L)),
+        Value_t(1.L/ (3.L*3.L*3.L*2.L*2.L*2.L*2.L))
     };
 
     struct PowiResolver


### PR DESCRIPTION
Trying to instantiate this array as std::complex<double> was causing
g++ 4.6 to segfault.

Doing these divisions in long double would lead to errors in cases
where Value_t is using higher (e.g. variable) precision arithmetic;
fortunately we don't instantiate any such cases.