### PR TITLE
Guards in NewmarkSolver

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -435,6 +435,7 @@ am__libmesh_dbg_la_SOURCES_DIST = src/base/dof_map.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
+	src/solvers/second_order_unsteady_solver.C \
 	src/solvers/slepc_eigen_solver.C src/solvers/steady_solver.C \
 	src/solvers/tao_optimization_solver.C \
 	src/solvers/time_solver.C \
@@ -836,6 +837,7 @@ am__objects_1 = src/base/libmesh_dbg_la-dof_map.lo \
 	src/solvers/libmesh_dbg_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_dbg_la-petscdmlibmesh.lo \
 	src/solvers/libmesh_dbg_la-petscdmlibmeshimpl.lo \
+	src/solvers/libmesh_dbg_la-second_order_unsteady_solver.lo \
 	src/solvers/libmesh_dbg_la-slepc_eigen_solver.lo \
 	src/solvers/libmesh_dbg_la-steady_solver.lo \
 	src/solvers/libmesh_dbg_la-tao_optimization_solver.lo \
@@ -1151,6 +1153,7 @@ am__libmesh_devel_la_SOURCES_DIST = src/base/dof_map.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
+	src/solvers/second_order_unsteady_solver.C \
 	src/solvers/slepc_eigen_solver.C src/solvers/steady_solver.C \
 	src/solvers/tao_optimization_solver.C \
 	src/solvers/time_solver.C \
@@ -1551,6 +1554,7 @@ am__objects_2 = src/base/libmesh_devel_la-dof_map.lo \
 	src/solvers/libmesh_devel_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_devel_la-petscdmlibmesh.lo \
 	src/solvers/libmesh_devel_la-petscdmlibmeshimpl.lo \
+	src/solvers/libmesh_devel_la-second_order_unsteady_solver.lo \
 	src/solvers/libmesh_devel_la-slepc_eigen_solver.lo \
 	src/solvers/libmesh_devel_la-steady_solver.lo \
 	src/solvers/libmesh_devel_la-tao_optimization_solver.lo \
@@ -1863,6 +1867,7 @@ am__libmesh_oprof_la_SOURCES_DIST = src/base/dof_map.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
+	src/solvers/second_order_unsteady_solver.C \
 	src/solvers/slepc_eigen_solver.C src/solvers/steady_solver.C \
 	src/solvers/tao_optimization_solver.C \
 	src/solvers/time_solver.C \
@@ -2263,6 +2268,7 @@ am__objects_3 = src/base/libmesh_oprof_la-dof_map.lo \
 	src/solvers/libmesh_oprof_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_oprof_la-petscdmlibmesh.lo \
 	src/solvers/libmesh_oprof_la-petscdmlibmeshimpl.lo \
+	src/solvers/libmesh_oprof_la-second_order_unsteady_solver.lo \
 	src/solvers/libmesh_oprof_la-slepc_eigen_solver.lo \
 	src/solvers/libmesh_oprof_la-steady_solver.lo \
 	src/solvers/libmesh_oprof_la-tao_optimization_solver.lo \
@@ -2575,6 +2581,7 @@ am__libmesh_opt_la_SOURCES_DIST = src/base/dof_map.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
+	src/solvers/second_order_unsteady_solver.C \
 	src/solvers/slepc_eigen_solver.C src/solvers/steady_solver.C \
 	src/solvers/tao_optimization_solver.C \
 	src/solvers/time_solver.C \
@@ -2975,6 +2982,7 @@ am__objects_4 = src/base/libmesh_opt_la-dof_map.lo \
 	src/solvers/libmesh_opt_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_opt_la-petscdmlibmesh.lo \
 	src/solvers/libmesh_opt_la-petscdmlibmeshimpl.lo \
+	src/solvers/libmesh_opt_la-second_order_unsteady_solver.lo \
 	src/solvers/libmesh_opt_la-slepc_eigen_solver.lo \
 	src/solvers/libmesh_opt_la-steady_solver.lo \
 	src/solvers/libmesh_opt_la-tao_optimization_solver.lo \
@@ -3286,6 +3294,7 @@ am__libmesh_prof_la_SOURCES_DIST = src/base/dof_map.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
+	src/solvers/second_order_unsteady_solver.C \
 	src/solvers/slepc_eigen_solver.C src/solvers/steady_solver.C \
 	src/solvers/tao_optimization_solver.C \
 	src/solvers/time_solver.C \
@@ -3686,6 +3695,7 @@ am__objects_5 = src/base/libmesh_prof_la-dof_map.lo \
 	src/solvers/libmesh_prof_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_prof_la-petscdmlibmesh.lo \
 	src/solvers/libmesh_prof_la-petscdmlibmeshimpl.lo \
+	src/solvers/libmesh_prof_la-second_order_unsteady_solver.lo \
 	src/solvers/libmesh_prof_la-slepc_eigen_solver.lo \
 	src/solvers/libmesh_prof_la-steady_solver.lo \
 	src/solvers/libmesh_prof_la-tao_optimization_solver.lo \
@@ -4977,6 +4987,7 @@ libmesh_SOURCES = \
         src/solvers/petsc_nonlinear_solver.C \
         src/solvers/petscdmlibmesh.C \
         src/solvers/petscdmlibmeshimpl.C \
+        src/solvers/second_order_unsteady_solver.C \
         src/solvers/slepc_eigen_solver.C \
         src/solvers/steady_solver.C \
         src/solvers/tao_optimization_solver.C \
@@ -6328,6 +6339,9 @@ src/solvers/libmesh_dbg_la-petscdmlibmesh.lo:  \
 src/solvers/libmesh_dbg_la-petscdmlibmeshimpl.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_dbg_la-second_order_unsteady_solver.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_dbg_la-slepc_eigen_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -7363,6 +7377,9 @@ src/solvers/libmesh_devel_la-petscdmlibmesh.lo:  \
 src/solvers/libmesh_devel_la-petscdmlibmeshimpl.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_devel_la-second_order_unsteady_solver.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_devel_la-slepc_eigen_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -8386,6 +8403,9 @@ src/solvers/libmesh_oprof_la-petscdmlibmesh.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_oprof_la-petscdmlibmeshimpl.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_oprof_la-second_order_unsteady_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_oprof_la-slepc_eigen_solver.lo:  \
@@ -9412,6 +9432,9 @@ src/solvers/libmesh_opt_la-petscdmlibmesh.lo:  \
 src/solvers/libmesh_opt_la-petscdmlibmeshimpl.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_opt_la-second_order_unsteady_solver.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_opt_la-slepc_eigen_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -10432,6 +10455,9 @@ src/solvers/libmesh_prof_la-petscdmlibmesh.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_prof_la-petscdmlibmeshimpl.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_prof_la-second_order_unsteady_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_prof_la-slepc_eigen_solver.lo:  \
