### PR TITLE
Point locator tree fixes

### DIFF
--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -76,16 +76,23 @@ public:
 
   /**
    * @returns a pointer to the element containing point p,
-   * optionally restricted to a set of allowed subdomains.
+   * optionally restricted to a set of allowed subdomains,
+   * optionally using a non-zero relative tolerance for searches.
    */
-  const Elem* find_element(const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
+  const Elem* find_element(const Point& p,
+                           const std::set<subdomain_id_type>
+                           *allowed_subdomains = NULL,
+                           Real relative_tol = TOLERANCE) const;
 
   /**
    * @returns a pointer to the element containing point p,
-   * optionally restricted to a set of allowed subdomains.
+   * optionally restricted to a set of allowed subdomains,
+   * optionally using a non-zero relative tolerance for searches.
    */
-  const Elem* operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
-
+  const Elem* operator() (const Point& p,
+                          const std::set<subdomain_id_type>
+                          *allowed_subdomains = NULL,
+                          Real relative_tol = TOLERANCE) const;
 
 private:
   /**

--- a/include/utils/tree_base.h
+++ b/include/utils/tree_base.h
@@ -90,9 +90,13 @@ public:
 
   /**
    * @returns a pointer to the element containing point p,
-   * optionally restricted to a set of allowed subdomains.
+   * optionally restricted to a set of allowed subdomains,
+   * optionally using a non-zero relative tolerance for searches.
    */
-  virtual const Elem* find_element(const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const = 0;
+  virtual const Elem* find_element(const Point& p,
+                                   const std::set<subdomain_id_type>
+                                   *allowed_subdomains = NULL,
+                                   Real relative_tol = TOLERANCE) const = 0;
 
 protected:
 

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -101,16 +101,18 @@ public:
   void set_bounding_box (const std::pair<Point, Point>& bbox);
 
   /**
-   * @returns true if this TreeNode (or its children) contain node n,
-   * false otherwise.
+   * @returns true if this TreeNode (or its children) contain node n
+   * (within relative tolerance), false otherwise.
    */
-  bool bounds_node (const Node* nd) const;
+  bool bounds_node (const Node* nd,
+                    Real relative_tol = 0) const;
 
   /**
-   * @returns true if this TreeNode (or its children) contain point p,
-   * false otherwise.
+   * @returns true if this TreeNode (or its children) contain point p
+   * (within relative tolerance), false otherwise.
    */
-  bool bounds_point (const Point &p) const;
+  bool bounds_point (const Point &p,
+                     Real relative_tol = 0) const;
 
   /**
    * @returns the level of the node.
@@ -144,7 +146,10 @@ public:
    * @returns an element containing point p,
    * optionally restricted to a set of allowed subdomains.
    */
-  const Elem* find_element (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
+  const Elem* find_element (const Point& p,
+                            const std::set<subdomain_id_type>
+                              *allowed_subdomains = NULL,
+                            Real relative_tol = TOLERANCE) const;
 
 
 private:
@@ -152,7 +157,10 @@ private:
    * Look for point \p p in our children,
    * optionally restricted to a set of allowed subdomains.
    */
-  const Elem* find_element_in_children (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains) const;
+  const Elem* find_element_in_children (const Point& p,
+                                        const std::set<subdomain_id_type>
+                                          *allowed_subdomains,
+                                        Real relative_tol) const;
 
   /**
    * Constructs the bounding box for child \p c.

--- a/src/apps/projection.C
+++ b/src/apps/projection.C
@@ -122,6 +122,7 @@ int main(int argc, char** argv)
     assert_argument(cl, "--inmesh", argv[0], std::string("mesh.xda"));
 
   old_mesh.read(meshname);
+  std::cout << "Old Mesh:" << std::endl;
   old_mesh.print_info();
 
   // Load the new mesh from --outmesh filename
@@ -130,6 +131,8 @@ int main(int argc, char** argv)
   const std::string outmeshname = cl.follow(std::string("out_"+meshname), "--outmesh");
 
   new_mesh.read(outmeshname);
+  std::cout << "New Mesh:" << std::endl;
+  new_mesh.print_info();
 
   // Load the old solution from --insoln filename
   // Construct the new solution from the old solution's headers, so

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -393,7 +393,7 @@ const PointLocatorBase& MeshBase::point_locator () const
       // PointLocator construction may not be safe within threads
       libmesh_assert(!Threads::in_threads);
 
-      _point_locator.reset (PointLocatorBase::build(TREE, *this).release());
+      _point_locator.reset (PointLocatorBase::build(TREE_ELEMENTS, *this).release());
     }
 
   return *_point_locator;
@@ -407,10 +407,10 @@ AutoPtr<PointLocatorBase> MeshBase::sub_point_locator () const
       // PointLocator construction may not be safe within threads
       libmesh_assert(!Threads::in_threads);
 
-      _point_locator.reset (PointLocatorBase::build(TREE, *this).release());
+      _point_locator.reset (PointLocatorBase::build(TREE_ELEMENTS, *this).release());
     }
 
-  return PointLocatorBase::build(TREE, *this, _point_locator.get());
+  return PointLocatorBase::build(TREE_ELEMENTS, *this, _point_locator.get());
 }
 
 

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -144,17 +144,25 @@ void Tree<N>::print_elements(std::ostream& my_out) const
 
 
 template <unsigned int N>
-const Elem* Tree<N>::find_element(const Point& p, const std::set<subdomain_id_type> *allowed_subdomains) const
+const Elem*
+Tree<N>::find_element
+(const Point& p,
+ const std::set<subdomain_id_type> *allowed_subdomains,
+ Real relative_tol) const
 {
-  return root.find_element(p,allowed_subdomains);
+  return root.find_element(p, allowed_subdomains, relative_tol);
 }
 
 
 
 template <unsigned int N>
-const Elem* Tree<N>::operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains) const
+const Elem*
+Tree<N>::operator()
+(const Point& p,
+ const std::set<subdomain_id_type> *allowed_subdomains,
+ Real relative_tol) const
 {
-  return this->find_element(p,allowed_subdomains);
+  return this->find_element(p, allowed_subdomains, relative_tol);
 }
 
 

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -500,40 +500,26 @@ const Elem* TreeNode<N>::find_element_in_children
 {
   libmesh_assert (!this->active());
 
-  unsigned int excluded_child = libMesh::invalid_uint;
+  std::vector<bool> searched_child(children.size(), false);
 
   // First only look in the children whose bounding box
-  // contain the point p.  Note that only one child will
-  // bound the point since the bounding boxes are not
-  // overlapping
+  // contain the point p.
   for (unsigned int c=0; c<children.size(); c++)
     if (children[c]->bounds_point(p, relative_tol))
       {
-        if (children[c]->active())
-          {
-            const Elem* e =
-              children[c]->find_element(p,allowed_subdomains,
-                                        relative_tol);
+        const Elem* e =
+          children[c]->find_element(p,allowed_subdomains,
+                                    relative_tol);
 
-            if (e != NULL)
-              return e;
-          }
-        else
-          {
-            const Elem* e =
-              children[c]->find_element_in_children(p,allowed_subdomains,
-                                                    relative_tol);
+        if (e != NULL)
+          return e;
 
-            if (e != NULL)
-              return e;
-          }
-
-        // If we get here than the child that bounds the
+        // If we get here then a child that bounds the
         // point does not have any elements that contain
         // the point.  So, we will search all our children.
         // However, we have already searched child c so there
         // is no use searching her again.
-        excluded_child = c;
+        searched_child[c] = true;
       }
 
 
@@ -542,26 +528,14 @@ const Elem* TreeNode<N>::find_element_in_children
   // the point p.  So, let's look at the other children
   // but exclude the one we have already searched.
   for (unsigned int c=0; c<children.size(); c++)
-    if (c != excluded_child)
+    if (!searched_child[c])
       {
-        if (children[c]->active())
-          {
-            const Elem* e =
-              children[c]->find_element(p,allowed_subdomains,
-                                        relative_tol);
+        const Elem* e =
+          children[c]->find_element(p,allowed_subdomains,
+                                    relative_tol);
 
-            if (e != NULL)
-              return e;
-          }
-        else
-          {
-            const Elem* e =
-              children[c]->find_element_in_children(p,allowed_subdomains,
-                                                    relative_tol);
-
-            if (e != NULL)
-              return e;
-          }
+        if (e != NULL)
+          return e;
       }
 
   // If we get here we have searched all our children.

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -196,7 +196,7 @@ bool TreeNode<N>::bounds_point (const Point& p,
   const Point& min = bounding_box.first;
   const Point& max = bounding_box.second;
 
-  const Real tol = (max - min).size();
+  const Real tol = (max - min).size() * relative_tol;
 
   if ((p(0) >= min(0) - tol)
       && (p(0) <= max(0) + tol)


### PR DESCRIPTION
This definitely isn't a complete set of fixes (I've still got a mesh where we appear to be failing to find points in the tree) but it does seem to be a correct set of fixes, and it does fix the tree for most of the meshes I've tried it on, so let's see what MooseBuild thinks of it.

For anyone who has use cases related to #432 or https://github.com/idaholab/moose/issues/4528 then you might want to play with them here, or you might just want to wait until I've exhausted all the failure cases I can come up with myself.