### PR TITLE
Free malloced digest buffer

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -518,6 +518,7 @@ bool FunctionParserADBase<Value_t>::JITCompileHelper(const std::string & Value_t
   unsigned char* digest = sha1->getDigest();
   for (unsigned int i = 0; i<20; ++i)
     sprintf(&(result[i*2]), "%02x", digest[i]);
+  free(digest);
   delete sha1;
 
   // function name


### PR DESCRIPTION
There is a small memory leak in my FParser code. The sha1 digest buffer is allocated via ```malloc``` in the sha1 library. It was up to me to free it. Done now.