### PR TITLE
Mixed Dimension Support for Trees and PointLocators

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -462,8 +462,8 @@ am__libmesh_dbg_la_SOURCES_DIST = src/base/dof_map.C \
 	src/utils/point_locator_base.C src/utils/point_locator_list.C \
 	src/utils/point_locator_tree.C src/utils/statistics.C \
 	src/utils/string_to_enum.C src/utils/timestamp.C \
-	src/utils/tree.C src/utils/tree_node.C src/utils/utility.C \
-	src/utils/xdr_cxx.C
+	src/utils/tree.C src/utils/tree_base.C src/utils/tree_node.C \
+	src/utils/utility.C src/utils/xdr_cxx.C
 am__dirstamp = $(am__leading_dot)dirstamp
 am__objects_1 = src/base/libmesh_dbg_la-dof_map.lo \
 	src/base/libmesh_dbg_la-dof_map_constraints.lo \
@@ -879,6 +879,7 @@ am__objects_1 = src/base/libmesh_dbg_la-dof_map.lo \
 	src/utils/libmesh_dbg_la-string_to_enum.lo \
 	src/utils/libmesh_dbg_la-timestamp.lo \
 	src/utils/libmesh_dbg_la-tree.lo \
+	src/utils/libmesh_dbg_la-tree_base.lo \
 	src/utils/libmesh_dbg_la-tree_node.lo \
 	src/utils/libmesh_dbg_la-utility.lo \
 	src/utils/libmesh_dbg_la-xdr_cxx.lo
@@ -1173,8 +1174,8 @@ am__libmesh_devel_la_SOURCES_DIST = src/base/dof_map.C \
 	src/utils/point_locator_base.C src/utils/point_locator_list.C \
 	src/utils/point_locator_tree.C src/utils/statistics.C \
 	src/utils/string_to_enum.C src/utils/timestamp.C \
-	src/utils/tree.C src/utils/tree_node.C src/utils/utility.C \
-	src/utils/xdr_cxx.C
+	src/utils/tree.C src/utils/tree_base.C src/utils/tree_node.C \
+	src/utils/utility.C src/utils/xdr_cxx.C
 am__objects_2 = src/base/libmesh_devel_la-dof_map.lo \
 	src/base/libmesh_devel_la-dof_map_constraints.lo \
 	src/base/libmesh_devel_la-dof_object.lo \
@@ -1589,6 +1590,7 @@ am__objects_2 = src/base/libmesh_devel_la-dof_map.lo \
 	src/utils/libmesh_devel_la-string_to_enum.lo \
 	src/utils/libmesh_devel_la-timestamp.lo \
 	src/utils/libmesh_devel_la-tree.lo \
+	src/utils/libmesh_devel_la-tree_base.lo \
 	src/utils/libmesh_devel_la-tree_node.lo \
 	src/utils/libmesh_devel_la-utility.lo \
 	src/utils/libmesh_devel_la-xdr_cxx.lo
@@ -1880,8 +1882,8 @@ am__libmesh_oprof_la_SOURCES_DIST = src/base/dof_map.C \
 	src/utils/point_locator_base.C src/utils/point_locator_list.C \
 	src/utils/point_locator_tree.C src/utils/statistics.C \
 	src/utils/string_to_enum.C src/utils/timestamp.C \
-	src/utils/tree.C src/utils/tree_node.C src/utils/utility.C \
-	src/utils/xdr_cxx.C
+	src/utils/tree.C src/utils/tree_base.C src/utils/tree_node.C \
+	src/utils/utility.C src/utils/xdr_cxx.C
 am__objects_3 = src/base/libmesh_oprof_la-dof_map.lo \
 	src/base/libmesh_oprof_la-dof_map_constraints.lo \
 	src/base/libmesh_oprof_la-dof_object.lo \
@@ -2296,6 +2298,7 @@ am__objects_3 = src/base/libmesh_oprof_la-dof_map.lo \
 	src/utils/libmesh_oprof_la-string_to_enum.lo \
 	src/utils/libmesh_oprof_la-timestamp.lo \
 	src/utils/libmesh_oprof_la-tree.lo \
+	src/utils/libmesh_oprof_la-tree_base.lo \
 	src/utils/libmesh_oprof_la-tree_node.lo \
 	src/utils/libmesh_oprof_la-utility.lo \
 	src/utils/libmesh_oprof_la-xdr_cxx.lo
@@ -2587,8 +2590,8 @@ am__libmesh_opt_la_SOURCES_DIST = src/base/dof_map.C \
 	src/utils/point_locator_base.C src/utils/point_locator_list.C \
 	src/utils/point_locator_tree.C src/utils/statistics.C \
 	src/utils/string_to_enum.C src/utils/timestamp.C \
