### PR TITLE
Make perturbations relative to parameter size

### DIFF
--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -777,7 +777,7 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity
       Number old_parameter = *parameters[j];
       // Number old_qoi = this->qoi;
 
-      *parameters[j] = old_parameter - delta_p;
+      *parameters[j] = old_parameter - delta_p*fmax(fabs(old_parameter),1.e-3);
       this->assemble_qoi(qoi_indices);
       std::vector<Number> qoi_minus = this->qoi;
 
@@ -788,19 +788,19 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity
       UniquePtr<NumericVector<Number> > partialR_partialp = this->rhs->clone();
       *partialR_partialp *= -1;
 
-      *parameters[j] = old_parameter + delta_p;
+      *parameters[j] = old_parameter + delta_p*fmax(fabs(old_parameter),1.e-3);
       this->assemble_qoi(qoi_indices);
       std::vector<Number>& qoi_plus = this->qoi;
 
       std::vector<Number> partialq_partialp(Nq, 0);
       for (unsigned int i=0; i != Nq; ++i)
         if (qoi_indices.has_index(i))
-          partialq_partialp[i] = (qoi_plus[i] - qoi_minus[i]) / (2.*delta_p);
+          partialq_partialp[i] = (qoi_plus[i] - qoi_minus[i]) / (2.*delta_p*fmax(fabs(old_parameter),1.e-3));
 
       this->assembly(true, false, true);
       this->rhs->close();
       *partialR_partialp += *this->rhs;
-      *partialR_partialp /= (2.*delta_p);
+      *partialR_partialp /= (2.*delta_p*fmax(fabs(old_parameter),1.e-3));
 
       // Don't leave the parameter changed
       *parameters[j] = old_parameter;


### PR DESCRIPTION
This works better for @vikramvgarg when taking sensitivities to small
turbulence model parameters.  But this is kind of a stopgap until we
find time to add support for configurable perturbation sizes and
analytic sensitivities.