### PR TITLE
Mixed Dimension Mesh Support for FEMContext

### DIFF
--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -616,15 +616,15 @@ public:
    * Accessor for element interior quadrature rule.
    */
   const QBase& get_element_qrule( unsigned char dim ) const
-  { libmesh_assert(_element_qrule.find(dim) != _element_qrule.end());
-    return *(this->_element_qrule.find(dim)->second); }
+  { libmesh_assert(_element_qrule[dim]);
+    return *(this->_element_qrule[dim]); }
 
   /**
    * Accessor for element side quadrature rule.
    */
   const QBase& get_side_qrule( unsigned char dim ) const
-  { libmesh_assert(_side_qrule.find(dim) != _side_qrule.end());
-    return *(this->_side_qrule.find(dim)->second); }
+  { libmesh_assert(_side_qrule[dim]);
+    return *(this->_side_qrule[dim]); }
 
   /**
    * Accessor for element edge quadrature rule.
@@ -845,8 +845,8 @@ protected:
    * We store FE objects for each element dimension present in the mesh,
    * except for edge_fe which only applies to 3D elements.
    */
-  std::map<unsigned char, std::map<FEType, FEAbstract*> > _element_fe;
-  std::map<unsigned char, std::map<FEType, FEAbstract*> > _side_fe;
+  std::vector<std::map<FEType, FEAbstract*> > _element_fe;
+  std::vector<std::map<FEType, FEAbstract*> > _side_fe;
   std::map<FEType, FEAbstract*> _edge_fe;
 
 
@@ -856,8 +856,8 @@ protected:
    * present in the mesh, except for edge_fe_var which only applies
    * for 3D elements.
    */
-  std::map<unsigned char, std::vector<FEAbstract*> > _element_fe_var;
-  std::map<unsigned char, std::vector<FEAbstract*> > _side_fe_var;
+  std::vector<std::vector<FEAbstract*> > _element_fe_var;
+  std::vector<std::vector<FEAbstract*> > _side_fe_var;
   std::vector<FEAbstract*> _edge_fe_var;
 
   /**
@@ -887,7 +887,7 @@ protected:
    * correctly integrates all variables. We prepare quadrature
    * rules for each element dimension in the mesh.
    */
-  std::map<unsigned char, QBase*> _element_qrule;
+  std::vector<QBase*> _element_qrule;
 
   /**
    * Quadrature rules for element sides
@@ -895,7 +895,7 @@ protected:
    * correctly integrates all variables. We prepare quadrature
    * rules for each element dimension in the mesh.
    */
-  std::map<unsigned char, QBase*> _side_qrule;
+  std::vector<QBase*> _side_qrule;
 
   /**
    * Quadrature rules for element edges.  If the FEM context is told
@@ -942,17 +942,17 @@ inline
 void FEMContext::get_element_fe( unsigned int var, FEGenericBase<OutputShape> *& fe,
                                  unsigned char dim ) const
 {
-  libmesh_assert( _element_fe_var.find(dim) != _element_fe_var.end() );
-  libmesh_assert_less ( var, (_element_fe_var.find(dim)->second).size() );
-  fe = cast_ptr<FEGenericBase<OutputShape>*>( (_element_fe_var.find(dim)->second)[var] );
+  libmesh_assert( !_element_fe_var[dim].empty() );
+  libmesh_assert_less ( var, (_element_fe_var[dim].size() ) );
+  fe = cast_ptr<FEGenericBase<OutputShape>*>( (_element_fe_var[dim][var] ) );
 }
 
 inline
 FEBase* FEMContext::get_element_fe( unsigned int var, unsigned char dim ) const
 {
-  libmesh_assert( _element_fe_var.find(dim) != _element_fe_var.end() );
-  libmesh_assert_less ( var, (_element_fe_var.find(dim)->second).size() );
-  return cast_ptr<FEBase*>( (_element_fe_var.find(dim)->second)[var] );
+  libmesh_assert( !_element_fe_var[dim].empty() );
+  libmesh_assert_less ( var, (_element_fe_var[dim].size() ) );
+  return cast_ptr<FEBase*>( (_element_fe_var[dim][var] ) );
 }
 
 template<typename OutputShape>
@@ -960,17 +960,17 @@ inline
 void FEMContext::get_side_fe( unsigned int var, FEGenericBase<OutputShape> *& fe,
                               unsigned char dim ) const
 {
-  libmesh_assert( _side_fe_var.find(dim) != _side_fe_var.end() );
-  libmesh_assert_less ( var, (_side_fe_var.find(dim)->second).size() );
-  fe = cast_ptr<FEGenericBase<OutputShape>*>( (_side_fe_var.find(dim)->second)[var] );
+  libmesh_assert( !_side_fe_var[dim].empty() );
+  libmesh_assert_less ( var, (_side_fe_var[dim].size() ) );
+  fe = cast_ptr<FEGenericBase<OutputShape>*>( (_side_fe_var[dim][var] ) );
 }
 
 inline
 FEBase* FEMContext::get_side_fe( unsigned int var, unsigned char dim ) const
 {
-  libmesh_assert( _side_fe_var.find(dim) != _side_fe_var.end() );
-  libmesh_assert_less ( var, (_side_fe_var.find(dim)->second).size() );
-  return cast_ptr<FEBase*>( (_side_fe_var.find(dim)->second)[var] );
+  libmesh_assert( !_side_fe_var[dim].empty() );
+  libmesh_assert_less ( var, (_side_fe_var[dim].size() ) );
+  return cast_ptr<FEBase*>( (_side_fe_var[dim][var] ) );
 }
 
 template<typename OutputShape>

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -670,10 +670,20 @@ public:
   { return edge; }
 
   /**
-   * Accessor for cached element dimension
+   * Accessor for cached mesh dimension. This is the largest dimension
+   * of the elements in the mesh. For the dimension of this->_elem, use
+   * get_elem_dim();
    */
   unsigned char get_dim() const
   { return this->_dim; }
