### PR TITLE
Another ACX_MPI fallback

### DIFF
--- a/configure
+++ b/configure
@@ -809,17 +809,17 @@ SLEPC_DIR
 LIBMESH_ENABLE_PETSC_FALSE
 LIBMESH_ENABLE_PETSC_TRUE
 enablepetsc
+PETSC_FC_INCLUDES
+PETSC_CC_INCLUDES
+PETSCINCLUDEDIRS
+PETSCLINKLIBS
 MPI_INCLUDES_PATHS
 MPI_INCLUDES_PATH
 MPI_LIBS_PATHS
 MPI_LIBS_PATH
 MPI_LIBS
-MPI
 MPI_IMPL
-PETSC_FC_INCLUDES
-PETSC_CC_INCLUDES
-PETSCINCLUDEDIRS
-PETSCLINKLIBS
+MPI
 petscmajorminor
 petscmajor
 petscversion
@@ -29782,11 +29782,524 @@ $as_echo "#define HAVE_PETSC 1" >>confdefs.h
 $as_echo "#define HAVE_MPI 1" >>confdefs.h
 
           MPI_IMPL="petsc_snooped"
-  	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with MPI from PETSC config >>>" >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with MPI from PETSC config >>>" >&5
 $as_echo "<<< Configuring library with MPI from PETSC config >>>" >&6; }
         else
