### PR TITLE
Added asserts against 'correct' sensitivity and error values

### DIFF
--- a/examples/adjoints/adjoints_ex1/adjoints_ex1.C
+++ b/examples/adjoints/adjoints_ex1/adjoints_ex1.C
@@ -505,6 +505,10 @@ int main (int argc, char** argv)
         std::cout<< "The relative error in QoI 1 is " << std::setprecision(17)
                  << std::abs(QoI_1_computed - QoI_1_exact) /
           std::abs(QoI_1_exact) << std::endl << std::endl;
+
+	// Hard coded asserts to ensure that the actual numbers we are getting are what they should be      
+	libmesh_assert_less(std::abs(QoI_0_computed - QoI_0_exact)/std::abs(QoI_0_exact), 1.e-6);
+	libmesh_assert_less(std::abs(QoI_1_computed - QoI_1_exact)/std::abs(QoI_1_exact), 1.e-5);
       }
   }
 

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -496,6 +496,10 @@ int main (int argc, char** argv)
                  << std::setprecision(17)
                  << std::abs(sensitivity_QoI_0_1_computed - sensitivity_QoI_0_1_exact)/sensitivity_QoI_0_1_exact << std::endl << std::endl;
 
+	// Hard coded asserts to ensure that the actual numbers we are getting are what they should be     
+	libmesh_assert_less(std::abs((sensitivity_QoI_0_0_computed - sensitivity_QoI_0_0_exact)/sensitivity_QoI_0_0_exact), 1.e-4);
+	libmesh_assert_less(std::abs((sensitivity_QoI_0_1_computed - sensitivity_QoI_0_1_exact)/sensitivity_QoI_0_1_exact), 1.e-4);
+
         NumericVector<Number> &dual_solution_0 = system.get_adjoint_solution(0);
 
         primal_solution.swap(dual_solution_0);

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -801,6 +801,10 @@ int main (int argc, char** argv)
 
       std::cout<< "The boundary QoI is " << std::setprecision(17) << QoI_0_computed << std::endl << std::endl;
 
+      // Hard coded assert to ensure that the actual numbers we are getting are what they should be
+      if(a_step == param.max_adaptivesteps)
+	libmesh_assert_less(std::abs(QoI_0_computed - 0.083294260583914453), 1.e-5);
+
       // You dont need to compute error estimates and refine at the last
       // adaptive step, only before that
       if(a_step!=param.max_adaptivesteps)

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -532,6 +532,10 @@ int main (int argc, char** argv)
                  << std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(1)) /
           std::abs(QoI_1_computed - QoI_1_exact) << std::endl << std::endl;
 
+	// Hard coded assert to ensure that the actual numbers we are getting are what they should be
+	libmesh_assert_less(std::abs(std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(0)) / std::abs(QoI_0_computed - QoI_0_exact) - 0.84010976704434637), 1.e-5);
+	libmesh_assert_less(std::abs(std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(1)) / std::abs(QoI_1_computed - QoI_1_exact) - 0.48294428289950514), 1.e-5);
+
       }
   }
 

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -516,6 +516,9 @@ int main (int argc, char** argv)
       // Print it out
       std::cout<<"Sensitivity of QoI 0 w.r.t parameter 0 is: " << sensitivity_0_0 << std::endl;
 
+      // Hard coded assert to ensure that the actual numbers we are getting are what they should be
+      libmesh_assert_less(std::abs(sensitivity_0_0 - (-5.37173)), 1.e-5);
+
 #ifdef NDEBUG
     }
   catch (...)


### PR DESCRIPTION
In case we're in store for more regressions in our adjoints apps (or worse, in the library code), I'd like to know about them sooner rather than later.  Thanks @vikramvgarg 