+
+  /**
+   * Returns the dimension of this->_elem. For mixed dimension meshes, this
+   * may be different from get_dim().
+   */
+  unsigned char get_elem_dim() const
+  { return _elem_dim; }
+
 
   /**
    * Uses the coordinate data specified by mesh_*_position configuration
@@ -719,9 +729,7 @@ protected:
   /**
    * Helper function to promote accessor usage
    */
-  void set_elem( const Elem* e )
-  { this->_elem = e; }
-
+  void set_elem( const Elem* e );
 
   // gcc-3.4, oracle 12.3 require this typedef to be public
   // in order to use it in a return type
@@ -802,9 +810,14 @@ protected:
   const Elem *_elem;
 
   /**
-   * Cached dimension of elements in this mesh
+   * Cached dimension of largest dimension element in this mesh
    */
   unsigned char _dim;
+
+  /**
+   * Cached dimension of this->_elem.
+   */
+  unsigned char _elem_dim;
 
   /**
    * Quadrature rule for element interior.

--- a/src/systems/dg_fem_context.C
+++ b/src/systems/dg_fem_context.C
@@ -125,7 +125,7 @@ void DGFEMContext::neighbor_side_fe_reinit ()
       FEAbstract* side_fe = _side_fe[neighbor_side_fe_type];
       qface_side_points = side_fe->get_xyz();
 
-      FEInterface::inverse_map (this->_dim,
+      FEInterface::inverse_map (this->get_dim(),
                                 neighbor_side_fe_type,
                                 &get_neighbor(),
                                 qface_side_points,

--- a/src/systems/dg_fem_context.C
+++ b/src/systems/dg_fem_context.C
@@ -122,7 +122,7 @@ void DGFEMContext::neighbor_side_fe_reinit ()
        i != local_fe_end; ++i)
     {
       FEType neighbor_side_fe_type = i->first;
-      FEAbstract* side_fe = _side_fe[neighbor_side_fe_type];
+      FEAbstract* side_fe = _side_fe[this->get_dim()][neighbor_side_fe_type];
       qface_side_points = side_fe->get_xyz();
 
       FEInterface::inverse_map (this->get_dim(),

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -43,6 +43,7 @@ FEMContext::FEMContext (const System &sys)
     _boundary_info(sys.get_mesh().get_boundary_info()),
     _elem(NULL),
     _dim(sys.get_mesh().mesh_dimension()),
+    _elem_dim(0), /* This will be reset in set_elem(). */
     _element_qrule(NULL), _side_qrule(NULL),
     _edge_qrule(NULL)
 {
@@ -1682,7 +1683,13 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
     }
 }
 
