### PR TITLE
Fix an issue with MeshBase::elem_dimensions().

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -444,12 +444,18 @@ public:
    * To add an element locally, set e->processor_id() before adding it.
    * To ensure a specific element id, call e->set_id() before adding it;
    * only do this in parallel if you are manually keeping ids consistent.
+   *
+   * Users should call MeshBase::prepare_for_use() after elements are
+   * added to and/or deleted from the mesh.
    */
   virtual Elem* add_elem (Elem* e) = 0;
 
   /**
    * Insert elem \p e to the element array, preserving its id
    * and replacing/deleting any existing element with the same id.
+   *
+   * Users should call MeshBase::prepare_for_use() after elements are
+   * added to and/or deleted from the mesh.
    */
   virtual Elem* insert_elem (Elem* e) = 0;
 
@@ -458,6 +464,9 @@ public:
    * method may produce isolated nodes, i.e. nodes not connected
    * to any element.  This method must be implemented in derived classes
    * in such a way that it does not invalidate element iterators.
+   *
+   * Users should call MeshBase::prepare_for_use() after elements are
+   * added to and/or deleted from the mesh.
    */
   virtual void delete_elem (Elem* e) = 0;
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -502,6 +502,10 @@ void MeshBase::cache_elem_dims()
   // This requires an inspection on every processor
   parallel_object_only();
 
+  // Need to clear _elem_dims first in case all elements of a
+  // particular dimension have been deleted.
+  _elem_dims.clear();
+
   const_element_iterator el  = this->active_local_elements_begin();
   const_element_iterator end = this->active_local_elements_end();
 


### PR DESCRIPTION
If all elements of dimension d are deleted from a mesh, then MeshBase::elem_dimensions() still returned
d as one of the dimensions in the mesh. The fix was just to clear _elem_dims at the start of MeshBase::cache_elem_dims().