### PR TITLE
Read additional data *iff available*

### DIFF
--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -100,6 +100,14 @@ public:
   bool is_open() const;
 
   /**
+   * Returns true if the Xdr file being read is at End-Of-File.
+   * Note that this is *not* a const method - the only portable way to
+   * test for an impending EOF is to peek at the next byte of the file
+   * first, which may set the eof flag on the istream. 
+   */
+  bool is_eof();
+
+  /**
    * Returns true if the file is opened in a reading
    * state, false otherwise.
    */

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -745,7 +745,12 @@ void System::read_serialized_data (Xdr& io,
   // 11.)
   // Only read additional vectors if the user requested them and
   // data is available
-  if (read_additional_data && !io.is_eof())
+  bool is_eof;
+  if (this->processor_id() == 0)
+    is_eof = io.is_eof();
+  this->comm().broadcast(is_eof);
+
+  if (read_additional_data && !is_eof)
     {
       std::map<std::string, NumericVector<Number>* >::const_iterator
         pos = _vectors.begin();

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -743,8 +743,9 @@ void System::read_serialized_data (Xdr& io,
   }
 
   // 11.)
-  // Only read additional vectors if wanted
-  if (read_additional_data)
+  // Only read additional vectors if the user requested them and
+  // data is available
+  if (read_additional_data && !io.is_eof())
     {
       std::map<std::string, NumericVector<Number>* >::const_iterator
         pos = _vectors.begin();

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -395,12 +395,33 @@ bool Xdr::is_open() const
 
 bool Xdr::is_eof()
 {
-  int next = in->peek();
-  if (next == EOF)
+  switch (mode)
     {
-      libmesh_assert(in->eof());
-      return true;
+    case ENCODE:
+    case DECODE:
+      {
+        libmesh_assert(fp);
+        int next = fgetc(fp);
+        if (next == EOF)
+          return true;
+        ungetc(next, fp);
+        break;
+      }
+    case READ:
+      {
+        libmesh_assert(in.get());
+        int next = in->peek();
+        if (next == EOF)
+          {
+            libmesh_assert(in->eof());
+            return true;
+          }
+        break;
+      }
+    default:
+      libmesh_error();
     }
+
   return false;
 }
 

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -392,6 +392,20 @@ bool Xdr::is_open() const
 }
 
 
+
+bool Xdr::is_eof()
+{
+  int next = in->peek();
+  if (next == EOF)
+    {
+      libmesh_assert(in->eof());
+      return true;
+    }
+  return false;
+}
+
+
+
 #ifdef LIBMESH_HAVE_XDR
 
 // Anonymous namespace for Xdr::data helper functions

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -402,10 +402,11 @@ bool Xdr::is_eof()
       {
         libmesh_assert(fp);
 
-        // If we're failing, was it due to eof?
-        if (ferror(fp))
-          return feof(fp);
+        // Are we already at eof?
+        if (feof(fp))
+          return true;
 
+        // Or about to reach eof?
         int next = fgetc(fp);
         if (next == EOF)
           {
@@ -429,10 +430,11 @@ bool Xdr::is_eof()
       {
         libmesh_assert(in.get());
 
-        // If we're failing, was it due to eof?
-        if (!in->good())
-          return in->eof();
+        // Are we already at eof?
+        if (in->eof())
+          return true;
 
+        // Or about to reach eof?
         int next = in->peek();
         if (next == EOF)
           {


### PR DESCRIPTION
Currently if a code tries to read a solution file while requesting additional vectors (as we do in e.g. projection.C to preserve as much data as possible), but the solution file was written without those additional vectors (as we do in e.g. many transient checkpoints when our time integrators don't need old solution vectors to restart), that code trips an assert and dies.

Now it instead leaves the additional vectors unchanged.