### PR TITLE
Handle adaptively refined meshes in ExodusII_IO::copy_elemental_solution()

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -231,9 +231,11 @@ public:
 
   /**
    * Reads elemental values for the variable 'elemental_var_name' at the
-   * specified timestep into the 'elem_var_values' array.
+   * specified timestep into the 'elem_var_value_map' which is passed in.
    */
-  void read_elemental_var_values(std::string elemental_var_name, int time_step);
+  void read_elemental_var_values(std::string elemental_var_name,
+                                 int time_step,
+                                 std::map<dof_id_type, Real> & elem_var_value_map);
 
   /**
    * Opens an \p ExodusII mesh file named \p filename for writing.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -473,11 +473,14 @@ void ExodusII_IO::copy_elemental_solution(System& system,
       if (!elem)
         libmesh_error_msg("Error! Mesh returned NULL pointer for elem " << it->first);
 
-      dof_id_type dof_index = elem->dof_number(system.number(), var_num, 0);
+      if (elem->n_comp(system.number(), var_num) > 0)
+        {
+          dof_id_type dof_index = elem->dof_number(system.number(), var_num, 0);
 
-      // If the dof_index is local to this processor, set the value
-      if ((dof_index >= system.solution->first_local_index()) && (dof_index < system.solution->last_local_index()))
-        system.solution->set (dof_index, it->second);
+          // If the dof_index is local to this processor, set the value
+          if ((dof_index >= system.solution->first_local_index()) && (dof_index < system.solution->last_local_index()))
+            system.solution->set (dof_index, it->second);
+        }
     }
 
   system.solution->close();


### PR DESCRIPTION
This should fix the second part of @micahjohnson150's issue with reading in elemental solutions on adaptively-refined meshes.  At least his test case no longer crashes for me. 