### PR TITLE
Bug fix for PointLocatorList 

### DIFF
--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -161,11 +161,11 @@ const Elem* PointLocatorList::operator() (const Point& p, const std::set<subdoma
   {
     std::vector<std::pair<Point, const Elem *> >& my_list = *(this->_list);
 
-    Real              last_distance_sq = Point(my_list[0].first -p).size_sq();
+    Real              last_distance_sq = std::numeric_limits<Real>::max();
     const Elem *      last_elem        = NULL;
     const std::size_t max_index        = my_list.size();
 
-    for (std::size_t n=1; n<max_index; n++)
+    for (std::size_t n=0; n<max_index; n++)
       {
         // Only consider elements in the allowed_subdomains list, if it exists
         if (!allowed_subdomains ||

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -28,6 +28,7 @@ public:
 
   CPPUNIT_TEST( testMesh );
   CPPUNIT_TEST( testDofOrdering );
+  CPPUNIT_TEST( testPointLocatorList );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -154,6 +155,25 @@ public:
        the same global ids as the top edge of the bottom QUAD4 element */
     CPPUNIT_ASSERT_EQUAL( top_quad_dof_indices[0], bottom_quad_dof_indices[3] );
     CPPUNIT_ASSERT_EQUAL( top_quad_dof_indices[1], bottom_quad_dof_indices[2] );
+  }
+
+  void testPointLocatorList()
+  {
+    AutoPtr<PointLocatorBase> locator = PointLocatorBase::build(LIST,*_mesh);
+
+    Point top_point(0.4, 0.5);
+    const Elem* top_elem = (*locator)(top_point);
+    CPPUNIT_ASSERT(top_elem);
+
+    // We should have gotten back the top quad
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)0, top_elem->id() );
+
+    Point bottom_point(0.5, -0.5);
+    const Elem* bottom_elem = (*locator)(bottom_point);
+    CPPUNIT_ASSERT(bottom_elem);
+
+    // We should have gotten back the bottom quad
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)1, bottom_elem->id() );
   }
 
 };


### PR DESCRIPTION
Before, the cached distance used the distance from the first element
in the list. But, the loop didn't include the first element so if
the first element was the closest one, we didn't detect it and the
accompanying unit test failed. I put the unit test in the mixed
dimension unit test because this bug was found as part of some
refactoring I'm doing and I went ahead and made this bug fix standalone.