### PR TITLE
Added SolverConfiguration class

### DIFF
--- a/examples/systems_of_equations/systems_of_equations_ex6/run.sh
+++ b/examples/systems_of_equations/systems_of_equations_ex6/run.sh
@@ -6,6 +6,6 @@ source $LIBMESH_DIR/examples/run_common.sh
 
 example_name=systems_of_equations_ex6
 
-options="-ksp_type cg -pc_type bjacobi"
+options=""
 
 run_example "$example_name" "$options"

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -855,6 +855,7 @@ include_HEADERS = \
         solvers/slepc_macro.h \
         solvers/solution_history.h \
         solvers/solver.h \
+        solvers/solver_configuration.h \
         solvers/steady_solver.h \
         solvers/tao_optimization_solver.h \
         solvers/time_solver.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -352,6 +352,7 @@ include_HEADERS =  \
         solvers/slepc_macro.h \
         solvers/solution_history.h \
         solvers/solver.h \
+        solvers/solver_configuration.h \
         solvers/steady_solver.h \
         solvers/tao_optimization_solver.h \
         solvers/time_solver.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -348,6 +348,7 @@ BUILT_SOURCES = \
         slepc_macro.h \
         solution_history.h \
         solver.h \
+        solver_configuration.h \
         steady_solver.h \
         tao_optimization_solver.h \
         time_solver.h \
@@ -1543,6 +1544,9 @@ solution_history.h: $(top_srcdir)/include/solvers/solution_history.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 solver.h: $(top_srcdir)/include/solvers/solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+solver_configuration.h: $(top_srcdir)/include/solvers/solver_configuration.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 steady_solver.h: $(top_srcdir)/include/solvers/steady_solver.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -556,7 +556,8 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	petsc_linear_solver.h petsc_nonlinear_solver.h \
 	petscdmlibmesh.h second_order_unsteady_solver.h \
 	slepc_eigen_solver.h slepc_macro.h solution_history.h solver.h \
-	steady_solver.h tao_optimization_solver.h time_solver.h \
+	solver_configuration.h steady_solver.h \
+	tao_optimization_solver.h time_solver.h \
 	trilinos_aztec_linear_solver.h trilinos_nox_nonlinear_solver.h \
 	twostep_time_solver.h unsteady_solver.h \
 	condensed_eigen_system.h continuation_system.h \
@@ -1847,6 +1848,9 @@ solution_history.h: $(top_srcdir)/include/solvers/solution_history.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 solver.h: $(top_srcdir)/include/solvers/solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+solver_configuration.h: $(top_srcdir)/include/solvers/solver_configuration.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 steady_solver.h: $(top_srcdir)/include/solvers/steady_solver.h

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -31,6 +31,7 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/auto_ptr.h"
+#include "libmesh/solver_configuration.h"
 
 // C++ includes
 #include <cstddef>
@@ -131,8 +132,16 @@ public:
    */
   void attach_preconditioner(Preconditioner<T> * preconditioner);
 
+  /**
+   * Set the same_preconditioner flag, which indicates if we reuse the
+   * same preconditioner for subsequent solves.
+   */
   virtual void reuse_preconditioner(bool );
 
+  /**
+   * @return same_preconditioner, which indicates if we reuse the
+   * same preconditioner for subsequent solves.
+   */
   bool get_same_preconditioner();
 
   /**
@@ -242,6 +251,11 @@ public:
    */
   virtual LinearConvergenceReason get_converged_reason() const = 0;
 
+  /**
+   * Set the solver configuration object.
+   */
+  void set_solver_configuration(SolverConfiguration& solver_configuration);
+
 protected:
 
 
@@ -273,6 +287,12 @@ protected:
    */
   bool same_preconditioner;
 
+  /**
+   * Optionally store a SolverOptions object that can be used
+   * to set parameters like solver type, tolerances and iteration limits.
+   */
+  SolverConfiguration* _solver_configuration;
+
 };
 
 
@@ -287,7 +307,8 @@ LinearSolver<T>::LinearSolver (const libMesh::Parallel::Communicator &comm_in) :
   _preconditioner_type (ILU_PRECOND),
   _is_initialized      (false),
   _preconditioner      (NULL),
-  same_preconditioner  (false)
+  same_preconditioner  (false),
+  _solver_configuration(NULL)
 {
 }
 

--- a/include/solvers/solver_configuration.h
+++ b/include/solvers/solver_configuration.h
@@ -1,0 +1,77 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_SOLVER_CONFIGURATION_H
+#define LIBMESH_SOLVER_CONFIGURATION_H
+
+// Local includes
+#include "libmesh/libmesh_common.h"
+
+namespace libMesh
+{
+
+/**
+ * This class stores solver configuration data, e.g. tolerances
+ * and iteration limits. Override the pure virtual function
+ * configure_solver() in order to provide specific behavior for
+ * particular types of solvers (e.g. LinearSolver, EigenSolver, etc).
+ *
+ * @author David Knezevic, 2015.
+ */
+
+class SolverConfiguration : public ReferenceCountedObject<SolverConfiguration>
+{
+public:
+
+  /**
+   *  Constructor.
+   */
+  SolverConfiguration () {}
+
+  /**
+   * Destructor.
+   */
+  virtual ~SolverConfiguration () {}
+
+  /**
+   * Apply solver options to a particular solver.
+   * Override in subclasses to provide specific behavior.
+   */
+  virtual void configure_solver() = 0;
+
+  /**
+   * Store real-valued solver parameters in this map, e.g. solver tolerances.
+   */
+  std::map<std::string, Real> real_valued_data;
+
+  /**
+   * Store integer solver parameters in this map, e.g. iteration limits.
+   */
+  std::map<std::string, int> int_valued_data;
+
+  /**
+   * Store string data in this map, e.g. "solver_type" : "gmres".
+   */
+  std::map<std::string, std::string> string_data;
+
+};
+
+} // namespace libMesh
+
+#endif // LIBMESH_SOLVER_CONFIGURATION_H

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -162,6 +162,12 @@ void LinearSolver<T>::print_converged_reason() const
   libMesh::out << "Linear solver convergence/divergence reason: " << Utility::enum_to_string(reason) << std::endl;
 }
 
+template <typename T>
+void LinearSolver<T>::set_solver_configuration(SolverConfiguration& solver_configuration)
+{
+  _solver_configuration = &solver_configuration;
+}
+
 //------------------------------------------------------------------
 // Explicit instantiations
 template class LinearSolver<Number>;

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -724,6 +724,13 @@ PetscLinearSolver<T>::solve (SparseMatrix<T>&  matrix_in,
                            PETSC_DEFAULT, max_its);
   LIBMESH_CHKERRABORT(ierr);
 
+  // If the SolverConfiguration object is provided, use it to override
+  // solver options.
+  if(this->_solver_configuration)
+    {
+      this->_solver_configuration->configure_solver();
+    }
+
   // Solve the linear system
   if(_restrict_solve_to_is!=NULL)
     {


### PR DESCRIPTION
The idea is that this can be used to programmatically configure the solvers by making a subclass of SolverConfiguration that overrides SolverConfiguration::configure_solver(). Note that we call configure_solver in petsc_linear_solver.C before we do the solve, and the same thing can be done in other solver types if desired.

This is related to the "solver exception" PR, since we sometimes need to be able to change solver options in order to redo a solve successfully.

The SolverConfiguration class is quite empty, where the expectation is that the solver specific data is implemented in sub-classes.