### PR TITLE
GetPot Unit Tests + GetPot::have_section()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -514,6 +514,7 @@ upload:
 # special things to do when running 'make dist'
 dist-hook:
 	rm -rf `find $(distdir) -name libmesh_config.h`
+	rm -rf `find $(distdir) -name getpot_test.C`
 	rm -rf `find $(distdir) -name .svn`
 
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -75,7 +75,8 @@ DIST_COMMON = README $(am__configure_deps) $(srcdir)/Makefile.am \
 	$(top_srcdir)/contrib/utils/libmesh-devel.pc.in \
 	$(top_srcdir)/contrib/utils/libmesh-oprof.pc.in \
 	$(top_srcdir)/contrib/utils/libmesh-opt.pc.in \
-	$(top_srcdir)/contrib/utils/libmesh-prof.pc.in AUTHORS COPYING \
+	$(top_srcdir)/contrib/utils/libmesh-prof.pc.in \
+	$(top_srcdir)/tests/base/getpot_test.C.in AUTHORS COPYING \
 	ChangeLog INSTALL NEWS build-aux/compile \
 	build-aux/config.guess build-aux/config.sub build-aux/depcomp \
 	build-aux/install-sh build-aux/ltmain.sh build-aux/missing \
@@ -142,11 +143,11 @@ am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
 mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/include/libmesh_config.h.tmp
 CONFIG_CLEAN_FILES = contrib/utils/Makefile contrib/utils/Make.common \
-	contrib/utils/libmesh.pc contrib/utils/libmesh-opt.pc \
-	contrib/utils/libmesh-dbg.pc contrib/utils/libmesh-devel.pc \
-	contrib/utils/libmesh-prof.pc contrib/utils/libmesh-oprof.pc \
-	contrib/bin/libmesh-config contrib/bin/xda2mgf \
-	contrib/bin/create_libmesh_release
+	tests/base/getpot_test.C contrib/utils/libmesh.pc \
+	contrib/utils/libmesh-opt.pc contrib/utils/libmesh-dbg.pc \
+	contrib/utils/libmesh-devel.pc contrib/utils/libmesh-prof.pc \
+	contrib/utils/libmesh-oprof.pc contrib/bin/libmesh-config \
+	contrib/bin/xda2mgf contrib/bin/create_libmesh_release
 CONFIG_CLEAN_VPATH_FILES =
 am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
 am__vpath_adj = case $$p in \
@@ -5279,6 +5280,8 @@ $(am__aclocal_m4_deps):
 contrib/utils/Makefile: $(top_builddir)/config.status $(top_srcdir)/contrib/utils/Makefile.in
 	cd $(top_builddir) && $(SHELL) ./config.status $@
 contrib/utils/Make.common: $(top_builddir)/config.status $(top_srcdir)/contrib/utils/Make.common.in
+	cd $(top_builddir) && $(SHELL) ./config.status $@
+tests/base/getpot_test.C: $(top_builddir)/config.status $(top_srcdir)/tests/base/getpot_test.C.in
 	cd $(top_builddir) && $(SHELL) ./config.status $@
 contrib/utils/libmesh.pc: $(top_builddir)/config.status $(top_srcdir)/contrib/utils/libmesh-opt.pc.in
 	cd $(top_builddir) && $(SHELL) ./config.status $@
@@ -28859,6 +28862,7 @@ upload:
 # special things to do when running 'make dist'
 dist-hook:
 	rm -rf `find $(distdir) -name libmesh_config.h`
+	rm -rf `find $(distdir) -name getpot_test.C`
 	rm -rf `find $(distdir) -name .svn`
 
 #

--- a/configure
+++ b/configure
@@ -3699,7 +3699,7 @@ test -n "$target_alias" &&
     NONENONEs,x,x, &&
   program_prefix=${target_alias}-
 
