### PR TITLE
Allow UniquePtr to be used in properly-namespaced code

### DIFF
--- a/contrib/unique_ptr/unique_ptr.hpp
+++ b/contrib/unique_ptr/unique_ptr.hpp
@@ -132,7 +132,7 @@ typename enable_if_c
 >::type
 forward(typename detail_unique_ptr::identity<T>::type& t)
 {
-    return move(t);
+    return boost::move(t);
 }
 
 template <class T>
@@ -144,7 +144,7 @@ typename enable_if_c
 >::type
 forward(const typename detail_unique_ptr::identity<T>::type& t)
 {
-    return move(const_cast<T&>(t));
+    return boost::move(const_cast<T&>(t));
 }
 
 namespace detail_unique_ptr {
@@ -167,10 +167,10 @@ public:
     unique_ptr_storage() : t1_(), t2_() {}
 
     explicit unique_ptr_storage(T1 t1)
-        : t1_(move(t1)), t2_() {}
+        : t1_(boost::move(t1)), t2_() {}
 
     unique_ptr_storage(T1 t1, T2 t2)
-        : t1_(move(t1)), t2_(forward<T2>(t2)) {}
+        : t1_(boost::move(t1)), t2_(boost::forward<T2>(t2)) {}
 
           T1& first()       {return t1_;}
     const T1& first() const {return t1_;}
@@ -194,10 +194,10 @@ public:
     unique_ptr_storage() : t1_() {}
 
     explicit unique_ptr_storage(T1 t1)
-        : t1_(move(t1)) {}
+        : t1_(boost::move(t1)) {}
 
     unique_ptr_storage(T1 t1, T2 t2)
-        : t2_(move(t2)), t1_(move(t1)) {}
+        : t2_(boost::move(t2)), t1_(boost::move(t1)) {}
 
           T1& first()       {return t1_;}
     const T1& first() const {return t1_;}
@@ -321,11 +321,11 @@ private:
 
 public:
     operator detail_unique_ptr::rv<unique_ptr>() {return detail_unique_ptr::rv<unique_ptr>(*this);}
-    unique_ptr(detail_unique_ptr::rv<unique_ptr> r) : ptr_(r->release(), forward<deleter_type>(r->get_deleter())) {}
+    unique_ptr(detail_unique_ptr::rv<unique_ptr> r) : ptr_(r->release(), boost::forward<deleter_type>(r->get_deleter())) {}
     unique_ptr& operator=(detail_unique_ptr::rv<unique_ptr> r)
     {
         reset(r->release());
-        ptr_.second() = move(r->get_deleter());
+        ptr_.second() = boost::move(r->get_deleter());
         return *this;
     }
 
@@ -344,7 +344,7 @@ public:
 
     unique_ptr(pointer p, typename mpl::if_<is_reference<D>,
                           volatile typename remove_reference<D>::type&, D>::type d)
-        : ptr_(move(p), forward<D>(const_cast<typename add_reference<D>::type>(d))) {}
+        : ptr_(boost::move(p), boost::forward<D>(const_cast<typename add_reference<D>::type>(d))) {}
 
     template <class U, class E>
         unique_ptr(unique_ptr<U, E> u,
@@ -358,7 +358,7 @@ public:
                      is_same<deleter_type, E>::value
                 )
                 >::type* = 0)
-            : ptr_(u.release(), forward<D>(forward<E>(u.get_deleter()))) {}
+          : ptr_(u.release(), boost::forward<D>(boost::forward<E>(u.get_deleter()))) {}
 
     ~unique_ptr() {reset();}
 
@@ -373,7 +373,7 @@ public:
         operator=(unique_ptr<U, E> u)
         {
             reset(u.release());
-            ptr_.second() = move(u.get_deleter());
+            ptr_.second() = boost::move(u.get_deleter());
             return *this;
         }
 
@@ -423,11 +423,11 @@ private:
 
 public:
     operator detail_unique_ptr::rv<unique_ptr>() {return detail_unique_ptr::rv<unique_ptr>(*this);}
