### PR TITLE
Remove "echo -e -n" from scripts.

### DIFF
--- a/contrib/bin/test_installed_examples.sh
+++ b/contrib/bin/test_installed_examples.sh
@@ -60,17 +60,21 @@ function test_example()
 
     stdout=`mktemp -t stdout.XXXXXXXXXX`
 
-    echo -n "Testing example installation $exdir ... " > $stdout
+    printf '%s' "Testing example installation $exdir ... " > $stdout
     cd $examples_install_path/$exdir
 
     if $CXX $installed_CXXFLAGS *.C -o $app_to_link $installed_LIBS > $errlog 2>&1 ; then
-
- 	echo -e $gotocolumn $white"["$green"   OK   "$white"]" >> $stdout
-	echo -e -n $colorreset >> $stdout
-
+        # See color codes above.  We:
+        # .) skip to column 65
+        # .) print [ in white
+        # .) print OK in green
+        # .) print ] in white
+        # .) reset the terminal color
+        # .) print a newline
+        printf '\e[65G\e[1;37m[\e[1;32m%s\e[1;37m]\e[m\e[m\n' "   OK   " >> $stdout
     else
- 	echo -e $gotocolumn $white"["$red" FAILED "$white"]" >> $stdout
-	echo -e -n $colorreset >> $stdout
+        # See comment above for OK status
+        printf '\e[65G\e[1;37m[\e[1;31m%s\e[1;37m]\e[m\e[m\n' " FAILED " >> $stdout
 	echo "Compile line:"  >> $stdout
 	echo $CXX $installed_CXXFLAGS *.C -o $app_to_link $installed_LIBS >> $stdout
 	echo ""  >> $stdout

--- a/contrib/bin/test_installed_headers.sh
+++ b/contrib/bin/test_installed_headers.sh
@@ -65,19 +65,23 @@ function test_header()
     errlog=$app_file.log
     stdout=$app_file.stdout
 
-    echo -n "Testing Header $header_to_test ... " > $stdout
-
-
+    printf '%s' "Testing Header $header_to_test ... " > $stdout
     echo "#include \"libmesh/$header_name\"" >> $source_file
     echo "int foo () { return 0; }" >> $source_file
 
     #echo $CXX $test_CXXFLAGS $source_file -o $app_file
     if $CXX $test_CXXFLAGS $source_file -c -o $object_file >$errlog 2>&1 ; then
-        echo -e $gotocolumn $white"["$green"   OK   "$white"]" >> $stdout
-        echo -e -n $colorreset >> $stdout
+        # See color codes above.  We:
+        # .) skip to column 65
+        # .) print [ in white
+        # .) print OK in green
+        # .) print ] in white
+        # .) reset the terminal color
+        # .) print a newline
+        printf '\e[65G\e[1;37m[\e[1;32m%s\e[1;37m]\e[m\e[m\n' "   OK   " >> $stdout
     else
-        echo -e $gotocolumn $white"["$red" FAILED "$white"]" >> $stdout
-        echo -e -n $colorreset >> $stdout
+        # See comment above for OK status
+        printf '\e[65G\e[1;37m[\e[1;31m%s\e[1;37m]\e[m\e[m\n' " FAILED " >> $stdout
         echo "Source file:" >> $stdout
         cat $source_file  >> $stdout
         echo ""  >> $stdout

--- a/contrib/bin/test_src.sh
+++ b/contrib/bin/test_src.sh
@@ -9,7 +9,7 @@
 # author: John W. Peterson, 2005
 
 print_usage () {
-echo -e "Usage: $0 filename.C"
+printf '%s\n' "Usage: $0 filename.C"
 }
 
 # Test input args
@@ -35,61 +35,53 @@ red="\033[01;31m";
 colorreset="\033[m";
 ########################################################
 
-
 # Informational message re: which file we are testing
-echo -e "Testing header removal in $1";
+printf '%s\n' "Testing header removal in $1";
 
 # The base filename
 fn=`basename $1`;
 
 # The base filename without the .C extension
 bn=`echo $fn | cut -d"." -f1`;
-#echo "$bn";
 
 # Find line numbers with local include statements.
 # Ignore lines for libmesh_config.h and libmesh_common.h,
 # assume they are definitely needed if they are present.
 inc_line_nums=`cat $1 | grep -n "^#include \"" | grep -v libmesh_config | grep -v libmesh_common | cut -d":" -f1`;