-ac_config_files="$ac_config_files Makefile include/Makefile include/libmesh/Makefile contrib/Makefile contrib/utils/Makefile contrib/utils/Make.common tests/Makefile contrib/utils/libmesh.pc:contrib/utils/libmesh-opt.pc.in contrib/utils/libmesh-opt.pc contrib/utils/libmesh-dbg.pc contrib/utils/libmesh-devel.pc contrib/utils/libmesh-prof.pc contrib/utils/libmesh-oprof.pc doc/Doxyfile doc/Makefile doc/html/Makefile"
+ac_config_files="$ac_config_files Makefile include/Makefile include/libmesh/Makefile contrib/Makefile contrib/utils/Makefile contrib/utils/Make.common tests/Makefile tests/base/getpot_test.C contrib/utils/libmesh.pc:contrib/utils/libmesh-opt.pc.in contrib/utils/libmesh-opt.pc contrib/utils/libmesh-dbg.pc contrib/utils/libmesh-devel.pc contrib/utils/libmesh-prof.pc contrib/utils/libmesh-oprof.pc doc/Doxyfile doc/Makefile doc/html/Makefile"
 
 
 ac_config_files="$ac_config_files contrib/bin/libmesh-config"
@@ -37400,6 +37400,7 @@ do
     "contrib/utils/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/utils/Makefile" ;;
     "contrib/utils/Make.common") CONFIG_FILES="$CONFIG_FILES contrib/utils/Make.common" ;;
     "tests/Makefile") CONFIG_FILES="$CONFIG_FILES tests/Makefile" ;;
+    "tests/base/getpot_test.C") CONFIG_FILES="$CONFIG_FILES tests/base/getpot_test.C" ;;
     "contrib/utils/libmesh.pc") CONFIG_FILES="$CONFIG_FILES contrib/utils/libmesh.pc:contrib/utils/libmesh-opt.pc.in" ;;
     "contrib/utils/libmesh-opt.pc") CONFIG_FILES="$CONFIG_FILES contrib/utils/libmesh-opt.pc" ;;
     "contrib/utils/libmesh-dbg.pc") CONFIG_FILES="$CONFIG_FILES contrib/utils/libmesh-dbg.pc" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AC_CONFIG_FILES([Makefile
                  contrib/utils/Makefile
                  contrib/utils/Make.common
                  tests/Makefile
+                 tests/base/getpot_test.C
                  contrib/utils/libmesh.pc:contrib/utils/libmesh-opt.pc.in
                  contrib/utils/libmesh-opt.pc
                  contrib/utils/libmesh-dbg.pc

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -201,6 +201,9 @@ public:
   inline bool have_variable(const char* VarName) const;
   inline bool have_variable(const std::string& VarName) const;
 
+  bool have_section(const char* section_name) const;
+  bool have_section(const std::string& section_name) const;
+
   /**
    * scalar values
    */
@@ -2141,7 +2144,20 @@ GetPot::have_variable(const std::string& VarName) const
   return have_variable(VarName.c_str());
 }
 
+inline bool
+GetPot::have_section(const char* section_name) const
+{
+  std::string s = std::string(section_name);
+  return this->have_section(s);
+}
 
+inline bool
+GetPot::have_section(const std::string& section_name) const
+{
+  /* We sorted the section_list after we were done parsing
+     so we can use a binary search instead of a linear search. */
+  return std::binary_search( section_list.begin(), section_list.end(), section_name );
+}
 
 template <typename T>
 inline T

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -1112,10 +1112,6 @@ GetPot::_parse_argument_vector(const STRING_VECTOR& ARGV)
                         arg.substr(equals_pos+1), false);
         }
     }
-
-  // We're done parsing, so go ahead and sort the section_list
-  // This is so we can use a binary search in have_section
-  std::sort( section_list.begin(), section_list.end() );
 }
 
 
@@ -2169,9 +2165,9 @@ GetPot::have_section(const char* section_name) const
 inline bool
 GetPot::have_section(const std::string& section_name) const
 {
-  /* We sorted the section_list after we were done parsing
-     so we can use a binary search instead of a linear search. */
-  return std::binary_search( section_list.begin(), section_list.end(), section_name );
+  /* We need to use a linear search because we can't sort section_list
+     without violating some assumptions. See libMesh #481 for more discussion. */
+  return ( std::find(section_list.begin(), section_list.end(), section_name) != section_list.end() );
 }
 
 template <typename T>

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -203,19 +203,23 @@ public:
 
   /**
    * Check for a section name. When querying, the section_name
-   * MUST end in a forward slash. e.g.
-   * /Section1/
-   * /Section1/Section2/
-   * /Section1/Section2/Section3/
+   * can be of the form
+   * Section1 or Section1/
+   *
+   * Section1/Section2 or Section1/Section2/
+   *
+   * etc.
    */
   bool have_section(const char* section_name) const;
 
   /**
    * Check for a section name. When querying, the section_name
-   * MUST end in a forward slash. e.g.
-   * /Section1/
-   * /Section1/Section2/
-   * /Section1/Section2/Section3/
+   * can be of the form
+   * Section1 or Section1/
+   *
+   * Section1/Section2 or Section1/Section2/
+   *
+   * etc.
    */
   bool have_section(const std::string& section_name) const;
 
