### PR TITLE
Allow adding additional variables to existing FParser objects

### DIFF
--- a/contrib/fparser/fparser.hh
+++ b/contrib/fparser/fparser.hh
@@ -32,6 +32,9 @@
 #pragma warning(disable : 4661)
 #endif
 
+template<typename Value_t>
+class FunctionParserADBase;
+
 namespace FPoptimizer_CodeTree { template<typename Value_t> class CodeTree; }
 
 template<typename Value_t>
@@ -140,6 +143,7 @@ class FunctionParserBase
  private:
 //========================================================================
 
+    friend class FunctionParserADBase<Value_t>;
     friend class FPoptimizer_CodeTree::CodeTree<Value_t>;
 
 // Private data:

--- a/contrib/fparser/fparser_ad.hh
+++ b/contrib/fparser/fparser_ad.hh
@@ -21,6 +21,11 @@ public:
   int AutoDiff(const std::string & var_name);
 
   /**
+   * add another variable
+   */
+  bool AddVariable(const std::string & var_name);
+
+  /**
    * check if the function is equal to 0
    * This is a common case for vanishing derivatives. This relies on the
    * function to be optimized.
@@ -66,8 +71,6 @@ public:
   void RegisterDerivative(const std::string & a, const std::string & b, const std::string & c);
 
 private:
-  typename FunctionParserBase<Value_t>::Data * mData;
-
   /// helper function to perform the JIT compilation (needs the Value_t typename as a string)
   bool JITCompileHelper(const std::string &, bool);
 

--- a/tests/fparser/autodiff.C
+++ b/tests/fparser/autodiff.C
@@ -123,7 +123,10 @@ public:
     std::string func = "x*a";
 
     // Parse the input expression into bytecode
-    R.Parse(func, "x,a,y");
+    R.Parse(func, "x,a");
+
+    // add a new variable y and map it to the da/dx derivative
+    R.AddVariable("y");
     R.RegisterDerivative("a", "x", "y");
 
     // parameter vector


### PR DESCRIPTION
This allows users to add variables to existing and parsed FParser objects (for example copies of fully build parsers). The main use is to add variables to use ```RegisterDerivative``` from #463 to make them targets of custom derivatives on demand (i.e. at different levels in an automatic differentiation chain to get a high order derivative).

I'm also using ```friend``` to allow the ```FunctionParserADBase``` class access to private members of ```FunctionParserBase```. These classes are closely tied together and the only alternative would be straight up modifying ```FunctionParserBase``` to put in the AD functionality.