### PR TITLE
Fix OpenMP Autoconf test 

### DIFF
--- a/configure
+++ b/configure
@@ -27476,32 +27476,37 @@ ax_cv_cxx_openmp=unknown
 # Flags to try:  -fopenmp (gcc), -openmp (icc), -mp (SGI & PGI),
 #                -xopenmp (Sun), -omp (Tru64), -qsmp=omp (AIX), none
 ax_openmp_flags="-fopenmp -openmp -mp -xopenmp -omp -qsmp=omp none"
+
 if test "x$OPENMP_CXXFLAGS" != x; then
   ax_openmp_flags="$OPENMP_CXXFLAGS $ax_openmp_flags"
 fi
+
 for ax_openmp_flag in $ax_openmp_flags; do
   case $ax_openmp_flag in
     none) CXXFLAGS=$saveCXX ;;
-    *) CXXFLAGS="$saveCXXFLAGS $ax_openmp_flag" ;;
+    *)    CXXFLAGS="$saveCXXFLAGS $ax_openmp_flag" ;;
   esac
+
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-void omp_set_num_threads(int);
+
+    #include <omp.h>
+
 int
 main ()
 {
-const int N = 100000;
-  int i, arr[N];
 
-  omp_set_num_threads(2);
+    const int N = 100000;
+    int i, arr[N];
 
-  #pragma omp parallel for
-  for (i = 0; i < N; i++) {
-    arr[i] = i;
-  }
+    omp_set_num_threads(2);
+
+    #pragma omp parallel for
+    for (i = 0; i < N; i++)
+    {
+      arr[i] = i;
+    }
+
   ;
   return 0;
 }
@@ -27512,11 +27517,13 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 done
+
 CXXFLAGS=$saveCXXFLAGS
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_cxx_openmp" >&5
 $as_echo "$ax_cv_cxx_openmp" >&6; }
+
 if test "x$ax_cv_cxx_openmp" = "xunknown"; then
   enableopenmp=no
 else

--- a/m4/ax_openmp.m4
+++ b/m4/ax_openmp.m4
@@ -75,29 +75,39 @@ ax_cv_[]_AC_LANG_ABBREV[]_openmp=unknown
 # Flags to try:  -fopenmp (gcc), -openmp (icc), -mp (SGI & PGI),
 #                -xopenmp (Sun), -omp (Tru64), -qsmp=omp (AIX), none
 ax_openmp_flags="-fopenmp -openmp -mp -xopenmp -omp -qsmp=omp none"
+
 if test "x$OPENMP_[]_AC_LANG_PREFIX[]FLAGS" != x; then
   ax_openmp_flags="$OPENMP_[]_AC_LANG_PREFIX[]FLAGS $ax_openmp_flags"
 fi
+
 for ax_openmp_flag in $ax_openmp_flags; do
   case $ax_openmp_flag in
     none) []_AC_LANG_PREFIX[]FLAGS=$save[]_AC_LANG_PREFIX[] ;;
-    *) []_AC_LANG_PREFIX[]FLAGS="$save[]_AC_LANG_PREFIX[]FLAGS $ax_openmp_flag" ;;
+    *)    []_AC_LANG_PREFIX[]FLAGS="$save[]_AC_LANG_PREFIX[]FLAGS $ax_openmp_flag" ;;
   esac
-  AC_TRY_LINK([#ifdef __cplusplus
-extern "C"
-#endif
-void omp_set_num_threads(int);], [const int N = 100000;
-  int i, arr[N];
 
-  omp_set_num_threads(2);
+  AC_TRY_LINK(
+  [
+    @%:@include <omp.h>
+  ],
+  [
+    const int N = 100000;
+    int i, arr[N];
 
-  #pragma omp parallel for
-  for (i = 0; i < N; i++) {
-    arr[i] = i;
-  }], [ax_cv_[]_AC_LANG_ABBREV[]_openmp=$ax_openmp_flag; break])
+    omp_set_num_threads(2);
+
+    @%:@pragma omp parallel for
+    for (i = 0; i < N; i++)
+    {
+      arr[i] = i;
+    }
+  ],
+  [ax_cv_[]_AC_LANG_ABBREV[]_openmp=$ax_openmp_flag; break])
 done
+
 []_AC_LANG_PREFIX[]FLAGS=$save[]_AC_LANG_PREFIX[]FLAGS
 ])
+
 if test "x$ax_cv_[]_AC_LANG_ABBREV[]_openmp" = "xunknown"; then
   m4_default([$2],:)
 else


### PR DESCRIPTION
This test now successfully disables OpenMP support for me on compilers that don't actually support it:
```
configure:27469: checking for OpenMP flag of C++ compiler
configure:27514: /usr/bin/clang++ -o conftest  -std=gnu++11 -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments    -fopenmp    conftest.cpp   >&5
conftest.cpp:84:14: fatal error: 'omp.h' file not found
    #include <omp.h>
             ^
1 error generated.
configure:27514: $? = 1
```

while still enabling it on compilers that do:
```
configure:27469: checking for OpenMP flag of C++ compiler
configure:27514: mpicxx -o conftest  -std=gnu++11 -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments    -fopenmp              conftest.cpp             >&5
configure:27514: $? = 0
configure:27524: result: -fopenmp
configure:27540: result: <<< Configuring library with OpenMP support >>>
```
