### PR TITLE
AdjointRefinement::estimate_error, Check if user already solved adjoint problem

### DIFF
--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -134,7 +134,9 @@ void AdjointRefinementEstimator::estimate_error (const System& _system,
   // adjoint Dirichlet conditions.
 
   // Solve the adjoint problem(s) on the coarse FE space
-  system.adjoint_solve(_qoi_set);
+  // Only if the user didn't already solve it for us
+  if (!system.is_adjoint_already_solved())
+     system.adjoint_solve(_qoi_set);
 
 
   // Loop over all the adjoint problems and, if any have heterogenous


### PR DESCRIPTION
When computing the AdjointRefinement::estimate_error, we solve
the adjoint problem on the coarse space first. But, the user may
have already computed this, so we should check.

I got identical results between adjoints/ex4 before and after this change, but that's the only thing I've checked.