### PR TITLE
Empty mesh fixes

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1036,6 +1036,7 @@ void DofMap::create_dof_constraints(const MeshBase& mesh, Real time)
   // We might get constraint equations from AMR hanging nodes in 2D/3D
   // or from boundary conditions in any dimension
   const bool possible_local_constraints = false
+    || !mesh.n_elem()
 #ifdef LIBMESH_ENABLE_AMR
     || mesh.mesh_dimension() > 1
 #endif

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -117,8 +117,9 @@ MeshBase::~MeshBase()
 
 unsigned int MeshBase::mesh_dimension() const
 {
-  libmesh_assert(!_elem_dims.empty());
-  return cast_int<unsigned int>(*_elem_dims.rbegin());
+  if (!_elem_dims.empty())
+    return cast_int<unsigned int>(*_elem_dims.rbegin());
+  return 0;
 }
 
 void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, const bool skip_find_neighbors)


### PR DESCRIPTION
I'm not sure why the FIN-S regression tests ever try to compute constraints on an empty mesh, but now they can get past that point without failure.