### PR TITLE
MeshFunction subdomain ids support

### DIFF
--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -154,11 +154,14 @@ public:
 
   /**
    * Computes gradients at coordinate \p p and for time \p time, which
-   * defaults to zero.
+   * defaults to zero, optionally restricting the point to the passed
+   * subdomain_ids. This is useful in cases where there are multiple
+   * dimensioned elements, for example.
    */
   void gradient (const Point& p,
                  const Real time,
-                 std::vector<Gradient>& output);
+                 std::vector<Gradient>& output,
+                 const std::set<subdomain_id_type>* subdomain_ids = NULL);
 
   /**
    * Computes gradients at coordinate \p p and for time \p time, which

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -165,11 +165,14 @@ public:
 
   /**
    * Computes gradients at coordinate \p p and for time \p time, which
-   * defaults to zero.
+   * defaults to zero, optionally restricting the point to the passed
+   * subdomain_ids. This is useful in cases where there are multiple
+   * dimensioned elements, for example.
    */
   void hessian (const Point& p,
                 const Real time,
-                std::vector<Tensor>& output);
+                std::vector<Tensor>& output,
+                const std::set<subdomain_id_type>* subdomain_ids = NULL);
 
   /**
    * Returns the current \p PointLocator object, for you might want to

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -219,6 +219,10 @@ public:
 
 protected:
 
+  /**
+   * Helper function to reduce code duplication
+   */
+  const Elem* find_element( const Point& p ) const;
 
   /**
    * The equation systems handler, from which

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -146,11 +146,23 @@ public:
 
   /**
    * Computes values at coordinate \p p and for time \p time, which
-   * defaults to zero.
+   * defaults to zero, optionally restricting the point to the passed
+   * subdomain_ids. This is useful in cases where there are multiple
+   * dimensioned elements, for example.
    */
   void operator() (const Point& p,
                    const Real time,
                    DenseVector<Number>& output);
+
+  /**
+   * Computes values at coordinate \p p and for time \p time,
+   * restricting the point to the passed subdomain_ids. This is useful in
+   * cases where there are multiple dimensioned elements, for example.
+   */
+  void operator() (const Point& p,
+                   const Real time,
+                   DenseVector<Number>& output,
+                   const std::set<subdomain_id_type>* subdomain_ids);
 
   /**
    * Computes gradients at coordinate \p p and for time \p time, which

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -222,7 +222,8 @@ protected:
   /**
    * Helper function to reduce code duplication
    */
-  const Elem* find_element( const Point& p ) const;
+  const Elem* find_element( const Point& p,
+                            const std::set<subdomain_id_type>* subdomain_ids = NULL ) const;
 
   /**
    * The equation systems handler, from which

--- a/include/numerics/function_base.h
+++ b/include/numerics/function_base.h
@@ -122,6 +122,10 @@ public:
    * coordinate \p p and for time \p time.
    * Purely virtual, so you have to overload it.
    * Note that this cannot be a const method, check \p MeshFunction.
+   * Can optionally provide subdomain_ids which will restrict
+   * the function to operate on elements with subdomain id contained
+   * in the set. This is useful in cases where there are multiple
+   * dimensioned elements, for example.
    */
   virtual void operator() (const Point& p,
                            const Real time,

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -363,11 +363,12 @@ void MeshFunction::gradient (const Point& p,
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 void MeshFunction::hessian (const Point& p,
                             const Real,
-                            std::vector<Tensor>& output)
+                            std::vector<Tensor>& output,
+                            const std::set<subdomain_id_type>* subdomain_ids)
 {
   libmesh_assert (this->initialized());
 
-  const Elem* element = this->find_element(p);
+  const Elem* element = this->find_element(p,subdomain_ids);
 
   if (!element)
     {

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -208,15 +208,21 @@ Tensor MeshFunction::hessian (const Point& p,
 }
 #endif
 
-
+void MeshFunction::operator() (const Point& p,
+                               const Real time,
+                               DenseVector<Number>& output)
+{
+  this->operator() (p,time,output,NULL);
+}
 
 void MeshFunction::operator() (const Point& p,
                                const Real,
-                               DenseVector<Number>& output)
+                               DenseVector<Number>& output,
+                               const std::set<subdomain_id_type>* subdomain_ids)
 {
   libmesh_assert (this->initialized());
 
-  const Elem* element = this->find_element(p);
+  const Elem* element = this->find_element(p,subdomain_ids);
 
   if (!element)
     {

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -292,11 +292,12 @@ void MeshFunction::operator() (const Point& p,
 
 void MeshFunction::gradient (const Point& p,
                              const Real,
-                             std::vector<Gradient>& output)
+                             std::vector<Gradient>& output,
+                             const std::set<subdomain_id_type>* subdomain_ids)
 {
   libmesh_assert (this->initialized());
 
-  const Elem* element = this->find_element(p);
+  const Elem* element = this->find_element(p,subdomain_ids);
 
   if (!element)
     {

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -429,7 +429,8 @@ void MeshFunction::hessian (const Point& p,
 }
 #endif
 
-const Elem* MeshFunction::find_element( const Point& p ) const
+const Elem* MeshFunction::find_element( const Point& p,
+                                        const std::set<subdomain_id_type>* subdomain_ids ) const
 {
   /* Ensure that in the case of a master mesh function, the
      out-of-mesh mode is enabled either for both or for none.  This is
@@ -448,7 +449,7 @@ const Elem* MeshFunction::find_element( const Point& p ) const
 #endif
 
   // locate the point in the other mesh
-  const Elem* element = this->_point_locator->operator()(p);
+  const Elem* element = this->_point_locator->operator()(p,subdomain_ids);
 
   // If we have an element, but it's not a local element, then we
   // either need to have a serialized vector or we need to find a

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -237,7 +237,7 @@ void MeshFunction::operator() (const Point& p,
 
 
       {
-        const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
+        const unsigned int dim = element->dim();
 
 
         /*
@@ -317,7 +317,7 @@ void MeshFunction::gradient (const Point& p,
 
 
       {
-        const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
+        const unsigned int dim = element->dim();
 
 
         /*
@@ -388,7 +388,7 @@ void MeshFunction::hessian (const Point& p,
 
 
       {
-        const unsigned int dim = this->_eqn_systems.get_mesh().mesh_dimension();
+        const unsigned int dim = element->dim();
 
 
         /*


### PR DESCRIPTION
Effectively replaces #473 based on the discussion there. In particular, we're going to assume that elements with different dimension will have different subdomain ids and that the user/other library code will construct subdomain id sets accordingly. Note I haven't updated the `FunctionBase` API yet, I was saving that for updating the projections, which will be more substantial work. In particular, I've left the old `operator()` API intact and it internally calls the new one with NULL subdomain ids pointer. I haven't put a `libmesh_deprecated` in yet --- will do that as part of the projections work. 

I've tested this with `ExactSolution` (forthcoming PR) as well as with GRINS and all is well.

Note that I did this without the changes #472 so I'll also be creating a PR to roll that one back.