### PR TITLE
Add test for cxx11 alias declarations

### DIFF
--- a/configure
+++ b/configure
@@ -6699,6 +6699,10 @@ else
     // at compile time.
     constexpr int multiply (int x, int y) { return x * y; }
 
+    // A minimally-conforming C++11 compiler must support alias declarations
+    template <typename T>
+    using MyCheck = check<T>;
+
 _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
   ax_cv_cxx_compile_cxx11=yes
@@ -6748,6 +6752,10 @@ else
     // const int val = multiply(10, 10);
     // at compile time.
     constexpr int multiply (int x, int y) { return x * y; }
+
+    // A minimally-conforming C++11 compiler must support alias declarations
+    template <typename T>
+    using MyCheck = check<T>;
 
 _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
@@ -6807,6 +6815,10 @@ else
     // const int val = multiply(10, 10);
     // at compile time.
     constexpr int multiply (int x, int y) { return x * y; }
+
+    // A minimally-conforming C++11 compiler must support alias declarations
+    template <typename T>
+    using MyCheck = check<T>;
 
 _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -59,6 +59,10 @@ m4_define([_AX_CXX_COMPILE_STDCXX_11_testbody], [[
     // const int val = multiply(10, 10);
     // at compile time.
     constexpr int multiply (int x, int y) { return x * y; }
+
+    // A minimally-conforming C++11 compiler must support alias declarations
+    template <typename T>
+    using MyCheck = check<T>;
 ]])
 
 AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl


### PR DESCRIPTION
I think these are sometimes conflated with template typedefs, e.g.
```
typedef check<int> check_type;
```
but the syntax is different and they are different features as far as I can tell...