### PR TITLE
ExactSolution subdomain ids support

### DIFF
--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -609,40 +609,6 @@ void ExactSolution::_compute_error(const std::string& sys_name,
   // Attach quadrature rule to FE object
   fe->attach_quadrature_rule (qrule.get());
 
-  // The Jacobian*weight at the quadrature points.
-  const std::vector<Real>& JxW                               = fe->get_JxW();
-
-  // The value of the shape functions at the quadrature points
-  // i.e. phi(i) = phi_values[i][qp]
-  const std::vector<std::vector<OutputShape> >&  phi_values         = fe->get_phi();
-
-  // The value of the shape function gradients at the quadrature points
-  const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputGradient> >&
-    dphi_values = fe->get_dphi();
-
-  // The value of the shape function curls at the quadrature points
-  // Only computed for vector-valued elements
-  const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputShape> >* curl_values = NULL;
-
-  // The value of the shape function divergences at the quadrature points
-  // Only computed for vector-valued elements
-  const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputDivergence> >* div_values = NULL;
-
-  if( FEInterface::field_type(fe_type) == TYPE_VECTOR )
-    {
-      curl_values = &fe->get_curl_phi();
-      div_values = &fe->get_div_phi();
-    }
-
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-  // The value of the shape function second derivatives at the quadrature points
-  const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> >&
-    d2phi_values = fe->get_d2phi();
-#endif
-
-  // The XYZ locations (in physical space) of the quadrature points
-  const std::vector<Point>& q_point                          = fe->get_xyz();
-
   // The global degree of freedom indices associated
   // with the local degrees of freedom.
   std::vector<dof_id_type> dof_indices;
@@ -662,6 +628,40 @@ void ExactSolution::_compute_error(const std::string& sys_name,
       // Store a pointer to the element we are currently
       // working on.  This allows for nicer syntax later.
       const Elem* elem = *el;
+
+      // The Jacobian*weight at the quadrature points.
+      const std::vector<Real>& JxW = fe->get_JxW();
+
+      // The value of the shape functions at the quadrature points
+      // i.e. phi(i) = phi_values[i][qp]
+      const std::vector<std::vector<OutputShape> >&  phi_values = fe->get_phi();
+
+      // The value of the shape function gradients at the quadrature points
+      const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputGradient> >&
+        dphi_values = fe->get_dphi();
+
+      // The value of the shape function curls at the quadrature points
+      // Only computed for vector-valued elements
+      const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputShape> >* curl_values = NULL;
+
+      // The value of the shape function divergences at the quadrature points
+      // Only computed for vector-valued elements
+      const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputDivergence> >* div_values = NULL;
+
+      if( FEInterface::field_type(fe_type) == TYPE_VECTOR )
+        {
+          curl_values = &fe->get_curl_phi();
+          div_values = &fe->get_div_phi();
+        }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+      // The value of the shape function second derivatives at the quadrature points
+      const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> >&
+        d2phi_values = fe->get_d2phi();
+#endif
+
+      // The XYZ locations (in physical space) of the quadrature points
+      const std::vector<Point>& q_point = fe->get_xyz();
 
       // reinitialize the element-specific data
       // for the current element

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -640,6 +640,12 @@ void ExactSolution::_compute_error(const std::string& sys_name,
       const Elem* elem = *el;
       const unsigned int dim = elem->dim();
 
+      const subdomain_id_type elem_subid = elem->subdomain_id();
+
+      // If the variable is not active on this subdomain, don't bother
+      if(!computed_system.variable(var).active_on_subdomain(elem_subid))
+        continue;
+
       FEGenericBase<OutputShape>* fe = fe_ptrs[dim];
       QBase* qrule = q_rules[dim];
       libmesh_assert(fe);


### PR DESCRIPTION
Do not merge before #475.

This builds off of #475 and refactors `MeshFunction::_compute_error` a bit to support the mixed dimension mesh case. We do this by using the current elements subdomain id to feed to `MeshFunction`. As far as I've tested, this is backward compatible, but we'll see if MooseBuild hits anything. We are making an assumption though.

The assumption we are making here is that the two systems we are comparing have compatible subdomain ids. For example, this will not work if one system has 1D elements labeled as subdomain id 1 and the comparing system has 1D elements with subdomain id 2.

With these changes, GRINS `make check` passes, including my new (grinsfem/grins#220) mixed dimension regression test case.