@@ -12746,6 +12772,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petscdmlibmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petscdmlibmeshimpl.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-second_order_unsteady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-slepc_eigen_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-steady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-tao_optimization_solver.Plo@am__quote@
@@ -12776,6 +12803,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petscdmlibmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petscdmlibmeshimpl.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-second_order_unsteady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-slepc_eigen_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-steady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-tao_optimization_solver.Plo@am__quote@
@@ -12806,6 +12834,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petscdmlibmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petscdmlibmeshimpl.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-second_order_unsteady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-slepc_eigen_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-steady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-tao_optimization_solver.Plo@am__quote@
@@ -12836,6 +12865,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petscdmlibmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petscdmlibmeshimpl.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-second_order_unsteady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-slepc_eigen_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-steady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-tao_optimization_solver.Plo@am__quote@
@@ -12866,6 +12896,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petscdmlibmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petscdmlibmeshimpl.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-second_order_unsteady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-slepc_eigen_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-steady_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-tao_optimization_solver.Plo@am__quote@
@@ -15683,6 +15714,13 @@ src/solvers/libmesh_dbg_la-petscdmlibmeshimpl.lo: src/solvers/petscdmlibmeshimpl
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petscdmlibmeshimpl.C' object='src/solvers/libmesh_dbg_la-petscdmlibmeshimpl.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_dbg_la-petscdmlibmeshimpl.lo `test -f 'src/solvers/petscdmlibmeshimpl.C' || echo '$(srcdir)/'`src/solvers/petscdmlibmeshimpl.C
+
+src/solvers/libmesh_dbg_la-second_order_unsteady_solver.lo: src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_dbg_la-second_order_unsteady_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_dbg_la-second_order_unsteady_solver.Tpo -c -o src/solvers/libmesh_dbg_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_dbg_la-second_order_unsteady_solver.Tpo src/solvers/$(DEPDIR)/libmesh_dbg_la-second_order_unsteady_solver.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/second_order_unsteady_solver.C' object='src/solvers/libmesh_dbg_la-second_order_unsteady_solver.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_dbg_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
 
 src/solvers/libmesh_dbg_la-slepc_eigen_solver.lo: src/solvers/slepc_eigen_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_dbg_la-slepc_eigen_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_dbg_la-slepc_eigen_solver.Tpo -c -o src/solvers/libmesh_dbg_la-slepc_eigen_solver.lo `test -f 'src/solvers/slepc_eigen_solver.C' || echo '$(srcdir)/'`src/solvers/slepc_eigen_solver.C
@@ -18617,6 +18655,13 @@ src/solvers/libmesh_devel_la-petscdmlibmeshimpl.lo: src/solvers/petscdmlibmeshim
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_devel_la-petscdmlibmeshimpl.lo `test -f 'src/solvers/petscdmlibmeshimpl.C' || echo '$(srcdir)/'`src/solvers/petscdmlibmeshimpl.C
 
+src/solvers/libmesh_devel_la-second_order_unsteady_solver.lo: src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_devel_la-second_order_unsteady_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_devel_la-second_order_unsteady_solver.Tpo -c -o src/solvers/libmesh_devel_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_devel_la-second_order_unsteady_solver.Tpo src/solvers/$(DEPDIR)/libmesh_devel_la-second_order_unsteady_solver.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/second_order_unsteady_solver.C' object='src/solvers/libmesh_devel_la-second_order_unsteady_solver.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_devel_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
+
 src/solvers/libmesh_devel_la-slepc_eigen_solver.lo: src/solvers/slepc_eigen_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_devel_la-slepc_eigen_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_devel_la-slepc_eigen_solver.Tpo -c -o src/solvers/libmesh_devel_la-slepc_eigen_solver.lo `test -f 'src/solvers/slepc_eigen_solver.C' || echo '$(srcdir)/'`src/solvers/slepc_eigen_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_devel_la-slepc_eigen_solver.Tpo src/solvers/$(DEPDIR)/libmesh_devel_la-slepc_eigen_solver.Plo
@@ -21549,6 +21594,13 @@ src/solvers/libmesh_oprof_la-petscdmlibmeshimpl.lo: src/solvers/petscdmlibmeshim
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petscdmlibmeshimpl.C' object='src/solvers/libmesh_oprof_la-petscdmlibmeshimpl.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_oprof_la-petscdmlibmeshimpl.lo `test -f 'src/solvers/petscdmlibmeshimpl.C' || echo '$(srcdir)/'`src/solvers/petscdmlibmeshimpl.C
+
+src/solvers/libmesh_oprof_la-second_order_unsteady_solver.lo: src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_oprof_la-second_order_unsteady_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_oprof_la-second_order_unsteady_solver.Tpo -c -o src/solvers/libmesh_oprof_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_oprof_la-second_order_unsteady_solver.Tpo src/solvers/$(DEPDIR)/libmesh_oprof_la-second_order_unsteady_solver.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/second_order_unsteady_solver.C' object='src/solvers/libmesh_oprof_la-second_order_unsteady_solver.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_oprof_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
 
 src/solvers/libmesh_oprof_la-slepc_eigen_solver.lo: src/solvers/slepc_eigen_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_oprof_la-slepc_eigen_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_oprof_la-slepc_eigen_solver.Tpo -c -o src/solvers/libmesh_oprof_la-slepc_eigen_solver.lo `test -f 'src/solvers/slepc_eigen_solver.C' || echo '$(srcdir)/'`src/solvers/slepc_eigen_solver.C
@@ -24483,6 +24535,13 @@ src/solvers/libmesh_opt_la-petscdmlibmeshimpl.lo: src/solvers/petscdmlibmeshimpl
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_opt_la-petscdmlibmeshimpl.lo `test -f 'src/solvers/petscdmlibmeshimpl.C' || echo '$(srcdir)/'`src/solvers/petscdmlibmeshimpl.C
 
+src/solvers/libmesh_opt_la-second_order_unsteady_solver.lo: src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_opt_la-second_order_unsteady_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_opt_la-second_order_unsteady_solver.Tpo -c -o src/solvers/libmesh_opt_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_opt_la-second_order_unsteady_solver.Tpo src/solvers/$(DEPDIR)/libmesh_opt_la-second_order_unsteady_solver.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/second_order_unsteady_solver.C' object='src/solvers/libmesh_opt_la-second_order_unsteady_solver.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_opt_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
+
 src/solvers/libmesh_opt_la-slepc_eigen_solver.lo: src/solvers/slepc_eigen_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_opt_la-slepc_eigen_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_opt_la-slepc_eigen_solver.Tpo -c -o src/solvers/libmesh_opt_la-slepc_eigen_solver.lo `test -f 'src/solvers/slepc_eigen_solver.C' || echo '$(srcdir)/'`src/solvers/slepc_eigen_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_opt_la-slepc_eigen_solver.Tpo src/solvers/$(DEPDIR)/libmesh_opt_la-slepc_eigen_solver.Plo
