### PR TITLE
Sparse CouplingMatrix

### DIFF
--- a/include/numerics/coupling_matrix.h
+++ b/include/numerics/coupling_matrix.h
@@ -24,13 +24,17 @@
 #include "libmesh/libmesh_common.h"
 
 // C++ includes
+#include <algorithm>
+#include <limits>
+#include <utility> // std::pair
 #include <vector>
 
 namespace libMesh
 {
 
-
-
+// Forward declarations
+class ConstCouplingAccessor;
+class CouplingAccessor;
 
 /**
  * This class defines a coupling matrix.  A coupling
@@ -52,15 +56,15 @@ public:
   /**
    * @returns the (i,j) entry of the matrix.
    */
-  unsigned char operator() (const unsigned int i,
-                            const unsigned int j) const;
+  bool operator() (const unsigned int i,
+                   const unsigned int j) const;
 
   /**
    * @returns the (i,j) entry of the matrix as
-   * a writeable reference.
+   * a smart-reference.
    */
-  unsigned char & operator() (const unsigned int i,
-                              const unsigned int j);
+  CouplingAccessor operator() (const unsigned int i,
+                               const unsigned int j);
 
   /**
    * @returns the size of the matrix, i.e. N for an
@@ -86,13 +90,23 @@ public:
 
 private:
 
+  friend class ConstCouplingAccessor;
+  friend class CouplingAccessor;
+
   /**
-   * The actual matrix values.  These
-   * are stored as unsigned chars because
-   * a vector of bools is not what you
-   * think.
+   * Coupling matrices are typically either full or very sparse, and
+   * all values are only zero or one.
+   *
+   * We store non-zeros as ranges: the first entry of each range pair
+   * is the location of the first non-zero, and the second is the
+   * location of the last subsequent non-zero (*not* the next
+   * subsequent zero; we drop empty ranges).
+   * 
+   * We store locations (i,j) as long integers i*_size+j
    */
-  std::vector<unsigned char> _values;
+  typedef std::pair<std::size_t, std::size_t> range_type;
+  typedef std::vector<range_type> rc_type;
+  rc_type _ranges;
 
   /**
    * The size of the matrix.
@@ -102,14 +116,208 @@ private:
 
 
 
+/**
+ * This accessor class allows simple access to CouplingMatrix values.
+ */
+class ConstCouplingAccessor
+{
+public:
+  ConstCouplingAccessor(std::size_t loc_in,
+                        const CouplingMatrix& mat_in) :
+    _location(loc_in), _mat(mat_in)
+  {
+    libmesh_assert_less(_location, _mat.size() * _mat.size());
+  }
+
+  operator bool() const {
+    const std::size_t max_size = std::numeric_limits<std::size_t>::max();
+
+    // Find the range that might contain i,j
+    // lower_bound isn't *quite* what we want
+    CouplingMatrix::rc_type::const_iterator lb = std::upper_bound
+      (_mat._ranges.begin(), _mat._ranges.end(),
+       std::make_pair(_location, max_size));
+    if (lb!=_mat._ranges.begin())
+      --lb;
+    else
+      lb=_mat._ranges.end();
+
+    // If no range might contain i,j then it's 0
+    if (lb == _mat._ranges.end())
+      return false;
+
+    const std::size_t firstloc = lb->first;
+    const std::size_t lastloc  = lb->second;
+    libmesh_assert_less_equal(firstloc, lastloc);
+    libmesh_assert_less_equal(firstloc, _location);
+
+#ifdef DEBUG
+    CouplingMatrix::rc_type::const_iterator next = lb;
+    next++;
+    if (next != _mat._ranges.end())
+      {
+        // Ranges should be sorted and should not touch
+        libmesh_assert_greater(next->first, lastloc+1);
+      }
+#endif
+
+    return (lastloc >= _location);
+  }
+
+protected:
+
+  std::size_t _location;
+  const CouplingMatrix& _mat;
+};
 
 
+/**
+ * This accessor class allows simple setting of CouplingMatrix values.
+ */
+class CouplingAccessor : public ConstCouplingAccessor
+{
+public:
+  CouplingAccessor(std::size_t loc_in,
+                   CouplingMatrix& mat_in) :
+    ConstCouplingAccessor(loc_in, mat_in), _my_mat(mat_in) {}
+
+  template <typename T>
+  CouplingAccessor& operator = (T new_value)
+  {
+    // For backwards compatibility we take integer arguments,
+    // but coupling matrix entries are really all zero or one.
+    const bool as_bool = new_value;
+    libmesh_assert_equal_to(new_value, as_bool);
+
+    *this = as_bool;
+    return *this;
+  }
+
+  CouplingAccessor& operator = (bool new_value)
+  {
+    const std::size_t max_size = std::numeric_limits<std::size_t>::max();
+
+    // Find the range that might contain i,j
+    // lower_bound isn't *quite* what we want
+    CouplingMatrix::rc_type::iterator lb =
+      std::upper_bound (_my_mat._ranges.begin(), _my_mat._ranges.end(),
+                        std::make_pair(_location, max_size));
+    if (lb!=_my_mat._ranges.begin())
+      --lb;
+    else
+      lb=_my_mat._ranges.end();
+
+    // If no range might contain i,j then we might need to make a new
+    // one.
+    if (lb == _my_mat._ranges.end())
+      {
+        if (new_value == true)
+          _my_mat._ranges.insert(_my_mat._ranges.begin(),
+                                 std::make_pair(_location, _location));
+      }
+    else
+      {
+        const std::size_t firstloc = lb->first;
+        const std::size_t lastloc  = lb->second;
+        libmesh_assert_less_equal(firstloc, lastloc);
+        libmesh_assert_less_equal(firstloc, _location);
+
+#ifdef DEBUG
+        CouplingMatrix::rc_type::const_iterator next = lb;
+        next++;
+        if (next != _my_mat._ranges.end())
+          {
+            // Ranges should be sorted and should not touch
+            libmesh_assert_greater(next->first, lastloc+1);
+          }
+#endif
+
+        // If we're in this range, we might need to shorten or remove
+        // or split it
+        if (new_value == false)
+          {
+            if (_location == firstloc)
+              {
+                if (_location == lastloc)
+                  {
+                    _my_mat._ranges.erase(lb);
+                  }
+                else
+                  {
+                    libmesh_assert_less (lb->first, lastloc);
+                    lb->first++;
+                  }
+              }
+            else if (_location == lastloc)
+              {
+                libmesh_assert_less (firstloc, lb->second);
+
+                lb->second--;
+              }
+            else if (_location < lastloc)
+              {
+                libmesh_assert_less_equal(_location+1, lastloc);
+
+                lb->first = _location+1;
+
+                libmesh_assert_less_equal(firstloc, _location-1);
+
+                _my_mat._ranges.insert
+                  (lb, std::make_pair(firstloc, _location-1));
+              }
+          }
+
+        // If we're not in this range, we might need to extend it or
+        // join it with its neighbor or add a new one.
+        else // new_value == true
+          {
+            CouplingMatrix::rc_type::iterator next = lb;
+            next++;
+            const std::size_t nextloc =
+              (next == _my_mat._ranges.end()) ?
+              std::numeric_limits<std::size_t>::max() :
+              next->first;
+
+            // Ranges should be sorted and should not touch
+            libmesh_assert_greater(nextloc, lastloc+1);
+
+            if (_location > lastloc)
+              {
+                if (_location == lastloc + 1)
+                  {
+                    if (_location == nextloc - 1)
+                      {
+                        next->first = firstloc;
+                        _my_mat._ranges.erase(lb);
+                      }
+                    else
+                      lb->second++;
+                  }
+                else
+                  {
+                    if (_location == nextloc - 1)
+                      next->first--;
+                    else
+                      _my_mat._ranges.insert
+                        (next, std::make_pair(_location, _location));
+                  }
+              }
+          }
+      }
+
+    return *this;
+  }
+
+private:
+
+  CouplingMatrix& _my_mat;
+};
 
 //--------------------------------------------------
 // CouplingMatrix inline methods
 inline
 CouplingMatrix::CouplingMatrix (const unsigned int n) :
-  _values(), _size(n)
+  _ranges(), _size(n)
 {
   this->resize(n);
 }
@@ -117,25 +325,27 @@ CouplingMatrix::CouplingMatrix (const unsigned int n) :
 
 
 inline
-unsigned char CouplingMatrix::operator() (const unsigned int i,
-                                          const unsigned int j) const
+bool CouplingMatrix::operator() (const unsigned int i,
+                                 const unsigned int j) const
 {
   libmesh_assert_less (i, _size);
   libmesh_assert_less (j, _size);
 
-  return _values[i*_size + j];
+  const std::size_t location = std::size_t(i)*_size + j;
+
+  return bool(ConstCouplingAccessor(location, *this));
 }
 
 
 
-inline
-unsigned char & CouplingMatrix::operator() (const unsigned int i,
-                                            const unsigned int j)
-{
-  libmesh_assert_less (i, _size);
-  libmesh_assert_less (j, _size);
 
-  return _values[i*_size + j];
+inline
+CouplingAccessor CouplingMatrix::operator() (const unsigned int i,
+                                             const unsigned int j)
+{
+  const std::size_t location = std::size_t(i)*_size + j;
+
+  return CouplingAccessor(location, *this);
 }
 
 
@@ -153,10 +363,7 @@ void CouplingMatrix::resize(const unsigned int n)
 {
   _size = n;
 
-  _values.resize(_size*_size);
-
-  for (unsigned int i=0; i<_values.size(); i++)
-    _values[i] = 0;
+  _ranges.clear();
 }
 
 
@@ -164,9 +371,7 @@ void CouplingMatrix::resize(const unsigned int n)
 inline
 void CouplingMatrix::clear()
 {
-  _size = 0;
-
-  _values.clear();
+  this->resize(0);
 }
 
 

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -745,23 +745,27 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
             {
               // Otherwise we should only add the relevant submatrices
               for(unsigned int var1=0; var1<n_vars(); var1++)
-                for(unsigned int var2=0; var2<n_vars(); var2++)
-                  {
-                    if( coupling_matrix->operator()(var1,var2) )
-                      {
-                        unsigned int sub_m = context.get_elem_jacobian( var1, var2 ).m();
-                        unsigned int sub_n = context.get_elem_jacobian( var1, var2 ).n();
-                        DenseMatrix<Number> sub_jac(sub_m, sub_n);
-                        for(unsigned int row=0; row<sub_m; row++)
-                          for(unsigned int col=0; col<sub_n; col++)
-                            {
-                              sub_jac(row,col) = context.get_elem_jacobian( var1, var2 ).el(row,col);
-                            }
-                        input_matrix->add_matrix (sub_jac,
-                                                  context.get_dof_indices(var1),
-                                                  context.get_dof_indices(var2) );
-                      }
-                  }
+                {
+                  ConstCouplingRow ccr(var1, *coupling_matrix);
+                  ConstCouplingRow::const_iterator end = ccr.end();
+                  for (ConstCouplingRow::const_iterator it =
+                       ccr.begin(); it != end; ++it)
+                    {
+                      unsigned int var2 = *it;
+
+                      unsigned int sub_m = context.get_elem_jacobian( var1, var2 ).m();
+                      unsigned int sub_n = context.get_elem_jacobian( var1, var2 ).n();
+                      DenseMatrix<Number> sub_jac(sub_m, sub_n);
+                      for(unsigned int row=0; row<sub_m; row++)
+                        for(unsigned int col=0; col<sub_n; col++)
+                          {
+                            sub_jac(row,col) = context.get_elem_jacobian( var1, var2 ).el(row,col);
+                          }
+                      input_matrix->add_matrix (sub_jac,
+                                                context.get_dof_indices(var1),
+                                                context.get_dof_indices(var2) );
+                    }
+                }
             }
 
         }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -157,12 +157,10 @@ void RBEIMConstruction::init_data()
 {
   // set the coupling matrix to be diagonal
   _coupling_matrix.resize(n_vars());
-  for(unsigned int var1=0; var1<n_vars(); var1++)
-    for(unsigned int var2=0; var2<n_vars(); var2++)
-      {
-        unsigned char value = (var1==var2) ? 1 : 0;
-        _coupling_matrix(var1,var2) = value;
-      }
+
+  // resize zeroed the matrix; we just need to set diagonal entries
+  for(unsigned int var=0; var<n_vars(); var++)
+    _coupling_matrix(var,var) = 1;
 
   this->get_dof_map()._dof_coupling = &_coupling_matrix;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,6 +19,7 @@ unit_tests_sources = \
 	mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C \
 	numerics/composite_function_test.C \
+	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C \
 	numerics/numeric_vector_test.h \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -128,6 +128,7 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C numerics/composite_function_test.C \
+	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
@@ -146,6 +147,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_dbg-composite_function_test.$(OBJEXT) \
+	numerics/unit_tests_dbg-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-laspack_vector_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-parsed_fem_function_test.$(OBJEXT) \
@@ -172,6 +174,7 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C numerics/composite_function_test.C \
+	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
@@ -189,6 +192,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_devel-composite_function_test.$(OBJEXT) \
+	numerics/unit_tests_devel-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_devel-laspack_vector_test.$(OBJEXT) \
 	numerics/unit_tests_devel-parsed_fem_function_test.$(OBJEXT) \
@@ -213,6 +217,7 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C numerics/composite_function_test.C \
+	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
@@ -230,6 +235,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_oprof-composite_function_test.$(OBJEXT) \
+	numerics/unit_tests_oprof-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-laspack_vector_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-parsed_fem_function_test.$(OBJEXT) \
@@ -254,6 +260,7 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C numerics/composite_function_test.C \
+	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
@@ -271,6 +278,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_opt-composite_function_test.$(OBJEXT) \
+	numerics/unit_tests_opt-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_opt-laspack_vector_test.$(OBJEXT) \
 	numerics/unit_tests_opt-parsed_fem_function_test.$(OBJEXT) \
@@ -293,6 +301,7 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C numerics/composite_function_test.C \
+	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
@@ -310,6 +319,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_prof-nodal_neighbors.$(OBJEXT) \
 	numerics/unit_tests_prof-composite_function_test.$(OBJEXT) \
+	numerics/unit_tests_prof-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT) \
 	numerics/unit_tests_prof-laspack_vector_test.$(OBJEXT) \
 	numerics/unit_tests_prof-parsed_fem_function_test.$(OBJEXT) \
@@ -724,6 +734,7 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	base/getpot_test.C geom/node_test.C geom/point_test.C \
 	geom/point_test.h mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C numerics/composite_function_test.C \
+	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/laspack_vector_test.C numerics/numeric_vector_test.h \
 	numerics/parsed_fem_function_test.C \
@@ -850,6 +861,8 @@ numerics/$(DEPDIR)/$(am__dirstamp):
 	@: > numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_dbg-coupling_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-laspack_vector_test.$(OBJEXT):  \
@@ -918,6 +931,8 @@ mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_devel-coupling_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-laspack_vector_test.$(OBJEXT):  \
@@ -955,6 +970,8 @@ mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT):  \
 mesh/unit_tests_oprof-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-composite_function_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_oprof-coupling_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -994,6 +1011,8 @@ mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_opt-coupling_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-laspack_vector_test.$(OBJEXT):  \