+void FEMContext::set_elem( const Elem* e )
+{
+  this->_elem = e;
 
+  // If e is NULL, we assume it's SCALAR and set _elem_dim to 0.
+  this->_elem_dim = this->_elem ? this->_elem->dim() : 0;
+}
 
 void FEMContext::_update_time_from_system(Real theta)
 {

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -44,7 +44,6 @@ FEMContext::FEMContext (const System &sys)
     _elem(NULL),
     _dim(sys.get_mesh().mesh_dimension()),
     _elem_dim(0), /* This will be reset in set_elem(). */
-    _element_qrule(NULL), _side_qrule(NULL),
     _edge_qrule(NULL)
 {
   // We need to know which of our variables has the hardest
@@ -54,6 +53,8 @@ FEMContext::FEMContext (const System &sys)
 
   libmesh_assert (nv);
   FEType hardest_fe_type = sys.variable_type(0);
+
+  bool have_scalar = false;
 
   for (unsigned int i=0; i != nv; ++i)
     {
@@ -65,78 +66,98 @@ FEMContext::FEMContext (const System &sys)
 
       if (fe_type.order > hardest_fe_type.order)
         hardest_fe_type = fe_type;
+
+      // We need to detect SCALAR's so we can prepare FE objects for them.
+      if( fe_type.family == SCALAR )
+        have_scalar = true;
     }
 
-  // Create an adequate quadrature rule
-  _element_qrule = hardest_fe_type.default_quadrature_rule
-    (this->_dim, sys.extra_quadrature_order).release();
-  _side_qrule = hardest_fe_type.default_quadrature_rule
-    (this->_dim-1, sys.extra_quadrature_order).release();
-  if (this->_dim == 3)
-    _edge_qrule = hardest_fe_type.default_quadrature_rule
-      (1, sys.extra_quadrature_order).release();
+  std::set<unsigned char> elem_dims( sys.get_mesh().elem_dimensions() );
+  if(have_scalar)
+    // SCALAR FEs have dimension 0 by assumption
+    elem_dims.insert(0);
 
-  // Next, create finite element objects
-  // Preserving backward compatibility here for now
-  // Should move to the protected/FEAbstract interface
-  _element_fe_var.resize(nv);
-  _side_fe_var.resize(nv);
-  if (this->_dim == 3)
-    _edge_fe_var.resize(nv);
-
-  for (unsigned int i=0; i != nv; ++i)
+  for( std::set<unsigned char>::const_iterator dim_it = elem_dims.begin();
+       dim_it != elem_dims.end(); ++dim_it )
     {
-      FEType fe_type = sys.variable_type(i);
+      const unsigned char dim = *dim_it;
 
-      if ( _element_fe[fe_type] == NULL )
+      // Create an adequate quadrature rule
+      _element_qrule[dim] = hardest_fe_type.default_quadrature_rule
+        (dim, sys.extra_quadrature_order).release();
+      _side_qrule[dim] = hardest_fe_type.default_quadrature_rule
+        (dim-1, sys.extra_quadrature_order).release();
+      if (dim == 3)
+        _edge_qrule = hardest_fe_type.default_quadrature_rule
+          (1, sys.extra_quadrature_order).release();
+
+      // Next, create finite element objects
+      _element_fe_var[dim].resize(nv);
+      _side_fe_var[dim].resize(nv);
+      if (dim == 3)
+        _edge_fe_var.resize(nv);
+
+
+      for (unsigned int i=0; i != nv; ++i)
         {
-          _element_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
-          _element_fe[fe_type]->attach_quadrature_rule(_element_qrule);
-          _side_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
-          _side_fe[fe_type]->attach_quadrature_rule(_side_qrule);
+          FEType fe_type = sys.variable_type(i);
 
-          if (this->_dim == 3)
+          if ( _element_fe[dim][fe_type] == NULL )
             {
-              _edge_fe[fe_type] = FEAbstract::build(this->_dim, fe_type).release();
-              _edge_fe[fe_type]->attach_quadrature_rule(_edge_qrule);
-            }
-        }
-      _element_fe_var[i] = _element_fe[fe_type];
-      _side_fe_var[i] = _side_fe[fe_type];
-      if (this->_dim == 3)
-        _edge_fe_var[i] = _edge_fe[fe_type];
+              _element_fe[dim][fe_type] = FEAbstract::build(dim, fe_type).release();
+              _element_fe[dim][fe_type]->attach_quadrature_rule(_element_qrule[dim]);
+              _side_fe[dim][fe_type] = FEAbstract::build(dim, fe_type).release();
+              _side_fe[dim][fe_type]->attach_quadrature_rule(_side_qrule[dim]);
 
+              if (this->_dim == 3)
+                {
+                  _edge_fe[fe_type] = FEAbstract::build(dim, fe_type).release();
+                  _edge_fe[fe_type]->attach_quadrature_rule(_edge_qrule);
+                }
+            }
+
+          _element_fe_var[dim][i] = _element_fe[dim][fe_type];
+          _side_fe_var[dim][i] = _side_fe[dim][fe_type];
+          if ((dim) == 3)
+            _edge_fe_var[i] = _edge_fe[fe_type];
+
+        }
     }
 }