@@ -2165,9 +2169,22 @@ GetPot::have_section(const char* section_name) const
 inline bool
 GetPot::have_section(const std::string& section_name) const
 {
-  /* We need to use a linear search because we can't sort section_list
+  const char slash('/');
+
+  std::string::const_reverse_iterator it = section_name.rbegin();
+
+  bool found_section = false;
+
+  /* Check if section_name ends with a "/". If not, append it for the search since
+     the section names are stored with a "/" at the end.*/
+  if( (*it) != slash )
+    /* We need to use a linear search because we can't sort section_list
      without violating some assumptions. See libMesh #481 for more discussion. */
-  return ( std::find(section_list.begin(), section_list.end(), section_name) != section_list.end() );
+    found_section = ( std::find(section_list.begin(), section_list.end(), section_name+slash) != section_list.end() );
+  else
+    found_section = ( std::find(section_list.begin(), section_list.end(), section_name) != section_list.end() );
+
+  return found_section;
 }
 
 template <typename T>

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -201,7 +201,22 @@ public:
   inline bool have_variable(const char* VarName) const;
   inline bool have_variable(const std::string& VarName) const;
 
+  /**
+   * Check for a section name. When querying, the section_name
+   * MUST end in a forward slash. e.g.
+   * /Section1/
+   * /Section1/Section2/
+   * /Section1/Section2/Section3/
+   */
   bool have_section(const char* section_name) const;
