### PR TITLE
Allow systems to be hidden from es writing

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1617,6 +1617,14 @@ public:
    */
   void zero_variable (NumericVector<Number>& v, unsigned int var_num) const;
 
+
+  /**
+   * Returns a writeable reference to a boolean that determines if this system
+   * can be written to to file or not.  If set to \p true, then
+   * \p EquationSystems::write will ignore this system.
+   */
+  bool & hide_output() {return _hide_output;}
+
 protected:
 
   /**
@@ -1935,6 +1943,12 @@ private:
    * it again.
    */
   bool adjoint_already_solved;
+
+  /**
+   * Are we allowed to write this system to file?  If \p _hide_output is
+   * \p true, then \p EquationSystems::write will ignore this system.
+   */
+  bool _hide_output;
 };
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -85,7 +85,8 @@ System::System (EquationSystems& es,
   _is_initialized                   (false),
   _identify_variable_groups         (true),
   _additional_data_written          (false),
-  adjoint_already_solved            (false)
+  adjoint_already_solved            (false),
+  _hide_output                      (false)
 {
 }
 


### PR DESCRIPTION
This PR adds a new method to systems, `hide_output()`, that can be used to prevent a system from being written to file when `EquationSystems::write` is called.  As per @jwpeterson's suggestion on libmesh-devel, the method returns a reference to a private boolean for getting/setting purposes.

I have tested this feature in MOOSE, and it's working as expected.  I'm not sure how libMesh's test suite works so I would appreciate some pointers on how to add a test.