### PR TITLE
Heterogeneous constraints assembly option

### DIFF
--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -124,7 +124,8 @@ public:
    * Assembles a residual in \p rhs and/or a jacobian in \p matrix,
    * as requested.
    */
-  virtual void assembly (bool get_residual, bool get_jacobian) = 0;
+  virtual void assembly (bool get_residual, bool get_jacobian,
+                         bool apply_heterogeneous_constraints = false) = 0;
 
   /**
    * Invokes the solver associated with the system.  For steady state

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -91,7 +91,8 @@ public:
    * Users may reimplement this to add pre- or post-assembly
    * code before or after calling FEMSystem::assembly()
    */
-  virtual void assembly (bool get_residual, bool get_jacobian);
+  virtual void assembly (bool get_residual, bool get_jacobian,
+                         bool apply_heterogeneous_constraints = false);
 
   /**
    * Invokes the solver associated with the system.  For steady state

--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -146,7 +146,10 @@ public:
    * This is undefined in ImplicitSystem; subclasses each have their
    * own way of handling assembly.
    */
-  virtual void assembly(bool /* get_residual */ , bool /* get_jacobian */)
+  virtual void assembly
+    (bool /* get_residual */,
+     bool /* get_jacobian */,
+     bool /* apply_heterogeneous_constraints */ = false)
   { libmesh_not_implemented(); }
 
   /**

--- a/include/systems/linear_implicit_system.h
+++ b/include/systems/linear_implicit_system.h
@@ -132,7 +132,8 @@ public:
    * Assembles a residual in \p rhs and/or a jacobian in \p matrix,
    * as requested.
    */
-  virtual void assembly(bool get_residual, bool get_jacobian);
+  virtual void assembly(bool get_residual, bool get_jacobian,
+                        bool apply_heterogeneous_constraints = false);
 
   /**
    * @returns \p "LinearImplicit".  Helps in identifying

--- a/include/systems/nonlinear_implicit_system.h
+++ b/include/systems/nonlinear_implicit_system.h
@@ -204,7 +204,8 @@ public:
    * Assembles a residual in \p rhs and/or a jacobian in \p matrix,
    * as requested.
    */
-  virtual void assembly(bool get_residual, bool get_jacobian);
+  virtual void assembly(bool get_residual, bool get_jacobian,
+                        bool apply_heterogeneous_constraints = false);
 
   /**
    * @returns \p "NonlinearImplicit".  Helps in identifying

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -49,6 +49,7 @@ femsystem_mutex assembly_mutex;
 void assemble_unconstrained_element_system
 (const FEMSystem& _sys,
  const bool _get_jacobian,
+ const bool _constrain_heterogeneously,
  FEMContext &_femcontext)
 {
   if (_sys.print_element_solutions)
@@ -72,12 +73,15 @@ void assemble_unconstrained_element_system
         }
     }
 
+  // We need jacobians to do heterogeneous residual constraints
+  const bool need_jacobian =
+    _get_jacobian || _constrain_heterogeneously;
 
   bool jacobian_computed =
-    _sys.time_solver->element_residual(_get_jacobian, _femcontext);
+    _sys.time_solver->element_residual(need_jacobian, _femcontext);
 
   // Compute a numeric jacobian if we have to
-  if (_get_jacobian && !jacobian_computed)
+  if (need_jacobian && !jacobian_computed)
     {
       // Make sure we didn't compute a jacobian and lie about it
       libmesh_assert_equal_to (_femcontext.get_elem_jacobian().l1_norm(), 0.0);
@@ -87,7 +91,7 @@ void assemble_unconstrained_element_system
 
   // Compute a numeric jacobian if we're asked to verify the
   // analytic jacobian we got
-  if (_get_jacobian && jacobian_computed &&
+  if (need_jacobian && jacobian_computed &&
       _sys.verify_analytic_jacobians != 0.0)
     {
       DenseMatrix<Number> analytic_jacobian(_femcontext.get_elem_jacobian());
@@ -153,18 +157,18 @@ void assemble_unconstrained_element_system
       // jacobian contribution separately.
       /* PB: We also need to account for the case when the user wants to
          use numerical Jacobians and not analytic Jacobians */
