### PR TITLE
Output QUAD8, HEX20, BCs in GmshIO

### DIFF
--- a/include/mesh/gmsh_io.h
+++ b/include/mesh/gmsh_io.h
@@ -103,6 +103,11 @@ public:
    */
   bool & binary ();
 
+  /**
+   * Access to the flag which controls whether boundary elements are
+   * written to the Mesh file.
+   */
+  bool & write_lower_dimensional_elements ();
 
 private:
   /**
@@ -131,6 +136,12 @@ private:
    * Flag to write binary data.
    */
   bool _binary;
+
+  /**
+   * If true, lower-dimensional elements representing the Mesh
+   * boundary get written to the output file.
+   */
+  bool _write_lower_dimensional_elements;
 };
 
 

--- a/include/mesh/gmsh_io.h
+++ b/include/mesh/gmsh_io.h
@@ -138,8 +138,8 @@ private:
   bool _binary;
 
   /**
-   * If true, lower-dimensional elements representing the Mesh
-   * boundary get written to the output file.
+   * If true, lower-dimensional elements based on the boundary
+   * conditions get written to the output file.
    */
   bool _write_lower_dimensional_elements;
 

--- a/include/mesh/gmsh_io.h
+++ b/include/mesh/gmsh_io.h
@@ -142,6 +142,57 @@ private:
    * boundary get written to the output file.
    */
   bool _write_lower_dimensional_elements;
+
+  /**
+   * Defines mapping from libMesh element types to Gmsh element types or vice-versa.
+   */
+  struct ElementDefinition
+  {
+    ElementDefinition(ElemType type_in,
+                      unsigned gmsh_type_in,
+                      unsigned dim_in,
+                      unsigned nnodes_in) :
+      type(type_in),
+      gmsh_type(gmsh_type_in),
+      dim(dim_in),
+      nnodes(nnodes_in)
+    {}
+
+    ElemType type;
+    unsigned int gmsh_type;
+    unsigned int dim;
+    unsigned int nnodes;
+    std::vector<unsigned int> nodes;
+  };
+
+  /**
+   * struct which holds a map from Gmsh to libMesh element numberings
+   * and vice-versa.
+   */
+  struct ElementMaps
+  {
+    // Helper function to add a (key, value) pair to both maps
+    void add_def(const ElementDefinition & eledef)
+    {
+      out.insert(std::make_pair(eledef.type, eledef));
+      in.insert(std::make_pair(eledef.gmsh_type, eledef));
+    }
+
+    std::map<ElemType, ElementDefinition> out;
+    std::map<unsigned int, ElementDefinition> in;
+  };
+
+  /**
+   * A static ElementMaps object that is built statically and used by
+   * all instances of this class.
+   */
+  static ElementMaps _element_maps;
+
+  /**
+   * A static function used to construct the _element_maps struct,
+   * statically.
+   */
+  static ElementMaps build_element_maps();
 };
 
 

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -30,273 +30,76 @@
 #include "libmesh/mesh_base.h"
 
 
