### PR TITLE
Don't run unit_tests-dbg with GLIBCXX_DEBUG flags

### DIFF
--- a/tests/run_unit_tests.sh.in
+++ b/tests/run_unit_tests.sh.in
@@ -3,5 +3,9 @@
 set -e
 
 for method in @METHODS@; do
+@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@    if [ "x$method" = "xdbg" ]; then
+@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@      continue;
+@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@    fi
+    echo $LIBMESH_RUN ./unit_tests-$method
     $LIBMESH_RUN ./unit_tests-$method
 done


### PR DESCRIPTION
That breaks on some cppunit installations.  We had this fixed before, but then I regressed it again when adding the LIBMESH_RUN support for unit tests.