### PR TITLE
Implement eigen_get_converged_reason()

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -395,6 +395,14 @@ int main (int argc, char** argv)
   libmesh_example_requires(false, "--enable-petsc or --enable-trilinos");
 #endif
 
+  if (libMesh::on_command_line ("--use-eigen"))
+    {
+      libMesh::err << "This example requires a NonlinearSolver, and therefore does not "
+                   << "support --use-eigen on the command line."
+                   << std::endl;
+      return 0;
+    }
+
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_example_requires(false, "--enable-amr");
 #else

--- a/examples/optimization/optimization_ex1/optimization_ex1.C
+++ b/examples/optimization/optimization_ex1/optimization_ex1.C
@@ -249,6 +249,14 @@ int main (int argc, char** argv)
   libmesh_example_requires(false, "PETSc >= 3.5.0 with built-in TAO support");
 #endif
 
+  if (libMesh::on_command_line ("--use-eigen"))
+    {
+      libMesh::err << "This example requires an OptimizationSolver, and therefore does not "
+                   << "support --use-eigen on the command line."
+                   << std::endl;
+      return 0;
+    }
+
   GetPot infile("optimization_ex1.in");
   const std::string approx_order = infile("approx_order", "FIRST");
   const std::string fe_family = infile("fe_family", "LAGRANGE");

--- a/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
+++ b/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
@@ -74,10 +74,9 @@ int main (int argc, char** argv)
   // XDR binary support requires double precision
   libmesh_example_requires(false, "--disable-singleprecision");
 #endif
-  // FIXME: This example currently segfaults with Trilinos?
-  // with Eigen sparse solvers, libMesh::EigenSparseLinearSolver<double>::get_converged_reason()
-  // aborts with not implemented
-  libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
+  // FIXME: This example currently segfaults with Trilinos?  It works
+  // with PETSc and Eigen sparse linear solvers though.
+  libmesh_example_requires(libMesh::default_solver_package() != TRILINOS_SOLVERS, "--enable-petsc");
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -55,10 +55,6 @@ int main (int argc, char** argv)
   // XDR binary support requires double precision
   libmesh_example_requires(false, "--disable-singleprecision");
 #endif
