### PR TITLE
Re-run JITCompile after Optimize

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -452,6 +452,13 @@ int ADImplementation<Value_t>::AutoDiff(unsigned int _var, typename FunctionPars
   return -1;
 }
 
+template<typename Value_t>
+void FunctionParserADBase<Value_t>::Optimize()
+{
+  FunctionParserBase<Value_t>::Optimize();
+  if (compiledFunction)
+    JITCompile();
+}
 
 template<typename Value_t>
 bool FunctionParserADBase<Value_t>::JITCompile(bool)
@@ -475,12 +482,18 @@ Value_t FunctionParserADBase<Value_t>::Eval(const Value_t* Vars)
   if (compiledFunction == NULL)
     return FunctionParserBase<Value_t>::Eval(Vars);
   else
-    return (*compiledFunction)(Vars, this->mData->mImmed.empty() ? 0 : &(this->mData->mImmed[0]), Epsilon<Value_t>::value);
+    return (*compiledFunction)(Vars, pImmed, Epsilon<Value_t>::value);
 }
 
 template<typename Value_t>
 bool FunctionParserADBase<Value_t>::JITCompileHelper(const std::string & Value_t_name, bool cacheFunction)
 {
+  // set compiled function pointer to zero to avoid stale values if JIT compilation fails
+  compiledFunction = NULL;
+
+  // get a pointer to the mImmed values
+  pImmed = this->mData->mImmed.empty() ? NULL : &(this->mData->mImmed[0]);
+
   // get a reference to the stored bytecode
   const std::vector<unsigned>& ByteCode = this->mData->mByteCode;
 

--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -475,7 +475,7 @@ Value_t FunctionParserADBase<Value_t>::Eval(const Value_t* Vars)
   if (compiledFunction == NULL)
     return FunctionParserBase<Value_t>::Eval(Vars);
   else
-    return (*compiledFunction)(Vars, &(this->mData->mImmed[0]), Epsilon<Value_t>::value);
+    return (*compiledFunction)(Vars, this->mData->mImmed.empty() ? 0 : &(this->mData->mImmed[0]), Epsilon<Value_t>::value);
 }
 
 template<typename Value_t>
@@ -483,6 +483,10 @@ bool FunctionParserADBase<Value_t>::JITCompileHelper(const std::string & Value_t
 {
   // get a reference to the stored bytecode
   const std::vector<unsigned>& ByteCode = this->mData->mByteCode;
+
+  // drop out if the ByteCode is empty
+  if (ByteCode.empty())
+    return false;
 
   // generate a sha1 hash of the current program and the Value type name
   SHA1 *sha1 = new SHA1();

--- a/contrib/fparser/fparser_ad.hh
+++ b/contrib/fparser/fparser_ad.hh
@@ -51,6 +51,12 @@ public:
    */
   bool JITCompile(bool cacheFunction = true);
 
+  /**
+   * wrap Optimize of the parent class to check for a JIT compiled version and redo
+   * the compilation after Optimization
+   */
+  void Optimize();
+
 #if LIBMESH_HAVE_FPARSER_JIT
   /**
    * Overwrite the Exec function with one that tests for a JIT compiled version
@@ -76,6 +82,9 @@ private:
 
   /// JIT function pointer
   Value_t (*compiledFunction)(const Value_t *, const Value_t *, const Value_t);
+
+  /// pointer to the mImmed values (or NULL if the mImmed vector is empty)
+  Value_t * pImmed;
 
   /**
    * In certain applications derivatives are built proactively and may never be used.


### PR DESCRIPTION
Wrap calls to Optimize and re-run JITCompile if necessary. This makes FParser objects more robust w.r.t. order of Optimize and JITCompile calls.

Makes #487 obsolete.
Closes #486.