-
 
 FEMContext::~FEMContext()
 {
   // We don't want to store AutoPtrs in STL containers, but we don't
   // want to leak memory either
-  for (std::map<FEType, FEAbstract *>::iterator i = _element_fe.begin();
-       i != _element_fe.end(); ++i)
-    delete i->second;
-  _element_fe.clear();
+  for (std::map<unsigned char, std::map<FEType, FEAbstract *> >::iterator d = _element_fe.begin();
+       d != _element_fe.end(); ++d)
+    for (std::map<FEType, FEAbstract *>::iterator i = (d->second).begin();
+         i != (d->second).end(); ++i)
+      delete i->second;
 
-  for (std::map<FEType, FEAbstract *>::iterator i = _side_fe.begin();
-       i != _side_fe.end(); ++i)
-    delete i->second;
-  _side_fe.clear();
+  for (std::map<unsigned char, std::map<FEType, FEAbstract *> >::iterator d = _side_fe.begin();
+       d != _side_fe.end(); ++d)
+    for (std::map<FEType, FEAbstract *>::iterator i = (d->second).begin();
+         i != (d->second).end(); ++i)
+      delete i->second;
 
   for (std::map<FEType, FEAbstract *>::iterator i = _edge_fe.begin();
        i != _edge_fe.end(); ++i)
     delete i->second;
   _edge_fe.clear();
 
-  delete _element_qrule;
-  _element_qrule = NULL;
+  for (std::map<unsigned char, QBase*>::iterator i = _element_qrule.begin();
+       i != _element_qrule.end(); ++i)
+    delete i->second;
+  _element_qrule.clear();
 
-  delete _side_qrule;
-  _side_qrule = NULL;
+  for (std::map<unsigned char, QBase*>::iterator i = _side_qrule.begin();
+       i != _side_qrule.end(); ++i)
+    delete i->second;
+  _side_qrule.clear();
 
   delete _edge_qrule;
-  _side_qrule = NULL;
+  _edge_qrule = NULL;
 }
 
 
