### PR TITLE
Solution derivative access in ParsedFEMFunction

### DIFF
--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -345,7 +345,14 @@ public:
       {
         FEBase* elem_fe;
         c.get_element_fe(v, elem_fe);
-        elem_fe->get_phi();
+        if (_n_requested_vars)
+          elem_fe->get_phi();
+        if (_n_requested_grad_components)
+          elem_fe->get_dphi();
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+        if (_n_requested_hess_components)
+          elem_fe->get_d2phi();
+#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
       }
   }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,6 +21,7 @@ unit_tests_sources = \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C \
 	numerics/numeric_vector_test.h \
+	numerics/parsed_fem_function_test.C \
 	numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -130,6 +130,7 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/parsed_fem_function_test.C \
 	numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/type_tensor_test.C \
@@ -146,6 +147,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	numerics/unit_tests_dbg-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_dbg-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-petsc_vector_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-trilinos_epetra_vector_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-type_tensor_test.$(OBJEXT) \
@@ -171,6 +173,7 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/parsed_fem_function_test.C \
 	numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/type_tensor_test.C \
@@ -186,6 +189,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	numerics/unit_tests_devel-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_devel-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_devel-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-petsc_vector_test.$(OBJEXT) \
 	numerics/unit_tests_devel-trilinos_epetra_vector_test.$(OBJEXT) \
 	numerics/unit_tests_devel-type_tensor_test.$(OBJEXT) \
@@ -209,6 +213,7 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/parsed_fem_function_test.C \
 	numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/type_tensor_test.C \
@@ -224,6 +229,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	numerics/unit_tests_oprof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_oprof-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-petsc_vector_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-trilinos_epetra_vector_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-type_tensor_test.$(OBJEXT) \
@@ -247,6 +253,7 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/parsed_fem_function_test.C \
 	numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/type_tensor_test.C \
@@ -262,6 +269,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	numerics/unit_tests_opt-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_opt-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_opt-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-petsc_vector_test.$(OBJEXT) \
 	numerics/unit_tests_opt-trilinos_epetra_vector_test.$(OBJEXT) \
 	numerics/unit_tests_opt-type_tensor_test.$(OBJEXT) \
@@ -283,6 +291,7 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/parsed_fem_function_test.C \
 	numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/type_tensor_test.C \
@@ -298,6 +307,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	numerics/unit_tests_prof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_prof-laspack_vector_test.$(OBJEXT) \
+	numerics/unit_tests_prof-parsed_fem_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-petsc_vector_test.$(OBJEXT) \
 	numerics/unit_tests_prof-trilinos_epetra_vector_test.$(OBJEXT) \
 	numerics/unit_tests_prof-type_tensor_test.$(OBJEXT) \
@@ -711,6 +721,7 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	numerics/composite_function_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
+	numerics/parsed_fem_function_test.C \
 	numerics/petsc_vector_test.C \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/type_tensor_test.C \
@@ -834,6 +845,8 @@ numerics/unit_tests_dbg-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-laspack_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_dbg-parsed_fem_function_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-petsc_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-trilinos_epetra_vector_test.$(OBJEXT):  \
@@ -898,6 +911,8 @@ numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-laspack_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_devel-parsed_fem_function_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-petsc_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-trilinos_epetra_vector_test.$(OBJEXT):  \
@@ -931,6 +946,8 @@ numerics/unit_tests_oprof-composite_function_test.$(OBJEXT):  \
 numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-laspack_vector_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_oprof-parsed_fem_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-petsc_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -966,6 +983,8 @@ numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-laspack_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_opt-parsed_fem_function_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-petsc_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-trilinos_epetra_vector_test.$(OBJEXT):  \
@@ -999,6 +1018,8 @@ numerics/unit_tests_prof-composite_function_test.$(OBJEXT):  \
 numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-laspack_vector_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_prof-parsed_fem_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-petsc_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -1069,30 +1090,35 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-petsc_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-type_tensor_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-petsc_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-type_tensor_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-petsc_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-type_tensor_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-petsc_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-type_tensor_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-petsc_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po@am__quote@
@@ -1252,6 +1278,20 @@ numerics/unit_tests_dbg-laspack_vector_test.obj: numerics/laspack_vector_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_vector_test.C' object='numerics/unit_tests_dbg-laspack_vector_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
+
+numerics/unit_tests_dbg-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_dbg-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_dbg-parsed_fem_function_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+
+numerics/unit_tests_dbg-parsed_fem_function_test.obj: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-parsed_fem_function_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_dbg-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_dbg-parsed_fem_function_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
 
 numerics/unit_tests_dbg-petsc_vector_test.o: numerics/petsc_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-petsc_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-petsc_vector_test.Tpo -c -o numerics/unit_tests_dbg-petsc_vector_test.o `test -f 'numerics/petsc_vector_test.C' || echo '$(srcdir)/'`numerics/petsc_vector_test.C