-// anonymous namespace to hold local data
-namespace
-{
-using namespace libMesh;
-
-/**
- * Defines mapping from libMesh element types to Gmsh element types.
- */
-struct elementDefinition
-{
-  std::string label;
-  std::vector<unsigned int> nodes;
-  ElemType type;
-  unsigned int exptype;
-  unsigned int dim;
-  unsigned int nnodes;
-};
-
-
-// maps from a libMesh element type to the proper
-// Gmsh elementDefinition.  Placing the data structure
-// here in this anonymous namespace gives us the
-// benefits of a global variable without the nasty
-// side-effects
-std::map<ElemType, elementDefinition> eletypes_exp;
-std::map<unsigned int, elementDefinition> eletypes_imp;
-
-
-
-// ------------------------------------------------------------
-// helper function to initialize the eletypes map
-void init_eletypes ()
-{
-  if (eletypes_exp.empty() && eletypes_imp.empty())
-    {
-      // This should happen only once.  The first time this method
-      // is called the eletypes data struture will be empty, and
-      // we will fill it.  Any subsequent calls will find an initialized
-      // eletypes map and will do nothing.
-
-      // set up the element definitions
-      elementDefinition eledef;
-
-      // use "swap trick" from Scott Meyer's "Effective STL" to initialize
-      // eledef.nodes vector
-
-      // POINT (only Gmsh)
-      {
-        eledef.type    = NODEELEM;
-        eledef.exptype = 15;
-        eledef.dim     = 0;
-        eledef.nnodes  = 1;
-        eledef.nodes.clear();
-
-        // import only
-        eletypes_imp[15] = eledef;
-      }
-
-      // EDGE2
-      {
-        eledef.type    = EDGE2;
-        eledef.dim     = 1;
-        eledef.nnodes  = 2;
-        eledef.exptype = 1;
-        eledef.nodes.clear();
-
-        eletypes_exp[EDGE2] = eledef;
-        eletypes_imp[1]     = eledef;
-      }
-
-      // EDGE3
-      {
-        eledef.type    = EDGE3;
-        eledef.dim     = 1;
-        eledef.nnodes  = 3;
-        eledef.exptype = 8;
-        eledef.nodes.clear();
-
-        eletypes_exp[EDGE3] = eledef;
-        eletypes_imp[8]     = eledef;
-      }
-
-      // TRI3
-      {
-        eledef.type    = TRI3;
-        eledef.dim     = 2;
-        eledef.nnodes  = 3;
-        eledef.exptype = 2;
-        eledef.nodes.clear();
-
-        eletypes_exp[TRI3] = eledef;
-        eletypes_imp[2] = eledef;
-      }
-
-      // TRI6
-      {
-        eledef.type    = TRI6;
-        eledef.dim     = 2;
-        eledef.nnodes  = 6;
-        eledef.exptype = 9;
-        eledef.nodes.clear();
-
-        eletypes_exp[TRI6] = eledef;
-        eletypes_imp[9]    = eledef;
-      }
-
-      // QUAD4
-      {
-        eledef.type    = QUAD4;
-        eledef.dim     = 2;
-        eledef.nnodes  = 4;
-        eledef.exptype = 3;
-        eledef.nodes.clear();
-
-        eletypes_exp[QUAD4] = eledef;
-        eletypes_imp[3]     = eledef;
-      }
-
-      // QUAD8
-      {
-        eledef.type    = QUAD8;
-        eledef.dim     = 2;
-        eledef.nnodes  = 8;
-        eledef.exptype = 16;
-        eledef.nodes.clear();
-
-        eletypes_exp[QUAD8] = eledef;
-        eletypes_imp[16]    = eledef;
-      }
-
-      // QUAD9
-      {
-        eledef.type    = QUAD9;
-        eledef.dim     = 2;
-        eledef.nnodes  = 9;
-        eledef.exptype = 10;
-        eledef.nodes.clear();
-
-        eletypes_exp[QUAD9] = eledef;
-        eletypes_imp[10]    = eledef;
-      }
-
-      // HEX8
-      {
-        eledef.type    = HEX8;
-        eledef.dim     = 3;
-        eledef.nnodes  = 8;
-        eledef.exptype = 5;
-        eledef.nodes.clear();
-
-        eletypes_exp[HEX8] = eledef;
-        eletypes_imp[5]    = eledef;
-      }
-
-      // HEX20
-      {
-        eledef.type    = HEX20;
-        eledef.dim     = 3;
-        eledef.nnodes  = 20;
-        eledef.exptype = 17;
-        const unsigned int nodes[] = {0,1,2,3,4,5,6,7,8,11,12,9,13,10,14,15,16,19,17,18};
-        std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes);
-
-        eletypes_exp[HEX20] = eledef;
-        eletypes_imp[17]    = eledef;
-      }
-
-      // HEX27
-      {
-        eledef.type    = HEX27;
-        eledef.dim     = 3;
-        eledef.nnodes  = 27;
-        eledef.exptype = 12;
-        const unsigned int nodes[] = {0,1,2,3,4,5,6,7,8,11,12,9,13,10,14,
-                                      15,16,19,17,18,20,21,24,22,23,25,26};
-        std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes);
-
-        eletypes_exp[HEX27] = eledef;
-        eletypes_imp[12]    = eledef;
-      }
-
-      // TET4
-      {
-        eledef.type    = TET4;
-        eledef.dim     = 3;
-        eledef.nnodes  = 4;
-        eledef.exptype = 4;
-        eledef.nodes.clear();
-
-        eletypes_exp[TET4] = eledef;
-        eletypes_imp[4]    = eledef;
-      }
-
-      // TET10
-      {
-        eledef.type    = TET10;
-        eledef.dim     = 3;
-        eledef.nnodes  = 10;
-        eledef.exptype = 11;
-        const unsigned int nodes[] = {0,1,2,3,4,5,6,7,9,8};
-        std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes);
-
-        eletypes_exp[TET10] = eledef;
-        eletypes_imp[11]    = eledef;
-      }
-
-      // PRISM6
-      {
-        eledef.type    = PRISM6;
-        eledef.dim     = 3;
-        eledef.nnodes  = 6;
-        eledef.exptype = 6;
-        eledef.nodes.clear();
-
-        eletypes_exp[PRISM6] = eledef;
-        eletypes_imp[6]      = eledef;
-      }
-
-      // PRISM15
-      // TODO: what should be done with this on writing?
-      {
-        eledef.type    = PRISM15;
-        eledef.dim     = 3;
-        eledef.nnodes  = 15;
-        eledef.exptype = 103;
-        eledef.nodes.clear();
-
-        eletypes_exp[PRISM15] = eledef;
-        eletypes_imp[13] = eledef;
-      }
-
-      // PRISM18
-      {
-        eledef.type    = PRISM18;
-        eledef.dim     = 3;
-        eledef.nnodes  = 18;
-        eledef.exptype = 13;
-        const unsigned int nodes[] = {0,1,2,3,4,5,6,8,9,7,10,11,
-                                      12,14,13,15,17,16};
-        std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes);
-
-        eletypes_exp[PRISM18] = eledef;
-        eletypes_imp[13]      = eledef;
-      }
-
-      // PYRAMID5
-      {
-        eledef.type    = PYRAMID5;
-        eledef.dim     = 3;
-        eledef.nnodes  = 5;
-        eledef.exptype = 7;
-        eledef.nodes.clear();
-
-        eletypes_exp[PYRAMID5] = eledef;
-        eletypes_imp[7]        = eledef;
-      }
-    }
-}
-
-} // end anonymous namespace
-
-
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// GmshIO  members
+// Initialize the static data member
+GmshIO::ElementMaps GmshIO::_element_maps = GmshIO::build_element_maps();
+
+
+
+// Definition of the static function which constructs the ElementMaps object.
+GmshIO::ElementMaps GmshIO::build_element_maps()
+{
+  // Object to be filled up
+  ElementMaps em;
+
+  // POINT (import only)
+  em.in.insert(std::make_pair(15, ElementDefinition(NODEELEM, 15, 0, 1)));
+
+  // Add elements with non-trivial node mappings
+  em.add_def(ElementDefinition(EDGE2, 1, 1, 2));
+  em.add_def(ElementDefinition(EDGE3, 8, 1, 3));
+  em.add_def(ElementDefinition(TRI3, 2, 2, 3));
+  em.add_def(ElementDefinition(TRI6, 9, 2, 6));
+  em.add_def(ElementDefinition(QUAD4, 3, 2, 4));
+  em.add_def(ElementDefinition(QUAD8, 16, 2, 8));
+  em.add_def(ElementDefinition(QUAD9, 10, 2, 9));
+  em.add_def(ElementDefinition(HEX8, 5, 3, 8));
+  em.add_def(ElementDefinition(TET4, 4, 3, 4));
+  em.add_def(ElementDefinition(PRISM6, 6, 3, 6));
+  em.add_def(ElementDefinition(PRISM15, 13, 3, 15)); // TODO: what should be done with this on writing?
+  em.add_def(ElementDefinition(PYRAMID5, 7, 3, 5));
+
+  // Add elements with non-trivial node mappings
+
+  // HEX20
+  {
+    ElementDefinition eledef(HEX20, 17, 3, 20);
+    const unsigned int nodes[] = {0,1,2,3,4,5,6,7,8,11,12,9,13,10,14,15,16,19,17,18};
+    std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes); // swap trick
+    em.add_def(eledef);
+  }
+
+  // HEX27
+  {
+    ElementDefinition eledef(HEX27, 12, 3, 27);
+    const unsigned int nodes[] = {0,1,2,3,4,5,6,7,8,11,12,9,13,10,14,
+                                  15,16,19,17,18,20,21,24,22,23,25,26};
+    std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes); // swap trick
+    em.add_def(eledef);
+  }
+
+  // TET10
+  {
+    ElementDefinition eledef(TET10, 11, 3, 10);
+    const unsigned int nodes[] = {0,1,2,3,4,5,6,7,9,8};
+    std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes); // swap trick
+    em.add_def(eledef);
+  }
+
+  // PRISM18
+  {
+    ElementDefinition eledef(PRISM18, 13, 3, 18);
+    const unsigned int nodes[] = {0,1,2,3,4,5,6,8,9,7,10,11,12,14,13,15,17,16};
+    std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes); // swap trick
+    em.add_def(eledef);
+  }
+
+  return em;
+}
+
+
 
 GmshIO::GmshIO (const MeshBase& mesh) :
   MeshOutput<MeshBase>(mesh),
