### PR TITLE
Pass elem_dim to FEMContext::get_element/side_fe

### DIFF
--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -820,17 +820,17 @@ protected:
     // Typedefs for "Value getter" function pointer
     typedef typename TensorTools::MakeReal<OutputType>::type value_shape;
     typedef FEGenericBase<value_shape> value_base;
-    typedef void (FEMContext::*value_getter) (unsigned int, value_base *&) const;
+    typedef void (FEMContext::*value_getter) (unsigned int, value_base *&, unsigned char) const;
 
     // Typedefs for "Grad getter" function pointer
     typedef typename TensorTools::MakeReal<Rank1Decrement>::type grad_shape;
     typedef FEGenericBase<grad_shape> grad_base;
-    typedef void (FEMContext::*grad_getter) (unsigned int, grad_base *&) const;
+    typedef void (FEMContext::*grad_getter) (unsigned int, grad_base *&, unsigned char) const;
 
     // Typedefs for "Hessian getter" function pointer
     typedef typename TensorTools::MakeReal<Rank2Decrement>::type hess_shape;
     typedef FEGenericBase<hess_shape> hess_base;
-    typedef void (FEMContext::*hess_getter) (unsigned int, hess_base *&) const;
+    typedef void (FEMContext::*hess_getter) (unsigned int, hess_base *&, unsigned char) const;
   };
 
 

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -220,9 +220,11 @@ public:
 
   /**
    * Accessor for interior finite element object for variable var for
-   * the largest dimension in the mesh. If you have lower dimensional elements
-   * in the mesh and need to query for those FE objects, use the alternative
-   * get_element_fe method.
+   * the largest dimension in the mesh. We default to the largest mesh dim
+   * because this method may be called before the Elem* is set in the FEMContext,
+   * e.g. in FEMSystem::init_context (or a subclass).
+   * If you have lower dimensional elements in the mesh and need to query for
+   * those FE objects, use the alternative get_element_fe method.
    */
   template<typename OutputShape>
   void get_element_fe( unsigned int var, FEGenericBase<OutputShape> *& fe ) const
@@ -230,9 +232,11 @@ public:
 
   /**
    * Accessor for interior finite element object for scalar-valued variable var
-   * for the largest dimension in the mesh. If you have lower dimensional elements
-   * in the mesh and need to query for those FE objects, use the alternative
-   * get_element_fe method.
+   * for the largest dimension in the mesh. We default to the largest mesh dim
+   * because this method may be called before the Elem* is set in the FEMContext,
+   * e.g. in FEMSystem::init_context (or a subclass).
+   * If you have lower dimensional elements in the mesh and need to query for
+   * those FE objects, use the alternative get_element_fe method.
    */
   FEBase* get_element_fe( unsigned int var ) const
   { return this->get_element_fe(var,this->get_dim()); }
@@ -253,9 +257,11 @@ public:
 
   /**
    * Accessor for edge/face (2D/3D) finite element object for variable var
-   * for the largest dimension in the mesh. If you have lower dimensional elements
-   * in the mesh and need to query for those FE objects, use the alternative
-   * get_side_fe method.
+   * for the largest dimension in the mesh. We default to the largest mesh dim
+   * because this method may be called before the Elem* is set in the FEMContext,
+   * e.g. in FEMSystem::init_context (or a subclass).
+   * If you have lower dimensional elements in the mesh and need to query for
+   * those FE objects, use the alternative get_side_fe method.
    */
   template<typename OutputShape>
   void get_side_fe( unsigned int var, FEGenericBase<OutputShape> *& fe ) const
@@ -263,9 +269,11 @@ public:
 
   /**
    * Accessor for side finite element object for scalar-valued variable var
-   * for the largest dimension in the mesh. If you have lower dimensional elements
-   * in the mesh and need to query for those FE objects, use the alternative
-   * get_side_fe method.
+   * for the largest dimension in the mesh. We default to the largest mesh dim
+   * because this method may be called before the Elem* is set in the FEMContext,
+   * e.g. in FEMSystem::init_context (or a subclass).
+   * If you have lower dimensional elements in the mesh and need to query for
+   * those FE objects, use the alternative get_side_fe method.
    */
   FEBase* get_side_fe( unsigned int var ) const
   { return this->get_side_fe(var,this->get_dim()); }

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -199,7 +199,7 @@ void FEMContext::some_value(unsigned int var, unsigned int qp, OutputType& u) co
 
   // Get finite element object
   typename FENeeded<OutputType>::value_base* fe = NULL;