-  // FIXME: This example currently segfaults with Trilinos?
-  // with Eigen sparse solvers, libMesh::EigenSparseLinearSolver<double>::get_converged_reason()
-  // aborts with not implemented
-  libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -79,9 +79,6 @@ int main(int argc, char** argv) {
   // XDR binary support requires double precision
   libmesh_example_requires(false, "--disable-singleprecision");
 #endif
-  // FIXME: with Eigen sparse solvers, libMesh::EigenSparseLinearSolver<double>::get_converged_reason()
-  // aborts with not implemented
-  libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
 
   // This example only works if libMesh was compiled for 3D
   const unsigned int dim = 3;
@@ -203,6 +200,10 @@ int main(int argc, char** argv) {
 
   if(!online_mode) // Perform the Offline stage of the RB method
     {
+      // Use CG solver.  This echoes the Petsc command line options set
+      // in run.sh, but also works for non-PETSc linear solvers.
+      rb_con.get_linear_solver()->set_solver_type(CG);
+
       // Read in the data that defines this problem from the specified text file
       rb_con.process_parameters_file(parameters_filename);
 

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -101,9 +101,6 @@ int main (int argc, char** argv)
   // XDR binary support requires double precision
   libmesh_example_requires(false, "--disable-singleprecision");
 #endif
-  // FIXME: with Eigen sparse solvers, libMesh::EigenSparseLinearSolver<double>::get_converged_reason()
-  // aborts with not implemented
-  libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
 
   // This is a 3D example
   libmesh_example_requires(3 == LIBMESH_DIM, "3D support");

--- a/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
+++ b/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
@@ -68,8 +68,6 @@ int main (int argc, char** argv)
   libmesh_example_requires(false, "--disable-singleprecision");
 #endif
   // FIXME: This example currently segfaults with Trilinos?
-  // FIXME: with Eigen sparse solvers, libMesh::EigenSparseLinearSolver<double>::get_converged_reason()
-  // aborts with not implemented
   libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
 
   // Skip this 2D example if libMesh was compiled as 1D-only.

--- a/include/solvers/eigen_sparse_linear_solver.h
+++ b/include/solvers/eigen_sparse_linear_solver.h
@@ -144,6 +144,11 @@ private:
   void set_eigen_preconditioner_type ();
 
   /**
+   * Store the result of the last solve.
+   */
+  Eigen::ComputationInfo _comp_info;
+
+  /**
    * Static map between Eigen ComputationInfo enumerations and libMesh
    * LinearConvergenceReason enumerations.
    */
@@ -171,17 +176,6 @@ private:
 template <typename T>
 std::map<Eigen::ComputationInfo, LinearConvergenceReason>
 EigenSparseLinearSolver<T>::_convergence_reasons = EigenSparseLinearSolver<T>::build_map();
-
-
-
-template <typename T>
-inline
-EigenSparseLinearSolver<T>::EigenSparseLinearSolver(const libMesh::Parallel::Communicator &comm_in) :
-  LinearSolver<T>(comm_in)
-{
-  // The GMRES iterative solver isn't supported by Eigen, so use BICGSTAB instead
-  this->_solver_type = BICGSTAB;
-}
 
 
 

--- a/include/solvers/eigen_sparse_linear_solver.h
+++ b/include/solvers/eigen_sparse_linear_solver.h
@@ -143,10 +143,37 @@ private:
    */
   void set_eigen_preconditioner_type ();
 
+  /**
+   * Static map between Eigen ComputationInfo enumerations and libMesh
+   * LinearConvergenceReason enumerations.
+   */
+  static std::map<Eigen::ComputationInfo, LinearConvergenceReason> _convergence_reasons;
+
+  /**
+   * Static function used to initialize _covergence_reasons map
+   */
+  static std::map<Eigen::ComputationInfo, LinearConvergenceReason> build_map()
+    {
+      std::map<Eigen::ComputationInfo, LinearConvergenceReason> ret;
+      ret[Eigen::Success]        = CONVERGED_ITS;
+      ret[Eigen::NumericalIssue] = DIVERGED_BREAKDOWN;
+      ret[Eigen::NoConvergence]  = DIVERGED_ITS;
+      ret[Eigen::InvalidInput]   = DIVERGED_NULL;
+      return ret;
+    }
 };
 
 
-/*----------------------- functions ----------------------------------*/
+
+// Call the class-static function to define the class-static member.
+// Since it's a template class, you actually do this in the header,
+// not the source file.
+template <typename T>
+std::map<Eigen::ComputationInfo, LinearConvergenceReason>
+EigenSparseLinearSolver<T>::_convergence_reasons = EigenSparseLinearSolver<T>::build_map();
+
+
+
 template <typename T>
 inline
 EigenSparseLinearSolver<T>::EigenSparseLinearSolver(const libMesh::Parallel::Communicator &comm_in) :

--- a/include/solvers/eigen_sparse_linear_solver.h
+++ b/include/solvers/eigen_sparse_linear_solver.h
@@ -125,12 +125,6 @@ public:
          const unsigned int m_its);
 
   /**
-   * Prints a useful message about why the latest linear solve
-   * con(di)verged.
-   */
-  virtual void print_converged_reason() const;
-
-  /**
    * Returns the solver's convergence flag
    */
   virtual LinearConvergenceReason get_converged_reason() const;

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -246,15 +246,6 @@ void EigenSparseLinearSolver<T>::set_eigen_preconditioner_type ()
 
 
 template <typename T>
-void EigenSparseLinearSolver<T>::print_converged_reason() const
-{
-  libMesh::out << "print_converged_reason() is currently only supported"
-               << "with Petsc 2.3.1 and later." << std::endl;
-}
-
-
-
-template <typename T>
 LinearConvergenceReason EigenSparseLinearSolver<T>::get_converged_reason() const
 {
   std::map<Eigen::ComputationInfo, LinearConvergenceReason>::iterator it =

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -257,7 +257,21 @@ void EigenSparseLinearSolver<T>::print_converged_reason() const
 template <typename T>
 LinearConvergenceReason EigenSparseLinearSolver<T>::get_converged_reason() const
 {
-  libmesh_not_implemented();
+  std::map<Eigen::ComputationInfo, LinearConvergenceReason>::iterator it =
+    _convergence_reasons.find(_comp_info);
+
+  // If later versions of Eigen start returning new enumerations,
+  // we'll need to add them to the map...
+  if (it == _convergence_reasons.end())
+    {
+      libmesh_warning("Warning: unknown Eigen::ComputationInfo: " \
+                      << _comp_info \
+                      << " returning CONVERGED_ITS." \
+                      << std::endl);
+      return CONVERGED_ITS;
+    }
+  else
+    return it->second;
 }
 
 

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -32,7 +32,18 @@
 namespace libMesh
 {
 
-/*----------------------- functions ----------------------------------*/
+template <typename T>
+EigenSparseLinearSolver<T>::
+EigenSparseLinearSolver(const Parallel::Communicator &comm_in) :
+  LinearSolver<T>(comm_in),
+  _comp_info(Eigen::Success)
+{
+  // The GMRES iterative solver isn't supported by Eigen, so use BICGSTAB instead
+  this->_solver_type = BICGSTAB;
+}
+
+
+
 template <typename T>
 void EigenSparseLinearSolver<T>::clear ()
 {
@@ -95,6 +106,7 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> &matrix_in,
         libMesh::out << "#iterations: " << solver.iterations() << std::endl;
         libMesh::out << "estimated error: " << solver.error() << std::endl;
         retval = std::make_pair(solver.iterations(), solver.error());
+        _comp_info = solver.info();
         break;
       }
 
@@ -108,6 +120,7 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> &matrix_in,
         libMesh::out << "#iterations: " << solver.iterations() << std::endl;
         libMesh::out << "estimated error: " << solver.error() << std::endl;
         retval = std::make_pair(solver.iterations(), solver.error());
+        _comp_info = solver.info();
         break;
       }
 


### PR DESCRIPTION
This trivial change allows us to run several of the reduced basis examples with `--use-eigen` on the command line.  I picked a somewhat arbitrary mapping between the Eigen::ComputationInfo enum and our LinearConvergenceReason enum in 11af914, but it's better than nothing.