### PR TITLE
Fix broken MPI behavior

### DIFF
--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -294,6 +294,8 @@ public:
 #ifdef LIBMESH_HAVE_MPI
   DataType (const DataType &other, unsigned int count)
   {
+    // FIXME - if we nest an inner type here will we run into bug
+    // https://github.com/libMesh/libmesh/issues/631 again?
     MPI_Type_contiguous(count, other._datatype, &_datatype);
     this->commit();
   }

--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -105,6 +105,52 @@ class Request;
 class Status;
 
 #ifdef LIBMESH_HAVE_MPI
+
+/*
+ * Macros to test MPI return values
+ */
+
+#ifndef NDEBUG
+#define libmesh_assert_mpi_success(error_code) \
+  do \
+    { \
+      if (error_code != MPI_SUCCESS) \
+        { \
+          char libmesh_mpi_error_string[MPI_MAX_ERROR_STRING+1]; \
+          int libmesh_mpi_error_string_len; \
+          MPI_Error_string(error_code, libmesh_mpi_error_string, \
+                           &libmesh_mpi_error_string_len); \
+          libmesh_assert_equal_to_msg(error_code, MPI_SUCCESS, \
+                                      libmesh_mpi_error_string); \
+        } \
+    } \
+  while(0)
+
+// Only catch MPI return values when asserts are active.
+#define libmesh_call_mpi(mpi_call) \
+  do \
+    { \
+      unsigned int libmesh_mpi_error_code = \
+        mpi_call; \
+      libmesh_assert_mpi_success (libmesh_mpi_error_code); \
+    } \
+  while(0)
+
+#else
+
+#define libmesh_assert_mpi_success(error_code)  ((void) 0)
+
+#define libmesh_call_mpi(mpi_call) \
+  do \
+    { \
+      mpi_call; \
+    } \
+  while(0)
+
+#endif
+
+
+
 //-------------------------------------------------------------------
 /**
  * Data types for communication

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -78,28 +78,24 @@ public:
 
 #if MPI_VERSION == 1
 
-        int blocklengths[LIBMESH_DIM+2];
-        MPI_Aint displs[LIBMESH_DIM+2];
-        MPI_Datatype types[LIBMESH_DIM+2];
+        int blocklengths[3] = {1, LIBMESH_DIM, 1};
+        MPI_Aint displs[3];
+        MPI_Datatype types[3] = {MPI_LB, T_type, MPI_UB};
         MPI_Aint start, later;
 
-        MPI_Address(ex, &start);
-        blocklengths[0] = 1;
+        libmesh_call_mpi
+          (MPI_Address(ex, &start));
         displs[0] = 0;
-        types[0] = MPI_LB;
-        for (unsigned int i=0; i != LIBMESH_DIM; ++i)
-          {
-            MPI_Address(&((*ex)(i)), &later);
-            blocklengths[i+1] = 1;
-            displs[i+1] = later - start;
-            types[i+1] = T_type;
-          }
-        MPI_Address((ex+1), &later);
-        blocklengths[LIBMESH_DIM+1] = 1;
-        displs[LIBMESH_DIM+1] = later - start;
-        types[LIBMESH_DIM+1] = MPI_UB;
+        libmesh_call_mpi
+          (MPI_Address(&((*ex)(0)), &later));
+        displs[1] = later - start;
+        libmesh_call_mpi
+          (MPI_Address((ex+1), &later));
+        displs[2] = later - start;
 
-        MPI_Type_struct (LIBMESH_DIM+2, blocklengths, displs, types, &_static_type);
+        libmesh_call_mpi
+          (MPI_Type_struct (3, blocklengths, displs, types,
+                            &_static_type));
 
 #else // MPI_VERSION >= 2
 
@@ -107,20 +103,29 @@ public:
         MPI_Aint displs, start;
         MPI_Datatype tmptype, type = T_type;
 
-        MPI_Get_address (ex,   &start);
-        MPI_Get_address (&((*ex)(0)), &displs);
+        libmesh_call_mpi
+          (MPI_Get_address (ex, &start));
+        libmesh_call_mpi
+          (MPI_Get_address (&((*ex)(0)), &displs));
 
         // subtract off offset to first value from the beginning of the structure
         displs -= start;
 
         // create a prototype structure
-        MPI_Type_create_struct (1, &blocklength, &displs, &type, &tmptype);
+        libmesh_call_mpi
+          (MPI_Type_create_struct (1, &blocklength, &displs, &type,
+                                   &tmptype));
+        libmesh_call_mpi
+          (MPI_Type_commit (&tmptype));
 
         // resize the structure type to account for padding, if any
-        MPI_Type_create_resized (tmptype, 0, sizeof(TypeVector<T>), &_static_type);
+        libmesh_call_mpi
+          (MPI_Type_create_resized (tmptype, 0, sizeof(TypeVector<T>),
+                                    &_static_type));
 #endif
 
-        MPI_Type_commit (&_static_type);
+        libmesh_call_mpi
+          (MPI_Type_commit (&_static_type));
 #endif // #ifdef LIBMESH_HAVE_MPI
 
         _is_initialized = true;
@@ -157,28 +162,24 @@ public:
 
 #if MPI_VERSION == 1
 
-        int blocklengths[LIBMESH_DIM+2];
-        MPI_Aint displs[LIBMESH_DIM+2];
-        MPI_Datatype types[LIBMESH_DIM+2];
+        int blocklengths[3] = {1, LIBMESH_DIM, 1};
+        MPI_Aint displs[3];
+        MPI_Datatype types[3] = {MPI_LB, T_type, MPI_UB};
         MPI_Aint start, later;
 
-        MPI_Address(ex, &start);
-        blocklengths[0] = 1;
+        libmesh_call_mpi
+          (MPI_Address(ex, &start));
         displs[0] = 0;
-        types[0] = MPI_LB;
-        for (unsigned int i=0; i != LIBMESH_DIM; ++i)
-          {
-            MPI_Address(&((*ex)(i)), &later);
-            blocklengths[i+1] = 1;
-            displs[i+1] = later - start;
-            types[i+1] = T_type;
-          }
-        MPI_Address((ex+1), &later);
-        blocklengths[LIBMESH_DIM+1] = 1;
-        displs[LIBMESH_DIM+1] = later - start;
-        types[LIBMESH_DIM+1] = MPI_UB;
+        libmesh_call_mpi
+          (MPI_Address(&((*ex)(0)), &later));
+        displs[1] = later - start;
+        libmesh_call_mpi
+          (MPI_Address((ex+1), &later));
+        displs[2] = later - start;
 
-        MPI_Type_struct (LIBMESH_DIM+2, blocklengths, displs, types, &_static_type);
+        libmesh_call_mpi
+          (MPI_Type_struct (3, blocklengths, displs, types,
+                            &_static_type));
 
 #else // MPI_VERSION >= 2
 
@@ -186,20 +187,30 @@ public:
         MPI_Aint displs, start;
         MPI_Datatype tmptype, type = T_type;
 
-        MPI_Get_address (ex,   &start);
-        MPI_Get_address (&((*ex)(0)), &displs);
+        libmesh_call_mpi
+          (MPI_Get_address (ex, &start));
+        libmesh_call_mpi
+          (MPI_Get_address (&((*ex)(0)), &displs));
 
         // subtract off offset to first value from the beginning of the structure
         displs -= start;
 
         // create a prototype structure
-        MPI_Type_create_struct (1, &blocklength, &displs, &type, &tmptype);
+        libmesh_call_mpi
+          (MPI_Type_create_struct (1, &blocklength, &displs, &type,
+                                   &tmptype));
+        libmesh_call_mpi
+          (MPI_Type_commit (&tmptype));
 
         // resize the structure type to account for padding, if any
-        MPI_Type_create_resized (tmptype, 0, sizeof(VectorValue<T>), &_static_type);
+        libmesh_call_mpi
+          (MPI_Type_create_resized (tmptype, 0,
+                                    sizeof(VectorValue<T>),
+                                    &_static_type));
 #endif
 
-        MPI_Type_commit (&_static_type);
+        libmesh_call_mpi
+          (MPI_Type_commit (&_static_type));
 #endif // #ifdef LIBMESH_HAVE_MPI
 
         _is_initialized = true;
@@ -242,28 +253,24 @@ public:
 
 #if MPI_VERSION == 1
 
-        int blocklengths[LIBMESH_DIM+2];
-        MPI_Aint displs[LIBMESH_DIM+2];
-        MPI_Datatype types[LIBMESH_DIM+2];
+        int blocklengths[3] = {1, LIBMESH_DIM, 1};
+        MPI_Aint displs[3];
+        MPI_Datatype types[3] = {MPI_LB, T_type, MPI_UB};
         MPI_Aint start, later;
 
-        MPI_Address(ex, &start);
-        blocklengths[0] = 1;
+        libmesh_call_mpi
+          (MPI_Address(ex, &start));
         displs[0] = 0;
-        types[0] = MPI_LB;
-        for (unsigned int i=0; i != LIBMESH_DIM; ++i)
-          {
-            MPI_Address(&((*ex)(i)), &later);
-            blocklengths[i+1] = 1;
-            displs[i+1] = later - start;
-            types[i+1] = T_type;
-          }
-        MPI_Address((ex+1), &later);
-        blocklengths[LIBMESH_DIM+1] = 1;
-        displs[LIBMESH_DIM+1] = later - start;
-        types[LIBMESH_DIM+1] = MPI_UB;
+        libmesh_call_mpi
+          (MPI_Address(&((*ex)(0)), &later));
+        displs[1] = later - start;
+        libmesh_call_mpi
+          (MPI_Address((ex+1), &later));
+        displs[2] = later - start;
 
-        MPI_Type_struct (LIBMESH_DIM+2, blocklengths, displs, types, &_static_type);
+        libmesh_call_mpi
+          (MPI_Type_struct (3, blocklengths, displs, types,
+                            &_static_type));
 
 #else // MPI_VERSION >= 2
 
@@ -271,20 +278,29 @@ public:
         MPI_Aint displs, start;
         MPI_Datatype tmptype, type = T_type;
 
-        MPI_Get_address (ex,   &start);
-        MPI_Get_address (&((*ex)(0)), &displs);
+        libmesh_call_mpi
+          (MPI_Get_address (ex, &start));
+        libmesh_call_mpi
+          (MPI_Get_address (&((*ex)(0)), &displs));
 
         // subtract off offset to first value from the beginning of the structure
         displs -= start;
 
         // create a prototype structure
-        MPI_Type_create_struct (1, &blocklength, &displs, &type, &tmptype);
+        libmesh_call_mpi
+          (MPI_Type_create_struct (1, &blocklength, &displs, &type,
+                                   &tmptype));
+        libmesh_call_mpi
+          (MPI_Type_commit (&tmptype));
 
         // resize the structure type to account for padding, if any
-        MPI_Type_create_resized (tmptype, 0, sizeof(Point), &_static_type);
+        libmesh_call_mpi
+          (MPI_Type_create_resized (tmptype, 0, sizeof(Point),
+                                    &_static_type));
 #endif
 
-        MPI_Type_commit (&_static_type);
+        libmesh_call_mpi
+          (MPI_Type_commit (&_static_type));
 #endif // #ifdef LIBMESH_HAVE_MPI
 
         _is_initialized = true;
@@ -295,9 +311,6 @@ public:
 
 // StandardType<> specializations to return a derived MPI datatype
 // to handle communication of LIBMESH_DIM*LIBMESH_DIM-tensors.
-//
-// We use a singleton pattern here because a global variable would
-// have tried to call MPI functions before MPI got initialized.
 //
 // We assume contiguous storage here
 template <typename T>

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -34,45 +34,6 @@ namespace Parallel {
 
 #ifdef LIBMESH_HAVE_MPI
 
-#ifndef NDEBUG
-#define libmesh_assert_mpi_success(error_code) \
-  do \
-    { \
-      if (error_code != MPI_SUCCESS) \
-        { \
-          char libmesh_mpi_error_string[MPI_MAX_ERROR_STRING+1]; \
-          int libmesh_mpi_error_string_len; \
-          MPI_Error_string(error_code, libmesh_mpi_error_string, \
-                           &libmesh_mpi_error_string_len); \
-          libmesh_assert_equal_to_msg(error_code, MPI_SUCCESS, \
-                                      libmesh_mpi_error_string); \
-        } \
-    } \
-  while(0)
-
-// Only catch MPI return values when asserts are active.
-#define libmesh_call_mpi(mpi_call) \
-  do \
-    { \
-      unsigned int libmesh_mpi_error_code = \
-        mpi_call; \
-      libmesh_assert_mpi_success (libmesh_mpi_error_code); \
-    } \
-  while(0)
-
-#else
-
-#define libmesh_assert_mpi_success(error_code)  ((void) 0)
-
-#define libmesh_call_mpi(mpi_call) \
-  do \
-    { \
-      mpi_call; \
-    } \
-  while(0)
-
-#endif
-
 #define STANDARD_TYPE(cxxtype,mpitype)                                  \
   template<>                                                            \
   class StandardType<cxxtype> : public DataType                         \


### PR DESCRIPTION
The third commit here fixes #631 on my OpenMPI 1.6 install, my OpenMPI 1.7 install, and (for the first time ever!) my MPICH2 3.1.3 install.  Wider testing before we merge would be greatly appreciated.