### PR TITLE
Refactor around FEMContext::some_foo

### DIFF
--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -808,14 +808,40 @@ public:
 
 protected:
   /**
+   * Helper nested class for C++03-compatible "template typedef"
+   */
+  template <typename OutputType>
+  struct FENeeded {
+    typedef typename TensorTools::MakeReal
+      <OutputType>::type value_shape;
+    typedef FEGenericBase<value_shape> value_base;
+    typedef void (FEMContext::*value_getter)
+      (unsigned int, value_base *&) const;
+
+    typedef typename TensorTools::MakeReal
+      <typename TensorTools::DecrementRank
+        <OutputType>::type>::type grad_shape;
+    typedef FEGenericBase<grad_shape> grad_base;
+    typedef void (FEMContext::*grad_getter)
+      (unsigned int, grad_base *&) const;
+
+    typedef typename TensorTools::MakeReal
+      <typename TensorTools::DecrementRank
+        <typename TensorTools::DecrementRank
+          <OutputType>::type>::type>::type hess_shape;
+    typedef FEGenericBase<hess_shape> hess_base;
+    typedef void (FEMContext::*hess_getter)
+      (unsigned int, hess_base *&) const;
+  };
+
+
+
+  /**
    * Helper function to reduce some code duplication in the
    * *interior_value methods.
    */
   template<typename OutputType,
-           void (FEMContext::*fe_getter)
-             (unsigned int,
-              FEGenericBase<typename TensorTools::MakeReal<OutputType>::type> *&)
-             const,
+           typename FENeeded<OutputType>::value_getter fe_getter,
            diff_subsolution_getter subsolution_getter>
   void some_value(unsigned int var, unsigned int qp, OutputType& u) const;
 
@@ -824,13 +850,7 @@ protected:
    * *interior_gradient methods.
    */
   template<typename OutputType,
-           void (FEMContext::*fe_getter)
-             (unsigned int,
-              FEGenericBase
-                <typename TensorTools::MakeReal
-                  <typename TensorTools::DecrementRank
-                    <OutputType>::type>::type> *&)
-             const,
+           typename FENeeded<OutputType>::grad_getter fe_getter,
            diff_subsolution_getter subsolution_getter>
   void some_gradient(unsigned int var, unsigned int qp, OutputType& u) const;
 
@@ -840,14 +860,7 @@ protected:
    * *interior_hessian methods.
    */
   template<typename OutputType,
-           void (FEMContext::*fe_getter)
-             (unsigned int,
-              FEGenericBase
-                <typename TensorTools::MakeReal
-                  <typename TensorTools::DecrementRank
-                    <typename TensorTools::DecrementRank
-                      <OutputType>::type>::type>::type> *&)
-             const,
+           typename FENeeded<OutputType>::hess_getter fe_getter,
            diff_subsolution_getter subsolution_getter>
   void some_hessian(unsigned int var, unsigned int qp, OutputType& u) const;
 #endif

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -812,16 +812,27 @@ protected:
    * *interior_value methods.
    */
   template<typename OutputType,
+           void (FEMContext::*fe_getter)
+             (unsigned int,
+              FEGenericBase<typename TensorTools::MakeReal<OutputType>::type> *&)
+             const,
            diff_subsolution_getter subsolution_getter>
-  void some_interior_value(unsigned int var, unsigned int qp, OutputType& u) const;
+  void some_value(unsigned int var, unsigned int qp, OutputType& u) const;
 
   /**
    * Helper function to reduce some code duplication in the
    * *interior_gradient methods.
    */
   template<typename OutputType,
+           void (FEMContext::*fe_getter)
+             (unsigned int,
+              FEGenericBase
+                <typename TensorTools::MakeReal
+                  <typename TensorTools::DecrementRank
+                    <OutputType>::type>::type> *&)
+             const,
            diff_subsolution_getter subsolution_getter>
-  void some_interior_gradient(unsigned int var, unsigned int qp, OutputType& u) const;
+  void some_gradient(unsigned int var, unsigned int qp, OutputType& u) const;
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
@@ -829,18 +840,17 @@ protected:
    * *interior_hessian methods.
    */
   template<typename OutputType,
+           void (FEMContext::*fe_getter)
+             (unsigned int,
+              FEGenericBase
+                <typename TensorTools::MakeReal
+                  <typename TensorTools::DecrementRank
+                    <typename TensorTools::DecrementRank
+                      <OutputType>::type>::type>::type> *&)
+             const,
            diff_subsolution_getter subsolution_getter>
-  void some_interior_hessian(unsigned int var, unsigned int qp, OutputType& u) const;
+  void some_hessian(unsigned int var, unsigned int qp, OutputType& u) const;
 #endif
