### PR TITLE
Cleaned up some of the reduced basis code.

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex5/run.sh
+++ b/examples/reduced_basis/reduced_basis_ex5/run.sh
@@ -8,7 +8,7 @@ example_name=reduced_basis_ex5
 
 example_dir=examples/reduced_basis/$example_name
 
-options="-online_mode 0 "
+options="-online_mode 0 -ksp_type cg"
 run_example "$example_name" "$options"
 
 options="-online_mode 1"

--- a/include/reduced_basis/transient_rb_construction.h
+++ b/include/reduced_basis/transient_rb_construction.h
@@ -326,10 +326,10 @@ protected:
   virtual void initialize_truth();
 
   /**
-   * Override to use the L2 product matrix for output
+   * Override to return the L2 product matrix for output
    * dual norm solves for transient state problems.
    */
-  virtual void assemble_matrix_for_output_dual_solves();
+  virtual SparseMatrix<Number>& get_matrix_for_output_dual_solves();
 
   /**
    * Initialize RB space by adding the truth initial condition


### PR DESCRIPTION
- Added RBConstruction::solve_for_matrix_and_rhs so that we can more easily mix and match solvers
and matrices. This resulted in a simplification to how we call the solvers, and how we set
reuse_preconditioner
- Removed a bunch of old unused code related to constraints (e.g. matrix that imposes incompressibility).
This code wasn't well tested anymore. If someone wants to add it back in, better to put it in a subclass
of RBConstruction.