@@ -27415,6 +27474,13 @@ src/solvers/libmesh_prof_la-petscdmlibmeshimpl.lo: src/solvers/petscdmlibmeshimp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petscdmlibmeshimpl.C' object='src/solvers/libmesh_prof_la-petscdmlibmeshimpl.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_prof_la-petscdmlibmeshimpl.lo `test -f 'src/solvers/petscdmlibmeshimpl.C' || echo '$(srcdir)/'`src/solvers/petscdmlibmeshimpl.C
+
+src/solvers/libmesh_prof_la-second_order_unsteady_solver.lo: src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_prof_la-second_order_unsteady_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_prof_la-second_order_unsteady_solver.Tpo -c -o src/solvers/libmesh_prof_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_prof_la-second_order_unsteady_solver.Tpo src/solvers/$(DEPDIR)/libmesh_prof_la-second_order_unsteady_solver.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/second_order_unsteady_solver.C' object='src/solvers/libmesh_prof_la-second_order_unsteady_solver.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_prof_la-second_order_unsteady_solver.lo `test -f 'src/solvers/second_order_unsteady_solver.C' || echo '$(srcdir)/'`src/solvers/second_order_unsteady_solver.C
 
 src/solvers/libmesh_prof_la-slepc_eigen_solver.lo: src/solvers/slepc_eigen_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_prof_la-slepc_eigen_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_prof_la-slepc_eigen_solver.Tpo -c -o src/solvers/libmesh_prof_la-slepc_eigen_solver.lo `test -f 'src/solvers/slepc_eigen_solver.C' || echo '$(srcdir)/'`src/solvers/slepc_eigen_solver.C

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -828,6 +828,7 @@ include_HEADERS = \
         solvers/eigen_time_solver.h \
         solvers/euler2_solver.h \
         solvers/euler_solver.h \
+        solvers/first_order_unsteady_solver.h \
         solvers/linear.h \
         solvers/linear_solver.h \
         solvers/memory_solution_history.h \
@@ -842,6 +843,7 @@ include_HEADERS = \
         solvers/petsc_linear_solver.h \
         solvers/petsc_nonlinear_solver.h \
         solvers/petscdmlibmesh.h \
+        solvers/second_order_unsteady_solver.h \
         solvers/slepc_eigen_solver.h \
         solvers/slepc_macro.h \
         solvers/solution_history.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -330,6 +330,7 @@ include_HEADERS =  \
         solvers/eigen_time_solver.h \
         solvers/euler2_solver.h \
         solvers/euler_solver.h \
+        solvers/first_order_unsteady_solver.h \
         solvers/linear.h \
         solvers/linear_solver.h \
         solvers/memory_solution_history.h \
@@ -344,6 +345,7 @@ include_HEADERS =  \
         solvers/petsc_linear_solver.h \
         solvers/petsc_nonlinear_solver.h \
         solvers/petscdmlibmesh.h \
+        solvers/second_order_unsteady_solver.h \
         solvers/slepc_eigen_solver.h \
         solvers/slepc_macro.h \
         solvers/solution_history.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -325,6 +325,7 @@ BUILT_SOURCES = \
         eigen_time_solver.h \
         euler2_solver.h \
         euler_solver.h \
+        first_order_unsteady_solver.h \
         laspack_linear_solver.h \
         linear.h \
         linear_solver.h \
@@ -340,6 +341,7 @@ BUILT_SOURCES = \
         petsc_linear_solver.h \
         petsc_nonlinear_solver.h \
         petscdmlibmesh.h \
+        second_order_unsteady_solver.h \
         slepc_eigen_solver.h \
         slepc_macro.h \
         solution_history.h \
@@ -1461,6 +1463,9 @@ euler2_solver.h: $(top_srcdir)/include/solvers/euler2_solver.h
 euler_solver.h: $(top_srcdir)/include/solvers/euler_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
+first_order_unsteady_solver.h: $(top_srcdir)/include/solvers/first_order_unsteady_solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
 laspack_linear_solver.h: $(top_srcdir)/include/solvers/laspack_linear_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
@@ -1504,6 +1509,9 @@ petsc_nonlinear_solver.h: $(top_srcdir)/include/solvers/petsc_nonlinear_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petscdmlibmesh.h: $(top_srcdir)/include/solvers/petscdmlibmesh.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+second_order_unsteady_solver.h: $(top_srcdir)/include/solvers/second_order_unsteady_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 slepc_eigen_solver.h: $(top_srcdir)/include/solvers/slepc_eigen_solver.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -539,15 +539,16 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	radial_basis_interpolation.h solution_transfer.h \
 	adaptive_time_solver.h diff_solver.h eigen_solver.h \
 	eigen_sparse_linear_solver.h eigen_time_solver.h \
-	euler2_solver.h euler_solver.h laspack_linear_solver.h \
-	linear.h linear_solver.h memory_solution_history.h \
-	newmark_solver.h newton_solver.h nlopt_optimization_solver.h \
-	no_solution_history.h nonlinear_solver.h optimization_solver.h \
+	euler2_solver.h euler_solver.h first_order_unsteady_solver.h \
+	laspack_linear_solver.h linear.h linear_solver.h \
+	memory_solution_history.h newmark_solver.h newton_solver.h \
+	nlopt_optimization_solver.h no_solution_history.h \
+	nonlinear_solver.h optimization_solver.h \
 	petsc_auto_fieldsplit.h petsc_diff_solver.h \
 	petsc_linear_solver.h petsc_nonlinear_solver.h \
-	petscdmlibmesh.h slepc_eigen_solver.h slepc_macro.h \
-	solution_history.h solver.h steady_solver.h \
-	tao_optimization_solver.h time_solver.h \
+	petscdmlibmesh.h second_order_unsteady_solver.h \
+	slepc_eigen_solver.h slepc_macro.h solution_history.h solver.h \
+	steady_solver.h tao_optimization_solver.h time_solver.h \
 	trilinos_aztec_linear_solver.h trilinos_nox_nonlinear_solver.h \
 	twostep_time_solver.h unsteady_solver.h \
 	condensed_eigen_system.h continuation_system.h \
@@ -1766,6 +1767,9 @@ euler2_solver.h: $(top_srcdir)/include/solvers/euler2_solver.h
 euler_solver.h: $(top_srcdir)/include/solvers/euler_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