-  	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Warning: configuring in serial - no MPI in PETSC config >>>" >&5
-$as_echo "<<< Warning: configuring in serial - no MPI in PETSC config >>>" >&6; }
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< PETSc did not define MPIEXEC.  Will try configuring MPI now... >>>" >&5
+$as_echo "<<< PETSc did not define MPIEXEC.  Will try configuring MPI now... >>>" >&6; }
+
+
+# if MPIHOME is empty, set it to /usr
+if (test "x$MPIHOME" = x) ; then
+  MPIHOME="/usr"
+fi
+
+
+# Check whether --with-mpi was given.
+if test "${with_mpi+set}" = set; then :
+  withval=$with_mpi; MPI="$withval"
+else
+
+              echo "note: MPI library path not given... trying prefix=$MPIHOME"
+	      MPI=$MPIHOME
+
+fi
+
+
+if test -z "$MPI"; then
+	MPI="/usr"
+fi
+
+
+
+MPI_LIBS_PATH="$MPI/lib"
+MPI_INCLUDES_PATH="$MPI/include"
+
+# Check that the compiler uses the library we specified...
+
+# look for LAM or other MPI implementation
+if (test -e $MPI_LIBS_PATH/libmpi.a || test -e $MPI_LIBS_PATH/libmpi.so) ; then
+	echo "note: using $MPI_LIBS_PATH/libmpi(.a/.so)"
+
+
+	# Ensure the comiler finds the library...
+	tmpLIBS=$LIBS
+
+	ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+	LIBS="-L$MPI_LIBS_PATH $LIBS"
+
+	# look for lam_version_show in liblam.(a/so)
+	# (this is needed in addition to libmpi.(a/so) for
+        # LAM MPI
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for lam_show_version in -llam" >&5
+$as_echo_n "checking for lam_show_version in -llam... " >&6; }
+if ${ac_cv_lib_lam_lam_show_version+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-llam  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char lam_show_version ();
+int
+main ()
+{
+return lam_show_version ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_lib_lam_lam_show_version=yes
+else
+  ac_cv_lib_lam_lam_show_version=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_lam_lam_show_version" >&5
+$as_echo "$ac_cv_lib_lam_lam_show_version" >&6; }
+if test "x$ac_cv_lib_lam_lam_show_version" = xyes; then :
+
+                       LIBS="-llam $LIBS"
+                       MPI_LIBS="-llam $MPI_LIBS"
+
+fi
+
+
+	# Quadricss MPI requires the elan library to be included too
+	if (nm $MPI_LIBS_PATH/libmpi.* | grep elan > /dev/null); then
+	  echo "note: MPI found to use Quadrics switch, looking for elan library"
+		 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for elan_init in -lelan" >&5
+$as_echo_n "checking for elan_init in -lelan... " >&6; }
+if ${ac_cv_lib_elan_elan_init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lelan  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char elan_init ();
+int
+main ()
+{
+return elan_init ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_lib_elan_elan_init=yes
+else
+  ac_cv_lib_elan_elan_init=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_elan_elan_init" >&5
+$as_echo "$ac_cv_lib_elan_elan_init" >&6; }
+if test "x$ac_cv_lib_elan_elan_init" = xyes; then :
+
+                                LIBS="-lelan $LIBS"
+                                MPI_LIBS="-lelan $MPI_LIBS"
+
+else
+  as_fn_error $? "Could not find elan library... exiting " "$LINENO" 5
+fi
+
+	fi
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for MPI_Init in -lmpi" >&5
+$as_echo_n "checking for MPI_Init in -lmpi... " >&6; }
+if ${ac_cv_lib_mpi_MPI_Init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lmpi  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char MPI_Init ();
+int
+main ()
+{
+return MPI_Init ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_lib_mpi_MPI_Init=yes
+else
+  ac_cv_lib_mpi_MPI_Init=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_mpi_MPI_Init" >&5
+$as_echo "$ac_cv_lib_mpi_MPI_Init" >&6; }
+if test "x$ac_cv_lib_mpi_MPI_Init" = xyes; then :
+
+		       MPI_LIBS="-lmpi $MPI_LIBS"
+	               MPI_LIBS_PATHS="-L$MPI_LIBS_PATH"
+	               MPI_IMPL="mpi"
+                       { $as_echo "$as_me:${as_lineno-$LINENO}: result: Found valid MPI installlaion..." >&5
+$as_echo "Found valid MPI installlaion..." >&6; }
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: Could not link in the MPI library..." >&5
+$as_echo "Could not link in the MPI library..." >&6; }; enablempi=no
+fi
+
+
+	ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+	LIBS=$tmpLIBS
+fi
+
+if (test -e $MPI_LIBS_PATH/libmpich.a || test -e $MPI_LIBS_PATH/libmpich.so) ; then
+	echo "note: using $MPI_LIBS_PATH/libmpich(.a/.so)"
+
+	# Ensure the comiler finds the library...
+	tmpLIBS=$LIBS
+
+	ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+	LIBS="-L$MPI_LIBS_PATH $LIBS"
+
+	# Myricomm MPICH requires the gm library to be included too
+	if (nm $MPI_LIBS_PATH/libmpich.* | grep gm_open > /dev/null); then
+	  echo "note: MPICH found to use Myricomm's Myrinet, looking for gm library"
+
+          if (test "x$GMHOME" = x) ; then
+            GMHOME="/usr"
+          fi
+
+# Check whether --with-gm was given.
+if test "${with_gm+set}" = set; then :
+  withval=$with_gm; GM="$withval"
+else
+
+                        echo "note: GM library path not given... trying prefix=$MPIHOME"
+	                GM=$GMHOME
+
+fi
+
+
+          LIBS="-L$GM/lib $LIBS"
+          MPI_LIBS="-L$GM/lib $MPI_LIBS"
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gm_open in -lgm" >&5
+$as_echo_n "checking for gm_open in -lgm... " >&6; }
+if ${ac_cv_lib_gm_gm_open+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lgm  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char gm_open ();
+int
+main ()
+{
+return gm_open ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_lib_gm_gm_open=yes
+else
+  ac_cv_lib_gm_gm_open=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gm_gm_open" >&5
+$as_echo "$ac_cv_lib_gm_gm_open" >&6; }
+if test "x$ac_cv_lib_gm_gm_open" = xyes; then :
+
+                         LIBS="$LIBS -lgm"
+                         MPI_LIBS="$MPI_LIBS -lgm"
+
+else
+  as_fn_error $? "Could not find gm library... exiting " "$LINENO" 5
+fi
+
+	fi
+
+	# look for MPI_Init in libmpich.(a/so)
+        # try adding libmpl if we see it there; some MPICH2 versions
+        # require it.
+	if (test -e $MPI_LIBS_PATH/libmpl.a || test -e $MPI_LIBS_PATH/libmpl.so) ; then
+		LIBS="-L$MPI_LIBS_PATH -lmpl $tmpLIBS"
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for MPI_Init in -lmpich" >&5
+$as_echo_n "checking for MPI_Init in -lmpich... " >&6; }
+if ${ac_cv_lib_mpich_MPI_Init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lmpich  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char MPI_Init ();
+int
+main ()
+{
+return MPI_Init ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_lib_mpich_MPI_Init=yes
+else
+  ac_cv_lib_mpich_MPI_Init=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_mpich_MPI_Init" >&5
+$as_echo "$ac_cv_lib_mpich_MPI_Init" >&6; }
+if test "x$ac_cv_lib_mpich_MPI_Init" = xyes; then :
+
+			       MPI_LIBS="-lmpich -lmpl $MPI_LIBS"
+			       MPI_LIBS_PATHS="-L$MPI_LIBS_PATH"
+		               MPI_IMPL="mpich"
+       	                { $as_echo "$as_me:${as_lineno-$LINENO}: result: Found valid MPICH installation with libmpl..." >&5
+$as_echo "Found valid MPICH installation with libmpl..." >&6; }
+
+else
+
+       	                { $as_echo "$as_me:${as_lineno-$LINENO}: result: Could not link in the MPI library..." >&5
+$as_echo "Could not link in the MPI library..." >&6; }; enablempi=no
+
+fi
+
+	else
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for MPI_Init in -lmpich" >&5
+$as_echo_n "checking for MPI_Init in -lmpich... " >&6; }
+if ${ac_cv_lib_mpich_MPI_Init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lmpich  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char MPI_Init ();
+int
+main ()
+{
+return MPI_Init ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_lib_mpich_MPI_Init=yes
+else
+  ac_cv_lib_mpich_MPI_Init=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_mpich_MPI_Init" >&5
+$as_echo "$ac_cv_lib_mpich_MPI_Init" >&6; }
+if test "x$ac_cv_lib_mpich_MPI_Init" = xyes; then :
+
+			       MPI_LIBS="-lmpich $MPI_LIBS"
+			       MPI_LIBS_PATHS="-L$MPI_LIBS_PATH"
+		               MPI_IMPL="mpich"
+       	                { $as_echo "$as_me:${as_lineno-$LINENO}: result: Found valid MPICH installation..." >&5
+$as_echo "Found valid MPICH installation..." >&6; }
+
+else
+
+       	                { $as_echo "$as_me:${as_lineno-$LINENO}: result: Could not link in the MPI library..." >&5
+$as_echo "Could not link in the MPI library..." >&6; }; enablempi=no
+
+fi
+
+	fi
+
+	ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+	LIBS=$tmpLIBS
+fi
+
+if (test "x$MPI_IMPL" != x) ; then
+
+	# Ensure the comiler finds the header file...
+	if test -e $MPI_INCLUDES_PATH/mpi.h; then
+		echo "note: using $MPI_INCLUDES_PATH/mpi.h"
+		tmpCPPFLAGS=$CPPFLAGS
+
+		ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+		CPPFLAGS="-I$MPI_INCLUDES_PATH $CPPFLAGS"
+		ac_fn_cxx_check_header_mongrel "$LINENO" "mpi.h" "ac_cv_header_mpi_h" "$ac_includes_default"
+if test "x$ac_cv_header_mpi_h" = xyes; then :
+
+$as_echo "#define HAVE_MPI 1" >>confdefs.h
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: Could not compile in the MPI headers..." >&5
+$as_echo "Could not compile in the MPI headers..." >&6; }; enablempi=no
+fi
+
+
+		MPI_INCLUDES_PATHS="-I$MPI_INCLUDES_PATH"
+		ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+		CPPFLAGS=$tmpCPPFLAGS
+	elif test -e $MPI_INCLUDES_PATH/mpi/mpi.h; then
+		MPI_INCLUDES_PATH=$MPI_INCLUDES_PATH/mpi
+		echo "note: using $MPI_INCLUDES_PATH/mpi.h"
+		tmpCPPFLAGS=$CPPFLAGS
+
+		ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+		CPPFLAGS="-I$MPI_INCLUDES_PATH $CPPFLAGS"
+		ac_fn_cxx_check_header_mongrel "$LINENO" "mpi.h" "ac_cv_header_mpi_h" "$ac_includes_default"
+if test "x$ac_cv_header_mpi_h" = xyes; then :
+
+$as_echo "#define HAVE_MPI 1" >>confdefs.h
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: Could not compile in the MPI headers..." >&5
+$as_echo "Could not compile in the MPI headers..." >&6; }; enablempi=no
+fi
+
+
+		MPI_INCLUDES_PATHS="-I$MPI_INCLUDES_PATH"
+		ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+		CPPFLAGS=$tmpCPPFLAGS
+	else
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: Could not find MPI header <mpi.h>..." >&5
+$as_echo "Could not find MPI header <mpi.h>..." >&6; }
+                enablempi=no
+	fi
+else
+
+	# no MPI install found, see if the compiler supports it
+      	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <mpi.h>
+int
+main ()
+{
+int np; MPI_Comm_size (MPI_COMM_WORLD, &np);
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+	                 MPI_IMPL="built-in"
+                         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CXX Compiler Supports MPI " >&5
+$as_echo "$CXX Compiler Supports MPI " >&6; }
+
+$as_echo "#define HAVE_MPI 1" >>confdefs.h
+
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CXX Compiler Does NOT Support MPI..." >&5
+$as_echo "$CXX Compiler Does NOT Support MPI..." >&6; }; enablempi=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+
+# Save variables...
+
+
+
+
+
+
+
+
         fi
 
         # Print informative message about the version of PETSc we detected

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -116,9 +116,10 @@ AC_DEFUN([CONFIGURE_PETSC],
           AC_DEFINE(HAVE_MPI, 1,
     	        [Flag indicating whether or not MPI is available])
           MPI_IMPL="petsc_snooped"
-  	AC_MSG_RESULT(<<< Configuring library with MPI from PETSC config >>>)
+          AC_MSG_RESULT(<<< Configuring library with MPI from PETSC config >>>)
         else
-  	AC_MSG_RESULT(<<< Warning: configuring in serial - no MPI in PETSC config >>>)
+          AC_MSG_RESULT(<<< PETSc did not define MPIEXEC.  Will try configuring MPI now... >>>)
+          ACX_MPI
         fi
 
         # Print informative message about the version of PETSc we detected


### PR DESCRIPTION
We currently end up in an inconsistent state when configuring against the repo libpetsc3.4.2-dev on Ubuntu 14.10 - PETSc is there, and configured with MPI, but doesn't define MPIEXEC, so we assume it's configured in serial, and we don't try to detect MPI.

This PR fixes the configure for me, by trying ACX_MPI in that case.  It's possible that this PR will *break* cases in which the user has an autodetectable MPI but wants to configure against a mpiuni PETSc, but in those cases "--with-mpi=false" ought to be an adequate workaround.