@@ -1477,6 +1517,20 @@ numerics/unit_tests_devel-laspack_vector_test.obj: numerics/laspack_vector_test.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
 
+numerics/unit_tests_devel-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_devel-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_devel-parsed_fem_function_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+
+numerics/unit_tests_devel-parsed_fem_function_test.obj: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-parsed_fem_function_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_devel-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_devel-parsed_fem_function_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
+
 numerics/unit_tests_devel-petsc_vector_test.o: numerics/petsc_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-petsc_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-petsc_vector_test.Tpo -c -o numerics/unit_tests_devel-petsc_vector_test.o `test -f 'numerics/petsc_vector_test.C' || echo '$(srcdir)/'`numerics/petsc_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-petsc_vector_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-petsc_vector_test.Po
@@ -1700,6 +1754,20 @@ numerics/unit_tests_oprof-laspack_vector_test.obj: numerics/laspack_vector_test.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_vector_test.C' object='numerics/unit_tests_oprof-laspack_vector_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
+
+numerics/unit_tests_oprof-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_oprof-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_oprof-parsed_fem_function_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+
+numerics/unit_tests_oprof-parsed_fem_function_test.obj: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-parsed_fem_function_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_oprof-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_oprof-parsed_fem_function_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
 
 numerics/unit_tests_oprof-petsc_vector_test.o: numerics/petsc_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-petsc_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-petsc_vector_test.Tpo -c -o numerics/unit_tests_oprof-petsc_vector_test.o `test -f 'numerics/petsc_vector_test.C' || echo '$(srcdir)/'`numerics/petsc_vector_test.C
@@ -1925,6 +1993,20 @@ numerics/unit_tests_opt-laspack_vector_test.obj: numerics/laspack_vector_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
 
+numerics/unit_tests_opt-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_opt-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_opt-parsed_fem_function_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+
+numerics/unit_tests_opt-parsed_fem_function_test.obj: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-parsed_fem_function_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_opt-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_opt-parsed_fem_function_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
+
 numerics/unit_tests_opt-petsc_vector_test.o: numerics/petsc_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-petsc_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-petsc_vector_test.Tpo -c -o numerics/unit_tests_opt-petsc_vector_test.o `test -f 'numerics/petsc_vector_test.C' || echo '$(srcdir)/'`numerics/petsc_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-petsc_vector_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-petsc_vector_test.Po