-    unique_ptr(detail_unique_ptr::rv<unique_ptr> r) : ptr_(r->release(), forward<deleter_type>(r->get_deleter())) {}
+    unique_ptr(detail_unique_ptr::rv<unique_ptr> r) : ptr_(r->release(), boost::forward<deleter_type>(r->get_deleter())) {}
     unique_ptr& operator=(detail_unique_ptr::rv<unique_ptr> r)
     {
         reset(r->release());
-        ptr_.second() = move(r->get_deleter());
+        ptr_.second() = boost::move(r->get_deleter());
         return *this;
     }
 
@@ -446,7 +446,7 @@ public:
 
     unique_ptr(pointer p, typename mpl::if_<is_reference<D>,
                           volatile typename remove_reference<D>::type&, D>::type d)
-        : ptr_(move(p), forward<D>(const_cast<typename add_reference<D>::type>(d))) {}
+        : ptr_(boost::move(p), boost::forward<D>(const_cast<typename add_reference<D>::type>(d))) {}
 
     ~unique_ptr() {reset();}
 

--- a/contrib/unique_ptr/unique_ptr.hpp
+++ b/contrib/unique_ptr/unique_ptr.hpp
@@ -291,6 +291,15 @@ struct pointer_type
 
 }  // detail_unique_ptr
 
+#ifdef LIBMESH_IS_COMPILING_HINNANT_UNIQUE_PTR
+} // namespace boost
+
+namespace libMesh {
+
+// Note: Bring in boost namespace
+using namespace ::boost;
+#endif
+
 template <class T, class D = default_delete<T> >
 class unique_ptr
 {
@@ -473,6 +482,15 @@ private:
                           volatile typename remove_reference<D>::type&, D>::type,
                           typename enable_if_c<detail_unique_ptr::is_convertible<U, pointer>::value>::type* = 0);
 };
