### PR TITLE
Revert "Fix JIT compilation when $CXX has spaces in it"

### DIFF
--- a/contrib/fparser/Makefile.am
+++ b/contrib/fparser/Makefile.am
@@ -101,7 +101,7 @@ EXTRA_DIST += $(FPOPTIMIZER_CC_FILES) fpoptimizer/fpoptimizer_header.txt fpoptim
 pkg_sources = fparser.cc fparser_ad.cc
 if FPARSER_SUPPORT_JIT
   pkg_sources += lib/sha1.cpp
-  pkg_cppflags += -DFPARSER_JIT_COMPILER="$(CXX)"
+  pkg_cppflags += -DFPARSER_JIT_COMPILER="\"$(CXX)\""
 endif
 
 pkg_cppflags += $(FEATURE_FLAGS)

--- a/contrib/fparser/Makefile.in
+++ b/contrib/fparser/Makefile.in
@@ -60,7 +60,7 @@ target_triplet = @target@
 @HAVE_CXX11_MOVE_TRUE@am__append_2 = -DFP_SUPPORT_CXX11_MOVE
 noinst_PROGRAMS = $(am__EXEEXT_1)
 @FPARSER_SUPPORT_JIT_TRUE@am__append_3 = lib/sha1.cpp
-@FPARSER_SUPPORT_JIT_TRUE@am__append_4 = -DFPARSER_JIT_COMPILER="$(CXX)"
+@FPARSER_SUPPORT_JIT_TRUE@am__append_4 = -DFPARSER_JIT_COMPILER="\"$(CXX)\""
 @FPARSER_DEVEL_TRUE@am__append_5 = fpoptimizer/grammar_data.cc
 @FPARSER_DEVEL_TRUE@am__append_6 = util/tree_grammar_parser \
 @FPARSER_DEVEL_TRUE@	util/bytecoderules_parser \

--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -77,8 +77,6 @@ private:
   } RefuseToTakeCrazyDerivativeException;
 };
 
-#define FPARSER_MAKE_STR(s) #s
-
 template<typename Value_t>
 FunctionParserADBase<Value_t>::FunctionParserADBase() :
     FunctionParserBase<Value_t>(),
@@ -799,9 +797,9 @@ bool FunctionParserADBase<Value_t>::JITCompileHelper(const std::string & Value_t
   // run compiler
 #if defined(__GNUC__) && defined(__APPLE__) && !defined(__INTEL_COMPILER)
   // gcc on OSX does neither need nor accept the  -rdynamic switch
-  std::string command = FPARSER_MAKE_STR(FPARSER_JIT_COMPILER) " -O2 -shared -fPIC ";
+  std::string command = FPARSER_JIT_COMPILER" -O2 -shared -fPIC ";
 #else
-  std::string command = FPARSER_MAKE_STR(FPARSER_JIT_COMPILER) " -O2 -shared -rdynamic -fPIC ";
+  std::string command = FPARSER_JIT_COMPILER" -O2 -shared -rdynamic -fPIC ";
 #endif
   command += ccname_cc + " -o " + object;
   status = system(command.c_str());


### PR DESCRIPTION
This reverts commit 9f2ac686e6103adf4c3df0accf8655755cb2c26c, which is borked. The code literally inserts the string ```FPARSER_JIT_COMPILER``` as the compiler name. I'm not sure there was a problem to be fixed here in the first place. Compiler names with spaces in them would fail either way. Im my version explicit double quotes are added. The call would simply fail on execution. Such a command (with spaces) would not work to build libmesh in the first place (unless the space is quited, but then my version should work as well).
