### PR TITLE
Slightly Better Support for Mixed Dimension Meshes

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -165,6 +165,12 @@ public:
   { _dim = d; }
 
   /**
+   * @returns set of dimensions of elements present in the mesh.
+   */
+  const std::set<unsigned char>& elem_dimensions() const
+  { return _elem_dims; }
+
+  /**
    * Returns the spatial dimension of the mesh.  Note that this is
    * defined at compile time in the header \p libmesh_common.h.
    */
@@ -880,6 +886,12 @@ protected:
   { return _n_parts; }
 
   /**
+   * Search the mesh and cache the different dimenions of the elements
+   * present in the mesh.
+   */
+  void cache_elem_dims();
+
+  /**
    * The number of partitions the mesh has.  This is set by
    * the partitioners, and may not be changed directly by
    * the user.
@@ -943,6 +955,12 @@ protected:
    */
   std::map<subdomain_id_type, std::string> _block_id_to_name;
 
+  /**
+   * We cache the dimension of the elements present in the mesh.
+   * So, if we have a mesh with 1D and 2D elements, this structure
+   * will contain 1 and 2.
+   */
+  std::set<unsigned char> _elem_dims;
   /**
    * The partitioner class is a friend so that it can set
    * the number of partitions.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -156,13 +156,19 @@ public:
    * then this will return the largest such dimension.
    */
   unsigned int mesh_dimension () const
-  { return cast_int<unsigned int>(_dim); }
+  { libmesh_assert(!_elem_dims.empty());
+    typedef std::set<unsigned char>::const_iterator it_type;
+    return cast_int<unsigned int>(*(std::max_element<it_type>(_elem_dims.begin(),_elem_dims.end()))); }
 
   /**
-   * Resets the logical dimension of the mesh.
+   * Resets the logical dimension of the mesh. If the mesh has
+   * elements of multiple dimensions, this should be set to the largest
+   * dimension. E.g. if the mesh has 1D and 2D elements, this should
+   * be set to 2. If the mesh has 2D and 3D elements, this should be
+   * set to 3.
    */
   void set_mesh_dimension (unsigned char d)
-  { _dim = d; }
+  { _elem_dims.clear(); _elem_dims.insert(d); }
 
   /**
    * @returns set of dimensions of elements present in the mesh.
@@ -505,10 +511,11 @@ public:
 
   /**
    * Prepare a newly created (or read) mesh for use.
-   * This involves 3 steps:
+   * This involves 4 steps:
    *  1.) call \p find_neighbors()
    *  2.) call \p partition()
    *  3.) call \p renumber_nodes_and_elements()
+   *  4.) call \p cache_elem_dims()
    *
    * The argument to skip renumbering is now deprecated - to prevent a
    * mesh from being renumbered, set allow_renumbering(false).

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -155,10 +155,7 @@ public:
    * multi-dimensional meshes (e.g. hexes and quads in the same mesh)
    * then this will return the largest such dimension.
    */
-  unsigned int mesh_dimension () const
-  { libmesh_assert(!_elem_dims.empty());
-    typedef std::set<unsigned char>::const_iterator it_type;
-    return cast_int<unsigned int>(*(std::max_element<it_type>(_elem_dims.begin(),_elem_dims.end()))); }
+  unsigned int mesh_dimension () const;
 
   /**
    * Resets the logical dimension of the mesh. If the mesh has

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -910,11 +910,6 @@ protected:
   unsigned int _n_parts;
 
   /**
-   * The logical dimension of the mesh.
-   */
-  unsigned char _dim;
-
-  /**
    * Flag indicating if the mesh has been prepared for use.
    */
   bool _is_prepared;

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -115,7 +115,11 @@ MeshBase::~MeshBase()
   libmesh_exceptionless_assert (!libMesh::closed());
 }
 
