### PR TITLE
ErrorEstimatorType

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -544,6 +544,7 @@ include_HEADERS = \
         enums/enum_eigen_solver_type.h \
         enums/enum_elem_quality.h \
         enums/enum_elem_type.h \
+        enums/enum_error_estimator_type.h \
         enums/enum_fe_family.h \
         enums/enum_inf_map_type.h \
         enums/enum_io_package.h \

--- a/include/enums/enum_error_estimator_type.h
+++ b/include/enums/enum_error_estimator_type.h
@@ -1,0 +1,38 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_ENUM_ERROR_ESTIMATOR_TYPE_H
+#define LIBMESH_ENUM_ERROR_ESTIMATOR_TYPE_H
+
+namespace libMesh {
+
+  enum ErrorEstimatorType {INVALID                 = -1,
+                           ADJOINT_REFINEMENT      =  0,
+                           ADJOINT_RESIDUAL        =  1,
+                           DISCONTINUITY_MEASURE   =  2,
+                           EXACT                   =  3,
+                           KELLY                   =  4,
+                           LAPLACIAN               =  5,
+                           PATCH_RECOVERY          =  6,
+                           WEIGHTED_PATCH_RECOVERY =  7,
+                           UNIFORM_REFINEMENT      =  8};
+
+} // end namespace libMesh
+
+#endif // LIBMESH_ENUM_ERROR_ESTIMATOR_TYPE_H

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -108,6 +108,9 @@ public:
     return computed_global_QoI_errors[qoi_index];
   }
 
+  virtual ErrorEstimatorType type() const
+  { return ADJOINT_REFINEMENT;}
+
   /**
    * How many h refinements to perform to get the fine grid
    */

--- a/include/error_estimation/adjoint_residual_error_estimator.h
+++ b/include/error_estimation/adjoint_residual_error_estimator.h
@@ -112,6 +112,9 @@ public:
                        const NumericVector<Number>* solution_vector = NULL,
                        bool estimate_parent_error = false);
 
+  virtual ErrorEstimatorType type() const
+  { return ADJOINT_RESIDUAL;}
+
 protected:
 
   /**

--- a/include/error_estimation/discontinuity_measure.h
+++ b/include/error_estimation/discontinuity_measure.h
@@ -72,6 +72,9 @@ public:
                                                                const Point& p,
                                                                const std::string& var_name));
 
+  virtual ErrorEstimatorType type() const
+  { return DISCONTINUITY_MEASURE;}
+
 protected:
 
   /**

--- a/include/error_estimation/error_estimator.h
+++ b/include/error_estimation/error_estimator.h
@@ -24,6 +24,7 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parallel.h"
 #include "libmesh/system_norm.h"
+#include "libmesh/enum_error_estimator_type.h"
 
 // C++ includes
 #include <cstddef>
@@ -125,6 +126,11 @@ public:
                                 ErrorMap& errors_per_cell,
                                 const std::map<const System*, const NumericVector<Number>* >* solution_vectors = NULL,
                                 bool estimate_parent_error = false);
+
+  /**
+   * Returns the type for the ErrorEstimator subclass.
+   */
+  virtual ErrorEstimatorType type() const = 0;
 
   /**
    * When estimating the error in a single system, the \p error_norm

--- a/include/error_estimation/exact_error_estimator.h
+++ b/include/error_estimation/exact_error_estimator.h
@@ -185,6 +185,9 @@ public:
                                const NumericVector<Number>* solution_vector = NULL,
                                bool estimate_parent_error = false);
 
+  virtual ErrorEstimatorType type() const
+  { return EXACT;}
+
 private:
 
   /**

--- a/include/error_estimation/fourth_error_estimators.h
+++ b/include/error_estimation/fourth_error_estimators.h
@@ -60,6 +60,9 @@ public:
    */
   ~LaplacianErrorEstimator() {}
 
