### PR TITLE
Fix a few more higher-precision issues

### DIFF
--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -79,8 +79,8 @@ void QGauss::init_2D(const ElemType type_in,
               _points.resize(1);
               _weights.resize(1);
 
-              _points[0](0) = 1.0L/3.0L;
-              _points[0](1) = 1.0L/3.0L;
+              _points[0](0) = Real(1)/3;
+              _points[0](1) = Real(1)/3;
 
               _weights[0] = 0.5;
 
@@ -102,19 +102,19 @@ void QGauss::init_2D(const ElemType type_in,
               // _points[2](0) = .5;
               // _points[2](1) = .0;
 
-              _points[0](0) = 2.0L/3.0L;
-              _points[0](1) = 1.0L/6.0L;
+              _points[0](0) = Real(2)/3;
+              _points[0](1) = Real(1)/6;
 
-              _points[1](0) = 1.0L/6.0L;
-              _points[1](1) = 2.0L/3.0L;
+              _points[1](0) = Real(1)/6;
+              _points[1](1) = Real(2)/3;
 
-              _points[2](0) = 1.0L/6.0L;
-              _points[2](1) = 1.0L/6.0L;
+              _points[2](0) = Real(1)/6;
+              _points[2](1) = Real(1)/6;
 
 
-              _weights[0] = 1.0L/6.0L;
-              _weights[1] = 1.0L/6.0L;
-              _weights[2] = 1.0L/6.0L;
+              _weights[0] = Real(1)/6;
+              _weights[1] = Real(1)/6;
+              _weights[2] = Real(1)/6;
 
               return;
             }
@@ -230,16 +230,16 @@ void QGauss::init_2D(const ElemType type_in,
               const unsigned int n_wts = 3;
               const Real wts[n_wts] =
                 {
-                  static_cast<Real>(9.0L/80.0L),
-                  static_cast<Real>(31.0L/480.0L + std::sqrt(15.0L)/2400.0L),
-                  static_cast<Real>(31.0L/480.0L - std::sqrt(15.0L)/2400.0L)
+                  Real(9)/80,
+                  static_cast<Real>(Real(31)/480 + std::sqrt(15.0L)/2400),
+                  static_cast<Real>(Real(31)/480 - std::sqrt(15.0L)/2400)
                 };
 
               const Real a[n_wts] =
                 {
                   0., // 'a' parameter not used for origin permutation
-                  static_cast<Real>(2.0L/7.0L + std::sqrt(15.0L)/21.0L),
-                  static_cast<Real>(2.0L/7.0L - std::sqrt(15.0L)/21.0L)
+                  static_cast<Real>(Real(2)/7 + std::sqrt(15.0L)/21),
+                  static_cast<Real>(Real(2)/7 - std::sqrt(15.0L)/21)
                 };
 
               const Real b[n_wts] = {0., 0., 0.}; // not used

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -73,7 +73,7 @@ void QGauss::init_3D(const ElemType type_in,
               _points[0](1) = .25;
               _points[0](2) = .25;
 
-              _weights[0] = .1666666666666666666666666666666666666666666667L;
+              _weights[0] = Real(1)/6;
 
               return;
             }
@@ -105,7 +105,7 @@ void QGauss::init_3D(const ElemType type_in,
 
 
 
-              _weights[0] = .0416666666666666666666666666666666666666666667;
+              _weights[0] = Real(1)/24;
               _weights[1] = _weights[0];
               _weights[2] = _weights[0];
               _weights[3] = _weights[0];
@@ -139,23 +139,23 @@ void QGauss::init_3D(const ElemType type_in,
                   _points[0](2) = .25;
 
                   _points[1](0) = .5;
-                  _points[1](1) = .16666666666666666666666666666666666666666667;
-                  _points[1](2) = .16666666666666666666666666666666666666666667;
+                  _points[1](1) = Real(1)/6;
+                  _points[1](2) = Real(1)/6;
 
-                  _points[2](0) = .16666666666666666666666666666666666666666667;
+                  _points[2](0) = Real(1)/6;
                   _points[2](1) = .5;
-                  _points[2](2) = .16666666666666666666666666666666666666666667;
+                  _points[2](2) = Real(1)/6;
 
-                  _points[3](0) = .16666666666666666666666666666666666666666667;
-                  _points[3](1) = .16666666666666666666666666666666666666666667;
+                  _points[3](0) = Real(1)/6;
+                  _points[3](1) = Real(1)/6;
                   _points[3](2) = .5;
 
-                  _points[4](0) = .16666666666666666666666666666666666666666667;
-                  _points[4](1) = .16666666666666666666666666666666666666666667;
-                  _points[4](2) = .16666666666666666666666666666666666666666667;
+                  _points[4](0) = Real(1)/6;
+                  _points[4](1) = Real(1)/6;
+                  _points[4](2) = Real(1)/6;
 
 
-                  _weights[0] = -.133333333333333333333333333333333333333333333;
+                  _weights[0] = Real(-2)/15;
                   _weights[1] = .075;
                   _weights[2] = _weights[1];
                   _weights[3] = _weights[1];
@@ -297,7 +297,7 @@ void QGauss::init_3D(const ElemType type_in,
 
               //       {
               // const Real a = 0.;
-              // const Real b = 0.333333333333333333333333333333333333333;
+              // const Real b = Real(1)/3;
 
               // _points[1](0) = a;
               // _points[1](1) = b;
@@ -316,8 +316,8 @@ void QGauss::init_3D(const ElemType type_in,
               // _points[4](2) = b;
               //       }
               //       {
-              // const Real a = 0.7272727272727272727272727272727272727272727272727272727;
-              // const Real b = 0.0909090909090909090909090909090909090909090909090909091;
+              // const Real a = Real(8)/11;
+              // const Real b = Real(1)/11;
 
               // _points[5](0) = a;
               // _points[5](1) = b;

--- a/src/quadrature/quadrature_gauss_lobatto_1D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_1D.C
@@ -62,8 +62,8 @@ void QGaussLobatto::init_1D(const ElemType,
         _points[1]    = 0.0L;
         _points[2]    = -_points[0];
 
-        _weights[0]   = 1.0L / 3.0L;
-        _weights[1]   = 4.0L / 3.0L;
+        _weights[0]   = Real(1)/3;
+        _weights[1]   = Real(4)/3;
         _weights[2]   = _weights[0];
         return;
       }
@@ -81,8 +81,8 @@ void QGaussLobatto::init_1D(const ElemType,
         _points[ 2]    = -_points[1];
         _points[ 3]    = -_points[0];
 
-        _weights[ 0]   = 1.0L/6.0L;
-        _weights[ 1]   = 5.0L/6.0L;
+        _weights[ 0]   = Real(1)/6;
+        _weights[ 1]   = Real(5)/6;
         _weights[ 2]   = _weights[1];
         _weights[ 3]   = _weights[0];
 
@@ -103,9 +103,9 @@ void QGaussLobatto::init_1D(const ElemType,
         _points[ 3]    = -_points[1];
         _points[ 4]    = -_points[0];
 
-        _weights[ 0]   = 1.0L/10.0L;
-        _weights[ 1]   = 49.0L/90.0L;
-        _weights[ 2]   = 32.0L/45.0L;
+        _weights[ 0]   = 0.1;
+        _weights[ 1]   = Real(49)/90;
+        _weights[ 2]   = Real(32)/45;
         _weights[ 3]   = _weights[1];
         _weights[ 4]   = _weights[0];
 

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -52,8 +52,8 @@ void QMonomial::init_2D(const ElemType type_in,
               // Luckily it's fairly easy to derive, which is what I've done
               // here [JWP].
               const Real
-                s=std::sqrt(Real(1)/3.),
-                t=std::sqrt(Real(2)/3.);
+                s=std::sqrt(1.L/3.L),
+                t=std::sqrt(2.L/3.L);
 
               const Real data[2][3] =
                 {

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -129,9 +129,9 @@ void QMonomial::init_2D(const ElemType type_in,
               // A tensor-product rule accurate for "bi-quintic" polynomials would have 9 points.
               const Real data[3][3] =
                 {
-                  {                                  0.L,                                     0.L, static_cast<Real>(8.L  /  7.L)}, // 1
-                  {                                  0.L, static_cast<Real>(std::sqrt(14.L/15.L)), static_cast<Real>(20.L / 63.L)}, // 2
-                  {static_cast<Real>(std::sqrt(3.L/5.L)),   static_cast<Real>(std::sqrt(1.L/3.L)), static_cast<Real>(20.L / 36.L)}  // 4
+                  {                                  0.L,                                     0.L, Real(8)/7  }, // 1
+                  {                                  0.L, static_cast<Real>(std::sqrt(14.L/15.L)), Real(20)/63}, // 2
+                  {static_cast<Real>(std::sqrt(3.L/5.L)),   static_cast<Real>(std::sqrt(1.L/3.L)), Real(20)/36}  // 4
                 };
 
               const unsigned int symmetry[3] = {
@@ -208,11 +208,11 @@ void QMonomial::init_2D(const ElemType type_in,
               // A tensor-product rule accurate for "bi-septic" polynomials would have 16 points.
               const Real
                 r  = std::sqrt(6.L/7.L),
-                s  = std::sqrt( (114.L - 3.L*std::sqrt(583.L)) / 287.L ),
-                t  = std::sqrt( (114.L + 3.L*std::sqrt(583.L)) / 287.L ),
-                B1 = 196.L / 810.L,
-                B2 = 4.L * (178981.L + 2769.L*std::sqrt(583.L)) / 1888920.L,
-                B3 = 4.L * (178981.L - 2769.L*std::sqrt(583.L)) / 1888920.L;
+                s  = std::sqrt( (114 - 3*std::sqrt(583.L)) / 287 ),
+                t  = std::sqrt( (114 + 3*std::sqrt(583.L)) / 287 ),
+                B1 = Real(196)/810,
+                B2 = 4 * (178981 + 2769*std::sqrt(583.L)) / 1888920,
+                B3 = 4 * (178981 - 2769*std::sqrt(583.L)) / 1888920;
 
               const Real data[3][3] =
                 {

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -177,10 +177,6 @@ void QMonomial::init_3D(const ElemType type_in,
             } // end case FOURTH,FIFTH
 
 
-// Tabulated-in-double-precision rules aren't accurate enough for
-// higher precision, so fall back on Gauss
-#if !defined(LIBMESH_DEFAULT_TRIPLE_PRECISION) && \
-    !defined(LIBMESH_DEFAULT_QUADRUPLE_PRECISION)
           case SIXTH:
           case SEVENTH:
             {
@@ -308,7 +304,6 @@ void QMonomial::init_3D(const ElemType type_in,
               kim_rule(data, rule_id, 5);
               return;
             } // end case EIGHTH
-#endif
 
 
             // By default: construct and use a Gauss quadrature rule

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -81,7 +81,7 @@ void QMonomial::init_3D(const ElemType type_in,
 
               // Convenient intermediate values.
               const Real sqrt19 = std::sqrt(19.L);
-              const Real tp     = std::sqrt(71440.L + 6802.L*sqrt19);
+              const Real tp     = std::sqrt(71440 + 6802*sqrt19);
 
               // Point data for permutations.
               const Real eta    =  0.00000000000000000000000000000000e+00L;
@@ -102,13 +102,13 @@ void QMonomial::init_3D(const ElemType type_in,
               // with the {lambda,xi} (resp {gamma,mu}) permutation.  The single-precision
               // results reported by Stroud are given for reference.
 
-              const Real A      = 32.0L / 19.0L;
+              const Real A      = Real(32)/19;
               // Stroud: 0.21052632  * 8.0 = 1.684210560;
 
-              const Real B      = 1.L / ( 260072.L/133225.L  - 1520*sqrt19/133225.L + (133.L - 37.L*sqrt19)*tp/133225.L );
+              const Real B      = Real(1) / (Real(260072)/133225  - 1520*sqrt19/133225 + (133 - 37*sqrt19)*tp/133225);
               // 5.4498735127757671684690782180890e-01L; // Stroud: 0.068123420 * 8.0 = 0.544987360;
 
-              const Real C      = 1.L / ( 260072.L/133225.L  - 1520*sqrt19/133225.L - (133.L - 37.L*sqrt19)*tp/133225.L );
+              const Real C      = Real(1) / (Real(260072)/133225  - 1520*sqrt19/133225 - (133 - 37*sqrt19)*tp/133225);
               // 5.0764422766979170420572375713840e-01L; // Stroud: 0.063455527 * 8.0 = 0.507644216;
 
               _points.resize(13);
@@ -227,17 +227,17 @@ void QMonomial::init_3D(const ElemType type_in,
                 r  = std::sqrt(6.L/7.L),
                 s  = std::sqrt((960.L - 3.L*std::sqrt(28798.L)) / 2726.L),
                 t  = std::sqrt((960.L + 3.L*std::sqrt(28798.L)) / 2726.L),
-                B1 = 8624.L / 29160.L,
-                B2 = 2744.L / 29160.L,
-                B3 = 8.L*(774.L*t*t - 230.L)/(9720.L*(t*t-s*s)),
-                B4 = 8.L*(230.L - 774.L*s*s)/(9720.L*(t*t-s*s));
+                B1 = Real(8624)/29160,
+                B2 = Real(2744)/29160,
+                B3 = 8*(774*t*t - 230)/(9720*(t*t-s*s)),
+                B4 = 8*(230 - 774*s*s)/(9720*(t*t-s*s));
 
               const Real data[4][4] =
                 {
-                  {r, 0.L, 0.L, B1},
-                  {r,   r, 0.L, B2},
-                  {s,   s,   s, B3},
-                  {t,   t,   t, B4}
+                  {r,  0,  0, B1},
+                  {r,  r,  0, B2},
+                  {s,  s,  s, B3},
+                  {t,  t,  t, B4}
                 };
 
               const unsigned int rule_id[4] = {


### PR DESCRIPTION
Following up @roystgnr's #623 with a few more fixes.

69f3a8ccbb should only be merged if the experimental re-enabling of 6th-8th order 3D monomial quadrature rules pass Roy's triple-precision regression tests, otherwise it should be dropped.