### PR TITLE
Attempted nonfullorder fix

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -2284,18 +2284,27 @@ ElemType Elem::second_order_equivalent_type (const ElemType et,
   switch (et)
     {
     case EDGE2:
+    case EDGE3:
       {
         // full_ordered not relevant
         return EDGE3;
       }
 
+    case EDGE4:
+      {
+        // full_ordered not relevant
+        return EDGE4;
+      }
+
     case TRI3:
+    case TRI6:
       {
         // full_ordered not relevant
         return TRI6;
       }
 
     case QUAD4:
+    case QUAD8:
       {
         if (full_ordered)
           return QUAD9;
@@ -2303,13 +2312,21 @@ ElemType Elem::second_order_equivalent_type (const ElemType et,
           return QUAD8;
       }
 
+    case QUAD9:
+      {
+        // full_ordered not relevant
+        return QUAD9;
+      }
+
     case TET4:
+    case TET10:
       {
         // full_ordered not relevant
         return TET10;
       }
 
     case HEX8:
+    case HEX20:
       {
         // see below how this correlates with INFHEX8
         if (full_ordered)
@@ -2318,7 +2335,14 @@ ElemType Elem::second_order_equivalent_type (const ElemType et,
           return HEX20;
       }
 
+    case HEX27:
+      {
+        // full_ordered not relevant
+        return HEX27;
+      }
+
     case PRISM6:
+    case PRISM15:
       {
         if (full_ordered)
           return PRISM18;
@@ -2326,14 +2350,25 @@ ElemType Elem::second_order_equivalent_type (const ElemType et,
           return PRISM15;
       }
 
+    case PRISM18:
+      {
+        // full_ordered not relevant
+        return PRISM18;
+      }
+
     case PYRAMID5:
+    case PYRAMID13:
       {
         if (full_ordered)
           return PYRAMID14;
         else
           return PYRAMID13;
+      }
 
-        return INVALID_ELEM;
+    case PYRAMID14:
+      {
+        // full_ordered not relevant
+        return PYRAMID14;
       }
 
 
@@ -2347,12 +2382,14 @@ ElemType Elem::second_order_equivalent_type (const ElemType et,
       }
 
     case INFQUAD4:
+    case INFQUAD6:
       {
         // full_ordered not relevant
         return INFQUAD6;
       }
 
     case INFHEX8:
+    case INFHEX16:
       {
         /*
          * Note that this matches with \p Hex8:
@@ -2366,7 +2403,14 @@ ElemType Elem::second_order_equivalent_type (const ElemType et,
           return INFHEX16;
       }
 
+    case INFHEX18:
+      {
+        // full_ordered not relevant
+        return INFHEX18;
+      }
+
     case INFPRISM6:
+    case INFPRISM12:
       {
         // full_ordered not relevant
         return INFPRISM12;
@@ -2377,8 +2421,8 @@ ElemType Elem::second_order_equivalent_type (const ElemType et,
 
     default:
       {
-        // second-order element
-        return INVALID_ELEM;
+        // what did we miss?
+        libmesh_error();
       }
     }
 }

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1798,6 +1798,43 @@ Elem::parent_bracketing_nodes(unsigned int child,
   // embedding matrix yet, let's do so now.
   if (cached_bracketing_nodes[em_vers].size() < nc)
     {
+      // If we're a second-order element but we're not a full-order
+      // element, then some of our bracketing nodes may not exist
+      // except on the equivalent full-order element.  Let's build an
+      // equivalent full-order element and make a copy of its cache to
+      // use.
+      if (this->default_order() != FIRST &&
+          second_order_equivalent_type
+            (this->type(), /*full_ordered=*/ true) !=
+          this->type())
+        {
+          // Check that we really are the non-full-order type
+          libmesh_assert_equal_to
+            (second_order_equivalent_type (this->type(), false),
+             this->type());
+
+          // Build the full-order type
+          ElemType full_type = 
+            second_order_equivalent_type
+              (this->type(), /*full_ordered=*/ true);
+          UniquePtr<Elem> full_elem = Elem::build(full_type);
+
+          // This won't work for elements with multiple
+          // embedding_matrix versions, but every such element is full
+          // order anyways.
+          libmesh_assert_equal_to(em_vers, 0);
+
+          // Make sure its cache has been built
+          full_elem->parent_bracketing_nodes(0,0);
+
+          // Copy its cache
+          cached_bracketing_nodes =
+            full_elem->_get_bracketing_node_cache();
+
+          // Now we don't need to build the cache ourselves.
+          return cached_bracketing_nodes[em_vers][child][child_node];
+        }
+
       cached_bracketing_nodes[em_vers].resize(nc);
 
       const unsigned int nn = this->n_nodes();
@@ -1941,7 +1978,73 @@ Elem::bracketing_nodes(unsigned int child,
     this->parent_bracketing_nodes(child,child_node);
 
   for (unsigned int i = 0; i != pbc.size(); ++i)
-    returnval.push_back(std::make_pair(this->node(pbc[i].first), this->node(pbc[i].second)));
+    {
+      if (pbc[i].first < this->n_nodes() &&
+          pbc[i].second < this->n_nodes())
+        returnval.push_back(std::make_pair(this->node(pbc[i].first), this->node(pbc[i].second)));
+      else
+        {
+          // We must be on a non-full-order higher order element...
+          libmesh_assert_not_equal_to(this->default_order(), FIRST);
+          libmesh_assert_not_equal_to
+            (second_order_equivalent_type (this->type(), true),
+             this->type());
+          libmesh_assert_equal_to
+            (second_order_equivalent_type (this->type(), false),
+             this->type());
+
+          // And that's a shame, because this is a nasty search:
+
+          // Build the full-order type
+          ElemType full_type = 
+            second_order_equivalent_type
+              (this->type(), /*full_ordered=*/ true);
+          UniquePtr<Elem> full_elem = Elem::build(full_type);
+
+          dof_id_type pt1 = DofObject::invalid_id;
+          dof_id_type pt2 = DofObject::invalid_id;
+
+          // Find the bracketing nodes by figuring out what
+          // already-created children will have them.
+
+          // This only doesn't break horribly because we add children
+          // and nodes in straightforward + hierarchical orders...
+          for (unsigned int c=0; c <= child; ++c)
+            for (unsigned int n=0; n != this->n_nodes_in_child(c); ++n)
+              {
+                if (c == child && n == child_node)
+                  break;
+
+                if (pbc[i].first == full_elem->as_parent_node(c,n))
+                  {
+                    // We should be consistent
+                    if (pt1 != DofObject::invalid_id)
+                      libmesh_assert_equal_to
+                        (pt1, this->child(c)->node(n));
+
+                    pt1 = this->child(c)->node(n);
+                  }
+
+                if (pbc[i].second == full_elem->as_parent_node(c,n))
+                  {
+                    // We should be consistent
+                    if (pt2 != DofObject::invalid_id)
+                      libmesh_assert_equal_to
+                        (pt2, this->child(c)->node(n));
+
+                    pt2 = this->child(c)->node(n);
+                  }
+              }
+
+          // We should always find all bracketing nodes by the time
+          // we query them (again, because of the child & node add
+          // order)
+          libmesh_assert_not_equal_to (pt1, DofObject::invalid_id);
+          libmesh_assert_not_equal_to (pt2, DofObject::invalid_id);
+
+          returnval.push_back(std::make_pair(pt1, pt2));
+        }
+    }
 
   return returnval;
 }

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1891,7 +1891,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh& mesh,
 
 
   // Convert to second-order elements if the user requested it.
-  if (Elem::second_order_equivalent_type(type) == INVALID_ELEM)
+  if (Elem::default_order(type) != FIRST)
     {
       // type is already a second-order, determine if it is the
       // "full-ordered" second-order element, or the "serendipity"

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1891,7 +1891,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh& mesh,
 
 
   // Convert to second-order elements if the user requested it.
-  if (Elem::default_order(type) != FIRST)
+  if (Elem::build(type)->default_order() != FIRST)
     {
       // type is already a second-order, determine if it is the
       // "full-ordered" second-order element, or the "serendipity"


### PR DESCRIPTION
As discovered in https://github.com/idaholab/moose/issues/4966 - https://github.com/libMesh/libmesh/pull/492 causes regressions when refining meshes with non-full-order second-order elements.

This "fallback" code path in the Elem::*bracketing_nodes() methods should hopefully fix that.  I'm not nearly done with my own testing yet, but I'm setting up the PR right away to get MooseBuild looking at it in parallel with me.

Regardless of what MooseBuild says, this shouldn't be merged until I've had time to hammer it with at least QUAD8 and a few of the 3D non-full-order options.