+
+  /**
+   * Check for a section name. When querying, the section_name
+   * MUST end in a forward slash. e.g.
+   * /Section1/
+   * /Section1/Section2/
+   * /Section1/Section2/Section3/
+   */
   bool have_section(const std::string& section_name) const;
 
   /**

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -1094,6 +1094,10 @@ GetPot::_parse_argument_vector(const STRING_VECTOR& ARGV)
                         arg.substr(equals_pos+1), false);
         }
     }
+
+  // We're done parsing, so go ahead and sort the section_list
+  // This is so we can use a binary search in have_section
+  std::sort( section_list.begin(), section_list.end() );
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,6 +30,8 @@ unit_tests_sources = \
         systems/equation_systems_test.C \
 	utils/vectormap_test.C
 
+EXTRA_DIST = base/getpot_test_input.in
+
 if LIBMESH_ENABLE_FPARSER
   unit_tests_sources += \
 	fparser/autodiff.C

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,7 @@ unit_tests_sources = \
 	driver.C \
         test_comm.h \
 	base/dof_object_test.h \
+        base/getpot_test.C \
 	geom/node_test.C \
 	geom/point_test.C \
 	geom/point_test.h \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -118,8 +118,8 @@ CONFIG_CLEAN_VPATH_FILES =
 @LIBMESH_PROF_MODE_TRUE@am__EXEEXT_4 = unit_tests-prof$(EXEEXT)
 @LIBMESH_OPROF_MODE_TRUE@am__EXEEXT_5 = unit_tests-oprof$(EXEEXT)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
@@ -132,6 +132,7 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 am__dirstamp = $(am__leading_dot)dirstamp
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_1 = fparser/unit_tests_dbg-autodiff.$(OBJEXT)
 am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
+	base/unit_tests_dbg-getpot_test.$(OBJEXT) \
 	geom/unit_tests_dbg-node_test.$(OBJEXT) \
 	geom/unit_tests_dbg-point_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT) \
@@ -157,8 +158,8 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
@@ -170,6 +171,7 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_3 = fparser/unit_tests_devel-autodiff.$(OBJEXT)
 am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
+	base/unit_tests_devel-getpot_test.$(OBJEXT) \
 	geom/unit_tests_devel-node_test.$(OBJEXT) \
 	geom/unit_tests_devel-point_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT) \
@@ -194,8 +196,8 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
@@ -207,6 +209,7 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_5 = fparser/unit_tests_oprof-autodiff.$(OBJEXT)
 am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
+	base/unit_tests_oprof-getpot_test.$(OBJEXT) \
 	geom/unit_tests_oprof-node_test.$(OBJEXT) \
 	geom/unit_tests_oprof-point_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT) \
@@ -231,8 +234,8 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
@@ -244,6 +247,7 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_7 = fparser/unit_tests_opt-autodiff.$(OBJEXT)
 am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
+	base/unit_tests_opt-getpot_test.$(OBJEXT) \
 	geom/unit_tests_opt-node_test.$(OBJEXT) \
 	geom/unit_tests_opt-point_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT) \
@@ -266,8 +270,8 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
@@ -279,6 +283,7 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_9 = fparser/unit_tests_prof-autodiff.$(OBJEXT)
 am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
+	base/unit_tests_prof-getpot_test.$(OBJEXT) \
 	geom/unit_tests_prof-node_test.$(OBJEXT) \
 	geom/unit_tests_prof-point_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT) \
@@ -690,8 +695,9 @@ AM_CPPFLAGS = $(libmesh_optional_INCLUDES) -I$(top_builddir)/include \
 
 AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/mixed_dim_mesh_test.C numerics/composite_function_test.C \
+	base/getpot_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h mesh/mixed_dim_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -700,6 +706,7 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	parallel/parallel_test.C quadrature/quadrature_test.C \
 	systems/equation_systems_test.C utils/vectormap_test.C \
 	$(am__append_1)
+EXTRA_DIST = base/getpot_test_input.in
 @LIBMESH_OPT_MODE_TRUE@unit_tests_opt_SOURCES = $(unit_tests_sources)
 @LIBMESH_OPT_MODE_TRUE@unit_tests_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
 @LIBMESH_OPT_MODE_TRUE@unit_tests_opt_CXXFLAGS = $(CXXFLAGS_OPT)
@@ -769,6 +776,14 @@ clean-checkPROGRAMS:
 	list=`for p in $$list; do echo "$$p"; done | sed 's/$(EXEEXT)$$//'`; \
 	echo " rm -f" $$list; \
 	rm -f $$list
+base/$(am__dirstamp):
+	@$(MKDIR_P) base
+	@: > base/$(am__dirstamp)
+base/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) base/$(DEPDIR)
+	@: > base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_dbg-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
+	base/$(DEPDIR)/$(am__dirstamp)
 geom/$(am__dirstamp):
 	@$(MKDIR_P) geom
 	@: > geom/$(am__dirstamp)
@@ -849,6 +864,8 @@ fparser/unit_tests_dbg-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-dbg$(EXEEXT): $(unit_tests_dbg_OBJECTS) $(unit_tests_dbg_DEPENDENCIES) $(EXTRA_unit_tests_dbg_DEPENDENCIES) 
 	@rm -f unit_tests-dbg$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_dbg_LINK) $(unit_tests_dbg_OBJECTS) $(unit_tests_dbg_LDADD) $(LIBS)
+base/unit_tests_devel-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
+	base/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-point_test.$(OBJEXT): geom/$(am__dirstamp) \
@@ -881,6 +898,8 @@ fparser/unit_tests_devel-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-devel$(EXEEXT): $(unit_tests_devel_OBJECTS) $(unit_tests_devel_DEPENDENCIES) $(EXTRA_unit_tests_devel_DEPENDENCIES) 
 	@rm -f unit_tests-devel$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_devel_LINK) $(unit_tests_devel_OBJECTS) $(unit_tests_devel_LDADD) $(LIBS)
+base/unit_tests_oprof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
+	base/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_oprof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_oprof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
@@ -913,6 +932,8 @@ fparser/unit_tests_oprof-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-oprof$(EXEEXT): $(unit_tests_oprof_OBJECTS) $(unit_tests_oprof_DEPENDENCIES) $(EXTRA_unit_tests_oprof_DEPENDENCIES) 
 	@rm -f unit_tests-oprof$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_oprof_LINK) $(unit_tests_oprof_OBJECTS) $(unit_tests_oprof_LDADD) $(LIBS)
+base/unit_tests_opt-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
+	base/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-point_test.$(OBJEXT): geom/$(am__dirstamp) \
@@ -945,6 +966,8 @@ fparser/unit_tests_opt-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-opt$(EXEEXT): $(unit_tests_opt_OBJECTS) $(unit_tests_opt_DEPENDENCIES) $(EXTRA_unit_tests_opt_DEPENDENCIES) 
 	@rm -f unit_tests-opt$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_opt_LINK) $(unit_tests_opt_OBJECTS) $(unit_tests_opt_LDADD) $(LIBS)
+base/unit_tests_prof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
+	base/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_prof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_prof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
@@ -980,6 +1003,7 @@ unit_tests-prof$(EXEEXT): $(unit_tests_prof_OBJECTS) $(unit_tests_prof_DEPENDENC
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
+	-rm -f base/*.$(OBJEXT)
 	-rm -f fparser/*.$(OBJEXT)
 	-rm -f geom/*.$(OBJEXT)
 	-rm -f mesh/*.$(OBJEXT)
@@ -997,6 +1021,11 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_oprof-driver.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_opt-driver.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_prof-driver.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-getpot_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-getpot_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_devel-autodiff.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_oprof-autodiff.Po@am__quote@
@@ -1105,6 +1134,20 @@ unit_tests_dbg-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='driver.C' object='unit_tests_dbg-driver.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_dbg-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
+
+base/unit_tests_dbg-getpot_test.o: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-getpot_test.Tpo -c -o base/unit_tests_dbg-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-getpot_test.Tpo base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_dbg-getpot_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+
+base/unit_tests_dbg-getpot_test.obj: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-getpot_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-getpot_test.Tpo -c -o base/unit_tests_dbg-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-getpot_test.Tpo base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_dbg-getpot_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
 
 geom/unit_tests_dbg-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_dbg-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_dbg-node_test.Tpo -c -o geom/unit_tests_dbg-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
@@ -1316,6 +1359,20 @@ unit_tests_devel-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_devel-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
 
+base/unit_tests_devel-getpot_test.o: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-getpot_test.Tpo -c -o base/unit_tests_devel-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-getpot_test.Tpo base/$(DEPDIR)/unit_tests_devel-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_devel-getpot_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+
+base/unit_tests_devel-getpot_test.obj: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-getpot_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-getpot_test.Tpo -c -o base/unit_tests_devel-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-getpot_test.Tpo base/$(DEPDIR)/unit_tests_devel-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_devel-getpot_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
+
 geom/unit_tests_devel-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_devel-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_devel-node_test.Tpo -c -o geom/unit_tests_devel-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_devel-node_test.Tpo geom/$(DEPDIR)/unit_tests_devel-node_test.Po
@@ -1525,6 +1582,20 @@ unit_tests_oprof-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='driver.C' object='unit_tests_oprof-driver.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_oprof-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
+
+base/unit_tests_oprof-getpot_test.o: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-getpot_test.Tpo -c -o base/unit_tests_oprof-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-getpot_test.Tpo base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_oprof-getpot_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+
+base/unit_tests_oprof-getpot_test.obj: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-getpot_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-getpot_test.Tpo -c -o base/unit_tests_oprof-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-getpot_test.Tpo base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_oprof-getpot_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
 
 geom/unit_tests_oprof-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_oprof-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_oprof-node_test.Tpo -c -o geom/unit_tests_oprof-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
@@ -1736,6 +1807,20 @@ unit_tests_opt-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_opt-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
 
+base/unit_tests_opt-getpot_test.o: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-getpot_test.Tpo -c -o base/unit_tests_opt-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-getpot_test.Tpo base/$(DEPDIR)/unit_tests_opt-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_opt-getpot_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+
+base/unit_tests_opt-getpot_test.obj: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-getpot_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-getpot_test.Tpo -c -o base/unit_tests_opt-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-getpot_test.Tpo base/$(DEPDIR)/unit_tests_opt-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_opt-getpot_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
+
 geom/unit_tests_opt-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_opt-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_opt-node_test.Tpo -c -o geom/unit_tests_opt-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_opt-node_test.Tpo geom/$(DEPDIR)/unit_tests_opt-node_test.Po
@@ -1945,6 +2030,20 @@ unit_tests_prof-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='driver.C' object='unit_tests_prof-driver.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_prof-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
+
+base/unit_tests_prof-getpot_test.o: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-getpot_test.Tpo -c -o base/unit_tests_prof-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-getpot_test.Tpo base/$(DEPDIR)/unit_tests_prof-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_prof-getpot_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
+
+base/unit_tests_prof-getpot_test.obj: base/getpot_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-getpot_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-getpot_test.Tpo -c -o base/unit_tests_prof-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-getpot_test.Tpo base/$(DEPDIR)/unit_tests_prof-getpot_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/getpot_test.C' object='base/unit_tests_prof-getpot_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-getpot_test.obj `if test -f 'base/getpot_test.C'; then $(CYGPATH_W) 'base/getpot_test.C'; else $(CYGPATH_W) '$(srcdir)/base/getpot_test.C'; fi`
 
 geom/unit_tests_prof-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_prof-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_prof-node_test.Tpo -c -o geom/unit_tests_prof-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
@@ -2370,6 +2469,8 @@ clean-generic:
 distclean-generic:
 	-test -z "$(CONFIG_CLEAN_FILES)" || rm -f $(CONFIG_CLEAN_FILES)
 	-test . = "$(srcdir)" || test -z "$(CONFIG_CLEAN_VPATH_FILES)" || rm -f $(CONFIG_CLEAN_VPATH_FILES)
+	-rm -f base/$(DEPDIR)/$(am__dirstamp)
+	-rm -f base/$(am__dirstamp)
 	-rm -f fparser/$(DEPDIR)/$(am__dirstamp)
 	-rm -f fparser/$(am__dirstamp)
 	-rm -f geom/$(DEPDIR)/$(am__dirstamp)
@@ -2396,7 +2497,7 @@ clean-am: clean-checkPROGRAMS clean-generic clean-libtool \
 	mostlyclean-am
 
 distclean: distclean-am
-	-rm -rf ./$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) base/$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -2442,7 +2543,7 @@ install-ps-am:
 installcheck-am:
 
 maintainer-clean: maintainer-clean-am
-	-rm -rf ./$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) base/$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/tests/base/getpot_test.C.in
+++ b/tests/base/getpot_test.C.in
@@ -1,0 +1,68 @@
+// Ignore unused parameter warnings coming from cppuint headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/getpot.h>
+
+using namespace libMesh;
+
+class GetPotTest : public CppUnit::TestCase {
+
+public:
+  CPPUNIT_TEST_SUITE( GetPotTest );
+
+  CPPUNIT_TEST( testVariables );
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+
+  GetPot input;
+
+public:
+
+  void setUp()
+  {
+    // @abs_top_srcdir@ will be substituted at configure time
+    // with the path for the top libMesh source tree
+    input.parse_input_file("@abs_top_srcdir@/tests/base/getpot_test_input.in");
+  }
+
+  void testVariables()
+  {
+    CPPUNIT_ASSERT( input.have_variable("Section1/var1") );
+    libMesh::Real var1 = input("Section1/var1", 1.0);
+    CPPUNIT_ASSERT_EQUAL( var1, 5.0);
+
+    CPPUNIT_ASSERT( input.have_variable("Section1/SubSection1/var2") );
+    std::string var2 = input("Section1/SubSection1/var2", "DIE!");
+    CPPUNIT_ASSERT_EQUAL( var2, std::string("blah") );
+
+    // This variable is commented out in the input file so we shouldn't find it.
+    CPPUNIT_ASSERT( !input.have_variable("Section2/var3") );
+    int var3 = input("Section2/var3", 314);
+    CPPUNIT_ASSERT_EQUAL( var3, 314 );
+
+    CPPUNIT_ASSERT( input.have_variable("Section2/Subsection2/var4") );
+    bool var4 = input("Section2/Subsection2/var4", true);
+    CPPUNIT_ASSERT_EQUAL( var4, false );
+
+    CPPUNIT_ASSERT( input.have_variable("Section2/Subsection2/Subsection3/var5") );
+    libMesh::Real var5 = input("Section2/Subsection2/Subsection3/var5", 3.1415);
+    CPPUNIT_ASSERT_EQUAL( var5, 6.02e23);
+
+    CPPUNIT_ASSERT( input.have_variable("Section2/Subsection4/var6") );
+    unsigned int var6 = input("Section2/Subsection4/var6", 21);
+    CPPUNIT_ASSERT_EQUAL( var6, (unsigned int)42 );
+
+    // We didn't use Section3/unused_var so it should be a UFO
+    std::vector<std::string> ufos = input.unidentified_variables();
+    CPPUNIT_ASSERT_EQUAL( ufos.size(),  (std::vector<std::string>::size_type)1 );
+    CPPUNIT_ASSERT_EQUAL( ufos[0], std::string("Section3/unused_var") );
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( GetPotTest );

--- a/tests/base/getpot_test.C.in
+++ b/tests/base/getpot_test.C.in
@@ -14,6 +14,7 @@ public:
   CPPUNIT_TEST_SUITE( GetPotTest );
 
   CPPUNIT_TEST( testVariables );
+  CPPUNIT_TEST( testSections );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -61,6 +62,20 @@ public:
     std::vector<std::string> ufos = input.unidentified_variables();
     CPPUNIT_ASSERT_EQUAL( ufos.size(),  (std::vector<std::string>::size_type)1 );
     CPPUNIT_ASSERT_EQUAL( ufos[0], std::string("Section3/unused_var") );
+  }
+
+  void testSections()
+  {
+    // GetPot stores the '/' at the end of each section name
+    CPPUNIT_ASSERT(input.have_section("Section1/"));
+    CPPUNIT_ASSERT(input.have_section("Section1/SubSection1/"));
+    CPPUNIT_ASSERT(input.have_section("Section2/Subsection2/"));
+    CPPUNIT_ASSERT(input.have_section("Section2/Subsection2/Subsection3/"));
+    CPPUNIT_ASSERT(input.have_section("Section2/Subsection4/"));
+    CPPUNIT_ASSERT(input.have_section("Section3/"));
+
+    // No such thing as this section
+    CPPUNIT_ASSERT(!input.have_section("ImNotASection/"));
   }
 
 };

--- a/tests/base/getpot_test.C.in
+++ b/tests/base/getpot_test.C.in
@@ -74,6 +74,11 @@ public:
     CPPUNIT_ASSERT(input.have_section("Section2/Subsection4/"));
     CPPUNIT_ASSERT(input.have_section("Section3/"));
 
+    // But we don't need to supply the trailing '/'
+    CPPUNIT_ASSERT(input.have_section("Section1"));
+    CPPUNIT_ASSERT(input.have_section("Section1/SubSection1"));
+    CPPUNIT_ASSERT(input.have_section("Section2/Subsection2/Subsection3"));
+
     // No such thing as this section
     CPPUNIT_ASSERT(!input.have_section("ImNotASection/"));
   }

--- a/tests/base/getpot_test_input.in
+++ b/tests/base/getpot_test_input.in
@@ -1,0 +1,31 @@
+[Section1]
+
+  var1 = '5.0'
+
+  [./SubSection1]
+
+      var2 = 'blah'
+
+[]
+
+[Section2]
+
+   #var3 = '5'
+
+   [./Subsection2]
+
+       var4 = 'false'
+
+       [./Subsection3]
+
+           var5 = '6.02e23'
+
+   [../../Subsection4]
+
+           var6 = '42'
+
+[]
+
+[Section3]
+
+     unused_var = 'not_used'


### PR DESCRIPTION
Added CppUnit tests for GetPot. Actual source file has to be generated by configure since CppUnit doesn't provide access to argv (annoying) and GetPot only takes file names in the constructor, no streams (so couldn't do stringstream). Motivation for the unit tests was adding a new API to GetPot - have_section(). It's useful to be able to test whether a given section is in the input file. To facilitate a binary search instead of a linear search, I added a sort() to the section_list at the end of parsing.