-	src/utils/tree.C src/utils/tree_node.C src/utils/utility.C \
-	src/utils/xdr_cxx.C
+	src/utils/tree.C src/utils/tree_base.C src/utils/tree_node.C \
+	src/utils/utility.C src/utils/xdr_cxx.C
 am__objects_4 = src/base/libmesh_opt_la-dof_map.lo \
 	src/base/libmesh_opt_la-dof_map_constraints.lo \
 	src/base/libmesh_opt_la-dof_object.lo \
@@ -3003,6 +3006,7 @@ am__objects_4 = src/base/libmesh_opt_la-dof_map.lo \
 	src/utils/libmesh_opt_la-string_to_enum.lo \
 	src/utils/libmesh_opt_la-timestamp.lo \
 	src/utils/libmesh_opt_la-tree.lo \
+	src/utils/libmesh_opt_la-tree_base.lo \
 	src/utils/libmesh_opt_la-tree_node.lo \
 	src/utils/libmesh_opt_la-utility.lo \
 	src/utils/libmesh_opt_la-xdr_cxx.lo
@@ -3293,8 +3297,8 @@ am__libmesh_prof_la_SOURCES_DIST = src/base/dof_map.C \
 	src/utils/point_locator_base.C src/utils/point_locator_list.C \
 	src/utils/point_locator_tree.C src/utils/statistics.C \
 	src/utils/string_to_enum.C src/utils/timestamp.C \
-	src/utils/tree.C src/utils/tree_node.C src/utils/utility.C \
-	src/utils/xdr_cxx.C
+	src/utils/tree.C src/utils/tree_base.C src/utils/tree_node.C \
+	src/utils/utility.C src/utils/xdr_cxx.C
 am__objects_5 = src/base/libmesh_prof_la-dof_map.lo \
 	src/base/libmesh_prof_la-dof_map_constraints.lo \
 	src/base/libmesh_prof_la-dof_object.lo \
@@ -3709,6 +3713,7 @@ am__objects_5 = src/base/libmesh_prof_la-dof_map.lo \
 	src/utils/libmesh_prof_la-string_to_enum.lo \
 	src/utils/libmesh_prof_la-timestamp.lo \
 	src/utils/libmesh_prof_la-tree.lo \
+	src/utils/libmesh_prof_la-tree_base.lo \
 	src/utils/libmesh_prof_la-tree_node.lo \
 	src/utils/libmesh_prof_la-utility.lo \
 	src/utils/libmesh_prof_la-xdr_cxx.lo
@@ -4994,6 +4999,7 @@ libmesh_SOURCES = \
         src/utils/string_to_enum.C \
         src/utils/timestamp.C \
         src/utils/tree.C \
+        src/utils/tree_base.C \
         src/utils/tree_node.C \
         src/utils/utility.C \
         src/utils/xdr_cxx.C 
@@ -6428,6 +6434,8 @@ src/utils/libmesh_dbg_la-timestamp.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_dbg_la-tree.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
+src/utils/libmesh_dbg_la-tree_base.lo: src/utils/$(am__dirstamp) \
+	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_dbg_la-tree_node.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_dbg_la-utility.lo: src/utils/$(am__dirstamp) \
@@ -7444,6 +7452,8 @@ src/utils/libmesh_devel_la-string_to_enum.lo:  \
 src/utils/libmesh_devel_la-timestamp.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_devel_la-tree.lo: src/utils/$(am__dirstamp) \
+	src/utils/$(DEPDIR)/$(am__dirstamp)
+src/utils/libmesh_devel_la-tree_base.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_devel_la-tree_node.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
@@ -8462,6 +8472,8 @@ src/utils/libmesh_oprof_la-timestamp.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_oprof_la-tree.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
+src/utils/libmesh_oprof_la-tree_base.lo: src/utils/$(am__dirstamp) \
+	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_oprof_la-tree_node.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_oprof_la-utility.lo: src/utils/$(am__dirstamp) \
@@ -9475,6 +9487,8 @@ src/utils/libmesh_opt_la-string_to_enum.lo: src/utils/$(am__dirstamp) \
 src/utils/libmesh_opt_la-timestamp.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_opt_la-tree.lo: src/utils/$(am__dirstamp) \
+	src/utils/$(DEPDIR)/$(am__dirstamp)
+src/utils/libmesh_opt_la-tree_base.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_opt_la-tree_node.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
@@ -10490,6 +10504,8 @@ src/utils/libmesh_prof_la-string_to_enum.lo:  \
 src/utils/libmesh_prof_la-timestamp.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_prof_la-tree.lo: src/utils/$(am__dirstamp) \
+	src/utils/$(DEPDIR)/$(am__dirstamp)
+src/utils/libmesh_prof_la-tree_base.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
 src/utils/libmesh_prof_la-tree_node.lo: src/utils/$(am__dirstamp) \
 	src/utils/$(DEPDIR)/$(am__dirstamp)