@@ -1031,6 +1050,8 @@ mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT):  \
 mesh/unit_tests_prof-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-composite_function_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_prof-coupling_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -1110,6 +1131,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-parsed_fem_function_test.Po@am__quote@
@@ -1117,6 +1139,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-type_tensor_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-parsed_fem_function_test.Po@am__quote@
@@ -1124,6 +1147,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-type_tensor_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-parsed_fem_function_test.Po@am__quote@
@@ -1131,6 +1155,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-type_tensor_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-parsed_fem_function_test.Po@am__quote@
@@ -1138,6 +1163,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-type_tensor_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-parsed_fem_function_test.Po@am__quote@
@@ -1286,6 +1312,20 @@ numerics/unit_tests_dbg-composite_function_test.obj: numerics/composite_function
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/composite_function_test.C' object='numerics/unit_tests_dbg-composite_function_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-composite_function_test.obj `if test -f 'numerics/composite_function_test.C'; then $(CYGPATH_W) 'numerics/composite_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/composite_function_test.C'; fi`
+
+numerics/unit_tests_dbg-coupling_matrix_test.o: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-coupling_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Tpo -c -o numerics/unit_tests_dbg-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_dbg-coupling_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+
+numerics/unit_tests_dbg-coupling_matrix_test.obj: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-coupling_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Tpo -c -o numerics/unit_tests_dbg-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_dbg-coupling_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
 
 numerics/unit_tests_dbg-distributed_vector_test.o: numerics/distributed_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-distributed_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Tpo -c -o numerics/unit_tests_dbg-distributed_vector_test.o `test -f 'numerics/distributed_vector_test.C' || echo '$(srcdir)/'`numerics/distributed_vector_test.C
