### PR TITLE
mesh_dimension() -> elem_dimensions() fixes

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -863,6 +863,13 @@ public:
   { return _block_id_to_name; }
 
 
+  /**
+   * Search the mesh and cache the different dimenions of the elements
+   * present in the mesh.  This is done in prepare_for_use(), but can
+   * be done manually by other classes after major mesh modifications.
+   */
+  void cache_elem_dims();
+
 
   /**
    * This class holds the boundary information.  It can store nodes, edges,
@@ -890,12 +897,6 @@ protected:
    */
   unsigned int& set_n_partitions ()
   { return _n_parts; }
-
-  /**
-   * Search the mesh and cache the different dimenions of the elements
-   * present in the mesh.
-   */
-  void cache_elem_dims();
 
   /**
    * The number of partitions the mesh has.  This is set by

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -175,9 +175,13 @@ void BoundaryInfo::sync (const std::set<boundary_id_type> &requested_boundary_id
    * interior mesh elements.
    *
    * cast_int will scream if the interior is a 0-D mesh
+   *
+   * This is incorrect for the case of mixed-dimension meshes, and
+   * we can skip it entirely because prepare_for_use() will call
+   * cache_elem_dims()
    */
-  boundary_mesh.set_mesh_dimension
-    (cast_int<unsigned char>(_mesh.mesh_dimension() - 1));
+  // boundary_mesh.set_mesh_dimension
+  //   (cast_int<unsigned char>(_mesh.mesh_dimension() - 1));
 
   /**
    * Re-create the boundary mesh.

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -174,14 +174,10 @@ void BoundaryInfo::sync (const std::set<boundary_id_type> &requested_boundary_id
    * The boundary mesh elements will be one lower dimension than the
    * interior mesh elements.
    *
-   * cast_int will scream if the interior is a 0-D mesh
-   *
-   * This is incorrect for the case of mixed-dimension meshes, and
-   * we can skip it entirely because prepare_for_use() will call
-   * cache_elem_dims()
+   * We no longer need to set_mesh_dimension() explicitly here,
+   * though: prepare_for_use() will call cache_elem_dims(), which will
+   * also be correct in the multi-dimensional case.
    */
-  // boundary_mesh.set_mesh_dimension
-  //   (cast_int<unsigned char>(_mesh.mesh_dimension() - 1));
 
   /**
    * Re-create the boundary mesh.

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -135,12 +135,6 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
   // cache_elem_dims() should get the elem_dimensions() and
   // mesh_dimension() correct later, and we don't need it earlier.
 
-  // if (!this->is_serial())
-  //   {
-  //     unsigned char dim = this->mesh_dimension();
-  //     this->comm().max(dim);
-  //     this->set_mesh_dimension(dim);
-  //   }
 
   // Renumber the nodes and elements so that they in contiguous
   // blocks.  By default, _skip_renumber_nodes_and_elements is false.

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -125,18 +125,22 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
 {
   parallel_object_only();
 
+  libmesh_assert(this->comm().verify(this->is_serial()));
+
   // A distributed mesh may have processors with no elements (or
   // processors with no elements of higher dimension, if we ever
   // support mixed-dimension meshes), but we want consistent
   // mesh_dimension anyways.
-  libmesh_assert(this->comm().verify(this->is_serial()));
+  //
+  // cache_elem_dims() should get the elem_dimensions() and
+  // mesh_dimension() correct later, and we don't need it earlier.
 
-  if (!this->is_serial())
-    {
-      unsigned char dim = this->mesh_dimension();
-      this->comm().max(dim);
-      this->set_mesh_dimension(dim);
-    }
+  // if (!this->is_serial())
+  //   {
+  //     unsigned char dim = this->mesh_dimension();
+  //     this->comm().max(dim);
+  //     this->set_mesh_dimension(dim);
+  //   }
 
   // Renumber the nodes and elements so that they in contiguous
   // blocks.  By default, _skip_renumber_nodes_and_elements is false.
@@ -319,8 +323,16 @@ std::string MeshBase::get_info() const
   std::ostringstream oss;
 
   oss << " Mesh Information:"                                  << '\n'
-      << "  mesh_dimension()="    << this->mesh_dimension()    << '\n'
-      << "  spatial_dimension()=" << this->spatial_dimension() << '\n'
+      << "  elem_dimensions()={";
+  {
+    std::set<unsigned char>::const_iterator it =
+      this->elem_dimensions().begin();
+    if (it != this->elem_dimensions().end())
+      oss << *it;
+    for (; it != this->elem_dimensions().end(); ++it)
+      oss << ',' << *it;
+  }
+  oss << "  spatial_dimension()=" << this->spatial_dimension() << '\n'
       << "  n_nodes()="           << this->n_nodes()           << '\n'
       << "    n_local_nodes()="   << this->n_local_nodes()     << '\n'
       << "  n_elem()="            << this->n_elem()            << '\n'

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -704,14 +704,8 @@ void MeshCommunication::broadcast (MeshBase& mesh) const
                                        &mesh,
                                        mesh_inserter_iterator<Elem>(mesh));
 
-  // Make sure mesh dimension is consistent
-  // We need to set a default first because other processors mesh_dimension is empty.
-  unsigned char mesh_dimension = 1;
-  if(mesh.processor_id() == 0)
-    mesh_dimension = mesh.mesh_dimension();
-
-  mesh.comm().broadcast(mesh_dimension);
-  mesh.set_mesh_dimension(mesh_dimension);
+  // Make sure mesh_dimension and elem_dimensions are consistent.
+  mesh.cache_elem_dims();
 
   // Broadcast all of the named entity information
   mesh.comm().broadcast(mesh.set_subdomain_name_map());


### PR DESCRIPTION
There's still a lot of libMesh code that assumes we don't mix elements of different dimension, but this should fix the worst offenders.