### PR TITLE
MeshBase::subdomain_ids(), MeshBase::recalculate_n_partitions() should use local iterators

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -211,8 +211,8 @@ void MeshBase::subdomain_ids (std::set<subdomain_id_type> &ids) const
 
   ids.clear();
 
-  const_element_iterator       el  = this->active_elements_begin();
-  const const_element_iterator end = this->active_elements_end();
+  const_element_iterator el  = this->active_local_elements_begin();
+  const_element_iterator end = this->active_local_elements_end();
 
   for (; el!=end; ++el)
     ids.insert((*el)->subdomain_id());

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -363,8 +363,11 @@ void MeshBase::partition (const unsigned int n_parts)
 
 unsigned int MeshBase::recalculate_n_partitions()
 {
-  const_element_iterator       el  = this->active_elements_begin();
-  const const_element_iterator end = this->active_elements_end();
+  // This requires an inspection on every processor
+  parallel_object_only();
+
+  const_element_iterator el  = this->active_local_elements_begin();
+  const_element_iterator end = this->active_local_elements_end();
 
   unsigned int max_proc_id=0;
 


### PR DESCRIPTION
Not Earth-shattering, but noticed these slight inefficiencies (active_elements go over the whole mesh whereas active_local_elements are only on the current processor, right?) and thought I'd throw in a quick fix. `make check` ran correctly on my workstation.

I set the PR to master, but I think it would be appropriate to merge to 0.9.4 for that release.