+
+#ifdef LIBMESH_IS_COMPILING_HINNANT_UNIQUE_PTR
+} // namespace libMesh
+
+
+namespace boost {
+
+using libMesh::unique_ptr;
+#endif
 
 template<class T, class D>
 inline

--- a/contrib/unique_ptr/unique_ptr.hpp
+++ b/contrib/unique_ptr/unique_ptr.hpp
@@ -296,23 +296,22 @@ struct pointer_type
 
 namespace libMesh {
 
-// Note: Bring in boost namespace
-using namespace ::boost;
 #endif
 
-template <class T, class D = default_delete<T> >
+template <class T, class D = boost::default_delete<T> >
 class unique_ptr
 {
 public:
     typedef T element_type;
     typedef D deleter_type;
-    typedef typename detail_unique_ptr::pointer_type<element_type, deleter_type>::type pointer;
+    typedef typename boost::detail_unique_ptr::pointer_type<element_type, deleter_type>::type pointer;
 
 private:
-    detail_unique_ptr::unique_ptr_storage<pointer, deleter_type> ptr_;
+    boost::detail_unique_ptr::unique_ptr_storage<pointer, deleter_type> ptr_;
 
-    typedef typename add_reference<deleter_type>::type deleter_reference;
-    typedef typename add_reference<const deleter_type>::type deleter_const_reference;
+    typedef typename boost::add_reference<deleter_type>::type deleter_reference;
+    typedef typename boost::add_reference<const deleter_type>::type deleter_const_reference;
+    typedef typename boost::detail_unique_ptr::rv<unique_ptr> rv;
 
     struct nat {int for_bool_;};
 
@@ -320,9 +319,9 @@ private:
     unique_ptr& operator=(unique_ptr&);
 
 public:
-    operator detail_unique_ptr::rv<unique_ptr>() {return detail_unique_ptr::rv<unique_ptr>(*this);}
-    unique_ptr(detail_unique_ptr::rv<unique_ptr> r) : ptr_(r->release(), boost::forward<deleter_type>(r->get_deleter())) {}
-    unique_ptr& operator=(detail_unique_ptr::rv<unique_ptr> r)
+    operator rv() {return rv(*this);}
+    unique_ptr(rv r) : ptr_(r->release(), boost::forward<deleter_type>(r->get_deleter())) {}
+    unique_ptr& operator=(rv r)
     {
         reset(r->release());
         ptr_.second() = boost::move(r->get_deleter());
@@ -331,31 +330,31 @@ public:
 
     unique_ptr()
         {
-            BOOST_STATIC_ASSERT(!is_reference<deleter_type>::value);
-            BOOST_STATIC_ASSERT(!is_pointer<deleter_type>::value);
+            BOOST_STATIC_ASSERT(!boost::is_reference<deleter_type>::value);
+            BOOST_STATIC_ASSERT(!boost::is_pointer<deleter_type>::value);
         }
 
     explicit unique_ptr(pointer p)
         : ptr_(p)
         {
-            BOOST_STATIC_ASSERT(!is_reference<deleter_type>::value);
-            BOOST_STATIC_ASSERT(!is_pointer<deleter_type>::value);
+            BOOST_STATIC_ASSERT(!boost::is_reference<deleter_type>::value);
+            BOOST_STATIC_ASSERT(!boost::is_pointer<deleter_type>::value);
         }
 
-    unique_ptr(pointer p, typename mpl::if_<is_reference<D>,
-                          volatile typename remove_reference<D>::type&, D>::type d)
-        : ptr_(boost::move(p), boost::forward<D>(const_cast<typename add_reference<D>::type>(d))) {}
+    unique_ptr(pointer p, typename boost::mpl::if_<boost::is_reference<D>,
+               volatile typename boost::remove_reference<D>::type&, D>::type d)
+      : ptr_(boost::move(p), boost::forward<D>(const_cast<typename boost::add_reference<D>::type>(d))) {}
 
     template <class U, class E>
         unique_ptr(unique_ptr<U, E> u,
-            typename enable_if_c
+                   typename boost::enable_if_c
                 <
                 !boost::is_array<U>::value &&
-                detail_unique_ptr::is_convertible<typename unique_ptr<U>::pointer, pointer>::value &&
-                detail_unique_ptr::is_convertible<E, deleter_type>::value &&
+                boost::detail_unique_ptr::is_convertible<typename unique_ptr<U>::pointer, pointer>::value &&
+                boost::detail_unique_ptr::is_convertible<E, deleter_type>::value &&
                 (
-                    !is_reference<deleter_type>::value ||
-                     is_same<deleter_type, E>::value
+                    !boost::is_reference<deleter_type>::value ||
+                    boost::is_same<deleter_type, E>::value
                 )
                 >::type* = 0)
           : ptr_(u.release(), boost::forward<D>(boost::forward<E>(u.get_deleter()))) {}
@@ -377,7 +376,7 @@ public:
             return *this;
         }
 
-    typename add_reference<T>::type operator*() const {return *get();}
+    typename boost::add_reference<T>::type operator*() const {return *get();}
     pointer operator->() const {return get();}
     pointer get() const {return ptr_.first();}
     deleter_reference       get_deleter()       {return ptr_.second();}
@@ -399,7 +398,7 @@ public:
         return tmp;
     }
 
-    void swap(unique_ptr& u) {detail_unique_ptr::swap(ptr_, u.ptr_);}
+    void swap(unique_ptr& u) {boost::detail_unique_ptr::swap(ptr_, u.ptr_);}
 };
 
 template <class T, class D>
@@ -408,13 +407,14 @@ class unique_ptr<T[], D>
 public:
     typedef T element_type;
     typedef D deleter_type;
-    typedef typename detail_unique_ptr::pointer_type<element_type, deleter_type>::type pointer;
+    typedef typename boost::detail_unique_ptr::pointer_type<element_type, deleter_type>::type pointer;
 
 private:
-    detail_unique_ptr::unique_ptr_storage<pointer, deleter_type> ptr_;
+    boost::detail_unique_ptr::unique_ptr_storage<pointer, deleter_type> ptr_;
 
-    typedef typename add_reference<deleter_type>::type deleter_reference;
-    typedef typename add_reference<const deleter_type>::type deleter_const_reference;
+    typedef typename boost::add_reference<deleter_type>::type deleter_reference;
+    typedef typename boost::add_reference<const deleter_type>::type deleter_const_reference;
+    typedef typename boost::detail_unique_ptr::rv<unique_ptr> rv;
 
     struct nat {int for_bool_;};
 
@@ -422,9 +422,9 @@ private:
     unique_ptr& operator=(unique_ptr&);
 
 public:
-    operator detail_unique_ptr::rv<unique_ptr>() {return detail_unique_ptr::rv<unique_ptr>(*this);}
-    unique_ptr(detail_unique_ptr::rv<unique_ptr> r) : ptr_(r->release(), boost::forward<deleter_type>(r->get_deleter())) {}
-    unique_ptr& operator=(detail_unique_ptr::rv<unique_ptr> r)
+    operator rv() {return rv(*this);}
+    unique_ptr(rv r) : ptr_(r->release(), boost::forward<deleter_type>(r->get_deleter())) {}
+    unique_ptr& operator=(rv r)
     {
         reset(r->release());
         ptr_.second() = boost::move(r->get_deleter());
@@ -433,20 +433,20 @@ public:
 
     unique_ptr()
         {
-            BOOST_STATIC_ASSERT(!is_reference<deleter_type>::value);
-            BOOST_STATIC_ASSERT(!is_pointer<deleter_type>::value);
+            BOOST_STATIC_ASSERT(!boost::is_reference<deleter_type>::value);
+            BOOST_STATIC_ASSERT(!boost::is_pointer<deleter_type>::value);
         }
 
     explicit unique_ptr(pointer p)
         : ptr_(p)
         {
-            BOOST_STATIC_ASSERT(!is_reference<deleter_type>::value);
-            BOOST_STATIC_ASSERT(!is_pointer<deleter_type>::value);
+            BOOST_STATIC_ASSERT(!boost::is_reference<deleter_type>::value);
+            BOOST_STATIC_ASSERT(!boost::is_pointer<deleter_type>::value);
         }
 
-    unique_ptr(pointer p, typename mpl::if_<is_reference<D>,
-                          volatile typename remove_reference<D>::type&, D>::type d)
-        : ptr_(boost::move(p), boost::forward<D>(const_cast<typename add_reference<D>::type>(d))) {}
+  unique_ptr(pointer p, typename boost::mpl::if_<boost::is_reference<D>,
+             volatile typename boost::remove_reference<D>::type&, D>::type d)
+    : ptr_(boost::move(p), boost::forward<D>(const_cast<typename boost::add_reference<D>::type>(d))) {}
 
     ~unique_ptr() {reset();}
 
@@ -471,16 +471,16 @@ public:
         return tmp;
     }
 
-    void swap(unique_ptr& u) {detail_unique_ptr::swap(ptr_, u.ptr_);}
+    void swap(unique_ptr& u) {boost::detail_unique_ptr::swap(ptr_, u.ptr_);}
 private:
     template <class U>
         explicit unique_ptr(U,
-            typename enable_if_c<detail_unique_ptr::is_convertible<U, pointer>::value>::type* = 0);
+                            typename boost::enable_if_c<boost::detail_unique_ptr::is_convertible<U, pointer>::value>::type* = 0);
 
     template <class U>