+  virtual ErrorEstimatorType type() const
+  { return LAPLACIAN;}
+
 protected:
 
   /**

--- a/include/error_estimation/kelly_error_estimator.h
+++ b/include/error_estimation/kelly_error_estimator.h
@@ -87,6 +87,9 @@ public:
                                                           const Point& p,
                                                           const std::string& var_name));
 
+  virtual ErrorEstimatorType type() const
+  { return KELLY;}
+
 protected:
 
   /**

--- a/include/error_estimation/patch_recovery_error_estimator.h
+++ b/include/error_estimation/patch_recovery_error_estimator.h
@@ -93,6 +93,9 @@ public:
 
   void set_patch_reuse (bool );
 
+  virtual ErrorEstimatorType type() const
+  { return PATCH_RECOVERY;}
+
 protected:
 
   /**

--- a/include/error_estimation/uniform_refinement_estimator.h
+++ b/include/error_estimation/uniform_refinement_estimator.h
@@ -107,6 +107,9 @@ public:
                                 const std::map<const System*, const NumericVector<Number>* >* solution_vectors = NULL,
                                 bool estimate_parent_error = false);
 
+  virtual ErrorEstimatorType type() const
+  { return UNIFORM_REFINEMENT;}
+
   /**
    * How many h refinements to perform to get the fine grid
    */

--- a/include/error_estimation/weighted_patch_recovery_error_estimator.h
+++ b/include/error_estimation/weighted_patch_recovery_error_estimator.h
@@ -81,6 +81,9 @@ public:
   */
   std::vector<FEMFunctionBase<Number>*> weight_functions;
 
+  virtual ErrorEstimatorType type() const
+  { return WEIGHTED_PATCH_RECOVERY;}
+
 private:
 
   /**

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -49,6 +49,7 @@ include_HEADERS =  \
         enums/enum_eigen_solver_type.h \
         enums/enum_elem_quality.h \
         enums/enum_elem_type.h \
+        enums/enum_error_estimator_type.h \
         enums/enum_fe_family.h \
         enums/enum_inf_map_type.h \
         enums/enum_io_package.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -38,6 +38,7 @@ BUILT_SOURCES = \
         enum_eigen_solver_type.h \
         enum_elem_quality.h \
         enum_elem_type.h \
+        enum_error_estimator_type.h \
         enum_fe_family.h \
         enum_inf_map_type.h \
         enum_io_package.h \
@@ -593,6 +594,9 @@ enum_elem_quality.h: $(top_srcdir)/include/enums/enum_elem_quality.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 enum_elem_type.h: $(top_srcdir)/include/enums/enum_elem_type.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+enum_error_estimator_type.h: $(top_srcdir)/include/enums/enum_error_estimator_type.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 enum_fe_family.h: $(top_srcdir)/include/enums/enum_fe_family.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -442,11 +442,12 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	single_predicates.h sparsity_pattern.h variable.h \
 	variant_filter_iterator.h enum_convergence_flags.h \
 	enum_eigen_solver_type.h enum_elem_quality.h enum_elem_type.h \
-	enum_fe_family.h enum_inf_map_type.h enum_io_package.h \
-	enum_norm_type.h enum_order.h enum_parallel_type.h \
-	enum_point_locator_type.h enum_preconditioner_type.h \
-	enum_quadrature_type.h enum_solver_package.h \
-	enum_solver_type.h enum_subset_solve_mode.h enum_xdr_mode.h \
+	enum_error_estimator_type.h enum_fe_family.h \
+	enum_inf_map_type.h enum_io_package.h enum_norm_type.h \
+	enum_order.h enum_parallel_type.h enum_point_locator_type.h \
+	enum_preconditioner_type.h enum_quadrature_type.h \
+	enum_solver_package.h enum_solver_type.h \
+	enum_subset_solve_mode.h enum_xdr_mode.h \
 	adjoint_refinement_estimator.h \
 	adjoint_residual_error_estimator.h discontinuity_measure.h \
 	error_estimator.h exact_error_estimator.h exact_solution.h \
@@ -898,6 +899,9 @@ enum_elem_quality.h: $(top_srcdir)/include/enums/enum_elem_quality.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 enum_elem_type.h: $(top_srcdir)/include/enums/enum_elem_type.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+enum_error_estimator_type.h: $(top_srcdir)/include/enums/enum_error_estimator_type.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 enum_fe_family.h: $(top_srcdir)/include/enums/enum_fe_family.h


### PR DESCRIPTION
It is useful for app codes to be able to query the error estimator type from the base class pointer. This PR adds the enum `ErrorEstimatorType` and an interface in the `ErrorEstimator` classes that returns the appropriate `ErrorEstimatorType`.