-
+unsigned int MeshBase::mesh_dimension() const
+{
+  libmesh_assert(!_elem_dims.empty());
+  return cast_int<unsigned int>(*_elem_dims.rbegin());
+}
 
 void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, const bool skip_find_neighbors)
 {

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -471,8 +471,8 @@ void MeshBase::cache_elem_dims()
   // This requires an inspection on every processor
   parallel_object_only();
 
-  const_element_iterator       el  = this->active_elements_begin();
-  const const_element_iterator end = this->active_elements_end();
+  const_element_iterator el  = this->active_local_elements_begin();
+  const_element_iterator end = this->active_local_elements_end();
 
   for (; el!=end; ++el)
     _elem_dims.insert((*el)->dim());

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -47,7 +47,6 @@ MeshBase::MeshBase (const Parallel::Communicator &comm_in,
   ParallelObject (comm_in),
   boundary_info  (new BoundaryInfo(*this)),
   _n_parts       (1),
-  _dim           (d),
   _is_prepared   (false),
   _point_locator (NULL),
   _partitioner   (NULL),
@@ -59,7 +58,7 @@ MeshBase::MeshBase (const Parallel::Communicator &comm_in,
 {
   _elem_dims.insert(d);
   libmesh_assert_less_equal (LIBMESH_DIM, 3);
-  libmesh_assert_greater_equal (LIBMESH_DIM, _dim);
+  libmesh_assert_greater_equal (LIBMESH_DIM, d);
   libmesh_assert (libMesh::initialized());
 }
 
@@ -69,7 +68,6 @@ MeshBase::MeshBase (unsigned char d) :
   ParallelObject (CommWorld),
   boundary_info  (new BoundaryInfo(*this)),
   _n_parts       (1),
-  _dim           (d),
   _is_prepared   (false),
   _point_locator (NULL),
   _partitioner   (NULL),
@@ -81,7 +79,7 @@ MeshBase::MeshBase (unsigned char d) :
 {
   _elem_dims.insert(d);
   libmesh_assert_less_equal (LIBMESH_DIM, 3);
-  libmesh_assert_greater_equal (LIBMESH_DIM, _dim);
+  libmesh_assert_greater_equal (LIBMESH_DIM, d);
   libmesh_assert (libMesh::initialized());
 }
 #endif // !LIBMESH_DISABLE_COMMWORLD
@@ -92,7 +90,6 @@ MeshBase::MeshBase (const MeshBase& other_mesh) :
   ParallelObject (other_mesh),
   boundary_info  (new BoundaryInfo(*this)),
   _n_parts       (other_mesh._n_parts),
-  _dim           (other_mesh._dim),
   _is_prepared   (other_mesh._is_prepared),
   _point_locator (NULL),
   _partitioner   (NULL),

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -57,6 +57,7 @@ MeshBase::MeshBase (const Parallel::Communicator &comm_in,
   _skip_partitioning(false),
   _skip_renumber_nodes_and_elements(false)
 {
+  _elem_dims.insert(d);
   libmesh_assert_less_equal (LIBMESH_DIM, 3);
   libmesh_assert_greater_equal (LIBMESH_DIM, _dim);
   libmesh_assert (libMesh::initialized());
@@ -78,6 +79,7 @@ MeshBase::MeshBase (unsigned char d) :
   _skip_partitioning(false),
   _skip_renumber_nodes_and_elements(false)
 {
+  _elem_dims.insert(d);
   libmesh_assert_less_equal (LIBMESH_DIM, 3);
   libmesh_assert_greater_equal (LIBMESH_DIM, _dim);
   libmesh_assert (libMesh::initialized());
@@ -98,7 +100,8 @@ MeshBase::MeshBase (const MeshBase& other_mesh) :
   _next_unique_id(other_mesh._next_unique_id),
 #endif
   _skip_partitioning(other_mesh._skip_partitioning),
-  _skip_renumber_nodes_and_elements(false)
+  _skip_renumber_nodes_and_elements(false),
+  _elem_dims(other_mesh._elem_dims)
 {
   if(other_mesh._partitioner.get())
     {

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -706,7 +706,11 @@ void MeshCommunication::broadcast (MeshBase& mesh) const
                                        mesh_inserter_iterator<Elem>(mesh));
 
   // Make sure mesh dimension is consistent
-  unsigned char mesh_dimension = mesh.mesh_dimension();
+  // We need to set a default first because other processors mesh_dimension is empty.
+  unsigned char mesh_dimension = 1;
+  if(mesh.processor_id() == 0)
+    mesh_dimension = mesh.mesh_dimension();
+
   mesh.comm().broadcast(mesh_dimension);
   mesh.set_mesh_dimension(mesh_dimension);
 

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -1386,7 +1386,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                                   // any of our neighbor's descendants
                                   if( (*my_side == *their_side) &&
                                       (el->level() == neighbor->level()) &&
-                                      ((_dim != 1) || (ns != s)) )
+                                      ((el->dim() != 1) || (ns != s)) )
                                     {
                                       // So share a side.  Is this a mixed pair
                                       // of subactive and active/ancestor

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -106,7 +106,7 @@ void UnstructuredMesh::copy_nodes_and_elements
 {
   // We're assuming our subclass data needs no copy
   libmesh_assert_equal_to (_n_parts, other_mesh._n_parts);
-  libmesh_assert_equal_to (_dim, other_mesh._dim);
+  libmesh_assert (std::equal(_elem_dims.begin(), _elem_dims.end(), other_mesh._elem_dims.begin()));
   libmesh_assert_equal_to (_is_prepared, other_mesh._is_prepared);
 
   // We're assuming the other mesh has proper element number ordering,

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -340,7 +340,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                         // any of our neighbor's descendants
                         if( (*my_side == *their_side) &&
                             (element->level() == neighbor->level()) &&
-                            ((_dim != 1) || (ns != ms)) )
+                            ((element->dim() != 1) || (ns != ms)) )
                           {
                             // So share a side.  Is this a mixed pair
                             // of subactive and active/ancestor

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,6 +15,7 @@ unit_tests_sources = \
 	geom/node_test.C \
 	geom/point_test.C \
 	geom/point_test.h \
+	mesh/mixed_dim_mesh_test.C \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -119,7 +119,8 @@ CONFIG_CLEAN_VPATH_FILES =
 @LIBMESH_OPROF_MODE_TRUE@am__EXEEXT_5 = unit_tests-oprof$(EXEEXT)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h numerics/composite_function_test.C \
+	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -133,6 +134,7 @@ am__dirstamp = $(am__leading_dot)dirstamp
 am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	geom/unit_tests_dbg-node_test.$(OBJEXT) \
 	geom/unit_tests_dbg-point_test.$(OBJEXT) \
+	mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-laspack_vector_test.$(OBJEXT) \
@@ -156,7 +158,8 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(LDFLAGS) -o $@
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h numerics/composite_function_test.C \
+	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -169,6 +172,7 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	geom/unit_tests_devel-node_test.$(OBJEXT) \
 	geom/unit_tests_devel-point_test.$(OBJEXT) \
+	mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_devel-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_devel-laspack_vector_test.$(OBJEXT) \
@@ -191,7 +195,8 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(LDFLAGS) -o $@
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h numerics/composite_function_test.C \
+	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -204,6 +209,7 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	geom/unit_tests_oprof-node_test.$(OBJEXT) \
 	geom/unit_tests_oprof-point_test.$(OBJEXT) \
+	mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-laspack_vector_test.$(OBJEXT) \
@@ -226,7 +232,8 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(LDFLAGS) -o $@
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h numerics/composite_function_test.C \
+	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -239,6 +246,7 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	geom/unit_tests_opt-node_test.$(OBJEXT) \
 	geom/unit_tests_opt-point_test.$(OBJEXT) \
+	mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_opt-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_opt-laspack_vector_test.$(OBJEXT) \
@@ -259,7 +267,8 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(LDFLAGS) -o $@
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h numerics/composite_function_test.C \
+	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -272,6 +281,7 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	geom/unit_tests_prof-node_test.$(OBJEXT) \
 	geom/unit_tests_prof-point_test.$(OBJEXT) \
+	mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_prof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_prof-laspack_vector_test.$(OBJEXT) \
@@ -681,7 +691,7 @@ AM_CPPFLAGS = $(libmesh_optional_INCLUDES) -I$(top_builddir)/include \
 AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	numerics/composite_function_test.C \
+	mesh/mixed_dim_mesh_test.C numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -769,6 +779,14 @@ geom/unit_tests_dbg-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_dbg-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+mesh/$(am__dirstamp):
+	@$(MKDIR_P) mesh
+	@: > mesh/$(am__dirstamp)
+mesh/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) mesh/$(DEPDIR)
+	@: > mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/$(am__dirstamp):
 	@$(MKDIR_P) numerics
 	@: > numerics/$(am__dirstamp)
@@ -835,6 +853,8 @@ geom/unit_tests_devel-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT):  \
@@ -865,6 +885,8 @@ geom/unit_tests_oprof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_oprof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT):  \
@@ -895,6 +917,8 @@ geom/unit_tests_opt-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT):  \
@@ -925,6 +949,8 @@ geom/unit_tests_prof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_prof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT):  \
@@ -956,6 +982,7 @@ mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
 	-rm -f fparser/*.$(OBJEXT)
 	-rm -f geom/*.$(OBJEXT)
+	-rm -f mesh/*.$(OBJEXT)
 	-rm -f numerics/*.$(OBJEXT)
 	-rm -f parallel/*.$(OBJEXT)
 	-rm -f quadrature/*.$(OBJEXT)
@@ -985,6 +1012,11 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po@am__quote@
@@ -1101,6 +1133,20 @@ geom/unit_tests_dbg-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/point_test.C' object='geom/unit_tests_dbg-point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
+
+mesh/unit_tests_dbg-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_dbg-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_dbg-mixed_dim_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+
+mesh/unit_tests_dbg-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mixed_dim_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_dbg-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_dbg-mixed_dim_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
 
 numerics/unit_tests_dbg-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Tpo -c -o numerics/unit_tests_dbg-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
@@ -1298,6 +1344,20 @@ geom/unit_tests_devel-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
 
+mesh/unit_tests_devel-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_devel-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_devel-mixed_dim_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+
+mesh/unit_tests_devel-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mixed_dim_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_devel-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_devel-mixed_dim_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+
 numerics/unit_tests_devel-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Tpo -c -o numerics/unit_tests_devel-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po
@@ -1493,6 +1553,20 @@ geom/unit_tests_oprof-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/point_test.C' object='geom/unit_tests_oprof-point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
+
+mesh/unit_tests_oprof-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_oprof-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_oprof-mixed_dim_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+
+mesh/unit_tests_oprof-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mixed_dim_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_oprof-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_oprof-mixed_dim_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
 
 numerics/unit_tests_oprof-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Tpo -c -o numerics/unit_tests_oprof-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
@@ -1690,6 +1764,20 @@ geom/unit_tests_opt-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
 
+mesh/unit_tests_opt-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_opt-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_opt-mixed_dim_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+
+mesh/unit_tests_opt-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mixed_dim_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_opt-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_opt-mixed_dim_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+
 numerics/unit_tests_opt-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Tpo -c -o numerics/unit_tests_opt-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po
@@ -1885,6 +1973,20 @@ geom/unit_tests_prof-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/point_test.C' object='geom/unit_tests_prof-point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
+
+mesh/unit_tests_prof-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_prof-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_prof-mixed_dim_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
+
+mesh/unit_tests_prof-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mixed_dim_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_prof-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_prof-mixed_dim_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
 
 numerics/unit_tests_prof-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Tpo -c -o numerics/unit_tests_prof-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
@@ -2272,6 +2374,8 @@ distclean-generic:
 	-rm -f fparser/$(am__dirstamp)
 	-rm -f geom/$(DEPDIR)/$(am__dirstamp)
 	-rm -f geom/$(am__dirstamp)
+	-rm -f mesh/$(DEPDIR)/$(am__dirstamp)
+	-rm -f mesh/$(am__dirstamp)
 	-rm -f numerics/$(DEPDIR)/$(am__dirstamp)
 	-rm -f numerics/$(am__dirstamp)
 	-rm -f parallel/$(DEPDIR)/$(am__dirstamp)
@@ -2292,7 +2396,7 @@ clean-am: clean-checkPROGRAMS clean-generic clean-libtool \
 	mostlyclean-am
 
 distclean: distclean-am
-	-rm -rf ./$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -2338,7 +2442,7 @@ install-ps-am:
 installcheck-am:
 
 maintainer-clean: maintainer-clean-am
-	-rm -rf ./$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -1,0 +1,274 @@
+// Ignore unused parameter warnings coming from cppuint headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/equation_systems.h>
+#include <libmesh/mesh.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/edge_edge2.h>
+#include <libmesh/face_quad4.h>
+#include <libmesh/dof_map.h>
+#include <libmesh/nonlinear_implicit_system.h>
+#include <libmesh/mesh_refinement.h>
+
+#include "test_comm.h"
+
+using namespace libMesh;
+
+class MixedDimensionMeshTest : public CppUnit::TestCase {
+  /**
+   * The goal of this test is to ensure that a 2D mesh with 1D elements overlapping
+   * on the edge is consistent. That is, they share the same global node numbers and
+   * the same dof numbers for a variable.
+   */
+public:
+  CPPUNIT_TEST_SUITE( MixedDimensionMeshTest );
+
+  CPPUNIT_TEST( testMesh );
+  CPPUNIT_TEST( testDofOrdering );
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+
+  SerialMesh* _mesh;
+
+  void build_mesh()
+  {
+    _mesh = new SerialMesh(*TestCommWorld);
+
+    /*
+      (0,1)           (1,1)
+        x---------------x
+        |               |
+        |               |
+        |               |
+        |               |
+        |               |
+        x---------------x
+       (0,0)           (1,0)
+        |               |
+        |               |
+        |               |
+        |               |
+        x---------------x
+       (0,-1)          (1,-1)
+     */
+
+    _mesh->set_mesh_dimension(2);
+
+    _mesh->add_point( Point(0.0,-1.0), 4 );
+    _mesh->add_point( Point(1.0,-1.0), 5 );
+    _mesh->add_point( Point(1.0, 0.0), 1 );
+    _mesh->add_point( Point(1.0, 1.0), 2 );
+    _mesh->add_point( Point(0.0, 1.0), 3 );
+    _mesh->add_point( Point(0.0, 0.0), 0 );
+
+    {
+      Elem* elem_top = _mesh->add_elem( new Quad4 );
+      elem_top->set_node(0) = _mesh->node_ptr(0);
+      elem_top->set_node(1) = _mesh->node_ptr(1);
+      elem_top->set_node(2) = _mesh->node_ptr(2);
+      elem_top->set_node(3) = _mesh->node_ptr(3);
+
+      Elem* elem_bottom = _mesh->add_elem( new Quad4 );
+      elem_bottom->set_node(0) = _mesh->node_ptr(4);
+      elem_bottom->set_node(1) = _mesh->node_ptr(5);
+      elem_bottom->set_node(2) = _mesh->node_ptr(1);
+      elem_bottom->set_node(3) = _mesh->node_ptr(0);
+
+      Elem* edge = _mesh->add_elem( new Edge2 );
+      edge->set_node(0) = _mesh->node_ptr(0);
+      edge->set_node(1) = _mesh->node_ptr(1);
+    }
+
+    // libMesh will renumber, but we numbered according to its scheme
+    // anyway. We do this because when we call uniformly_refine subsequenly,
+    // it's going use skip_renumber=false.
+    _mesh->prepare_for_use(false /*skip_renumber*/);
+  }
+
+public:
+  void setUp()
+  {
+    this->build_mesh();
+  }
+
+  void tearDown()
+  {
+    delete _mesh;
+   }
+
+  void testMesh()
+  {
+    // There'd better be 3 elements
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)3, _mesh->n_elem() );
+
+    // There'd better be only 6 nodes
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)6, _mesh->n_nodes() );
+
+    /* The nodes for the EDGE2 element should have the same global ids
+       as the bottom edge of the top QUAD4 element */
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(2)->node(0), _mesh->elem(0)->node(0) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(2)->node(1), _mesh->elem(0)->node(1) );
+
+    /* The nodes for the EDGE2 element should have the same global ids
+       as the top edge of the bottom QUAD4 element */
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(2)->node(0), _mesh->elem(1)->node(3) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(2)->node(1), _mesh->elem(1)->node(2) );
+
+    /* The nodes for the bottom edge of the top QUAD4 element should have
+       the same global ids as the top edge of the bottom QUAD4 element */
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(0)->node(0), _mesh->elem(1)->node(3) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(0)->node(1), _mesh->elem(1)->node(2) );
+  }
+
+  void testDofOrdering()
+  {
+    EquationSystems es(*_mesh);
+    es.add_system<NonlinearImplicitSystem>("TestDofSystem");
+    es.get_system("TestDofSystem").add_variable("u",FIRST);
+    es.init();
+
+    DofMap& dof_map = es.get_system("TestDofSystem").get_dof_map();
+
+    std::vector<dof_id_type> top_quad_dof_indices, bottom_quad_dof_indices, edge_dof_indices;
+
+    dof_map.dof_indices( _mesh->elem(0), top_quad_dof_indices );
+    dof_map.dof_indices( _mesh->elem(1), bottom_quad_dof_indices );
+    dof_map.dof_indices( _mesh->elem(2), edge_dof_indices );
+
+    /* The dofs for the EDGE2 element should be the same
+       as the bottom edge of the top QUAD4 dofs */
+    CPPUNIT_ASSERT_EQUAL( edge_dof_indices[0], top_quad_dof_indices[0] );
+    CPPUNIT_ASSERT_EQUAL( edge_dof_indices[1], top_quad_dof_indices[1] );
+
+    /* The dofs for the EDGE2 element should be the same
+       as the top edge of the bottom QUAD4 dofs */
+    CPPUNIT_ASSERT_EQUAL( edge_dof_indices[0], bottom_quad_dof_indices[3] );
+    CPPUNIT_ASSERT_EQUAL( edge_dof_indices[1], bottom_quad_dof_indices[2] );
+
+    /* The nodes for the bottom edge of the top QUAD4 element should have
+       the same global ids as the top edge of the bottom QUAD4 element */
+    CPPUNIT_ASSERT_EQUAL( top_quad_dof_indices[0], bottom_quad_dof_indices[3] );
+    CPPUNIT_ASSERT_EQUAL( top_quad_dof_indices[1], bottom_quad_dof_indices[2] );
+  }
+
+};
+
+class MixedDimensionRefinedMeshTest : public MixedDimensionMeshTest {
+  /**
+   * The goal of this test is the same as the previous, but now we do a
+   * uniform refinement and make sure the result mesh is consistent. i.e.
+   * the new node shared between the 1D elements is the same as the node
+   * shared on the underlying quads, and so on.
+   */
+public:
+  CPPUNIT_TEST_SUITE( MixedDimensionRefinedMeshTest );
+
+  CPPUNIT_TEST( testMesh );
+  CPPUNIT_TEST( testDofOrdering );
+
+  CPPUNIT_TEST_SUITE_END();
+
+  // Yes, this is necesarry. Somewhere in those macros is a protected/private
+public:
+
+  void setUp()
+  {
+    /*
+
+        3-------10------2
+        |       |       |
+        |   5   |   6   |
+        8-------7-------9
+        |       |       |
+        |   3   |   4   |
+        0-------6-------1
+        |       |       |
+        |   9   |  10   |
+       13------12-------14
+        |       |       |
+        |   7   |   8   |
+        4-------11------5
+
+     */
+    this->build_mesh();
+    MeshRefinement(*_mesh).uniformly_refine(1);
+  }
+
+  void testMesh()
+  {
+    // We should have 13 total and 10 active elements.
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)13, _mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)10, _mesh->n_active_elem() );
+
+    // We should have 15 nodes
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)15, _mesh->n_nodes() );
+
+    // EDGE2,id=11 should have same nodes of bottom of QUAD4, id=3
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(11)->node(0), _mesh->elem(3)->node(0) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(11)->node(1), _mesh->elem(3)->node(1) );
+
+    // EDGE2,id=12 should have same nodes of bottom of QUAD4, id=4
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(12)->node(0), _mesh->elem(4)->node(0) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(12)->node(1), _mesh->elem(4)->node(1) );
+
+    // EDGE2,id=11 should have same nodes of top of QUAD4, id=9
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(11)->node(0), _mesh->elem(9)->node(3) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(11)->node(1), _mesh->elem(9)->node(2) );
+
+    // EDGE2,id=12 should have same nodes of top of QUAD4, id=10
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(12)->node(0), _mesh->elem(10)->node(3) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(12)->node(1), _mesh->elem(10)->node(2) );
+
+    // Shared node between the EDGE2 elements should have the same global id
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(11)->node(1), _mesh->elem(12)->node(0) );
+  }
+
+  void testDofOrdering()
+  {
+    EquationSystems es(*_mesh);
+    es.add_system<NonlinearImplicitSystem>("TestDofSystem");
+    es.get_system("TestDofSystem").add_variable("u",FIRST);
+    es.init();
+
+    DofMap& dof_map = es.get_system("TestDofSystem").get_dof_map();
+
+    std::vector<dof_id_type> top_quad3_dof_indices, top_quad4_dof_indices;
+    std::vector<dof_id_type> bottom_quad9_dof_indices, bottom_quad10_dof_indices;
+    std::vector<dof_id_type> edge11_dof_indices, edge12_dof_indices;
+
+    dof_map.dof_indices( _mesh->elem(3), top_quad3_dof_indices );
+    dof_map.dof_indices( _mesh->elem(4), top_quad4_dof_indices );
+    dof_map.dof_indices( _mesh->elem(9), bottom_quad9_dof_indices );
+    dof_map.dof_indices( _mesh->elem(10), bottom_quad10_dof_indices );
+    dof_map.dof_indices( _mesh->elem(11), edge11_dof_indices );
+    dof_map.dof_indices( _mesh->elem(12), edge12_dof_indices );
+
+    // EDGE2,id=11 should have same dofs as of bottom of QUAD4, id=3
+    CPPUNIT_ASSERT_EQUAL( edge11_dof_indices[0], top_quad3_dof_indices[0] );
+    CPPUNIT_ASSERT_EQUAL( edge11_dof_indices[1], top_quad3_dof_indices[1] );
+
+    // EDGE2,id=12 should have same dofs of bottom of QUAD4, id=4
+    CPPUNIT_ASSERT_EQUAL( edge12_dof_indices[0], top_quad4_dof_indices[0] );
+    CPPUNIT_ASSERT_EQUAL( edge12_dof_indices[1], top_quad4_dof_indices[1] );
+
+    // EDGE2,id=11 should have same dofs of top of QUAD4, id=9
+    CPPUNIT_ASSERT_EQUAL( edge11_dof_indices[0], bottom_quad9_dof_indices[3] );
+    CPPUNIT_ASSERT_EQUAL( edge11_dof_indices[1], bottom_quad9_dof_indices[2] );
+
+    // EDGE2,id=12 should have same dofs of top of QUAD4, id=10
+    CPPUNIT_ASSERT_EQUAL( edge12_dof_indices[0], bottom_quad10_dof_indices[3] );
+    CPPUNIT_ASSERT_EQUAL( edge12_dof_indices[1], bottom_quad10_dof_indices[2] );
+
+    //EDGE2 elements should have same shared dof number
+    CPPUNIT_ASSERT_EQUAL( edge11_dof_indices[1], edge12_dof_indices[0] );
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( MixedDimensionMeshTest );
+CPPUNIT_TEST_SUITE_REGISTRATION( MixedDimensionRefinedMeshTest );


### PR DESCRIPTION
This is the first PR to help better support mixed dimensional meshes. The second will update FEMContext/FEMSystem. (FYI, my main focus is mixed 1D/2D meshes.)

I'm going to push a test case to this branch later, but wanted people to be able to start laying eyes on this sooner rather than later as it changes `MeshBase`. Before, it was assumed that the mesh had only one dimension (`MeshBase::_dim`). The issue is that we will need to be able to query the different dimensions of elements present in the mesh without doing a loop over elements each time (e.g. for deciding which FE objects need to be created). So, the main goal of this PR is to add that capability. `mesh_dimension()` still returns the largest dimension present in the mesh. Internally, the dimensions are stored in `std::set` instead of a single `unsigned char`. We can also now query this `std::set` to grab which element dimensions are present in the mesh.

make check passes for me. Again, I'll push a test case here later (hopefully today) - the test case is a mixed 1D and 2D element mesh where 1 EDGE2 element overlaps the edge where 2 QUAD4 elements meet. Then, I do a uniform refinement and check that the node numbers and dof numbers also overlap, i.e. the 1D nodes shared by the 2D element nodes are the same node and similarly for the dofs. I've manually checked so far in the test, now  just need to automate that part and put it in the tests (somewhere... any suggestions?).