+first_order_unsteady_solver.h: $(top_srcdir)/include/solvers/first_order_unsteady_solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
 laspack_linear_solver.h: $(top_srcdir)/include/solvers/laspack_linear_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
@@ -1809,6 +1813,9 @@ petsc_nonlinear_solver.h: $(top_srcdir)/include/solvers/petsc_nonlinear_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petscdmlibmesh.h: $(top_srcdir)/include/solvers/petscdmlibmesh.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+second_order_unsteady_solver.h: $(top_srcdir)/include/solvers/second_order_unsteady_solver.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 slepc_eigen_solver.h: $(top_srcdir)/include/solvers/slepc_eigen_solver.h

--- a/include/solvers/adaptive_time_solver.h
+++ b/include/solvers/adaptive_time_solver.h
@@ -22,7 +22,7 @@
 
 // Local includes
 #include "libmesh/system_norm.h"
-#include "libmesh/unsteady_solver.h"
+#include "libmesh/first_order_unsteady_solver.h"
 
 // C++ includes
 
@@ -48,13 +48,13 @@ class System;
 
 // ------------------------------------------------------------
 // Solver class definition
-class AdaptiveTimeSolver : public UnsteadySolver
+class AdaptiveTimeSolver : public FirstOrderUnsteadySolver
 {
 public:
   /**
    * The parent class
    */
-  typedef UnsteadySolver Parent;
+  typedef FirstOrderUnsteadySolver Parent;
 
   /**
    * Constructor. Requires a reference to the system

--- a/include/solvers/euler2_solver.h
+++ b/include/solvers/euler2_solver.h
@@ -21,7 +21,7 @@
 #define LIBMESH_EULER2_SOLVER_H
 
 // Local includes
-#include "libmesh/unsteady_solver.h"
+#include "libmesh/first_order_unsteady_solver.h"
 
 // C++ includes
 
@@ -47,13 +47,13 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // Solver class definition
-class Euler2Solver : public UnsteadySolver
+class Euler2Solver : public FirstOrderUnsteadySolver
 {
 public:
   /**
    * The parent class
    */
-  typedef UnsteadySolver Parent;
+  typedef FirstOrderUnsteadySolver Parent;
 
   /**
    * Constructor. Requires a reference to the system

--- a/include/solvers/euler_solver.h
+++ b/include/solvers/euler_solver.h
@@ -21,7 +21,7 @@
 #define LIBMESH_EULER_SOLVER_H
 
 // Local includes
-#include "libmesh/unsteady_solver.h"
+#include "libmesh/first_order_unsteady_solver.h"
 
 // C++ includes
 
@@ -42,13 +42,13 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // Solver class definition
-class EulerSolver : public UnsteadySolver
+class EulerSolver : public FirstOrderUnsteadySolver
 {
 public:
   /**
    * The parent class
    */
-  typedef UnsteadySolver Parent;
+  typedef FirstOrderUnsteadySolver Parent;
 
   /**
    * Constructor. Requires a reference to the system

--- a/include/solvers/first_order_unsteady_solver.h
+++ b/include/solvers/first_order_unsteady_solver.h
@@ -50,8 +50,8 @@ public:
    */
   virtual ~FirstOrderUnsteadySolver (){}
 
-  virtual Real time_order() const
-  { return 1.0; }
+  virtual unsigned int time_order() const
+  { return 1; }
 };
 
 } // end namespace libMesh

--- a/include/solvers/first_order_unsteady_solver.h
+++ b/include/solvers/first_order_unsteady_solver.h
@@ -1,0 +1,59 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_FIRST_ORDER_UNSTEADY_SOLVER_H
+#define LIBMESH_FIRST_ORDER_UNSTEADY_SOLVER_H
+
+#include "libmesh/unsteady_solver.h"
+
+namespace libMesh
+{
+/**
+ * Generic class from which first order UnsteadySolvers should subclass.
+ *
+ * Subclasses of this class are meant to solve problems of the form
+ * \f[ M(u)\dot{u} = F(u)\f]
+ *
+ * This class is part of the new DifferentiableSystem framework,
+ * which is still experimental.  Users of this framework should
+ * beware of bugs and future API changes.
+ *
+ * @author Paul T. Bauman 2015
+ */
+class FirstOrderUnsteadySolver : public UnsteadySolver
+{
+public:
+  /**
+   * Constructor. Requires a reference to the system
+   * to be solved.
+   */
+  explicit
+  FirstOrderUnsteadySolver (sys_type& s)
+    : UnsteadySolver(s) {}
+
+  /**
+   * Destructor.
+   */
+  virtual ~FirstOrderUnsteadySolver (){}
+
+  virtual Real time_order() const
+  { return 1.0; }
+};
+
+} // end namespace libMesh
+
+#endif // LIBMESH_FIRST_ORDER_UNSTEADY_SOLVER_H

--- a/include/solvers/newmark_solver.h
+++ b/include/solvers/newmark_solver.h
@@ -100,6 +100,13 @@ public:
   virtual Real error_order() const;
 
   /**
+   * This method solves for the solution at the next timestep.
+   * Usually we will only need to solve one (non)linear system per timestep,
+   * but more complex subclasses may override this.
+   */
+  virtual void solve ();
+
+  /**
    * This method uses the DifferentiablePhysics'
    * element_time_derivative() and element_constraint()
    * to build a full residual on an element.  What combination
@@ -149,6 +156,12 @@ protected:
   bool _is_accel_solve;
 
 
+  /**
+   * This method requires an initial acceleration. So, we force the
+   * user to call either compute_initial_accel or project_initial_accel
+   * to set the initial acceleration.
+   */
+  bool _initial_accel_set;
 
   /**
    * This method is the underlying implementation of the public

--- a/include/solvers/newmark_solver.h
+++ b/include/solvers/newmark_solver.h
@@ -21,7 +21,7 @@
 #define LIBMESH_NEWMARK_SOLVER_H
 
 // Local includes
-#include "libmesh/unsteady_solver.h"
+#include "libmesh/second_order_unsteady_solver.h"
 
 namespace libMesh
 {
@@ -43,7 +43,7 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // Solver class definition
-class NewmarkSolver : public UnsteadySolver
+class NewmarkSolver : public SecondOrderUnsteadySolver
 {
 public:
   /**
@@ -64,25 +64,6 @@ public:
   virtual ~NewmarkSolver ();
 
   /**
-   * The initialization function.  This method is used to
-   * initialize internal data structures before a simulation begins.
-   */
-  virtual void init ();
-
-  /**
-   * The data initialization function.  This method is used to
-   * initialize internal data structures after the underlying System
-   * has been initialized
-   */
-  virtual void init_data ();
-
-  /**
-   * The reinitialization function.  This method is used to
-   * resize internal data vectors after a mesh change.
-   */
-  virtual void reinit ();
-
-  /**
    * This method advances the solution to the next timestep, after a
    * solve() has been performed.  Often this will be done after every
    * UnsteadySolver::solve(), but adaptive mesh refinement and/or adaptive
@@ -98,18 +79,10 @@ public:
   virtual void adjoint_advance_timestep ();
 
   /**
-   * This method retrieves all the stored solutions at the current
-   * system.time
+   * This method uses the specified initial displacement and velocity
+   * to compute the initial acceleration \f$a_0\f$.
    */
