### PR TITLE
Rename protected FEMContext members

### DIFF
--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -111,13 +111,13 @@ public:
    * Accessor for element solution.
    */
   const DenseVector<Number>& get_elem_solution() const
-  { return elem_solution; }
+  { return _elem_solution; }
 
   /**
    * Non-const accessor for element solution.
    */
   DenseVector<Number>& get_elem_solution()
-  { return elem_solution; }
+  { return _elem_solution; }
 
   /**
    * Accessor for element solution of a particular variable corresponding
@@ -125,9 +125,9 @@ public:
    */
   const DenseSubVector<Number>& get_elem_solution( unsigned int var ) const
   {
-    libmesh_assert_greater(elem_subsolutions.size(), var);
-    libmesh_assert(elem_subsolutions[var]);
-    return *(elem_subsolutions[var]);
+    libmesh_assert_greater(_elem_subsolutions.size(), var);
+    libmesh_assert(_elem_subsolutions[var]);
+    return *(_elem_subsolutions[var]);
   }
 
   /**
@@ -136,9 +136,9 @@ public:
    */
   DenseSubVector<Number>& get_elem_solution( unsigned int var )
   {
-    libmesh_assert_greater(elem_subsolutions.size(), var);
-    libmesh_assert(elem_subsolutions[var]);
-    return *(elem_subsolutions[var]);
+    libmesh_assert_greater(_elem_subsolutions.size(), var);
+    libmesh_assert(_elem_subsolutions[var]);
+    return *(_elem_subsolutions[var]);
   }
 
   /**
@@ -472,7 +472,7 @@ public:
    * Adds a vector to the map of localized vectors. We can later evaluate interior_values,
    * interior_gradients and side_values for these fields these vectors represent.
    */
-  void add_localized_vector (NumericVector<Number> & _localized_vector, const System & _sys);
+  void add_localized_vector (NumericVector<Number> & localized_vector, const System & sys);
 
   /**
    * Typedef for the localized_vectors iterator
@@ -480,26 +480,26 @@ public:
   typedef std::map<const NumericVector<Number>*, std::pair<DenseVector<Number>, std::vector<DenseSubVector<Number>*> > >::iterator localized_vectors_iterator;
 
   /**
-   * Return a reference to DenseVector localization of _localized_vector
-   * contained in the localized_vectors map
+   * Return a reference to DenseVector localization of localized_vector
+   * contained in the _localized_vectors map
    */
-  DenseVector<Number> & get_localized_vector (const NumericVector<Number> & _localized_vector);
+  DenseVector<Number> & get_localized_vector (const NumericVector<Number> & localized_vector);
 
   /**
    * const accessible version of get_localized_vector function
    */
-  const DenseVector<Number> & get_localized_vector (const NumericVector<Number> & _localized_vector) const;
+  const DenseVector<Number> & get_localized_vector (const NumericVector<Number> & localized_vector) const;
 
   /**
-   * Return a reference to DenseSubVector localization of _localized_vector at variable _var
-   * contained in the localized_vectors map
+   * Return a reference to DenseSubVector localization of localized_vector at variable var
+   * contained in the _localized_vectors map
    */
-  DenseSubVector<Number> & get_localized_subvector (const NumericVector<Number> & _localized_vector, unsigned int _var);
+  DenseSubVector<Number> & get_localized_subvector (const NumericVector<Number> & localized_vector, unsigned int var);
 
   /**
    * const accessible version of get_localized_subvector function
    */
-  const DenseSubVector<Number> & get_localized_subvector (const NumericVector<Number> & _localized_vector, unsigned int _var) const;
+  const DenseSubVector<Number> & get_localized_subvector (const NumericVector<Number> & localized_vector, unsigned int var) const;
 
 protected:
 
@@ -508,14 +508,14 @@ protected:
    * pairs of element localized versions of that vector and per variable views
    */
 
-  std::map<const NumericVector<Number>*, std::pair<DenseVector<Number>, std::vector<DenseSubVector<Number>*> > > localized_vectors;
+  std::map<const NumericVector<Number>*, std::pair<DenseVector<Number>, std::vector<DenseSubVector<Number>*> > > _localized_vectors;
 
   /**
    * Element by element components of nonlinear_solution
    * as adjusted by a time_solver
    */
-  DenseVector<Number> elem_solution;
-  std::vector<DenseSubVector<Number> *> elem_subsolutions;
+  DenseVector<Number> _elem_solution;
+  std::vector<DenseSubVector<Number> *> _elem_subsolutions;
 
   /**
    * Element by element components of du/dt

--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -145,14 +145,14 @@ public:
    * Accessor for element solution rate of change w.r.t. time.
    */
   const DenseVector<Number>& get_elem_solution_rate() const
-  { return elem_solution_rate; }
+  { return _elem_solution_rate; }
 
   /**
    * Non-const accessor for element solution rate of change w.r.t.
    * time.
    */
   DenseVector<Number>& get_elem_solution_rate()
-  { return elem_solution_rate; }
+  { return _elem_solution_rate; }
 
   /**
    * Accessor for element solution rate for a particular variable
@@ -160,9 +160,9 @@ public:
    */
   const DenseSubVector<Number>& get_elem_solution_rate( unsigned int var ) const
   {
-    libmesh_assert_greater(elem_subsolution_rates.size(), var);
-    libmesh_assert(elem_subsolution_rates[var]);
-    return *(elem_subsolution_rates[var]);
+    libmesh_assert_greater(_elem_subsolution_rates.size(), var);
+    libmesh_assert(_elem_subsolution_rates[var]);
+    return *(_elem_subsolution_rates[var]);
   }
 
   /**
@@ -171,9 +171,9 @@ public:
    */
   DenseSubVector<Number>& get_elem_solution_rate( unsigned int var )
   {
-    libmesh_assert_greater(elem_subsolution_rates.size(), var);
-    libmesh_assert(elem_subsolution_rates[var]);
-    return *(elem_subsolution_rates[var]);
+    libmesh_assert_greater(_elem_subsolution_rates.size(), var);
+    libmesh_assert(_elem_subsolution_rates[var]);
+    return *(_elem_subsolution_rates[var]);
   }
 
 
@@ -521,8 +521,8 @@ protected:
    * Element by element components of du/dt
    * as adjusted by a time_solver
    */
-  DenseVector<Number> elem_solution_rate;
-  std::vector<DenseSubVector<Number> *> elem_subsolution_rates;
+  DenseVector<Number> _elem_solution_rate;
+  std::vector<DenseSubVector<Number> *> _elem_subsolution_rates;
 
   /**
    * Element by element components of nonlinear_solution

--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -124,7 +124,18 @@ public:
    * to the variable index argument.
    */
   const DenseSubVector<Number>& get_elem_solution( unsigned int var ) const
