### PR TITLE
VTK 6.2 linking fixes

### DIFF
--- a/configure
+++ b/configure
@@ -33921,12 +33921,18 @@ _ACEOF
                   old_LIBS="$LIBS"
          old_CPPFLAGS="$CPPFLAGS"
 
-         if (test $vtkmajor -gt 5); then
+                  if (test $vtkmajor -eq 5); then
+           VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
+
+                  elif (test $vtkmajor -eq 6 -a $vtkminor -eq 1); then
            VTK_LIBRARY="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                    -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
                                    -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor"
-         else
-           VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
+
+                  else # elif (test $vtkmajor -eq 6 -a $vtkminor -eq 2); then
+           VTK_LIBRARY="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
+                                   -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
+                                   -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor -lvtkIOParallelXML-$vtkmajorminor"
          fi
 
          if (test "x$RPATHFLAG" != "x" -a -d $VTK_LIB); then # add the VTK_LIB to the linker run path, if it is a directory
@@ -33968,7 +33974,11 @@ _ACEOF
 if ac_fn_cxx_try_link "$LINENO"; then :
   enablevtk=yes
 else
-  enablevtk=no
+
+             enablevtk=no
+                                       { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Linking a test program against the VTK libraries failed >>>" >&5
+$as_echo "<<< Linking a test program against the VTK libraries failed >>>" >&6; }
+
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -167,7 +167,13 @@ AC_DEFUN([CONFIGURE_VTK],
              vtkSmartPointer<vtkImageThreshold> threshold = vtkSmartPointer<vtkImageThreshold>::New();
                              ])
            ],
-           [enablevtk=yes], [enablevtk=no])
+           [enablevtk=yes],
+           [
+             enablevtk=no
+             dnl Print an informative message if linking failed, otherwise the user will just see:
+             dnl "Configuring library without VTK support"
+             AC_MSG_RESULT(<<< Linking a test program against the VTK libraries failed >>>)
+           ])
 
          dnl Check for VTK 5.x libraries
          else

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -127,12 +127,21 @@ AC_DEFUN([CONFIGURE_VTK],
          old_LIBS="$LIBS"
          old_CPPFLAGS="$CPPFLAGS"
 
-         if (test $vtkmajor -gt 5); then
+         dnl VTK 5.x
+         if (test $vtkmajor -eq 5); then
+           VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
+
+         dnl VTK 6.1.x
+         elif (test $vtkmajor -eq 6 -a $vtkminor -eq 1); then
            VTK_LIBRARY="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                    -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
                                    -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor"
-         else
-           VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
+
+         dnl VTK 6.2.x and above
+         else # elif (test $vtkmajor -eq 6 -a $vtkminor -eq 2); then
+           VTK_LIBRARY="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
+                                   -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
+                                   -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor -lvtkIOParallelXML-$vtkmajorminor"
          fi
 
          if (test "x$RPATHFLAG" != "x" -a -d $VTK_LIB); then # add the VTK_LIB to the linker run path, if it is a directory


### PR DESCRIPTION
This branch adds `-lvtkIOParallelXML-$vtkmajorminor` to the link line when using VTK 6.2 and higher.  It also improves the error reporting when linking a VTK test program fails.

Fixes #512.