### PR TITLE
Call PCSetFromOptions() even when using Hypre

### DIFF
--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -250,12 +250,8 @@ void PetscPreconditioner<T>::set_petsc_preconditioner_type (const Preconditioner
 #endif
 
   // Let the commandline override stuff
-  // FIXME: Unless we are doing AMG???
-  if (preconditioner_type != AMG_PRECOND)
-    {
-      ierr = PCSetFromOptions(pc);
-      CHKERRABORT(comm,ierr);
-    }
+  ierr = PCSetFromOptions(pc);
+  CHKERRABORT(comm,ierr);
 }
 
 


### PR DESCRIPTION
See also discussion in #546.