@@ -1539,6 +1579,20 @@ numerics/unit_tests_devel-composite_function_test.obj: numerics/composite_functi
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-composite_function_test.obj `if test -f 'numerics/composite_function_test.C'; then $(CYGPATH_W) 'numerics/composite_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/composite_function_test.C'; fi`
 
+numerics/unit_tests_devel-coupling_matrix_test.o: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-coupling_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Tpo -c -o numerics/unit_tests_devel-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_devel-coupling_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+
+numerics/unit_tests_devel-coupling_matrix_test.obj: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-coupling_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Tpo -c -o numerics/unit_tests_devel-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_devel-coupling_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
+
 numerics/unit_tests_devel-distributed_vector_test.o: numerics/distributed_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-distributed_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Tpo -c -o numerics/unit_tests_devel-distributed_vector_test.o `test -f 'numerics/distributed_vector_test.C' || echo '$(srcdir)/'`numerics/distributed_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po
@@ -1790,6 +1844,20 @@ numerics/unit_tests_oprof-composite_function_test.obj: numerics/composite_functi
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/composite_function_test.C' object='numerics/unit_tests_oprof-composite_function_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-composite_function_test.obj `if test -f 'numerics/composite_function_test.C'; then $(CYGPATH_W) 'numerics/composite_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/composite_function_test.C'; fi`
+
+numerics/unit_tests_oprof-coupling_matrix_test.o: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-coupling_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Tpo -c -o numerics/unit_tests_oprof-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_oprof-coupling_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+
+numerics/unit_tests_oprof-coupling_matrix_test.obj: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-coupling_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Tpo -c -o numerics/unit_tests_oprof-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_oprof-coupling_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
 
 numerics/unit_tests_oprof-distributed_vector_test.o: numerics/distributed_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-distributed_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Tpo -c -o numerics/unit_tests_oprof-distributed_vector_test.o `test -f 'numerics/distributed_vector_test.C' || echo '$(srcdir)/'`numerics/distributed_vector_test.C
