### PR TITLE
Reorder parens in assert

### DIFF
--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1288,8 +1288,8 @@ void Elem::make_links_to_me_local(unsigned int n)
       // link to elem's parent instead.
 #ifdef LIBMESH_ENABLE_AMR
       libmesh_assert((neigh_family_member->neighbor(nn) &&
-                      (neigh_family_member->neighbor(nn)->active()) ||
-                       neigh_family_member->neighbor(nn)->is_ancestor_of(this)) ||
+                      (neigh_family_member->neighbor(nn)->active() ||
+                       neigh_family_member->neighbor(nn)->is_ancestor_of(this))) ||
                      (neigh_family_member->neighbor(nn) == remote_elem) ||
                      ((this->refinement_flag() == JUST_REFINED) &&
                       (this->parent() != NULL) &&


### PR DESCRIPTION
I tried to squash a compile warning here and this ends up being a logic change. I believe the parenthesis was set wrong here. My guess is that the ```&&``` is a guard for both terms combined with ```||```.