### PR TITLE
old_local_nonlinear_solution is only in UnsteadySolver now

### DIFF
--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -258,11 +258,6 @@ protected:
   sys_type& _system;
 
   /**
-   * Serial vector of _system.get_vector("_old_nonlinear_solution")
-   */
-  UniquePtr<NumericVector<Number> > old_local_nonlinear_solution;
-
-  /**
    * An UniquePtr to a SolutionHistory object. Default is
    * NoSolutionHistory, which the user can override by declaring a
    * different kind of SolutionHistory in the application


### PR DESCRIPTION
The shadowed version in TimeSolver wasn't even being initialized.