@@ -2043,6 +2111,20 @@ numerics/unit_tests_opt-composite_function_test.obj: numerics/composite_function
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-composite_function_test.obj `if test -f 'numerics/composite_function_test.C'; then $(CYGPATH_W) 'numerics/composite_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/composite_function_test.C'; fi`
 
+numerics/unit_tests_opt-coupling_matrix_test.o: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-coupling_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Tpo -c -o numerics/unit_tests_opt-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_opt-coupling_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+
+numerics/unit_tests_opt-coupling_matrix_test.obj: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-coupling_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Tpo -c -o numerics/unit_tests_opt-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_opt-coupling_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
+
 numerics/unit_tests_opt-distributed_vector_test.o: numerics/distributed_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-distributed_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Tpo -c -o numerics/unit_tests_opt-distributed_vector_test.o `test -f 'numerics/distributed_vector_test.C' || echo '$(srcdir)/'`numerics/distributed_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po
@@ -2294,6 +2376,20 @@ numerics/unit_tests_prof-composite_function_test.obj: numerics/composite_functio
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/composite_function_test.C' object='numerics/unit_tests_prof-composite_function_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-composite_function_test.obj `if test -f 'numerics/composite_function_test.C'; then $(CYGPATH_W) 'numerics/composite_function_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/composite_function_test.C'; fi`
+
+numerics/unit_tests_prof-coupling_matrix_test.o: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-coupling_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Tpo -c -o numerics/unit_tests_prof-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_prof-coupling_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-coupling_matrix_test.o `test -f 'numerics/coupling_matrix_test.C' || echo '$(srcdir)/'`numerics/coupling_matrix_test.C
+
+numerics/unit_tests_prof-coupling_matrix_test.obj: numerics/coupling_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-coupling_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Tpo -c -o numerics/unit_tests_prof-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/coupling_matrix_test.C' object='numerics/unit_tests_prof-coupling_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-coupling_matrix_test.obj `if test -f 'numerics/coupling_matrix_test.C'; then $(CYGPATH_W) 'numerics/coupling_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/coupling_matrix_test.C'; fi`
 
 numerics/unit_tests_prof-distributed_vector_test.o: numerics/distributed_vector_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-distributed_vector_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Tpo -c -o numerics/unit_tests_prof-distributed_vector_test.o `test -f 'numerics/distributed_vector_test.C' || echo '$(srcdir)/'`numerics/distributed_vector_test.C

