### PR TITLE
Be more permissive with the derivatives of conditionals

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -333,13 +333,17 @@ typename ADImplementation<Value_t>::CodeTreeAD ADImplementation<Value_t>::D(cons
     case cFloor:
     case cCeil:
     case cTrunc:
+      throw RefuseToTakeCrazyDerivativeException;
+
+    // we gloss over the single undifferentiable point here
+
     case cEqual:
     case cNEqual:
     case cLess:
     case cLessOrEq:
     case cGreater:
     case cGreaterOrEq:
-      throw RefuseToTakeCrazyDerivativeException;
+      return CodeTreeAD(CodeTreeImmed(Value_t(0)));
 
     // these opcodes will never appear in the tree when building with keep_powi == false
     // they will be replaced by cPow, cMul, cDiv etc.:


### PR DESCRIPTION
I'm already allowing derivatives of ```if``` statements, but the optimizer may turn a statement like 

```
if(c<0, 1, 0) 
```

into 

```
c<0
```

While the former statement is differentiable the later is not. This prevents users form optimizing a function before taking its derivatives (which will be required in the new version of the MOOSE ```DerivativeParsedMaterial```). We can easily be more permissive here and _not_ throw an exception in the second case.