@@ -12934,6 +12950,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_dbg_la-string_to_enum.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_dbg_la-timestamp.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_dbg_la-tree.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_dbg_la-tree_base.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_dbg_la-tree_node.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_dbg_la-utility.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_dbg_la-xdr_cxx.Plo@am__quote@
@@ -12953,6 +12970,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_devel_la-string_to_enum.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_devel_la-timestamp.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_devel_la-tree.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_devel_la-tree_base.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_devel_la-tree_node.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_devel_la-utility.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_devel_la-xdr_cxx.Plo@am__quote@
@@ -12972,6 +12990,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_oprof_la-string_to_enum.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_oprof_la-timestamp.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_oprof_la-tree.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_oprof_la-tree_base.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_oprof_la-tree_node.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_oprof_la-utility.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_oprof_la-xdr_cxx.Plo@am__quote@
@@ -12991,6 +13010,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_opt_la-string_to_enum.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_opt_la-timestamp.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_opt_la-tree.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_opt_la-tree_base.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_opt_la-tree_node.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_opt_la-utility.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_opt_la-xdr_cxx.Plo@am__quote@
@@ -13010,6 +13030,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_prof_la-string_to_enum.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_prof_la-timestamp.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_prof_la-tree.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_prof_la-tree_base.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_prof_la-tree_node.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_prof_la-utility.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/utils/$(DEPDIR)/libmesh_prof_la-xdr_cxx.Plo@am__quote@
@@ -15929,6 +15950,13 @@ src/utils/libmesh_dbg_la-tree.lo: src/utils/tree.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_dbg_la-tree.lo `test -f 'src/utils/tree.C' || echo '$(srcdir)/'`src/utils/tree.C
 
+src/utils/libmesh_dbg_la-tree_base.lo: src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_dbg_la-tree_base.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_dbg_la-tree_base.Tpo -c -o src/utils/libmesh_dbg_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmesh_dbg_la-tree_base.Tpo src/utils/$(DEPDIR)/libmesh_dbg_la-tree_base.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/utils/tree_base.C' object='src/utils/libmesh_dbg_la-tree_base.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_dbg_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
+
 src/utils/libmesh_dbg_la-tree_node.lo: src/utils/tree_node.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_dbg_la-tree_node.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_dbg_la-tree_node.Tpo -c -o src/utils/libmesh_dbg_la-tree_node.lo `test -f 'src/utils/tree_node.C' || echo '$(srcdir)/'`src/utils/tree_node.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmesh_dbg_la-tree_node.Tpo src/utils/$(DEPDIR)/libmesh_dbg_la-tree_node.Plo
@@ -18840,6 +18868,13 @@ src/utils/libmesh_devel_la-tree.lo: src/utils/tree.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/utils/tree.C' object='src/utils/libmesh_devel_la-tree.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_devel_la-tree.lo `test -f 'src/utils/tree.C' || echo '$(srcdir)/'`src/utils/tree.C
+
+src/utils/libmesh_devel_la-tree_base.lo: src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_devel_la-tree_base.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_devel_la-tree_base.Tpo -c -o src/utils/libmesh_devel_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmesh_devel_la-tree_base.Tpo src/utils/$(DEPDIR)/libmesh_devel_la-tree_base.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/utils/tree_base.C' object='src/utils/libmesh_devel_la-tree_base.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_devel_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
 
 src/utils/libmesh_devel_la-tree_node.lo: src/utils/tree_node.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_devel_la-tree_node.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_devel_la-tree_node.Tpo -c -o src/utils/libmesh_devel_la-tree_node.lo `test -f 'src/utils/tree_node.C' || echo '$(srcdir)/'`src/utils/tree_node.C
@@ -21753,6 +21788,13 @@ src/utils/libmesh_oprof_la-tree.lo: src/utils/tree.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_oprof_la-tree.lo `test -f 'src/utils/tree.C' || echo '$(srcdir)/'`src/utils/tree.C
 
+src/utils/libmesh_oprof_la-tree_base.lo: src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_oprof_la-tree_base.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_oprof_la-tree_base.Tpo -c -o src/utils/libmesh_oprof_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmesh_oprof_la-tree_base.Tpo src/utils/$(DEPDIR)/libmesh_oprof_la-tree_base.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/utils/tree_base.C' object='src/utils/libmesh_oprof_la-tree_base.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_oprof_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
+
 src/utils/libmesh_oprof_la-tree_node.lo: src/utils/tree_node.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_oprof_la-tree_node.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_oprof_la-tree_node.Tpo -c -o src/utils/libmesh_oprof_la-tree_node.lo `test -f 'src/utils/tree_node.C' || echo '$(srcdir)/'`src/utils/tree_node.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmesh_oprof_la-tree_node.Tpo src/utils/$(DEPDIR)/libmesh_oprof_la-tree_node.Plo