@@ -1410,8 +1431,14 @@ void FEMContext::elem_fe_reinit ()
 {
   // Initialize all the interior FE objects on elem.
   // Logging of FE::reinit is done in the FE functions
-  std::map<FEType, FEAbstract *>::iterator local_fe_end = _element_fe.end();
-  for (std::map<FEType, FEAbstract *>::iterator i = _element_fe.begin();
+  // We only reinit the FE objects for the current element
+  // dimension
+  const unsigned char dim = this->get_elem_dim();
+
+  libmesh_assert( _element_fe.find(dim) != _element_fe.end() );
+
+  std::map<FEType, FEAbstract *>::iterator local_fe_end = _element_fe[dim].end();
+  for (std::map<FEType, FEAbstract *>::iterator i = _element_fe[dim].begin();
        i != local_fe_end; ++i)
     {
       i->second->reinit(&(this->get_elem()));
@@ -1423,8 +1450,14 @@ void FEMContext::side_fe_reinit ()
 {
   // Initialize all the side FE objects on elem/side.
   // Logging of FE::reinit is done in the FE functions
-  std::map<FEType, FEAbstract *>::iterator local_fe_end = _side_fe.end();
-  for (std::map<FEType, FEAbstract *>::iterator i = _side_fe.begin();
+  // We only reinit the FE objects for the current element
+  // dimension
+  const unsigned char dim = this->get_elem_dim();
+
+  libmesh_assert( _side_fe.find(dim) != _side_fe.end() );
+
+  std::map<FEType, FEAbstract *>::iterator local_fe_end = _side_fe[dim].end();
+  for (std::map<FEType, FEAbstract *>::iterator i = _side_fe[dim].begin();
        i != local_fe_end; ++i)
     {
       i->second->reinit(&(this->get_elem()), this->get_side());
@@ -1463,22 +1496,25 @@ void FEMContext::elem_position_get()
   //  if (_mesh_sys == this->number())
   //    {
   unsigned int n_nodes = this->get_elem().n_nodes();
+
+  const unsigned char dim = this->get_elem_dim();
+
   // For simplicity we demand that mesh coordinates be stored
   // in a format that allows a direct copy
   libmesh_assert(this->get_mesh_x_var() == libMesh::invalid_uint ||
-                 (this->get_element_fe(this->get_mesh_x_var())->get_fe_type().family
+                 (this->get_element_fe(this->get_mesh_x_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
-                  this->get_element_fe(this->get_mesh_x_var())->get_fe_type().order
+                  this->get_element_fe(this->get_mesh_x_var(), dim)->get_fe_type().order
                   == this->get_elem().default_order()));
   libmesh_assert(this->get_mesh_y_var() == libMesh::invalid_uint ||
-                 (this->get_element_fe(this->get_mesh_y_var())->get_fe_type().family
+                 (this->get_element_fe(this->get_mesh_y_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
-                  this->get_element_fe(this->get_mesh_y_var())->get_fe_type().order
+                  this->get_element_fe(this->get_mesh_y_var(), dim)->get_fe_type().order
                   == this->get_elem().default_order()));
   libmesh_assert(this->get_mesh_z_var() == libMesh::invalid_uint ||
-                 (this->get_element_fe(this->get_mesh_z_var())->get_fe_type().family
+                 (this->get_element_fe(this->get_mesh_z_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
-                  this->get_element_fe(this->get_mesh_z_var())->get_fe_type().order
+                  this->get_element_fe(this->get_mesh_z_var(), dim)->get_fe_type().order
                   == this->get_elem().default_order()));
 
   // Get degree of freedom coefficients from point coordinates
@@ -1518,6 +1554,8 @@ void FEMContext::_do_elem_position_set(Real)
   // operating on elements which share a node
   libmesh_assert_equal_to (libMesh::n_threads(), 1);
 
+  const unsigned char dim = this->get_elem_dim();
+
   // If the coordinate data is in our own system, it's already
   // been set up for us, and we can ignore our input parameter theta
   //  if (_mesh_sys == this->number())
@@ -1526,15 +1564,15 @@ void FEMContext::_do_elem_position_set(Real)
   // For simplicity we demand that mesh coordinates be stored
   // in a format that allows a direct copy
   libmesh_assert(this->get_mesh_x_var() == libMesh::invalid_uint ||
-                 (this->get_element_fe(this->get_mesh_x_var())->get_fe_type().family
+                 (this->get_element_fe(this->get_mesh_x_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
                   this->get_elem_solution(this->get_mesh_x_var()).size() == n_nodes));
   libmesh_assert(this->get_mesh_y_var() == libMesh::invalid_uint ||
-                 (this->get_element_fe(this->get_mesh_y_var())->get_fe_type().family
+                 (this->get_element_fe(this->get_mesh_y_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
                   this->get_elem_solution(this->get_mesh_y_var()).size() == n_nodes));
   libmesh_assert(this->get_mesh_z_var() == libMesh::invalid_uint ||
-                 (this->get_element_fe(this->get_mesh_z_var())->get_fe_type().family
+                 (this->get_element_fe(this->get_mesh_z_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
                   this->get_elem_solution(this->get_mesh_z_var()).size() == n_nodes));
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1435,7 +1435,7 @@ void FEMContext::side_fe_reinit ()
 
 void FEMContext::edge_fe_reinit ()
 {
-  libmesh_assert_equal_to (this->_dim, 3);
+  libmesh_assert_equal_to (this->get_elem_dim(), 3);
 
   // Initialize all the interior FE objects on elem/edge.
   // Logging of FE::reinit is done in the FE functions


### PR DESCRIPTION
Updated `FEMContext` to support cases of mixed dimension meshes. This is accomplished by caching `FEAbstract*` etc. now for all dimensions present in the mesh as well as `FEType`. It is fully backward compatible with dimension dependent calls defaulting to element dimension if it's guaranteed (or at least supposed to be) available or to mesh dimension if it's not. `FEMSystem` examples ran for me and I have a working GRINS test case that I'll create a PR for in a bit, but at least wanted a chance for eyes to be put on this.