### PR TITLE
Enable ParallelMesh repartitioning

### DIFF
--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -433,6 +433,8 @@ void libmesh_assert_valid_refinement_tree (const MeshBase &mesh);
 /**
  * A function for verifying that neighbor connectivity is correct (each
  * element is a neighbor of or descendant of a neighbor of its neighbors)
+ * and consistent (each neighbor link goes to either the same neighbor
+ * or to a RemoteElem on each processor)
  */
 void libmesh_assert_valid_neighbors (const MeshBase &mesh);
 #endif

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -34,6 +34,22 @@ namespace Parallel {
 
 #ifdef LIBMESH_HAVE_MPI
 
+#ifndef NDEBUG
+#define libmesh_assert_mpi_success(error_code) \
+  do { \
+    if (error_code != MPI_SUCCESS) \
+      { \
+        char error_string[MPI_MAX_ERROR_STRING+1]; \
+        int resultlen; \
+        MPI_Error_string(error_code, error_string, &resultlen); \
+        libmesh_assert_equal_to_msg(error_code, MPI_SUCCESS, error_string); \
+      } \
+    } \
+  while(0)
+#else
+#define libmesh_assert_mpi_success(error_code)  ((void) 0)
+#endif
+
 #define STANDARD_TYPE(cxxtype,mpitype)                                  \
   template<>                                                            \
   class StandardType<cxxtype> : public DataType                         \
@@ -1963,7 +1979,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                             tag.value(),
                             this->get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("send()", "Parallel");
 }
@@ -1993,7 +2009,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                               this->get(),
                               req.get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("send()", "Parallel");
 }
@@ -2021,7 +2037,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                             tag.value(),
                             this->get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("send()", "Parallel");
 }
@@ -2051,7 +2067,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                               this->get(),
                               req.get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("send()", "Parallel");
 }
@@ -2165,7 +2181,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                             tag.value(),
                             this->get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("send()", "Parallel");
 }
@@ -2194,7 +2210,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                               this->get(),
                               req.get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("send()", "Parallel");
 }
@@ -2360,7 +2376,7 @@ inline Status Communicator::receive (const unsigned int src_processor_id,
               tag.value(),
               this->get(),
               stat.get());
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("receive()", "Parallel");
 
@@ -2388,7 +2404,7 @@ inline void Communicator::receive (const unsigned int src_processor_id,
                tag.value(),
                this->get(),
                req.get());
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("receive()", "Parallel");
 }
@@ -2521,7 +2537,9 @@ inline Status Communicator::receive (const unsigned int src_processor_id,
               tag.value(),
               this->get(),
               stat.get());
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
+
+  libmesh_assert_equal_to (stat.size(), buf.size());
 
   STOP_LOG("receive()", "Parallel");
 
@@ -2550,7 +2568,7 @@ inline void Communicator::receive (const unsigned int src_processor_id,
                tag.value(),
                this->get(),
                req.get());
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("receive()", "Parallel");
 }
@@ -2883,7 +2901,7 @@ inline void Communicator::gather(const unsigned int root_id,
                  root_id,
                  this->get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("gather()", "Parallel");
 }
@@ -2991,7 +3009,7 @@ inline void Communicator::allgather
                     &r[0], &sendlengths[0],
                     &displacements[0], send_type, this->get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("allgather()", "Parallel");
 }
@@ -3095,7 +3113,7 @@ inline void Communicator::alltoall(std::vector<T> &buf) const
                   size_per_proc,
                   send_type,
                   this->get());
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("alltoall()", "Parallel");
 }
@@ -3123,7 +3141,7 @@ inline void Communicator::broadcast (T &data, const unsigned int root_id) const
 #endif
     MPI_Bcast (&data, 1, StandardType<T>(&data), root_id, this->get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("broadcast()", "Parallel");
 }
