### PR TITLE
Output the PerfLog when we terminate

### DIFF
--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -306,6 +306,11 @@ void libmesh_terminate_handler()
   // unwind, for example.
   libMesh::write_traceout();
 
+  // We may care about performance data pre-crash; it would be sad to
+  // throw that away.
+  libMesh::perflog.print_log();
+  libMesh::perflog.clear();
+
   // If we have MPI and it has been initialized, we need to be sure
   // and call MPI_Abort instead of std::abort, so that the parallel
   // job can die nicely.


### PR DESCRIPTION
This is nice when you can't figure out why a process is taking
forever.  "Ctrl-C" doesn't trigger a terminate, but "kill $ITS_PID"
does.