### PR TITLE
Fixed bug in Tree code.

### DIFF
--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -40,7 +40,7 @@ PointLocatorTree::PointLocatorTree (const MeshBase& mesh,
   _tree            (NULL),
   _element         (NULL),
   _out_of_mesh_mode(false),
-  _target_bin_size (300),
+  _target_bin_size (200),
   _build_type(Trees::NODES)
 {
   this->init(_build_type);
@@ -55,7 +55,7 @@ PointLocatorTree::PointLocatorTree (const MeshBase& mesh,
   _tree            (NULL),
   _element         (NULL),
   _out_of_mesh_mode(false),
-  _target_bin_size (300),
+  _target_bin_size (200),
   _build_type(build_type)
 {
   this->init(_build_type);

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -77,7 +77,9 @@ bool TreeNode<N>::insert (const Elem* elem)
   for (unsigned i=1; i<elem->n_nodes(); ++i)
     {
       Point p = elem->point(i);
-      for (unsigned d=0; d<elem->dim(); ++d)
+
+      // LIBMESH_DIM gives the number of non-zero components in a Point
+      for (unsigned d=0; d<LIBMESH_DIM; ++d)
         {
           if (min_coord(d) > p(d))
             min_coord(d) = p(d);
@@ -90,7 +92,9 @@ bool TreeNode<N>::insert (const Elem* elem)
   // Next, find out whether this cuboid has got non-empty intersection
   // with the bounding box of the current tree node.
   bool intersects = true;
-  for (unsigned int d=0; d<elem->dim(); d++)
+
+  // LIBMESH_DIM gives the number of non-zero components in a Point
+  for (unsigned int d=0; d<LIBMESH_DIM; d++)
     {
       if (max_coord(d) < this->bounding_box.first(d) || min_coord(d) > this->bounding_box.second(d))
         intersects = false;


### PR DESCRIPTION
There was a bug in TreeNode in the case that we have 2D elements that aren't in the xy-plane. Should use LIBMESH_DIM instead of elem->dim() to get the number of non-zero Point coordinates.