-      if ( (_sys.verify_analytic_jacobians != 0.0 && _get_jacobian) ||
-           (!jacobian_computed && _get_jacobian) )
+      if ( (_sys.verify_analytic_jacobians != 0.0 && need_jacobian) ||
+           (!jacobian_computed && need_jacobian) )
 #endif // ifndef DEBUG
         {
           old_jacobian = _femcontext.get_elem_jacobian();
           _femcontext.get_elem_jacobian().zero();
         }
       jacobian_computed =
-        _sys.time_solver->side_residual(_get_jacobian, _femcontext);
+        _sys.time_solver->side_residual(need_jacobian, _femcontext);
 
       // Compute a numeric jacobian if we have to
-      if (_get_jacobian && !jacobian_computed)
+      if (need_jacobian && !jacobian_computed)
         {
           // In DEBUG mode, we've already set elem_jacobian == 0,
           // so we can make sure side_residual didn't compute a
@@ -180,7 +184,7 @@ void assemble_unconstrained_element_system
 
       // Compute a numeric jacobian if we're asked to verify the
       // analytic jacobian we got
-      if (_get_jacobian && jacobian_computed &&
+      if (need_jacobian && jacobian_computed &&
           _sys.verify_analytic_jacobians != 0.0)
         {
           DenseMatrix<Number> analytic_jacobian(_femcontext.get_elem_jacobian());
@@ -228,7 +232,7 @@ void assemble_unconstrained_element_system
       // In DEBUG mode, we've set elem_jacobian == 0, and we
       // may still need to add the old jacobian back
 #ifdef DEBUG
-      if (_get_jacobian && jacobian_computed &&
+      if (need_jacobian && jacobian_computed &&
           _sys.verify_analytic_jacobians == 0.0)
         {
           _femcontext.get_elem_jacobian() += old_jacobian;
@@ -241,6 +245,7 @@ void add_element_system
 (const FEMSystem& _sys,
  const bool _get_residual,
  const bool _get_jacobian,
+ const bool _constrain_heterogeneously,
  FEMContext &_femcontext)
 {
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
@@ -259,15 +264,36 @@ void add_element_system
   // We turn off the asymmetric constraint application;
   // enforce_constraints_exactly() should be called in the solver
   if (_get_residual && _get_jacobian)
-    _sys.get_dof_map().constrain_element_matrix_and_vector
-      (_femcontext.get_elem_jacobian(), _femcontext.get_elem_residual(),
-       _femcontext.get_dof_indices(), false);
+    {
+      if (_constrain_heterogeneously)
+        _sys.get_dof_map().heterogenously_constrain_element_matrix_and_vector
+          (_femcontext.get_elem_jacobian(),
+           _femcontext.get_elem_residual(),
+           _femcontext.get_dof_indices(), false);
+      else
+        _sys.get_dof_map().constrain_element_matrix_and_vector
+          (_femcontext.get_elem_jacobian(),
+           _femcontext.get_elem_residual(),
+           _femcontext.get_dof_indices(), false);
+    }
   else if (_get_residual)
-    _sys.get_dof_map().constrain_element_vector
-      (_femcontext.get_elem_residual(), _femcontext.get_dof_indices(), false);
+    {
+      if (_constrain_heterogeneously)
+        _sys.get_dof_map().heterogenously_constrain_element_vector
+          (_femcontext.get_elem_jacobian(),
+           _femcontext.get_elem_residual(),
+           _femcontext.get_dof_indices(), false);
+      else
+        _sys.get_dof_map().constrain_element_vector
+          (_femcontext.get_elem_residual(), _femcontext.get_dof_indices(), false);
+    }
   else if (_get_jacobian)
-    _sys.get_dof_map().constrain_element_matrix
-      (_femcontext.get_elem_jacobian(), _femcontext.get_dof_indices(), false);
+    {
+      // Heterogeneous and homogeneous constraints are the same on the
+      // matrix
+        _sys.get_dof_map().constrain_element_matrix
+          (_femcontext.get_elem_jacobian(), _femcontext.get_dof_indices(), false);
+    }
 #endif // #ifdef LIBMESH_ENABLE_CONSTRAINTS
 
   if (_get_residual && _sys.print_element_residuals)
@@ -316,10 +342,12 @@ public:
    */
   AssemblyContributions(FEMSystem &sys,
                         bool get_residual,
-                        bool get_jacobian) :
+                        bool get_jacobian,
+                        bool constrain_heterogeneously) :
     _sys(sys),
     _get_residual(get_residual),
-    _get_jacobian(get_jacobian) {}
+    _get_jacobian(get_jacobian),
+    _constrain_heterogeneously(constrain_heterogeneously) {}
 
   /**
    * operator() for use with Threads::parallel_for().
@@ -339,10 +367,12 @@ public:
         _femcontext.elem_fe_reinit();
 
         assemble_unconstrained_element_system
-          (_sys, _get_jacobian, _femcontext);
+          (_sys, _get_jacobian, _constrain_heterogeneously,
+           _femcontext);
 
         add_element_system
-          (_sys, _get_residual, _get_jacobian, _femcontext);
+          (_sys, _get_residual, _get_jacobian,
+           _constrain_heterogeneously, _femcontext);
       }
   }
 
@@ -350,7 +380,7 @@ private:
 
   FEMSystem& _sys;
 
-  const bool _get_residual, _get_jacobian;
+  const bool _get_residual, _get_jacobian, _constrain_heterogeneously;
 };
 
 class PostprocessContributions
@@ -800,7 +830,8 @@ void FEMSystem::init_data ()
 }
 
 
-void FEMSystem::assembly (bool get_residual, bool get_jacobian)
+void FEMSystem::assembly (bool get_residual, bool get_jacobian,
+                          bool apply_heterogeneous_constraints)
 {
   libmesh_assert(get_residual || get_jacobian);
   std::string log_name;
@@ -867,9 +898,11 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian)
 
   // Build the residual and jacobian contributions on every active
   // mesh element on this processor
-  Threads::parallel_for(elem_range.reset(mesh.active_local_elements_begin(),
-                                         mesh.active_local_elements_end()),
-                        AssemblyContributions(*this, get_residual, get_jacobian));
+  Threads::parallel_for
+    (elem_range.reset(mesh.active_local_elements_begin(),
+                      mesh.active_local_elements_end()),
+     AssemblyContributions(*this, get_residual, get_jacobian,
+                           apply_heterogeneous_constraints));
 
   // Check and see if we have SCALAR variables
   bool have_scalar = false;
@@ -953,7 +986,8 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian)
             }
 
           add_element_system
-            (*this, get_residual, get_jacobian, _femcontext);
+            (*this, get_residual, get_jacobian,
+             apply_heterogeneous_constraints, _femcontext);
         }
     }
 

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -677,13 +677,13 @@ void ImplicitSystem::assemble_residual_derivatives(const ParameterVector& parame
       Number old_parameter = *parameters[p];
       *parameters[p] -= deltap;
 
-      this->assembly(true, false);
+      this->assembly(true, false, true);
       this->rhs->close();
       sensitivity_rhs = *this->rhs;
 
       *parameters[p] = old_parameter + deltap;
 
-      this->assembly(true, false);
+      this->assembly(true, false, true);
       this->rhs->close();
 
       sensitivity_rhs -= *this->rhs;

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -605,7 +605,7 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector& parameters_in
   parameterperturbation *= delta_p;
   parameters += parameterperturbation;
 
-  this->assembly(true, false);
+  this->assembly(true, false, true);
   this->rhs->close();
 
   AutoPtr<NumericVector<Number> > temprhs = this->rhs->clone();
@@ -614,7 +614,7 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector& parameters_in
   parameterperturbation *= -1.0;
   parameters += parameterperturbation;
 
-  this->assembly(true, false);
+  this->assembly(true, false, true);
   this->rhs->close();
 
   *temprhs -= *(this->rhs);
@@ -779,7 +779,7 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity
       this->assemble_qoi(qoi_indices);
       std::vector<Number> qoi_minus = this->qoi;
 
-      this->assembly(true, false);
+      this->assembly(true, false, true);
       this->rhs->close();
 
       // FIXME - this can and should be optimized to avoid the clone()
@@ -795,7 +795,7 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity
         if (qoi_indices.has_index(i))
           partialq_partialp[i] = (qoi_plus[i] - qoi_minus[i]) / (2.*delta_p);
 
-      this->assembly(true, false);
+      this->assembly(true, false, true);
       this->rhs->close();
       *partialR_partialp += *this->rhs;
       *partialR_partialp /= (2.*delta_p);
@@ -1008,7 +1008,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product
 
       *parameters[k] = old_parameter + delta_p;
       this->assemble_qoi(qoi_indices);
-      this->assembly(true, false);
+      this->assembly(true, false, true);
       this->rhs->close();
       std::vector<Number> partial2q_term = this->qoi;
       std::vector<Number> partial2R_term(this->qoi.size());
@@ -1018,7 +1018,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product
 
       *parameters[k] = old_parameter - delta_p;
       this->assemble_qoi(qoi_indices);
-      this->assembly(true, false);
+      this->assembly(true, false, true);
       this->rhs->close();
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
@@ -1036,7 +1036,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product
 
       *parameters[k] = old_parameter + delta_p;
       this->assemble_qoi(qoi_indices);
-      this->assembly(true, false);
+      this->assembly(true, false, true);
       this->rhs->close();
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
@@ -1047,7 +1047,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product
 
       *parameters[k] = old_parameter - delta_p;
       this->assemble_qoi(qoi_indices);
-      this->assembly(true, false);
+      this->assembly(true, false, true);
       this->rhs->close();
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
@@ -1212,7 +1212,7 @@ void ImplicitSystem::qoi_parameter_hessian
           *parameters[k] += delta_p;
           *parameters[l] += delta_p;
           this->assemble_qoi(qoi_indices);
-          this->assembly(true, false);
+          this->assembly(true, false, true);
           this->rhs->close();
           std::vector<Number> partial2q_term = this->qoi;
           std::vector<Number> partial2R_term(this->qoi.size());
@@ -1222,7 +1222,7 @@ void ImplicitSystem::qoi_parameter_hessian
 
           *parameters[l] -= 2.*delta_p;
           this->assemble_qoi(qoi_indices);
-          this->assembly(true, false);
+          this->assembly(true, false, true);
           this->rhs->close();
           for (unsigned int i=0; i != Nq; ++i)
             if (qoi_indices.has_index(i))
@@ -1233,7 +1233,7 @@ void ImplicitSystem::qoi_parameter_hessian
 
           *parameters[k] -= 2.*delta_p;
           this->assemble_qoi(qoi_indices);
-          this->assembly(true, false);
+          this->assembly(true, false, true);
           this->rhs->close();
           for (unsigned int i=0; i != Nq; ++i)
             if (qoi_indices.has_index(i))
@@ -1244,7 +1244,7 @@ void ImplicitSystem::qoi_parameter_hessian
 
           *parameters[l] += 2.*delta_p;
           this->assemble_qoi(qoi_indices);
-          this->assembly(true, false);
+          this->assembly(true, false, true);
           this->rhs->close();
           for (unsigned int i=0; i != Nq; ++i)
             if (qoi_indices.has_index(i))

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -377,6 +377,7 @@ void LinearImplicitSystem::release_linear_solver(LinearSolver<Number>*) const
 
 
 void LinearImplicitSystem::assembly(bool,
+                                    bool,
                                     bool)
 {
   // Residual R(u(p),p) := A(p)*u(p) - b(p)

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -209,7 +209,8 @@ std::pair<unsigned int, Real> NonlinearImplicitSystem::get_linear_solve_paramete
 
 
 void NonlinearImplicitSystem::assembly(bool get_residual,
-                                       bool get_jacobian)
+                                       bool get_jacobian,
+                                       bool apply_heterogeneous_constraints)
 {
   // Get current_local_solution in sync
   this->update();


### PR DESCRIPTION
This isn't ready to merge yet, but I'll put it up ahead of time for public perusal while @vikramvgarg tries some apps on it and while I write up some documentation for it.

Summary: libMesh with FEMSystem or NonlinearSystem currently fails to take parameter sensitivities w.r.t. constraint equation right hand sides, because when we assemble residuals, we're setting up a homogeneously constrained system (the better for solving for delta_u in a Newton loop) and we don't end up having any direct influence from heterogeneous constraints (which get directly applied to u before the nonlinear solve and corrected after each step).  This PR adds an option to request heterogeneous constraint application in a forward problem assembly, modifies FEMSystem to implement that option, and modifies the ImplicitSystem sensitivity code to use that option.