### PR TITLE
Added MeshCommunication::check_for_duplicate_global_indices. 

### DIFF
--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -155,6 +155,11 @@ public:
    */
   void assign_global_indices (MeshBase &) const;
 
+  /**
+   * Throw an error if we have any index clashes in the numbering used by
+   * assign_global_indices.
+   */
+  void check_for_duplicate_global_indices (MeshBase & ) const;
 
   /**
    * This method determines a globally unique, partition-agnostic

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -597,14 +597,10 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase& mesh) cons
 {
   START_LOG ("check_for_duplicate_global_indices()", "MeshCommunication");
 
-  const Parallel::Communicator &communicator (mesh.comm());
-
   // Global bounding box
   MeshTools::BoundingBox bbox =
     MeshTools::bounding_box (mesh);
 
-  //-------------------------------------------------------------
-  // (1) compute Hilbert keys
   std::vector<Hilbert::HilbertIndices>
     node_keys, elem_keys;
 
@@ -681,7 +677,7 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase& mesh) cons
             }
         }
     }
-  } // done computing Hilbert keys
+  } // done checking Hilbert keys
 
   STOP_LOG ("check_for_duplicate_global_indices()", "MeshCommunication");
 }


### PR DESCRIPTION
This just calls some of the debugging code that was commented out in MeshCommunication::assign_global_indices.