@@ -24665,6 +24707,13 @@ src/utils/libmesh_opt_la-tree.lo: src/utils/tree.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_opt_la-tree.lo `test -f 'src/utils/tree.C' || echo '$(srcdir)/'`src/utils/tree.C
 
+src/utils/libmesh_opt_la-tree_base.lo: src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_opt_la-tree_base.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_opt_la-tree_base.Tpo -c -o src/utils/libmesh_opt_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmesh_opt_la-tree_base.Tpo src/utils/$(DEPDIR)/libmesh_opt_la-tree_base.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/utils/tree_base.C' object='src/utils/libmesh_opt_la-tree_base.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_opt_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
+
 src/utils/libmesh_opt_la-tree_node.lo: src/utils/tree_node.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_opt_la-tree_node.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_opt_la-tree_node.Tpo -c -o src/utils/libmesh_opt_la-tree_node.lo `test -f 'src/utils/tree_node.C' || echo '$(srcdir)/'`src/utils/tree_node.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmesh_opt_la-tree_node.Tpo src/utils/$(DEPDIR)/libmesh_opt_la-tree_node.Plo
@@ -27576,6 +27625,13 @@ src/utils/libmesh_prof_la-tree.lo: src/utils/tree.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/utils/tree.C' object='src/utils/libmesh_prof_la-tree.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_prof_la-tree.lo `test -f 'src/utils/tree.C' || echo '$(srcdir)/'`src/utils/tree.C
+
+src/utils/libmesh_prof_la-tree_base.lo: src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_prof_la-tree_base.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_prof_la-tree_base.Tpo -c -o src/utils/libmesh_prof_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/utils/$(DEPDIR)/libmesh_prof_la-tree_base.Tpo src/utils/$(DEPDIR)/libmesh_prof_la-tree_base.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/utils/tree_base.C' object='src/utils/libmesh_prof_la-tree_base.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/utils/libmesh_prof_la-tree_base.lo `test -f 'src/utils/tree_base.C' || echo '$(srcdir)/'`src/utils/tree_base.C
 
 src/utils/libmesh_prof_la-tree_node.lo: src/utils/tree_node.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/utils/libmesh_prof_la-tree_node.lo -MD -MP -MF src/utils/$(DEPDIR)/libmesh_prof_la-tree_node.Tpo -c -o src/utils/libmesh_prof_la-tree_node.lo `test -f 'src/utils/tree_node.C' || echo '$(srcdir)/'`src/utils/tree_node.C

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -91,10 +91,23 @@ public:
 
   /**
    * Locates the element in which the point with global coordinates
-   * \p p is located.  Pure virtual. Optionally allows the user to restrict
-   * the subdomains searched.
+   * \p p is located. Optionally allows the user to restrict
+   * the subdomains searched. To restrict the search to element dimension other
+   * than _mesh.mesh_dimension(), use the more general form of this function
+   * (for mixed dimension meshes).
    */
-  virtual const Elem* operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const = 0;
+  const Elem* operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL ) const;
+
+  /**
+   * Locates the element in which the point with global coordinates
+   * \p p is located.  Pure virtual. Restricts the search to elements
+   * with dimension elem_dim. Optionally allows the user to restrict
+   * the subdomains searched. For the default elem_dim = _mesh.mesh_dimension(),
+   * use operator()(const Point& p, const std::set<subdomain_id_type> *allowed_subdomains)
+   * version of this function.
+   */
+  virtual const Elem* operator() (const Point& p, const unsigned int elem_dim,
+                                  const std::set<subdomain_id_type> *allowed_subdomains = NULL ) const = 0;
 
   /**
    * @returns \p true when this object is properly initialized

--- a/include/utils/point_locator_list.h
+++ b/include/utils/point_locator_list.h
@@ -97,11 +97,12 @@ public:
   virtual void init();
 
   /**
-   * Locates the element in which the point with global coordinates
-   * \p p is located, optionally restricted to a set of allowed subdomains.
+   * Locates the element, with dimension elem_dim, in which the point with global
+   * coordinates \p p is located, optionally restricted to a set of allowed subdomains.
    * Overloaded from base class.
    */
