### PR TITLE
issue #648: fix trilinos and dtk library checks for new versions.

### DIFF
--- a/configure
+++ b/configure
@@ -32907,7 +32907,23 @@ ac_fn_cxx_check_header_mongrel "$LINENO" "$withtrilinosdir/packages/tpetra/src/T
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   enabletpetra=yes
 else
+  as_ac_Header=`$as_echo "ac_cv_header_$withtrilinosdir/packages/tpetra/core/src/TpetraCore_config.h" | $as_tr_sh`
+ac_fn_cxx_check_header_mongrel "$LINENO" "$withtrilinosdir/packages/tpetra/core/src/TpetraCore_config.h" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  enabletpetra=yes
+else
+  as_ac_Header=`$as_echo "ac_cv_header_$withtrilinosdir/include/TpetraCore_config.h" | $as_tr_sh`
+ac_fn_cxx_check_header_mongrel "$LINENO" "$withtrilinosdir/include/TpetraCore_config.h" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  enabletpetra=yes
+else
   enabletpetra=no
+fi
+
+
+fi
+
+
 fi
 
 
@@ -32941,7 +32957,23 @@ ac_fn_cxx_check_header_mongrel "$LINENO" "$withtrilinosdir/DataTransferKit/src/D
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   enabledtk=yes
 else
+  as_ac_Header=`$as_echo "ac_cv_header_$withtrilinosdir/DataTransferKit/packages/Utils/src/DataTransferKitUtils_config.hpp" | $as_tr_sh`
+ac_fn_cxx_check_header_mongrel "$LINENO" "$withtrilinosdir/DataTransferKit/packages/Utils/src/DataTransferKitUtils_config.hpp" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  enabledtk=yes
+else
+  as_ac_Header=`$as_echo "ac_cv_header_$withtrilinosdir/include/DataTransferKitUtils_config.hpp" | $as_tr_sh`
+ac_fn_cxx_check_header_mongrel "$LINENO" "$withtrilinosdir/include/DataTransferKitUtils_config.hpp" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  enabledtk=yes
+else
   enabledtk=no
+fi
+
+
+fi
+
+
 fi
 
 

--- a/m4/trilinos.m4
+++ b/m4/trilinos.m4
@@ -109,7 +109,11 @@ AC_DEFUN([CONFIGURE_TRILINOS_10],
                                         [enabletpetra=yes],
                                         [AC_CHECK_HEADER([$withtrilinosdir/packages/tpetra/src/Tpetra_config.h],
                                                          [enabletpetra=yes],
-                                                         [enabletpetra=no])])])
+                                                         [AC_CHECK_HEADER([$withtrilinosdir/packages/tpetra/core/src/TpetraCore_config.h],
+                                                                          [enabletpetra=yes],
+                                                                     	  [AC_CHECK_HEADER([$withtrilinosdir/include/TpetraCore_config.h],
+										[enabletpetra=yes],
+                                                                          	[enabletpetra=no])])])])])
 
        if test "$enabletpetra" != no ; then
           AC_DEFINE(HAVE_TPETRA, 1,
@@ -126,7 +130,11 @@ AC_DEFUN([CONFIGURE_TRILINOS_10],
                                         [enabledtk=yes],
                                         [AC_CHECK_HEADER([$withtrilinosdir/DataTransferKit/src/DataTransferKit_config.hpp],
                                                          [enabledtk=yes],
-                                                         [enabledtk=no])])])
+                                                         [AC_CHECK_HEADER([$withtrilinosdir/DataTransferKit/packages/Utils/src/DataTransferKitUtils_config.hpp],
+                                                                          [enabledtk=yes],
+                                                         		  [AC_CHECK_HEADER([$withtrilinosdir/include/DataTransferKitUtils_config.hpp],
+										[enabledtk=yes],
+                                                                          	[enabledtk=no])])])])])
 
        if test "$enabledtk" != no ; then
           AC_DEFINE(HAVE_DTK, 1,


### PR DESCRIPTION
Trilinos 12.0 and DTK 2.0 changed to subpackages.  This moved the place where the config files are generated that autotools checks.  This commit adds alternate paths so that the libmesh configure passes for the latest versions.