### PR TITLE
Shape function second derivatives on non-affine elements

### DIFF
--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -783,6 +783,13 @@ protected:
    * Jacobian*Weight values at quadrature points
    */
   std::vector<Real> JxW;
+
+private:
+  /**
+   * A helper function used by FEMap::compute_single_point_map() to
+   * second derivatives of the inverse map.
+   */
+  void compute_inverse_map_second_derivs(unsigned p);
 };
 
 }

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -266,6 +266,26 @@ public:
   const std::vector<Real>& get_dzetadz() const
   { return dzetadz_map; }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+  /**
+   * Second derivatives of "xi" reference coordinate wrt physical coordinates.
+   */
+  const std::vector<std::vector<Real> >& get_d2xidxyz2() const
+  { return d2xidxyz2_map; }
+
+  /**
+   * Second derivatives of "eta" reference coordinate wrt physical coordinates.
+   */
+  const std::vector<std::vector<Real> >& get_d2etadxyz2() const
+  { return d2etadxyz2_map; }
+
+  /**
+   * Second derivatives of "zeta" reference coordinate wrt physical coordinates.
+   */
+  const std::vector<std::vector<Real> >& get_d2zetadxyz2() const
+  { return d2zetadxyz2_map; }
+#endif
+
   /**
    * @returns the reference to physical map for the side/edge
    */
@@ -624,6 +644,26 @@ protected:
    * d(zeta)/d(z). Needed for the Jacobian.
    */
   std::vector<Real> dzetadz_map;
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+  /**
+   * Second derivatives of "xi" reference coordinate wrt physical coordinates.
+   * At each qp: (xi_{xx}, xi_{xy}, xi_{xz}, xi_{yy}, xi_{yz}, xi_{zz})
+   */
+  std::vector<std::vector<Real> > d2xidxyz2_map;
+
+  /**
+   * Second derivatives of "eta" reference coordinate wrt physical coordinates.
+   * At each qp: (eta_{xx}, eta_{xy}, eta_{xz}, eta_{yy}, eta_{yz}, eta_{zz})
+   */
+  std::vector<std::vector<Real> > d2etadxyz2_map;
+
+  /**
+   * Second derivatives of "zeta" reference coordinate wrt physical coordinates.
+   * At each qp: (zeta_{xx}, zeta_{xy}, zeta_{xz}, zeta_{yy}, zeta_{yz}, zeta_{zz})
+   */
+  std::vector<std::vector<Real> > d2zetadxyz2_map;
+#endif
 
   /**
    * Map for the shape function phi.

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -787,7 +787,7 @@ protected:
 private:
   /**
    * A helper function used by FEMap::compute_single_point_map() to
-   * second derivatives of the inverse map.
+   * compute second derivatives of the inverse map.
    */
   void compute_inverse_map_second_derivs(unsigned p);
 };

