### PR TITLE
Better ParameterAccessor::operator=

### DIFF
--- a/include/systems/parameter_accessor.h
+++ b/include/systems/parameter_accessor.h
@@ -69,7 +69,8 @@ public:
    * This is included for backward compatibility, but will be
    * deprecated in some classes and not implemented in others.
    */
-  virtual void operator= (T * /* new_ptr */) { libmesh_error(); }
+  virtual ParameterAccessor<T> &
+  operator= (T * /* new_ptr */) { libmesh_error(); return *this; }
 
   /**
    * Proxy: for backward compatibility, we allow codes to treat a

--- a/include/systems/parameter_multipointer.h
+++ b/include/systems/parameter_multipointer.h
@@ -51,6 +51,12 @@ public:
   ParameterMultiPointer(T * param_ptr) : _ptrs(1, param_ptr) {}
 
   /**
+   * A simple reseater won't work with a multipointer
+   */
+  virtual ParameterAccessor<T> &
+  operator= (T * /* new_ptr */) { libmesh_error(); return *this; }
+
+  /**
    * Setter: change the value of the parameter we access.
    */
   virtual void set (const T & new_value)

--- a/include/systems/parameter_pointer.h
+++ b/include/systems/parameter_pointer.h
@@ -58,7 +58,8 @@ public:
    * Reseater: change the location of the parameter we access.
    * This is included for backward compatibility, but is deprecated.
    */
-  virtual void operator= (T * new_ptr) { libmesh_deprecated(); _ptr = new_ptr; }
+  virtual ParameterAccessor<T> &
+  operator= (T * new_ptr) { libmesh_deprecated(); _ptr = new_ptr; return *this; }
 
 private:
   T* _ptr;


### PR DESCRIPTION
This ought to extend backwards compatibility a bit, and be more in
line from what people expect operator= to return.  It also fixes a
overloaded method warning when I compile parameter_multipointer.h

I'll merge this right away when MooseBuild is happy; it's a simple change that shouldn't even touch anyone not using sensitivity solves.