### PR TITLE
use C++ for the trivial PETSc compile test

### DIFF
--- a/configure
+++ b/configure
@@ -30787,18 +30787,18 @@ $as_echo "<<< Configuring library with Hypre support >>>" >&6; }
         # variable, which happened when PETSc 3.6 came out.
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we can compile a trivial PETSc program" >&5
 $as_echo_n "checking whether we can compile a trivial PETSc program... " >&6; }
-        ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
+        ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-        # Save the original CFLAGS contents
-        saveCFLAGS="$CFLAGS"
+        # Save the original CXXFLAGS contents
+        saveCXXFLAGS="$CXXFLAGS"
 
-        # Append PETSc include paths to the CFLAGS variables
-        CFLAGS="$saveCFLAGS $PETSCINCLUDEDIRS"
+        # Append PETSc include paths to the CXXFLAGS variables
+        CXXFLAGS="$saveCXXFLAGS $PETSCINCLUDEDIRS"
 
         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -30814,7 +30814,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
         }
 
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
+if ac_fn_cxx_try_compile "$LINENO"; then :
 
           { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
@@ -30830,8 +30830,8 @@ $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-        # Return C flags to their original state.
-        CFLAGS="$saveCFLAGS"
+        # Return CXXFLAGS to their original state.
+        CXXFLAGS="$saveCXXFLAGS"
 
         ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -238,13 +238,13 @@ AC_DEFUN([CONFIGURE_PETSC],
         # by the tests above with an invalid PETSCINCLUDEDIRS
         # variable, which happened when PETSc 3.6 came out.
         AC_MSG_CHECKING(whether we can compile a trivial PETSc program)
-        AC_LANG_PUSH([C])
+        AC_LANG_PUSH([C++])
 
-        # Save the original CFLAGS contents
-        saveCFLAGS="$CFLAGS"
+        # Save the original CXXFLAGS contents
+        saveCXXFLAGS="$CXXFLAGS"
 
-        # Append PETSc include paths to the CFLAGS variables
-        CFLAGS="$saveCFLAGS $PETSCINCLUDEDIRS"
+        # Append PETSc include paths to the CXXFLAGS variables
+        CXXFLAGS="$saveCXXFLAGS $PETSCINCLUDEDIRS"
 
         AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
         @%:@include <petsc.h>
@@ -263,10 +263,10 @@ AC_DEFUN([CONFIGURE_PETSC],
           AC_MSG_RESULT(no)
         ])
 
-        # Return C flags to their original state.
-        CFLAGS="$saveCFLAGS"
+        # Return CXXFLAGS to their original state.
+        CXXFLAGS="$saveCXXFLAGS"
 
-        AC_LANG_POP([C])
+        AC_LANG_POP([C++])
 
 
         # PETSc >= 3.5.0 should have TAO built-in, we don't currently support any other type of TAO installation.


### PR DESCRIPTION
Since we ultimately will be using PETSc under C++ it would seem to be more consistent to use C++ to test the PETSc installation to guard against this issue:

```pre
configure:30788: checking whether we can compile a trivial PETSc program
configure:30817: /software/x86_64/mpi/openmpi-1.7.4-gcc-4.4/bin/mpicc -c  -I/software/x86_64/petsc/3.1-p8/include -I/software/x86_64/petsc/3.1-p8/aerolab_workstations-openmpi-1.7-gcc-4.4/include -I/software/x86_64/petsc/3.1-p8/aerolab_workstations-openmpi-1.7-gcc-4.4/include -I/software/x86_64/mpi/openmpi-1.7.2-gcc-4.4/include -I/software/x86_64/mpi/openmpi-1.7.2-gcc-4.4/lib -I/software/x86_64/petsc/3.1-p8/aerolab_workstations-openmpi-1.7-gcc-4.4/include -I/software/x86_64/mpi/openmpi-1.7.2-gcc-4.4/include -I/software/x86_64/mpi/openmpi-1.7.2-gcc-4.4/lib -I/software/x86_64/petsc/3.1-p8/aerolab_workstations-openmpi-1.7-gcc-4.4/include -I/software/x86_64/petsc/3.1-p8/include -I/software/x86_64/petsc/3.1-p8/aerolab_workstations-openmpi-1.7-gcc-4.4/include -I/software/x86_64/mpi/openmpi-1.7.2-gcc-4.4/include -I/software/x86_64/mpi/openmpi-1.7.2-gcc-4.4/lib  conftest.c >&5
In file included from /software/x86_64/petsc/3.1-p8/include/petscmesh.h:6,
                 from /software/x86_64/petsc/3.1-p8/include/petsc.h:4,
                 from conftest.c:113:
/software/x86_64/petsc/3.1-p8/include/petscsys.h:22:2: error: #error "PETSc configured with --with-clanguage=c++ and NOT --with-c-support - it can be used only with a C++ compiler"
```