-        unique_ptr(U, typename mpl::if_<is_reference<D>,
-                          volatile typename remove_reference<D>::type&, D>::type,
-                          typename enable_if_c<detail_unique_ptr::is_convertible<U, pointer>::value>::type* = 0);
+    unique_ptr(U, typename boost::mpl::if_<boost::is_reference<D>,
+               volatile typename boost::remove_reference<D>::type&, D>::type,
+               typename boost::enable_if_c<boost::detail_unique_ptr::is_convertible<U, pointer>::value>::type* = 0);
 };
 
 #ifdef LIBMESH_IS_COMPILING_HINNANT_UNIQUE_PTR

--- a/examples/reduced_basis/reduced_basis_ex1/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex1/rb_classes.h
@@ -34,6 +34,7 @@ using libMesh::FEMContext;
 using libMesh::RBConstruction;
 using libMesh::RBEvaluation;
 using libMesh::Real;
+using libMesh::UniquePtr;
 
 
 // A simple subclass of RBEvaluation, which just needs to specify

--- a/examples/reduced_basis/reduced_basis_ex2/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex2/rb_classes.h
@@ -40,6 +40,7 @@ using libMesh::RBThetaExpansion;
 using libMesh::RBAssemblyExpansion;
 using libMesh::DirichletBoundary;
 using libMesh::Real;
+using libMesh::UniquePtr;
 
 // local include
 #include "assembly.h"

--- a/examples/reduced_basis/reduced_basis_ex3/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex3/rb_classes.h
@@ -35,6 +35,7 @@ using libMesh::RBEvaluation;
 using libMesh::Real;
 using libMesh::TransientRBEvaluation;
 using libMesh::TransientRBConstruction;
