### PR TITLE
Less draconian get_id_by_name()

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -468,8 +468,8 @@ public:
   std::string& nodeset_name(boundary_id_type id);
 
   /**
-   * Returns a the id of the requested boundary by name.  Throws an error
-   * if a sideset or nodeset by name is not found
+   * Returns the id of the named boundary if it exists, invalid_id
+   * otherwise.
    */
   boundary_id_type get_id_by_name(const std::string& name) const;
 

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -702,8 +702,8 @@ public:
   const std::string& subdomain_name(subdomain_id_type id) const;
 
   /**
-   * Returns a the id of the requested block by name.  Throws an error
-   * if a block by name is not found
+   * Returns the id of the named subdomain if it exists,
+   * Elem::invalid_subdomain_id otherwise.
    */
   subdomain_id_type get_id_by_name(const std::string& name) const;
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1914,27 +1914,25 @@ std::string& BoundaryInfo::nodeset_name(boundary_id_type id)
 
 boundary_id_type BoundaryInfo::get_id_by_name(const std::string& name) const
 {
-  // This function is searching the keys of the map
-  // We might want to make this more efficient
-  std::map<boundary_id_type, std::string>::const_iterator iter = _ss_id_to_name.begin();
-  std::map<boundary_id_type, std::string>::const_iterator end_iter = _ss_id_to_name.end();
+  // Search sidesets
+  std::map<boundary_id_type, std::string>::const_iterator
+    iter = _ss_id_to_name.begin(),
+    end_iter = _ss_id_to_name.end();
 
-  for ( ; iter != end_iter; ++iter)
-    {
-      if (iter->second == name)
-        return iter->first;
-    }
+  for (; iter != end_iter; ++iter)
+    if (iter->second == name)
+      return iter->first;
 
-  // Loop over nodesets
+  // Search nodesets
   iter = _ns_id_to_name.begin();
   end_iter = _ns_id_to_name.end();
-  for ( ; iter != end_iter; ++iter)
-    {
-      if (iter->second == name)
-        return iter->first;
-    }
+  for (; iter != end_iter; ++iter)
+    if (iter->second == name)
+      return iter->first;
 
-  libmesh_error_msg("The sideset/nodeset named " << name << " does not exist in mesh!");
+  // If we made it here without returning, we don't have a sideset or
+  // nodeset by the requested name, so return invalid_id
+  return invalid_id;
 }
 
 } // namespace libMesh

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -444,19 +444,18 @@ const std::string& MeshBase::subdomain_name(subdomain_id_type id) const
 
 subdomain_id_type MeshBase::get_id_by_name(const std::string& name) const
 {
-  // This function is searching the *values* of the map (linear search)
-  // We might want to make this more efficient...
+  // Linear search over the map values.
   std::map<subdomain_id_type, std::string>::const_iterator
     iter = _block_id_to_name.begin(),
     end_iter = _block_id_to_name.end();
 
   for ( ; iter != end_iter; ++iter)
-    {
-      if (iter->second == name)
-        return iter->first;
-    }
+    if (iter->second == name)
+      return iter->first;
 
-  libmesh_error_msg("Block '" << name << "' does not exist in mesh");
+  // If we made it here without returning, we don't have a subdomain
+  // with the requested name, so return Elem::invalid_subdomain_id.
+  return Elem::invalid_subdomain_id;
 }
 
 


### PR DESCRIPTION
Instead of throwing an error, return the proper type of "invalid" id when a named sideset/nodeset/subdomain is not found.  That way the calling application can decide what to do about it.  As requested by @YaqiWang.
