### PR TITLE
Fixes to find_nodal_neighbors() for 1D elements

### DIFF
--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -313,7 +313,7 @@ unsigned int max_level (const MeshBase &mesh);
  * every node directly attached to the given one.
  */
 void find_nodal_neighbors(const MeshBase &mesh, const Node &n,
-                          std::vector<std::vector<const Elem*> > &nodes_to_elem_map,
+                          const std::vector<std::vector<const Elem*> > &nodes_to_elem_map,
                           std::vector<const Node*> &neighbors);
 
 /**

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -703,15 +703,19 @@ unsigned int MeshTools::n_p_levels (const MeshBase& mesh)
 
 void MeshTools::find_nodal_neighbors(const MeshBase&,
                                      const Node& node,
-                                     std::vector<std::vector<const Elem*> >& nodes_to_elem_map,
+                                     const std::vector<std::vector<const Elem*> >& nodes_to_elem_map,
                                      std::vector<const Node*>& neighbors)
 {
   // We'll refer back to the Node ID several times
   dof_id_type global_id = node.id();
 
+  // Clear out the input nighbors vector in case there are leftover entries in there.
+  neighbors.clear();
+
   // Iterators to iterate through the elements that include this node
-  std::vector<const Elem*>::const_iterator el     = nodes_to_elem_map[global_id].begin();
-  std::vector<const Elem*>::const_iterator end_el = nodes_to_elem_map[global_id].end();
+  std::vector<const Elem*>::const_iterator
+    el = nodes_to_elem_map[global_id].begin(),
+    end_el = nodes_to_elem_map[global_id].end();
 
   // Look through the elements that contain this node
   // find the local node id... then find the side that

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,6 +17,7 @@ unit_tests_sources = \
 	geom/point_test.C \
 	geom/point_test.h \
 	mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -127,7 +127,7 @@ PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
-	numerics/composite_function_test.C \
+	mesh/nodal_neighbors.C numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -143,6 +143,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	geom/unit_tests_dbg-node_test.$(OBJEXT) \
 	geom/unit_tests_dbg-point_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT) \
+	mesh/unit_tests_dbg-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_dbg-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-laspack_vector_test.$(OBJEXT) \
@@ -168,7 +169,7 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
-	numerics/composite_function_test.C \
+	mesh/nodal_neighbors.C numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -183,6 +184,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	geom/unit_tests_devel-node_test.$(OBJEXT) \
 	geom/unit_tests_devel-point_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT) \
+	mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_devel-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_devel-laspack_vector_test.$(OBJEXT) \
@@ -206,7 +208,7 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
-	numerics/composite_function_test.C \
+	mesh/nodal_neighbors.C numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -221,6 +223,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	geom/unit_tests_oprof-node_test.$(OBJEXT) \
 	geom/unit_tests_oprof-point_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT) \
+	mesh/unit_tests_oprof-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_oprof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-laspack_vector_test.$(OBJEXT) \
@@ -244,7 +247,7 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
-	numerics/composite_function_test.C \
+	mesh/nodal_neighbors.C numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -259,6 +262,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	geom/unit_tests_opt-node_test.$(OBJEXT) \
 	geom/unit_tests_opt-point_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT) \
+	mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_opt-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_opt-laspack_vector_test.$(OBJEXT) \
@@ -280,7 +284,7 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
-	numerics/composite_function_test.C \
+	mesh/nodal_neighbors.C numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -295,6 +299,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	geom/unit_tests_prof-node_test.$(OBJEXT) \
 	geom/unit_tests_prof-point_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT) \
+	mesh/unit_tests_prof-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_prof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_prof-laspack_vector_test.$(OBJEXT) \
@@ -708,7 +713,7 @@ AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	base/getpot_test.C geom/node_test.C geom/point_test.C \
 	geom/point_test.h mesh/mixed_dim_mesh_test.C \
-	numerics/composite_function_test.C \
+	mesh/nodal_neighbors.C numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/petsc_vector_test.C \
@@ -822,6 +827,8 @@ mesh/$(DEPDIR)/$(am__dirstamp):
 	@: > mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/$(am__dirstamp):
 	@$(MKDIR_P) numerics
 	@: > numerics/$(am__dirstamp)
@@ -892,6 +899,8 @@ geom/unit_tests_devel-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT):  \
@@ -926,6 +935,8 @@ geom/unit_tests_oprof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT):  \
@@ -960,6 +971,8 @@ geom/unit_tests_opt-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT):  \
@@ -994,6 +1007,8 @@ geom/unit_tests_prof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT):  \
@@ -1062,10 +1077,15 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po@am__quote@
@@ -1210,6 +1230,20 @@ mesh/unit_tests_dbg-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_dbg-mixed_dim_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+
+mesh/unit_tests_dbg-nodal_neighbors.o: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-nodal_neighbors.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Tpo -c -o mesh/unit_tests_dbg-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_dbg-nodal_neighbors.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+
+mesh/unit_tests_dbg-nodal_neighbors.obj: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-nodal_neighbors.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Tpo -c -o mesh/unit_tests_dbg-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_dbg-nodal_neighbors.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
 
 numerics/unit_tests_dbg-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Tpo -c -o numerics/unit_tests_dbg-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
@@ -1435,6 +1469,20 @@ mesh/unit_tests_devel-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
 
+mesh/unit_tests_devel-nodal_neighbors.o: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-nodal_neighbors.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Tpo -c -o mesh/unit_tests_devel-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_devel-nodal_neighbors.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+
+mesh/unit_tests_devel-nodal_neighbors.obj: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-nodal_neighbors.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Tpo -c -o mesh/unit_tests_devel-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_devel-nodal_neighbors.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
+
 numerics/unit_tests_devel-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Tpo -c -o numerics/unit_tests_devel-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po
@@ -1658,6 +1706,20 @@ mesh/unit_tests_oprof-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_oprof-mixed_dim_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+
+mesh/unit_tests_oprof-nodal_neighbors.o: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-nodal_neighbors.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Tpo -c -o mesh/unit_tests_oprof-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_oprof-nodal_neighbors.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+
+mesh/unit_tests_oprof-nodal_neighbors.obj: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-nodal_neighbors.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Tpo -c -o mesh/unit_tests_oprof-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_oprof-nodal_neighbors.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
 
 numerics/unit_tests_oprof-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Tpo -c -o numerics/unit_tests_oprof-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
@@ -1883,6 +1945,20 @@ mesh/unit_tests_opt-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
 
+mesh/unit_tests_opt-nodal_neighbors.o: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-nodal_neighbors.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Tpo -c -o mesh/unit_tests_opt-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_opt-nodal_neighbors.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+
+mesh/unit_tests_opt-nodal_neighbors.obj: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-nodal_neighbors.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Tpo -c -o mesh/unit_tests_opt-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_opt-nodal_neighbors.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
+
 numerics/unit_tests_opt-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Tpo -c -o numerics/unit_tests_opt-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po
@@ -2106,6 +2182,20 @@ mesh/unit_tests_prof-mixed_dim_mesh_test.obj: mesh/mixed_dim_mesh_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mixed_dim_mesh_test.C' object='mesh/unit_tests_prof-mixed_dim_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mixed_dim_mesh_test.obj `if test -f 'mesh/mixed_dim_mesh_test.C'; then $(CYGPATH_W) 'mesh/mixed_dim_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mixed_dim_mesh_test.C'; fi`
+
+mesh/unit_tests_prof-nodal_neighbors.o: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-nodal_neighbors.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Tpo -c -o mesh/unit_tests_prof-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_prof-nodal_neighbors.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-nodal_neighbors.o `test -f 'mesh/nodal_neighbors.C' || echo '$(srcdir)/'`mesh/nodal_neighbors.C
+
+mesh/unit_tests_prof-nodal_neighbors.obj: mesh/nodal_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-nodal_neighbors.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Tpo -c -o mesh/unit_tests_prof-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Tpo mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/nodal_neighbors.C' object='mesh/unit_tests_prof-nodal_neighbors.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-nodal_neighbors.obj `if test -f 'mesh/nodal_neighbors.C'; then $(CYGPATH_W) 'mesh/nodal_neighbors.C'; else $(CYGPATH_W) '$(srcdir)/mesh/nodal_neighbors.C'; fi`
 
 numerics/unit_tests_prof-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Tpo -c -o numerics/unit_tests_prof-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C

--- a/tests/mesh/nodal_neighbors.C
+++ b/tests/mesh/nodal_neighbors.C
@@ -1,0 +1,157 @@
+// Ignore unused parameter warnings coming from cppuint headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/libmesh.h>
+#include <libmesh/mesh.h>
+#include <libmesh/node.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/mesh_tools.h>
+
+#include "test_comm.h"
+
+using namespace libMesh;
+
+class NodalNeighborsTest : public CppUnit::TestCase
+{
+  /**
+   * The goal of this test is to ensure that MeshTools::find_nodal_neighbors()
+   * works in 1D.  If the numbering of MeshGeneration::build_line()
+   * ever changes, this test will break, as it compares hand-checked
+   * hard-coded "validation" data with the results of
+   * MeshTools::find_nodal_neighbors().
+   */
+public:
+  CPPUNIT_TEST_SUITE( NodalNeighborsTest );
+
+  CPPUNIT_TEST( testEdge2 );
+  CPPUNIT_TEST( testEdge3 );
+  CPPUNIT_TEST( testEdge4 );
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+
+  // Builds a 1D mesh with the specified ElemType and number of elements
+  void do_test(unsigned n_elem,
+               ElemType elem_type,
+               dof_id_type * validation_data)
+  {
+    Mesh mesh(*TestCommWorld, /*dim=*/1);
+
+    MeshTools::Generation::build_line(mesh,
+                                      n_elem,
+                                      /*xmin=*/0.,
+                                      /*xmax=*/1.,
+                                      elem_type);
+
+    // find_nodal_neighbors() needs a data structure which is prepared by another function
+    std::vector<std::vector<const Elem*> > nodes_to_elem_map;
+    MeshTools::build_nodes_to_elem_map(mesh, nodes_to_elem_map);
+
+    // Loop over the nodes and call find_nodal_neighbors()
+    {
+      MeshBase::const_node_iterator       nd     = mesh.nodes_begin();
+      const MeshBase::const_node_iterator end_nd = mesh.nodes_end();
+
+      std::vector<const Node*> neighbor_nodes;
+
+      unsigned ctr = 0;
+      for (; nd != end_nd; ++nd, ++ctr)
+        {
+          Node* node = *nd;
+
+          MeshTools::find_nodal_neighbors(mesh, *node, nodes_to_elem_map, neighbor_nodes);
+
+          // The entries in neighbor_nodes are just sorted according
+          // to memory address, which is somewhat arbitrary, so create
+          // a vector sorted by IDs for test purposes.
+          std::vector<dof_id_type> neighbor_node_ids(neighbor_nodes.size());
+          for (unsigned i=0; i<neighbor_nodes.size(); ++i)
+            neighbor_node_ids[i] = neighbor_nodes[i]->id();
+          std::sort(neighbor_node_ids.begin(), neighbor_node_ids.end());
+
+          // Compare to validation_data
+          for (unsigned j=0; j<neighbor_node_ids.size(); ++j)
+            {
+              CPPUNIT_ASSERT_EQUAL( validation_data[2*ctr + j], neighbor_node_ids[j] );
+            }
+        }
+    }
+  }
+
+public:
+  void setUp() {}
+
+  void tearDown() {}
+
+  void testEdge2()
+  {
+    // 11 nodes, 2 neighbor entries per node
+    dof_id_type validation_data[22] =
+      {
+        1, DofObject::invalid_id,
+        0, 2,
+        1, 3,
+        2, 4,
+        3, 5,
+        4, 6,
+        5, 7,
+        6, 8,
+        7, 9,
+        8, 10,
+        9, DofObject::invalid_id
+      };
+
+    do_test(/*n_elem=*/10, EDGE2, validation_data);
+  }
+
+
+  void testEdge3()
+  {
+    // 11 nodes, 2 neighbor entries per node
+    dof_id_type validation_data[22] =
+      {
+        2, DofObject::invalid_id,
+        2, 4,
+        0, 1,
+        4, 6,
+        1, 3,
+        6, 8,
+        3, 5,
+        8, 10,
+        5, 7,
+        10, DofObject::invalid_id,
+        7, 9
+      };
+
+    do_test(/*n_elem=*/5, EDGE3, validation_data);
+  }
+
+
+  void testEdge4()
+  {
+    // 10 nodes, 2 neighbor entries per node
+    dof_id_type validation_data[20] =
+      {
+        2, DofObject::invalid_id,
+        3, 5,
+        0, 3,
+        1, 2,
+        6, 8,
+        1, 6,
+        4, 5,
+        9, DofObject::invalid_id,
+        4, 9,
+        7, 8
+      };
+
+    do_test(/*n_elem=*/3, EDGE4, validation_data);
+  }
+
+};
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION( NodalNeighborsTest );


### PR DESCRIPTION
The edge-based algorithm we were using didn't work with 1D elements, because they don't have edges.