### PR TITLE
Avoid std::unordered container types on Clang/OSX until they are fixed

### DIFF
--- a/configure
+++ b/configure
@@ -26159,6 +26159,22 @@ else
 fi
 
 
+  # After a lengthy investigation in Jan. 2015, it was determined that
+  # there is a quality of implementation issue with clang's
+  # unordered container types on OSX, which does not appear to affect
+  # Linux.  Until this gets resolved, we will fall back to the "ordered"
+  # containers (map/set/multimap) for this compiler/architecture combination.
+  # https://github.com/idaholab/moose/issues/4624#issuecomment-72278831
+  if test "x$is_clang" != "x" ; then
+    case "${host_os}" in
+      *darwin*)
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Disabling unordered containers to work around Clang/OSX QOI issues >>>" >&5
+$as_echo "<<< Disabling unordered containers to work around Clang/OSX QOI issues >>>" >&6; }
+        enableunorderedcontainers=no
+        ;;
+    esac
+  fi
+
   if test "$enableunorderedcontainers" != no ; then
     # The following routines, defined in unordered.m4, check to see if the compiler can compile programs using
     # various quasi-standard hash containers.

--- a/m4/libmesh_compiler_features.m4
+++ b/m4/libmesh_compiler_features.m4
@@ -164,6 +164,21 @@ AC_ARG_ENABLE(unordered-containers,
               enableunorderedcontainers=$enableval,
               enableunorderedcontainers=yes)
 
+  # After a lengthy investigation in Jan. 2015, it was determined that
+  # there is a quality of implementation issue with clang's
+  # unordered container types on OSX, which does not appear to affect
+  # Linux.  Until this gets resolved, we will fall back to the "ordered"
+  # containers (map/set/multimap) for this compiler/architecture combination.
+  # https://github.com/idaholab/moose/issues/4624#issuecomment-72278831
+  if test "x$is_clang" != "x" ; then
+    case "${host_os}" in
+      *darwin*)
+        AC_MSG_RESULT(<<< Disabling unordered containers to work around Clang/OSX QOI issues >>>)
+        enableunorderedcontainers=no
+        ;;
+    esac
+  fi
+
   if test "$enableunorderedcontainers" != no ; then
     # The following routines, defined in unordered.m4, check to see if the compiler can compile programs using
     # various quasi-standard hash containers.


### PR DESCRIPTION
See also this [issue](https://github.com/idaholab/moose/issues/4624#issuecomment-72278831).

The slowness affects `unordered_map`, `unordered_set`, and `unordered_multimap`. This patch makes the BEST_UNORDERED_XYZ types fall back to `map`, `set` and `multimap`, respectively, on Clang/OSX.