### PR TITLE
Disable tetgen when configured with --enable-strict-lgpl

### DIFF
--- a/configure
+++ b/configure
@@ -34105,8 +34105,13 @@ fi
 
 
 # -------------------------------------------------------------
-# TetGen -- enabled by default
+# TetGen -- enabled unless --enable-strict-lgpl is specified
 # -------------------------------------------------------------
+if (test $enablestrictlgpl = yes) ; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Tetgen support is disabled, configure with --disable-strict-lgpl to enable it >>>" >&5
+$as_echo "<<< Tetgen support is disabled, configure with --disable-strict-lgpl to enable it >>>" >&6; }
+  enabletetgen=no;
+else
 
   # Check whether --enable-tetgen was given.
 if test "${enable_tetgen+set}" = set; then :
@@ -34139,9 +34144,11 @@ $as_echo "<<< Configuring library with Tetgen support >>>" >&6; }
 
 
 
-if (test $enabletetgen = yes); then
-  libmesh_contrib_INCLUDES="$TETGEN_INCLUDE $libmesh_contrib_INCLUDES"
+  if (test $enabletetgen = yes); then
+    libmesh_contrib_INCLUDES="$TETGEN_INCLUDE $libmesh_contrib_INCLUDES"
+  fi
 fi
+
  if test x$enabletetgen = xyes; then
   LIBMESH_ENABLE_TETGEN_TRUE=
   LIBMESH_ENABLE_TETGEN_FALSE='#'

--- a/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
+++ b/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
@@ -214,6 +214,9 @@ void tetrahedralize_domain(const Parallel::Communicator& comm)
 
   // Finally, write out the result
   mesh.write("hole_3D.e");
+#else
+  // Avoid compiler warnings
+  libmesh_ignore(comm);
 #endif // LIBMESH_HAVE_TETGEN
 }
 
@@ -327,5 +330,10 @@ void add_cube_convex_hull_to_mesh(MeshBase& mesh, Point lower_limit, Point upper
           }
       }
   }
+#else
+  // Avoid compiler warnings
+  libmesh_ignore(mesh);
+  libmesh_ignore(lower_limit);
+  libmesh_ignore(upper_limit);
 #endif // LIBMESH_HAVE_TETGEN
 }

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -375,12 +375,18 @@ fi
 
 
 # -------------------------------------------------------------
-# TetGen -- enabled by default
+# TetGen -- enabled unless --enable-strict-lgpl is specified
 # -------------------------------------------------------------
-CONFIGURE_TETGEN
-if (test $enabletetgen = yes); then
-  libmesh_contrib_INCLUDES="$TETGEN_INCLUDE $libmesh_contrib_INCLUDES"
+if (test $enablestrictlgpl = yes) ; then
+  AC_MSG_RESULT([<<< Tetgen support is disabled, configure with --disable-strict-lgpl to enable it >>>])
+  enabletetgen=no;
+else
+  CONFIGURE_TETGEN
+  if (test $enabletetgen = yes); then
+    libmesh_contrib_INCLUDES="$TETGEN_INCLUDE $libmesh_contrib_INCLUDES"
+  fi
 fi
+
 AM_CONDITIONAL(LIBMESH_ENABLE_TETGEN, test x$enabletetgen = xyes)
 AC_CONFIG_FILES([contrib/tetgen/Makefile])
 # -------------------------------------------------------------


### PR DESCRIPTION
Tetgen does not have an LGPL2-compatible license.

It has an MIT license encumbered with the following non-commerical clause:

"Distribution of this code for  any  commercial purpose  is permissible
 ONLY BY DIRECT ARRANGEMENT WITH THE COPYRIGHT OWNER."

In case anyone is interested, the PETSc team forked and rewrote Tetgen
(renaming it ctetgen) a little while back, but they don't distribute
it in the main PETSc repo because of the original license.  The
ctetgen source is available from https://bitbucket.org/petsc/ctetgen.
