### PR TITLE
Mixed Dimension Support for MeshFunction

### DIFF
--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -219,6 +219,10 @@ public:
 
 protected:
 
+  /**
+   * Helper function to reduce code duplication
+   */
+  const Elem* find_element( const Point& p ) const;
 
   /**
    * The equation systems handler, from which

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -145,16 +145,24 @@ public:
 #endif
 
   /**
-   * Computes values at coordinate \p p and for time \p time, which
-   * defaults to zero.
+   * Computes values at coordinate \p p, that lies in element with
+   * dimemnsion mesh_dimension() (for mixed dimension meshes), and for
+   * time \p time, which defaults to zero.
    */
   void operator() (const Point& p,
                    const Real time,
                    DenseVector<Number>& output);
 
   /**
-   * Computes gradients at coordinate \p p and for time \p time, which
-   * defaults to zero.
+   * Computes values at coordinate \p p, that lies in element with
+   * dimemnsion elem_dim (for mixed dimension meshes), and for
+   * time \p time, which defaults to zero.
+   */
+  void operator() (const Point& p,
+                   unsigned int elem_dim,
+                   const Real time,
+                   DenseVector<Number>& output);
+
    */
   void gradient (const Point& p,
                  const Real time,

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -183,10 +183,21 @@ public:
                  std::vector<Gradient>& output);
 
   /**
-   * Computes gradients at coordinate \p p and for time \p time, which
-   * defaults to zero.
+   * Computes gradients at coordinate \p p, that lies in element with
+   * dimemnsion mesh_dimension() (for mixed dimension meshes), and for
+   * time \p time, which defaults to zero.
    */
   void hessian (const Point& p,
+                const Real time,
+                std::vector<Tensor>& output);
+
+  /**
+   * Computes gradients at coordinate \p p, that lies in element with
+   * dimemnsion elem_dim (for mixed dimension meshes), and for
+   * time \p time, which defaults to zero.
+   */
+  void hessian (const Point& p,
+                unsigned int elem_dim,
                 const Real time,
                 std::vector<Tensor>& output);
 

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -163,8 +163,22 @@ public:
                    const Real time,
                    DenseVector<Number>& output);
 
+  /**
+   * Computes gradients at coordinate \p p, that lies in element with
+   * dimemnsion mesh_dimension() (for mixed dimension meshes), and for
+   * time \p time, which defaults to zero.
    */
   void gradient (const Point& p,
+                 const Real time,
+                 std::vector<Gradient>& output);
+
+  /**
+   * Computes gradients at coordinate \p p, that lies in element with
+   * dimemnsion elem_dim (for mixed dimension meshes), and for
+   * time \p time, which defaults to zero.
+   */
+  void gradient (const Point& p,
+                 unsigned int elem_dim,
                  const Real time,
                  std::vector<Gradient>& output);
 

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -222,7 +222,7 @@ protected:
   /**
    * Helper function to reduce code duplication
    */
-  const Elem* find_element( const Point& p ) const;
+  const Elem* find_element( const Point& p, unsigned int elem_dim ) const;
 
   /**
    * The equation systems handler, from which

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -203,6 +203,15 @@ Gradient MeshFunction::gradient (const Point& p,
   return buf[0];
 }
 
+void MeshFunction::gradient (const Point& p,
+                             const Real time,
+                             std::vector<Gradient>& output)
+{
+  libmesh_assert (this->initialized());
+  unsigned int mesh_dim = this->_eqn_systems.get_mesh().mesh_dimension();
+  this->gradient(p, mesh_dim, time, output);
+}
+
 
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
@@ -299,14 +308,13 @@ void MeshFunction::operator() (const Point& p,
 
 
 void MeshFunction::gradient (const Point& p,
+                             unsigned int elem_dim,
                              const Real,
                              std::vector<Gradient>& output)
 {
   libmesh_assert (this->initialized());
 
-  const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
-
-  const Elem* element = this->find_element(p,dim);
+  const Elem* element = this->find_element(p,elem_dim);
 
   if (!element)
     {
@@ -326,7 +334,7 @@ void MeshFunction::gradient (const Point& p,
          * Note that the fe_type can safely be used from the 0-variable,
          * since the inverse mapping is the same for all FEFamilies
          */
