### PR TITLE
Better error messages

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -358,8 +358,8 @@ extern bool warned_about_auto_ptr;
 // throws a ConvergenceFailure exception
 #define libmesh_error_msg(msg)                                          \
   do {                                                                  \
-    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, __LIBMESH_DATE__, __LIBMESH_TIME__); \
     libMesh::err << msg << std::endl;                                   \
+    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, __LIBMESH_DATE__, __LIBMESH_TIME__); \
     LIBMESH_THROW(libMesh::LogicError());                               \
   } while(0)
 
@@ -367,8 +367,8 @@ extern bool warned_about_auto_ptr;
 
 #define libmesh_exceptionless_error_msg(msg)                            \
   do {                                                                  \
-    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, __LIBMESH_DATE__, __LIBMESH_TIME__); \
     libMesh::err << msg << std::endl;                                   \
+    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, __LIBMESH_DATE__, __LIBMESH_TIME__); \
     std::terminate();                                                   \
   } while(0)
 
@@ -376,8 +376,8 @@ extern bool warned_about_auto_ptr;
 
 #define libmesh_not_implemented_msg(msg)                                \
   do {                                                                  \
-    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, __LIBMESH_DATE__, __LIBMESH_TIME__); \
     libMesh::err << msg << std::endl;                                   \
+    libMesh::MacroFunctions::report_error(__FILE__, __LINE__, __LIBMESH_DATE__, __LIBMESH_TIME__); \
     LIBMESH_THROW(libMesh::NotImplemented());                           \
   } while(0)
 

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -442,7 +442,8 @@ const T& Parameters::get (const std::string& name) const
       oss << ' ' << demangle(typeid(T).name());
 #endif
       oss << " parameter named \""
-          << name << "\":\n"
+          << name << "\" found.\n\n"
+          << "Known parameters:\n"
           << *this;
 
       libmesh_error_msg(oss.str());


### PR DESCRIPTION
My crack at @friedmud's wish in #275

This should be an improvement in error reporting for every libmesh_foo_msg() macro, not just that particular Parameters case.