-  virtual void retrieve_timestep ();
-
-  /**
-   * Specify non-zero initial velocity. Should be called before solve().
-   * The function value f and its gradient g are user-provided cloneable functors.
-   * A gradient g is only required/used for projecting onto finite element spaces
-   * with continuous derivatives.
-   */
-  void project_initial_rate( FunctionBase<Number> *f, FunctionBase<Gradient> *g = NULL );
+  virtual void compute_initial_accel();
 
   /**
    * Specify non-zero initial acceleration. Should be called before solve().
@@ -120,12 +93,6 @@ public:
    * with continuous derivatives.
    */
   void project_initial_accel( FunctionBase<Number> *f, FunctionBase<Gradient> *g = NULL );
-
-  /**
-   * This method uses the specified initial displacement and velocity
-   * to compute the initial acceleration \f$a_0\f$.
-   */
-  virtual void compute_initial_accel();
 
   /**
    * Error convergence order: 2 for \f$\gamma=0.5\f$, 1 otherwise
@@ -159,18 +126,6 @@ public:
   virtual bool nonlocal_residual (bool request_jacobian,
                                   DiffContext&);
 
-  /**
-   * @returns the solution rate at the previous time step, \f$\dot{u}_n\f$,
-   * for the specified global DOF.
-   */
-  Number old_solution_rate (const dof_id_type global_dof_number) const;
-
-  /**
-   * @returns the solution acceleration at the previous time step, \f$\ddot{u}_n\f$,
-   * for the specified global DOF.
-   */
-  Number old_solution_accel (const dof_id_type global_dof_number) const;
-
 
 protected:
 
@@ -193,15 +148,7 @@ protected:
    */
   bool _is_accel_solve;
 
-  /**
-   * Serial vector of previous time step velocity \f$ \dot{u}_n \f$
-   */
-  UniquePtr<NumericVector<Number> > _old_local_solution_rate;
 
-  /**
-   * Serial vector of previous time step accleration \f$ \ddot{u}_n \f$
-   */
-  UniquePtr<NumericVector<Number> > _old_local_solution_accel;
 
   /**
    * This method is the underlying implementation of the public

--- a/include/solvers/second_order_unsteady_solver.h
+++ b/include/solvers/second_order_unsteady_solver.h
@@ -1,0 +1,126 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_SECOND_ORDER_UNSTEADY_SOLVER_H
+#define LIBMESH_SECOND_ORDER_UNSTEADY_SOLVER_H
+
+#include "libmesh/unsteady_solver.h"
+
+namespace libMesh
+{
+/**
+ * Generic class from which second order UnsteadySolvers should subclass.
+ *
+ * Subclasses of this class are meant to solve problems of the form
+ * \f[ M(u)\ddot{u} + C(u)\dot{u} + F(u) = 0 \f]
+ *
+ * This class is part of the new DifferentiableSystem framework,
+ * which is still experimental.  Users of this framework should
+ * beware of bugs and future API changes.
+ *
+ * @author Paul T. Bauman 2015
+ */
+class SecondOrderUnsteadySolver : public UnsteadySolver
+{
+public:
+  /**
+   * Constructor. Requires a reference to the system
+   * to be solved.
+   */
+  explicit
+  SecondOrderUnsteadySolver (sys_type& s);
+
+  /**
+   * Destructor.
+   */
+  virtual ~SecondOrderUnsteadySolver ();
+
+  virtual Real time_order() const
+  { return 2.0; }
+
+  /**
+   * The initialization function.  This method is used to
+   * initialize internal data structures before a simulation begins.
+   */
+  virtual void init ();
+
+  /**
+   * The data initialization function.  This method is used to
+   * initialize internal data structures after the underlying System
+   * has been initialized
+   */
+  virtual void init_data ();
+
+  /**
+   * The reinitialization function.  This method is used to
+   * resize internal data vectors after a mesh change.
+   */
+  virtual void reinit ();
+
+  /**
+   * This method retrieves all the stored solutions at the current
+   * system.time
+   */
+  virtual void retrieve_timestep ();
+
+  /**
+   * Specify non-zero initial velocity. Should be called before solve().
+   * The function value f and its gradient g are user-provided cloneable functors.
+   * A gradient g is only required/used for projecting onto finite element spaces
+   * with continuous derivatives.
+   */
+  void project_initial_rate( FunctionBase<Number> *f, FunctionBase<Gradient> *g = NULL );
+
+  /**
+   * Specify non-zero initial acceleration. Should be called before solve().
+   * This is an alternative to compute_initial_acceleration() if the
+   * initial acceleration is actually known.
+   * The function value f and its gradient g are user-provided cloneable functors.
+   * A gradient g is only required/used for projecting onto finite element spaces
+   * with continuous derivatives.
+   */
+  void project_initial_accel( FunctionBase<Number> *f, FunctionBase<Gradient> *g = NULL );
+
+  /**
+   * @returns the solution rate at the previous time step, \f$\dot{u}_n\f$,
+   * for the specified global DOF.
+   */
+  Number old_solution_rate (const dof_id_type global_dof_number) const;
+
+  /**
+   * @returns the solution acceleration at the previous time step, \f$\ddot{u}_n\f$,
+   * for the specified global DOF.
+   */
+  Number old_solution_accel (const dof_id_type global_dof_number) const;
+
+protected:
+
+  /**
+   * Serial vector of previous time step velocity \f$ \dot{u}_n \f$
+   */
+  UniquePtr<NumericVector<Number> > _old_local_solution_rate;
+
+  /**
+   * Serial vector of previous time step accleration \f$ \ddot{u}_n \f$
+   */
+  UniquePtr<NumericVector<Number> > _old_local_solution_accel;
+
+};
+
+} // end namespace libMesh
+
+# endif // LIBMESH_SECOND_ORDER_UNSTEADY_SOLVER_H

--- a/include/solvers/second_order_unsteady_solver.h
+++ b/include/solvers/second_order_unsteady_solver.h
@@ -49,8 +49,8 @@ public:
    */
   virtual ~SecondOrderUnsteadySolver ();
 
