### PR TITLE
Don't include our METIS header when we're using PETSc's METIS

### DIFF
--- a/configure
+++ b/configure
@@ -33138,12 +33138,14 @@ fi
 
 
       if (test $enablemetis = yes); then
-     METIS_INCLUDE="-I\$(top_srcdir)/contrib/metis/include"
-     METIS_LIB="\$(EXTERNAL_LIBDIR)/libmetis\$(libext) \$(EXTERNAL_LIBDIR)/libGK\$(libext)"
+        if (test $build_metis = yes); then
+      METIS_INCLUDE="-I\$(top_srcdir)/contrib/metis/include"
+      METIS_LIB="\$(EXTERNAL_LIBDIR)/libmetis\$(libext) \$(EXTERNAL_LIBDIR)/libGK\$(libext)"
+    fi
 
 $as_echo "#define HAVE_METIS 1" >>confdefs.h
 
-     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with Metis support >>>" >&5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with Metis support >>>" >&5
 $as_echo "<<< Configuring library with Metis support >>>" >&6; }
 
 
@@ -33253,17 +33255,19 @@ fi
 
 
       if (test $enableparmetis = yes); then
-     PARMETIS_INCLUDE="-I\$(top_srcdir)/contrib/parmetis/include"
-     PARMETIS_LIB="\$(EXTERNAL_LIBDIR)/libparmetis\$(libext)"
+            if (test $build_metis = yes); then
+      PARMETIS_INCLUDE="-I\$(top_srcdir)/contrib/parmetis/include"
+      PARMETIS_LIB="\$(EXTERNAL_LIBDIR)/libparmetis\$(libext)"
+    fi
 
 $as_echo "#define HAVE_PARMETIS 1" >>confdefs.h
 
-     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with Parmetis support >>>" >&5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with Parmetis support >>>" >&5
 $as_echo "<<< Configuring library with Parmetis support >>>" >&6; }
   else
-     PARMETIS_INCLUDE=""
-     PARMETIS_LIB=""
-     enableparmetis=no
+    PARMETIS_INCLUDE=""
+    PARMETIS_LIB=""
+    enableparmetis=no
   fi
 
 

--- a/m4/metis.m4
+++ b/m4/metis.m4
@@ -28,13 +28,16 @@ AC_DEFUN([CONFIGURE_METIS],
   dnl The METIS API is distributed with libmesh, so we don't have to guess
   dnl where it might be installed...
   if (test $enablemetis = yes); then
-     METIS_INCLUDE="-I\$(top_srcdir)/contrib/metis/include"
-     METIS_LIB="\$(EXTERNAL_LIBDIR)/libmetis\$(libext) \$(EXTERNAL_LIBDIR)/libGK\$(libext)"
-     AC_DEFINE(HAVE_METIS, 1, [Flag indicating whether the library will be compiled with Metis support])
-     AC_MSG_RESULT(<<< Configuring library with Metis support >>>)
+    dnl Only put Metis contrib directories into the compiler include paths if we're building our own Metis.
+    if (test $build_metis = yes); then
+      METIS_INCLUDE="-I\$(top_srcdir)/contrib/metis/include"
+      METIS_LIB="\$(EXTERNAL_LIBDIR)/libmetis\$(libext) \$(EXTERNAL_LIBDIR)/libGK\$(libext)"
+    fi
+    AC_DEFINE(HAVE_METIS, 1, [Flag indicating whether the library will be compiled with Metis support])
+    AC_MSG_RESULT(<<< Configuring library with Metis support >>>)
 
-     dnl look for thread-local storage
-     AX_TLS
+    dnl look for thread-local storage
+    AX_TLS
  else
      METIS_INCLUDE=""
      METIS_LIB=""

--- a/m4/parmetis.m4
+++ b/m4/parmetis.m4
@@ -39,37 +39,3 @@ AC_DEFUN([CONFIGURE_PARMETIS],
   AC_SUBST(PARMETIS_INCLUDE)
   AC_SUBST(PARMETIS_LIB)
 ])
-
-
-# AC_DEFUN([CONFIGURE_PARMETIS],
-# [
-#   AC_REQUIRE([ACX_MPI])
-
-#   dnl We require a valid MPI installation for Parmetis
-#   if (test "x$MPI_IMPL" != x) ; then
-
-#     dnl need Metis for Parmetis
-#     AC_REQUIRE([CONFIGURE_METIS])
-
-#     if (test $enablemetis = yes) ; then
-#       AC_CHECK_HEADER(./contrib/parmetis/Lib/parmetis.h,
-#       	        [
-
-#       	          PARMETIS_INCLUDE_PATH=$PWD/contrib/parmetis/Lib
-#                       PARMETIS_INCLUDE=-I$PARMETIS_INCLUDE_PATH
-#                       PARMETIS_LIB="\$(EXTERNAL_LIBDIR)/libparmetis\$(libext)"
-#       		  AC_SUBST(PARMETIS_INCLUDE)
-#                       AC_SUBST(PARMETIS_LIB)
-#                       AC_DEFINE(HAVE_PARMETIS, 1,
-#       	                     [Flag indicating whether or not ParMetis is available])
-#                       AC_MSG_RESULT(<<< Configuring library with ParMetis support >>>)
-#       	          enableparmetis=yes
-#                     ],
-#                     [enableparmetis=no])
-#     else
-#       enableparmetis=no
-#     fi
-#   else
-#     enableparmetis=no
-#   fi
-# ])

--- a/m4/parmetis.m4
+++ b/m4/parmetis.m4
@@ -22,14 +22,18 @@ AC_DEFUN([CONFIGURE_PARMETIS],
   dnl The PARMETIS API is distributed with libmesh, so we don't have to guess
   dnl where it might be installed...
   if (test $enableparmetis = yes); then
-     PARMETIS_INCLUDE="-I\$(top_srcdir)/contrib/parmetis/include"
-     PARMETIS_LIB="\$(EXTERNAL_LIBDIR)/libparmetis\$(libext)"
-     AC_DEFINE(HAVE_PARMETIS, 1, [Flag indicating whether the library will be compiled with Parmetis support])
-     AC_MSG_RESULT(<<< Configuring library with Parmetis support >>>)
+    dnl We always configure for Metis before ParMetis, and we will respect the value of $build_metis
+    dnl determined there -- if we are using PETSc's Metis, we'll assume we are also using PETSc's ParMetis.
+    if (test $build_metis = yes); then
+      PARMETIS_INCLUDE="-I\$(top_srcdir)/contrib/parmetis/include"
+      PARMETIS_LIB="\$(EXTERNAL_LIBDIR)/libparmetis\$(libext)"
+    fi
+    AC_DEFINE(HAVE_PARMETIS, 1, [Flag indicating whether the library will be compiled with Parmetis support])
+    AC_MSG_RESULT(<<< Configuring library with Parmetis support >>>)
   else
-     PARMETIS_INCLUDE=""
-     PARMETIS_LIB=""
-     enableparmetis=no
+    PARMETIS_INCLUDE=""
+    PARMETIS_LIB=""
+    enableparmetis=no
   fi
 
   AC_SUBST(PARMETIS_INCLUDE)


### PR DESCRIPTION
I haven't heard back from @manavbhatia, but I think this is at least a step in the right direction as far as correctly interoperating with PETSc's METIS.  

I'm also investigating METIS bugfixes that are available in PETSc but not in METIS upstream, which is apparently no longer supported, and making METIS'  `REALTYPEWIDTH` and `IDXTYPEWIDTH` consistent with libmesh's `Real` and `dof_id_type` types, but that will be another PR...

See also #498.