### PR TITLE
Add more options for disabling GDB backtrace

### DIFF
--- a/configure
+++ b/configure
@@ -1984,7 +1984,8 @@ Optional Packages:
   --with-sysroot=DIR Search for dependent libraries within DIR
                         (or the compiler's sysroot if not specified).
   --with-gdb-command=commandname
-                          command to invoke gdb
+                          Specify command to invoke gdb. Use
+                          --without-gdb-command to disable GDB backtraces.
   --with-boundary-id-bytes=<1|2|4|8>
                           bytes used per boundary side per boundary_id [2]
   --with-dof-id-bytes=<1|2|4|8>
@@ -28150,7 +28151,10 @@ $as_echo "---------------------------------------------" >&6; }
 
 
 # -------------------------------------------------------------
-# gdb backtrace command-- default "gdb"
+# gdb backtrace command -- default "gdb"
+#
+# Note: if you want to completely disable GDB backtraces, configure
+# libmesh with --without-gdb-command.
 # -------------------------------------------------------------
 
 # Check whether --with-gdb-command was given.

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -8,11 +8,14 @@ AC_MSG_RESULT(---------------------------------------------)
 
 
 # -------------------------------------------------------------
-# gdb backtrace command-- default "gdb"
+# gdb backtrace command -- default "gdb"
+#
+# Note: if you want to completely disable GDB backtraces, configure
+# libmesh with --without-gdb-command.
 # -------------------------------------------------------------
 AC_ARG_WITH([gdb-command],
     AS_HELP_STRING([--with-gdb-command=commandname],
-                          [command to invoke gdb]),
+                   [Specify command to invoke gdb.  Use --without-gdb-command to disable GDB backtraces.]),
     [gdb_command="$withval"],
     [gdb_command="gdb"])
 

--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -185,8 +185,10 @@ void print_trace(std::ostream &out_stream)
   // calling backtrace().
   bool gdb_worked = false;
 
-  // Let the user disable GDB backtraces with a command line option.
-  if (!libMesh::on_command_line("--no-gdb-backtrace"))
+  // Let the user disable GDB backtraces by configuring with
+  // --without-gdb-command or with a command line option.
+  if (std::string(LIBMESH_GDB_COMMAND) != std::string("no") &&
+      !libMesh::on_command_line("--no-gdb-backtrace"))
     gdb_worked = gdb_backtrace(out_stream);
 
   // This part requires that your compiler at least supports

--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -140,7 +140,7 @@ bool gdb_backtrace(std::ostream &out_stream)
           command << gdb_command
                   << " -p "
                   << this_pid
-                  << " -batch -ex bt 2>/dev/null 1>"
+                  << " -batch -ex bt -ex detach 2>/dev/null 1>"
                   << temp_file;
           exit_status = std::system(command.str().c_str());
         }

--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -183,7 +183,11 @@ void print_trace(std::ostream &out_stream)
   // demangling, and they include line numbers!  If the GDB backtrace
   // fails, for example if your system does not have GDB, fall back to
   // calling backtrace().
-  bool gdb_worked = gdb_backtrace(out_stream);
+  bool gdb_worked = false;
+
+  // Let the user disable GDB backtraces with a command line option.
+  if (!libMesh::on_command_line("--no-gdb-backtrace"))
+    gdb_worked = gdb_backtrace(out_stream);
 
   // This part requires that your compiler at least supports
   // backtraces.  Demangling is also nice, but it will still run


### PR DESCRIPTION
We have found that GDB backtraces cause issues with MOOSE's `run_tests` script on some OS's (see idaholab/moose#4201) so this branch provides both a compile time and runtime method for disabling them.  If GDB backtraces are enabled at compile time (the default) they can be turned off by passing `--no-gdb-backtrace` on the command line. 