### PR TITLE
Default comm self

### DIFF
--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -157,7 +157,7 @@ protected:
   AutoPtr<SerialMesh> _inside_mesh_3D;
   AutoPtr<SerialMesh> _outside_mesh_3D;
 
-  AutoPtr<Parallel::Communicator> _comm_self;
+  Parallel::Communicator _comm_self; // defaults to MPI_COMM_SELF
 
   AutoPtr<TriangleInterface>   _triangle_inside;
   AutoPtr<TriangleInterface>   _triangle_outside;

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -468,7 +468,7 @@ inline void unpack_range (const std::vector<buffertype>& buffer,
 
 inline Communicator::Communicator () :
 #ifdef LIBMESH_HAVE_MPI
-  _communicator(MPI_COMM_NULL),
+  _communicator(MPI_COMM_SELF),
 #endif
   _rank(0),
   _size(1),
@@ -478,7 +478,7 @@ inline Communicator::Communicator () :
 
 inline Communicator::Communicator (const communicator &comm) :
 #ifdef LIBMESH_HAVE_MPI
-  _communicator(MPI_COMM_NULL),
+  _communicator(MPI_COMM_SELF),
 #endif
   _rank(0),
   _size(1),

--- a/src/geom/elem_cutter.C
+++ b/src/geom/elem_cutter.C
@@ -40,15 +40,11 @@ namespace libMesh
 // ElemCutter implementation
 ElemCutter::ElemCutter()
 {
-  _comm_self.reset (new Parallel::Communicator (MPI_COMM_SELF));
+  _inside_mesh_2D.reset  (new SerialMesh(_comm_self,2)); /**/ _triangle_inside.reset  (new TriangleInterface (*_inside_mesh_2D));
+  _outside_mesh_2D.reset (new SerialMesh(_comm_self,2)); /**/ _triangle_outside.reset (new TriangleInterface (*_outside_mesh_2D));
 
-  libmesh_assert (_comm_self.get() != NULL);
-
-  _inside_mesh_2D.reset  (new SerialMesh(*_comm_self,2)); /**/ _triangle_inside.reset  (new TriangleInterface (*_inside_mesh_2D));
-  _outside_mesh_2D.reset (new SerialMesh(*_comm_self,2)); /**/ _triangle_outside.reset (new TriangleInterface (*_outside_mesh_2D));
-
-  _inside_mesh_3D.reset  (new SerialMesh(*_comm_self,3)); /**/ _tetgen_inside.reset  (new TetGenMeshInterface (*_inside_mesh_3D));
-  _outside_mesh_3D.reset (new SerialMesh(*_comm_self,3)); /**/ _tetgen_outside.reset (new TetGenMeshInterface (*_outside_mesh_3D));
+  _inside_mesh_3D.reset  (new SerialMesh(_comm_self,3)); /**/ _tetgen_inside.reset  (new TetGenMeshInterface (*_inside_mesh_3D));
+  _outside_mesh_3D.reset (new SerialMesh(_comm_self,3)); /**/ _tetgen_outside.reset (new TetGenMeshInterface (*_outside_mesh_3D));
 
   cut_cntr = 0;
 }


### PR DESCRIPTION
Default-construct Communicator objects with MPI_COMM_SELF, so they're at least good for *something*, instead of MPI_COMM_NULL.

Use that Communicator rather than explicitly referring to MPI (which may not be enabled!) in ElemCutter.

Hopefully this fixes #483 