### PR TITLE
Make subdivision elements compatible with DirichletBoundary and RB

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -351,7 +351,7 @@ private:
 
     const FEContinuity cont = fe->get_continuity();
 
-    if (cont == C_ONE)
+    if ( (cont == C_ONE) && (fe_type.family != SUBDIVISION) )
       {
         // We'll need gradient data for a C1 projection
         libmesh_assert(g || g_fem);
@@ -528,7 +528,7 @@ private:
               }
             // Assume that C_ZERO elements have a single nodal
             // value shape function
-            else if (cont == C_ZERO)
+            else if ( (cont == C_ZERO) || (fe_type.family == SUBDIVISION) )
               {
                 libmesh_assert_equal_to (nc, n_vec_dim);
                 for( unsigned int c = 0; c < n_vec_dim; c++ )


### PR DESCRIPTION
Subdivision elements are C1 but their data structure is similar to C0 elements.
In order to use the DirichletBoundary with subdivision elements (not compatible until now), I added a few flags in dof_map_constraints.C so that they are treated as C0.

Also, when performing assembly on subdivision elements, "ghosts" need to be discarded and a particular quadrature rule needs to be initialized. I modified rb_construction.C so that it can handle subdivision elements.