-
-  /**
-   * Helper function to reduce some code duplication in the
-   * *side_value methods.
-   */
-  template<typename OutputType,
-           diff_subsolution_getter subsolution_getter>
-  void some_side_value(unsigned int var, unsigned int qp, OutputType& u) const;
-
 
   /**
    * Finite element objects for each variable's interior, sides and edges.

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -185,15 +185,10 @@ std::vector<boundary_id_type> FEMContext::side_boundary_ids() const
 
 
 template<typename OutputType,
-         void (FEMContext::*fe_getter)
-           (unsigned int,
-            FEGenericBase<typename TensorTools::MakeReal<OutputType>::type> *&)
-           const,
+         typename FEMContext::FENeeded<OutputType>::value_getter fe_getter,
          FEMContext::diff_subsolution_getter subsolution_getter>
 void FEMContext::some_value(unsigned int var, unsigned int qp, OutputType& u) const
 {
-  typedef typename TensorTools::MakeReal<OutputType>::type OutputShape;
-
   // Get local-to-global dof index lookup
   libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
@@ -203,11 +198,12 @@ void FEMContext::some_value(unsigned int var, unsigned int qp, OutputType& u) co
   const DenseSubVector<Number> &coef = (this->*subsolution_getter)(var);
 
   // Get finite element object
-  FEGenericBase<OutputShape>* fe = NULL;
+  typename FENeeded<OutputType>::value_base* fe = NULL;
   (this->*fe_getter)( var, fe );
 
   // Get shape function values at quadrature point
-  const std::vector<std::vector<OutputShape> > &phi = fe->get_phi();
+  const std::vector<std::vector
+    <typename FENeeded<OutputType>::value_shape> > &phi = fe->get_phi();
 
   // Accumulate solution value
   u = 0.;
@@ -219,18 +215,10 @@ void FEMContext::some_value(unsigned int var, unsigned int qp, OutputType& u) co
 
 
 template<typename OutputType,
-         void (FEMContext::*fe_getter)
-           (unsigned int,
-            FEGenericBase<typename TensorTools::MakeReal<
-              typename TensorTools::DecrementRank<OutputType>::type>::type> *&)
-           const,
+         typename FEMContext::FENeeded<OutputType>::grad_getter fe_getter,
          FEMContext::diff_subsolution_getter subsolution_getter>
 void FEMContext::some_gradient(unsigned int var, unsigned int qp, OutputType& du) const
 {
-  typedef typename TensorTools::MakeReal
-    <typename TensorTools::DecrementRank<OutputType>::type>::type
-    OutputShape;
-
   // Get local-to-global dof index lookup
   libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
@@ -240,11 +228,13 @@ void FEMContext::some_gradient(unsigned int var, unsigned int qp, OutputType& du
   const DenseSubVector<Number> &coef = (this->*subsolution_getter)(var);
 
   // Get finite element object
-  FEGenericBase<OutputShape>* fe = NULL;
+  typename FENeeded<OutputType>::grad_base* fe = NULL;
   (this->*fe_getter)( var, fe );
 
   // Get shape function values at quadrature point
-  const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputGradient> > &dphi = fe->get_dphi();
+  const std::vector<std::vector
+    <typename FENeeded<OutputType>::grad_base::OutputGradient> >
+    &dphi = fe->get_dphi();
 
   // Accumulate solution derivatives
   du = 0;
@@ -259,23 +249,10 @@ void FEMContext::some_gradient(unsigned int var, unsigned int qp, OutputType& du
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template<typename OutputType,
-         void (FEMContext::*fe_getter)
-           (unsigned int,
-            FEGenericBase
-              <typename TensorTools::MakeReal
-                <typename TensorTools::DecrementRank
-                  <typename TensorTools::DecrementRank
-                    <OutputType>::type>::type>::type> *&)
-           const,
+         typename FEMContext::FENeeded<OutputType>::hess_getter fe_getter,
          FEMContext::diff_subsolution_getter subsolution_getter>
 void FEMContext::some_hessian(unsigned int var, unsigned int qp, OutputType& d2u) const
 {
-  typedef typename TensorTools::MakeReal<
-    typename TensorTools::DecrementRank<
-    typename TensorTools::DecrementRank<
-    OutputType>::type>::type>::type
-    OutputShape;
-
   // Get local-to-global dof index lookup
   libmesh_assert_greater (this->get_dof_indices().size(), var);
   const unsigned int n_dofs = cast_int<unsigned int>
@@ -285,11 +262,13 @@ void FEMContext::some_hessian(unsigned int var, unsigned int qp, OutputType& d2u
   const DenseSubVector<Number> &coef = (this->*subsolution_getter)(var);
 
   // Get finite element object
-  FEGenericBase<OutputShape>* fe = NULL;
+  typename FENeeded<OutputType>::hess_base* fe = NULL;
   (this->*fe_getter)( var, fe );
 
   // Get shape function values at quadrature point
-  const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> > &d2phi = fe->get_d2phi();
+  const std::vector<std::vector
+    <typename FENeeded<OutputType>::hess_base::OutputTensor> >
+    &d2phi = fe->get_d2phi();
 
   // Accumulate solution second derivatives
   d2u = 0.0;


### PR DESCRIPTION
This saves a little code, but more importantly it adds implementations
of a few obscure methods like side_rate().

This passes the GRINS test suite, which ought to exercise this code fairly well.