--- a/include/fe/fe_transformation_base.h
+++ b/include/fe/fe_transformation_base.h
@@ -79,7 +79,6 @@ public:
    * finite element transformation.
    */
   virtual void map_d2phi( const unsigned int dim,
-                          const Elem* const elem,
                           const std::vector<Point>& qp,
                           const FEGenericBase<OutputShape>& fe,
                           std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> >& d2phi,

--- a/include/fe/h1_fe_transformation.h
+++ b/include/fe/h1_fe_transformation.h
@@ -72,7 +72,6 @@ public:
    *        The second derivative terms of the FEMap are not implemented.
    */
   virtual void map_d2phi( const unsigned int dim,
-                          const Elem* const elem,
                           const std::vector<Point>& qp,
                           const FEGenericBase<OutputShape>& fe,
                           std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> >& d2phi,

--- a/include/fe/hcurl_fe_transformation.h
+++ b/include/fe/hcurl_fe_transformation.h
@@ -73,7 +73,6 @@ public:
    * finite element transformation.
    */
   virtual void map_d2phi( const unsigned int /*dim*/,
-                          const Elem* const /*elem*/,
                           const std::vector<Point>& /*qp*/,
                           const FEGenericBase<OutputShape>& /*fe*/,
                           std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> >& /*d2phi*/,

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -726,7 +726,7 @@ void FEGenericBase<OutputType> ::compute_shape_functions (const Elem* elem,
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   if( calculate_d2phi )
-    this->_fe_trans->map_d2phi( this->dim, elem, qp, (*this), this->d2phi,
+    this->_fe_trans->map_d2phi( this->dim, qp, (*this), this->d2phi,
                                 this->d2phidx2, this->d2phidxdy, this->d2phidxdz,
                                 this->d2phidy2, this->d2phidydz, this->d2phidz2 );
 #endif //LIBMESH_ENABLE_SECOND_DERIVATIVES

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -340,6 +340,8 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         dxyzdxi_map[p].zero();
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         d2xyzdxi2_map[p].zero();
+        // Inverse map second derivatives
+        d2xidxyz2_map[p].assign(6, 0.);
 #endif
 
         // compute x, dx, d2x at the quadrature point
@@ -414,6 +416,9 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         d2xyzdxi2_map[p].zero();
         d2xyzdxideta_map[p].zero();
         d2xyzdeta2_map[p].zero();
+        // Inverse map second derivatives
+        d2xidxyz2_map[p].assign(6, 0.);
+        d2etadxyz2_map[p].assign(6, 0.);
 #endif
 
 
@@ -560,6 +565,10 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         d2xyzdeta2_map[p].zero();
         d2xyzdetadzeta_map[p].zero();
         d2xyzdzeta2_map[p].zero();
+        // Inverse map second derivatives
+        d2xidxyz2_map[p].assign(6, 0.);
+        d2etadxyz2_map[p].assign(6, 0.);
+        d2zetadxyz2_map[p].assign(6, 0.);
 #endif
 
 
@@ -656,6 +665,12 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
   dxidz_map.resize(n_qp); // ... or 3D
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   d2xyzdxi2_map.resize(n_qp);
+
+  // Inverse map second derivatives
+  d2xidxyz2_map.resize(n_qp);
+  for (unsigned i=0; i<d2xidxyz2_map.size(); ++i)
+    d2xidxyz2_map[i].assign(6, 0.);
+
 #endif
   if (dim > 1)
     {
@@ -666,6 +681,11 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
       d2xyzdxideta_map.resize(n_qp);
       d2xyzdeta2_map.resize(n_qp);
+
+      // Inverse map second derivatives
+      d2etadxyz2_map.resize(n_qp);
+      for (unsigned i=0; i<d2etadxyz2_map.size(); ++i)
+        d2etadxyz2_map[i].assign(6, 0.);
 #endif
       if (dim > 2)
         {
@@ -677,6 +697,11 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
           d2xyzdxidzeta_map.resize(n_qp);
           d2xyzdetadzeta_map.resize(n_qp);
           d2xyzdzeta2_map.resize(n_qp);
+
+          // Inverse map second derivatives
+          d2zetadxyz2_map.resize(n_qp);
+          for (unsigned i=0; i<d2zetadxyz2_map.size(); ++i)
+            d2zetadxyz2_map[i].assign(6, 0.);
 #endif
         }
     }

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -395,6 +395,77 @@ void FEMap::compute_single_point_map(const unsigned int dim,
 
         JxW[p] = jac[p]*qw[p];
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
+#if LIBMESH_DIM == 1
+        // Compute inverse map second derivatives for 1D-element-living-in-1D case
+        this->compute_inverse_map_second_derivs(p);
+#elif LIBMESH_DIM == 2
+        // Compute inverse map second derivatives for 1D-element-living-in-2D case
+        // See JWP notes for details
+
+        // numer = x_xi*x_{xi xi} + y_xi*y_{xi xi}
+        Real numer =
+          dxyzdxi_map[p](0)*d2xyzdxi2_map[p](0) +
+          dxyzdxi_map[p](1)*d2xyzdxi2_map[p](1);
+
+        // denom = (x_xi)^2 + (y_xi)^2 must be >= 0.0
+        Real denom =
+          dxyzdxi_map[p](0)*dxyzdxi_map[p](0) +
+          dxyzdxi_map[p](1)*dxyzdxi_map[p](1);
+
+        if (denom <= 0.0)
+          libmesh_error_msg("Encountered invalid 1D element!");
+
+        // xi_{x x}
+        d2xidxyz2_map[p][0] = -numer * dxidx_map[p]*dxidx_map[p] / denom;
+
+        // xi_{x y}
+        d2xidxyz2_map[p][1] = -numer * dxidx_map[p]*dxidy_map[p] / denom;
+
+        // xi_{y y}
+        d2xidxyz2_map[p][3] = -numer * dxidy_map[p]*dxidy_map[p] / denom;
+
+#elif LIBMESH_DIM == 3
+        // Compute inverse map second derivatives for 1D-element-living-in-3D case
+        // See JWP notes for details
+
+        // numer = x_xi*x_{xi xi} + y_xi*y_{xi xi} + z_xi*z_{xi xi}
+        Real numer =
+          dxyzdxi_map[p](0)*d2xyzdxi2_map[p](0) +
+          dxyzdxi_map[p](1)*d2xyzdxi2_map[p](1) +
+          dxyzdxi_map[p](2)*d2xyzdxi2_map[p](2);
+
+        // denom = (x_xi)^2 + (y_xi)^2 + (z_xi)^2 must be >= 0.0
+        Real denom =
+          dxyzdxi_map[p](0)*dxyzdxi_map[p](0) +
+          dxyzdxi_map[p](1)*dxyzdxi_map[p](1) +
+          dxyzdxi_map[p](2)*dxyzdxi_map[p](2);
+
+        if (denom <= 0.0)
+          libmesh_error_msg("Encountered invalid 1D element!");
+
+        // xi_{x x}
+        d2xidxyz2_map[p][0] = -numer * dxidx_map[p]*dxidx_map[p] / denom;
+
+        // xi_{x y}
+        d2xidxyz2_map[p][1] = -numer * dxidx_map[p]*dxidy_map[p] / denom;
+
+        // xi_{x z}
+        d2xidxyz2_map[p][2] = -numer * dxidx_map[p]*dxidz_map[p] / denom;
+
+        // xi_{y y}
+        d2xidxyz2_map[p][3] = -numer * dxidy_map[p]*dxidy_map[p] / denom;
+
+        // xi_{y z}
+        d2xidxyz2_map[p][4] = -numer * dxidy_map[p]*dxidz_map[p] / denom;
+
+        // xi_{z z}
+        d2xidxyz2_map[p][5] = -numer * dxidz_map[p]*dxidz_map[p] / denom;
+#endif
+
+#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
+
         // done computing the map
         break;
       }

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -1107,9 +1107,8 @@ void FEMap::compute_inverse_map_second_derivs(unsigned p)
     dzeta(0.,            0.,            0.);
 
   // In 2D, we have xx, xy, and yy second derivatives
-  valid_indices.insert(0);
-  valid_indices.insert(1);
-  valid_indices.insert(3);
+  const unsigned tmp[3] = {0,1,3};
+  valid_indices.insert(tmp, tmp+3);
 
 #elif LIBMESH_DIM==3
   RealTensor
@@ -1131,12 +1130,8 @@ void FEMap::compute_inverse_map_second_derivs(unsigned p)
     dzeta(dzetadx_map[p], dzetady_map[p], dzetadz_map[p]);
 
   // In 3D, we have xx, xy, xz, yy, yz, and zz second derivatives
-  valid_indices.insert(0);
-  valid_indices.insert(1);
-  valid_indices.insert(2);
-  valid_indices.insert(3);
-  valid_indices.insert(4);
-  valid_indices.insert(5);
+  const unsigned tmp[6] = {0,1,2,3,4,5};
+  valid_indices.insert(tmp, tmp+6);
 
 #endif
 
@@ -1146,7 +1141,7 @@ void FEMap::compute_inverse_map_second_derivs(unsigned p)
   for (unsigned s=0; s<3; ++s)
     for (unsigned t=s; t<3; ++t)
       {
-        if (std::find(valid_indices.begin(), valid_indices.end(), ctr) != valid_indices.end())
+        if (valid_indices.count(ctr))
           {
             RealVectorValue
               v1(dxi(s)*dxi(t),

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -224,16 +224,6 @@ void H1FETransformation<OutputShape>::map_d2phi( const unsigned int dim,
                                                  std::vector<std::vector<OutputShape> >& d2phidydz,
                                                  std::vector<std::vector<OutputShape> >& d2phidz2  ) const
 {
-  libmesh_do_once(
-                  if (!elem->has_affine_map())
-                    {
-                      libMesh::err << "WARNING: Second derivatives are not currently "
-                                   << "correctly calculated on non-affine elements!"
-                                   << std::endl;
-                    }
-                  );
-
-
   switch (dim)
     {
     case 0: // No derivatives in 0D

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -213,7 +213,6 @@ void H1FETransformation<OutputShape>::map_dphi( const unsigned int dim,
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template< typename OutputShape >
 void H1FETransformation<OutputShape>::map_d2phi( const unsigned int dim,
-                                                 const Elem* const elem,
                                                  const std::vector<Point>&,
                                                  const FEGenericBase<OutputShape>& fe,
                                                  std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> >& d2phi,


### PR DESCRIPTION
This is a very old branch that I created a long time ago with @roystgnr and @pbauman but never quite got merged into master.  Here's a basic [description](https://drive.google.com/file/d/0B9BK7pg8se_iWm9XenJSd0p5Z0k/view?usp=sharing) of what was implemented back then.

I have now tested it fairly extensively using this [code](https://gist.github.com/jwpeterson/a085afd592feca73f81f) and am pretty confident it's working.  The main idea of the test code is to verify the second derivatives on distorted elements by central differencing the first derivatives and ensuring that the result converges at second order in the differencing parameter, epsilon.  An example of the convergence results for the Pyramid14 element is available [here](https://drive.google.com/file/d/0B9BK7pg8se_iREN2djg5blNpVmc/view?usp=sharing).  Similar convergence results hold for the other geometric element types.