### PR TITLE
Fix "can't plot error on super coarse grids" bug; improve verification

### DIFF
--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -771,6 +771,8 @@ void PetscVector<T>::init (const numeric_index_type n,
                            const bool fast,
                            const ParallelType ptype)
 {
+  parallel_object_only();
+
   PetscErrorCode ierr=0;
   PetscInt petsc_n=static_cast<PetscInt>(n);
   PetscInt petsc_n_local=static_cast<PetscInt>(n_local);
@@ -851,6 +853,8 @@ void PetscVector<T>::init (const numeric_index_type n,
                            const bool fast,
                            const ParallelType libmesh_dbg_var(ptype))
 {
+  parallel_object_only();
+
   PetscErrorCode ierr=0;
   PetscInt petsc_n=static_cast<PetscInt>(n);
   PetscInt petsc_n_local=static_cast<PetscInt>(n_local);
@@ -908,6 +912,8 @@ inline
 void PetscVector<T>::init (const NumericVector<T>& other,
                            const bool fast)
 {
+  parallel_object_only();
+
   // Clear initialized vectors
   if (this->initialized())
     this->clear();
@@ -944,6 +950,8 @@ template <typename T>
 inline
 void PetscVector<T>::close ()
 {
+  parallel_object_only();
+
   this->_restore_array();
 
   PetscErrorCode ierr=0;
@@ -970,6 +978,8 @@ template <typename T>
 inline
 void PetscVector<T>::clear ()
 {
+  parallel_object_only();
+
   if (this->initialized())
     this->_restore_array();
 
@@ -992,6 +1002,8 @@ template <typename T>
 inline
 void PetscVector<T>::zero ()
 {
+  parallel_object_only();
+
   libmesh_assert(this->closed());
 
   this->_restore_array();
@@ -1250,6 +1262,8 @@ template <typename T>
 inline
 Real PetscVector<T>::min () const
 {
+  parallel_object_only();
+
   this->_restore_array();
 
   PetscErrorCode ierr=0;
@@ -1269,6 +1283,8 @@ template <typename T>
 inline
 Real PetscVector<T>::max() const
 {
+  parallel_object_only();
+
   this->_restore_array();
 
   PetscErrorCode ierr=0;
@@ -1288,6 +1304,8 @@ template <typename T>
 inline
 void PetscVector<T>::swap (NumericVector<T> &other)
 {
+  parallel_object_only();
+
   NumericVector<T>::swap(other);
 
   PetscVector<T>& v = cast_ref<PetscVector<T>&>(other);

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -1256,7 +1256,22 @@ inline bool Communicator::verify(const T &r) const
       this->min(verified);
       return verified;
     }
+
+#ifdef LIBMESH_HAVE_CXX11
+  static_assert(Attributes<T>::has_min_max,
+                "Tried to verify an unverifiable type");
+#endif
+
   return true;
+}
+
+
+
+template <>
+inline bool Communicator::verify(const bool &r) const
+{
+  const unsigned char rnew = r;
+  return this->verify(rnew);
 }
 
 
@@ -1281,7 +1296,28 @@ inline bool Communicator::semiverify(const T *r) const
       this->max(invalid);
       return !invalid;
     }
+
+#ifdef LIBMESH_HAVE_CXX11
+  static_assert(Attributes<T>::has_min_max,
+                "Tried to semiverify an unverifiable type");
+#endif
+
   return true;
+}
+
+
+
+template <>
+inline bool Communicator::semiverify(const bool *r) const
+{
+  if (r)
+    {
+      const unsigned char rnew = *r;
+      return this->semiverify(&rnew);
+    }
+
+  const unsigned char *rptr = NULL;
+  return this->semiverify(rptr);
 }
 
 
@@ -1318,6 +1354,12 @@ inline bool Communicator::semiverify(const std::vector<T> *r) const
       this->max(invalid);
       return !invalid;
     }
+
+#ifdef LIBMESH_HAVE_CXX11
+  static_assert(Attributes<T>::has_min_max,
+                "Tried to semiverify a vector of an unverifiable type");
+#endif
+
   return true;
 }
 
@@ -2972,7 +3014,7 @@ inline void Communicator::allgather
                      cast_int<int>(r_src.size()),
                      send_type,
                      this->get());
-      libmesh_assert(this->verify(r));
+      // libmesh_assert(this->verify(r));
       STOP_LOG("allgather()", "Parallel");
       return;
     }

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -795,6 +795,7 @@ void EquationSystems::build_solution_vector (std::vector<Number>& soln,
         // locked read-only, for example when printing the solution
         // during during the middle of a solve...  So try to be a bit
         // more careful about calling close() unnecessarily.
+        libmesh_assert(this->comm().verify(non_const_sys.solution->closed()));
         if (!non_const_sys.solution->closed())
           non_const_sys.solution->close();
         non_const_sys.update();
@@ -963,6 +964,7 @@ void EquationSystems::get_solution (std::vector<Number>& soln,
         // locked read-only, for example when printing the solution
         // during during the middle of a solve...  So try to be a bit
         // more careful about calling close() unnecessarily.
+        libmesh_assert(this->comm().verify(non_const_sys.solution->closed()));
         if (!non_const_sys.solution->closed())
           non_const_sys.solution->close();
         non_const_sys.update();

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1994,7 +1994,13 @@ Number System::point_value(unsigned int var, const Point &p, const bool insist_o
   // And every processor had better agree about which point we're
   // looking for
 #ifndef NDEBUG
-  this->comm().verify(p);
+  this->comm().verify(p(0));
+#if LIBMESH_DIM > 1
+  this->comm().verify(p(1));
+#endif
+#if LIBMESH_DIM > 2
+  this->comm().verify(p(2));
+#endif
 #endif // NDEBUG
 
   // Get a reference to the mesh object associated with the system object that calls this function
@@ -2091,7 +2097,13 @@ Gradient System::point_gradient(unsigned int var, const Point &p, const bool ins
   // And every processor had better agree about which point we're
   // looking for
 #ifndef NDEBUG
-  this->comm().verify(p);
+  this->comm().verify(p(0));
+#if LIBMESH_DIM > 1
+  this->comm().verify(p(1));
+#endif
+#if LIBMESH_DIM > 2
+  this->comm().verify(p(2));
+#endif
 #endif // NDEBUG
 
   // Get a reference to the mesh object associated with the system object that calls this function
@@ -2190,7 +2202,13 @@ Tensor System::point_hessian(unsigned int var, const Point &p, const bool insist
   // And every processor had better agree about which point we're
   // looking for
 #ifndef NDEBUG
-  this->comm().verify(p);
+  this->comm().verify(p(0));
+#if LIBMESH_DIM > 1
+  this->comm().verify(p(1));
+#endif
+#if LIBMESH_DIM > 2
+  this->comm().verify(p(2));
+#endif
 #endif // NDEBUG
 
   // Get a reference to the mesh object associated with the system object that calls this function

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -257,6 +257,8 @@ void ErrorVector::plot_error(const std::string& filename,
       error_system.solution->set(solution_index, (*this)[elem_id]);
     }
 
+  error_system.solution->close();
+
   // We may have to renumber if the original numbering was not
   // contiguous.  Since this is just a temporary mesh, that's probably
   // fine.


### PR DESCRIPTION
This fixes the corner-case bug that #630 introduced, as well as some bugs and lacunae in our debugging code that I caught along the way.

I heard you like debugging so I put a static assertion in our runtime assertion so we can debug while we debug.