### PR TITLE
Residual evaluation needs System::init_context()

### DIFF
--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -476,6 +476,9 @@ public:
         }
 #endif
 
+    if (have_some_heterogenous_qoi_bc)
+      _sys.init_context(_femcontext);
+
     for (ConstElemRange::const_iterator elem_it = range.begin();
          elem_it != range.end(); ++elem_it)
       {
@@ -609,6 +612,9 @@ public:
             have_some_heterogenous_qoi_bc = true;
           }
 #endif
+
+    if (have_some_heterogenous_qoi_bc)
+      _sys.init_context(_femcontext);
 
     for (ConstElemRange::const_iterator elem_it = range.begin();
          elem_it != range.end(); ++elem_it)


### PR DESCRIPTION
Without this call, cases with only adjoint-based QoIs were using
the inefficient context code path, and cases with a mix of standard-
and adjoint-based- QoIs could potentially error() or segfault.

Going to merge this as soon as MooseBuild is happy.