-  virtual const Elem* operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
+  virtual const Elem* operator() (const Point& p, const unsigned int elem_dim,
+                                  const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
 
   /**
    * Enables out-of-mesh mode.  In this mode, if asked to find a point

--- a/include/utils/point_locator_tree.h
+++ b/include/utils/point_locator_tree.h
@@ -113,10 +113,26 @@ public:
    * search over the entire mesh. This can be used if operator()
    * fails to find an element that contains \p p, for example.
    * Optionally specify a "close to point" tolerance to use in
-   * the linear search.
+   * the linear search. This only looks for elements with
+   * dimension mesh.mesh_dimension().
    * Return NULL if no element is found.
    */
   const Elem* perform_linear_search(const Point& p,
+                                    const std::set<subdomain_id_type> *allowed_subdomains,
+                                    bool use_close_to_point,
+                                    Real close_to_point_tolerance=TOLERANCE) const;
+
+  /**
+   * As a fallback option, it's helpful to be able to do a linear
+   * search over the entire mesh. This can be used if operator()
+   * fails to find an element that contains \p p, for example.
+   * Optionally specify a "close to point" tolerance to use in
+   * the linear search. This only looks for elements with
+   * dimension elem_dim.
+   * Return NULL if no element is found.
+   */
+  const Elem* perform_linear_search(const Point& p,
+                                    unsigned int elem_dim,
                                     const std::set<subdomain_id_type> *allowed_subdomains,
                                     bool use_close_to_point,
                                     Real close_to_point_tolerance=TOLERANCE) const;

--- a/include/utils/point_locator_tree.h
+++ b/include/utils/point_locator_tree.h
@@ -99,13 +99,14 @@ public:
   virtual void init();
 
   /**
-   * Locates the element in which the point with global coordinates
-   * \p p is located, optionally restricted to a set of allowed subdomains.
-   * The mutable _element member is used to cache
+   * Locates the element, with dimension elem_dim, in which the point with
+   * global coordinates \p p is located, optionally restricted to a set of
+   * allowed subdomains. The mutable _element member is used to cache
    * the result and allow it to be used during the next call to
    * operator().
    */
-  virtual const Elem* operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
+  virtual const Elem* operator() (const Point& p, const unsigned int elem_dim,
+                                  const std::set<subdomain_id_type> *allowed_subdomains = NULL) const;
 
   /**
    * As a fallback option, it's helpful to be able to do a linear

--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -76,13 +76,15 @@ public:
 
   /**
    * @returns a pointer to the element containing point p,
+   * for elements of dimension elem_dim,
    * optionally restricted to a set of allowed subdomains,
    * optionally using a non-zero relative tolerance for searches.
    */
-  const Elem* find_element(const Point& p,
-                           const std::set<subdomain_id_type>
-                           *allowed_subdomains = NULL,
-                           Real relative_tol = TOLERANCE) const;
+  virtual const Elem* find_element(const Point& p,
+                                   unsigned int elem_dim,
+                                   const std::set<subdomain_id_type>
+                                   *allowed_subdomains = NULL,
+                                   Real relative_tol = TOLERANCE) const;
 
   /**
    * @returns a pointer to the element containing point p,

--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -88,6 +88,7 @@ public:
 
   /**
    * @returns a pointer to the element containing point p,
+   * for elements with dimension mesh.mesh_dimension(),
    * optionally restricted to a set of allowed subdomains,
    * optionally using a non-zero relative tolerance for searches.
    */

--- a/include/utils/tree_base.h
+++ b/include/utils/tree_base.h
@@ -90,13 +90,24 @@ public:
 
   /**
    * @returns a pointer to the element containing point p,
+   * for elements of dimension mesh->mesh_dimension(),
    * optionally restricted to a set of allowed subdomains,
    * optionally using a non-zero relative tolerance for searches.
    */
-  virtual const Elem* find_element(const Point& p,
-                                   const std::set<subdomain_id_type>
-                                   *allowed_subdomains = NULL,
-                                   Real relative_tol = TOLERANCE) const = 0;
+   const Elem* find_element(const Point& p,
+                            const std::set<subdomain_id_type> *allowed_subdomains = NULL,
+                            Real relative_tol = TOLERANCE) const;
+
+  /**
+   * @returns a pointer to the element containing point p,
+   * for elements of dimension elem_dim,
+   * optionally restricted to a set of allowed subdomains,
+   * optionally using a non-zero relative tolerance for searches.
+   */
+   virtual const Elem* find_element(const Point& p,
+                                    unsigned int elem_dim,
+                                    const std::set<subdomain_id_type> *allowed_subdomains = NULL,
+                                    Real relative_tol = TOLERANCE) const = 0;
 
 protected:
 

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -165,9 +165,11 @@ public:
 private:
   /**
    * Look for point \p p in our children,
+   * but only for elements of dimension elem_dim
    * optionally restricted to a set of allowed subdomains.
    */
   const Elem* find_element_in_children (const Point& p,
+                                        unsigned int elem_dim,
                                         const std::set<subdomain_id_type>* allowed_subdomains,
                                         Real relative_tol) const;
 

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -144,9 +144,20 @@ public:
 
   /**
    * @returns an element containing point p,
+   * but only if there's an element of dimension mesh.mesh_dimension(),
    * optionally restricted to a set of allowed subdomains.
    */
   const Elem* find_element (const Point& p,
+                            const std::set<subdomain_id_type>* allowed_subdomains = NULL,
+                            Real relative_tol = TOLERANCE) const;
+
+  /**
+   * @returns an element containing point p,
+   * but only if there's an element of dimension elem_dim,
+   * optionally restricted to a set of allowed subdomains.
+   */
+  const Elem* find_element (const Point& p,
+                            unsigned int elem_dim,
                             const std::set<subdomain_id_type>* allowed_subdomains = NULL,
                             Real relative_tol = TOLERANCE) const;
 

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -415,6 +415,7 @@ libmesh_SOURCES =  \
         src/utils/string_to_enum.C \
         src/utils/timestamp.C \
         src/utils/tree.C \
+        src/utils/tree_base.C \
         src/utils/tree_node.C \
         src/utils/utility.C \
         src/utils/xdr_cxx.C 

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -24,6 +24,7 @@
 #include "libmesh/point_locator_base.h"
 #include "libmesh/point_locator_tree.h"
 #include "libmesh/point_locator_list.h"
+#include "libmesh/mesh_base.h"
 
 namespace libMesh
 {
@@ -98,6 +99,11 @@ AutoPtr<PointLocatorBase> PointLocatorBase::build (PointLocatorType t,
   libmesh_error_msg("We'll never get here!");
   AutoPtr<PointLocatorBase> ap(NULL);
   return ap;
+}
+
+const Elem* PointLocatorBase:: operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains) const
+{
+  return (*this)(p, _mesh.mesh_dimension(), allowed_subdomains);
 }
 
 void PointLocatorBase::set_close_to_point_tol (Real close_to_point_tol)

--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -177,8 +177,9 @@ const Elem* PointLocatorList::operator() (const Point& p, const unsigned int ele
     for (std::size_t n=0; n<max_index; n++)
       {
         // Only consider elements in the allowed_subdomains list, if it exists
-        if (!allowed_subdomains ||
-            allowed_subdomains->count(my_list[n].second->subdomain_id()))
+        if ( (!allowed_subdomains ||
+              allowed_subdomains->count(my_list[n].second->subdomain_id())) &&
+             my_list[n].second->dim() == elem_dim )
           {
             const Real current_distance_sq = Point(my_list[n].first -p).size_sq();
 

--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -134,7 +134,8 @@ void PointLocatorList::init ()
 
 
 
-const Elem* PointLocatorList::operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains) const
+const Elem* PointLocatorList::operator() (const Point& p, const unsigned int elem_dim,
+                                          const std::set<subdomain_id_type> *allowed_subdomains) const
 {
   libmesh_assert (this->_initialized);
 
@@ -159,6 +160,14 @@ const Elem* PointLocatorList::operator() (const Point& p, const std::set<subdoma
   // here to avoid repeated calls to std::sqrt(), which is
   // pretty expensive.
   {
+    // Make sure the mesh has elements of dimension elem_dim
+    if( _mesh.elem_dimensions().find(elem_dim) == _mesh.elem_dimensions().end() )
+      {
+        libMesh::err << "ERROR: There are no elements of dimension " << elem_dim
+                     << " in the mesh to find!" << std::endl;
+        libmesh_error();
+      }
+
     std::vector<std::pair<Point, const Elem *> >& my_list = *(this->_list);
 
     Real              last_distance_sq = std::numeric_limits<Real>::max();

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -212,7 +212,7 @@ const Elem* PointLocatorTree::operator() (const Point& p, const unsigned int ele
   if (this->_element==NULL || !(this->_element->contains_point(p)))
     {
       // ask the tree
-      this->_element = this->_tree->find_element (p,allowed_subdomains);
+      this->_element = this->_tree->find_element (p,elem_dim,allowed_subdomains);
 
       if (this->_element == NULL)
         {

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -187,9 +187,18 @@ void PointLocatorTree::init (Trees::BuildType build_type)
 
 
 
-const Elem* PointLocatorTree::operator() (const Point& p, const std::set<subdomain_id_type> *allowed_subdomains) const
+const Elem* PointLocatorTree::operator() (const Point& p, const unsigned int elem_dim,
+                                          const std::set<subdomain_id_type> *allowed_subdomains) const
 {
   libmesh_assert (this->_initialized);
+
+  // Make sure the mesh has elements of dimension elem_dim
+  if( _mesh.elem_dimensions().find(elem_dim) == _mesh.elem_dimensions().end() )
+    {
+      libMesh::err << "ERROR: There are no elements of dimension " << elem_dim
+                   << " in the mesh to find!" << std::endl;
+      libmesh_error();
+    }
 
   START_LOG("operator()", "PointLocatorTree");
 

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -271,8 +271,18 @@ const Elem* PointLocatorTree::operator() (const Point& p, const unsigned int ele
 }
 
 
+const Elem* PointLocatorTree::perform_linear_search(const Point& p,
+                                                    const std::set<subdomain_id_type> *allowed_subdomains,
+                                                    bool use_close_to_point,
+                                                    Real close_to_point_tolerance) const
+{
+  return this->perform_linear_search(p, this->_mesh.mesh_dimension(), allowed_subdomains,
+                                     use_close_to_point, close_to_point_tolerance);
+}
+
 
 const Elem* PointLocatorTree::perform_linear_search(const Point& p,
+                                                    unsigned int elem_dim,
                                                     const std::set<subdomain_id_type> *allowed_subdomains,
                                                     bool use_close_to_point,
                                                     Real close_to_point_tolerance) const
@@ -293,8 +303,9 @@ const Elem* PointLocatorTree::perform_linear_search(const Point& p,
 
   for ( ; pos != end_pos; ++pos)
     {
-      if (!allowed_subdomains ||
-          allowed_subdomains->count((*pos)->subdomain_id()))
+      if ( (!allowed_subdomains ||
+            allowed_subdomains->count((*pos)->subdomain_id())) &&
+           (*pos)->dim() == elem_dim )
         {
           if(!use_close_to_point)
             {

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -205,6 +205,9 @@ const Elem* PointLocatorTree::operator() (const Point& p, const unsigned int ele
   // If we're provided with an allowed_subdomains list and have a cached element, make sure it complies
   if (allowed_subdomains && this->_element && !allowed_subdomains->count(this->_element->subdomain_id())) this->_element = NULL;
 
+  // If we have a cached element, make sure it is of the right dimension
+  if( this->_element && this->_element->dim() != elem_dim ) this->_element = NULL;
+
   // First check the element from last time before asking the tree
   if (this->_element==NULL || !(this->_element->contains_point(p)))
     {

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -147,6 +147,7 @@ template <unsigned int N>
 const Elem*
 Tree<N>::find_element
 (const Point& p,
+ unsigned int /*elem_dim*/,
  const std::set<subdomain_id_type> *allowed_subdomains,
  Real relative_tol) const
 {
@@ -161,7 +162,7 @@ Tree<N>::operator() (const Point& p,
                      const std::set<subdomain_id_type> *allowed_subdomains,
                      Real relative_tol) const
 {
-  return this->find_element(p, allowed_subdomains, relative_tol);
+  return this->find_element(p, this->mesh.mesh_dimension(), allowed_subdomains, relative_tol);
 }
 
 

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -147,11 +147,11 @@ template <unsigned int N>
 const Elem*
 Tree<N>::find_element
 (const Point& p,
- unsigned int /*elem_dim*/,
+ unsigned int elem_dim,
  const std::set<subdomain_id_type> *allowed_subdomains,
  Real relative_tol) const
 {
-  return root.find_element(p, allowed_subdomains, relative_tol);
+  return root.find_element(p, elem_dim, allowed_subdomains, relative_tol);
 }
 
 

--- a/src/utils/tree_base.C
+++ b/src/utils/tree_base.C
@@ -1,0 +1,30 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/tree_base.h"
+#include "libmesh/mesh_base.h"
+
+namespace libMesh
+{
+  const Elem* TreeBase::find_element(const Point& p,
+                                     const std::set<subdomain_id_type> *allowed_subdomains,
+                                     Real relative_tol) const
+  {
+    return this->find_element(p,this->mesh.mesh_dimension(),allowed_subdomains,relative_tol);
+  }
+
+} // namespace libMesh

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -457,12 +457,21 @@ unsigned int TreeNode<N>::n_active_bins() const
     }
 }
 
-
+template <unsigned int N>
+const Elem*
+TreeNode<N>::find_element
+(const Point& p,
+ const std::set<subdomain_id_type> *allowed_subdomains,
+ Real relative_tol) const
+{
+  return this->find_element(p, this->mesh.mesh_dimension(), allowed_subdomains, relative_tol);
+}
 
 template <unsigned int N>
 const Elem*
 TreeNode<N>::find_element
 (const Point& p,
+ unsigned int elem_dim,
  const std::set<subdomain_id_type> *allowed_subdomains,
  Real relative_tol) const
 {
@@ -474,7 +483,8 @@ TreeNode<N>::find_element
         // Search the active elements in the active TreeNode.
         for (std::vector<const Elem*>::const_iterator pos=elements.begin();
              pos != elements.end(); ++pos)
-          if (!allowed_subdomains || allowed_subdomains->count((*pos)->subdomain_id()))
+          if ( (!allowed_subdomains || allowed_subdomains->count((*pos)->subdomain_id())) &&
+               (*pos)->dim() == elem_dim )
             if ((*pos)->active() && (*pos)->contains_point(p, relative_tol))
               return *pos;
 

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -492,7 +492,7 @@ TreeNode<N>::find_element
       return NULL;
     }
   else
-    return this->find_element_in_children(p,allowed_subdomains,
+    return this->find_element_in_children(p,elem_dim,allowed_subdomains,
                                           relative_tol);
 
   libmesh_error_msg("We'll never get here!");
@@ -505,6 +505,7 @@ TreeNode<N>::find_element
 template <unsigned int N>
 const Elem* TreeNode<N>::find_element_in_children
 (const Point& p,
+ unsigned int elem_dim,
  const std::set<subdomain_id_type> *allowed_subdomains,
  Real relative_tol) const
 {
@@ -518,7 +519,7 @@ const Elem* TreeNode<N>::find_element_in_children
     if (children[c]->bounds_point(p, relative_tol))
       {
         const Elem* e =
-          children[c]->find_element(p,allowed_subdomains,
+          children[c]->find_element(p,elem_dim,allowed_subdomains,
                                     relative_tol);
 
         if (e != NULL)
@@ -541,7 +542,7 @@ const Elem* TreeNode<N>::find_element_in_children
     if (!searched_child[c])
       {
         const Elem* e =
-          children[c]->find_element(p,allowed_subdomains,
+          children[c]->find_element(p,elem_dim,allowed_subdomains,
                                     relative_tol);
 
         if (e != NULL)

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -29,6 +29,7 @@ public:
   CPPUNIT_TEST( testMesh );
   CPPUNIT_TEST( testDofOrdering );
   CPPUNIT_TEST( testPointLocatorList );
+  CPPUNIT_TEST( testPointLocatorTree );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -86,7 +87,7 @@ protected:
     }
 
     // libMesh will renumber, but we numbered according to its scheme
-    // anyway. We do this because when we call uniformly_refine subsequenly,
+    // anyway. We do this because when we call uniformly_refine subsequently,
     // it's going use skip_renumber=false.
     _mesh->prepare_for_use(false /*skip_renumber*/);
   }
@@ -176,6 +177,23 @@ public:
     CPPUNIT_ASSERT_EQUAL( (dof_id_type)1, bottom_elem->id() );
   }
 
+  void testPointLocatorTree()
+  {
+    AutoPtr<PointLocatorBase> locator = _mesh->sub_point_locator();
+
+    Point top_point(0.5, 0.5);
+    const Elem* top_elem = (*locator)(top_point);
+
+    // We should have gotten back the top quad
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)0, top_elem->id() );
+
+    Point bottom_point(0.5, -0.5);
+    const Elem* bottom_elem = (*locator)(bottom_point);
+
+    // We should have gotten back the bottom quad
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)1, bottom_elem->id() );
+  }
+
 };
 
 class MixedDimensionRefinedMeshTest : public MixedDimensionMeshTest {
@@ -193,7 +211,7 @@ public:
 
   CPPUNIT_TEST_SUITE_END();
 
-  // Yes, this is necesarry. Somewhere in those macros is a protected/private
+  // Yes, this is necessary. Somewhere in those macros is a protected/private
 public:
 
   void setUp()

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -175,6 +175,15 @@ public:
 
     // We should have gotten back the bottom quad
     CPPUNIT_ASSERT_EQUAL( (dof_id_type)1, bottom_elem->id() );
+
+    // Now try to find the 1d element overlapping the interface edge
+    Point interface_point(0.2, 0.0);
+    const Elem* interface_elem = (*locator)(interface_point,1);
+
+    CPPUNIT_ASSERT(interface_elem);
+
+    // We should have gotten back the bottom quad
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)2, interface_elem->id() );
   }
 
   void testPointLocatorTree()
@@ -192,6 +201,15 @@ public:
 
     // We should have gotten back the bottom quad
     CPPUNIT_ASSERT_EQUAL( (dof_id_type)1, bottom_elem->id() );
+
+    // Now try to find the 1d element overlapping the interface edge
+    Point interface_point(0.2, 0.0);
+    const Elem* interface_elem = (*locator)(interface_point,1);
+
+    CPPUNIT_ASSERT(interface_elem);
+
+    // We should have gotten back the bottom quad
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)2, interface_elem->id() );
   }
 
 };


### PR DESCRIPTION
Ultimate goal is to have ExactSolution do the right thing with mixed dimension meshes. This is the first stage. Second stage will be MeshFunction updates. Final stage will be ExactSolution.

I've updated the Tree* and PointLocator* APIs to now accept the desired dimension of the element in the search. I've retained the former API which defaults to the mesh_dimension which should be completely backward compatible. I've also updated the MixedDimensionMeshTest to test out the PointLocators (which actually uncovered #470).

In doing this, I preferred to avoid include the mesh_base.h in the header file Tree* and PointLocator* headers; this is why the 1 liner backward compatible function implementations are in the .C files.

I also made the detection of missing elements of dimension elem_dim a runtime check instead of an assert.