@@ -3154,7 +3172,7 @@ inline void Communicator::broadcast (bool &data, const unsigned int root_id) con
 #endif
     MPI_Bcast (&char_data, 1, StandardType<char>(&char_data), root_id, this->get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   data = char_data;
 
@@ -3229,7 +3247,7 @@ inline void Communicator::broadcast (std::vector<T> &data,
     MPI_Bcast (data_ptr, cast_int<int>(data.size()),
                StandardType<T>(data_ptr), root_id, this->get());
 
-  libmesh_assert (ierr == MPI_SUCCESS);
+  libmesh_assert_mpi_success (ierr);
 
   STOP_LOG("broadcast()", "Parallel");
 }

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -954,7 +954,7 @@ void Elem::find_interior_neighbors(std::set<const Elem *> &neighbor_set) const
             if (!elem->contains_point(this->point(p)))
               {
                 neighbor_set.erase(current);
-                continue;
+                break;
               }
         }
     }

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1287,8 +1287,9 @@ void Elem::make_links_to_me_local(unsigned int n)
       // neighbor links, we might have an out of date neighbor
       // link to elem's parent instead.
 #ifdef LIBMESH_ENABLE_AMR
-      libmesh_assert((neigh_family_member->neighbor(nn)->active() &&
-                      neigh_family_member->neighbor(nn)->is_ancestor_of(this)) ||
+      libmesh_assert((neigh_family_member->neighbor(nn) &&
+                      (neigh_family_member->neighbor(nn)->active()) ||
+                       neigh_family_member->neighbor(nn)->is_ancestor_of(this)) ||
                      (neigh_family_member->neighbor(nn) == remote_elem) ||
                      ((this->refinement_flag() == JUST_REFINED) &&
                       (this->parent() != NULL) &&

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1287,11 +1287,12 @@ void Elem::make_links_to_me_local(unsigned int n)
       // neighbor links, we might have an out of date neighbor
       // link to elem's parent instead.
 #ifdef LIBMESH_ENABLE_AMR
-      libmesh_assert((neigh_family_member->neighbor(nn) == this) ||
-                     (neigh_family_member->neighbor(nn) == remote_elem)
-                     || ((this->refinement_flag() == JUST_REFINED) &&
-                         (this->parent() != NULL) &&
-                         (neigh_family_member->neighbor(nn) == this->parent())));
+      libmesh_assert((neigh_family_member->neighbor(nn)->active() &&
+                      neigh_family_member->neighbor(nn)->is_ancestor_of(this)) ||
+                     (neigh_family_member->neighbor(nn) == remote_elem) ||
+                     ((this->refinement_flag() == JUST_REFINED) &&
+                      (this->parent() != NULL) &&
+                      (neigh_family_member->neighbor(nn) == this->parent())));
 #else
       libmesh_assert((neigh_family_member->neighbor(nn) == this) ||
                      (neigh_family_member->neighbor(nn) == remote_elem));

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1270,7 +1270,7 @@ void Elem::make_links_to_me_local(unsigned int n)
 #ifdef LIBMESH_ENABLE_AMR
   if (this->active())
     neigh->family_tree_by_side(neigh_family, nn);
-  else
+  else if (neigh->subactive())
 #endif
     neigh_family.push_back(neigh);
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -374,8 +374,7 @@ void MeshBase::partition (const unsigned int n_parts)
   // NULL partitioner means don't repartition
   // Non-serial meshes may not be ready for repartitioning here.
   else if(!skip_partitioning() &&
-          partitioner().get() &&
-          this->is_serial())
+          partitioner().get())
     {
       partitioner()->partition (*this, n_parts);
     }

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -167,7 +167,17 @@ void MeshCommunication::redistribute (ParallelMesh &mesh) const
 
               for (unsigned int n=0; n<elem->n_nodes(); n++)
                 if (connected_nodes.count(elem->get_node(n)))
-                  elements_to_send.insert (elem);
+                  {
+                    elements_to_send.insert (elem);
+
+                    // The remote processor needs all its semilocal
+                    // elements' ancestors, and it's possible that
+                    // they might not all be connected to the remote
+                    // processor's nodes.
+                    for (const Elem* parent = elem->parent(); parent;
+                         parent = parent->parent())
+                      elements_to_send.insert(parent);
+                  }
             }
         }
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -741,9 +741,14 @@ void MeshCommunication::gather_neighboring_elements (ParallelMesh &mesh) const
   // allow any pending requests to complete
   Parallel::wait (send_requests);
 
