### PR TITLE
Need to increase bin size further for point_locator_tree

### DIFF
--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -40,7 +40,7 @@ PointLocatorTree::PointLocatorTree (const MeshBase& mesh,
   _tree            (NULL),
   _element         (NULL),
   _out_of_mesh_mode(false),
-  _target_bin_size (250),
+  _target_bin_size (300),
   _build_type(Trees::NODES)
 {
   this->init(_build_type);
@@ -55,7 +55,7 @@ PointLocatorTree::PointLocatorTree (const MeshBase& mesh,
   _tree            (NULL),
   _element         (NULL),
   _out_of_mesh_mode(false),
-  _target_bin_size (250),
+  _target_bin_size (300),
   _build_type(build_type)
 {
   this->init(_build_type);


### PR DESCRIPTION
I have another mesh (this one is quite reasonable) which hits the same infinite loop as yesterday with a bin size of 250.

As a result, I propose we increase the default bin size to 300 (and work towards a more reliable fix for this issue).