-#echo -e "$inc_line_nums"
+
+# This script requires that you have libmesh installed in $LIBMESH_DIR
+# with a valid libmesh-config script.
+LIBMESH_CONFIG=${LIBMESH_DIR}/bin/libmesh-config
 
 # Save the compiler name determined by libmesh-config
-compiler_name=`./libmesh-config --cxx`
-#echo "Using compiler: $compiler_name"
+compiler_name=`$LIBMESH_CONFIG --cxx`
 
 # Save the compile flags determined by libmesh-config
-compile_flags=`./libmesh-config --cppflags --cxxflags --include`
-#echo "Using compiler flags: $compile_flags"
+compile_flags=`$LIBMESH_CONFIG --cppflags --cxxflags --include`
 
 for i in $inc_line_nums; do
   # Grab the i'th line from the file
   line_i=`head -$i $1 | tail -1`;
 
-  # Print informative message(s)
-  # echo "Using compile command: $compiler_name $compile_flags -c $temp_file.C"
-
-  # echo -n "Testing with line $i removed ... ";
-  echo -n "Testing with ($line_i) removed ... ";
+  printf '%s' "Testing with ($line_i) removed ... ";
   
   # Name for temporary file to test line deletion
-  temp_file=`echo -e "line_${i}_$bn"`;
+  temp_file=`printf '%s' "line_${i}_$bn"`;
   
   # Create a temporary file with line $i deleted
   cat $1 | sed "${i}d" > $temp_file.C;
 
   # Attempt to compile $temp_file
-  $compiler_name $compile_flags -c $temp_file.C &> /dev/null #$temp_file.log 
+  $compiler_name $compile_flags -c $temp_file.C &> /dev/null
 
   # If an object file is successfully created, the compilation succeeds!
   if [ -f $temp_file.o ]; then
-      echo -e $gotocolumn $white"["$green"   Compilation succeeds!   "$white"]";
+      printf '\e[65G\e[1;37m[\e[1;32m%s\e[1;37m]\e[m\e[m\n' "   OK   "
       rm $temp_file.o
   else
-      echo -e $gotocolumn $white"["$red" Compilation fails! "$white"]";
+      printf '\e[65G\e[1;37m[\e[1;31m%s\e[1;37m]\e[m\e[m\n' " FAILED "
   fi
 
-  # Reset the colors
-  echo -e -n $colorreset;
-  
   # Clean up temporary file(s)
   rm $temp_file.C
 done;

--- a/contrib/bin/test_src.sh
+++ b/contrib/bin/test_src.sh
@@ -88,7 +88,7 @@ for i in $inc_line_nums; do
   fi
 
   # Reset the colors
-  echo -e -n $colorreset;    
+  echo -e -n $colorreset;
   
   # Clean up temporary file(s)
   rm $temp_file.C

--- a/contrib/qhull/2012.1/config/bootstrap.sh
+++ b/contrib/qhull/2012.1/config/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 run () {
-  echo -n Running `$1 --version | sed q`...
+  printf '%s' "Running `$1 --version | sed q`..."
   $* > /dev/null
   echo " done"
 }
@@ -12,7 +12,7 @@ if test ! -f config/configure.ac ; then
   exit 1
 fi
 
-echo -n Copying autoconf and automake files...
+printf '%s' "Copying autoconf and automake files..."
 cp config/configure.ac .
 cp config/Makefile-am-main Makefile.am
 for d in html eg ; do
@@ -21,7 +21,7 @@ done
 for d in libqhull ; do
   cp config/Makefile-am-$d src/$d/Makefile.am
 done
-echo -en ' done\nCopying program sources to src/libqhull...'
+printf '%s' " done\nCopying program sources to src/libqhull..."
 sources="src/qconvex/qconvex.c src/qdelaunay/qdelaun.c src/qhalf/qhalf.c \
   src/qhull/unix.c src/qvoronoi/qvoronoi.c src/rbox/rbox.c src/testqset/testqset.c"
 cp $sources src/libqhull