-  { 
+  {
+    libmesh_assert_greater(elem_subsolutions.size(), var);
+    libmesh_assert(elem_subsolutions[var]);
+    return *(elem_subsolutions[var]);
+  }
+
+  /**
+   * Accessor for element solution of a particular variable corresponding
+   * to the variable index argument.
+   */
+  DenseSubVector<Number>& get_elem_solution( unsigned int var )
+  {
     libmesh_assert_greater(elem_subsolutions.size(), var);
     libmesh_assert(elem_subsolutions[var]);
     return *(elem_subsolutions[var]);
@@ -148,7 +159,18 @@ public:
    * corresponding to the variable index argument.
    */
   const DenseSubVector<Number>& get_elem_solution_rate( unsigned int var ) const
-  { 
+  {
+    libmesh_assert_greater(elem_subsolution_rates.size(), var);
+    libmesh_assert(elem_subsolution_rates[var]);
+    return *(elem_subsolution_rates[var]);
+  }
+
+  /**
+   * Accessor for element solution rate for a particular variable
+   * corresponding to the variable index argument.
+   */
+  DenseSubVector<Number>& get_elem_solution_rate( unsigned int var )
+  {
     libmesh_assert_greater(elem_subsolution_rates.size(), var);
     libmesh_assert(elem_subsolution_rates[var]);
     return *(elem_subsolution_rates[var]);
@@ -172,7 +194,18 @@ public:
    * to the variable index argument.
    */
   const DenseSubVector<Number>& get_elem_fixed_solution( unsigned int var ) const
-  { 
+  {
+    libmesh_assert_greater(elem_fixed_subsolutions.size(), var);
+    libmesh_assert(elem_fixed_subsolutions[var]);
+    return *(elem_fixed_subsolutions[var]);
+  }
+
+  /**
+   * Accessor for element fixed solution of a particular variable corresponding
+   * to the variable index argument.
+   */
+  DenseSubVector<Number>& get_elem_fixed_solution( unsigned int var )
+  {
     libmesh_assert_greater(elem_fixed_subsolutions.size(), var);
     libmesh_assert(elem_fixed_subsolutions[var]);
     return *(elem_fixed_subsolutions[var]);
@@ -313,6 +346,16 @@ public:
    * to the index argument.
    */
   const std::vector<dof_id_type>& get_dof_indices( unsigned int var ) const
+  {
+    libmesh_assert_greater(dof_indices_var.size(), var);
+    return dof_indices_var[var];
+  }
+
+  /**
+   * Accessor for element dof indices of a particular variable corresponding
+   * to the index argument.
+   */
+  std::vector<dof_id_type>& get_dof_indices( unsigned int var )
   {
     libmesh_assert_greater(dof_indices_var.size(), var);
     return dof_indices_var[var];

--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -99,7 +99,7 @@ public:
    * Number of variables in solution.
    */
   unsigned int n_vars() const
-  { return cast_int<unsigned int>(dof_indices_var.size()); }
+  { return cast_int<unsigned int>(_dof_indices_var.size()); }
 
   /**
    * Accessor for associated system.
@@ -181,13 +181,13 @@ public:
    * Accessor for element fixed solution.
    */
   const DenseVector<Number>& get_elem_fixed_solution() const
-  { return elem_fixed_solution; }
+  { return _elem_fixed_solution; }
 
   /**
    * Non-const accessor for element fixed solution.
    */
   DenseVector<Number>& get_elem_fixed_solution()
-  { return elem_fixed_solution; }
+  { return _elem_fixed_solution; }
 
   /**
    * Accessor for element fixed solution of a particular variable corresponding
@@ -195,9 +195,9 @@ public:
    */
   const DenseSubVector<Number>& get_elem_fixed_solution( unsigned int var ) const
   {
-    libmesh_assert_greater(elem_fixed_subsolutions.size(), var);
-    libmesh_assert(elem_fixed_subsolutions[var]);
-    return *(elem_fixed_subsolutions[var]);
+    libmesh_assert_greater(_elem_fixed_subsolutions.size(), var);
+    libmesh_assert(_elem_fixed_subsolutions[var]);
+    return *(_elem_fixed_subsolutions[var]);
   }
 
   /**
@@ -206,22 +206,22 @@ public:
    */
   DenseSubVector<Number>& get_elem_fixed_solution( unsigned int var )
   {
-    libmesh_assert_greater(elem_fixed_subsolutions.size(), var);
-    libmesh_assert(elem_fixed_subsolutions[var]);
-    return *(elem_fixed_subsolutions[var]);
+    libmesh_assert_greater(_elem_fixed_subsolutions.size(), var);
+    libmesh_assert(_elem_fixed_subsolutions[var]);
+    return *(_elem_fixed_subsolutions[var]);
   }
 
   /**
    * Const accessor for element residual.
    */
   const DenseVector<Number>& get_elem_residual() const
-  { return elem_residual; }
+  { return _elem_residual; }
 
   /**
    * Non-const accessor for element residual.
    */
   DenseVector<Number>& get_elem_residual()
-  { return elem_residual; }
+  { return _elem_residual; }
 
   /**
    * Const accessor for element residual of a particular variable corresponding
@@ -229,9 +229,9 @@ public:
    */
   const DenseSubVector<Number>& get_elem_residual( unsigned int var ) const
   {
-    libmesh_assert_greater(elem_subresiduals.size(), var);
-    libmesh_assert(elem_subresiduals[var]);
-    return *(elem_subresiduals[var]);
+    libmesh_assert_greater(_elem_subresiduals.size(), var);
+    libmesh_assert(_elem_subresiduals[var]);
+    return *(_elem_subresiduals[var]);
   }
 
   /**
@@ -240,22 +240,22 @@ public:
    */
   DenseSubVector<Number>& get_elem_residual( unsigned int var )
   {
-    libmesh_assert_greater(elem_subresiduals.size(), var);
-    libmesh_assert(elem_subresiduals[var]);
-    return *(elem_subresiduals[var]);
+    libmesh_assert_greater(_elem_subresiduals.size(), var);
+    libmesh_assert(_elem_subresiduals[var]);
+    return *(_elem_subresiduals[var]);
   }
 
   /**
    * Const accessor for element Jacobian.
    */
   const DenseMatrix<Number>& get_elem_jacobian() const
-  { return elem_jacobian; }
+  { return _elem_jacobian; }
 
   /**
    * Non-const accessor for element Jacobian.
    */
   DenseMatrix<Number>& get_elem_jacobian()
-  { return elem_jacobian; }
+  { return _elem_jacobian; }
 
   /**
    * Const accessor for element Jacobian of particular variables corresponding
@@ -263,10 +263,10 @@ public:
    */
   const DenseSubMatrix<Number>& get_elem_jacobian( unsigned int var1, unsigned int var2 ) const
   {
-    libmesh_assert_greater(elem_subjacobians.size(), var1);
-    libmesh_assert_greater(elem_subjacobians[var1].size(), var2);
-    libmesh_assert(elem_subjacobians[var1][var2]);
-    return *(elem_subjacobians[var1][var2]);
+    libmesh_assert_greater(_elem_subjacobians.size(), var1);
+    libmesh_assert_greater(_elem_subjacobians[var1].size(), var2);
+    libmesh_assert(_elem_subjacobians[var1][var2]);
+    return *(_elem_subjacobians[var1][var2]);
   }
 
   /**
@@ -275,35 +275,35 @@ public:
    */
   DenseSubMatrix<Number>& get_elem_jacobian( unsigned int var1, unsigned int var2 )
   {
-    libmesh_assert_greater(elem_subjacobians.size(), var1);
-    libmesh_assert_greater(elem_subjacobians[var1].size(), var2);
-    libmesh_assert(elem_subjacobians[var1][var2]);
-    return *(elem_subjacobians[var1][var2]);
+    libmesh_assert_greater(_elem_subjacobians.size(), var1);
+    libmesh_assert_greater(_elem_subjacobians[var1].size(), var2);
+    libmesh_assert(_elem_subjacobians[var1][var2]);
+    return *(_elem_subjacobians[var1][var2]);
   }
 
   /**
    * Const accessor for QoI vector.
    */
   const std::vector<Number>& get_qois() const
-  { return elem_qoi; }
+  { return _elem_qoi; }
 
   /**
    * Non-const accessor for QoI vector.
    */
   std::vector<Number>& get_qois()
-  { return elem_qoi; }
+  { return _elem_qoi; }
 
   /**
    * Const accessor for QoI derivatives.
    */
   const std::vector<DenseVector<Number> > & get_qoi_derivatives() const
-  { return elem_qoi_derivative; }
+  { return _elem_qoi_derivative; }
 
   /**
    * Non-const accessor for QoI derivatives.
    */
   std::vector<DenseVector<Number> > & get_qoi_derivatives()
-  { return elem_qoi_derivative; }
+  { return _elem_qoi_derivative; }
 
   /**
    * Const accessor for QoI derivative of a particular qoi and variable corresponding
@@ -311,10 +311,10 @@ public:
    */
   const DenseSubVector<Number>& get_qoi_derivatives( unsigned int qoi, unsigned int var ) const
   {
-    libmesh_assert_greater(elem_qoi_subderivatives.size(), qoi);
-    libmesh_assert_greater(elem_qoi_subderivatives[qoi].size(), var);
-    libmesh_assert(elem_qoi_subderivatives[qoi][var]);
-    return *(elem_qoi_subderivatives[qoi][var]);
+    libmesh_assert_greater(_elem_qoi_subderivatives.size(), qoi);
+    libmesh_assert_greater(_elem_qoi_subderivatives[qoi].size(), var);
+    libmesh_assert(_elem_qoi_subderivatives[qoi][var]);
+    return *(_elem_qoi_subderivatives[qoi][var]);
   }
 
   /**
@@ -323,23 +323,23 @@ public:
    */
   DenseSubVector<Number>& get_qoi_derivatives( unsigned int qoi, unsigned int var )
   {
-    libmesh_assert_greater(elem_qoi_subderivatives.size(), qoi);
-    libmesh_assert_greater(elem_qoi_subderivatives[qoi].size(), var);
-    libmesh_assert(elem_qoi_subderivatives[qoi][var]);
-    return *(elem_qoi_subderivatives[qoi][var]);
+    libmesh_assert_greater(_elem_qoi_subderivatives.size(), qoi);
+    libmesh_assert_greater(_elem_qoi_subderivatives[qoi].size(), var);
+    libmesh_assert(_elem_qoi_subderivatives[qoi][var]);
+    return *(_elem_qoi_subderivatives[qoi][var]);
   }
 
   /**
    * Accessor for element dof indices
    */
   const std::vector<dof_id_type>& get_dof_indices() const
-  { return dof_indices; }
+  { return _dof_indices; }
 
   /**
    * Non-const accessor for element dof indices
    */
   std::vector<dof_id_type>& get_dof_indices()
-  { return dof_indices; }
+  { return _dof_indices; }
 
   /**
    * Accessor for element dof indices of a particular variable corresponding
@@ -347,8 +347,8 @@ public:
    */
   const std::vector<dof_id_type>& get_dof_indices( unsigned int var ) const
   {
-    libmesh_assert_greater(dof_indices_var.size(), var);
-    return dof_indices_var[var];
+    libmesh_assert_greater(_dof_indices_var.size(), var);
+    return _dof_indices_var[var];
   }
 
   /**
@@ -357,8 +357,8 @@ public:
    */
   std::vector<dof_id_type>& get_dof_indices( unsigned int var )
   {
-    libmesh_assert_greater(dof_indices_var.size(), var);
-    return dof_indices_var[var];
+    libmesh_assert_greater(_dof_indices_var.size(), var);
+    return _dof_indices_var[var];
   }
 
   /**
@@ -529,42 +529,42 @@ protected:
    * at a fixed point in a timestep, for optional use by e.g.
    * stabilized methods
    */
-  DenseVector<Number> elem_fixed_solution;
-  std::vector<DenseSubVector<Number> *> elem_fixed_subsolutions;
+  DenseVector<Number> _elem_fixed_solution;
+  std::vector<DenseSubVector<Number> *> _elem_fixed_subsolutions;
 
   /**
    * Element residual vector
    */
-  DenseVector<Number> elem_residual;
+  DenseVector<Number> _elem_residual;
 
   /**
    * Element jacobian: derivatives of elem_residual with respect to
    * elem_solution
    */
-  DenseMatrix<Number> elem_jacobian;
+  DenseMatrix<Number> _elem_jacobian;
 
   /**
    * Element quantity of interest contributions
    */
-  std::vector<Number> elem_qoi;
+  std::vector<Number> _elem_qoi;
 
   /**
    * Element quantity of interest derivative contributions
    */
-  std::vector<DenseVector<Number> > elem_qoi_derivative;
-  std::vector<std::vector<DenseSubVector<Number> *> > elem_qoi_subderivatives;
+  std::vector<DenseVector<Number> > _elem_qoi_derivative;
+  std::vector<std::vector<DenseSubVector<Number> *> > _elem_qoi_subderivatives;
 
   /**
    * Element residual subvectors and Jacobian submatrices
    */
-  std::vector<DenseSubVector<Number> *> elem_subresiduals;
-  std::vector<std::vector<DenseSubMatrix<Number> *> > elem_subjacobians;
+  std::vector<DenseSubVector<Number> *> _elem_subresiduals;
+  std::vector<std::vector<DenseSubMatrix<Number> *> > _elem_subjacobians;
 
   /**
    * Global Degree of freedom index lists
    */
-  std::vector<dof_id_type> dof_indices;
-  std::vector<std::vector<dof_id_type> > dof_indices_var;
+  std::vector<dof_id_type> _dof_indices;
+  std::vector<std::vector<dof_id_type> > _dof_indices_var;
 
 private:
 

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -560,19 +560,19 @@ public:
    * Accessor for element interior quadrature rule.
    */
   const QBase& get_element_qrule() const
-  { return *(this->element_qrule); }
+  { return *(this->_element_qrule); }
 
   /**
    * Accessor for element side quadrature rule.
    */
   const QBase& get_side_qrule() const
-  { return *(this->side_qrule); }
+  { return *(this->_side_qrule); }
 
   /**
    * Accessor for element edge quadrature rule.
    */
   const QBase& get_edge_qrule() const
-  { return *(this->edge_qrule); }
+  { return *(this->_edge_qrule); }
 
   /**
    * Tells the FEMContext that system \p sys contains the
@@ -805,21 +805,21 @@ protected:
    * The FEM context will try to find a quadrature rule that
    * correctly integrates all variables
    */
-  QBase *element_qrule;
+  QBase *_element_qrule;
 
   /**
    * Quadrature rules for element sides
    * The FEM context will try to find a quadrature rule that
    * correctly integrates all variables
    */
-  QBase *side_qrule;
+  QBase *_side_qrule;
 
   /**
    * Quadrature rules for element edges.  If the FEM context is told
    * to prepare for edge integration on 3D elements, it will try to
    * find a quadrature rule that correctly integrates all variables
    */
-  QBase *edge_qrule;
+  QBase *_edge_qrule;
 
 private:
   /**

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -643,19 +643,19 @@ public:
    * Test for current Elem object
    */
   bool has_elem() const
-  { return (elem != NULL); }
+  { return (this->_elem != NULL); }
 
   /**
    * Accessor for current Elem object
    */
   const Elem& get_elem() const
-  { return *elem; }
+  { return *(this->_elem); }
 
   /**
    * Accessor for current Elem object
    */
   Elem& get_elem()
-  { return *(const_cast<Elem*>(elem)); }
+  { return *(const_cast<Elem*>(this->_elem)); }
 
   /**
    * Accessor for current side of Elem object
@@ -793,7 +793,7 @@ protected:
   /**
    * Current element for element_* to examine
    */
-  const Elem *elem;
+  const Elem *_elem;
 
   /**
    * Cached dimension of elements in this mesh

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -673,7 +673,7 @@ public:
    * Accessor for cached element dimension
    */
   unsigned char get_dim() const
-  { return dim; }
+  { return this->_dim; }
 
   /**
    * Uses the coordinate data specified by mesh_*_position configuration
@@ -798,7 +798,7 @@ protected:
   /**
    * Cached dimension of elements in this mesh
    */
-  unsigned char dim;
+  unsigned char _dim;
 
   /**
    * Quadrature rule for element interior.

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -716,6 +716,12 @@ protected:
   template<typename OutputShape>
   AutoPtr<FEGenericBase<OutputShape> > build_new_fe( const FEGenericBase<OutputShape>* fe, const Point &p ) const;
 
+  /**
+   * Helper function to promote accessor usage
+   */
+  void set_elem( const Elem* e )
+  { this->_elem = e; }
+
 
   // gcc-3.4, oracle 12.3 require this typedef to be public
   // in order to use it in a return type

--- a/src/systems/dg_fem_context.C
+++ b/src/systems/dg_fem_context.C
@@ -144,7 +144,7 @@ void DGFEMContext::neighbor_side_fe_reinit ()
   get_system().get_dof_map().dof_indices (&get_neighbor(), _neighbor_dof_indices);
 
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices.size());
+    (this->get_dof_indices().size());
   const unsigned int n_neighbor_dofs = cast_int<unsigned int>
     (_neighbor_dof_indices.size());
 
@@ -172,7 +172,7 @@ void DGFEMContext::neighbor_side_fe_reinit ()
           {
             const unsigned int n_dofs_var_j =
               cast_int<unsigned int>
-              (dof_indices_var[j].size());
+              (this->get_dof_indices(j).size());
 
             _elem_elem_subjacobians[i][j]->reposition
               (sub_dofs, _neighbor_subresiduals[j]->i_off(),

--- a/src/systems/dg_fem_context.C
+++ b/src/systems/dg_fem_context.C
@@ -71,7 +71,7 @@ DGFEMContext::DGFEMContext (const System &sys)
 
       if ( _neighbor_side_fe[fe_type] == NULL )
         {
-          _neighbor_side_fe[fe_type] = FEAbstract::build(dim, fe_type).release();
+          _neighbor_side_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
         }
       _neighbor_side_fe_var[i] = _neighbor_side_fe[fe_type];
     }
@@ -125,7 +125,7 @@ void DGFEMContext::neighbor_side_fe_reinit ()
       FEAbstract* side_fe = _side_fe[neighbor_side_fe_type];
       qface_side_points = side_fe->get_xyz();
 
-      FEInterface::inverse_map (dim,
+      FEInterface::inverse_map (this->_dim,
                                 neighbor_side_fe_type,
                                 &get_neighbor(),
                                 qface_side_points,
@@ -226,4 +226,3 @@ void DGFEMContext::neighbor_side_fe_reinit ()
 }
 
 }
-

--- a/src/systems/diff_context.C
+++ b/src/systems/diff_context.C
@@ -41,7 +41,7 @@ DiffContext::DiffContext (const System& sys) :
   _elem_subsolutions.reserve(nv);
   elem_subresiduals.reserve(nv);
   elem_subjacobians.resize(nv);
-  elem_subsolution_rates.reserve(nv);
+  _elem_subsolution_rates.reserve(nv);
   if (sys.use_fixed_solution)
     elem_fixed_subsolutions.reserve(nv);
 
@@ -60,7 +60,7 @@ DiffContext::DiffContext (const System& sys) :
       for (std::size_t q=0; q != n_qoi; ++q)
         elem_qoi_subderivatives[q].push_back(new DenseSubVector<Number>(elem_qoi_derivative[q]));
       elem_subjacobians[i].reserve(nv);
-      elem_subsolution_rates.push_back(new DenseSubVector<Number>(elem_solution_rate));
+      _elem_subsolution_rates.push_back(new DenseSubVector<Number>(_elem_solution_rate));
 
       if (sys.use_fixed_solution)
         elem_fixed_subsolutions.push_back
@@ -84,7 +84,7 @@ DiffContext::~DiffContext ()
       delete elem_subresiduals[i];
       for (std::size_t q=0; q != elem_qoi_subderivatives.size(); ++q)
         delete elem_qoi_subderivatives[q][i];
-      delete elem_subsolution_rates[i];
+      delete _elem_subsolution_rates[i];
       if (!elem_fixed_subsolutions.empty())
         delete elem_fixed_subsolutions[i];
 

--- a/src/systems/diff_context.C
+++ b/src/systems/diff_context.C
@@ -30,7 +30,7 @@ DiffContext::DiffContext (const System& sys) :
   elem_solution_derivative(1.),
   elem_solution_rate_derivative(1.),
   fixed_solution_derivative(0.),
-  dof_indices_var(sys.n_vars()),
+  _dof_indices_var(sys.n_vars()),
   _deltat(NULL),
   _system(sys),
   _is_adjoint(false)
@@ -39,37 +39,37 @@ DiffContext::DiffContext (const System& sys) :
   unsigned int nv = sys.n_vars();
 
   _elem_subsolutions.reserve(nv);
-  elem_subresiduals.reserve(nv);
-  elem_subjacobians.resize(nv);
+  _elem_subresiduals.reserve(nv);
+  _elem_subjacobians.resize(nv);
   _elem_subsolution_rates.reserve(nv);
   if (sys.use_fixed_solution)
-    elem_fixed_subsolutions.reserve(nv);
+    _elem_fixed_subsolutions.reserve(nv);
 
   // If the user resizes sys.qoi, it will invalidate us
   std::size_t n_qoi = sys.qoi.size();
-  elem_qoi.resize(n_qoi);
-  elem_qoi_derivative.resize(n_qoi);
-  elem_qoi_subderivatives.resize(n_qoi);
+  _elem_qoi.resize(n_qoi);
+  _elem_qoi_derivative.resize(n_qoi);
+  _elem_qoi_subderivatives.resize(n_qoi);
   for (std::size_t q=0; q != n_qoi; ++q)
-    elem_qoi_subderivatives[q].reserve(nv);
+    _elem_qoi_subderivatives[q].reserve(nv);
 
   for (unsigned int i=0; i != nv; ++i)
     {
       _elem_subsolutions.push_back(new DenseSubVector<Number>(_elem_solution));
-      elem_subresiduals.push_back(new DenseSubVector<Number>(elem_residual));
+      _elem_subresiduals.push_back(new DenseSubVector<Number>(_elem_residual));
       for (std::size_t q=0; q != n_qoi; ++q)
-        elem_qoi_subderivatives[q].push_back(new DenseSubVector<Number>(elem_qoi_derivative[q]));
-      elem_subjacobians[i].reserve(nv);
+        _elem_qoi_subderivatives[q].push_back(new DenseSubVector<Number>(_elem_qoi_derivative[q]));
+      _elem_subjacobians[i].reserve(nv);
       _elem_subsolution_rates.push_back(new DenseSubVector<Number>(_elem_solution_rate));
 
       if (sys.use_fixed_solution)
-        elem_fixed_subsolutions.push_back
-          (new DenseSubVector<Number>(elem_fixed_solution));
+        _elem_fixed_subsolutions.push_back
+          (new DenseSubVector<Number>(_elem_fixed_solution));
 
       for (unsigned int j=0; j != nv; ++j)
         {
-          elem_subjacobians[i].push_back
-            (new DenseSubMatrix<Number>(elem_jacobian));
+          _elem_subjacobians[i].push_back
+            (new DenseSubMatrix<Number>(_elem_jacobian));
         }
     }
 }
@@ -81,15 +81,15 @@ DiffContext::~DiffContext ()
   for (std::size_t i=0; i != _elem_subsolutions.size(); ++i)
     {
       delete _elem_subsolutions[i];
-      delete elem_subresiduals[i];
-      for (std::size_t q=0; q != elem_qoi_subderivatives.size(); ++q)
-        delete elem_qoi_subderivatives[q][i];
+      delete _elem_subresiduals[i];
+      for (std::size_t q=0; q != _elem_qoi_subderivatives.size(); ++q)
+        delete _elem_qoi_subderivatives[q][i];
       delete _elem_subsolution_rates[i];
-      if (!elem_fixed_subsolutions.empty())
-        delete elem_fixed_subsolutions[i];
+      if (!_elem_fixed_subsolutions.empty())
+        delete _elem_fixed_subsolutions[i];
 
-      for (std::size_t j=0; j != elem_subjacobians[i].size(); ++j)
-        delete elem_subjacobians[i][j];
+      for (std::size_t j=0; j != _elem_subjacobians[i].size(); ++j)
+        delete _elem_subjacobians[i][j];
     }
 
   // We also need to delete all the DenseSubVectors from the localized_vectors map

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -142,13 +142,13 @@ FEMContext::~FEMContext()
 
 bool FEMContext::has_side_boundary_id(boundary_id_type id) const
 {
-  return _boundary_info.has_boundary_id(this->_elem, side, id);
+  return _boundary_info.has_boundary_id(&(this->get_elem()), side, id);
 }
 
 
 std::vector<boundary_id_type> FEMContext::side_boundary_ids() const
 {
-  return _boundary_info.boundary_ids(this->_elem, side);
+  return _boundary_info.boundary_ids(&(this->get_elem()), side);
 }
 
 
@@ -161,9 +161,9 @@ void FEMContext::some_interior_value
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = (this->*subsolution_getter)(var);
@@ -194,9 +194,9 @@ void FEMContext::some_interior_gradient
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = (this->*subsolution_getter)(var);
@@ -232,9 +232,9 @@ void FEMContext::some_interior_hessian
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = (this->*subsolution_getter)(var);
@@ -266,9 +266,9 @@ void FEMContext::some_side_value
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = (this->*subsolution_getter)(var);
@@ -315,9 +315,9 @@ void FEMContext::interior_values (unsigned int var,
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = get_localized_subvector(_system_vector, var);
@@ -376,9 +376,9 @@ void FEMContext::interior_gradients
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = get_localized_subvector(_system_vector, var);
@@ -437,9 +437,9 @@ void FEMContext::interior_hessians
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = get_localized_subvector(_system_vector, var);
@@ -477,9 +477,9 @@ void FEMContext::interior_curl(unsigned int var, unsigned int qp,
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
@@ -512,9 +512,9 @@ void FEMContext::interior_div(unsigned int var, unsigned int qp,
     <typename TensorTools::MakeReal<OutputType>::type>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
@@ -555,9 +555,9 @@ void FEMContext::side_value(unsigned int var, unsigned int qp,
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
@@ -590,9 +590,9 @@ void FEMContext::side_values
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = get_localized_subvector(_system_vector, var);
@@ -638,9 +638,9 @@ void FEMContext::side_gradient(unsigned int var, unsigned int qp,
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
@@ -676,9 +676,9 @@ void FEMContext::side_gradients
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = get_localized_subvector(_system_vector, var);
@@ -726,9 +726,9 @@ void FEMContext::side_hessian(unsigned int var, unsigned int qp,
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
@@ -765,9 +765,9 @@ void FEMContext::side_hessians
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   const DenseSubVector<Number> &coef = get_localized_subvector(_system_vector, var);
@@ -816,9 +816,9 @@ void FEMContext::point_value(unsigned int var, const Point &p,
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
@@ -865,9 +865,9 @@ void FEMContext::point_gradient(unsigned int var, const Point &p,
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
@@ -917,9 +917,9 @@ void FEMContext::point_hessian(unsigned int var, const Point &p,
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
@@ -954,7 +954,7 @@ void FEMContext::point_curl(unsigned int var, const Point &p,
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
     (dof_indices_var[var].size());
 
@@ -1063,9 +1063,9 @@ void FEMContext::fixed_side_value(unsigned int var, unsigned int qp,
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
@@ -1109,9 +1109,9 @@ void FEMContext::fixed_side_gradient(unsigned int var, unsigned int qp,
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
@@ -1157,9 +1157,9 @@ void FEMContext::fixed_side_hessian(unsigned int var, unsigned int qp,
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
@@ -1201,9 +1201,9 @@ void FEMContext::fixed_point_value(unsigned int var, const Point &p,
   typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
@@ -1250,9 +1250,9 @@ void FEMContext::fixed_point_gradient(unsigned int var, const Point &p,
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
@@ -1302,9 +1302,9 @@ void FEMContext::fixed_point_hessian(unsigned int var, const Point &p,
     OutputShape;
 
   // Get local-to-global dof index lookup
-  libmesh_assert_greater (dof_indices.size(), var);
+  libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
@@ -1584,9 +1584,9 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
   this->_elem = e;
 
   // Initialize the per-element data for elem.
-  sys.get_dof_map().dof_indices (this->_elem, dof_indices);
+  sys.get_dof_map().dof_indices (this->_elem, this->get_dof_indices());
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices.size());
+    (this->get_dof_indices().size());
   const std::size_t n_qoi = sys.qoi.size();
 
   // This also resizes elem_solution

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -483,7 +483,7 @@ void FEMContext::interior_curl(unsigned int var, unsigned int qp,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
-  libmesh_assert(elem_subsolutions[var]);
+  libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
@@ -518,7 +518,7 @@ void FEMContext::interior_div(unsigned int var, unsigned int qp,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
-  libmesh_assert(elem_subsolutions[var]);
+  libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
@@ -561,7 +561,7 @@ void FEMContext::side_value(unsigned int var, unsigned int qp,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
-  libmesh_assert(elem_subsolutions[var]);
+  libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
@@ -644,7 +644,7 @@ void FEMContext::side_gradient(unsigned int var, unsigned int qp,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
-  libmesh_assert(elem_subsolutions[var]);
+  libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
@@ -732,7 +732,7 @@ void FEMContext::side_hessian(unsigned int var, unsigned int qp,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
-  libmesh_assert(elem_subsolutions[var]);
+  libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
@@ -822,7 +822,7 @@ void FEMContext::point_value(unsigned int var, const Point &p,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
-  libmesh_assert(elem_subsolutions[var]);
+  libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
@@ -871,7 +871,7 @@ void FEMContext::point_gradient(unsigned int var, const Point &p,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
-  libmesh_assert(elem_subsolutions[var]);
+  libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
@@ -923,7 +923,7 @@ void FEMContext::point_hessian(unsigned int var, const Point &p,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
-  libmesh_assert(elem_subsolutions[var]);
+  libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
@@ -956,11 +956,11 @@ void FEMContext::point_curl(unsigned int var, const Point &p,
   // Get local-to-global dof index lookup
   libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
-    (dof_indices_var[var].size());
+    (this->get_dof_indices(var).size());
 
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
-  libmesh_assert(elem_subsolutions[var]);
+  libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
@@ -1413,7 +1413,7 @@ void FEMContext::elem_fe_reinit ()
   for (std::map<FEType, FEAbstract *>::iterator i = _element_fe.begin();
        i != local_fe_end; ++i)
     {
-      i->second->reinit(this->_elem);
+      i->second->reinit(&(this->get_elem()));
     }
 }
 
@@ -1426,7 +1426,7 @@ void FEMContext::side_fe_reinit ()
   for (std::map<FEType, FEAbstract *>::iterator i = _side_fe.begin();
        i != local_fe_end; ++i)
     {
-      i->second->reinit(this->_elem, side);
+      i->second->reinit(&(this->get_elem()), side);
     }
 }
 
@@ -1442,7 +1442,7 @@ void FEMContext::edge_fe_reinit ()
   for (std::map<FEType, FEAbstract *>::iterator i = _edge_fe.begin();
        i != local_fe_end; ++i)
     {
-      i->second->edge_reinit(this->_elem, edge);
+      i->second->edge_reinit(&(this->get_elem()), edge);
     }
 }
 
@@ -1464,34 +1464,34 @@ void FEMContext::elem_position_get()
   unsigned int n_nodes = this->get_elem().n_nodes();
   // For simplicity we demand that mesh coordinates be stored
   // in a format that allows a direct copy
-  libmesh_assert(_mesh_x_var == libMesh::invalid_uint ||
-                 (_element_fe_var[_mesh_x_var]->get_fe_type().family
+  libmesh_assert(this->get_mesh_x_var() == libMesh::invalid_uint ||
+                 (this->get_element_fe(this->get_mesh_x_var())->get_fe_type().family
                   == LAGRANGE &&
-                  _element_fe_var[_mesh_x_var]->get_fe_type().order
+                  this->get_element_fe(this->get_mesh_x_var())->get_fe_type().order
                   == this->get_elem().default_order()));
-  libmesh_assert(_mesh_y_var == libMesh::invalid_uint ||
-                 (_element_fe_var[_mesh_y_var]->get_fe_type().family
+  libmesh_assert(this->get_mesh_y_var() == libMesh::invalid_uint ||
+                 (this->get_element_fe(this->get_mesh_y_var())->get_fe_type().family
                   == LAGRANGE &&
-                  _element_fe_var[_mesh_y_var]->get_fe_type().order
+                  this->get_element_fe(this->get_mesh_y_var())->get_fe_type().order
                   == this->get_elem().default_order()));
-  libmesh_assert(_mesh_z_var == libMesh::invalid_uint ||
-                 (_element_fe_var[_mesh_z_var]->get_fe_type().family
+  libmesh_assert(this->get_mesh_z_var() == libMesh::invalid_uint ||
+                 (this->get_element_fe(this->get_mesh_z_var())->get_fe_type().family
                   == LAGRANGE &&
-                  _element_fe_var[_mesh_z_var]->get_fe_type().order
+                  this->get_element_fe(this->get_mesh_z_var())->get_fe_type().order
                   == this->get_elem().default_order()));
 
   // Get degree of freedom coefficients from point coordinates
-  if (_mesh_x_var != libMesh::invalid_uint)
+  if (this->get_mesh_x_var() != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      (*elem_subsolutions[_mesh_x_var])(i) = this->get_elem().point(i)(0);
+      (*elem_subsolutions[this->get_mesh_x_var()])(i) = this->get_elem().point(i)(0);
 
-  if (_mesh_y_var != libMesh::invalid_uint)
+  if (this->get_mesh_y_var() != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      (*elem_subsolutions[_mesh_y_var])(i) = this->get_elem().point(i)(1);
+      (*elem_subsolutions[this->get_mesh_y_var()])(i) = this->get_elem().point(i)(1);
 
-  if (_mesh_z_var != libMesh::invalid_uint)
+  if (this->get_mesh_z_var() != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      (*elem_subsolutions[_mesh_z_var])(i) = this->get_elem().point(i)(2);
+      (*elem_subsolutions[this->get_mesh_z_var()])(i) = this->get_elem().point(i)(2);
   //    }
   // FIXME - If the coordinate data is not in our own system, someone
   // had better get around to implementing that... - RHS
@@ -1524,34 +1524,34 @@ void FEMContext::_do_elem_position_set(Real)
   unsigned int n_nodes = this->get_elem().n_nodes();
   // For simplicity we demand that mesh coordinates be stored
   // in a format that allows a direct copy
-  libmesh_assert(_mesh_x_var == libMesh::invalid_uint ||
-                 (_element_fe_var[_mesh_x_var]->get_fe_type().family
+  libmesh_assert(this->get_mesh_x_var() == libMesh::invalid_uint ||
+                 (this->get_element_fe(this->get_mesh_x_var())->get_fe_type().family
                   == LAGRANGE &&
-                  elem_subsolutions[_mesh_x_var]->size() == n_nodes));
-  libmesh_assert(_mesh_y_var == libMesh::invalid_uint ||
-                 (_element_fe_var[_mesh_y_var]->get_fe_type().family
+                  elem_subsolutions[this->get_mesh_x_var()]->size() == n_nodes));
+  libmesh_assert(this->get_mesh_y_var() == libMesh::invalid_uint ||
+                 (this->get_element_fe(this->get_mesh_y_var())->get_fe_type().family
                   == LAGRANGE &&
-                  elem_subsolutions[_mesh_y_var]->size() == n_nodes));
-  libmesh_assert(_mesh_z_var == libMesh::invalid_uint ||
-                 (_element_fe_var[_mesh_z_var]->get_fe_type().family
+                  elem_subsolutions[this->get_mesh_y_var()]->size() == n_nodes));
+  libmesh_assert(this->get_mesh_z_var() == libMesh::invalid_uint ||
+                 (this->get_element_fe(this->get_mesh_z_var())->get_fe_type().family
                   == LAGRANGE &&
-                  elem_subsolutions[_mesh_z_var]->size() == n_nodes));
+                  elem_subsolutions[this->get_mesh_z_var()]->size() == n_nodes));
 
   // Set the new point coordinates
-  if (_mesh_x_var != libMesh::invalid_uint)
+  if (this->get_mesh_x_var() != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      const_cast<Elem*>(this->_elem)->point(i)(0) =
-        libmesh_real((*elem_subsolutions[_mesh_x_var])(i));
+      const_cast<Elem*>(&(this->get_elem()))->point(i)(0) =
+        libmesh_real(this->get_elem_solution(this->get_mesh_x_var())(i));
 
-  if (_mesh_y_var != libMesh::invalid_uint)
+  if (this->get_mesh_y_var() != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      const_cast<Elem*>(this->_elem)->point(i)(1) =
-        libmesh_real((*elem_subsolutions[_mesh_y_var])(i));
+      const_cast<Elem*>(&(this->get_elem()))->point(i)(1) =
+        libmesh_real(this->get_elem_solution(this->get_mesh_y_var())(i));
 
-  if (_mesh_z_var != libMesh::invalid_uint)
+  if (this->get_mesh_z_var() != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      const_cast<Elem*>(this->_elem)->point(i)(2) =
-        libmesh_real((*elem_subsolutions[_mesh_z_var])(i));
+      const_cast<Elem*>(&(this->get_elem()))->point(i)(2) =
+        libmesh_real(this->get_elem_solution(this->get_mesh_z_var())(i));
   //    }
   // FIXME - If the coordinate data is not in our own system, someone
   // had better get around to implementing that... - RHS
@@ -1581,16 +1581,16 @@ void FEMContext::_do_elem_position_set(Real)
 
 void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
 {
-  this->_elem = e;
+  this->set_elem(e);
 
   // Initialize the per-element data for elem.
-  sys.get_dof_map().dof_indices (this->_elem, this->get_dof_indices());
+  sys.get_dof_map().dof_indices (&(this->get_elem()), this->get_dof_indices());
   const unsigned int n_dofs = cast_int<unsigned int>
     (this->get_dof_indices().size());
   const std::size_t n_qoi = sys.qoi.size();
 
   // This also resizes elem_solution
-  sys.current_local_solution->get(dof_indices, elem_solution.get_values());
+  sys.current_local_solution->get(this->get_dof_indices(), this->get_elem_solution().get_values());
 
   if (sys.use_fixed_solution)
     elem_fixed_solution.resize(n_dofs);
@@ -1610,7 +1610,7 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
     unsigned int sub_dofs = 0;
     for (unsigned int i=0; i != sys.n_vars(); ++i)
       {
-        sys.get_dof_map().dof_indices (this->_elem, dof_indices_var[i], i);
+        sys.get_dof_map().dof_indices (&(this->get_elem()), dof_indices_var[i], i);
 
         const unsigned int n_dofs_var = cast_int<unsigned int>
           (dof_indices_var[i].size());
@@ -1671,7 +1671,7 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
         {
           const unsigned int n_dofs_var = cast_int<unsigned int>
             (dof_indices_var[i].size());
-          sys.get_dof_map().dof_indices (this->_elem, dof_indices_var[i], i);
+          sys.get_dof_map().dof_indices (&(this->get_elem()), dof_indices_var[i], i);
 
           localized_vec_it->second.second[i]->reposition
             (sub_dofs, n_dofs_var);
@@ -1706,16 +1706,16 @@ AutoPtr<FEGenericBase<OutputShape> > FEMContext::build_new_fe( const FEGenericBa
   // If we don't have an Elem to evaluate on, then the only functions
   // we can sensibly evaluate are the scalar dofs which are the same
   // everywhere.
-  libmesh_assert(this->_elem || fe_type.family == SCALAR);
+  libmesh_assert(&(this->get_elem()) || fe_type.family == SCALAR);
 
-  unsigned int elem_dim = this->_elem ? this->get_elem().dim() : 0;
+  unsigned int elem_dim = &(this->get_elem()) ? this->get_elem().dim() : 0;
 
   AutoPtr<FEGenericBase<OutputShape> >
     fe_new(FEGenericBase<OutputShape>::build(elem_dim, fe_type));
 
   // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h
   // Build a vector of point co-ordinates to send to reinit
-  Point master_point = this->_elem ?
+  Point master_point = &(this->get_elem()) ?
     FEInterface::inverse_map(elem_dim, fe_type, &this->get_elem(), p) :
     Point(0);
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -42,7 +42,7 @@ FEMContext::FEMContext (const System &sys)
     side(0), edge(0),
     _boundary_info(sys.get_mesh().get_boundary_info()),
     _elem(NULL),
-    dim(sys.get_mesh().mesh_dimension()),
+    _dim(sys.get_mesh().mesh_dimension()),
     element_qrule(NULL), side_qrule(NULL),
     edge_qrule(NULL)
 {
@@ -68,10 +68,10 @@ FEMContext::FEMContext (const System &sys)
 
   // Create an adequate quadrature rule
   element_qrule = hardest_fe_type.default_quadrature_rule
-    (dim, sys.extra_quadrature_order).release();
+    (this->_dim, sys.extra_quadrature_order).release();
   side_qrule = hardest_fe_type.default_quadrature_rule
-    (dim-1, sys.extra_quadrature_order).release();
-  if (dim == 3)
+    (this->_dim-1, sys.extra_quadrature_order).release();
+  if (this->_dim == 3)
     edge_qrule = hardest_fe_type.default_quadrature_rule
       (1, sys.extra_quadrature_order).release();
 
@@ -80,7 +80,7 @@ FEMContext::FEMContext (const System &sys)
   // Should move to the protected/FEAbstract interface
   _element_fe_var.resize(nv);
   _side_fe_var.resize(nv);
-  if (dim == 3)
+  if (this->_dim == 3)
     _edge_fe_var.resize(nv);
 
   for (unsigned int i=0; i != nv; ++i)
@@ -89,20 +89,20 @@ FEMContext::FEMContext (const System &sys)
 
       if ( _element_fe[fe_type] == NULL )
         {
-          _element_fe[fe_type] = FEAbstract::build(dim, fe_type).release();
+          _element_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
           _element_fe[fe_type]->attach_quadrature_rule(element_qrule);
-          _side_fe[fe_type] = FEAbstract::build(dim, fe_type).release();
+          _side_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
           _side_fe[fe_type]->attach_quadrature_rule(side_qrule);
 
-          if (dim == 3)
+          if (this->_dim == 3)
             {
-              _edge_fe[fe_type] = FEAbstract::build(dim, fe_type).release();
+              _edge_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
               _edge_fe[fe_type]->attach_quadrature_rule(edge_qrule);
             }
         }
       _element_fe_var[i] = _element_fe[fe_type];
       _side_fe_var[i] = _side_fe[fe_type];
-      if (dim == 3)
+      if (this->_dim == 3)
         _edge_fe_var[i] = _edge_fe[fe_type];
 
     }
@@ -1434,7 +1434,7 @@ void FEMContext::side_fe_reinit ()
 
 void FEMContext::edge_fe_reinit ()
 {
-  libmesh_assert_equal_to (dim, 3);
+  libmesh_assert_equal_to (this->_dim, 3);
 
   // Initialize all the interior FE objects on elem/edge.
   // Logging of FE::reinit is done in the FE functions

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -482,7 +482,7 @@ void FEMContext::interior_curl(unsigned int var, unsigned int qp,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_subsolutions.size(), var);
+  libmesh_assert_greater (this->_elem_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
@@ -517,7 +517,7 @@ void FEMContext::interior_div(unsigned int var, unsigned int qp,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_subsolutions.size(), var);
+  libmesh_assert_greater (this->_elem_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
@@ -560,7 +560,7 @@ void FEMContext::side_value(unsigned int var, unsigned int qp,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_subsolutions.size(), var);
+  libmesh_assert_greater (this->_elem_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
@@ -643,7 +643,7 @@ void FEMContext::side_gradient(unsigned int var, unsigned int qp,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_subsolutions.size(), var);
+  libmesh_assert_greater (this->_elem_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
@@ -731,7 +731,7 @@ void FEMContext::side_hessian(unsigned int var, unsigned int qp,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_subsolutions.size(), var);
+  libmesh_assert_greater (this->_elem_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
@@ -821,7 +821,7 @@ void FEMContext::point_value(unsigned int var, const Point &p,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_subsolutions.size(), var);
+  libmesh_assert_greater (this->_elem_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
@@ -870,7 +870,7 @@ void FEMContext::point_gradient(unsigned int var, const Point &p,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_subsolutions.size(), var);
+  libmesh_assert_greater (this->_elem_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
@@ -922,7 +922,7 @@ void FEMContext::point_hessian(unsigned int var, const Point &p,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_subsolutions.size(), var);
+  libmesh_assert_greater (this->_elem_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
@@ -959,7 +959,7 @@ void FEMContext::point_curl(unsigned int var, const Point &p,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_subsolutions.size(), var);
+  libmesh_assert_greater (this->_elem_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
@@ -1483,15 +1483,15 @@ void FEMContext::elem_position_get()
   // Get degree of freedom coefficients from point coordinates
   if (this->get_mesh_x_var() != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      (*elem_subsolutions[this->get_mesh_x_var()])(i) = this->get_elem().point(i)(0);
+      (this->get_elem_solution(this->get_mesh_x_var()))(i) = this->get_elem().point(i)(0);
 
   if (this->get_mesh_y_var() != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      (*elem_subsolutions[this->get_mesh_y_var()])(i) = this->get_elem().point(i)(1);
+      (this->get_elem_solution(this->get_mesh_y_var()))(i) = this->get_elem().point(i)(1);
 
   if (this->get_mesh_z_var() != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      (*elem_subsolutions[this->get_mesh_z_var()])(i) = this->get_elem().point(i)(2);
+      (this->get_elem_solution(this->get_mesh_z_var()))(i) = this->get_elem().point(i)(2);
   //    }
   // FIXME - If the coordinate data is not in our own system, someone
   // had better get around to implementing that... - RHS
@@ -1655,8 +1655,8 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
   }
 
   // Now do the localization for the user requested vectors
-  DiffContext::localized_vectors_iterator localized_vec_it = localized_vectors.begin();
-  const DiffContext::localized_vectors_iterator localized_vec_end = localized_vectors.end();
+  DiffContext::localized_vectors_iterator localized_vec_it = this->_localized_vectors.begin();
+  const DiffContext::localized_vectors_iterator localized_vec_end = this->_localized_vectors.end();
 
   for(; localized_vec_it != localized_vec_end; ++localized_vec_it)
     {

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -484,7 +484,7 @@ void FEMContext::interior_curl(unsigned int var, unsigned int qp,
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
   libmesh_assert(elem_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_subsolutions[var];
+  const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
@@ -519,7 +519,7 @@ void FEMContext::interior_div(unsigned int var, unsigned int qp,
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
   libmesh_assert(elem_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_subsolutions[var];
+  const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
@@ -562,7 +562,7 @@ void FEMContext::side_value(unsigned int var, unsigned int qp,
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
   libmesh_assert(elem_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_subsolutions[var];
+  const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
@@ -645,7 +645,7 @@ void FEMContext::side_gradient(unsigned int var, unsigned int qp,
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
   libmesh_assert(elem_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_subsolutions[var];
+  const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
@@ -733,7 +733,7 @@ void FEMContext::side_hessian(unsigned int var, unsigned int qp,
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
   libmesh_assert(elem_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_subsolutions[var];
+  const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
@@ -823,7 +823,7 @@ void FEMContext::point_value(unsigned int var, const Point &p,
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
   libmesh_assert(elem_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_subsolutions[var];
+  const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
@@ -872,7 +872,7 @@ void FEMContext::point_gradient(unsigned int var, const Point &p,
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
   libmesh_assert(elem_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_subsolutions[var];
+  const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
@@ -924,7 +924,7 @@ void FEMContext::point_hessian(unsigned int var, const Point &p,
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
   libmesh_assert(elem_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_subsolutions[var];
+  const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
@@ -961,7 +961,7 @@ void FEMContext::point_curl(unsigned int var, const Point &p,
   // Get current local coefficients
   libmesh_assert_greater (elem_subsolutions.size(), var);
   libmesh_assert(elem_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_subsolutions[var];
+  const DenseSubVector<Number> &coef = this->get_elem_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
@@ -1461,37 +1461,37 @@ void FEMContext::elem_position_get()
   // been set up for us
   //  if (_mesh_sys == this->number())
   //    {
-  unsigned int n_nodes = this->_elem->n_nodes();
+  unsigned int n_nodes = this->get_elem().n_nodes();
   // For simplicity we demand that mesh coordinates be stored
   // in a format that allows a direct copy
   libmesh_assert(_mesh_x_var == libMesh::invalid_uint ||
                  (_element_fe_var[_mesh_x_var]->get_fe_type().family
                   == LAGRANGE &&
                   _element_fe_var[_mesh_x_var]->get_fe_type().order
-                  == this->_elem->default_order()));
+                  == this->get_elem().default_order()));
   libmesh_assert(_mesh_y_var == libMesh::invalid_uint ||
                  (_element_fe_var[_mesh_y_var]->get_fe_type().family
                   == LAGRANGE &&
                   _element_fe_var[_mesh_y_var]->get_fe_type().order
-                  == this->_elem->default_order()));
+                  == this->get_elem().default_order()));
   libmesh_assert(_mesh_z_var == libMesh::invalid_uint ||
                  (_element_fe_var[_mesh_z_var]->get_fe_type().family
                   == LAGRANGE &&
                   _element_fe_var[_mesh_z_var]->get_fe_type().order
-                  == this->_elem->default_order()));
+                  == this->get_elem().default_order()));
 
   // Get degree of freedom coefficients from point coordinates
   if (_mesh_x_var != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      (*elem_subsolutions[_mesh_x_var])(i) = this->_elem->point(i)(0);
+      (*elem_subsolutions[_mesh_x_var])(i) = this->get_elem().point(i)(0);
 
   if (_mesh_y_var != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      (*elem_subsolutions[_mesh_y_var])(i) = this->_elem->point(i)(1);
+      (*elem_subsolutions[_mesh_y_var])(i) = this->get_elem().point(i)(1);
 
   if (_mesh_z_var != libMesh::invalid_uint)
     for (unsigned int i=0; i != n_nodes; ++i)
-      (*elem_subsolutions[_mesh_z_var])(i) = this->_elem->point(i)(2);
+      (*elem_subsolutions[_mesh_z_var])(i) = this->get_elem().point(i)(2);
   //    }
   // FIXME - If the coordinate data is not in our own system, someone
   // had better get around to implementing that... - RHS
@@ -1521,7 +1521,7 @@ void FEMContext::_do_elem_position_set(Real)
   // been set up for us, and we can ignore our input parameter theta
   //  if (_mesh_sys == this->number())
   //    {
-  unsigned int n_nodes = this->_elem->n_nodes();
+  unsigned int n_nodes = this->get_elem().n_nodes();
   // For simplicity we demand that mesh coordinates be stored
   // in a format that allows a direct copy
   libmesh_assert(_mesh_x_var == libMesh::invalid_uint ||
@@ -1708,7 +1708,7 @@ AutoPtr<FEGenericBase<OutputShape> > FEMContext::build_new_fe( const FEGenericBa
   // everywhere.
   libmesh_assert(this->_elem || fe_type.family == SCALAR);
 
-  unsigned int elem_dim = this->_elem ? this->_elem->dim() : 0;
+  unsigned int elem_dim = this->_elem ? this->get_elem().dim() : 0;
 
   AutoPtr<FEGenericBase<OutputShape> >
     fe_new(FEGenericBase<OutputShape>::build(elem_dim, fe_type));
@@ -1716,13 +1716,13 @@ AutoPtr<FEGenericBase<OutputShape> > FEMContext::build_new_fe( const FEGenericBa
   // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h
   // Build a vector of point co-ordinates to send to reinit
   Point master_point = this->_elem ?
-    FEInterface::inverse_map(elem_dim, fe_type, this->_elem, p) :
+    FEInterface::inverse_map(elem_dim, fe_type, &this->get_elem(), p) :
     Point(0);
 
   std::vector<Point> coor(1, master_point);
 
   // Reinitialize the element and compute the shape function values at coor
-  fe_new->reinit (this->_elem, &coor);
+  fe_new->reinit (&this->get_elem(), &coor);
 
   return fe_new;
 }

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1068,7 +1068,7 @@ void FEMContext::fixed_side_value(unsigned int var, unsigned int qp,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
+  libmesh_assert_greater (_elem_fixed_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_fixed_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
@@ -1114,7 +1114,7 @@ void FEMContext::fixed_side_gradient(unsigned int var, unsigned int qp,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
+  libmesh_assert_greater (_elem_fixed_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_fixed_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
@@ -1162,7 +1162,7 @@ void FEMContext::fixed_side_hessian(unsigned int var, unsigned int qp,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
+  libmesh_assert_greater (_elem_fixed_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_fixed_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
@@ -1206,7 +1206,7 @@ void FEMContext::fixed_point_value(unsigned int var, const Point &p,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
+  libmesh_assert_greater (_elem_fixed_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_fixed_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
@@ -1255,7 +1255,7 @@ void FEMContext::fixed_point_gradient(unsigned int var, const Point &p,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
+  libmesh_assert_greater (_elem_fixed_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_fixed_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
@@ -1307,7 +1307,7 @@ void FEMContext::fixed_point_hessian(unsigned int var, const Point &p,
     (this->get_dof_indices(var).size());
 
   // Get current local coefficients
-  libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
+  libmesh_assert_greater (_elem_fixed_subsolutions.size(), var);
   libmesh_assert(&(this->get_elem_fixed_solution(var)));
   const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
@@ -1601,7 +1601,7 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
   this->get_elem_jacobian().resize(n_dofs, n_dofs);
 
   this->get_qoi_derivatives().resize(n_qoi);
-  elem_qoi_subderivatives.resize(n_qoi);
+  this->_elem_qoi_subderivatives.resize(n_qoi);
   for (std::size_t q=0; q != n_qoi; ++q)
     (this->get_qoi_derivatives())[q].resize(n_dofs);
 
@@ -1663,7 +1663,7 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
       const NumericVector<Number>& current_localized_vector = *localized_vec_it->first;
       DenseVector<Number>& target_vector = localized_vec_it->second.first;
 
-      current_localized_vector.get(dof_indices, target_vector.get_values());
+      current_localized_vector.get(this->get_dof_indices(), target_vector.get_values());
 
       // Initialize the per-variable data for elem.
       unsigned int sub_dofs = 0;

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -43,8 +43,8 @@ FEMContext::FEMContext (const System &sys)
     _boundary_info(sys.get_mesh().get_boundary_info()),
     _elem(NULL),
     _dim(sys.get_mesh().mesh_dimension()),
-    element_qrule(NULL), side_qrule(NULL),
-    edge_qrule(NULL)
+    _element_qrule(NULL), _side_qrule(NULL),
+    _edge_qrule(NULL)
 {
   // We need to know which of our variables has the hardest
   // shape functions to numerically integrate.
@@ -67,12 +67,12 @@ FEMContext::FEMContext (const System &sys)
     }
 
   // Create an adequate quadrature rule
-  element_qrule = hardest_fe_type.default_quadrature_rule
+  _element_qrule = hardest_fe_type.default_quadrature_rule
     (this->_dim, sys.extra_quadrature_order).release();
-  side_qrule = hardest_fe_type.default_quadrature_rule
+  _side_qrule = hardest_fe_type.default_quadrature_rule
     (this->_dim-1, sys.extra_quadrature_order).release();
   if (this->_dim == 3)
-    edge_qrule = hardest_fe_type.default_quadrature_rule
+    _edge_qrule = hardest_fe_type.default_quadrature_rule
       (1, sys.extra_quadrature_order).release();
 
   // Next, create finite element objects
@@ -90,14 +90,14 @@ FEMContext::FEMContext (const System &sys)
       if ( _element_fe[fe_type] == NULL )
         {
           _element_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
-          _element_fe[fe_type]->attach_quadrature_rule(element_qrule);
+          _element_fe[fe_type]->attach_quadrature_rule(_element_qrule);
           _side_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
-          _side_fe[fe_type]->attach_quadrature_rule(side_qrule);
+          _side_fe[fe_type]->attach_quadrature_rule(_side_qrule);
 
           if (this->_dim == 3)
             {
               _edge_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
-              _edge_fe[fe_type]->attach_quadrature_rule(edge_qrule);
+              _edge_fe[fe_type]->attach_quadrature_rule(_edge_qrule);
             }
         }
       _element_fe_var[i] = _element_fe[fe_type];
@@ -128,14 +128,14 @@ FEMContext::~FEMContext()
     delete i->second;
   _edge_fe.clear();
 
-  delete element_qrule;
-  element_qrule = NULL;
+  delete _element_qrule;
+  _element_qrule = NULL;
 
-  delete side_qrule;
-  side_qrule = NULL;
+  delete _side_qrule;
+  _side_qrule = NULL;
 
-  delete edge_qrule;
-  side_qrule = NULL;
+  delete _edge_qrule;
+  _side_qrule = NULL;
 }
 
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1069,8 +1069,8 @@ void FEMContext::fixed_side_value(unsigned int var, unsigned int qp,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
-  libmesh_assert(elem_fixed_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_fixed_subsolutions[var];
+  libmesh_assert(&(this->get_elem_fixed_solution(var)));
+  const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
@@ -1115,8 +1115,8 @@ void FEMContext::fixed_side_gradient(unsigned int var, unsigned int qp,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
-  libmesh_assert(elem_fixed_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_fixed_subsolutions[var];
+  libmesh_assert(&(this->get_elem_fixed_solution(var)));
+  const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
@@ -1163,8 +1163,8 @@ void FEMContext::fixed_side_hessian(unsigned int var, unsigned int qp,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
-  libmesh_assert(elem_fixed_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_fixed_subsolutions[var];
+  libmesh_assert(&(this->get_elem_fixed_solution(var)));
+  const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
@@ -1207,8 +1207,8 @@ void FEMContext::fixed_point_value(unsigned int var, const Point &p,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
-  libmesh_assert(elem_fixed_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_fixed_subsolutions[var];
+  libmesh_assert(&(this->get_elem_fixed_solution(var)));
+  const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
@@ -1256,8 +1256,8 @@ void FEMContext::fixed_point_gradient(unsigned int var, const Point &p,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
-  libmesh_assert(elem_fixed_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_fixed_subsolutions[var];
+  libmesh_assert(&(this->get_elem_fixed_solution(var)));
+  const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
@@ -1308,8 +1308,8 @@ void FEMContext::fixed_point_hessian(unsigned int var, const Point &p,
 
   // Get current local coefficients
   libmesh_assert_greater (elem_fixed_subsolutions.size(), var);
-  libmesh_assert(elem_fixed_subsolutions[var]);
-  DenseSubVector<Number> &coef = *elem_fixed_subsolutions[var];
+  libmesh_assert(&(this->get_elem_fixed_solution(var)));
+  const DenseSubVector<Number> &coef = this->get_elem_fixed_solution(var);
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
@@ -1426,7 +1426,7 @@ void FEMContext::side_fe_reinit ()
   for (std::map<FEType, FEAbstract *>::iterator i = _side_fe.begin();
        i != local_fe_end; ++i)
     {
-      i->second->reinit(&(this->get_elem()), side);
+      i->second->reinit(&(this->get_elem()), this->get_side());
     }
 }
 
@@ -1442,7 +1442,7 @@ void FEMContext::edge_fe_reinit ()
   for (std::map<FEType, FEAbstract *>::iterator i = _edge_fe.begin();
        i != local_fe_end; ++i)
     {
-      i->second->edge_reinit(&(this->get_elem()), edge);
+      i->second->edge_reinit(&(this->get_elem()), this->get_edge());
     }
 }
 
@@ -1527,15 +1527,15 @@ void FEMContext::_do_elem_position_set(Real)
   libmesh_assert(this->get_mesh_x_var() == libMesh::invalid_uint ||
                  (this->get_element_fe(this->get_mesh_x_var())->get_fe_type().family
                   == LAGRANGE &&
-                  elem_subsolutions[this->get_mesh_x_var()]->size() == n_nodes));
+                  this->get_elem_solution(this->get_mesh_x_var()).size() == n_nodes));
   libmesh_assert(this->get_mesh_y_var() == libMesh::invalid_uint ||
                  (this->get_element_fe(this->get_mesh_y_var())->get_fe_type().family
                   == LAGRANGE &&
-                  elem_subsolutions[this->get_mesh_y_var()]->size() == n_nodes));
+                  this->get_elem_solution(this->get_mesh_y_var()).size() == n_nodes));
   libmesh_assert(this->get_mesh_z_var() == libMesh::invalid_uint ||
                  (this->get_element_fe(this->get_mesh_z_var())->get_fe_type().family
                   == LAGRANGE &&
-                  elem_subsolutions[this->get_mesh_z_var()]->size() == n_nodes));
+                  this->get_elem_solution(this->get_mesh_z_var()).size() == n_nodes));
 
   // Set the new point coordinates
   if (this->get_mesh_x_var() != libMesh::invalid_uint)
@@ -1593,59 +1593,59 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
   sys.current_local_solution->get(this->get_dof_indices(), this->get_elem_solution().get_values());
 
   if (sys.use_fixed_solution)
-    elem_fixed_solution.resize(n_dofs);
-  elem_solution_rate.resize(n_dofs);
+    this->get_elem_fixed_solution().resize(n_dofs);
+  this->get_elem_solution_rate().resize(n_dofs);
 
   // These resize calls also zero out the residual and jacobian
-  elem_residual.resize(n_dofs);
-  elem_jacobian.resize(n_dofs, n_dofs);
+  this->get_elem_residual().resize(n_dofs);
+  this->get_elem_jacobian().resize(n_dofs, n_dofs);
 
-  elem_qoi_derivative.resize(n_qoi);
+  this->get_qoi_derivatives().resize(n_qoi);
   elem_qoi_subderivatives.resize(n_qoi);
   for (std::size_t q=0; q != n_qoi; ++q)
-    elem_qoi_derivative[q].resize(n_dofs);
+    (this->get_qoi_derivatives())[q].resize(n_dofs);
 
   // Initialize the per-variable data for elem.
   {
     unsigned int sub_dofs = 0;
     for (unsigned int i=0; i != sys.n_vars(); ++i)
       {
-        sys.get_dof_map().dof_indices (&(this->get_elem()), dof_indices_var[i], i);
+        sys.get_dof_map().dof_indices (&(this->get_elem()), this->get_dof_indices(i), i);
 
         const unsigned int n_dofs_var = cast_int<unsigned int>
-          (dof_indices_var[i].size());
+          (this->get_dof_indices(i).size());
 
-        elem_subsolutions[i]->reposition
+        this->get_elem_solution(i).reposition
           (sub_dofs, n_dofs_var);
 
-        elem_subsolution_rates[i]->reposition
+        this->get_elem_solution_rate(i).reposition
           (sub_dofs, n_dofs_var);
 
         if (sys.use_fixed_solution)
-          elem_fixed_subsolutions[i]->reposition
+          this->get_elem_fixed_solution(i).reposition
             (sub_dofs, n_dofs_var);
 
-        elem_subresiduals[i]->reposition
+        this->get_elem_residual(i).reposition
           (sub_dofs, n_dofs_var);
 
         for (std::size_t q=0; q != n_qoi; ++q)
-          elem_qoi_subderivatives[q][i]->reposition
+          this->get_qoi_derivatives(q,i).reposition
             (sub_dofs, n_dofs_var);
 
         for (unsigned int j=0; j != i; ++j)
           {
             const unsigned int n_dofs_var_j =
               cast_int<unsigned int>
-              (dof_indices_var[j].size());
+              (this->get_dof_indices(j).size());
 
-            elem_subjacobians[i][j]->reposition
-              (sub_dofs, elem_subresiduals[j]->i_off(),
+            this->get_elem_jacobian(i,j).reposition
+              (sub_dofs, this->get_elem_residual(j).i_off(),
                n_dofs_var, n_dofs_var_j);
-            elem_subjacobians[j][i]->reposition
-              (elem_subresiduals[j]->i_off(), sub_dofs,
+            this->get_elem_jacobian(j,i).reposition
+              (this->get_elem_residual(j).i_off(), sub_dofs,
                n_dofs_var_j, n_dofs_var);
           }
-        elem_subjacobians[i][i]->reposition
+        this->get_elem_jacobian(i,i).reposition
           (sub_dofs, sub_dofs,
            n_dofs_var,
            n_dofs_var);
@@ -1670,8 +1670,8 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
       for (unsigned int i=0; i != sys.n_vars(); ++i)
         {
           const unsigned int n_dofs_var = cast_int<unsigned int>
-            (dof_indices_var[i].size());
-          sys.get_dof_map().dof_indices (&(this->get_elem()), dof_indices_var[i], i);
+            (this->get_dof_indices(i).size());
+          sys.get_dof_map().dof_indices (&(this->get_elem()), this->get_dof_indices(i), i);
 
           localized_vec_it->second.second[i]->reposition
             (sub_dofs, n_dofs_var);
@@ -1692,7 +1692,7 @@ void FEMContext::_update_time_from_system(Real theta)
   // assert in debug mode if the requested pointer is NULL.
   const Real deltat = this->get_deltat_value();
 
-  this->time = theta*(this->system_time + deltat) + (1.-theta)*this->system_time;
+  this->set_time(theta*(this->get_system_time() + deltat) + (1.-theta)*this->get_system_time());
 }
 
 


### PR DESCRIPTION
This falls squarely in OCD minutiae, but this was annoying enough when reading the code that I went ahead and changed it (actually separated this from a forthcoming PR). Doesn't touch the interface or public members. Compiles and fem_system examples run. Unless I offend @roystgnr or @jwpeterson sensibilities, I'll merge later today. (I did them separately, but I can squash these into 1 if y'all would rather.)