@@ -2148,6 +2230,20 @@ numerics/unit_tests_prof-laspack_vector_test.obj: numerics/laspack_vector_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/laspack_vector_test.C' object='numerics/unit_tests_prof-laspack_vector_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-laspack_vector_test.obj `if test -f 'numerics/laspack_vector_test.C'; then $(CYGPATH_W) 'numerics/laspack_vector_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/laspack_vector_test.C'; fi`
+
+numerics/unit_tests_prof-parsed_fem_function_test.o: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-parsed_fem_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_prof-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_prof-parsed_fem_function_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-parsed_fem_function_test.o `test -f 'numerics/parsed_fem_function_test.C' || echo '$(srcdir)/'`numerics/parsed_fem_function_test.C
+
+numerics/unit_tests_prof-parsed_fem_function_test.obj: numerics/parsed_fem_function_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-parsed_fem_function_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Tpo -c -o numerics/unit_tests_prof-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/parsed_fem_function_test.C' object='numerics/unit_tests_prof-parsed_fem_function_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-parsed_fem_function_test.obj `if test -f 'numerics/parsed_fem_function_test.C'; then $(CYGPATH_W) 'numerics/parsed_fem_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/parsed_fem_function_test.C'; fi`
 
 numerics/unit_tests_prof-petsc_vector_test.o: numerics/petsc_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-petsc_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-petsc_vector_test.Tpo -c -o numerics/unit_tests_prof-petsc_vector_test.o `test -f 'numerics/petsc_vector_test.C' || echo '$(srcdir)/'`numerics/petsc_vector_test.C

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -1,0 +1,117 @@
+// Ignore unused parameter warnings coming from cppuint headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+// libmesh includes
+#include "libmesh/auto_ptr.h"
+#include "libmesh/elem.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/mesh.h"
+#include "libmesh/mesh_generation.h"
+#include "libmesh/numeric_vector.h"
+#include "libmesh/parsed_fem_function.h"
+#include "libmesh/system.h"
+
+// test includes
+#include "test_comm.h"
+
+using namespace libMesh;
+
+class ParsedFEMFunctionTest : public CppUnit::TestCase
+{
+public:
+  void setUp() {
+    mesh.reset(new Mesh(*TestCommWorld));
+    MeshTools::Generation::build_cube(*mesh, 1, 1, 1);
+    es.reset(new EquationSystems(*mesh));
+    sys = &(es->add_system<System> ("SimpleSystem"));
+    sys->add_variable("x2");
+    sys->add_variable("x3");
+    sys->add_variable("c05");
+    sys->add_variable("y4");
+    sys->add_variable("xy");
+    sys->add_variable("yz");
+    sys->add_variable("xyz");
+
+    es->init();
+
+    NumericVector<Number> & sol = *sys->solution;
+    Elem *elem = mesh->elem(0);
+
+    // Set x2 = 2*x
+    sol.set(elem->get_node(1)->dof_number(0,0,0), 2);
+    sol.set(elem->get_node(2)->dof_number(0,0,0), 2);
+    sol.set(elem->get_node(4)->dof_number(0,0,0), 2);
+    sol.set(elem->get_node(5)->dof_number(0,0,0), 2);
+
+    // Set x3 = 3*x
+    sol.set(elem->get_node(1)->dof_number(0,1,0), 3);
+    sol.set(elem->get_node(2)->dof_number(0,1,0), 3);
+    sol.set(elem->get_node(4)->dof_number(0,1,0), 3);
+    sol.set(elem->get_node(5)->dof_number(0,1,0), 3);
+
+    // Set c05 = 0.5
+    sol.set(elem->get_node(0)->dof_number(0,2,0), 0.5);
+    sol.set(elem->get_node(1)->dof_number(0,2,0), 0.5);
+    sol.set(elem->get_node(2)->dof_number(0,2,0), 0.5);
+    sol.set(elem->get_node(3)->dof_number(0,2,0), 0.5);
+    sol.set(elem->get_node(4)->dof_number(0,2,0), 0.5);
+    sol.set(elem->get_node(5)->dof_number(0,2,0), 0.5);
+    sol.set(elem->get_node(6)->dof_number(0,2,0), 0.5);
+    sol.set(elem->get_node(7)->dof_number(0,2,0), 0.5);
+
+    // Set y4 = 4*y
+    sol.set(elem->get_node(2)->dof_number(0,3,0), 4);
+    sol.set(elem->get_node(3)->dof_number(0,3,0), 4);
+    sol.set(elem->get_node(6)->dof_number(0,3,0), 4);
+    sol.set(elem->get_node(7)->dof_number(0,3,0), 4);
+
+    // Set xy = x*y
+    sol.set(elem->get_node(2)->dof_number(0,4,0), 1);
+    sol.set(elem->get_node(6)->dof_number(0,4,0), 1);
+
+    // Set yz = y*z
+    sol.set(elem->get_node(6)->dof_number(0,5,0), 1);
+    sol.set(elem->get_node(7)->dof_number(0,5,0), 1);
+
+    // Set xyz = x*y*z
+    sol.set(elem->get_node(7)->dof_number(0,6,0), 1);
+
+    sol.close();
+    sys->update();
+  }
+
+  void tearDown() {
+    es.reset();
+    mesh.reset();
+  }
+
+  CPPUNIT_TEST_SUITE(ParsedFEMFunctionTest);
+
+  CPPUNIT_TEST(testValues);
+
+  CPPUNIT_TEST_SUITE_END();
+
+
+private:
+  AutoPtr<Mesh> mesh;
+  AutoPtr<EquationSystems> es;
+  System * sys;
+
+  void testValues()
+  {
+    Elem *elem = mesh->elem(0);
+
+    ParsedFEMFunction<Number> parsed_func(*sys, "x2*y4");
+
+    FEMContext c(*sys);
+
+    c.pre_fe_reinit(*sys, elem);
+    c.elem_fe_reinit();
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ParsedFEMFunctionTest);

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -43,14 +43,14 @@ public:
     // Set x2 = 2*x
     sol.set(elem->get_node(1)->dof_number(0,0,0), 2);
     sol.set(elem->get_node(2)->dof_number(0,0,0), 2);
-    sol.set(elem->get_node(4)->dof_number(0,0,0), 2);
     sol.set(elem->get_node(5)->dof_number(0,0,0), 2);
+    sol.set(elem->get_node(6)->dof_number(0,0,0), 2);
 
     // Set x3 = 3*x
     sol.set(elem->get_node(1)->dof_number(0,1,0), 3);
     sol.set(elem->get_node(2)->dof_number(0,1,0), 3);
-    sol.set(elem->get_node(4)->dof_number(0,1,0), 3);
     sol.set(elem->get_node(5)->dof_number(0,1,0), 3);
+    sol.set(elem->get_node(6)->dof_number(0,1,0), 3);
 
     // Set c05 = 0.5
     sol.set(elem->get_node(0)->dof_number(0,2,0), 0.5);
@@ -77,13 +77,18 @@ public:
     sol.set(elem->get_node(7)->dof_number(0,5,0), 1);
 
     // Set xyz = x*y*z
-    sol.set(elem->get_node(7)->dof_number(0,6,0), 1);
+    sol.set(elem->get_node(6)->dof_number(0,6,0), 1);
 
     sol.close();
     sys->update();
+
+    c.reset(new FEMContext(*sys));
+    c->pre_fe_reinit(*sys, elem);
+    c->elem_fe_reinit();
   }
 
   void tearDown() {
+    c.reset();
     es.reset();
     mesh.reset();
   }
