### PR TITLE
Always repartition mesh nodes

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -47,6 +47,8 @@ class Node;
 class Point;
 class MeshData;
 
+template <class MT>
+class MeshInput;
 
 
 /**
@@ -960,11 +962,18 @@ protected:
    * will contain 1 and 2.
    */
   std::set<unsigned char> _elem_dims;
+
   /**
    * The partitioner class is a friend so that it can set
    * the number of partitions.
    */
   friend class Partitioner;
+
+  /**
+   * The MeshInput classes are friends so that they can set the number
+   * of partitions.
+   */
+  friend class MeshInput<MeshBase>;
 
   /**
    * Make the \p BoundaryInfo class a friend so that

--- a/include/mesh/mesh_input.h
+++ b/include/mesh/mesh_input.h
@@ -87,6 +87,14 @@ protected:
   MT& mesh ();
 
   /**
+   * Sets the number of partitions in the mesh.  Typically this gets
+   * done by the partitioner, but some parallel file formats begin
+   * "pre-partitioned".
+   */
+  void set_n_partitions (unsigned int n_parts)
+    { this->mesh().set_n_partitions() = n_parts; }
+
+  /**
    * A vector of bools describing what dimension elements
    * have been encountered when reading a mesh.
    */

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -426,14 +426,20 @@ const PointLocatorBase& MeshBase::point_locator () const
 
 AutoPtr<PointLocatorBase> MeshBase::sub_point_locator () const
 {
+  // If there's no master point locator, then we need one.
   if (_point_locator.get() == NULL)
     {
       // PointLocator construction may not be safe within threads
       libmesh_assert(!Threads::in_threads);
 
+      // And it may require parallel communication
+      parallel_object_only();
+
       _point_locator.reset (PointLocatorBase::build(TREE_ELEMENTS, *this).release());
     }
 
+  // Otherwise there was a master point locator, and we can grab a
+  // sub-locator easily.
   return PointLocatorBase::build(TREE_ELEMENTS, *this, _point_locator.get());
 }
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -53,7 +53,7 @@ MeshBase::MeshBase (const Parallel::Communicator &comm_in,
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   _next_unique_id(DofObject::invalid_unique_id),
 #endif
-  _skip_partitioning(false),
+  _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false)
 {
   _elem_dims.insert(d);
@@ -74,7 +74,7 @@ MeshBase::MeshBase (unsigned char d) :
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   _next_unique_id(DofObject::invalid_unique_id),
 #endif
-  _skip_partitioning(false),
+  _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false)
 {
   _elem_dims.insert(d);
@@ -96,7 +96,7 @@ MeshBase::MeshBase (const MeshBase& other_mesh) :
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   _next_unique_id(other_mesh._next_unique_id),
 #endif
-  _skip_partitioning(other_mesh._skip_partitioning),
+  _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false),
   _elem_dims(other_mesh._elem_dims)
 {

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -364,6 +364,11 @@ void MeshBase::partition (const unsigned int n_parts)
     }
   else
     {
+      // Adaptive coarsening may have "orphaned" nodes on processors
+      // whose elements no longer share them.  We need to check for
+      // and possibly fix that.
+      Partitioner::set_node_processor_ids(*this);
+
       // Make sure locally cached partition count
       this->recalculate_n_partitions();
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -354,9 +354,17 @@ std::ostream& operator << (std::ostream& os, const MeshBase& m)
 
 void MeshBase::partition (const unsigned int n_parts)
 {
-  // NULL partitioner means don't partition
-  // Non-serial meshes aren't ready for partitioning yet.
-  if(!skip_partitioning() &&
+  // If we get here and we have unpartitioned elements, we need that
+  // fixed.
+  if (this->n_unpartitioned_elem() > 0)
+    {
+      libmesh_assert (partitioner().get());
+      libmesh_assert (this->is_serial());
+      partitioner()->partition (*this, n_parts);
+    }
+  // NULL partitioner means don't repartition
+  // Non-serial meshes may not be ready for repartitioning here.
+  else if(!skip_partitioning() &&
      partitioner().get() &&
      this->is_serial())
     {

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -169,6 +169,10 @@ void Nemesis_IO::read (const std::string& base_filename)
   // MeshBase& mesh = this->mesh();
   MeshBase& mesh = MeshInput<MeshBase>::mesh();
 
+  // We're reading a file on each processor, so our mesh is
+  // partitioned into that many parts as it's created
+  this->set_n_partitions(this->n_processors());
+
   // Local information: Read the following information from the standard Exodus header
   //  title[0]
   //  num_dim

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1114,6 +1114,9 @@ void XdrIO::read (const std::string& name)
   mesh.reserve_elem(n_elem);
   mesh.reserve_nodes(n_nodes);
 
+  // Our mesh is pre-partitioned as it's created
+  this->set_n_partitions(this->n_processors());
+
   /**
    * We are future proofing the layout of this file by adding in size information for all stored types.
    * TODO: All types are stored as the same size. Use the size information to pack things efficiently.


### PR DESCRIPTION
This fixes potential errors resulting from adaptive mesh coarsening:

Imagine a node N connected to element E on partition 1 and B on
partition 2.  By current libMesh rules, N.processor_id() should be 1.

Now imagine that E is adaptively coarsened away, and N is not also a node of
E->parent().  Now, N.processor_id() should be 2.  But if
skip_partitioning is true, N.processor_id() will remain 1.  When
processor 1 notices that it owns a node but no elements connected to
that node, then assertions (and algorithms, later) fail.

This fixed the case @permcody set up in https://github.com/permcody/libmesh/tree/adaptivity_ex2_assertion for me.  Hopefully it also fixes https://github.com/idaholab/moose/pull/4638 more generally.

Even if it does: I'd like to know before we merge if others consider this to be an adequate fix.  The comment documenting MeshBase::skip_partitioning() suggests that it's an attempt at performance optimization, and certainly tweaking a few node processor ids should still be cheaper than setting up and calling *Metis.  We could just clarify that documentation further.  But if skip_partitioning() is also required to guarantee unchanged processor_id() values, then any bug fix is going to have to be much deeper: IIRC there are places scattered throughout libMesh code where we assume that a loop over local elements wrapping a loop over elements' nodes will touch all local nodes.