--- a/tests/numerics/coupling_matrix_test.C
+++ b/tests/numerics/coupling_matrix_test.C
@@ -20,6 +20,8 @@ public:
 
   CPPUNIT_TEST(testSimpleAPI);
 
+  CPPUNIT_TEST(testIteratorAPI);
+
   CPPUNIT_TEST_SUITE_END();
 
 
@@ -27,6 +29,10 @@ private:
   void testSimpleAPI()
   {
     CouplingMatrix cm(2);
+
+    // Use a constant reference to make sure we test both const and
+    // non-const operator() implementations
+    const CouplingMatrix& cmr = cm;
 
     cm(0,1) = 1;
 
@@ -39,6 +45,8 @@ private:
       for (unsigned j=0; j<2; ++j)
         {
           bool cmij = cm(i,j);
+          bool cmrij = cmr(i,j);
+          CPPUNIT_ASSERT_EQUAL(cmij, cmrij);
           CPPUNIT_ASSERT_EQUAL(cmij, (i != j));
         }
 
@@ -48,6 +56,8 @@ private:
       for (unsigned j=0; j<8; ++j)
         {
           bool cmij = cm(i,j);
+          bool cmrij = cmr(i,j);
+          CPPUNIT_ASSERT_EQUAL(cmij, cmrij);
           CPPUNIT_ASSERT_EQUAL(cmij, false);
         }
 
@@ -68,6 +78,8 @@ private:
       for (unsigned j=0; j<8; ++j)
         {
           bool cmij = cm(i,j);
+          bool cmrij = cmr(i,j);
+          CPPUNIT_ASSERT_EQUAL(cmij, cmrij);
           if ((i != 0) && (i != 5) && (j != 4) && (j != 7))
             {
               CPPUNIT_ASSERT_EQUAL(cmij, true);
@@ -91,6 +103,8 @@ private:
       for (unsigned j=0; j<8; ++j)
         {
           bool cmij = cm(i,j);
+          bool cmrij = cmr(i,j);
+          CPPUNIT_ASSERT_EQUAL(cmij, cmrij);
           if ((i != 0) && (i != 3) && (i != 5) &&
               (j != 0) && (j != 4) && (j != 7))
             {
@@ -102,6 +116,66 @@ private:
             }
         }
   }
+
+  void testIteratorAPI()
+  {
+    CouplingMatrix cm(8);
+
+    // Set some elements true, in a weird order.
+    for (unsigned i=6; i>0; --i)
+      {
+        const unsigned int pi = i + (i > 4);
+        for (unsigned j=0; j<6; ++j)
+          {
+            const unsigned int pj = j + (j > 3);
+            cm(pi, pj) = true;
+          }
+      }
+
+    // Now the tensor product of {1,2,3,4,6,7} with {0,1,2,3,5,6}
+    // should be 1.
+
+    // Set some elements to false.
+    for (unsigned k=0; k<8; ++k)
+      {
+        cm(3, k) = false;
+        cm(k, 0) = false;
+      }
+
+    // Now the tensor product of {1,2,4,6,7} with {1,2,3,5,6}
+    // should be 1.
+    const unsigned int ivals[] = {1,2,4,6,7};
+    const unsigned int non_ivals[] = {0,3,5};
+    const unsigned int jvals[] = {1,2,3,5,6};
+    // const unsigned int non_jvals[] = {0,4,7};
+
+    const unsigned int isize = sizeof(unsigned int);
+
+    for (unsigned int pi = 0; pi != sizeof(non_ivals)/isize; ++pi)
+      {
+        unsigned int i = non_ivals[pi];
+        ConstCouplingRow ccr(i,cm);
+        CPPUNIT_ASSERT(ccr.begin() == ccr.end());
+      }
+
+    for (unsigned int pi = 0; pi != sizeof(ivals)/isize; ++pi)
+      {
+        unsigned int i = ivals[pi];
+        ConstCouplingRow ccr(i,cm);
+
+        ConstCouplingRow::const_iterator ccr_it = ccr.begin();
+
+        for (unsigned int pj = 0; pj != sizeof(jvals)/isize; ++pj)
+          {
+            CPPUNIT_ASSERT(ccr_it != ccr.end());
+            CPPUNIT_ASSERT_EQUAL(*ccr_it, jvals[pj]);
+            ++ccr_it;
+          }
+
+        CPPUNIT_ASSERT(ccr_it == ccr.end());
+      }
+  }
+
 
 };
 

--- a/tests/numerics/coupling_matrix_test.C
+++ b/tests/numerics/coupling_matrix_test.C
@@ -1,0 +1,108 @@
+// Ignore unused parameter warnings coming from cppuint headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+// libmesh includes
+#include <libmesh/coupling_matrix.h>
+
+using namespace libMesh;
+
+class CouplingMatrixTest : public CppUnit::TestCase
+{
+public:
+  void setUp() {}
+
+  void tearDown() {}
+
+  CPPUNIT_TEST_SUITE(CouplingMatrixTest);
+
+  CPPUNIT_TEST(testSimpleAPI);
+
+  CPPUNIT_TEST_SUITE_END();
+
+
+private:
+  void testSimpleAPI()
+  {
+    CouplingMatrix cm(2);
+
+    cm(0,1) = 1;
+
+    bool cm01 = cm(0,1);
+    CPPUNIT_ASSERT_EQUAL(cm01, true);
+
+    cm(1,0) = 1;
+
+    for (unsigned i=0; i<2; ++i)
+      for (unsigned j=0; j<2; ++j)
+        {
+          bool cmij = cm(i,j);
+          CPPUNIT_ASSERT_EQUAL(cmij, (i != j));
+        }
+
+    cm.resize(8);
+
+    for (unsigned i=0; i<8; ++i)
+      for (unsigned j=0; j<8; ++j)
+        {
+          bool cmij = cm(i,j);
+          CPPUNIT_ASSERT_EQUAL(cmij, false);
+        }
+
+    // Set some elements true, in a weird order.
+    for (unsigned i=6; i>0; --i)
+      {
+        const unsigned int pi = i + (i > 4);
+        for (unsigned j=0; j<6; ++j)
+          {
+            const unsigned int pj = j + (j > 3);
+            cm(pi, pj) = true;
+          }
+      }
+
+    // Now the tensor product of {1,2,3,4,6,7} with {0,1,2,3,5,6}
+    // should be 1.
+    for (unsigned i=0; i<8; ++i)
+      for (unsigned j=0; j<8; ++j)
+        {
+          bool cmij = cm(i,j);
+          if ((i != 0) && (i != 5) && (j != 4) && (j != 7))
+            {
+              CPPUNIT_ASSERT_EQUAL(cmij, true);
+            }
+          else
+            {
+              CPPUNIT_ASSERT_EQUAL(cmij, false);
+            }
+        }
+
+    // Set some elements to false.
+    for (unsigned k=0; k<8; ++k)
+      {
+        cm(3, k) = false;
+        cm(k, 0) = false;
+      }
+
+    // Now the tensor product of {1,2,4,6,7} with {1,2,3,5,6}
+    // should be 1.
+    for (unsigned i=0; i<8; ++i)
+      for (unsigned j=0; j<8; ++j)
+        {
+          bool cmij = cm(i,j);
+          if ((i != 0) && (i != 3) && (i != 5) &&
+              (j != 0) && (j != 4) && (j != 7))
+            {
+              CPPUNIT_ASSERT_EQUAL(cmij, true);
+            }
+          else
+            {
+              CPPUNIT_ASSERT_EQUAL(cmij, false);
+            }
+        }
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(CouplingMatrixTest);


### PR DESCRIPTION
My attempt to optimize the hotspot found in #586.  This should be much faster in the many-sparsely-coupled-variables case, and should use much less memory in all but the most perverse cases.

This API change changes the return type of operator(), but the proxy class it uses should be backwards compatible for essentially everyone.