@@ -91,6 +96,8 @@ public:
   CPPUNIT_TEST_SUITE(ParsedFEMFunctionTest);
 
   CPPUNIT_TEST(testValues);
+  CPPUNIT_TEST(testGradients);
+  CPPUNIT_TEST(testHessians);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -99,25 +106,57 @@ private:
   AutoPtr<Mesh> mesh;
   AutoPtr<EquationSystems> es;
   System * sys;
+  AutoPtr<FEMContext> c;
 
   void testValues()
   {
-    Elem *elem = mesh->elem(0);
-
-    FEMContext c(*sys);
-
-    c.pre_fe_reinit(*sys, elem);
-    c.elem_fe_reinit();
-
     ParsedFEMFunction<Number> x2(*sys, "x2");
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL
-      (x2(c,Point(0.5,0.5,0.5)), 1.0, 1.e-12);
+      (x2(*c,Point(0.5,0.5,0.5)), 1.0, 1.e-12);
 
     ParsedFEMFunction<Number> xy8(*sys, "x2*y4");
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL
-      (xy8(c,Point(0.5,0.5,0.5)), 2.0, 1.e-12);
+      (xy8(*c,Point(0.5,0.5,0.5)), 2.0, 1.e-12);
+  }
+
+
+  void testGradients()
+  {
+    ParsedFEMFunction<Number> c2(*sys, "grad_x_x2");
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL
+      (c2(*c,Point(0.35,0.45,0.55)), 2.0, 1.e-12);
+
+    ParsedFEMFunction<Number> xz(*sys, "grad_y_xyz");
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL
+      (xz(*c,Point(0.25,0.35,0.75)), 0.1875, 1.e-12);
+
+    ParsedFEMFunction<Number> xyz(*sys, "grad_y_xyz*grad_x_xy");
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL
+      (xyz(*c,Point(0.25,0.5,0.75)), 0.09375, 1.e-12);
+  }
+
+
+  void testHessians()
+  {
+    ParsedFEMFunction<Number> c1(*sys, "hess_xy_xy");
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL
+      (c1(*c,Point(0.35,0.45,0.55)), 1.0, 1.e-12);
+
+    ParsedFEMFunction<Number> x(*sys, "hess_yz_xyz");
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL
+      (x(*c,Point(0.25,0.35,0.55)), 0.25, 1.e-12);
+
+    ParsedFEMFunction<Number> xz(*sys, "hess_yz_xyz*grad_y_yz");
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL
+      (xz(*c,Point(0.25,0.4,0.75)), 0.1875, 1.e-12);
   }
 
 };

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -104,12 +104,20 @@ private:
   {
     Elem *elem = mesh->elem(0);
 
-    ParsedFEMFunction<Number> parsed_func(*sys, "x2*y4");
-
     FEMContext c(*sys);
 
     c.pre_fe_reinit(*sys, elem);
     c.elem_fe_reinit();
+
+    ParsedFEMFunction<Number> x2(*sys, "x2");
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL
+      (x2(c,Point(0.5,0.5,0.5)), 1.0, 1.e-12);
+
+    ParsedFEMFunction<Number> xy8(*sys, "x2*y4");
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL
+      (xy8(c,Point(0.5,0.5,0.5)), 2.0, 1.e-12);
   }
 
 };


### PR DESCRIPTION
If we have scalar variables "u", "Temperature", etc. then this lets us also compute parsed functions using e.g. "grad_x_u", "hess_xy_Temperature", etc.

We now also only compute input FEM data for a given variable and derivative level if the expressions we've been asked to evaluate include that data.