### PR TITLE
Don't compute second derivative-specific values when second derivatives ...

### DIFF
--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -52,15 +52,14 @@ public:
    * single point with index p.  Takes the integration weights as
    * input, along with a pointer to the element and a list of points
    * that contribute to the element.  Also takes a boolean flag
-   * telling whether the element has an affine map to enable various
-   * optimizations.
+   * telling whether second derivatives should actually be computed.
    */
   void compute_single_point_map(const unsigned int dim,
                                 const std::vector<Real>& qw,
                                 const Elem* elem,
                                 unsigned int p,
                                 const std::vector<Node*>& elem_nodes,
-                                bool elem_is_affine);
+                                bool compute_second_derivatives);
 
   /**
    * Compute the jacobian and some other additional
@@ -85,10 +84,14 @@ public:
    * Compute the jacobian and some other additional
    * data fields. Takes the integration weights
    * as input, along with a pointer to the element.
+   * Also takes a boolean parameter indicating whether second
+   * derivatives need to be calculated, allowing us to potentially
+   * skip unnecessary, expensive computations.
    */
   virtual void compute_map(const unsigned int dim,
                            const std::vector<Real>& qw,
-                           const Elem* elem);
+                           const Elem* elem,
+                           bool calculate_d2phi);
 
   /**
    * Same as compute_map, but for a side.  Useful for boundary integration.

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -247,17 +247,17 @@ void FE<Dim,T>::reinit(const Elem* elem,
     {
       if (weights != NULL)
         {
-          this->_fe_map->compute_map (this->dim,*weights, elem);
+          this->_fe_map->compute_map (this->dim, *weights, elem, this->calculate_d2phi);
         }
       else
         {
           std::vector<Real> dummy_weights (pts->size(), 1.);
-          this->_fe_map->compute_map (this->dim,dummy_weights, elem);
+          this->_fe_map->compute_map (this->dim, dummy_weights, elem, this->calculate_d2phi);
         }
     }
   else
     {
-      this->_fe_map->compute_map (this->dim,this->qrule->get_weights(), elem);
+      this->_fe_map->compute_map (this->dim, this->qrule->get_weights(), elem, this->calculate_d2phi);
     }
 
   // Compute the shape functions and the derivatives at all of the

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -316,7 +316,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                                      const Elem* elem,
                                      unsigned int p,
                                      const std::vector<Node*>& elem_nodes,
-                                     bool elem_is_affine)
+                                     bool compute_second_derivatives)
 {
   libmesh_assert(elem);
   libmesh_assert_equal_to(phi_map.size(), elem_nodes.size());
@@ -400,7 +400,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
-        if (!elem_is_affine)
+        if (compute_second_derivatives)
           {
 #if LIBMESH_DIM == 1
         // Compute inverse map second derivatives for 1D-element-living-in-1D case
@@ -468,7 +468,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         // xi_{z z}
         d2xidxyz2_map[p][5] = -numer * dxidz_map[p]*dxidz_map[p] / denom;
 #endif
-          } // !elem_is_affine
+          } // compute_second_derivatives
 
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
 
@@ -552,7 +552,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
 
         dxidz_map[p] = detadz_map[p] = 0.;
 
-        if (!elem_is_affine)
+        if (compute_second_derivatives)
           this->compute_inverse_map_second_derivs(p);
 
 #else // LIBMESH_DIM == 3
@@ -621,7 +621,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
-        if (!elem_is_affine)
+        if (compute_second_derivatives)
           {
         // Compute inverse map second derivative values for
         // 2D-element-living-in-3D case.  We pursue a least-squares
@@ -799,7 +799,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         dzetady_map[p] = (dz_dxi*dx_deta   - dx_dxi*dz_deta  )*inv_jac;
         dzetadz_map[p] = (dx_dxi*dy_deta   - dy_dxi*dx_deta  )*inv_jac;
 
-        if (!elem_is_affine)
+        if (compute_second_derivatives)
           this->compute_inverse_map_second_derivs(p);
 
         // done computing the map
@@ -890,7 +890,7 @@ void FEMap::compute_affine_map( const unsigned int dim,
     elem_nodes[i] = elem->get_node(i);
 
   // Compute map at quadrature point 0
-  this->compute_single_point_map(dim, qw, elem, 0, elem_nodes, /*elem_is_affine=*/true);
+  this->compute_single_point_map(dim, qw, elem, 0, elem_nodes, /*compute_second_derivatives=*/false);
 
   // Compute xyz at all other quadrature points
   for (unsigned int p=1; p<n_qp; p++)
@@ -1000,7 +1000,8 @@ void FEMap::compute_null_map( const unsigned int dim,
 
 void FEMap::compute_map(const unsigned int dim,
                         const std::vector<Real>& qw,
-                        const Elem* elem)
+                        const Elem* elem,
+                        bool calculate_d2phi)
 {
   if (!elem)
     {
@@ -1043,7 +1044,7 @@ void FEMap::compute_map(const unsigned int dim,
 
   // Compute map at all quadrature points
   for (unsigned int p=0; p!=n_qp; p++)
-    this->compute_single_point_map(dim, qw, elem, p, elem_nodes, /*elem_is_affine=*/false);
+    this->compute_single_point_map(dim, qw, elem, p, elem_nodes, calculate_d2phi);
 
   // Stop logging the map computation.
   STOP_LOG("compute_map()", "FEMap");

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -708,7 +708,7 @@ void FESubdivision::reinit(const Elem* elem,
   shapes_on_quadrature = true;
 
   // Compute the map for this element.
-  this->_fe_map->compute_map (this->dim, this->qrule->get_weights(), elem);
+  this->_fe_map->compute_map (this->dim, this->qrule->get_weights(), elem, this->calculate_d2phi);
 
   STOP_LOG("reinit()", "FESubdivision");
 }

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -220,7 +220,7 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem* inf_elem,
       // each and every new element), throw radial and base part together
       this->combine_base_radial (inf_elem);
 
-      this->_fe_map->compute_map (this->dim,_total_qrule_weights, inf_elem);
+      this->_fe_map->compute_map (this->dim, _total_qrule_weights, inf_elem, this->calculate_d2phi);
 
       // Compute the shape functions and the derivatives
       // at all quadrature points.
@@ -258,12 +258,12 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem* inf_elem,
       // weights
       if (weights != NULL)
         {
-          this->_fe_map->compute_map (this->dim, *weights, inf_elem);
+          this->_fe_map->compute_map (this->dim, *weights, inf_elem, this->calculate_d2phi);
         }
       else
         {
           std::vector<Real> dummy_weights (pts->size(), 1.);
-          this->_fe_map->compute_map (this->dim, dummy_weights, inf_elem);
+          this->_fe_map->compute_map (this->dim, dummy_weights, inf_elem, this->calculate_d2phi);
         }
 
       // finally compute the ifem shapes


### PR DESCRIPTION
...aren't required.

This handles the case where an element is non-affine but the user has
not requested second derivatives to be computed.