### PR TITLE
Bugfix for refine_by_nelem_target

### DIFF
--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -275,7 +275,8 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector& error_per
   this->clean_refinement_flags();
 
   // The target number of elements to add or remove
-  const std::ptrdiff_t n_elem_new = _nelem_target - n_active_elem;
+  const std::ptrdiff_t n_elem_new =
+    std::ptrdiff_t(_nelem_target) - std::ptrdiff_t(n_active_elem);
 
   // Create an vector with active element errors and ids,
   // sorted by highest errors first


### PR DESCRIPTION
This seems to have been a casualty of some of the 64-bit compatibility work.

Signed arithmetic needs to be done by signed datatypes, not just converted to a signed datatype later.