+using libMesh::UniquePtr;
 
 
 // A simple subclass of RBEvaluation, which just needs to specify

--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -9,6 +9,7 @@
 // Just the bits we're using, since this is a header.
 using libMesh::EquationSystems;
 using libMesh::RBEIMEvaluation;
+using libMesh::UniquePtr;
 
 // A simple subclass of RBEIMEvaluation. Overload
 // evaluate_parametrized_function to define the

--- a/examples/reduced_basis/reduced_basis_ex4/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/rb_classes.h
@@ -28,6 +28,7 @@
 using libMesh::DirichletBoundary;
 using libMesh::RBConstruction;
 using libMesh::RBEvaluation;
+using libMesh::UniquePtr;
 
 // A simple subclass of RBEvaluation.
 class SimpleRBEvaluation : public RBEvaluation

--- a/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
@@ -34,6 +34,7 @@ using libMesh::FEMContext;
 using libMesh::RBConstruction;
 using libMesh::RBEvaluation;
 using libMesh::Real;
+using libMesh::UniquePtr;
 
 
 // A simple subclass of RBEvaluation, which just needs to specify

--- a/include/base/auto_ptr.h
+++ b/include/base/auto_ptr.h
@@ -36,18 +36,32 @@
 // upgrading.
 #ifdef LIBMESH_ENABLE_UNIQUE_PTR
 #ifdef LIBMESH_HAVE_CXX11_UNIQUE_PTR
+// If C++11 std::unique_ptr is available, alias declarations are also
+// guaranteed to be available.
 #  include <memory>
-#  define UniquePtr std::unique_ptr
+namespace libMesh
+{
+  template<typename T>
+  using UniquePtr = std::unique_ptr<T>;
+}
 #elif LIBMESH_HAVE_HINNANT_UNIQUE_PTR
+// In libmesh, we modify the unique_ptr.hpp file slightly to place the
+// boost::unique_ptr type into the libMesh namespace.  This
+// allows for properly namespaced code, i.e. libMesh::UniquePtr, to
+// work correctly.  We've used #ifdefs to cleanly separate our changes
+// from the original unique_ptr.hpp file.
+#  ifndef LIBMESH_IS_COMPILING_HINNANT_UNIQUE_PTR
+#  define LIBMESH_IS_COMPILING_HINNANT_UNIQUE_PTR
+#  endif
 #  include "libmesh/unique_ptr.hpp"
-#  define UniquePtr boost::unique_ptr
+#  define UniquePtr unique_ptr
 #else
-#  define UniquePtr libMesh::AutoPtr
+#  define UniquePtr AutoPtr
 #endif
 #else
 // libMesh was configured with --disable-unique-ptr, so we'll use
 // libMesh's AutoPtr class instead.
-#define UniquePtr libMesh::AutoPtr
+#define UniquePtr AutoPtr
 #endif
 
 namespace libMesh

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -79,15 +79,15 @@ EXTERN_C_FOR_PETSC_END
 // Local anonymous namespace to hold miscelaneous bits
 namespace {
 
-UniquePtr<GetPot> command_line;
-UniquePtr<std::ofstream> _ofstream;
+libMesh::UniquePtr<GetPot> command_line;
+libMesh::UniquePtr<std::ofstream> _ofstream;
 // If std::cout and std::cerr are redirected, we need to
 // be a little careful and save the original streambuf objects,
 // replacing them in the destructor before program termination.
 std::streambuf* out_buf (NULL);
 std::streambuf* err_buf (NULL);
 
-UniquePtr<libMesh::Threads::task_scheduler_init> task_scheduler;
+libMesh::UniquePtr<libMesh::Threads::task_scheduler_init> task_scheduler;
 #if defined(LIBMESH_HAVE_MPI)
 bool libmesh_initialized_mpi = false;
 #endif


### PR DESCRIPTION
This is similar to @francesco-ballarin's solution in #529 except that instead of text-replacing `boost::unique_ptr` to UniquePtr, we add `unique_ptr` to the libMesh namespace.  This solution is a bit less invasive, and the original unique_ptr.hpp header is recovered if you don't `#define LIBMESH_IS_COMPILING_HINNANT_UNIQUE_PTR` when including it.  Also fixed a few ambiguous uses of `boost::move` and `boost::forward` triggered by the clang 3.5.0 compiler.
