### PR TITLE
Avoid throwing exceptions in backtrace

### DIFF
--- a/src/base/libmesh_common.C
+++ b/src/base/libmesh_common.C
@@ -63,6 +63,18 @@ void stop(const char* file, int line, const char* date, const char* time)
 
 void report_error(const char* file, int line, const char* date, const char* time)
 {
+  // It is possible to have an error *inside* report_error; e.g. from
+  // print_trace.  We don't want to infinitely recurse.
+  static bool reporting_error = false;
+  if (reporting_error)
+    {
+      // I heard you like error reporting, so we put an error report
+      // in report_error() so you can report errors from the report.
+      libMesh::err << "libMesh encountered an error while attempting to report_error." << std::endl;
+      return;
+    }
+  reporting_error = true;
+
   if (libMesh::global_n_processors() == 1 ||
       // Note: support both 'underscore' and 'dash' flavors of the option
       libMesh::on_command_line("--print_trace") ||
@@ -71,6 +83,8 @@ void report_error(const char* file, int line, const char* date, const char* time
   else
     libMesh::write_traceout();
   libMesh::MacroFunctions::here(file, line, date, time);
+
+  reporting_error = false;
 }
 
 } // namespace MacroFunctions

--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -129,12 +129,21 @@ bool gdb_backtrace(std::ostream &out_stream)
       // temporary file.
       pid_t this_pid = getpid();
 
-      std::string gdb_command =
-        libMesh::command_line_value("gdb",std::string(LIBMESH_GDB_COMMAND));
+      int exit_status = 1;
 
-      std::ostringstream command;
-      command << gdb_command << " -p " << this_pid << " -batch -ex bt 2>/dev/null 1>" << temp_file;
-      int exit_status = std::system(command.str().c_str());
+      try {
+        std::string gdb_command =
+          libMesh::command_line_value("gdb",std::string(LIBMESH_GDB_COMMAND));
+
+        std::ostringstream command;
+        command << gdb_command << " -p " << this_pid <<
+                   " -batch -ex bt 2>/dev/null 1>" << temp_file;
+        exit_status = std::system(command.str().c_str());
+      }
+      catch (...)
+      {
+        std::cerr << "Unable to run gdb" << std::endl;
+      }
 
       // If we can open the temp_file, the file is not empty, and the
       // exit status from the system call is 0, we'll assume that gdb


### PR DESCRIPTION
I just had an application go into an infinite loop when a backtrace was
called before the command line had been set up.