### PR TITLE
configure --with-gdb-command="/your/own/gdb"

### DIFF
--- a/configure
+++ b/configure
@@ -1079,6 +1079,7 @@ enable_exceptions
 enable_timestamps
 enable_unordered_containers
 enable_openmp
+with_gdb_command
 enable_warnings
 enable_blocked_storage
 enable_default_comm_world
@@ -1950,6 +1951,8 @@ Optional Packages:
   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
   --with-sysroot=DIR Search for dependent libraries within DIR
                         (or the compiler's sysroot if not specified).
+  --with-gdb-command=commandname
+                          command to invoke gdb
   --with-boundary-id-bytes=<1|2|4|8>
                           bytes used per boundary side per boundary_id [2]
   --with-dof-id-bytes=<1|2|4|8>
@@ -27738,6 +27741,29 @@ $as_echo "---------------------------------------------" >&6; }
 $as_echo "----- Configuring core library features -----" >&6; }
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: ---------------------------------------------" >&5
 $as_echo "---------------------------------------------" >&6; }
+
+
+# -------------------------------------------------------------
+# gdb backtrace command-- default "gdb"
+# -------------------------------------------------------------
+
+# Check whether --with-gdb-command was given.
+if test "${with_gdb_command+set}" = set; then :
+  withval=$with_gdb_command; gdb_command="$withval"
+else
+  gdb_command="gdb"
+fi
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define GDB_COMMAND "$gdb_command"
+_ACEOF
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: configuring gdb command... \"$gdb_command\"" >&5
+$as_echo "configuring gdb command... \"$gdb_command\"" >&6; }
+# -------------------------------------------------------------
+
 
 
 # --------------------------------------------------------------

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -165,6 +165,9 @@
 /* Enable fparser debugging functions */
 #undef FPARSER_SUPPORT_DEBUGGING
 
+/* command to invoke gdb */
+#undef GDB_COMMAND
+
 /* Flag indicating whether the library shall be compiled to use the Trilinos
    solver collection */
 #undef HAVE_AZTECOO

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -7,6 +7,21 @@ AC_MSG_RESULT(----- Configuring core library features -----)
 AC_MSG_RESULT(---------------------------------------------)
 
 
+# -------------------------------------------------------------
+# gdb backtrace command-- default "gdb"
+# -------------------------------------------------------------
+AC_ARG_WITH([gdb-command],
+    AS_HELP_STRING([--with-gdb-command=commandname],
+                          [command to invoke gdb]),
+    [gdb_command="$withval"],
+    [gdb_command="gdb"])
+
+AC_DEFINE_UNQUOTED(GDB_COMMAND, "$gdb_command", [command to invoke gdb])
+AC_MSG_RESULT([configuring gdb command... "$gdb_command"])
+# -------------------------------------------------------------
+
+
+
 # --------------------------------------------------------------
 # library warnings - enable by default
 # --------------------------------------------------------------

--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -110,6 +110,7 @@ std::string process_trace(const char *name)
 // source code, a really helpful feature when debugging something...
 bool gdb_backtrace(std::ostream &out_stream)
 {
+#ifdef LIBMESH_GDB_COMMAND
   // Eventual return value, true if gdb succeeds, false otherwise.
   bool success = true;
 
@@ -127,8 +128,12 @@ bool gdb_backtrace(std::ostream &out_stream)
       // Run gdb using a system() call, redirecting the output to our
       // temporary file.
       pid_t this_pid = getpid();
+
+      std::string gdb_command =
+        libMesh::command_line_value("gdb",std::string(LIBMESH_GDB_COMMAND));
+
       std::ostringstream command;
-      command << "gdb -p " << this_pid << " -batch -ex bt 2>/dev/null 1>" << temp_file;
+      command << gdb_command << " -p " << this_pid << " -batch -ex bt 2>/dev/null 1>" << temp_file;
       int exit_status = std::system(command.str().c_str());
 
       // If we can open the temp_file, the file is not empty, and the
@@ -147,6 +152,9 @@ bool gdb_backtrace(std::ostream &out_stream)
   std::remove(temp_file);
 
   return success;
+#else
+  return false;
+#endif
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
This allows us to choose a different gdb path for backtraces (or to eschew gdb entirely, falling back on glibc backtrace if available) at configure time.