### PR TITLE
BoundaryInfo::add_elements()

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -91,12 +91,11 @@ public:
   void clear ();
 
   /**
-   * Close the data structures and prepare for use.
-   * Synchronizes the \p boundary_mesh
-   * data structures with the \p mesh data structures.
-   * Allows the \p boundary_mesh to be used like any other mesh.
-   * Before this is called the \p boundary_mesh data structure is
-   * empty.
+   * Generates \p boundary_mesh data structures corresponding to the
+   * \p mesh data structures.  Allows the \p boundary_mesh to be used
+   * like any other mesh, except with interior_parent() values defined
+   * for algorithms which couple boundary and interior mesh
+   * information.  Any pre-existing \p boundary_mesh data is cleared.
    *
    * If you are using a MeshData class with this Mesh, you can
    * pass a pointer to both the boundary_mesh's MeshData object,
@@ -107,13 +106,12 @@ public:
              MeshData* this_mesh_data=NULL);
 
   /**
-   * Close the data structures and prepare for use.
-   * Synchronizes the \p boundary_mesh
-   * data structures with the \p mesh data structures.
-   * Allows the \p boundary_mesh to be used like any other mesh.
-   * Before this is called the \p boundary_mesh data structure is
-   * empty.  Only boundary elements with the specified ids are
-   * extracted.
+   * Generates \p boundary_mesh data structures corresponding to the
+   * \p mesh data structures.  Allows the \p boundary_mesh to be used
+   * like any other mesh, except with interior_parent() values defined
+   * for algorithms which couple boundary and interior mesh
+   * information.  Any pre-existing \p boundary_mesh data is cleared.
+   * Only boundary elements with the specified ids are extracted.
    *
    * If you are using a MeshData class with this Mesh, you can
    * pass a pointer to both the boundary_mesh's MeshData object,
@@ -123,6 +121,20 @@ public:
              UnstructuredMesh& boundary_mesh,
              MeshData* boundary_mesh_data=NULL,
              MeshData* this_mesh_data=NULL);
+
+
+  /**
+   * Generates \p elements along the boundary of our _mesh, which
+   * use pre-existing nodes on the boundary_mesh, and which have
+   * interior_parent values properly defined.
+   *
+   * The \p boundary_mesh may be the *same* as the interior mesh; this
+   * generates a mesh with elements of mixed dimension.
+   *
+   * Only boundary elements with the specified ids are created. 
+   */
+  void add_elements (const std::set<boundary_id_type> &requested_boundary_ids,
+                     UnstructuredMesh& boundary_mesh);
 
   /**
    * Add \p Node \p node with boundary id \p id to the boundary
@@ -498,6 +510,15 @@ public:
 
 private:
 
+  /**
+   * Helper method for finding consistent maps of interior to boundary
+   * dof_object ids.  Either node_id_map or side_id_map can be NULL,
+   * in which case it will not be filled.
+   */
+  void _find_id_maps
+    (const std::set<boundary_id_type> &requested_boundary_ids,
+     std::map<dof_id_type, dof_id_type> * node_id_map,
+     std::map<std::pair<dof_id_type, unsigned char>, dof_id_type> * side_id_map);
 
   /**
    * The Mesh this boundary info pertains to.

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -496,6 +496,9 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
               continue;
             }
 
+          // For node comparisons we'll need a sensible tolerance
+          Real node_tolerance = current_elem->hmin() * TOLERANCE;
+
           // Otherwise our interior_parent should be a child of our
           // parent's interior_parent.
           for (unsigned int c=0; c != pip->n_children(); ++c)
@@ -513,8 +516,16 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
               for (unsigned int n=0; n != current_elem->n_nodes();
                    ++n)
                 {
-                  if (child->local_node(current_elem->node(n)) ==
-                      libMesh::invalid_uint)
+                  bool child_contains_this_node = false;
+                  for (unsigned int cn=0; cn != current_elem->n_nodes();
+                       ++cn)
+                    if (child->point(cn).absolute_fuzzy_equals
+                          (current_elem->point(n), node_tolerance))
+                      {
+                        child_contains_this_node = true;
+                        break;
+                      }
+                  if (!child_contains_this_node)
                     {
                       child_contains_our_nodes = false;
                       break;


### PR DESCRIPTION
Since we should now support fun tricks with mixes of "interior" and "boundary" elements on the same mesh, let's add an easy way to put them into the same mesh.

This passes the FIN-S test suite, which was at least exhaustive enough of BoundaryInfo::sync() to catch bugs in my initial refactoring attempts.