-  (this->*fe_getter)( var, fe );
+  (this->*fe_getter)( var, fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector
@@ -229,7 +229,7 @@ void FEMContext::some_gradient(unsigned int var, unsigned int qp, OutputType& du
 
   // Get finite element object
   typename FENeeded<OutputType>::grad_base* fe = NULL;
-  (this->*fe_getter)( var, fe );
+  (this->*fe_getter)( var, fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector
@@ -263,7 +263,7 @@ void FEMContext::some_hessian(unsigned int var, unsigned int qp, OutputType& d2u
 
   // Get finite element object
   typename FENeeded<OutputType>::hess_base* fe = NULL;
-  (this->*fe_getter)( var, fe );
+  (this->*fe_getter)( var, fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector
@@ -318,7 +318,7 @@ void FEMContext::interior_values (unsigned int var,
 
   // Get the finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector<OutputShape> > &phi = fe->get_phi();
@@ -382,7 +382,7 @@ void FEMContext::interior_gradients
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputGradient> > &dphi = fe->get_dphi();
@@ -448,7 +448,7 @@ void FEMContext::interior_hessians
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> > &d2phi = fe->get_d2phi();
@@ -489,7 +489,7 @@ void FEMContext::interior_curl(unsigned int var, unsigned int qp,
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputShape> > &curl_phi = fe->get_curl_phi();
@@ -523,7 +523,7 @@ void FEMContext::interior_div(unsigned int var, unsigned int qp,
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputDivergence> > &div_phi = fe->get_div_phi();
@@ -576,7 +576,7 @@ void FEMContext::side_values
 
   // Get the finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
-  this->get_side_fe<OutputShape>( var, the_side_fe );
+  this->get_side_fe<OutputShape>( var, the_side_fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector<OutputShape> > &phi = the_side_fe->get_phi();
@@ -625,7 +625,7 @@ void FEMContext::side_gradient(unsigned int var, unsigned int qp,
 
   // Get finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
-  this->get_side_fe<OutputShape>( var, the_side_fe );
+  this->get_side_fe<OutputShape>( var, the_side_fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector< typename FEGenericBase<OutputShape>::OutputGradient> > &dphi = the_side_fe->get_dphi();
@@ -661,7 +661,7 @@ void FEMContext::side_gradients
 
   // Get finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
-  this->get_side_fe<OutputShape>( var, the_side_fe );
+  this->get_side_fe<OutputShape>( var, the_side_fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputGradient> > &dphi = the_side_fe->get_dphi();
@@ -730,7 +730,7 @@ void FEMContext::side_hessians
 
   // Get finite element object
   FEGenericBase<OutputShape>* the_side_fe = NULL;
-  this->get_side_fe<OutputShape>( var, the_side_fe );
+  this->get_side_fe<OutputShape>( var, the_side_fe, this->get_elem_dim() );
 
   // Get shape function values at quadrature point
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> > &d2phi = the_side_fe->get_d2phi();
@@ -782,7 +782,7 @@ void FEMContext::point_value(unsigned int var, const Point &p,
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Build a FE for calculating u(p)
   UniquePtr<FEGenericBase<OutputShape> > fe_new = this->build_new_fe( fe, p );
@@ -830,7 +830,7 @@ void FEMContext::point_gradient(unsigned int var, const Point &p,
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Build a FE for calculating u(p)
   UniquePtr<FEGenericBase<OutputShape> > fe_new = this->build_new_fe( fe, p );
@@ -881,7 +881,7 @@ void FEMContext::point_hessian(unsigned int var, const Point &p,
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Build a FE for calculating u(p)
   UniquePtr<FEGenericBase<OutputShape> > fe_new = this->build_new_fe( fe, p );
@@ -917,7 +917,7 @@ void FEMContext::point_curl(unsigned int var, const Point &p,
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Build a FE for calculating u(p)
   UniquePtr<FEGenericBase<OutputShape> > fe_new = this->build_new_fe( fe, p );
@@ -1111,7 +1111,7 @@ void FEMContext::fixed_point_value(unsigned int var, const Point &p,
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Build a FE for calculating u(p)
   UniquePtr<FEGenericBase<OutputShape> > fe_new = this->build_new_fe( fe, p );
@@ -1159,7 +1159,7 @@ void FEMContext::fixed_point_gradient(unsigned int var, const Point &p,
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Build a FE for calculating u(p)
   UniquePtr<FEGenericBase<OutputShape> > fe_new = this->build_new_fe( fe, p );
@@ -1210,7 +1210,7 @@ void FEMContext::fixed_point_hessian(unsigned int var, const Point &p,
 
   // Get finite element object
   FEGenericBase<OutputShape>* fe = NULL;
-  this->get_element_fe<OutputShape>( var, fe );
+  this->get_element_fe<OutputShape>( var, fe, this->get_elem_dim() );
 
   // Build a FE for calculating u(p)
   UniquePtr<FEGenericBase<OutputShape> > fe_new = this->build_new_fe( fe, p );


### PR DESCRIPTION
Internally in FEMContext, when evaluating quantities, pass the
element dimension to make sure we get the right element in mixed
dimension meshes. We can do this because the element will have
already been set in the FEMContext before these methods are called.

I didn't hit this before because I wasn't actually calling these methods due to the nature of the solid mechanics weak forms I was using (derivatives are w.r.t. reference element coordinates, not spatial coordinates). I hit this in the mixed-dimensional dynamic case in the mass_residual/interior_accel (#582) case. This fixes that.