@@ -347,9 +150,6 @@ void GmshIO::read_mesh(std::istream& in)
   libmesh_assert_equal_to (MeshOutput<MeshBase>::mesh().processor_id(), 0);
 
   libmesh_assert(in.good());
-
-  // initialize the map with element types
-  init_eletypes();
 
   // clear any data in the mesh
   MeshBase& mesh = MeshInput<MeshBase>::mesh();
@@ -490,14 +290,14 @@ void GmshIO::read_mesh(std::istream& in)
                     }
 
                   // Consult the import element table to determine which element to build
-                  std::map<unsigned int, elementDefinition>::iterator eletypes_it = eletypes_imp.find(type);
+                  std::map<unsigned int, GmshIO::ElementDefinition>::iterator eletypes_it = _element_maps.in.find(type);
 
                   // Make sure we actually found something
-                  if (eletypes_it == eletypes_imp.end())
+                  if (eletypes_it == _element_maps.in.end())
                     libmesh_error_msg("Element type " << type << " not found!");
 
-                  // Get a reference to the elementDefinition
-                  const elementDefinition& eletype = eletypes_it->second;
+                  // Get a reference to the ElementDefinition
+                  const GmshIO::ElementDefinition& eletype = eletypes_it->second;
 
                   // If we read nnodes, make sure it matches the number in eletype.nnodes
                   if (nnodes != 0 && nnodes != eletype.nnodes)