-  virtual Real time_order() const
-  { return 2.0; }
+  virtual unsigned int time_order() const
+  { return 2; }
 
   /**
    * The initialization function.  This method is used to

--- a/include/solvers/second_order_unsteady_solver.h
+++ b/include/solvers/second_order_unsteady_solver.h
@@ -86,16 +86,6 @@ public:
   void project_initial_rate( FunctionBase<Number> *f, FunctionBase<Gradient> *g = NULL );
 
   /**
-   * Specify non-zero initial acceleration. Should be called before solve().
-   * This is an alternative to compute_initial_acceleration() if the
-   * initial acceleration is actually known.
-   * The function value f and its gradient g are user-provided cloneable functors.
-   * A gradient g is only required/used for projecting onto finite element spaces
-   * with continuous derivatives.
-   */
-  void project_initial_accel( FunctionBase<Number> *f, FunctionBase<Gradient> *g = NULL );
-
-  /**
    * @returns the solution rate at the previous time step, \f$\dot{u}_n\f$,
    * for the specified global DOF.
    */

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -119,6 +119,13 @@ public:
   virtual Real error_order () const = 0;
 
   /**
+   * Returns the maximum order of time derivatives for which the
+   * UnsteadySolver subclass is capable of handling. E.g. EulerSolver
+   * will have time_order = 1 and NewmarkSolver will have time_order = 2
+   */
+  virtual Real time_order () const = 0;
+
+  /**
    * @returns the old nonlinear solution for the specified global
    * DOF.
    */

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -123,7 +123,7 @@ public:
    * UnsteadySolver subclass is capable of handling. E.g. EulerSolver
    * will have time_order = 1 and NewmarkSolver will have time_order = 2
    */