-        const Point mapped_point (FEInterface::inverse_map (dim,
+        const Point mapped_point (FEInterface::inverse_map (elem_dim,
                                                             this->_dof_map.variable_type(0),
                                                             element,
                                                             p));
@@ -342,7 +350,7 @@ void MeshFunction::gradient (const Point& p,
             const unsigned int var = _system_vars[index];
             const FEType& fe_type = this->_dof_map.variable_type(var);
 
-            AutoPtr<FEBase> point_fe (FEBase::build(dim, fe_type));
+            AutoPtr<FEBase> point_fe (FEBase::build(elem_dim, fe_type));
             const std::vector<std::vector<RealGradient> >& dphi = point_fe->get_dphi();
             point_fe->reinit(element, &point_list);
 

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -216,7 +216,9 @@ void MeshFunction::operator() (const Point& p,
 {
   libmesh_assert (this->initialized());
 
-  const Elem* element = this->find_element(p);
+  const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
+
+  const Elem* element = this->find_element(p,dim);
 
   if (!element)
     {
@@ -231,8 +233,6 @@ void MeshFunction::operator() (const Point& p,
 
 
       {
-        const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
-
 
         /*
          * Get local coordinates to feed these into compute_data().
@@ -296,7 +296,9 @@ void MeshFunction::gradient (const Point& p,
 {
   libmesh_assert (this->initialized());
 
-  const Elem* element = this->find_element(p);
+  const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
+
+  const Elem* element = this->find_element(p,dim);
 
   if (!element)
     {
@@ -310,8 +312,6 @@ void MeshFunction::gradient (const Point& p,
 
 
       {
-        const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
-
 
         /*
          * Get local coordinates to feed these into compute_data().
@@ -366,7 +366,9 @@ void MeshFunction::hessian (const Point& p,
 {
   libmesh_assert (this->initialized());
 
-  const Elem* element = this->find_element(p);
+  const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
+
+  const Elem* element = this->find_element(p,dim);
 
   if (!element)
     {
@@ -380,8 +382,6 @@ void MeshFunction::hessian (const Point& p,
 
 
       {
-        const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
-
 
         /*
          * Get local coordinates to feed these into compute_data().
@@ -429,7 +429,7 @@ void MeshFunction::hessian (const Point& p,
 }
 #endif
 
-const Elem* MeshFunction::find_element( const Point& p ) const
+const Elem* MeshFunction::find_element( const Point& p, unsigned int elem_dim ) const
 {
   /* Ensure that in the case of a master mesh function, the
      out-of-mesh mode is enabled either for both or for none.  This is
@@ -448,7 +448,7 @@ const Elem* MeshFunction::find_element( const Point& p ) const
 #endif
 
   // locate the point in the other mesh
-  const Elem* element = this->_point_locator->operator()(p);
+  const Elem* element = this->_point_locator->operator()(p,elem_dim);
 
   // If we have an element, but it's not a local element, then we
   // either need to have a serialized vector or we need to find a

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -182,6 +182,15 @@ Number MeshFunction::operator() (const Point& p,
   return buf(0);
 }
 
+void MeshFunction::operator() (const Point& p,
+                               const Real time,
+                               DenseVector<Number>& output)
+{
+  libmesh_assert (this->initialized());
+  unsigned int mesh_dim = this->_eqn_systems.get_mesh().mesh_dimension();
+  this->operator() (p, mesh_dim, time, output);
+}
+
 
 
 Gradient MeshFunction::gradient (const Point& p,
@@ -211,14 +220,13 @@ Tensor MeshFunction::hessian (const Point& p,
 
 
 void MeshFunction::operator() (const Point& p,
+                               unsigned int elem_dim,
                                const Real,
                                DenseVector<Number>& output)
 {
   libmesh_assert (this->initialized());
 
-  const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
-
-  const Elem* element = this->find_element(p,dim);
+  const Elem* element = this->find_element(p,elem_dim);
 
   if (!element)
     {
@@ -239,7 +247,7 @@ void MeshFunction::operator() (const Point& p,
          * Note that the fe_type can safely be used from the 0-variable,
          * since the inverse mapping is the same for all FEFamilies
          */
-        const Point mapped_point (FEInterface::inverse_map (dim,
+        const Point mapped_point (FEInterface::inverse_map (elem_dim,
                                                             this->_dof_map.variable_type(0),
                                                             element,
                                                             p));
@@ -261,7 +269,7 @@ void MeshFunction::operator() (const Point& p,
             {
               FEComputeData data (this->_eqn_systems, mapped_point);
 
-              FEInterface::compute_data (dim, fe_type, element, data);
+              FEInterface::compute_data (elem_dim, fe_type, element, data);
 
               // where the solution values for the var-th variable are stored
               std::vector<dof_id_type> dof_indices;


### PR DESCRIPTION
Updated MeshFunction to support Point queries with element dimension restriction. Previous methods default to mesh_dimension(). I ran GRINS `make check` with this and all is well (ExactSolution uses this implicitly). Note I have not yet exercised the non mesh_dimension() case, that will be forthcoming.

This should be merged after #472.