### PR TITLE
Turn off asserts in FEMContext::get_elem()

### DIFF
--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -707,14 +707,14 @@ public:
    * Accessor for current Elem object
    */
   const Elem& get_elem() const
-  { libmesh_assert(this->_elem);
+  { //libmesh_assert(this->_elem); PB: SCALAR variables have elem=NULL
     return *(this->_elem); }
 
   /**
    * Accessor for current Elem object
    */
   Elem& get_elem()
-  { libmesh_assert(this->_elem);
+  { //libmesh_assert(this->_elem); PB: SCALAR variables have elem=NULL
     return *(const_cast<Elem*>(this->_elem)); }
 
   /**


### PR DESCRIPTION
When we have SCALAR variables present, it is assumed that elem=NULL. While I'd like to keep these asserts in principle, this really snowballs on us, granted mostly in GRINS. There's two places in FEMContext that I had to change before I tripped asserts from GRINS calling get_elem() with SCALAR variables.

These asserts were not there before #462, so I don't feel like it's a huge step backwards. Thoughts @roystgnr?