-  virtual Real time_order () const = 0;
+  virtual unsigned int time_order () const = 0;
 
   /**
    * @returns the old nonlinear solution for the specified global

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -367,6 +367,7 @@ libmesh_SOURCES =  \
         src/solvers/petsc_nonlinear_solver.C \
         src/solvers/petscdmlibmesh.C \
         src/solvers/petscdmlibmeshimpl.C \
+        src/solvers/second_order_unsteady_solver.C \
         src/solvers/slepc_eigen_solver.C \
         src/solvers/steady_solver.C \
         src/solvers/tao_optimization_solver.C \

--- a/src/solvers/adaptive_time_solver.C
+++ b/src/solvers/adaptive_time_solver.C
@@ -25,7 +25,7 @@ namespace libMesh
 
 
 AdaptiveTimeSolver::AdaptiveTimeSolver (sys_type& s)
-  : UnsteadySolver(s),
+  : FirstOrderUnsteadySolver(s),
     core_time_solver(),
     target_tolerance(1.e-3),
     upper_tolerance(0.0),

--- a/src/solvers/euler2_solver.C
+++ b/src/solvers/euler2_solver.C
@@ -25,7 +25,7 @@ namespace libMesh
 
 
 Euler2Solver::Euler2Solver (sys_type& s)
-  : UnsteadySolver(s), theta(1.)
+  : FirstOrderUnsteadySolver(s), theta(1.)
 {
 }
 

--- a/src/solvers/euler_solver.C
+++ b/src/solvers/euler_solver.C
@@ -25,7 +25,7 @@ namespace libMesh
 
 
 EulerSolver::EulerSolver (sys_type& s)
-  : UnsteadySolver(s), theta(1.)
+  : FirstOrderUnsteadySolver(s), theta(1.)
 {
 }
 

--- a/src/solvers/second_order_unsteady_solver.C
+++ b/src/solvers/second_order_unsteady_solver.C
@@ -103,14 +103,6 @@ namespace libMesh
     _system.project_vector( old_solution_rate, f, g );
   }
 
-  void SecondOrderUnsteadySolver::project_initial_accel( FunctionBase<Number> *f, FunctionBase<Gradient> *g )
-  {
-    NumericVector<Number> &old_solution_accel =
-      _system.get_vector("_old_solution_accel");
-
-    _system.project_vector( old_solution_accel, f, g );
-  }
-
   Number SecondOrderUnsteadySolver::old_solution_rate(const dof_id_type global_dof_number)
   const
   {

--- a/src/solvers/second_order_unsteady_solver.C
+++ b/src/solvers/second_order_unsteady_solver.C
@@ -1,0 +1,132 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/second_order_unsteady_solver.h"
+
+#include "libmesh/diff_system.h"
+#include "libmesh/dof_map.h"
+
+namespace libMesh
+{
+  SecondOrderUnsteadySolver::SecondOrderUnsteadySolver (sys_type& s)
+    : UnsteadySolver(s),
+      _old_local_solution_rate(NumericVector<Number>::build(s.comm())),
+      _old_local_solution_accel(NumericVector<Number>::build(s.comm()))
+  {}
+
+  SecondOrderUnsteadySolver::~SecondOrderUnsteadySolver ()
+  {}
+
+  void SecondOrderUnsteadySolver::init ()
+  {
+    UnsteadySolver::init();
+
+    _system.add_vector("_old_solution_rate");
+    _system.add_vector("_old_solution_accel");
+  }
+
+  void SecondOrderUnsteadySolver::init_data()
+  {
+    UnsteadySolver::init_data();
+
+#ifdef LIBMESH_ENABLE_GHOSTED
+    _old_local_solution_rate->init (_system.n_dofs(), _system.n_local_dofs(),
+                                    _system.get_dof_map().get_send_list(), false,
+                                    GHOSTED);
+
+    _old_local_solution_accel->init (_system.n_dofs(), _system.n_local_dofs(),
+                                     _system.get_dof_map().get_send_list(), false,
+                                     GHOSTED);
+#else
+    _old_local_solution_rate->init (_system.n_dofs(), false, SERIAL);
+    _old_local_solution_accel->init (_system.n_dofs(), false, SERIAL);
+#endif
+  }
+
+  void SecondOrderUnsteadySolver::reinit ()
+  {
+    UnsteadySolver::reinit();
+
+#ifdef LIBMESH_ENABLE_GHOSTED
+    _old_local_solution_rate->init (_system.n_dofs(), _system.n_local_dofs(),
+                                    _system.get_dof_map().get_send_list(), false,
+                                    GHOSTED);
+
+    _old_local_solution_accel->init (_system.n_dofs(), _system.n_local_dofs(),
+                                     _system.get_dof_map().get_send_list(), false,
+                                     GHOSTED);
+#else
+    _old_local_solution_rate->init (_system.n_dofs(), false, SERIAL);
+    _old_local_solution_accel->init (_system.n_dofs(), false, SERIAL);
+#endif
+
+    // localize the old solutions
+    NumericVector<Number> &old_solution_rate =
+      _system.get_vector("_old_solution_rate");
+
+    NumericVector<Number> &old_solution_accel =
+      _system.get_vector("_old_solution_accel");
+
+    old_solution_rate.localize
+      (*_old_local_solution_rate,
+       _system.get_dof_map().get_send_list());
+
+    old_solution_accel.localize
+      (*_old_local_solution_accel,
+       _system.get_dof_map().get_send_list());
+  }
+
+  void SecondOrderUnsteadySolver::retrieve_timestep()
+  {
+    libmesh_not_implemented();
+  }
+
+  void SecondOrderUnsteadySolver::project_initial_rate( FunctionBase<Number> *f, FunctionBase<Gradient> *g )
+  {
+    NumericVector<Number> &old_solution_rate =
+      _system.get_vector("_old_solution_rate");
+
+    _system.project_vector( old_solution_rate, f, g );
+  }
+
+  void SecondOrderUnsteadySolver::project_initial_accel( FunctionBase<Number> *f, FunctionBase<Gradient> *g )
+  {
+    NumericVector<Number> &old_solution_accel =
+      _system.get_vector("_old_solution_accel");
+
+    _system.project_vector( old_solution_accel, f, g );
+  }
+
+  Number SecondOrderUnsteadySolver::old_solution_rate(const dof_id_type global_dof_number)
+  const
+  {
+    libmesh_assert_less (global_dof_number, _system.get_dof_map().n_dofs());
+    libmesh_assert_less (global_dof_number, _old_local_solution_rate->size());
+
+    return (*_old_local_solution_rate)(global_dof_number);
+  }
+
+  Number SecondOrderUnsteadySolver::old_solution_accel(const dof_id_type global_dof_number)
+  const
+  {
+    libmesh_assert_less (global_dof_number, _system.get_dof_map().n_dofs());
+    libmesh_assert_less (global_dof_number, _old_local_solution_accel->size());
+
+    return (*_old_local_solution_accel)(global_dof_number);
+  }
+
+} // end namespace libMesh

--- a/src/systems/diff_context.C
+++ b/src/systems/diff_context.C
@@ -18,6 +18,8 @@
 
 #include "libmesh/diff_context.h"
 #include "libmesh/diff_system.h"
+#include "libmesh/fem_system.h"
+#include "libmesh/unsteady_solver.h"
 
 namespace libMesh
 {
@@ -48,6 +50,7 @@ DiffContext::DiffContext (const System& sys) :
     _elem_fixed_subsolutions.reserve(nv);
 
   // If the user resizes sys.qoi, it will invalidate us
+
   std::size_t n_qoi = sys.qoi.size();
   _elem_qoi.resize(n_qoi);
   _elem_qoi_derivative.resize(n_qoi);
@@ -62,8 +65,24 @@ DiffContext::DiffContext (const System& sys) :
       for (std::size_t q=0; q != n_qoi; ++q)
         _elem_qoi_subderivatives[q].push_back(new DenseSubVector<Number>(_elem_qoi_derivative[q]));
       _elem_subjacobians[i].reserve(nv);
-      _elem_subsolution_rates.push_back(new DenseSubVector<Number>(_elem_solution_rate));
-      _elem_subsolution_accels.push_back(new DenseSubVector<Number>(_elem_solution_accel));
+
+      // Only make space for these if we're using FEMSystem
+      // This is assuming *only* FEMSystem is using elem_solution_rate/accel
+      const FEMSystem* fem_system = dynamic_cast<const FEMSystem*>(&sys);
+      if(fem_system)
+        {
+          // Now, we only need these if the solver is unsteady
+          if( !fem_system->get_time_solver().is_steady() )
+            {
+              _elem_subsolution_rates.push_back(new DenseSubVector<Number>(_elem_solution_rate));
+
+              // We only need accel space if the TimeSolver is second order
+              const UnsteadySolver& time_solver = cast_ref<const UnsteadySolver&>(fem_system->get_time_solver());
+
+              if( time_solver.time_order() >= 2 )
+                _elem_subsolution_accels.push_back(new DenseSubVector<Number>(_elem_solution_accel));
+            }
+        }
 
       if (sys.use_fixed_solution)
         _elem_fixed_subsolutions.push_back
@@ -87,8 +106,10 @@ DiffContext::~DiffContext ()
       delete _elem_subresiduals[i];
       for (std::size_t q=0; q != _elem_qoi_subderivatives.size(); ++q)
         delete _elem_qoi_subderivatives[q][i];
-      delete _elem_subsolution_rates[i];
-      delete _elem_subsolution_accels[i];
+      if( !_elem_subsolution_rates.empty() )
+        delete _elem_subsolution_rates[i];
+      if( !_elem_subsolution_accels.empty() )
+        delete _elem_subsolution_accels[i];
       if (!_elem_fixed_subsolutions.empty())
         delete _elem_fixed_subsolutions[i];
 

--- a/src/systems/diff_context.C
+++ b/src/systems/diff_context.C
@@ -18,7 +18,7 @@
 
 #include "libmesh/diff_context.h"
 #include "libmesh/diff_system.h"
-#include "libmesh/fem_system.h"
+#include "libmesh/diff_system.h"
 #include "libmesh/unsteady_solver.h"
 
 namespace libMesh
@@ -66,18 +66,18 @@ DiffContext::DiffContext (const System& sys) :
         _elem_qoi_subderivatives[q].push_back(new DenseSubVector<Number>(_elem_qoi_derivative[q]));
       _elem_subjacobians[i].reserve(nv);
 
-      // Only make space for these if we're using FEMSystem
-      // This is assuming *only* FEMSystem is using elem_solution_rate/accel
-      const FEMSystem* fem_system = dynamic_cast<const FEMSystem*>(&sys);
-      if(fem_system)
+      // Only make space for these if we're using DiffSystem
+      // This is assuming *only* DiffSystem is using elem_solution_rate/accel
+      const DifferentiableSystem* diff_system = dynamic_cast<const DifferentiableSystem*>(&sys);
+      if(diff_system)
         {
           // Now, we only need these if the solver is unsteady
-          if( !fem_system->get_time_solver().is_steady() )
+          if( !diff_system->get_time_solver().is_steady() )
             {
               _elem_subsolution_rates.push_back(new DenseSubVector<Number>(_elem_solution_rate));
 
               // We only need accel space if the TimeSolver is second order
-              const UnsteadySolver& time_solver = cast_ref<const UnsteadySolver&>(fem_system->get_time_solver());
+              const UnsteadySolver& time_solver = cast_ref<const UnsteadySolver&>(diff_system->get_time_solver());
 
               if( time_solver.time_order() >= 2 )
                 _elem_subsolution_accels.push_back(new DenseSubVector<Number>(_elem_solution_accel));

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -27,7 +27,7 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/system.h"
-#include "libmesh/fem_system.h"
+#include "libmesh/diff_system.h"
 #include "libmesh/time_solver.h"
 #include "libmesh/unsteady_solver.h" // For euler_residual
 
@@ -1555,18 +1555,18 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
   if (sys.use_fixed_solution)
     this->get_elem_fixed_solution().resize(n_dofs);
 
-  // Only make space for these if we're using FEMSystem
-  // This is assuming *only* FEMSystem is using elem_solution_rate/accel
-  const FEMSystem* fem_system = dynamic_cast<const FEMSystem*>(&sys);
-  if(fem_system)
+  // Only make space for these if we're using DiffSystem
+  // This is assuming *only* DiffSystem is using elem_solution_rate/accel
+  const DifferentiableSystem* diff_system = dynamic_cast<const DifferentiableSystem*>(&sys);
+  if(diff_system)
     {
       // Now, we only need these if the solver is unsteady
-      if( !fem_system->get_time_solver().is_steady() )
+      if( !diff_system->get_time_solver().is_steady() )
         {
           this->get_elem_solution_rate().resize(n_dofs);
 
           // We only need accel space if the TimeSolver is second order
-          const UnsteadySolver& time_solver = cast_ref<const UnsteadySolver&>(fem_system->get_time_solver());
+          const UnsteadySolver& time_solver = cast_ref<const UnsteadySolver&>(diff_system->get_time_solver());
 
           if( time_solver.time_order() >= 2 )
             this->get_elem_solution_accel().resize(n_dofs);
@@ -1600,19 +1600,19 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
         this->get_elem_solution(i).reposition
           (sub_dofs, n_dofs_var);
 
-        // Only make space for these if we're using FEMSystem
-        // This is assuming *only* FEMSystem is using elem_solution_rate/accel
-        const FEMSystem* fem_system = dynamic_cast<const FEMSystem*>(&sys);
-        if(fem_system)
+        // Only make space for these if we're using DiffSystem
+        // This is assuming *only* DiffSystem is using elem_solution_rate/accel
+        const DifferentiableSystem* diff_system = dynamic_cast<const DifferentiableSystem*>(&sys);
+        if(diff_system)
           {
             // Now, we only need these if the solver is unsteady
-            if( !fem_system->get_time_solver().is_steady() )
+            if( !diff_system->get_time_solver().is_steady() )
               {
                 this->get_elem_solution_rate(i).reposition
                   (sub_dofs, n_dofs_var);
 
                 // We only need accel space if the TimeSolver is second order
-                const UnsteadySolver& time_solver = cast_ref<const UnsteadySolver&>(fem_system->get_time_solver());
+                const UnsteadySolver& time_solver = cast_ref<const UnsteadySolver&>(diff_system->get_time_solver());
 
                 if( time_solver.time_order() >= 2 )
                   this->get_elem_solution_accel(i).reposition

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -27,6 +27,7 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/system.h"
+#include "libmesh/fem_system.h"
 #include "libmesh/time_solver.h"
 #include "libmesh/unsteady_solver.h" // For euler_residual
 
@@ -1553,8 +1554,24 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
 
   if (sys.use_fixed_solution)
     this->get_elem_fixed_solution().resize(n_dofs);
-  this->get_elem_solution_rate().resize(n_dofs);
-  this->get_elem_solution_accel().resize(n_dofs);
+
+  // Only make space for these if we're using FEMSystem
+  // This is assuming *only* FEMSystem is using elem_solution_rate/accel
+  const FEMSystem* fem_system = dynamic_cast<const FEMSystem*>(&sys);
+  if(fem_system)
+    {
+      // Now, we only need these if the solver is unsteady
+      if( !fem_system->get_time_solver().is_steady() )
+        {
+          this->get_elem_solution_rate().resize(n_dofs);
+
+          // We only need accel space if the TimeSolver is second order
+          const UnsteadySolver& time_solver = cast_ref<const UnsteadySolver&>(fem_system->get_time_solver());
+
+          if( time_solver.time_order() >= 2 )
+            this->get_elem_solution_accel().resize(n_dofs);
+        }
+    }
 
   // These resize calls also zero out the residual and jacobian
   this->get_elem_residual().resize(n_dofs);
@@ -1583,11 +1600,25 @@ void FEMContext::pre_fe_reinit(const System &sys, const Elem *e)
         this->get_elem_solution(i).reposition
           (sub_dofs, n_dofs_var);
 
-        this->get_elem_solution_rate(i).reposition
-          (sub_dofs, n_dofs_var);
+        // Only make space for these if we're using FEMSystem
+        // This is assuming *only* FEMSystem is using elem_solution_rate/accel
+        const FEMSystem* fem_system = dynamic_cast<const FEMSystem*>(&sys);
+        if(fem_system)
+          {
+            // Now, we only need these if the solver is unsteady
+            if( !fem_system->get_time_solver().is_steady() )
+              {
+                this->get_elem_solution_rate(i).reposition
+                  (sub_dofs, n_dofs_var);
 
-        this->get_elem_solution_accel(i).reposition
-          (sub_dofs, n_dofs_var);
+                // We only need accel space if the TimeSolver is second order
+                const UnsteadySolver& time_solver = cast_ref<const UnsteadySolver&>(fem_system->get_time_solver());
+
+                if( time_solver.time_order() >= 2 )
+                  this->get_elem_solution_accel(i).reposition
+                    (sub_dofs, n_dofs_var);
+              }
+          }
 
         if (sys.use_fixed_solution)
           this->get_elem_fixed_solution(i).reposition


### PR DESCRIPTION
The primary purpose of this PR is to add two guards in NewmarkSolver that were discussed in #582, namely only build the elem_solution_rate/accel (in DiffContext) if we need it and to force the user to set the initial acceleration either by directly projecting it or computing it using the helper method.

The changes for the latter guard are straight forward and are in 53b38bd.

Changes for the former ended up being a bit more involved because I can't help myself. The underlying idea is to add a `time_order()` method that we can query to figure out if we need rates and, possibly, acceleration. It occurred to me that I could've made the second order solver stuff more extensible. So, I ended up making intermediate classes for first order and second order (in time) solvers. The first order one just holds the `time_order()`. I could see the argument for just having `UnsteadySolver` default to 1 and override in the `SecondOrderUnsteadySolver`, but I think have the intermediate is more self-documenting. I moved common functionality out of `NewmarkSolver` into `SecondOrderUnsteadySolver`. After that preliminary work, `time_order()` was made pure virtual in `UnsteadySolver` and we can query it from there (see log for f2bb932 on why I chose this). All that was the first 7 commits in this PR. 

After that is the only-build-rate-structures-if-they're-needed (dd287bb). I welcome suggestions - those (a little) lengthy checks were repeated 3 times for different operations on those data structures in 3 different places; felt dirty and wrong.