-  // Ghost elements may not have correct neighbor links, and we may
-  // not be able to locally infer correct neighbor links to remote
-  // elements.  So we synchronize ghost element neighbor links.
+  // We can now find neighbor information for the interfaces between
+  // local elements and ghost elements.
+  mesh.find_neighbors (/* reset_remote_elements = */ true,
+                       /* reset_current_list    = */ false);
+
+  // Ghost elements may not have correct remote_elem neighbor links,
+  // and we may not be able to locally infer correct neighbor links to
+  // remote elements.  So we synchronize ghost element neighbor links.
   SyncNeighbors nsync(mesh);
 
   Parallel::sync_dofobject_data_by_id

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -753,6 +753,11 @@ void ParallelMesh::redistribute ()
 
       this->update_parallel_id_counts();
 
+      // We probably had valid neighbors previously, so that a quality
+      // new partitioning could be found, but we might not have valid
+      // neighbor links on the newly-redistributed elements
+      this->find_neighbors();
+
       // Is this necessary?  If we are called from prepare_for_use(), this will be called
       // anyway... but users can always call partition directly, in which case we do need
       // to call delete_remote_elements()...

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -439,7 +439,8 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                       neigh = const_cast<RemoteElem*>(remote_elem);
                     }
 
-                  current_elem->set_neighbor(s, neigh);
+                  if (!current_elem->subactive())
+                    current_elem->set_neighbor(s, neigh);
 #ifdef DEBUG
                   if (neigh != NULL && neigh != remote_elem)
                     // We ignore subactive elements here because

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -211,18 +211,23 @@ void unpack (std::vector<largest_id_type>::const_iterator in,
       libmesh_assert_equal_to (node->processor_id(), processor_id);
 
       // We currently don't communicate mesh motion via packed Nodes,
-      // so it should be safe to assume (and assert) that Node
-      // locations are consistent between processors
-#ifndef NDEBUG
+      // so it should usually be safe to assume (and assert) that Node
+      // locations are consistent between processors.
+      //
+      // There may be exceptions due to rounding in file I/O, so we'll
+      // only assert equality to within a tight tolerance, and we'll
+      // believe the sender's node locations over our own if we don't
+      // own the node.
       for (unsigned int i=0; i != LIBMESH_DIM; ++i)
         {
-          const Real* idtypes_as_Real = reinterpret_cast<const Real*>(&(*in));
-          libmesh_assert_equal_to ((*node)(i), *idtypes_as_Real);
+          const Real& idtypes_as_Real = *(reinterpret_cast<const Real*>(&(*in)));
+          libmesh_assert_less_equal ((*node)(i), idtypes_as_Real + (std::max(Real(1),idtypes_as_Real)*TOLERANCE*TOLERANCE));
+          libmesh_assert_greater_equal ((*node)(i), idtypes_as_Real - (std::max(Real(1),idtypes_as_Real)*TOLERANCE*TOLERANCE));
+
+          if (processor_id != mesh->processor_id())
+            (*node)(i) = idtypes_as_Real;
           in += idtypes_per_Real;
         }
-#else
-      in += LIBMESH_DIM * idtypes_per_Real;
-#endif // !NDEBUG
 
       if (!node->has_dofs())
         {

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -41,6 +41,16 @@ protected:
     MeshTools::Generation::build_square(*_mesh, 3, 5,
                                         0.1, 0.9, 0.1, 0.9, QUAD9);
 
+    // We'll need to skip repartitioning with ParallelMesh for now;
+    // otherwise the boundary meshes' interior parents might get
+    // shuffled off to different processors.
+    if (!_mesh->is_serial())
+      {
+        _mesh->skip_partitioning(true);
+        _left_boundary_mesh->skip_partitioning(true);
+        _all_boundary_mesh->skip_partitioning(true);
+      }
+
     // Get the border of the square
     _mesh->boundary_info->sync(*_all_boundary_mesh);
 


### PR DESCRIPTION
And add bugfixes for everything I've found so far that gets triggered by ParallelMesh repartitioning.

This probably isn't working yet, but it's passing enough of my tests that I'd like MooseBuild to hammer at it too.