@@ -528,7 +328,7 @@ void GmshIO::read_mesh(std::istream& in)
                         if (elem->n_nodes() != nnodes)
                           libmesh_error_msg("Number of nodes for element " \
                                             << id \
-                                            << " of type " << eletypes_imp[type].type \
+                                            << " of type " << eletype.type \
                                             << " (Gmsh type " << type \
                                             << ") does not match Libmesh definition. " \
                                             << "I expected " << elem->n_nodes() \
@@ -797,9 +597,6 @@ void GmshIO::write_mesh (std::ostream& out_stream)
   // Be sure that the stream is valid.
   libmesh_assert (out_stream.good());
 
-  // initialize the map with element types
-  init_eletypes();
-
   // Get a const reference to the mesh
   const MeshBase& mesh = MeshOutput<MeshBase>::mesh();
 
@@ -851,10 +648,17 @@ void GmshIO::write_mesh (std::ostream& out_stream)
 
         // Make sure we have a valid entry for
         // the current element type.
-        libmesh_assert (eletypes_exp.count(elem->type()));
+        libmesh_assert (_element_maps.out.count(elem->type()));
 
         // consult the export element table
-        const elementDefinition& eletype = eletypes_exp[elem->type()];
+        std::map<ElemType, ElementDefinition>::iterator def_it =
+          _element_maps.out.find(elem->type());
+
+        // Assert that we found it
+        libmesh_assert(def_it != _element_maps.out.end());
+
+        // Get a reference to the ElementDefinition object
+        const ElementDefinition& eletype = def_it->second;
 
         // The element mapper better not require any more nodes
         // than are present in the current element!
@@ -863,7 +667,7 @@ void GmshIO::write_mesh (std::ostream& out_stream)
         // elements ids are 1 based in Gmsh
         out_stream << elem->id()+1 << " ";
         // element type
-        out_stream << eletype.exptype;
+        out_stream << eletype.gmsh_type;
 
         // write the number of tags (3) and their values:
         // 1 (physical entity)
@@ -914,11 +718,14 @@ void GmshIO::write_mesh (std::ostream& out_stream)
 
               UniquePtr<Elem> side = elem->build_side(s);
 
-              // Make sure we have a valid entry for the current element type.
-              libmesh_assert (eletypes_exp.count(side->type()));
+              std::map<ElemType, ElementDefinition>::iterator def_it =
+                _element_maps.out.find(side->type());
+
+              // Assert that we found it
+              libmesh_assert(def_it != _element_maps.out.end());
 
               // consult the export element table
-              const elementDefinition& eletype = eletypes_exp[side->type()];
+              const GmshIO::ElementDefinition& eletype = def_it->second;
 
               // The element mapper better not require any more nodes
               // than are present in the current element!
@@ -928,7 +735,7 @@ void GmshIO::write_mesh (std::ostream& out_stream)
               out_stream << e_id+1 << " ";
 
               // element type
-              out_stream << eletype.exptype;
+              out_stream << eletype.gmsh_type;
 
               // write the number of tags:
               // 1 (physical entity)
@@ -977,9 +784,6 @@ void GmshIO::write_post (const std::string& fname,
   // Make sure it opened correctly
   if (!out_stream.good())
     libmesh_file_error(fname.c_str());
-
-  // initialize the map with element types
-  init_eletypes();
 
   // create a character buffer
   char buf[80];

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -203,7 +203,8 @@ void init_eletypes ()
         eledef.dim     = 3;
         eledef.nnodes  = 27;
         eledef.exptype = 12;
-        const unsigned int nodes[] = {0,1,2,3,4,5,6,7,8,11,12,9,13,10,14,15,16,19,17,18,20,21,24,22,23,25,26};
+        const unsigned int nodes[] = {0,1,2,3,4,5,6,7,8,11,12,9,13,10,14,
+                                      15,16,19,17,18,20,21,24,22,23,25,26};
         std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes);
 
         eletypes_exp[HEX27] = eledef;
@@ -266,7 +267,8 @@ void init_eletypes ()
         eledef.dim     = 3;
         eledef.nnodes  = 18;
         eledef.exptype = 13;
-        const unsigned int nodes[] = {0,1,2,3,4,5,6,8,9,7,10,11,12,14,13,15,17,16};
+        const unsigned int nodes[] = {0,1,2,3,4,5,6,8,9,7,10,11,
+                                      12,14,13,15,17,16};
         std::vector<unsigned int>(nodes, nodes+eledef.nnodes).swap(eledef.nodes);
 
         eletypes_exp[PRISM18] = eledef;
@@ -833,7 +835,6 @@ void GmshIO::write_mesh (std::ostream& out_stream)
     const MeshBase::const_element_iterator end = mesh.active_elements_end();
 
     // loop over the elements
-    it  = mesh.active_elements_begin();
     for ( ; it != end; ++it)
       {
         const Elem* elem = *it;
@@ -850,7 +851,7 @@ void GmshIO::write_mesh (std::ostream& out_stream)
         libmesh_assert_less_equal (eletype.nodes.size(), elem->n_nodes());
 
         // elements ids are 1 based in Gmsh
-        out_stream << (e_id+1) << " ";
+        out_stream << e_id+1 << " ";
         // element type
         out_stream << eletype.exptype;
 
@@ -864,11 +865,11 @@ void GmshIO::write_mesh (std::ostream& out_stream)
         // if there is a node translation table, use it
         if (eletype.nodes.size() > 0)
           for (unsigned int i=0; i < elem->n_nodes(); i++)
-            out_stream << (elem->node(eletype.nodes[i])+1) << " "; // gmsh is 1-based
+            out_stream << elem->node(eletype.nodes[i])+1 << " "; // gmsh is 1-based
         // otherwise keep the same node order
         else
           for (unsigned int i=0; i < elem->n_nodes(); i++)
-            out_stream << (elem->node(i)+1) << " ";                // gmsh is 1-based
+            out_stream << elem->node(i)+1 << " ";                  // gmsh is 1-based
         out_stream << "\n";
 
         // increment this index too...

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -827,9 +827,6 @@ void GmshIO::write_mesh (std::ostream& out_stream)
                << mesh.node(v)(2) << '\n';
   out_stream << "$EndNodes\n";
 
-  // A counter for writing elements to the Gmsh file sequentially.
-  unsigned int e_id = 0;
-
   {
     // write the connectivity
     out_stream << "$Elements\n";
@@ -855,7 +852,7 @@ void GmshIO::write_mesh (std::ostream& out_stream)
         libmesh_assert_less_equal (eletype.nodes.size(), elem->n_nodes());
 
         // elements ids are 1 based in Gmsh
-        out_stream << e_id+1 << " ";
+        out_stream << elem->id()+1 << " ";
         // element type
         out_stream << eletype.exptype;
 
@@ -875,13 +872,19 @@ void GmshIO::write_mesh (std::ostream& out_stream)
           for (unsigned int i=0; i < elem->n_nodes(); i++)
             out_stream << elem->node(i)+1 << " ";                  // gmsh is 1-based
         out_stream << "\n";
-
-        // increment this index too...
-        ++e_id;
       } // element loop
   }
 
   {
+    // A counter for writing surface elements to the Gmsh file
+    // sequentially.  We start numbering them with a number strictly
+    // larger than the largest element ID in the mesh.  Note: the
+    // MeshBase docs say "greater than or equal to" the maximum
+    // element id in the mesh, so technically we might need a +1 here,
+    // but all of the implementations return an ID strictly greater
+    // than the largest element ID in the Mesh.
+    unsigned int e_id = mesh.max_elem_id();
+
     // loop over the elements, writing out boundary faces
     MeshBase::const_element_iterator       it  = mesh.active_elements_begin();
     const MeshBase::const_element_iterator end = mesh.active_elements_end();


### PR DESCRIPTION
This branch builds on a patch from Vasileios Vavourakis adding QUAD8, HEX20, and lower-dimensional element output from `GmshIO`.  The output of lower-dimensional elements is generally used for specifying boundary conditions in Gmsh files, so I decided to limit the output to those boundary sides which actually have BCs on them, but could probably be convinced to output all sides if someone really requires that.  Along the way, I also refactored the code which builds the mapping between libmesh and Gmsh element types into a class-static function that is much less verbose than it was previously.