--- a/contrib/qhull/2012.1/eg/make-vcproj.sh
+++ b/contrib/qhull/2012.1/eg/make-vcproj.sh
@@ -59,8 +59,8 @@ for f in buildvc/*.vcproj buildqt/qhulltest/*.vcproj; do
 	$f > $dest
 done
 
-echo -e '\nExcept for qhulltest.vcproj,\n*.vcproj: delete empty File in Files section near end of vcproj'
-echo -e '\nExcept for qhulltest.vcproj,\n*.vcproj: rename debug targets to qhull_d.dll, etc.'
+printf '%s\n' "\nExcept for qhulltest.vcproj,\n*.vcproj: delete empty File in Files section near end of vcproj"
+printf '%s\n' "\nExcept for qhulltest.vcproj,\n*.vcproj: rename debug targets to qhull_d.dll, etc."
 
 # If need to rebuild sln
 sed -e '\|Project.*ALL_BUILD|,\|EndProject$| d' \

--- a/include/libmesh/rebuild_makefile.sh
+++ b/include/libmesh/rebuild_makefile.sh
@@ -32,10 +32,10 @@ EXTRA_DIST = rebuild_makefile.sh
 
 EOF
 
-echo -n "BUILT_SOURCES =" >> Makefile.am
+printf '%s' "BUILT_SOURCES =" >> Makefile.am
 for built_src in $built_sources ; do
     echo " \\" >> Makefile.am
-    echo -n "        "$built_src >> Makefile.am
+    printf '%s' "        "$built_src >> Makefile.am
 done
 
 echo >> Makefile.am

--- a/include/rebuild_include_HEADERS.sh
+++ b/include/rebuild_include_HEADERS.sh
@@ -19,10 +19,10 @@ echo "# These are headers we need to compile the libMesh library but should" >> 
 echo "# not be installed.  These header files may have implementation" >> include_HEADERS
 echo "# details which are not required for the public interface" >> include_HEADERS
 
-echo -n "noinst_HEADERS = " >> include_HEADERS
+printf '%s' "noinst_HEADERS = " >> include_HEADERS
 for header_with_path in $noinst_blacklist ; do
     echo " \\" >> include_HEADERS
-    echo -n "        "$header_with_path >> include_HEADERS
+    printf '%s' "        "$header_with_path >> include_HEADERS
 done
 echo >> include_HEADERS
 echo >> include_HEADERS
@@ -35,7 +35,7 @@ headers="libmesh_config.h $headers"
 echo "# These are the headers we actually want to install and make available" >> include_HEADERS
 echo "# to a user.  Consider these the public interface of libMesh." >> include_HEADERS
 echo "# will get installed into '\$(prefix)/include/libmesh'" >> include_HEADERS
-echo -n "include_HEADERS = " >> include_HEADERS
+printf '%s' "include_HEADERS = " >> include_HEADERS
 for header_with_path in $headers ; do
     add_header=1
     for blacklist in $noinst_blacklist ; do
@@ -45,10 +45,7 @@ for header_with_path in $headers ; do
     done
     if (test $add_header -eq 1); then
 	echo " \\" >> include_HEADERS
-	echo -n "        "$header_with_path >> include_HEADERS
+        printf '%s' "        "$header_with_path >> include_HEADERS
     fi
 done
 echo " " >> include_HEADERS
-
-
-

--- a/src/rebuild_libmesh_SOURCES.sh
+++ b/src/rebuild_libmesh_SOURCES.sh
@@ -3,11 +3,11 @@
 sources=`find base error_estimation fe geom mesh numerics parallel partitioning physics quadrature reduced_basis solution_transfer solvers systems utils -name "*.C" -o -name "*.c" -o -name "*.data" -type f | LC_COLLATE=POSIX sort`
 
 echo "# Do not edit - automatically generated from $0" > libmesh_SOURCES
-echo -n "libmesh_SOURCES = " >> libmesh_SOURCES
+printf '%s' "libmesh_SOURCES = " >> libmesh_SOURCES
 for source_with_path in $sources ; do
 
     echo " \\" >> libmesh_SOURCES
-    echo -n "        "src/$source_with_path >> libmesh_SOURCES
+    printf '%s' "        "src/$source_with_path >> libmesh_SOURCES
 
 done
 


### PR DESCRIPTION
Not all of these scripts use /bin/sh, but it doesn't hurt to make /bin/bash scripts a bit more portable.

Refs #575.