### PR TITLE
gcc-3.4 fixes

### DIFF
--- a/include/utils/topology_map.h
+++ b/include/utils/topology_map.h
@@ -66,7 +66,10 @@ public:
 class TopologyMap
 {
   // We need to supply our own hash function if we're hashing
-#if defined(LIBMESH_HAVE_STD_UNORDERED_MAP) || defined(LIBMESH_HAVE_TR1_UNORDERED_MAP)
+#if defined(LIBMESH_HAVE_STD_UNORDERED_MAP) || \
+    defined(LIBMESH_HAVE_TR1_UNORDERED_MAP) || \
+    defined(LIBMESH_HAVE_EXT_HASH_MAP) || \
+    defined(LIBMESH_HAVE_HASH_MAP) 
 #  define MYHASH ,myhash
 #else
 #  define MYHASH

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -227,7 +227,7 @@ void RBConstruction::process_parameters_file (const std::string& parameters_file
   const bool write_data_during_training_in = infile("write_data_during_training",
                                                     write_data_during_training);
   unsigned int training_parameters_random_seed_in =
-    static_cast<int>(-1);
+    static_cast<unsigned int>(-1);
   training_parameters_random_seed_in = infile("training_parameters_random_seed",
                                               training_parameters_random_seed_in);
   const bool quiet_mode_in = infile("quiet_mode", quiet_mode);

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -814,7 +814,10 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
     num_vecs   = cast_int<unsigned int>(vecs.size());
   const dof_id_type
     io_blksize = cast_int<dof_id_type>(std::min(max_io_blksize, static_cast<std::size_t>(n_objs))),
-    num_blks   = std::ceil(static_cast<double>(n_objs)/static_cast<double>(io_blksize));
+    num_blks =
+      cast_int<unsigned int>
+        (std::ceil(static_cast<double>(n_objs)/
+                   static_cast<double>(io_blksize)));
 
   libmesh_assert_less_equal (_written_var_indices.size(), this->n_vars());
 
@@ -1836,7 +1839,10 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
   const unsigned int
     sys_num    = this->number(),
     num_vecs   = cast_int<unsigned int>(vecs.size()),
-    num_blks   = std::ceil(static_cast<double>(n_objs)/static_cast<double>(io_blksize));
+    num_blks =
+      cast_int<unsigned int>
+        (std::ceil(static_cast<double>(n_objs)/
+                   static_cast<double>(io_blksize)));
 
   // libMesh::out << "io_blksize = "    << io_blksize
   //     << ", num_objects = " << n_objs
@@ -2237,7 +2243,7 @@ std::size_t System::read_serialized_vectors (Xdr &io,
     n_nodes = this->get_mesh().n_nodes(),
     n_elem  = this->get_mesh().n_elem();
 
-  std::size_t read_length = 0.;
+  std::size_t read_length = 0;
 
   //---------------------------------
   // Collect the values for all nodes
@@ -2296,7 +2302,7 @@ std::size_t System::write_serialized_vectors (Xdr &io,
     n_nodes       = this->get_mesh().n_nodes(),
     n_elem        = this->get_mesh().n_elem();
 
-  std::size_t written_length = 0.;
+  std::size_t written_length = 0;
 
   if (this->processor_id() == 0)
     {


### PR DESCRIPTION
This fixes the compilation error Ben noticed in #550 for me.

It also fixes a compilation error in the new coupling_matrix.h - it looks like the previous code was correct C++11 but C++98 was more restrictive about nested class access to private things accessible in the enclosing class?

A few warning fixes are thrown in too.  We'd have run into these with newer compilers too eventually once we cranked up the warning level again.