### PR TITLE
Enhance/clean up documentation

### DIFF
--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Adaptivity Example 1 - Solving 1D PDE Using Adaptive Mesh Refinement</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This example demonstrates how to solve a simple 1D problem
 // using adaptive mesh refinement. The PDE that is solved is:

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Adaptivity Example 2 - Solving a Transient System with Adaptive Mesh Refinement</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This example shows how a simple, linear transient
 // system can be solved in parallel.  The system is simple

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2004  Benjamin S. Kirk, John W. Peterson */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Adaptivity Example 3 - Laplace Equation in the L-Shaped Domain</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This example solves the Laplace equation on the classic "L-shaped"
 // domain with adaptive mesh refinement.  In this case, the exact

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -1,21 +1,23 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2004  Benjamin S. Kirk, John W. Peterson */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // <h1>Adaptivity Example 4 - Biharmonic Equation</h1>
+// \author Benjamin S. Kirk
+// \date 2004
 //
 // This example solves the Biharmonic equation on a square or cube,
 // using a Galerkin formulation with C1 elements approximating the

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Adaptivity Example 5 - Periodic Boundary Conditions with Adaptive Mesh Refinement</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This example uses the same simple, linear transient
 // system as in example 10; however in this case periodic boundary

--- a/examples/adjoints/adjoints_ex1/adjoints_ex1.C
+++ b/examples/adjoints/adjoints_ex1/adjoints_ex1.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2004  Benjamin S. Kirk, John W. Peterson */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  U$ */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Adjoints Example 1 - Laplace Equation in the L-Shaped Domain with Adjoint based mesh refinement</h1>
+// \author Roy Stogner
+// \date 2011
 //
 // This example solves the Laplace equation on the classic "L-shaped"
 // domain with adaptive mesh refinement. The exact

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -1,22 +1,26 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2004  Benjamin S. Kirk, John W. Peterson */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  U$ */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Adjoints Example 2 - Laplace Equation in the L-Shaped Domain with
 // Adjoint based sensitivity</h1>
+// \author Roy Stogner
+// \date 2003
 //
 // This example solves the Laplace equation on the classic "L-shaped"
 // domain with adaptive mesh refinement. The exact solution is

--- a/examples/adjoints/adjoints_ex3/coupled_system.C
+++ b/examples/adjoints/adjoints_ex3/coupled_system.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 #include "libmesh/dirichlet_boundaries.h"

--- a/examples/adjoints/adjoints_ex3/coupled_system.h
+++ b/examples/adjoints/adjoints_ex3/coupled_system.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #ifndef __coupled_system_h__
 #define __coupled_system_h__

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2004  Benjamin S. Kirk, John W. Peterson */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  U$ */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// <h1>Adjoints Example 1 - Laplace Equation in the L-Shaped Domain with Adjoint based error estimation</h1>
+
+
+// <h1>Adjoints Example 4 - Laplace Equation in the L-Shaped Domain with AdjointRefinementErrorEstimator</h1>
+// \author Vikram Garg
+// \date 2012
 //
 // This example solves the Laplace equation on the classic "L-shaped"
 // domain with adaptive mesh refinement. The exact

--- a/examples/adjoints/adjoints_ex5/adjoint_initial.C
+++ b/examples/adjoints/adjoints_ex5/adjoint_initial.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2002-2013 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 

--- a/examples/adjoints/adjoints_ex5/adjoint_initial.h
+++ b/examples/adjoints/adjoints_ex5/adjoint_initial.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2002-2013 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -1,24 +1,30 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2002-2013 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // Adjoints Example 5 - SolutionHistory, General Localized Vectors and Unsteady Adjoints.
-// This example showcases three new capabilities in libMesh. The primary motivation is adjoint sensitivity analysis for unsteady problems. The PDE we are interested in is the simple 2-d heat equation:
+// \author Vikram Garg
+// \date 2013
+//
+// This example showcases three new capabilities in libMesh. The
+// primary motivation is adjoint sensitivity analysis for unsteady
+// problems. The PDE we are interested in is the simple 2-d heat
+// equation:
 // partial(T)/partial(t) - K Laplacian(T) = 0
 // with initial condition:
 // T(x,y;0) = sin(pi*x) sin(pi*y) and boundary conditions:

--- a/examples/adjoints/adjoints_ex5/element_qoi_derivative.C
+++ b/examples/adjoints/adjoints_ex5/element_qoi_derivative.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2002-2013 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 

--- a/examples/adjoints/adjoints_ex5/factoryfunction.C
+++ b/examples/adjoints/adjoints_ex5/factoryfunction.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2002-2013 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 

--- a/examples/adjoints/adjoints_ex5/heatsystem.C
+++ b/examples/adjoints/adjoints_ex5/heatsystem.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2002-2013 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 

--- a/examples/adjoints/adjoints_ex5/heatsystem.h
+++ b/examples/adjoints/adjoints_ex5/heatsystem.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2002-2013 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 

--- a/examples/adjoints/adjoints_ex5/initial.C
+++ b/examples/adjoints/adjoints_ex5/initial.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2002-2013 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 

--- a/examples/adjoints/adjoints_ex5/initial.h
+++ b/examples/adjoints/adjoints_ex5/initial.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2002-2013 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 

--- a/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
+++ b/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Eigenproblems Example 1 - Solving an Eigen Problem</h1>
+// \author Steffen Petersen
+// \date 2005
 //
 // This example introduces the EigenSystem and shows
 // how libMesh can be used for eigenvalue analysis.

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Eigenproblems Example 2 - Solving a generalized Eigen Problem</h1>
+// \author Steffen Petersen
+// \date 2006
 //
 // This example shows how the previous EigenSolver example
 // can be adapted to solve generailzed eigenvalue problems.

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -1,25 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Eigenproblems Example 3 - Can you "hear the shape" of a drum?</h1>
-//
-//   By David Knezevic
+// \author David Knezevic
+// \date 2012
 //
 // The sound that a drum makes is determined by it's resonant frequencies,
 // which are given by the eigenvalues of the Laplacian. "Can One Hear the

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -1,22 +1,26 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>FEMSystem Example 1 - Unsteady Navier-Stokes Equations with
 // FEMSystem</h1>
+// \author Roy Stogner
+// \date 2006
 //
 // This example shows how the transient nonlinear problem from
 // example 13 can be solved using the

--- a/examples/fem_system/fem_system_ex1/naviersystem.C
+++ b/examples/fem_system/fem_system_ex1/naviersystem.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/getpot.h"
 

--- a/examples/fem_system/fem_system_ex1/naviersystem.h
+++ b/examples/fem_system/fem_system_ex1/naviersystem.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // DiffSystem framework files
 #include "libmesh/fem_system.h"

--- a/examples/fem_system/fem_system_ex2/fem_system_ex2.C
+++ b/examples/fem_system/fem_system_ex2/fem_system_ex2.C
@@ -1,21 +1,24 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-/* fem_system_ex2.C Copyright 2012 Robert Weidlich, also LGPL-licensed */
+
+// <h1>FEMSystem Example 2</h1>
+// \author Robert Weidlich
+// \date 2012
 
 #include "libmesh/equation_systems.h"
 #include "libmesh/getpot.h"

--- a/examples/fem_system/fem_system_ex2/nonlinear_neohooke_cc.C
+++ b/examples/fem_system/fem_system_ex2/nonlinear_neohooke_cc.C
@@ -1,21 +1,24 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-/* nonlinear_neohooke_cc.C Copyright 2012 Robert Weidlich, also LGPL-licensed */
+
+
+// \author Robert Weidlich
+// \date Copyright 2012
 
 #include "nonlinear_neohooke_cc.h"
 

--- a/examples/fem_system/fem_system_ex2/nonlinear_neohooke_cc.h
+++ b/examples/fem_system/fem_system_ex2/nonlinear_neohooke_cc.h
@@ -1,21 +1,24 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-/* nonlinear_neohooke_cc.h Copyright 2012 Robert Weidlich, also LGPL-licensed */
+
+
+// \author Robert Weidlich
+// \date Copyright 2012
 
 #ifndef NONLINEAR_NEOHOOKE_CC_H_
 #define NONLINEAR_NEOHOOKE_CC_H_

--- a/examples/fem_system/fem_system_ex2/solid_system.C
+++ b/examples/fem_system/fem_system_ex2/solid_system.C
@@ -1,21 +1,24 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-/* solid_system.C Copyright 2012 Robert Weidlich, also LGPL-licensed */
+
+
+// \author Robert Weidlich
+// \date Copyright 2012
 
 #include "libmesh/boundary_info.h"
 #include "libmesh/diff_solver.h"

--- a/examples/fem_system/fem_system_ex2/solid_system.h
+++ b/examples/fem_system/fem_system_ex2/solid_system.h
@@ -1,21 +1,24 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-/* solid_system.h Copyright 2012 Robert Weidlich, also LGPL-licensed */
+
+
+// \author Robert Weidlich
+// \date Copyright 2012
 
 #ifndef SOLID_SYSTEM_H_
 #define SOLID_SYSTEM_H_

--- a/examples/fem_system/fem_system_ex3/elasticity_system.C
+++ b/examples/fem_system/fem_system_ex3/elasticity_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/examples/fem_system/fem_system_ex3/elasticity_system.h
+++ b/examples/fem_system/fem_system_ex3/elasticity_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -15,8 +15,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+
+
 // <h1>FEMSystem Example 3 - Unsteady Linear Elasticity with
 // FEMSystem</h1>
+// \author Paul Bauman
+// \date 2015
 //
 // This example shows how to solve the three-dimensional transient
 // linear elasticity equations using the DifferentiableSystem class framework.

--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.C
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.C
@@ -1,22 +1,26 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>FEMSystem Example 4 - Mixed-dimension heat transfer equation
 // with FEMSystem</h1>
+// \author Roy Stogner
+// \date 2015
 //
 // This example shows how elements of multiple dimensions can be
 // linked and computed upon simultaneously within the

--- a/examples/introduction/introduction_ex1/introduction_ex1.C
+++ b/examples/introduction/introduction_ex1/introduction_ex1.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Introduction Example 1 - Creation of a Mesh Object</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This is the first example program.  It simply demonstrates
 // how to create a mesh object.  A mesh is read from file,

--- a/examples/introduction/introduction_ex2/introduction_ex2.C
+++ b/examples/introduction/introduction_ex2/introduction_ex2.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Introduction Example 2 - Defining a Simple System</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This is the second example program.  It demonstrates how to
 // create an equation system for a simple scalar system.  This

--- a/examples/introduction/introduction_ex3/introduction_ex3.C
+++ b/examples/introduction/introduction_ex3/introduction_ex3.C
@@ -1,22 +1,24 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 // <h1>Introduction Example 3 - Solving a Poisson Problem</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This is the third example program.  It builds on
 // the second example program by showing how to solve a simple

--- a/examples/introduction/introduction_ex4/introduction_ex4.C
+++ b/examples/introduction/introduction_ex4/introduction_ex4.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Introduction Example 4 - Solving a 1D, 2D or 3D Poisson Problem in Parallel</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This is the fourth example program.  It builds on
 // the third example program by showing how to formulate

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -1,24 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
-
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Introduction Example 5 - Run-Time Quadrature Rule Selection</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This is the fifth example program.  It builds on
 // the previous two examples, and extends the use

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -1,24 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
-
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Miscellaneous Example 1 - Infinite Elements for the Wave Equation</h1>
+// \author Daniel Dreyer
+// \date 2003
 //
 // This is the sixth example program.  It builds on
 // the previous examples, and introduces the Infinite

--- a/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
+++ b/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Miscellaneous Example 10 - Stitching meshes </h1>
+// \author Dana Christen
+// \date 2014
 //
 // This example shows how to generate a domain by stitching 8 cubic meshes
 // together.  Then a Poisson problem is solved on the stitched domain,

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -1,31 +1,34 @@
-/* The Next Great Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
- // <h1>Miscellaneous Example 11 - Using Loop Subdivision Shell Elements</h1>
- //
- // This example demonstrates how subdivision surface shell elements
- // are used, and how boundary conditions can be applied to them.  To
- // keep it simple, we solve the static deflection of a clamped, square,
- // linearly elastic Kirchhoff-Love plate subject to a uniform
- // load distribution.  Refer to Cirak et al., Int. J. Numer. Meth.
- // Engng. 2000; 47: 2039-2072, for a detailed description of what's
- // implemented.  In fact, this example follows that paper very closely.
+// <h1>Miscellaneous Example 11 - Using Loop Subdivision Shell Elements</h1>
+// \author Roman Vetter
+// \author Norbert Stoop
+// \date 2014
+//
+// This example demonstrates how subdivision surface shell elements
+// are used, and how boundary conditions can be applied to them.  To
+// keep it simple, we solve the static deflection of a clamped, square,
+// linearly elastic Kirchhoff-Love plate subject to a uniform
+// load distribution.  Refer to Cirak et al., Int. J. Numer. Meth.
+// Engng. 2000; 47: 2039-2072, for a detailed description of what's
+// implemented.  In fact, this example follows that paper very closely.
 
 
 // C++ include files that we need

--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -1,24 +1,26 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 
 // <h1>Miscellaneous Example 2 - Complex Numbers and the "FrequencySystem"</h1>
+// \author Steffen Petersen
+// \date 2003
 //
 // This is the seventh example program.  It builds on
 // the previous example programs, introduces complex

--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Miscellaneous Example 3 - 2D Laplace-Young Problem Using Nonlinear Solvers</h1>
+// \author Derek Gaston
+// \date 2008
 //
 // This example shows how to use the NonlinearImplicitSystem class to
 // solve nonlinear problems in libMesh.  The NonlinearImplicitSystem

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Miscellaneous Example 4 - Using a shell matrix</h1>
+// \author Tim Kroger
+// \date 2008
 //
 // This example solves the equation
 //

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2004  Benjamin S. Kirk, John W. Peterson */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Miscellaneous Example 5 - Interior Penalty Discontinuous Galerkin</h1>
-//
-// By Lorenzo Botti
+// \author Lorenzo Botti
+// \date 2010
 //
 // This example is based on Adaptivity Example 3, but uses an
 // Interior Penalty Discontinuous Galerkin formulation.

--- a/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
+++ b/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Miscellaneous Example 6 - Meshing with LibMesh's TetGen and Triangle Interfaces</h1>
+// \author John W. Peterson
+// \date 2011
 //
 // LibMesh provides interfaces to both Triangle and TetGen for generating
 // Delaunay triangulations and tetrahedralizations in two and three dimensions

--- a/examples/miscellaneous/miscellaneous_ex7/miscellaneous_ex7.C
+++ b/examples/miscellaneous/miscellaneous_ex7/miscellaneous_ex7.C
@@ -1,31 +1,33 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
-// <h1>Miscellaneous Example 7 - Can use the PetscDMNonlinearSolver (available in PETSc-3.3.0 or above) to solve a VI version of the problem.</h1>
+// <h1>Miscellaneous Example 7 - The PetscDMNonlinearSolver and
+// Variational Inequality (VI) problems</h1>
+// \author Dmitry Karpeyev
+// \date 2012
 //
-// LibMesh interfaces directly with PETSc's variational inequality solver,
-// this example shows how to do it.
-// Author: Dmitry Karpeev, 2012
+// In this example, LibMesh interfaces directly with PETSc's
+// variational inequality solver through PetscDMNonlinearSolver
+// (available in PETSc-3.3.0 or above).
 
 // Example include files
 #include "biharmonic.h"
-
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/miscellaneous/miscellaneous_ex8/meshless_interpolation_function.h
+++ b/examples/miscellaneous/miscellaneous_ex8/meshless_interpolation_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
+++ b/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Miscellaneous Example 8 - Meshfree Interpolation Utilities.</h1>
+// \author Benjamin S. Kirk
+// \date 2012
 //
 // LibMesh provides some utilities for pointcloud-type interpolation, as
 // demonstrated in this example.

--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -1,45 +1,54 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
-// <h1>Miscellaneous Example 9 - Implement an interface term to model a thermal "film resistance"</h1>
+// <h1>Miscellaneous Example 9 - Implement an interface term to model
+// a thermal "film resistance"</h1>
+// \author David Knezevic
+// \date 2013
 //
-// In this example we solve a Poisson problem, -\Laplacian u = f, with a non-standard interface
-// condition on the domain interior which models a thermal "film resistance". The interface condition
-// requires continuity of flux, and a jump in temperature proportional to the flux:
+// In this example we solve a Poisson problem, -\Laplacian u = f, with
+// a non-standard interface condition on the domain interior which
+// models a thermal "film resistance". The interface condition
+// requires continuity of flux, and a jump in temperature proportional
+// to the flux:
 //  \nabla u_1 \cdot n = \nabla u_2 \cdot n,
 //  u_1 - u_2 = R * \nabla u \cdot n
 //
-// To implement this PDE, we use two mesh subdomains, \Omega_1 and \Omega_2, with coincident boundaries,
-// but which are not connected in the FE sense. Let \Gamma denote the coincident boundary.
-// The term on \Gamma takes the form:
+// To implement this PDE, we use two mesh subdomains, \Omega_1 and
+// \Omega_2, with coincident boundaries, but which are not connected
+// in the FE sense. Let \Gamma denote the coincident boundary.  The
+// term on \Gamma takes the form:
 //
 //  1/R * \int_\Gamma (u_1 - u_2) (v_1 - v_2) ds,
 //
-// where u_1, u_2 (resp. v_1, v_2) are the trial (resp. test) functions on either side of \Gamma.
-// We implement this condition using C0 basis functions, but the "crack" in the mesh at \Gamma permits
-// a discontinuity in the solution. We also impose a heat flux on the bottom surface of the mesh, and a zero Dirichlet
-// condition on the top surface.
+// where u_1, u_2 (resp. v_1, v_2) are the trial (resp. test)
+// functions on either side of \Gamma.  We implement this condition
+// using C0 basis functions, but the "crack" in the mesh at \Gamma
+// permits a discontinuity in the solution. We also impose a heat flux
+// on the bottom surface of the mesh, and a zero Dirichlet condition
+// on the top surface.
 //
-// In order to implement the interface condition, we need to augment the matrix sparsity pattern,
-// which is handled by the class AugmentSparsityPatternOnInterface. (We do not need to augment the
-// send-list in this case since the PDE is linear and hence there is no need to broadcast non-local
-// solution values).
+// In order to implement the interface condition, we need to augment
+// the matrix sparsity pattern, which is handled by the class
+// AugmentSparsityPatternOnInterface. (We do not need to augment the
+// send-list in this case since the PDE is linear and hence there is
+// no need to broadcast non-local solution values).
 
 
 // C++ include files that we need

--- a/examples/optimization/optimization_ex1/optimization_ex1.C
+++ b/examples/optimization/optimization_ex1/optimization_ex1.C
@@ -1,29 +1,34 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Optimization Example 1 - Optimization of a quadratic objective function</h1>
+// \author David Knezevic
+// \date 2015
 //
-// In this example we demonstrate how to use OptimizationSystem to solve the
-// optimization problem:
+// In this example we demonstrate how to use OptimizationSystem to
+// solve the optimization problem:
 //   min_U 0.5*U^T A U - U^T F
-// We enforce Dirichlet constraints on U so that the minimization is well-posed.
-// But note that we do not use OptimizationSystem's interface for imposing constraints
-// in this case, so we can use an unconstrained solver (e.g. TAO's "Newton's method
-// with line search" for unconstrained optimization is the default choice).
+// We enforce Dirichlet constraints on U so that the minimization is
+// well-posed.  But note that we do not use OptimizationSystem's
+// interface for imposing constraints in this case, so we can use an
+// unconstrained solver (e.g. TAO's "Newton's method with line search"
+// for unconstrained optimization is the default choice).
 
 // C++ include files that we need
 #include <iostream>

--- a/examples/optimization/optimization_ex2/optimization_ex2.C
+++ b/examples/optimization/optimization_ex2/optimization_ex2.C
@@ -1,24 +1,29 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Optimization Example 2 - Optimization with constraints</h1>
+// \author David Knezevic
+// \date 2015
 //
-// In this example we extend example 1 to demonstrate how to use OptimizationSystem's
-// interface for imposing equality and inequality constraints.
+// In this example we extend example 1 to demonstrate how to use
+// OptimizationSystem's interface for imposing equality and inequality
+// constraints.
 
 // C++ include files that we need
 #include <iostream>

--- a/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
+++ b/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
@@ -1,41 +1,50 @@
-/* rbOOmit: An implementation of the Certified Reduced Basis method. */
-/* Copyright (C) 2009, 2010 David J. Knezevic */
-/*     This file is part of rbOOmit. */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* rbOOmit is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* rbOOmit is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010 David J. Knezevic
+// This file is part of rbOOmit.
+
+
 
 // <h1>Reduced Basis Example 1 - Certified Reduced Basis Method</h1>
-
+// \author David Knezevic
+// \date 2010
+//
 // In this example problem we use the Certified Reduced Basis method
 // to solve a steady convection-diffusion problem on the unit square.
 // The reduced basis method relies on an expansion of the PDE in the
-// form \sum_q=1^Q_a theta_a^q(\mu) * a^q(u,v) = \sum_q=1^Q_f theta_f^q(\mu) f^q(v)
-// where theta_a, theta_f are parameter dependent functions and
-// a^q, f^q are parameter independent operators (\mu denotes a parameter).
-
+// form \sum_q=1^Q_a theta_a^q(\mu) * a^q(u,v) = \sum_q=1^Q_f
+// theta_f^q(\mu) f^q(v) where theta_a, theta_f are parameter
+// dependent functions and a^q, f^q are parameter independent
+// operators (\mu denotes a parameter).
+//
 // We first attach the parameter dependent functions and paramater
 // independent operators to the RBSystem. Then in Offline mode, a
 // reduced basis space is generated and written out to the directory
-// "offline_data". In Online mode, the reduced basis data in "offline_data"
-// is read in and used to solve the reduced problem for the parameters
-// specified in reduced_basis_ex1.in.
-
-// We also attach four outputs to the system which are averages over certain
-// subregions of the domain. In Online mode, we print out the values of these
-// outputs as well as rigorous error bounds with respect to the output
-// associated with the "truth" finite element discretization.
+// "offline_data". In Online mode, the reduced basis data in
+// "offline_data" is read in and used to solve the reduced problem for
+// the parameters specified in reduced_basis_ex1.in.
+//
+// We also attach four outputs to the system which are averages over
+// certain subregions of the domain. In Online mode, we print out the
+// values of these outputs as well as rigorous error bounds with
+// respect to the output associated with the "truth" finite element
+// discretization.
 
 // C++ include files that we need
 #include <iostream>

--- a/examples/reduced_basis/reduced_basis_ex2/reduced_basis_ex2.C
+++ b/examples/reduced_basis/reduced_basis_ex2/reduced_basis_ex2.C
@@ -1,30 +1,39 @@
-/* rbOOmit: An implementation of the Certified Reduced Basis method. */
-/* Copyright (C) 2009, 2010 David J. Knezevic */
-/*     This file is part of rbOOmit. */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* rbOOmit is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* rbOOmit is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010 David J. Knezevic
+// This file is part of rbOOmit.
+
+
 
 // <h1>Reduced Basis Example 2 - Successive Constraint Method</h1>
-
-// In this example we extend reduced_basis_ex1 to solve a steady convection-diffusion
-// problem on the unit square via the Reduced Basis Method. In this case, we modify the
-// PDE so that it no longer has a parameter-independent coercivity constant. Therefore,
-// in order to obtain an error bound, we need to employ the Successive Constraint
-// Method (SCM) implemented in RBSCMConstruction/RBSCMEvaluation to obtain a
-// parameter-dependent lower bound for the coercivity constant.
-
+// \author David Knezevic
+// \date 2011
+//
+// In this example we extend reduced_basis_ex1 to solve a steady
+// convection-diffusion problem on the unit square via the Reduced
+// Basis Method. In this case, we modify the PDE so that it no longer
+// has a parameter-independent coercivity constant. Therefore, in
+// order to obtain an error bound, we need to employ the Successive
+// Constraint Method (SCM) implemented in
+// RBSCMConstruction/RBSCMEvaluation to obtain a parameter-dependent
+// lower bound for the coercivity constant.
+//
 // The PDE being solved is div(k*grad(u)) + Beta*grad(u) = f
 // k is the diffusion coefficient :
 // - constant in the domain 0<=x<0.5 , its value is given by the first parameter mu[0]

--- a/examples/reduced_basis/reduced_basis_ex3/reduced_basis_ex3.C
+++ b/examples/reduced_basis/reduced_basis_ex3/reduced_basis_ex3.C
@@ -1,23 +1,30 @@
-/* rbOOmit: An implementation of the Certified Reduced Basis method. */
-/* Copyright (C) 2009, 2010 David J. Knezevic */
-/*     This file is part of rbOOmit. */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* rbOOmit is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* rbOOmit is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010 David J. Knezevic
+// This file is part of rbOOmit.
+
+
 
 // <h1>Reduced Basis Example 3 - Transient Reduced Basis Problem</h1>
-
+// \author David Knezevic
+// \date 2011
+//
 // In this example problem we use the Certified Reduced Basis method
 // to solve a transient convection-diffusion problem on the unit square.
 // The PDE is similar to reduced_basis_ex1, except there is a time-derivative

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -1,33 +1,42 @@
-/* rbOOmit: An implementation of the Certified Reduced Basis method. */
-/* Copyright (C) 2009, 2010 David J. Knezevic */
-/*     This file is part of rbOOmit. */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* rbOOmit is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* rbOOmit is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010 David J. Knezevic
+// This file is part of rbOOmit.
+
+
 
 // <h1>Reduced Basis Example 4 - Empirical Interpolation Method</h1>
-
-// In this example problem we develop a reduced basis approximation for a parametrized
-// PDE that has "non-affine" parameter dependence. This requires the use of the
-// Empirical Interpolation Method (EIM).
+// \author David Knezevic
+// \date 2011
 //
-// We first use EIM to construct an affine approximation to the non-affine term,
-// which is a parametrized function that is a Gaussian with "center" defined
-// by the two parameters (mu_1,mu_2) \in [-1,1]^2. We then employ this EIM
-// approximation in order to generate a reduced basis approximation for the
-// parametrized PDE: -0.05 * Laplacian(u) = f(mu_1,mu_2), with zero Dirichlet
-// boundary conditions.
+// In this example problem we develop a reduced basis approximation
+// for a parametrized PDE that has "non-affine" parameter
+// dependence. This requires the use of the Empirical Interpolation
+// Method (EIM).
+//
+// We first use EIM to construct an affine approximation to the
+// non-affine term, which is a parametrized function that is a
+// Gaussian with "center" defined by the two parameters (mu_1,mu_2)
+// \in [-1,1]^2. We then employ this EIM approximation in order to
+// generate a reduced basis approximation for the parametrized PDE:
+// -0.05 * Laplacian(u) = f(mu_1,mu_2), with zero Dirichlet boundary
+// conditions.
 
 // Basic include file needed for the mesh functionality.
 #include "libmesh/libmesh.h"

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -1,24 +1,31 @@
-/* rbOOmit: An implementation of the Certified Reduced Basis method. */
-/* Copyright (C) 2009, 2010 David J. Knezevic */
-/*     This file is part of rbOOmit. */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* rbOOmit is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* rbOOmit is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010 David J. Knezevic
+// This file is part of rbOOmit.
+
+
 
 // <h1>Reduced Basis: Example 5 - Reduced Basis Cantilever</h1>
 // 3D cantilever beam using the Reduced Basis Method
-// David Knezevic, Kyunghoon "K" Lee
+// \author David Knezevic
+// \author Kyunghoon "K" Lee
+// \date 2012
 //
 // We consider four parameters in this problem:
 //  x_scaling: scales the length of the cantilever

--- a/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
+++ b/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
@@ -1,28 +1,35 @@
-/* rbOOmit: An implementation of the Certified Reduced Basis method. */
-/* Copyright (C) 2009, 2010 David J. Knezevic */
-/*     This file is part of rbOOmit. */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* rbOOmit is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* rbOOmit is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010 David J. Knezevic
+// This file is part of rbOOmit.
+
+
 
 // <h1>Reduced Basis Example 7 - Acoustic Horn</h1>
-
+// \author David Knezevic
+// \date 2012
+//
 // In this example problem we use the Certified Reduced Basis method
 // to solve a complex-valued Helmholtz problem for acoustics. There is only
 // one parameter in this problem: the forcing frequency at the horn inlet.
 // We impose a radiation boundary condition on the outer boundary.
-
+//
 // In the Online stage we write out the reflection coefficient as a function
 // of frequency. The reflection coefficient gives the ratio of the reflected
 // wave to the applied wave at the inlet.

--- a/examples/solution_transfer/solution_transfer_ex1/main.C
+++ b/examples/solution_transfer/solution_transfer_ex1/main.C
@@ -1,3 +1,29 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+// <h1>Solution Transfer Example 1 - </h1>
+// \author Derek Gaston
+// \date 2013
+//
+// This example demonstrates how to use the DTKSolutionTransfer object
+// to transfer a solution from one Mesh to another.
+
 // Basic include files needed for the mesh functionality.
 #include "libmesh/libmesh.h"
 #include "libmesh/mesh.h"

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Subdomains Example 1 - Solving on a Subdomain</h1>
+// \author Tim Kroger
+// \date 2010
 //
 // This example builds on the example 4 by showing what to do in
 // order to solve an equation only on a subdomain.

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Subdomains Example 2 - Subdomain-Restricted Variables</h1>
+// \author Benjamin S. Kirk
+// \date 2011
 //
 // This example builds on the fourth example program by showing how
 // to restrict solution fields to a subdomain (or union of

--- a/examples/subdomains/subdomains_ex3/subdomains_ex3.C
+++ b/examples/subdomains/subdomains_ex3/subdomains_ex3.C
@@ -1,24 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2013  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
- // <h1>Subdomains Example 3 - Integrating discontinuous data that cuts the mesh</h1>
- //
+// <h1>Subdomains Example 3 - Integrating discontinuous data that cuts the mesh</h1>
+// \author Benjamin S. Kirk
+// \date 2013
 
 
 // C++ include files that we need

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Systems Example 1 - Stokes Equations</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This example shows how a simple, linear system of equations
 // can be solved in parallel.  The system of equations are the familiar

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Systems Example 2 - Unsteady Nonlinear Navier-Stokes</h1>
+// \author John W. Peterson
+// \date 2004
 //
 // This example shows how a simple, unsteady, nonlinear system of equations
 // can be solved in parallel.  The system of equations are the familiar

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -1,26 +1,30 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Systems Example 3 - Navier-Stokes with SCALAR Lagrange Multiplier</h1>
+// \author David Knezevic
+// \date 2010
 //
 // This example shows how the transient Navier-Stokes problem from
-// example 13 can be solved using a scalar Lagrange multiplier formulation to
-// constrain the integral of the pressure variable, rather than pinning the
-// pressure at a single point.
+// example 13 can be solved using a scalar Lagrange multiplier
+// formulation to constrain the integral of the pressure variable,
+// rather than pinning the pressure at a single point.
 
 // C++ include files that we need
 #include <iostream>

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -1,24 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1> Systems Example 4 - Linear Elastic Cantilever </h1>
-//      By David Knezevic
+// \author David Knezevic
+// \date 2012
 //
 // In this example we model a homogeneous isotropic cantilever
 // using the equations of linear elasticity. We set the Poisson ratio to

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -1,24 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1> Systems Example 5 - Linear Elastic Cantilever with Constraint </h1>
-//      By David Knezevic
+// \author David Knezevic
+// \date 2012
 //
 // In this example we extend systems_of_equations_ex4 to enforce a constraint.
 // We apply a uniform load on the top surface of the cantilever, and we

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -1,24 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1> Systems Example 6 - 3D Linear Elastic Cantilever </h1>
-//      By David Knezevic
+// \author David Knezevic
+// \date 2012
 //
 // This is a 3D version of systems_of_equations_ex4. The weak form PDE for
 // equilibrium elasticity is:

--- a/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
+++ b/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 // <h1> Systems Example 7 - Large deformation elasticity (St. Venant-Kirchoff material) </h1>
-// Example contributed by Lorenzo Zanon and David Knezevic.
+// \author Lorenzo Zanon
+// \author David Knezevic
+// \date 2014
 //
 // In this example, we consider an elastic cantilever beam modeled as a St. Venant-Kirchoff
 // material (which is an extension of the linear elastic material model to the nonlinear

--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
@@ -1,22 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
 
 
 // <h1> Systems Example 8 - Linear elasticity with contact. </h1>
+// \author David Knezevic
+// \date 2015
 //
 // In this example, we consider a linear elastic model with contact. This is a nonlinear
 // problem due to the contact condition.

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -1,23 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Transient Example 1 - Solving a Transient Linear System in Parallel</h1>
+// \author Benjamin S. Kirk
+// \date 2003
 //
 // This example shows how a simple, linear transient
 // system can be solved in parallel.  The system is simple

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -1,25 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
-
-
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
 
 // <h1>Transient Example 2 - The Newmark System and the Wave Equation</h1>
+// \author Steffen Petersen
+// \date 2003
 //
 // This is the eighth example program. It builds on
 // the previous example programs.  It introduces the

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -1,22 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
 
 
 // <h1>Vector Finite Element Example 1 - Solving an uncoupled Poisson Problem</h1>
+// \author Paul Bauman
+// \date 2012
 //
 // This is the first vector FE example program.  It builds on
 // the introduction_ex3 example program by showing how to solve a simple

--- a/examples/vector_fe/vector_fe_ex2/laplace_exact_solution.h
+++ b/examples/vector_fe/vector_fe_ex2/laplace_exact_solution.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/libmesh_common.h"
 

--- a/examples/vector_fe/vector_fe_ex2/laplace_system.C
+++ b/examples/vector_fe/vector_fe_ex2/laplace_system.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/getpot.h"
 

--- a/examples/vector_fe/vector_fe_ex2/laplace_system.h
+++ b/examples/vector_fe/vector_fe_ex2/laplace_system.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // DiffSystem framework files
 #include "libmesh/fem_system.h"

--- a/examples/vector_fe/vector_fe_ex2/solution_function.h
+++ b/examples/vector_fe/vector_fe_ex2/solution_function.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/function_base.h"
 #include "laplace_exact_solution.h"

--- a/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
+++ b/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
@@ -1,22 +1,26 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>FEMSystem Example 1 - Unsteady Navier-Stokes Equations with
 // FEMSystem</h1>
+// \author Paul Bauman
+// \date 2012
 //
 // This example shows how the transient nonlinear problem from
 // example 13 can be solved using the

--- a/examples/vector_fe/vector_fe_ex3/curl_curl_exact_solution.h
+++ b/examples/vector_fe/vector_fe_ex3/curl_curl_exact_solution.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/libmesh_common.h"
 #include "libmesh/vector_value.h"

--- a/examples/vector_fe/vector_fe_ex3/curl_curl_system.C
+++ b/examples/vector_fe/vector_fe_ex3/curl_curl_system.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/getpot.h"
 

--- a/examples/vector_fe/vector_fe_ex3/curl_curl_system.h
+++ b/examples/vector_fe/vector_fe_ex3/curl_curl_system.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // DiffSystem framework files
 #include "libmesh/fem_system.h"

--- a/examples/vector_fe/vector_fe_ex3/solution_function.h
+++ b/examples/vector_fe/vector_fe_ex3/solution_function.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/function_base.h"
 #include "curl_curl_exact_solution.h"

--- a/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
+++ b/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
 
 // <h1>Vector Finite Elements Example 3 - Nedelec Elements</h1>
+// \author Paul Bauman
+// \date 2012
 //
 // This example shows an example of using the Nedelec elements of the
 // first type to solve a model problem in H(curl).

--- a/examples/vector_fe/vector_fe_ex4/curl_curl_exact_solution.h
+++ b/examples/vector_fe/vector_fe_ex4/curl_curl_exact_solution.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/libmesh_common.h"
 #include "libmesh/vector_value.h"

--- a/examples/vector_fe/vector_fe_ex4/curl_curl_system.C
+++ b/examples/vector_fe/vector_fe_ex4/curl_curl_system.C
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/getpot.h"
 

--- a/examples/vector_fe/vector_fe_ex4/curl_curl_system.h
+++ b/examples/vector_fe/vector_fe_ex4/curl_curl_system.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 // DiffSystem framework files
 #include "libmesh/fem_system.h"

--- a/examples/vector_fe/vector_fe_ex4/solution_function.h
+++ b/examples/vector_fe/vector_fe_ex4/solution_function.h
@@ -1,19 +1,19 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/function_base.h"
 #include "curl_curl_exact_solution.h"

--- a/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
+++ b/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
@@ -1,21 +1,25 @@
-/* The libMesh Finite Element Library. */
-/* Copyright (C) 2003  Benjamin S. Kirk */
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
-/* This library is free software; you can redistribute it and/or */
-/* modify it under the terms of the GNU Lesser General Public */
-/* License as published by the Free Software Foundation; either */
-/* version 2.1 of the License, or (at your option) any later version. */
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
 
-/* This library is distributed in the hope that it will be useful, */
-/* but WITHOUT ANY WARRANTY; without even the implied warranty of */
-/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU */
-/* Lesser General Public License for more details. */
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
 
-/* You should have received a copy of the GNU Lesser General Public */
-/* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// <h1>Vector Finite Elements Example 3 - Nedelec Elements</h1>
+
+
+// <h1>Vector Finite Elements Example 4 - Nedelec Elements</h1>
+// \author Paul Bauman
+// \date 2013
 //
 // This example shows an example of using the Nedelec elements of the
 // first type to solve a model problem in H(curl).

--- a/include/base/auto_ptr.h
+++ b/include/base/auto_ptr.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/dirichlet_boundaries.h
+++ b/include/base/dirichlet_boundaries.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/dirichlet_boundaries.h
+++ b/include/base/dirichlet_boundaries.h
@@ -42,9 +42,6 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// DirichletBoundary class definition
-
 /**
  * This class allows one to associate dirichlet boundary values with
  * a given set of mesh boundary ids and system variable ids.
@@ -60,7 +57,6 @@ namespace libMesh
  * adjoining face interiors unconstrained, but would still permit the
  * other edge and node DoFs around those faces to be constrained.
  */
-
 class DirichletBoundary
 {
 public:

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -159,7 +159,8 @@ class NodeConstraints : public std::map<const Node *,
  * belong to distinct processors.  This is so that the resulting data
  * structures will work well with parallel linear algebra packages.
  *
- * @author Benjamin S. Kirk, 2002-2007
+ * \author Benjamin S. Kirk
+ * \date 2002-2007
  */
 class DofMap : public ReferenceCountedObject<DofMap>,
                public ParallelObject

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -152,9 +152,6 @@ class NodeConstraints : public std::map<const Node *,
 
 
 
-// ------------------------------------------------------------
-// DofMap class definition
-
 /**
  * This class handles the numbering of degrees of freedom on a mesh.
  * For systems of equations the class supports a fixed number of variables.

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/factory.h
+++ b/include/base/factory.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -128,7 +128,8 @@ namespace GETPOT_NAMESPACE {
  * GetPot - A class for parsing comand line arguments and
  * configuration files.
  *
- * @author (C) 2001-2002 Frank R. Schaefer
+ * \author Frank R. Schaefer
+ * \date (C) 2001-2002
  */
 class GetPot
 {

--- a/include/base/id_types.h
+++ b/include/base/id_types.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/libmesh_C_isnan.h
+++ b/include/base/libmesh_C_isnan.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/libmesh_augment_std_namespace.h
+++ b/include/base/libmesh_augment_std_namespace.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/libmesh_base.h
+++ b/include/base/libmesh_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/libmesh_logging.h
+++ b/include/base/libmesh_logging.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/libmesh_version.h
+++ b/include/base/libmesh_version.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -35,7 +35,8 @@ class BoundaryInfo;
  * the element and node iterators.  These classes are not in general
  * used by the user, although they could be.
  *
- * @author John W. Peterson, 2004
+ * \author John W. Peterson
+ * \date 2004
  */
 namespace Predicates
 {

--- a/include/base/periodic_boundaries.h
+++ b/include/base/periodic_boundaries.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/periodic_boundary.h
+++ b/include/base/periodic_boundary.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/periodic_boundary_base.h
+++ b/include/base/periodic_boundary_base.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/print_trace.h
+++ b/include/base/print_trace.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/reference_counted_object.h
+++ b/include/base/reference_counted_object.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/reference_counted_object.h
+++ b/include/base/reference_counted_object.h
@@ -29,8 +29,6 @@
 namespace libMesh
 {
 
-
-
 /**
  * This class implements reference counting. Any class that
  * is properly derived from this class will get reference counted, provided
@@ -60,7 +58,8 @@ namespace libMesh
  * or \p DEBUG is not defined then this class does nothing.
  * All members are inlined and empty, so they should effectively disappear.
  *
- * \author Benjamin S. Kirk, 2002-2007
+ * \author Benjamin S. Kirk
+ * \date 2002-2007
  */
 template <typename T>
 class ReferenceCountedObject : public ReferenceCounter

--- a/include/base/reference_counted_object.h
+++ b/include/base/reference_counted_object.h
@@ -62,9 +62,6 @@ namespace libMesh
  *
  * \author Benjamin S. Kirk, 2002-2007
  */
-
-// ------------------------------------------------------------
-// ReferenceCounter class definition
 template <typename T>
 class ReferenceCountedObject : public ReferenceCounter
 {

--- a/include/base/reference_counter.h
+++ b/include/base/reference_counter.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/reference_counter.h
+++ b/include/base/reference_counter.h
@@ -33,13 +33,12 @@
 namespace libMesh
 {
 
-
-
 /**
  * This is the base class for enabling reference counting.  It
  * should not be used by the user, thus it has a private constructor.
  *
- * \author Benjamin S. Kirk, 2002-2007
+ * \author Benjamin S. Kirk
+ * \date 2002-2007
  */
 class ReferenceCounter
 {

--- a/include/base/reference_counter.h
+++ b/include/base/reference_counter.h
@@ -41,9 +41,6 @@ namespace libMesh
  *
  * \author Benjamin S. Kirk, 2002-2007
  */
-
-// ------------------------------------------------------------
-// ReferenceCounter class definition
 class ReferenceCounter
 {
 protected:

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -39,7 +39,8 @@ namespace libMesh
  * as building blocks to create the "multi predicates" which can be found
  * in the multi_predicates.h header file.
  *
- * @author John W. Peterson, 2004
+ * \author John W. Peterson
+ * \date 2004
  */
 namespace Predicates
 {

--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/base/variant_filter_iterator.h
+++ b/include/base/variant_filter_iterator.h
@@ -43,7 +43,8 @@
  * off the end or the beginning.  To reduce complexity, we only allow
  * traversal in one direction.
  *
- * @author John W. Peterson, 2004.
+ * \author John W. Peterson
+ * \date 2004
  */
 template<class Predicate, class Type, class ReferenceType = Type&, class PointerType = Type*>
 class variant_filter_iterator :

--- a/include/enums/enum_convergence_flags.h
+++ b/include/enums/enum_convergence_flags.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_eigen_solver_type.h
+++ b/include/enums/enum_eigen_solver_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_elem_quality.h
+++ b/include/enums/enum_elem_quality.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_elem_type.h
+++ b/include/enums/enum_elem_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_error_estimator_type.h
+++ b/include/enums/enum_error_estimator_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_fe_family.h
+++ b/include/enums/enum_fe_family.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_inf_map_type.h
+++ b/include/enums/enum_inf_map_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_io_package.h
+++ b/include/enums/enum_io_package.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_norm_type.h
+++ b/include/enums/enum_norm_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_order.h
+++ b/include/enums/enum_order.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_parallel_type.h
+++ b/include/enums/enum_parallel_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_point_locator_type.h
+++ b/include/enums/enum_point_locator_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_preconditioner_type.h
+++ b/include/enums/enum_preconditioner_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_quadrature_type.h
+++ b/include/enums/enum_quadrature_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_solver_package.h
+++ b/include/enums/enum_solver_package.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_solver_type.h
+++ b/include/enums/enum_solver_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_subset_solve_mode.h
+++ b/include/enums/enum_subset_solve_mode.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/enums/enum_xdr_mode.h
+++ b/include/enums/enum_xdr_mode.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -41,7 +41,8 @@ namespace libMesh
  * solution as weighted against an adjoint solution on a uniformly
  * refined (in h and/or p, for an arbitrary number of levels) grid.
  *
- * @author Roy H. Stogner, 2009.
+ * \author Roy H. Stogner
+ * \date 2009
  */
 class AdjointRefinementEstimator : public ErrorEstimator
 {

--- a/include/error_estimation/adjoint_residual_error_estimator.h
+++ b/include/error_estimation/adjoint_residual_error_estimator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/adjoint_residual_error_estimator.h
+++ b/include/error_estimation/adjoint_residual_error_estimator.h
@@ -50,7 +50,8 @@ namespace libMesh
  * misimplementation will be the fault of Roy Stogner.  It's also
  * Roy's fault there's no literature reference here yet.
  *
- * @author Roy H. Stogner, 2009.
+ * \author Roy H. Stogner
+ * \date 2009
  */
 class AdjointResidualErrorEstimator : public ErrorEstimator
 {

--- a/include/error_estimation/discontinuity_measure.h
+++ b/include/error_estimation/discontinuity_measure.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/discontinuity_measure.h
+++ b/include/error_estimation/discontinuity_measure.h
@@ -43,7 +43,8 @@ class Point;
  * for debugging purposes.  It derives from ErrorEstimator
  * just in case someone finds it useful in a DG framework.
  *
- * @author Roy H. Stogner, 2006.
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class DiscontinuityMeasure : public JumpErrorEstimator
 {

--- a/include/error_estimation/error_estimator.h
+++ b/include/error_estimation/error_estimator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/error_estimator.h
+++ b/include/error_estimation/error_estimator.h
@@ -49,7 +49,8 @@ template <typename T> class NumericVector;
  * the computed errors are stored as floats rather than doubles
  * since the required precision is low.
  *
- * @author Benjamin S. Kirk, 2003.
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 class ErrorEstimator
 {

--- a/include/error_estimation/exact_error_estimator.h
+++ b/include/error_estimation/exact_error_estimator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/exact_error_estimator.h
+++ b/include/error_estimation/exact_error_estimator.h
@@ -61,7 +61,8 @@ typedef NumberVectorValue   Gradient;
  * approximation error in other estimates, so this
  * estimator can be used to calculate effectivity.
  *
- * @author Roy Stogner, 2006.
+ * \author Roy Stogner
+ * \date 2006
  */
 class ExactErrorEstimator : public ErrorEstimator
 {

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -56,11 +56,10 @@ typedef NumberVectorValue   Gradient;
  * for any component of any system.  These are the exact_value
  * and exact_deriv functions below.
  *
- * @author Benjamin S. Kirk w/ modifications for libmesh
- * by John W. Peterson
+ * \author Benjamin S. Kirk
+ * \author John W. Peterson (modifications for libmesh)
+ * \date 2004
  */
-
-
 class ExactSolution
 {
 

--- a/include/error_estimation/fourth_error_estimators.h
+++ b/include/error_estimation/fourth_error_estimators.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/fourth_error_estimators.h
+++ b/include/error_estimation/fourth_error_estimators.h
@@ -30,18 +30,13 @@
 namespace libMesh
 {
 
-
-
-
-
-
-
 /**
  * This class is an error indicator based on laplacian jumps between
  * elements.
  * See the JumpErrorEstimator class for most user APIs
  *
- * @author Roy H. Stogner, 2005
+ * \author Roy H. Stogner
+ * \date 2005
  */
 class LaplacianErrorEstimator : public JumpErrorEstimator
 {

--- a/include/error_estimation/hp_coarsentest.h
+++ b/include/error_estimation/hp_coarsentest.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/hp_coarsentest.h
+++ b/include/error_estimation/hp_coarsentest.h
@@ -62,7 +62,8 @@ typedef RealTensorValue RealTensor;
  * This code is currently experimental and will not produce optimal
  * hp meshes without significant improvement.
  *
- * @author Roy H. Stogner, 2006.
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class HPCoarsenTest : public HPSelector
 {

--- a/include/error_estimation/hp_selector.h
+++ b/include/error_estimation/hp_selector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/hp_selector.h
+++ b/include/error_estimation/hp_selector.h
@@ -42,7 +42,8 @@ class System;
  * for h refinement, and we may want to change some of those elements
  * to be flagged for p refinement.
  *
- * @author Roy H. Stogner, 2006.
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class HPSelector
 {

--- a/include/error_estimation/hp_singular.h
+++ b/include/error_estimation/hp_singular.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/hp_singular.h
+++ b/include/error_estimation/hp_singular.h
@@ -43,7 +43,8 @@ class System;
  * for h refinement - any elements which do not contain a
  * user-provided singular point are instead flagged for p refinement.
  *
- * @author Roy H. Stogner, 2006.
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class HPSingularity
 {

--- a/include/error_estimation/jump_error_estimator.h
+++ b/include/error_estimation/jump_error_estimator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/jump_error_estimator.h
+++ b/include/error_estimation/jump_error_estimator.h
@@ -38,15 +38,12 @@ namespace libMesh
 class Point;
 class Elem;
 
-
-
-
-
 /**
  * This abstract base class implements utility functions for error estimators
  * which are based on integrated jumps between elements.
  *
- * @author Roy H. Stogner, 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class JumpErrorEstimator : public ErrorEstimator
 {

--- a/include/error_estimation/kelly_error_estimator.h
+++ b/include/error_estimation/kelly_error_estimator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/kelly_error_estimator.h
+++ b/include/error_estimation/kelly_error_estimator.h
@@ -57,7 +57,8 @@ class Point;
  * }
  * \endverbatim
  *
- * @author Benjamin S. Kirk, 2003.
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 class KellyErrorEstimator : public JumpErrorEstimator
 {

--- a/include/error_estimation/patch_recovery_error_estimator.h
+++ b/include/error_estimation/patch_recovery_error_estimator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/patch_recovery_error_estimator.h
+++ b/include/error_estimation/patch_recovery_error_estimator.h
@@ -41,8 +41,9 @@ class Elem;
 /**
  * This class implements the Patch Recovery error indicator.
  *
- *
- * @author Varis Carey, Benjamin S. Kirk, 2004.
+ * \author Varis Carey
+ * \author Benjamin S. Kirk
+ * \date 2004
  */
 class PatchRecoveryErrorEstimator : public ErrorEstimator
 {

--- a/include/error_estimation/uniform_refinement_estimator.h
+++ b/include/error_estimation/uniform_refinement_estimator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/uniform_refinement_estimator.h
+++ b/include/error_estimation/uniform_refinement_estimator.h
@@ -39,7 +39,8 @@ namespace libMesh
  * and the solution on a uniformly refined (in h and/or p,
  * for an arbitrary number of levels) grid.
  *
- * @author Roy H. Stogner, 2006.
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class UniformRefinementEstimator : public ErrorEstimator
 {

--- a/include/error_estimation/weighted_patch_recovery_error_estimator.h
+++ b/include/error_estimation/weighted_patch_recovery_error_estimator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/error_estimation/weighted_patch_recovery_error_estimator.h
+++ b/include/error_estimation/weighted_patch_recovery_error_estimator.h
@@ -43,8 +43,8 @@ class Elem;
 /**
  * This class implements the Patch Recovery error indicator.
  *
- *
- * @author Vikram Garg 2012.
+ * \author Vikram Garg
+ * \date 2012
  */
 class WeightedPatchRecoveryErrorEstimator : public PatchRecoveryErrorEstimator
 {

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -84,9 +84,6 @@ struct FEOutputType<NEDELEC_ONE>
  * \author Benjamin S. Kirk
  * \date 2002-2007
  */
-
-//-------------------------------------------------------------
-// FE class definition
 template <unsigned int Dim, FEFamily T>
 class FE : public FEGenericBase<typename FEOutputType<T>::type>
 {
@@ -489,9 +486,6 @@ protected:
  * \author Roy Stogner
  * \date 2004
  */
-
-//-------------------------------------------------------------
-// FEHierarchic class definition
 template <unsigned int Dim>
 class FEClough : public FE<Dim,CLOUGH>
 {
@@ -514,9 +508,6 @@ public:
  * \author Roy Stogner
  * \date 2005
  */
-
-//-------------------------------------------------------------
-// FEHierarchic class definition
 template <unsigned int Dim>
 class FEHermite : public FE<Dim,HERMITE>
 {
@@ -540,17 +531,14 @@ public:
                                 const Real xi);
 };
 
+
+
 /**
  * Subdivision finite elements.
+ *
+ * Template specialization prototypes are needed for calling from
+ * inside FESubdivision::init_shape_functions
  */
-
-//-------------------------------------------------------------
-// FESubdivision class definition
-
-
-// template specialization prototypes, needed for being able to
-// call them from inside FESubdivision::init_shape_functions
-
 template <>
 Real FE<2,SUBDIVISION>::shape(const Elem* elem,
                               const Order order,
@@ -688,9 +676,6 @@ public:
  * \author Benjamin S. Kirk
  * \date 2002-2007
  */
-
-//-------------------------------------------------------------
-// FEHierarchic class definition
 template <unsigned int Dim>
 class FEHierarchic : public FE<Dim,HIERARCHIC>
 {
@@ -713,9 +698,6 @@ public:
  * \author Truman E. Ellis
  * \date 2011
  */
-
-//-------------------------------------------------------------
-// FEL2Hierarchic class definition
 template <unsigned int Dim>
 class FEL2Hierarchic : public FE<Dim,L2_HIERARCHIC>
 {
@@ -738,9 +720,6 @@ public:
  * \author Benjamin S. Kirk
  * \date 2002-2007
  */
-
-//-------------------------------------------------------------
-// FELagrange class definition
 template <unsigned int Dim>
 class FELagrange : public FE<Dim,LAGRANGE>
 {
@@ -758,8 +737,6 @@ public:
 /**
  * Discontinuous Lagrange finite elements.
  */
-//-------------------------------------------------------------
-// FEL2Lagrange class definition
 template <unsigned int Dim>
 class FEL2Lagrange : public FE<Dim,L2_LAGRANGE>
 {
@@ -781,9 +758,6 @@ public:
  * \author Benjamin S. Kirk
  * \date 2002-2007
  */
-
-//-------------------------------------------------------------
-// FEMonomial class definition
 template <unsigned int Dim>
 class FEMonomial : public FE<Dim,MONOMIAL>
 {
@@ -798,8 +772,9 @@ public:
 };
 
 
-//-------------------------------------------------------------
-// FEScalar class definition
+/**
+ * The FEScalar class is used for workign with SCALAR variables.
+ */
 template <unsigned int Dim>
 class FEScalar : public FE<Dim,SCALAR>
 {
@@ -824,9 +799,6 @@ public:
  * \author Benjamin S. Kirk
  * \date 2002-2007
  */
-
-//-------------------------------------------------------------
-// FEXYZ class definition
 template <unsigned int Dim>
 class FEXYZ : public FE<Dim,XYZ>
 {
@@ -891,8 +863,14 @@ protected:
                             const std::vector<Real>& weights);
 };
 
-//-------------------------------------------------------------
-// FELagrangeVec class definition
+
+
+/**
+ * FELagrangeVec objects are used for working with vector-valued
+ * finite elements
+ *
+ * @author Paul T. Bauman 2013.
+ */
 template <unsigned int Dim>
 class FELagrangeVec : public FE<Dim,LAGRANGE_VEC>
 {
@@ -907,8 +885,14 @@ public:
 
 };
 
-//-------------------------------------------------------------
-// FENedelecOne class definition
+
+
+/**
+ * FENedelecOne objects are used for working with vector-valued
+ * Nedelec finite elements of the first kind.
+ *
+ * @author Paul T. Bauman 2013.
+ */
 template <unsigned int Dim>
 class FENedelecOne : public FE<Dim,NEDELEC_ONE>
 {

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -869,7 +869,8 @@ protected:
  * FELagrangeVec objects are used for working with vector-valued
  * finite elements
  *
- * @author Paul T. Bauman 2013.
+ * \author Paul T. Bauman
+ * \date 2013
  */
 template <unsigned int Dim>
 class FELagrangeVec : public FE<Dim,LAGRANGE_VEC>
@@ -891,7 +892,8 @@ public:
  * FENedelecOne objects are used for working with vector-valued
  * Nedelec finite elements of the first kind.
  *
- * @author Paul T. Bauman 2013.
+ * \author Paul T. Bauman
+ * \date 2013
  */
 template <unsigned int Dim>
 class FENedelecOne : public FE<Dim,NEDELEC_ONE>

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -89,7 +89,8 @@ class InfFE;
  * This class is well 'at the heart' of the library, so
  * things in here should better remain unchanged.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
 class FEAbstract : public ReferenceCountedObject<FEAbstract>
 {

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -91,9 +91,6 @@ class InfFE;
  *
  * @author Benjamin S. Kirk, 2002
  */
-
-// ------------------------------------------------------------
-// FEAbstract class definition
 class FEAbstract : public ReferenceCountedObject<FEAbstract>
 {
 protected:

--- a/include/fe/fe_base.h
+++ b/include/fe/fe_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/fe_base.h
+++ b/include/fe/fe_base.h
@@ -95,9 +95,6 @@ class InfFE;
  *
  * @author Benjamin S. Kirk, 2002
  */
-
-// ------------------------------------------------------------
-// FEBase class definition
 template <typename OutputType>
 class FEGenericBase : public FEAbstract
 {

--- a/include/fe/fe_base.h
+++ b/include/fe/fe_base.h
@@ -93,7 +93,8 @@ class InfFE;
  * This class is well 'at the heart' of the library, so
  * things in here should better remain unchanged.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
 template <typename OutputType>
 class FEGenericBase : public FEAbstract

--- a/include/fe/fe_compute_data.h
+++ b/include/fe/fe_compute_data.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -57,10 +57,6 @@ class PointLocatorBase;
  *
  * @author Daniel Dreyer, 2002-2007
  */
-
-// ------------------------------------------------------------
-// FEInterface class definition
-
 class FEInterface
 {
 private:

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -55,7 +55,8 @@ class PointLocatorBase;
  * Using this class, one need not worry about the correct
  * finite element class.
  *
- * @author Daniel Dreyer, 2002-2007
+ * \author Daniel Dreyer
+ * \date 2002-2007
  */
 class FEInterface
 {

--- a/include/fe/fe_macro.h
+++ b/include/fe/fe_macro.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/fe_transformation_base.h
+++ b/include/fe/fe_transformation_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/fe_transformation_base.h
+++ b/include/fe/fe_transformation_base.h
@@ -35,7 +35,8 @@ template< typename T > class HCurlFETransformation;
  * class assumes the \p FEGenericBase object has been initialized in the reference
  * domain (i.e. init_shape_functions has been called).
  *
- * @author Paul T. Bauman, 2012
+ * \author Paul T. Bauman
+ * \date 2012
  */
 template< typename OutputShape >
 class FETransformationBase

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/fe_xyz_map.h
+++ b/include/fe/fe_xyz_map.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/h1_fe_transformation.h
+++ b/include/fe/h1_fe_transformation.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/h1_fe_transformation.h
+++ b/include/fe/h1_fe_transformation.h
@@ -29,7 +29,8 @@ namespace libMesh
  * for H1 conforming elements. This class assumes the \p FEGenericBase object has been
  * initialized in the reference domain (i.e. \p init_shape_functions has been called).
  *
- * @author Paul T. Bauman, 2012
+ * \author Paul T. Bauman
+ * \date 2012
  */
 template< typename OutputShape >
 class H1FETransformation : public FETransformationBase<OutputShape>

--- a/include/fe/hcurl_fe_transformation.h
+++ b/include/fe/hcurl_fe_transformation.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/hcurl_fe_transformation.h
+++ b/include/fe/hcurl_fe_transformation.h
@@ -28,7 +28,8 @@ namespace libMesh
  * for HCurl conforming elements. This class assumes the \p FEGenericBase object has been
  * initialized in the reference domain (i.e. \p init_shape_functions has been called).
  *
- * @author Paul T. Bauman, 2012
+ * \author Paul T. Bauman
+ * \date 2012
  */
 template< typename OutputShape >
 class HCurlFETransformation : public FETransformationBase<OutputShape>

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -70,9 +70,6 @@ class FEComputeData;
  * \author Daniel Dreyer
  * \date 2003
  */
-
-//-------------------------------------------------------------
-// InfFE class definition
 template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 class InfFE : public FEBase
 {
@@ -92,8 +89,6 @@ protected:
    * \author Daniel Dreyer
    * \date 2003
    */
-  //-------------------------------------------------------------
-  // InfFE::Radial class definition
   class Radial
   {
   private:
@@ -183,8 +178,6 @@ protected:
    * \author Daniel Dreyer
    * \date 2003
    */
-  //-------------------------------------------------------------
-  // InfFE::Base class definition
   class Base
   {
   private:

--- a/include/fe/inf_fe_instantiate_1D.h
+++ b/include/fe/inf_fe_instantiate_1D.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/inf_fe_instantiate_2D.h
+++ b/include/fe/inf_fe_instantiate_2D.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/inf_fe_instantiate_3D.h
+++ b/include/fe/inf_fe_instantiate_3D.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/fe/inf_fe_macro.h
+++ b/include/fe/inf_fe_macro.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell.h
+++ b/include/geom/cell.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_inf.h
+++ b/include/geom/cell_inf.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/edge_inf_edge2.h
+++ b/include/geom/edge_inf_edge2.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -85,7 +85,8 @@ class PointLocatorBase;
  * In all that follows, nodes that live either on edges, faces or the
  * interior are named @e second-order nodes.
  *
- * \author Benjamin S. Kirk, 2002-2007
+ * \author Benjamin S. Kirk
+ * \date 2002-2007
  */
 class Elem : public ReferenceCountedObject<Elem>,
              public DofObject

--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -52,9 +52,6 @@ class TetGenMeshInterface;
  *
  * \author Benjamin S. Kirk, 2013
  */
-
-// ------------------------------------------------------------
-// ElemCutter class definition
 class ElemCutter
 {
 public:

--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -50,7 +50,8 @@ class TetGenMeshInterface;
  * interfaces, the former of which is only defined if libmesh is configured
  * with --disable-strict-lgpl.
  *
- * \author Benjamin S. Kirk, 2013
+ * \author Benjamin S. Kirk
+ * \date 2013
  */
 class ElemCutter
 {

--- a/include/geom/elem_quality.h
+++ b/include/geom/elem_quality.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/elem_range.h
+++ b/include/geom/elem_range.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/elem_type.h
+++ b/include/geom/elem_type.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face.h
+++ b/include/geom/face.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -38,20 +38,18 @@ namespace libMesh
  * The \p Tri3 is an element in 2D composed of 3 nodes.
  * It is numbered like this:
  * \verbatim
- *   TRI3:  2
- *          o
- *         / \
- *        /   \
- *       /     \
- *      /       \
- *     /         \
- *    o-----------o
- *    0           1
+ *   TRI3:
+ *    2
+ *    o
+ *    |\
+ *    | \
+ *    |  \
+ *    |   \
+ *    |    \
+ *    o-----o
+ *    0      1
  * \endverbatim
  */
-
-// ------------------------------------------------------------
-// Tri3 class definition
 class Tri3 : public Tri
 {
 public:

--- a/include/geom/face_tri3_subdivision.h
+++ b/include/geom/face_tri3_subdivision.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/node.h
+++ b/include/geom/node.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/node_range.h
+++ b/include/geom/node_range.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/plane.h
+++ b/include/geom/plane.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/plane.h
+++ b/include/geom/plane.h
@@ -28,11 +28,11 @@
 namespace libMesh
 {
 
-
 /**
  * This class defines a plane.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
 class Plane : public Surface
 {

--- a/include/geom/point.h
+++ b/include/geom/point.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/point.h
+++ b/include/geom/point.h
@@ -28,17 +28,14 @@
 namespace libMesh
 {
 
-
-
-
 /**
  * A \p Point defines a location in LIBMESH_DIM dimensional Real space.  Points
  * are always real-valued, even if the library is configured with
  * \p --enable-complex.
  *
- * \author Benjamin S. Kirk, 2003.
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
-
 class Point : public TypeVector<Real>
 {
 public:

--- a/include/geom/reference_elem.h
+++ b/include/geom/reference_elem.h
@@ -36,7 +36,8 @@ class Elem;
  * This namespace implements singleton reference elements for each
  * fundamental element type supported by \p libMesh.
  *
- * \author Benjamin S. Kirk, 2013.
+ * \author Benjamin S. Kirk
+ * \date 2013
  */
 namespace ReferenceElem
 {

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -31,10 +31,6 @@
 namespace libMesh
 {
 
-// Forward declarations
-
-
-
 /**
  * In parallel meshes where a ghost element has neighbors which do
  * not exist on the local processor, the ghost element's neighbors
@@ -42,7 +38,8 @@ namespace libMesh
  * Library code can then distinguish between such elements and
  * boundary elements (with NULL neighbors).
  *
- * \author Roy H. Stogner, 2007
+ * \author Roy H. Stogner
+ * \date 2007
  */
 class RemoteElem : public Elem,
                    public Singleton

--- a/include/geom/side.h
+++ b/include/geom/side.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/side.h
+++ b/include/geom/side.h
@@ -110,9 +110,6 @@ private:
  *
  * \author  Roy H. Stogner
  */
-
-// ------------------------------------------------------------
-//SideEdge class definition
 template <class EdgeType, class ParentType>
 class SideEdge : public EdgeType
 {

--- a/include/geom/sphere.h
+++ b/include/geom/sphere.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/stored_range.h
+++ b/include/geom/stored_range.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/stored_range.h
+++ b/include/geom/stored_range.h
@@ -29,7 +29,6 @@
 namespace libMesh
 {
 
-
 /**
  * The \p StoredRange class defined a contiguous, divisible set of objects
  * This class is used primarily as the argument to function objects.  The
@@ -45,7 +44,8 @@ namespace libMesh
  * such iterators has a cost proportional to the amount the iterator is advanced.
  * Hence in this implementation the user-provided range is packed into a vector.
  *
- * \author Benjamin S. Kirk, 2008.
+ * \author Benjamin S. Kirk
+ * \date 2008
  */
 template <typename iterator_type, typename object_type>
 class StoredRange

--- a/include/geom/surface.h
+++ b/include/geom/surface.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/geom/surface.h
+++ b/include/geom/surface.h
@@ -28,7 +28,6 @@
 namespace libMesh
 {
 
-
 /**
  * This class defines a surface.  A surface is a two-dimensional
  * object living in three-dimensional space.  Examples of surfaces
@@ -37,7 +36,8 @@ namespace libMesh
  * a surface will provide.  Specific derived classes actually implement
  * the functionality, so this class has pure virtual members.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
 class Surface
 {
@@ -107,9 +107,6 @@ public:
    * simply do not have to overload this method.
    */
   virtual Point world_coords (const Point& surf_coords) const;
-
-protected:
-
 };
 
 // ------------------------------------------------------------

--- a/include/mesh/abaqus_io.h
+++ b/include/mesh/abaqus_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/abaqus_io.h
+++ b/include/mesh/abaqus_io.h
@@ -29,11 +29,13 @@
 
 namespace libMesh
 {
+
 /**
  * The AbaqusIO class is a preliminary implementation for reading
  * Abaqus mesh files in ASCII format.
  *
- * @author John W. Peterson, 2011.
+ * \author John W. Peterson
+ * \date 2011
  */
 class AbaqusIO : public MeshInput<MeshBase>
 {

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -53,9 +53,6 @@ class MeshData;
  *
  * TODO[JWP]: Generalize this to work with MeshBase again.
  */
-
-//------------------------------------------------------
-// BoundaryInfo class definition
 class BoundaryInfo : public ParallelObject
 {
 protected:

--- a/include/mesh/boundary_mesh.h
+++ b/include/mesh/boundary_mesh.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/boundary_mesh.h
+++ b/include/mesh/boundary_mesh.h
@@ -36,9 +36,6 @@ namespace libMesh
  * This is useful for writing the boundary of a domain for inspecting
  * boundary conditions and other things.
  */
-
-// ------------------------------------------------------------
-// BoundaryMesh class definition
 class BoundaryMesh : public Mesh
 {
 public:

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -39,14 +39,16 @@ class MeshData;
 class Xdr;
 class Elem;
 
-
 /**
  * The CheckpointIO class can be used to write simplified restart
  * files that can be used to restart simulations that have
  * crashed. Only N-to-N (procs) restart is supported with CheckpointIO
  * files.
  *
- * @author Benjamin Kirk, John Peterson, Derek Gaston
+ * \author Benjamin Kirk
+ * \author John Peterson
+ * \author Derek Gaston
+ * \date 2013
  */
 class CheckpointIO : public MeshInput<MeshBase>,
                      public MeshOutput<MeshBase>,

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -41,12 +41,13 @@ class Elem;
 
 
 /**
+ * The CheckpointIO class can be used to write simplified restart
+ * files that can be used to restart simulations that have
+ * crashed. Only N-to-N (procs) restart is supported with CheckpointIO
+ * files.
  *
  * @author Benjamin Kirk, John Peterson, Derek Gaston
  */
-
-// ------------------------------------------------------------
-// CheckpointIO class definition
 class CheckpointIO : public MeshInput<MeshBase>,
                      public MeshOutput<MeshBase>,
                      public ParallelObject

--- a/include/mesh/diva_io.h
+++ b/include/mesh/diva_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/diva_io.h
+++ b/include/mesh/diva_io.h
@@ -31,15 +31,14 @@ namespace libMesh
 // Forward declarations
 class MeshBase;
 
-
-
 /**
  * This class implements writing meshes in the Diva format.
  * This is a scientific visualization program created by Kelly Gaither.
  * More information on Diva can be found here:
  * http://www.erc.msstate.edu/simcenter/docs/diva/
  *
- * @author John W. Peterson, 2004
+ * \author John W. Peterson
+ * \date 2004
  */
 class DivaIO : public MeshOutput<MeshBase>
 {

--- a/include/mesh/diva_io.h
+++ b/include/mesh/diva_io.h
@@ -41,9 +41,6 @@ class MeshBase;
  *
  * @author John W. Peterson, 2004
  */
-
-// ------------------------------------------------------------
-// DivaIO class definition
 class DivaIO : public MeshOutput<MeshBase>
 {
 public:

--- a/include/mesh/ensight_io.h
+++ b/include/mesh/ensight_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -46,9 +46,6 @@ class System;
  *
  * @author Benjamin Kirk, John Peterson, 2004.
  */
-
-// ------------------------------------------------------------
-// ExodusII_IO class definition
 class ExodusII_IO : public MeshInput<MeshBase>,
                     public MeshOutput<MeshBase>,
                     public ParallelObject

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -44,7 +44,9 @@ class System;
  * default, LibMesh expects ExodusII files to have a ".exd"
  * or ".e" file extension.
  *
- * @author Benjamin Kirk, John Peterson, 2004.
+ * \author Benjamin Kirk
+ * \author John Peterson
+ * \date 2004
  */
 class ExodusII_IO : public MeshInput<MeshBase>,
                     public MeshOutput<MeshBase>,

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -60,15 +60,16 @@ extern "C" {
 }
 
 /**
- * This is the \p ExodusII_IO_Helper class.  This class hides the implementation
- * details of interfacing with the Exodus binary format.
+ * This is the \p ExodusII_IO_Helper class.  This class hides the
+ * implementation details of interfacing with the Exodus binary
+ * format.
  *
- * @author Johw W. Peterson, 2002.
+ * \author Johw W. Peterson
+ * \date 2002
  */
 class ExodusII_IO_Helper : public ParallelObject
 {
 public:
-
   /**
    * Constructor. Automatically initializes all the private members of
    * the class.  Also allows you to set the verbosity level to v=true

--- a/include/mesh/fro_io.h
+++ b/include/mesh/fro_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/fro_io.h
+++ b/include/mesh/fro_io.h
@@ -32,13 +32,12 @@ namespace libMesh
 // Forward declarations
 class MeshBase;
 
-
-
 /**
  * This class implements writing meshes in the .fro format
  * used by the MIT ACDL.  Valid only for triangular meshes.
  *
- * @author Benjamin S. Kirk, 2007
+ * \author Benjamin S. Kirk
+ * \date 2007
  */
 class FroIO : public MeshOutput<MeshBase>
 {
@@ -55,10 +54,6 @@ public:
    * This method implements writing a mesh to a specified file.
    */
   virtual void write (const std::string& );
-
-
-private:
-
 };
 
 

--- a/include/mesh/fro_io.h
+++ b/include/mesh/fro_io.h
@@ -40,9 +40,6 @@ class MeshBase;
  *
  * @author Benjamin S. Kirk, 2007
  */
-
-// ------------------------------------------------------------
-// FroIO class definition
 class FroIO : public MeshOutput<MeshBase>
 {
 public:

--- a/include/mesh/gmsh_io.h
+++ b/include/mesh/gmsh_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/gmsh_io.h
+++ b/include/mesh/gmsh_io.h
@@ -44,11 +44,8 @@ class MeshBase;
  *
  * @author John W. Peterson, 2004, 2014
  * @author Martin Luthi (mluthi@tnoo.net), 2005: massive overhaul and extension,
- *                                         plus support for reading meshes and writing results
+ *   plus support for reading meshes and writing results
  */
-
-// ------------------------------------------------------------
-// GMVIO class definition
 class GmshIO : public MeshInput<MeshBase>,
                public MeshOutput<MeshBase>
 {

--- a/include/mesh/gmsh_io.h
+++ b/include/mesh/gmsh_io.h
@@ -42,9 +42,10 @@ class MeshBase;
  * GMSH software see
  * <a href="http://http://www.geuz.org/gmsh/">the Gmsh home page</a>
  *
- * @author John W. Peterson, 2004, 2014
- * @author Martin Luthi (mluthi@tnoo.net), 2005: massive overhaul and extension,
- *   plus support for reading meshes and writing results
+ * \author John W. Peterson
+ * \date 2004, 2014
+ * \author Martin Luthi
+ * \date 2005
  */
 class GmshIO : public MeshInput<MeshBase>,
                public MeshOutput<MeshBase>

--- a/include/mesh/gmv_io.h
+++ b/include/mesh/gmv_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/gmv_io.h
+++ b/include/mesh/gmv_io.h
@@ -47,9 +47,6 @@ class MeshBase;
  *
  * @author Benjamin S. Kirk, 2004
  */
-
-// ------------------------------------------------------------
-// GMVIO class definition
 class GMVIO : public MeshInput<MeshBase>,
               public MeshOutput<MeshBase>
 {

--- a/include/mesh/gmv_io.h
+++ b/include/mesh/gmv_io.h
@@ -37,15 +37,14 @@ namespace libMesh
 // Forward declarations
 class MeshBase;
 
-
-
 /**
  * This class implements writing meshes in the GMV format.
  * For a full description of the GMV format and to obtain the
  * GMV software see
  * <a href="http://laws.lanl.gov/XCM/gmv/GMVHome.html">the GMV home page</a>
  *
- * @author Benjamin S. Kirk, 2004
+ * \author Benjamin S. Kirk
+ * \date 2004
  */
 class GMVIO : public MeshInput<MeshBase>,
               public MeshOutput<MeshBase>

--- a/include/mesh/gnuplot_io.h
+++ b/include/mesh/gnuplot_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/gnuplot_io.h
+++ b/include/mesh/gnuplot_io.h
@@ -34,14 +34,11 @@ namespace libMesh
 class MeshBase;
 
 /**
- * This class implements writing meshes using GNUplot, designed for use only
- * with 1D meshes.
+ * This class implements writing meshes using GNUplot, designed for
+ * use only with 1D meshes.
  *
  * @author David Knezevic, 2005
  */
-
-// ------------------------------------------------------------
-// GnuPlotIO class definition
 class GnuPlotIO : public MeshOutput<MeshBase>
 {
 public:

--- a/include/mesh/gnuplot_io.h
+++ b/include/mesh/gnuplot_io.h
@@ -37,7 +37,8 @@ class MeshBase;
  * This class implements writing meshes using GNUplot, designed for
  * use only with 1D meshes.
  *
- * @author David Knezevic, 2005
+ * \author David Knezevic
+ * \date 2005
  */
 class GnuPlotIO : public MeshOutput<MeshBase>
 {

--- a/include/mesh/inf_elem_builder.h
+++ b/include/mesh/inf_elem_builder.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/inf_elem_builder.h
+++ b/include/mesh/inf_elem_builder.h
@@ -46,8 +46,9 @@ class Node;
  * top of an existing mesh.  It only makes sense to
  * use this if LIBMESH_ENABLE_INFINITE_ELEMENTS is true.
  *
- * @author original code by Daniel Dreyer, converted
- * to InfElemBuilder class by John W. Peterson, 2004.
+ * \author Daniel Dreyer
+ * \author John W. Peterson
+ * \date 2004
  */
 class InfElemBuilder
 {

--- a/include/mesh/legacy_xdr_io.h
+++ b/include/mesh/legacy_xdr_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/legacy_xdr_io.h
+++ b/include/mesh/legacy_xdr_io.h
@@ -38,7 +38,9 @@ class MeshData;
 /**
  * The LegacyXdrIO class has been replaced by the XdrIO class.
  *
- * @author Benjamin Kirk, John Peterson, 2004.
+ * \author Benjamin Kirk
+ * \author John Peterson
+ * \date 2004
  */
 class LegacyXdrIO : public MeshInput<MeshBase>,
                     public MeshOutput<MeshBase>

--- a/include/mesh/legacy_xdr_io.h
+++ b/include/mesh/legacy_xdr_io.h
@@ -36,16 +36,13 @@ class MeshBase;
 class MeshData;
 
 /**
+ * The LegacyXdrIO class has been replaced by the XdrIO class.
  *
  * @author Benjamin Kirk, John Peterson, 2004.
  */
-
-// ------------------------------------------------------------
-// LegacyXdrIO class definition
 class LegacyXdrIO : public MeshInput<MeshBase>,
                     public MeshOutput<MeshBase>
 {
-
 public:
   /**
    * Enumeration flag for the type of software.

--- a/include/mesh/matlab_io.h
+++ b/include/mesh/matlab_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/matlab_io.h
+++ b/include/mesh/matlab_io.h
@@ -31,8 +31,6 @@ namespace libMesh
 // Forward declarations
 class MeshBase;
 
-
-
 /**
  * This class implements reading meshes in the Matlab PDE toolkit
  * in a proprietary  format.
@@ -79,7 +77,8 @@ class MeshBase;
  * o The e matrix is entirely irrelevant in this code
  * o All of the matrices are row based
  *
- * @author John W. Peterson, 2004
+ * \author John W. Peterson
+ * \date 2004
  */
 class MatlabIO : public MeshInput<MeshBase>
 {

--- a/include/mesh/matlab_io.h
+++ b/include/mesh/matlab_io.h
@@ -81,11 +81,6 @@ class MeshBase;
  *
  * @author John W. Peterson, 2004
  */
-
-
-
-// ------------------------------------------------------------
-// MatlabIO class definition
 class MatlabIO : public MeshInput<MeshBase>
 {
 public:

--- a/include/mesh/medit_io.h
+++ b/include/mesh/medit_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/medit_io.h
+++ b/include/mesh/medit_io.h
@@ -33,8 +33,6 @@ namespace libMesh
 // Forward declarations:
 class MeshBase;
 
-
-
 /**
  * This class implements writing meshes in the mesh format
  * used by the MEdit visualization tool developed in the Gamma Project
@@ -43,7 +41,8 @@ class MeshBase;
  * MEdit software see the
  * <a href="http://www-rocq1.inria.fr/gamma/medit/medit.html">MEdit home page</a>.
  *
- * @author F. Prill, 2004
+ * \author Florian Prill
+ * \date 2004
  */
 class MEDITIO : public MeshOutput<MeshBase>
 {

--- a/include/mesh/medit_io.h
+++ b/include/mesh/medit_io.h
@@ -45,9 +45,6 @@ class MeshBase;
  *
  * @author F. Prill, 2004
  */
-
-// ------------------------------------------------------------
-// medit_io class definition
 class MEDITIO : public MeshOutput<MeshBase>
 {
 public:

--- a/include/mesh/mesh.h
+++ b/include/mesh/mesh.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh.h
+++ b/include/mesh/mesh.h
@@ -39,14 +39,10 @@ namespace libMesh
 // Forward declarations don't like typedefs...
 // typedef SerialMesh Mesh;
 
-
 /**
  * The \p Mesh class is a thin wrapper, around the \p SerialMesh class
  * by default.
  */
-
-// ------------------------------------------------------------
-// Mesh class definition
 class Mesh : public DefaultMesh
 {
 public:

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -64,10 +64,6 @@ class MeshInput;
  *
  * \author  Benjamin S. Kirk
  */
-
-
-// ------------------------------------------------------------
-// MeshBase class definition
 class MeshBase : public ParallelObject
 {
 public:

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -45,10 +45,6 @@ class BoundaryInfo;
  *
  * @author Benjamin S. Kirk, 2003
  */
-
-
-// ------------------------------------------------------------
-// MeshCommunication class definition
 class MeshCommunication
 {
 public:

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -36,14 +36,13 @@ class MeshBase;
 class ParallelMesh;
 class BoundaryInfo;
 
-
-
 /**
  * This is the \p MeshCommunication class.  It handles all the details
  * of communicating mesh information from one processor to another.  All
  * parallelization of the \p Mesh data structures is done via this class.
  *
- * @author Benjamin S. Kirk, 2003
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 class MeshCommunication
 {

--- a/include/mesh/mesh_data.h
+++ b/include/mesh/mesh_data.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_data.h
+++ b/include/mesh/mesh_data.h
@@ -52,14 +52,9 @@ class MeshDataUnvHeader;
  *
  * @author Daniel Dreyer, 2003
  */
-
-// ------------------------------------------------------------
-// MeshData class definition
 class MeshData
 {
 public:
-
-
   //----------------------------------------------------------
   // convenient typedefs
   /**
@@ -633,9 +628,6 @@ protected:
 };
 
 
-
-//-----------------------------------------------------------
-// MeshDataUnvHeader class definition
 
 /**
  * Class \p MeshDataUnvHeader handles the data specified at

--- a/include/mesh/mesh_data.h
+++ b/include/mesh/mesh_data.h
@@ -32,13 +32,11 @@
 namespace libMesh
 {
 
-
 // Forward Declarations
 class Node;
 class Elem;
 class MeshBase;
 class MeshDataUnvHeader;
-
 
 /**
  * The \p MeshData class handles actual data and the corresponding
@@ -50,7 +48,8 @@ class MeshDataUnvHeader;
  * To use \p MeshData, it has to be either activated or the compatibility
  * mode has to be enabled.
  *
- * @author Daniel Dreyer, 2003
+ * \author Daniel Dreyer
+ * \date 2003
  */
 class MeshData
 {

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -51,9 +51,6 @@ class PointLocatorBase;
  *
  * @author Daniel Dreyer, 2003
  */
-
-// ------------------------------------------------------------
-// MeshFunction class definition
 class MeshFunction : public FunctionBase<Number>,
                      public ParallelObject
 {

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -43,13 +43,12 @@ template <typename T> class NumericVector;
 class DofMap;
 class PointLocatorBase;
 
-
-
 /**
  * This class provides function-like objects for data
  * distributed over a mesh.
  *
- * @author Daniel Dreyer, 2003
+ * \author Daniel Dreyer
+ * \date 2003
  */
 class MeshFunction : public FunctionBase<Number>,
                      public ParallelObject

--- a/include/mesh/mesh_generation.h
+++ b/include/mesh/mesh_generation.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_input.h
+++ b/include/mesh/mesh_input.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_input.h
+++ b/include/mesh/mesh_input.h
@@ -44,9 +44,6 @@ namespace libMesh
  * \author Benjamin S. Kirk
  * \date 2004
  */
-
-// ------------------------------------------------------------
-// MeshInput class definition
 template <class MT>
 class MeshInput
 {

--- a/include/mesh/mesh_inserter_iterator.h
+++ b/include/mesh/mesh_inserter_iterator.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_modification.h
+++ b/include/mesh/mesh_modification.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -48,9 +48,6 @@ class EquationSystems;
  * \author Benjamin S. Kirk
  * \date 2004
  */
-
-// ------------------------------------------------------------
-// MeshOutput class definition
 template <class MT>
 class MeshOutput
 {

--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -47,13 +47,12 @@ class Node;
 class ErrorVector;
 class PeriodicBoundaries;
 
-
-
 /**
  * This is the \p MeshRefinement class.  This class implements
  * adaptive mesh refinement algorithms for a \p MeshBase.
  *
- * @author Benjamin S. Kirk, 2002-2007.
+ * \author Benjamin S. Kirk
+ * \date 2002-2007
  */
 class MeshRefinement : public ParallelObject
 {

--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -55,10 +55,6 @@ class PeriodicBoundaries;
  *
  * @author Benjamin S. Kirk, 2002-2007.
  */
-
-
-// ------------------------------------------------------------
-// MeshRefinement class definition
 class MeshRefinement : public ParallelObject
 {
 public:

--- a/include/mesh/mesh_serializer.h
+++ b/include/mesh/mesh_serializer.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_smoother.h
+++ b/include/mesh/mesh_smoother.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_smoother.h
+++ b/include/mesh/mesh_smoother.h
@@ -20,12 +20,6 @@
 #ifndef LIBMESH_MESH_SMOOTHER_H
 #define LIBMESH_MESH_SMOOTHER_H
 
-
-
-// Local Includes -----------------------------------
-
-// C++ Includes   -----------------------------------
-
 namespace libMesh
 {
 
@@ -41,10 +35,6 @@ class UnstructuredMesh;
  * \author John W. Peterson
  * \date 2002-2007
  */
-
-
-// ------------------------------------------------------------
-// MeshSmoother class definition
 class MeshSmoother
 {
 public:
@@ -69,7 +59,6 @@ public:
 protected:
 
   UnstructuredMesh& _mesh;
-
 };
 
 } // namespace libMesh

--- a/include/mesh/mesh_smoother_laplace.h
+++ b/include/mesh/mesh_smoother_laplace.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_smoother_laplace.h
+++ b/include/mesh/mesh_smoother_laplace.h
@@ -45,10 +45,6 @@ namespace libMesh
  * \author John W. Peterson
  * \date 2002-2007
  */
-
-
-// ------------------------------------------------------------
-// LaplaceMeshSmoother class definition
 class LaplaceMeshSmoother : public MeshSmoother
 {
 public:

--- a/include/mesh/mesh_smoother_vsmoother.h
+++ b/include/mesh/mesh_smoother_vsmoother.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_subdivision_support.h
+++ b/include/mesh/mesh_subdivision_support.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_tetgen_interface.h
+++ b/include/mesh/mesh_tetgen_interface.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_tetgen_interface.h
+++ b/include/mesh/mesh_tetgen_interface.h
@@ -40,15 +40,16 @@ namespace libMesh
 class UnstructuredMesh;
 class TetGenWrapper;
 
-
 /**
  * Class \p TetGenMeshInterface provides an interface for
  * tetrahedrization of meshes using the TetGen library.  For
  * information about TetGen cf.
  * <a href="http://tetgen.berlios.de/">TetGen home page</a>.
  *
- * @author, Steffen Petersen, 2004
- * Refactoring, John W. Peterson, 2011
+ * \author Steffen Petersen
+ * \date 2004
+ * \author John W. Peterson
+ * \date 2011
  */
 class TetGenMeshInterface
 {

--- a/include/mesh/mesh_tetgen_wrapper.h
+++ b/include/mesh/mesh_tetgen_wrapper.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_tetgen_wrapper.h
+++ b/include/mesh/mesh_tetgen_wrapper.h
@@ -35,8 +35,10 @@ namespace libMesh
  * The \p TetGenWrapper provides an interface for basic
  * access to TetGen data structures and methods.
  *
- * @author, Steffen Petersen, 2004
- * Refactoring, John W. Peterson, 2011
+ * \author Steffen Petersen
+ * \date 2004
+ * \author John W. Peterson
+ * \date 2011
  */
 class TetGenWrapper
 {

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_triangle_holes.h
+++ b/include/mesh/mesh_triangle_holes.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_triangle_interface.h
+++ b/include/mesh/mesh_triangle_interface.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/mesh_triangle_interface.h
+++ b/include/mesh/mesh_triangle_interface.h
@@ -44,7 +44,8 @@ class UnstructuredMesh;
  * A C++ interface between LibMesh and the Triangle library written by
  * J.R. Shewchuk.
  *
- * @author John W. Peterson
+ * \author John W. Peterson
+ * \date 2011
  */
 class TriangleInterface
 {

--- a/include/mesh/mesh_triangle_wrapper.h
+++ b/include/mesh/mesh_triangle_wrapper.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/namebased_io.h
+++ b/include/mesh/namebased_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/namebased_io.h
+++ b/include/mesh/namebased_io.h
@@ -38,7 +38,8 @@ class MeshBase;
  * Other I/O classes may have more advanced features that are not
  * accessible via this interface.
  *
- * @author Roy H. Stogner, 2015
+ * \author Roy H. Stogner
+ * \date 2015
  */
 class NameBasedIO : public MeshInput<MeshBase>,
                     public MeshOutput<MeshBase>

--- a/include/mesh/namebased_io.h
+++ b/include/mesh/namebased_io.h
@@ -40,9 +40,6 @@ class MeshBase;
  *
  * @author Roy H. Stogner, 2015
  */
-
-// ------------------------------------------------------------
-// NameBasedIO class definition
 class NameBasedIO : public MeshInput<MeshBase>,
                     public MeshOutput<MeshBase>
 {

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -35,7 +35,6 @@ namespace libMesh
 // Forward declarations
 class Nemesis_IO_Helper;
 
-
 /**
  * The \p Nemesis_IO class implements reading parallel meshes in the
  * \p Nemesis file format from Sandia National Labs.  Nemesis files
@@ -45,7 +44,8 @@ class Nemesis_IO_Helper;
  * of files the Mesh is split into and rank is the ID of the processor's
  * elements that were written to the file.
  *
- * @author John Peterson, 2008.
+ * \author John Peterson
+ * \date 2008
  */
 class Nemesis_IO : public MeshInput<MeshBase>,
                    public MeshOutput<MeshBase>,

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -47,9 +47,6 @@ class Nemesis_IO_Helper;
  *
  * @author John Peterson, 2008.
  */
-
-// ------------------------------------------------------------
-// Nemesis_IO class definition
 class Nemesis_IO : public MeshInput<MeshBase>,
                    public MeshOutput<MeshBase>,
                    public ParallelObject

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -55,7 +55,8 @@ extern "C" {
  * ExodusII_IO_Helper object, since Nemesis is based on
  * the same file format.
  *
- * @author John W. Peterson, 2008.
+ * \author John W. Peterson
+ * \date 2008
  */
 class Nemesis_IO_Helper : public ExodusII_IO_Helper
 {

--- a/include/mesh/off_io.h
+++ b/include/mesh/off_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/off_io.h
+++ b/include/mesh/off_io.h
@@ -37,9 +37,6 @@ class MeshBase;
  * triangulated surface in the
  * standard OFF OOGL format.
  */
-
-// ------------------------------------------------------------
-// OFFIO class definition
 class OFFIO : public MeshInput<MeshBase>
 {
 public:

--- a/include/mesh/parallel_mesh.h
+++ b/include/mesh/parallel_mesh.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/parallel_mesh.h
+++ b/include/mesh/parallel_mesh.h
@@ -43,9 +43,6 @@ class Node;
  * By "is intended" I mean that it doesn't work that way yet.  Don't
  * use this class unless you're developing or debugging it.
  */
-
-// ------------------------------------------------------------
-// UnstructuredMesh class definition
 class ParallelMesh : public UnstructuredMesh
 {
 public:

--- a/include/mesh/patch.h
+++ b/include/mesh/patch.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/patch.h
+++ b/include/mesh/patch.h
@@ -35,14 +35,15 @@ namespace libMesh
 // Forward Declarations
 class Elem;
 
-
-
 /**
  * This class implements useful utility functions for a patch of
  * elements
  *
- * @author Roy H. Stogner, 2007.
- * based on code by Varis Carey, Benjamin S. Kirk, 2004.
+ * \author Varis Carey
+ * \author Benjamin S. Kirk
+ * \date 2004
+ * \author Roy H. Stogner
+ * \date 2007
  */
 class Patch : public std::set<const Elem *>
 {

--- a/include/mesh/postscript_io.h
+++ b/include/mesh/postscript_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/postscript_io.h
+++ b/include/mesh/postscript_io.h
@@ -47,7 +47,8 @@ class Elem;
  * images for publications, since I didn't find/don't know of a free
  * visualization program which would do this.
  *
- * @author John W. Peterson, 2008
+ * \author John W. Peterson
+ * \date 2008
  */
 class PostscriptIO : public MeshOutput<MeshBase>
 {

--- a/include/mesh/serial_mesh.h
+++ b/include/mesh/serial_mesh.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/serial_mesh.h
+++ b/include/mesh/serial_mesh.h
@@ -30,20 +30,12 @@
 namespace libMesh
 {
 
-
-
-
-
-
 /**
  * The \p SerialMesh class is derived from the \p MeshBase class,
  * and currently represents the default Mesh implementation.
  * Most methods for this class are found in MeshBase, and most
  * implementation details are found in UnstructuredMesh.
  */
-
-// ------------------------------------------------------------
-// Mesh class definition
 class SerialMesh : public UnstructuredMesh
 {
 public:

--- a/include/mesh/tecplot_io.h
+++ b/include/mesh/tecplot_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/tecplot_io.h
+++ b/include/mesh/tecplot_io.h
@@ -34,12 +34,11 @@ namespace libMesh
 // Forward declarations
 class MeshBase;
 
-
-
 /**
  * This class implements writing meshes in the Tecplot format.
  *
- * @author Benjamin S. Kirk, 2004
+ * \author Benjamin S. Kirk
+ * \date 2004
  */
 class TecplotIO : public MeshOutput<MeshBase>
 {

--- a/include/mesh/tecplot_io.h
+++ b/include/mesh/tecplot_io.h
@@ -41,9 +41,6 @@ class MeshBase;
  *
  * @author Benjamin S. Kirk, 2004
  */
-
-// ------------------------------------------------------------
-// TecplotIO class definition
 class TecplotIO : public MeshOutput<MeshBase>
 {
 public:

--- a/include/mesh/tetgen_io.h
+++ b/include/mesh/tetgen_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/tetgen_io.h
+++ b/include/mesh/tetgen_io.h
@@ -44,9 +44,6 @@ class MeshData;
  *
  * @author Benjamin S. Kirk, 2004
  */
-
-// ------------------------------------------------------------
-// TetGenIO class definition
 class TetGenIO : public MeshInput<MeshBase>,
                  public MeshOutput<MeshBase>
 {

--- a/include/mesh/tetgen_io.h
+++ b/include/mesh/tetgen_io.h
@@ -42,7 +42,8 @@ class MeshData;
  * Format description:
  * cf. <a href="http://tetgen.berlios.de/">TetGen home page</a>.
  *
- * @author Benjamin S. Kirk, 2004
+ * \author Benjamin S. Kirk
+ * \date 2004
  */
 class TetGenIO : public MeshInput<MeshBase>,
                  public MeshOutput<MeshBase>

--- a/include/mesh/ucd_io.h
+++ b/include/mesh/ucd_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/ucd_io.h
+++ b/include/mesh/ucd_io.h
@@ -41,9 +41,6 @@ class MeshBase;
  *
  * @author Benjamin S. Kirk, 2004
  */
-
-// ------------------------------------------------------------
-// UCDIO class definition
 class UCDIO : public MeshInput<MeshBase>,
               public MeshOutput<MeshBase>
 {

--- a/include/mesh/ucd_io.h
+++ b/include/mesh/ucd_io.h
@@ -34,12 +34,11 @@ namespace libMesh
 // Forward declarations
 class MeshBase;
 
-
-
 /**
  * This class implements reading & writing meshes in the AVS's UCD format.
  *
- * @author Benjamin S. Kirk, 2004
+ * \author Benjamin S. Kirk
+ * \date 2004
  */
 class UCDIO : public MeshInput<MeshBase>,
               public MeshOutput<MeshBase>

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -45,9 +45,6 @@ class MeshData;
  * boundary, instantiate a BoundaryMesh with a reference to
  * this class, and then use that object's functionality.
  */
-
-// ------------------------------------------------------------
-// UnstructuredMesh class definition
 class UnstructuredMesh : public MeshBase
 {
 public:

--- a/include/mesh/unv_io.h
+++ b/include/mesh/unv_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -55,9 +55,6 @@ class MeshData;
  * @author Wout Ruijter, 2007
  * (Checked in to LibMesh by J.W. Peterson)
  */
-
-// ------------------------------------------------------------
-// VTKIO class definition
 class VTKIO : public MeshInput<MeshBase>,
               public MeshOutput<MeshBase>
 {

--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -52,8 +52,9 @@ class MeshData;
  * This class will not have any functionality unless VTK is detected
  * during configure and hence LIBMESH_HAVE_VTK is defined.
  *
- * @author Wout Ruijter, 2007
- * (Checked in to LibMesh by J.W. Peterson)
+ * \author Wout Ruijter
+ * \author John W. Peterson
+ * \date 2007
  */
 class VTKIO : public MeshInput<MeshBase>,
               public MeshOutput<MeshBase>

--- a/include/mesh/xdr_head.h
+++ b/include/mesh/xdr_head.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/xdr_head.h
+++ b/include/mesh/xdr_head.h
@@ -29,7 +29,9 @@ namespace libMesh
  * solution (\p XdrSHEAD) or mesh (\p XdrMHEAD) header interface
  * classes.
  *
- * @author Bill Barth, Robert McLay.
+ * \author Bill Barth
+ * \author Robert McLay
+ * \date 2000
  */
 class XdrHEAD
 {

--- a/include/mesh/xdr_io.h
+++ b/include/mesh/xdr_io.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/xdr_io.h
+++ b/include/mesh/xdr_io.h
@@ -42,12 +42,13 @@ class Elem;
 
 
 /**
+ * MeshIO class used for writing XDR (eXternal Data Representation)
+ * and XDA mesh files.  XDR/XDA is libmesh's internal data format, and
+ * allows the full refinement tree structure of the mesh to be written
+ * to file.
  *
  * @author Benjamin Kirk, John Peterson, 2004.
  */
-
-// ------------------------------------------------------------
-// XdrIO class definition
 class XdrIO : public MeshInput<MeshBase>,
               public MeshOutput<MeshBase>,
               public ParallelObject

--- a/include/mesh/xdr_io.h
+++ b/include/mesh/xdr_io.h
@@ -40,14 +40,15 @@ class MeshData;
 class Xdr;
 class Elem;
 
-
 /**
  * MeshIO class used for writing XDR (eXternal Data Representation)
  * and XDA mesh files.  XDR/XDA is libmesh's internal data format, and
  * allows the full refinement tree structure of the mesh to be written
  * to file.
  *
- * @author Benjamin Kirk, John Peterson, 2004.
+ * \author Benjamin Kirk
+ * \author John Peterson
+ * \date 2004
  */
 class XdrIO : public MeshInput<MeshBase>,
               public MeshOutput<MeshBase>,

--- a/include/mesh/xdr_mesh.h
+++ b/include/mesh/xdr_mesh.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/xdr_mesh.h
+++ b/include/mesh/xdr_mesh.h
@@ -36,7 +36,9 @@ class XdrMHEAD;
  * information about the mesh
  * to \p xdr style binary files.
  *
- * @author Bill Barth, Robert McLay.
+ * \author Bill Barth
+ * \author Robert McLay
+ * \date 2000
  */
 class XdrMESH: public XdrMGF
 {

--- a/include/mesh/xdr_mgf.h
+++ b/include/mesh/xdr_mgf.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/xdr_mgf.h
+++ b/include/mesh/xdr_mgf.h
@@ -67,8 +67,6 @@ namespace libMesh
  * platforms.  For more information on the \p xdr format, see the
  * standard C include file \p rpc/rpc.h.
  *
- * @author Bill Barth, Robert McLay.
- *
  * There are essentially two inheritance trees and six classes:
  *       XdrMGF                         XdrHEAD
  *     ^        ^                    ^          ^
@@ -81,6 +79,10 @@ namespace libMesh
  *
  * XdrMGF, XdrMESH, and XdrSOLN handle the "meat" of the files: everything
  * other than the headers.
+ *
+ * \author Bill Barth
+ * \author Robert McLay
+ * \date 2000
  */
 class XdrMGF
 {

--- a/include/mesh/xdr_mhead.h
+++ b/include/mesh/xdr_mhead.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/xdr_mhead.h
+++ b/include/mesh/xdr_mhead.h
@@ -34,7 +34,10 @@ namespace libMesh
  * This class is responsible
  * for reading/writing \p xdr mesh file headers.
  *
- * @author Bill Barth, Robert McLay.  Modified: John W. Peterson
+ * \author Bill Barth
+ * \author Robert McLay
+ * \author John W. Peterson
+ * \date 2000
  */
 class XdrMHEAD : public XdrHEAD
 {

--- a/include/mesh/xdr_shead.h
+++ b/include/mesh/xdr_shead.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/xdr_shead.h
+++ b/include/mesh/xdr_shead.h
@@ -31,7 +31,9 @@ namespace libMesh
  * The \p XdrSHEAD class.  This class is responsible for
  * reading/writing \p xdr solution file headers.
  *
- * @author Bill Barth, Robert McLay.
+ * \author Bill Barth
+ * \author Robert McLay
+ * \date 2000
  */
 class XdrSHEAD : public XdrHEAD
 {

--- a/include/mesh/xdr_soln.h
+++ b/include/mesh/xdr_soln.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/mesh/xdr_soln.h
+++ b/include/mesh/xdr_soln.h
@@ -36,7 +36,9 @@ class XdrSHEAD;
  * information about the solution
  * to \p xdr style binary files.
  *
- * @author Bill Barth, Robert McLay.
+ * \author Bill Barth
+ * \author Robert McLay
+ * \date 2000
  */
 class XdrSOLN: public XdrMGF
 {

--- a/include/numerics/analytic_function.h
+++ b/include/numerics/analytic_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/analytic_function.h
+++ b/include/numerics/analytic_function.h
@@ -29,19 +29,17 @@
 namespace libMesh
 {
 
-
-
 // Forward Declarations
 template <typename T>
 class DenseVector;
-
 
 /**
  * This class provides function-like objects for which an
  * analytical expression can be provided.  The user may
  * either provide vector-return or number-return functions.
  *
- * @author Daniel Dreyer, 2003
+ * \author Daniel Dreyer
+ * \date 2003
  */
 template <typename Output=Number>
 class AnalyticFunction : public FunctionBase<Output>

--- a/include/numerics/analytic_function.h
+++ b/include/numerics/analytic_function.h
@@ -43,9 +43,6 @@ class DenseVector;
  *
  * @author Daniel Dreyer, 2003
  */
-
-// ------------------------------------------------------------
-// AnalyticFunction class definition
 template <typename Output=Number>
 class AnalyticFunction : public FunctionBase<Output>
 {

--- a/include/numerics/composite_fem_function.h
+++ b/include/numerics/composite_fem_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/composite_function.h
+++ b/include/numerics/composite_function.h
@@ -1,5 +1,5 @@
 //-------------// The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/const_fem_function.h
+++ b/include/numerics/const_fem_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/const_function.h
+++ b/include/numerics/const_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/coupling_matrix.h
+++ b/include/numerics/coupling_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -43,9 +43,6 @@ template <typename T> class DenseVector;
  *
  * @author Benjamin S. Kirk, 2002
  */
-
-// ------------------------------------------------------------
-// Dense Matrix class definition
 template<typename T>
 class DenseMatrix : public DenseMatrixBase<T>
 {

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -34,14 +34,13 @@ namespace libMesh
 // Forward Declarations
 template <typename T> class DenseVector;
 
-
-
 /**
  * Defines a dense matrix for use in Finite Element-type computations.
  * Useful for storing element stiffness matrices before summation
  * into a global matrix.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
 template<typename T>
 class DenseMatrix : public DenseMatrixBase<T>

--- a/include/numerics/dense_matrix_base.h
+++ b/include/numerics/dense_matrix_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/dense_matrix_base.h
+++ b/include/numerics/dense_matrix_base.h
@@ -32,15 +32,13 @@ namespace libMesh
 // Forward Delcarations
 template <typename T> class DenseVectorBase;
 
-
-
-
 /**
  * Defines an abstract dense matrix base class for use in Finite Element-type
  * computations.  Specialized dense matrices, for example DenseSubMatrices,
  * can be derived from this class.
  *
- * @author John W. Peterson, 2003
+ * \author John W. Peterson
+ * \date 2003
  */
 template<typename T>
 class DenseMatrixBase

--- a/include/numerics/dense_submatrix.h
+++ b/include/numerics/dense_submatrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/dense_submatrix.h
+++ b/include/numerics/dense_submatrix.h
@@ -39,9 +39,6 @@ namespace libMesh
  *
  * @author Benjamin S. Kirk, 2003
  */
-
-// ------------------------------------------------------------
-// DenseSubMatrix class definition
 template<typename T>
 class DenseSubMatrix : public DenseMatrixBase<T>
 {

--- a/include/numerics/dense_submatrix.h
+++ b/include/numerics/dense_submatrix.h
@@ -30,14 +30,13 @@
 namespace libMesh
 {
 
-
-
 /**
  * Defines a dense submatrix for use in Finite Element-type computations.
  * Useful for storing element stiffness matrices before summation
  * into a global matrix, particularly when you have systems of equations.
  *
- * @author Benjamin S. Kirk, 2003
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 template<typename T>
 class DenseSubMatrix : public DenseMatrixBase<T>

--- a/include/numerics/dense_subvector.h
+++ b/include/numerics/dense_subvector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/dense_subvector.h
+++ b/include/numerics/dense_subvector.h
@@ -29,20 +29,18 @@
 namespace libMesh
 {
 
-
-
 /**
  * Defines a dense subvector for use in Finite Element-type computations.
  * Useful for storing element load vectors  before summation
  * into a global vector, particularly when you have systems of equations.
  *
- * @author Benjamin S. Kirk, 2003
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 template<typename T>
 class DenseSubVector : public DenseVectorBase<T>
 {
 public:
-
   /**
    * Constructor.  Creates a dense subvector of the vector
    * \p parent.  The subvector has dimensions \f$(m \times n)\f$,

--- a/include/numerics/dense_subvector.h
+++ b/include/numerics/dense_subvector.h
@@ -38,9 +38,6 @@ namespace libMesh
  *
  * @author Benjamin S. Kirk, 2003
  */
-
-// ------------------------------------------------------------
-// DenseSubVector class definition
 template<typename T>
 class DenseSubVector : public DenseVectorBase<T>
 {

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -44,9 +44,6 @@ namespace libMesh
  *
  * @author Benjamin S. Kirk, 2003
  */
-
-// ------------------------------------------------------------
-// DenseVector class definition
 template<typename T>
 class DenseVector : public DenseVectorBase<T>
 {

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -32,17 +32,14 @@
 namespace libMesh
 {
 
-// Forward Declarations
-
-
-
 /**
  * Defines a dense vector for use in Finite Element-type computations.
  * This class is to basically compliment the \p DenseMatix class.  It
  * has additional capabilities over the \p std::vector that make it
  * useful for finite elements, particulary for systems of equations.
  *
- * @author Benjamin S. Kirk, 2003
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 template<typename T>
 class DenseVector : public DenseVectorBase<T>

--- a/include/numerics/dense_vector_base.h
+++ b/include/numerics/dense_vector_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/dense_vector_base.h
+++ b/include/numerics/dense_vector_base.h
@@ -39,9 +39,6 @@ namespace libMesh
  *
  * @author John W. Peterson, 2003
  */
-
-// ------------------------------------------------------------
-// DenseVectorBase class definition
 template<typename T>
 class DenseVectorBase
 {

--- a/include/numerics/dense_vector_base.h
+++ b/include/numerics/dense_vector_base.h
@@ -29,21 +29,18 @@
 namespace libMesh
 {
 
-
-
-
 /**
  * Defines an abstract dense vector base class for use in
  * Finite Element-type computations. Specialized dense vectors,
  * for example DenseSubVectors, can be derived from this class.
  *
- * @author John W. Peterson, 2003
+ * \author John W. Peterson
+ * \date 2003
  */
 template<typename T>
 class DenseVectorBase
 {
 public:
-
   /**
    * Constructor.  Empty.
    */
@@ -103,14 +100,6 @@ public:
   void print_scientific(std::ostream& os) const;
 
 };
-
-
-
-// ------------------------------------------------------------
-// DenseVectorBase member functions
-
-
-
 
 } // namespace libMesh
 

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -36,8 +36,6 @@
 namespace libMesh
 {
 
-
-
 /**
  * Distributed vector. Provides an interface for simple
  * parallel, distributed vectors. Offers some collective
@@ -45,9 +43,9 @@ namespace libMesh
  * sill function without MPI, but only on one processor.
  * This lets us keep the parallel details behind the scenes.
  *
- * @author Benjamin S. Kirk, 2003
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
-
 template <typename T>
 class DistributedVector : public NumericVector<T>
 {

--- a/include/numerics/eigen_core_support.h
+++ b/include/numerics/eigen_core_support.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/eigen_preconditioner.h
+++ b/include/numerics/eigen_preconditioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/eigen_preconditioner.h
+++ b/include/numerics/eigen_preconditioner.h
@@ -33,10 +33,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 
-// Eigen includes
-
-// C++ includes
-
 namespace libMesh
 {
 
@@ -49,14 +45,13 @@ template <typename T> class ShellMatrix;
  * This class provides an interface to the suite of preconditioners available
  * from Eigen.
  *
- * @author Benjamin Kirk, 2013.
+ * \author Benjamin Kirk
+ * \date 2013
  */
-
 template <typename T>
 class EigenPreconditioner : public Preconditioner<T>
 {
 public:
-
   /**
    *  Constructor. Initializes EigenPreconditioner data structures
    */
@@ -83,8 +78,6 @@ public:
    * Initialize data structures if not done so already.
    */
   virtual void init ();
-
-protected:
 };
 
 

--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -37,22 +37,18 @@
 namespace libMesh
 {
 
-
-
 // Forward declarations
 template <typename T> class DenseMatrix;
 template <typename T> class EigenSparseVector;
 template <typename T> class EigenSparseLinearSolver;
 
-
-
 /**
  * The EigenSparseMatrix class wraps a sparse matrix object from the Eigen
  * library.
  *
- * @author Benjamin S. Kirk, 2013
+ * \author Benjamin S. Kirk
+ * \date 2013
  */
-
 template <typename T>
 class EigenSparseMatrix : public SparseMatrix<T>
 {

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -31,27 +31,21 @@
 #include "libmesh/eigen_core_support.h"
 #include "libmesh/numeric_vector.h"
 
-// C++ includes
-
-// Eigen includes
-
 namespace libMesh
 {
-
 
 // Forward declarations
 template <typename T> class EigenSparseMatrix;
 template <typename T> class EigenSparseLinearSolver;
 template <typename T> class SparseMatrix;
 
-
 /**
  * Eigen vector.  Provides a nice interface to the
  * Eigen C-based data structures for serial vectors.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
-
 template <typename T>
 class EigenSparseVector : public NumericVector<T>
 {

--- a/include/numerics/fem_function_base.h
+++ b/include/numerics/fem_function_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/fem_function_base.h
+++ b/include/numerics/fem_function_base.h
@@ -39,8 +39,13 @@ namespace libMesh
 class Point;
 
 
-// ------------------------------------------------------------
-// FEMFunctionBase class definition
+/**
+ * FEMFunctionBase is a base class from which users can derive in
+ * order to define "function-like" objects that can be used within
+ * FEMSystem.
+ *
+ * @author Roy Stogner, 2012.
+ */
 template <typename Output=Number>
 class FEMFunctionBase
 {

--- a/include/numerics/fem_function_base.h
+++ b/include/numerics/fem_function_base.h
@@ -33,18 +33,16 @@
 namespace libMesh
 {
 
-
-
 // Forward Declarations
 class Point;
-
 
 /**
  * FEMFunctionBase is a base class from which users can derive in
  * order to define "function-like" objects that can be used within
  * FEMSystem.
  *
- * @author Roy Stogner, 2012.
+ * \author Roy Stogner
+ * \date 2012
  */
 template <typename Output=Number>
 class FEMFunctionBase

--- a/include/numerics/function_base.h
+++ b/include/numerics/function_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/function_base.h
+++ b/include/numerics/function_base.h
@@ -31,11 +31,8 @@
 namespace libMesh
 {
 
-
-
 // Forward Declarations
 class Point;
-
 
 /**
  * This is the base class for functor-like classes.  These
@@ -56,7 +53,8 @@ class Point;
  * spatial dimensions, libMesh is expecting 2 components (i.e.
  * mesh_dimension() number of components).
  *
- * @author Daniel Dreyer, 2003
+ * \author Daniel Dreyer
+ * \date 2003
  */
 template <typename Output=Number>
 class FunctionBase

--- a/include/numerics/function_base.h
+++ b/include/numerics/function_base.h
@@ -58,9 +58,6 @@ class Point;
  *
  * @author Daniel Dreyer, 2003
  */
-
-// ------------------------------------------------------------
-// FunctionBase class definition
 template <typename Output=Number>
 class FunctionBase
 {

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -37,14 +37,10 @@
 namespace libMesh
 {
 
-
-
 // Forward declarations
 template <typename T> class DenseMatrix;
 template <typename T> class LaspackVector;
 template <typename T> class LaspackLinearSolver;
-
-
 
 /**
  * The LaspackMatrix class wraps a QMatrix object from the Laspack
@@ -52,9 +48,9 @@ template <typename T> class LaspackLinearSolver;
  * class is a full specialization of \p SparseMatrix<T> with \p T = \p
  * Real.
  *
- * @author Benjamin S. Kirk, 2003
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
-
 template <typename T>
 class LaspackMatrix : public SparseMatrix<T>
 {

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -40,19 +40,17 @@
 namespace libMesh
 {
 
-
 // Forward declarations
 template <typename T> class LaspackLinearSolver;
 template <typename T> class SparseMatrix;
-
 
 /**
  * Laspack vector.  Provides a nice interface to the
  * Laspack C-based data structures for serial vectors.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
-
 template <typename T>
 class LaspackVector : public NumericVector<T>
 {

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -54,7 +54,8 @@ template <typename T> class ShellMatrix;
  * to vector storage schemes for different linear
  * algebra libraries.
  *
- * @author Benjamin S. Kirk, 2003
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 template <typename T>
 class NumericVector : public ReferenceCountedObject<NumericVector<T> >,

--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -42,7 +42,8 @@ namespace libMesh
  * ParsedFEMFunction provides support for FParser-based parsed
  * functions in FEMSystem.
  *
- * @author Roy Stogner, 2014.
+ * \author Roy Stogner
+ * \date 2014
  */
 template <typename Output=Number>
 class ParsedFEMFunction : public FEMFunctionBase<Output>

--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -38,8 +38,12 @@
 namespace libMesh
 {
 
-// ------------------------------------------------------------
-// ParsedFEMFunction class definition
+/**
+ * ParsedFEMFunction provides support for FParser-based parsed
+ * functions in FEMSystem.
+ *
+ * @author Roy Stogner, 2014.
+ */
 template <typename Output=Number>
 class ParsedFEMFunction : public FEMFunctionBase<Output>
 {

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/petsc_macro.h
+++ b/include/numerics/petsc_macro.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -70,9 +70,9 @@ template <typename T> class DenseMatrix;
  * Petsc C-based data structures for parallel,
  * sparse matrices.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
-
 template <typename T>
 class PetscMatrix : public SparseMatrix<T>
 {

--- a/include/numerics/petsc_preconditioner.h
+++ b/include/numerics/petsc_preconditioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/petsc_preconditioner.h
+++ b/include/numerics/petsc_preconditioner.h
@@ -52,9 +52,9 @@ template <typename T> class ShellMatrix;
  * This class provides an interface to the suite of preconditioners available
  * from Petsc.
  *
- * @author Derek Gaston, 2009
+ * \author Derek Gaston
+ * \date 2009
  */
-
 template <typename T>
 class PetscPreconditioner : public Preconditioner<T>
 {

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -47,8 +47,6 @@ EXTERN_C_FOR_PETSC_END
 namespace libMesh
 {
 
-
-
 // forward declarations
 template <typename T> class SparseMatrix;
 
@@ -56,9 +54,9 @@ template <typename T> class SparseMatrix;
  * Petsc vector. Provides a nice interface to the
  * Petsc C-based data structures for parallel vectors.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
-
 template <typename T>
 class PetscVector : public NumericVector<T>
 {

--- a/include/numerics/preconditioner.h
+++ b/include/numerics/preconditioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/preconditioner.h
+++ b/include/numerics/preconditioner.h
@@ -41,10 +41,6 @@ template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
 
-
-
-
-
 /**
  * This class provides a uniform interface for preconditioners.  This base
  * class is overloaded to provide linear solvers from different packages
@@ -54,9 +50,9 @@ template <typename T> class ShellMatrix;
  * performing the equivalent of the matrix vector product P^-1 x.  This
  * can also be thought of as (usually approximately) solving for Py=x.
  *
- * @author Derek Gaston, 2009
+ * \author Derek Gaston
+ * \date 2009
  */
-
 template <typename T>
 class Preconditioner : public ReferenceCountedObject<Preconditioner<T> >,
                        public ParallelObject

--- a/include/numerics/raw_accessor.h
+++ b/include/numerics/raw_accessor.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/refinement_selector.h
+++ b/include/numerics/refinement_selector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/refinement_selector.h
+++ b/include/numerics/refinement_selector.h
@@ -42,7 +42,8 @@ class System;
  * refinement.  Future subclasses may handle anisotropic refinement
  * instead.
  *
- * @author Roy H. Stogner, 2006.
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class RefinementSelector
 {

--- a/include/numerics/shell_matrix.h
+++ b/include/numerics/shell_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/shell_matrix.h
+++ b/include/numerics/shell_matrix.h
@@ -40,9 +40,9 @@ template <typename T> class NumericVector;
  * but its action on a vector.  This class contains pure virtual
  * members that must be overloaded in derived classes.
  *
- * @author Tim Kroeger, 2008
+ * \author Tim Kroeger
+ * \date 2008
  */
-
 template <typename T>
 class ShellMatrix : public ReferenceCountedObject<ShellMatrix<T> >,
                     public ParallelObject

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -58,9 +58,9 @@ std::ostream& operator << (std::ostream& os, const SparseMatrix<T>& m);
  * from various different solver packages in
  * different formats.
  *
- * @author Benjamin S. Kirk, 2003
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
-
 template <typename T>
 class SparseMatrix : public ReferenceCountedObject<SparseMatrix<T> >,
                      public ParallelObject

--- a/include/numerics/sparse_shell_matrix.h
+++ b/include/numerics/sparse_shell_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/sparse_shell_matrix.h
+++ b/include/numerics/sparse_shell_matrix.h
@@ -31,13 +31,12 @@
 namespace libMesh
 {
 
-
 /**
  * This class allows to use any SparseMatrix object as a shell matrix.
  *
- * @author Tim Kroeger, 2008
+ * \author Tim Kroeger
+ * \date 2008
  */
-
 template <typename T>
 class SparseShellMatrix : public ShellMatrix<T>
 {

--- a/include/numerics/sum_shell_matrix.h
+++ b/include/numerics/sum_shell_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/sum_shell_matrix.h
+++ b/include/numerics/sum_shell_matrix.h
@@ -32,15 +32,13 @@
 namespace libMesh
 {
 
-
-
 /**
  * This class combines any number of shell matrices to a single shell
  * matrix, acting as the sum of the matrices.
  *
- * @author Tim Kroeger, 2008
+ * \author Tim Kroeger
+ * \date 2008
  */
-
 template <typename T>
 class SumShellMatrix : public ShellMatrix<T>
 {

--- a/include/numerics/tensor_shell_matrix.h
+++ b/include/numerics/tensor_shell_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/tensor_shell_matrix.h
+++ b/include/numerics/tensor_shell_matrix.h
@@ -35,9 +35,9 @@ namespace libMesh
  * Shell matrix that is given by a tensor of two vectors, i.e. A =
  * v*w^T.
  *
- * @author Tim Kroeger, 2008
+ * \author Tim Kroeger
+ * \date 2008
  */
-
 template <typename T>
 class TensorShellMatrix : public ShellMatrix<T>
 {

--- a/include/numerics/tensor_tools.h
+++ b/include/numerics/tensor_tools.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/tensor_value.h
+++ b/include/numerics/tensor_value.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/tensor_value.h
+++ b/include/numerics/tensor_value.h
@@ -34,7 +34,8 @@ namespace libMesh
  * and NumberTensorValue defines a real or complex-valued tensor depending
  * on how the library was configured.
  *
- * \author Roy H. Stogner 2004
+ * \author Roy H. Stogner
+ * \date 2004
  */
 template <typename T>
 class TensorValue : public TypeTensor<T>

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -50,9 +50,9 @@ template <typename T> class DenseMatrix;
  * Epetra data structures for parallel,
  * sparse matrices.
  *
- * @author Benjamin S. Kirk, 2008
+ * \author Benjamin S. Kirk
+ * \date 2008
  */
-
 template <typename T>
 class EpetraMatrix : public SparseMatrix<T>
 {

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -53,9 +53,9 @@ template <typename T> class SparseMatrix;
  * Epetra vector. Provides a nice interface to the
  * Trilinos Epetra data structures for parallel vectors.
  *
- * @author Derek R. Gaston, 2008
+ * \author Derek R. Gaston
+ * \date 2008
  */
-
 template <typename T>
 class EpetraVector : public NumericVector<T>
 {

--- a/include/numerics/trilinos_preconditioner.h
+++ b/include/numerics/trilinos_preconditioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/trilinos_preconditioner.h
+++ b/include/numerics/trilinos_preconditioner.h
@@ -53,9 +53,9 @@ template <typename T> class ShellMatrix;
  * This class provides an interface to the suite of preconditioners available
  * from Trilinos.
  *
- * @author David Andrs, 2011
+ * \author David Andrs
+ * \date 2011
  */
-
 template <typename T>
 class TrilinosPreconditioner :
     public Preconditioner<T>,

--- a/include/numerics/type_n_tensor.h
+++ b/include/numerics/type_n_tensor.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/type_n_tensor.h
+++ b/include/numerics/type_n_tensor.h
@@ -31,7 +31,6 @@
 namespace libMesh
 {
 
-
 /**
  * This class will eventually define a rank-N tensor in \p LIBMESH_DIM
  * dimensional space of type T.
@@ -39,9 +38,9 @@ namespace libMesh
  * compile (but not give correct results) in the case of vector-valued
  * elements and second derivatives.
  *
- * \author Roy Stogner, 2012.
+ * \author Roy Stogner
+ * \date 2012
  */
-
 template <unsigned int N, typename T>
 class TypeNTensor
 {

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -36,17 +36,15 @@ template <typename T> class TypeTensorColumn;
 template <typename T> class ConstTypeTensorColumn;
 template <unsigned int N, typename T> class TypeNTensor;
 
-
-
 /**
  * This class defines a tensor in \p LIBMESH_DIM dimensional space of type T.
  * T may either be Real or Complex.  The default constructor for
  * this class is protected, suggesting that you should not instantiate
  * one of these directly.
  *
- * \author Roy Stogner, 2004.
+ * \author Roy Stogner
+ * \date 2004
  */
-
 template <typename T>
 class TypeTensor
 {

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -46,9 +46,9 @@ template <typename T> class TensorValue;
  * for a real-valued point in LIBMESH_DIM-space, or \p SpaceVector for a real
  * or complex-valued vector in LIBMESH_DIM-space.
  *
- * \author Benjamin S. Kirk, 2003.
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
-
 template <typename T>
 class TypeVector
 {

--- a/include/numerics/vector_value.h
+++ b/include/numerics/vector_value.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/vector_value.h
+++ b/include/numerics/vector_value.h
@@ -34,7 +34,8 @@ namespace libMesh
  * and NumberVectorValue defines a real or complex-valued vector depending
  * on how the library was configured.
  *
- * \author Benjamin S. Kirk, 2003.
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 template <typename T>
 class VectorValue : public TypeVector<T>

--- a/include/numerics/wrapped_function.h
+++ b/include/numerics/wrapped_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/wrapped_function.h
+++ b/include/numerics/wrapped_function.h
@@ -42,9 +42,6 @@ namespace libMesh
  *
  * @author Roy Stogner, 2012
  */
-
-// ------------------------------------------------------------
-// WrappedFunction class definition
 template <typename Output=Number>
 class WrappedFunction : public FunctionBase<Output>
 {

--- a/include/numerics/wrapped_function.h
+++ b/include/numerics/wrapped_function.h
@@ -34,13 +34,13 @@
 namespace libMesh
 {
 
-
 /**
  * This class provides a wrapper with which to evaluate a
  * (libMesh-style) function pointer in a FunctionBase-compatible
  * interface.
  *
- * @author Roy Stogner, 2012
+ * \author Roy Stogner
+ * \date 2012
  */
 template <typename Output=Number>
 class WrappedFunction : public FunctionBase<Output>

--- a/include/numerics/wrapped_functor.h
+++ b/include/numerics/wrapped_functor.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/numerics/wrapped_functor.h
+++ b/include/numerics/wrapped_functor.h
@@ -31,13 +31,13 @@
 namespace libMesh
 {
 
-
 /**
  * This class provides a wrapper with which to evaluate a
  * (libMesh-style) function pointer in a FunctionBase-compatible
  * interface.
  *
- * @author Roy Stogner, 2015
+ * \author Roy Stogner
+ * \date 2015
  */
 template <typename Output=Number>
 class WrappedFunctor : public FEMFunctionBase<Output>

--- a/include/numerics/wrapped_functor.h
+++ b/include/numerics/wrapped_functor.h
@@ -39,10 +39,6 @@ namespace libMesh
  *
  * @author Roy Stogner, 2015
  */
-
-
-// ------------------------------------------------------------
-// WrappedFunctor class definition
 template <typename Output=Number>
 class WrappedFunctor : public FEMFunctionBase<Output>
 {

--- a/include/numerics/zero_function.h
+++ b/include/numerics/zero_function.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_bin_sorter.h
+++ b/include/parallel/parallel_bin_sorter.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_conversion_utils.h
+++ b/include/parallel/parallel_conversion_utils.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_elem.h
+++ b/include/parallel/parallel_elem.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_histogram.h
+++ b/include/parallel/parallel_histogram.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_node.h
+++ b/include/parallel/parallel_node.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/parallel_object.h
+++ b/include/parallel/parallel_object.h
@@ -42,7 +42,8 @@ namespace libMesh
  * \p ParalelObject *requires* a \p Parallel::Communicator object
  * for construction.
  *
- * \author Benjamin S. Kirk, 2013.
+ * \author Benjamin S. Kirk
+ * \date 2013
  */
 class ParallelObject
 {

--- a/include/parallel/parallel_sort.h
+++ b/include/parallel/parallel_sort.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/parallel/threads_allocators.h
+++ b/include/parallel/threads_allocators.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/centroid_partitioner.h
+++ b/include/partitioning/centroid_partitioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/centroid_partitioner.h
+++ b/include/partitioning/centroid_partitioner.h
@@ -43,7 +43,9 @@ class Elem;
  * define "less than" differently than if you cared about radial
  * distance.
  *
- * @author John W. Peterson and Benjamin S. Kirk, 2003
+ * \author John W. Peterson
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 class CentroidPartitioner : public Partitioner
 {

--- a/include/partitioning/centroid_partitioner.h
+++ b/include/partitioning/centroid_partitioner.h
@@ -45,10 +45,6 @@ class Elem;
  *
  * @author John W. Peterson and Benjamin S. Kirk, 2003
  */
-
-
-
-// CentroidPartitioner class definition
 class CentroidPartitioner : public Partitioner
 {
 public:

--- a/include/partitioning/hilbert_sfc_partitioner.h
+++ b/include/partitioning/hilbert_sfc_partitioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/hilbert_sfc_partitioner.h
+++ b/include/partitioning/hilbert_sfc_partitioner.h
@@ -34,9 +34,6 @@ namespace libMesh
  * The \p HilbertSFCPartitioner uses a Hilbert space
  * filling curve to partition the elements.
  */
-
-// ------------------------------------------------------------
-// HilbertSFCLinearPartitioner class definition
 class HilbertSFCPartitioner : public SFCPartitioner
 {
 public:
@@ -64,12 +61,9 @@ protected:
    */
   virtual void _do_partition (MeshBase& mesh,
                               const unsigned int n)
-  { SFCPartitioner::_do_partition (mesh, n); }
-
-
-
-private:
-
+  {
+    SFCPartitioner::_do_partition (mesh, n);
+  }
 };
 
 } // namespace libMesh

--- a/include/partitioning/linear_partitioner.h
+++ b/include/partitioning/linear_partitioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/linear_partitioner.h
+++ b/include/partitioning/linear_partitioner.h
@@ -36,9 +36,6 @@ namespace libMesh
  * to each processor.  Health Warning: THIS PARTITIONER COULD BE ARBITRARILY
  * BAD!!
  */
-
-// ------------------------------------------------------------
-// LinearPartitioner class definition
 class LinearPartitioner : public Partitioner
 {
 public:
@@ -63,9 +60,6 @@ protected:
    */
   virtual void _do_partition (MeshBase& mesh,
                               const unsigned int n);
-
-private:
-
 };
 
 

--- a/include/partitioning/metis_csr_graph.h
+++ b/include/partitioning/metis_csr_graph.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/metis_partitioner.h
+++ b/include/partitioning/metis_partitioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/metis_partitioner.h
+++ b/include/partitioning/metis_partitioner.h
@@ -32,9 +32,6 @@ namespace libMesh
  * The \p MetisPartitioner uses the Metis graph partitioner
  * to partition the elements.
  */
-
-// ------------------------------------------------------------
-// MetisPartitioner class definition
 class MetisPartitioner : public Partitioner
 {
 public:

--- a/include/partitioning/morton_sfc_partitioner.h
+++ b/include/partitioning/morton_sfc_partitioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/morton_sfc_partitioner.h
+++ b/include/partitioning/morton_sfc_partitioner.h
@@ -34,9 +34,6 @@ namespace libMesh
  * The \p MortonSFCPartitioner uses a Morton space
  * filling curve to partition the elements.
  */
-
-// ------------------------------------------------------------
-// MortonSFCLinearPartitioner class definition
 class MortonSFCPartitioner : public SFCPartitioner
 {
 public:
@@ -64,11 +61,9 @@ protected:
    */
   virtual void _do_partition (MeshBase& mesh,
                               const unsigned int n)
-  { SFCPartitioner::_do_partition (mesh, n); }
-
-
-private:
-
+  {
+    SFCPartitioner::_do_partition (mesh, n);
+  }
 };
 
 } // namespace libMesh

--- a/include/partitioning/parmetis_helper.h
+++ b/include/partitioning/parmetis_helper.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/parmetis_partitioner.h
+++ b/include/partitioning/parmetis_partitioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/partitioner.h
+++ b/include/partitioning/partitioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/partitioner.h
+++ b/include/partitioning/partitioner.h
@@ -42,9 +42,6 @@ class ErrorVector;
  * object as input, which it will partition into a number of
  * subdomains.
  */
-
-// ------------------------------------------------------------
-// Partitioner class definition
 class Partitioner
 {
 public:

--- a/include/partitioning/sfc_partitioner.h
+++ b/include/partitioning/sfc_partitioner.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/partitioning/sfc_partitioner.h
+++ b/include/partitioning/sfc_partitioner.h
@@ -35,9 +35,6 @@ namespace libMesh
  * The \p SFCPartitioner uses a Hilbert or Morton-ordered space
  * filling curve to partition the elements.
  */
-
-// ------------------------------------------------------------
-// SFCPartitioner class definition
 class SFCPartitioner : public Partitioner
 {
 public:
@@ -82,7 +79,6 @@ private:
    * The type of space-filling curve to use.  Hilbert by default.
    */
   std::string _sfc_type;
-
 };
 
 

--- a/include/physics/diff_physics.h
+++ b/include/physics/diff_physics.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/physics/diff_physics.h
+++ b/include/physics/diff_physics.h
@@ -74,10 +74,6 @@ template <typename T> class NumericVector;
  *
  * @author Roy H. Stogner 2006
  */
-
-// ------------------------------------------------------------
-// DifferentiablePhysics class definition
-
 class DifferentiablePhysics
 {
 public:

--- a/include/physics/diff_physics.h
+++ b/include/physics/diff_physics.h
@@ -72,7 +72,8 @@ template <typename T> class NumericVector;
  * DiffContext::get_elem_solution_accel_derivative(). The should be incorporated
  * into the Jacobian evaluations, if the Jacobian is being provided.
  *
- * @author Roy H. Stogner 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class DifferentiablePhysics
 {

--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -43,10 +43,6 @@ namespace libMesh
  *
  * @author Roy H. Stogner 2006
  */
-
-// ------------------------------------------------------------
-// DifferentiableQoI class definition
-
 class DifferentiableQoI
 {
 public:

--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -41,7 +41,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class DifferentiableQoI
 {

--- a/include/physics/fem_physics.h
+++ b/include/physics/fem_physics.h
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/physics/fem_physics.h
+++ b/include/physics/fem_physics.h
@@ -39,7 +39,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2012
+ * \author Roy H. Stogner
+ * \date 2012
  */
 class FEMPhysics : public virtual DifferentiablePhysics
 {

--- a/include/physics/fem_physics.h
+++ b/include/physics/fem_physics.h
@@ -41,10 +41,6 @@ namespace libMesh
  *
  * @author Roy H. Stogner 2012
  */
-
-// ------------------------------------------------------------
-// Finite Element Method Physics class definition
-
 class FEMPhysics : public virtual DifferentiablePhysics
 {
 public:

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -47,7 +47,8 @@ class Elem;
  * \p dim dimensional points describing the quadrature locations
  * (referenced to a master object) and associated weights.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
 class QBase : public ReferenceCountedObject<QBase>
 {

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -49,10 +49,6 @@ class Elem;
  *
  * @author Benjamin S. Kirk, 2002
  */
-
-// ------------------------------------------------------------
-// QBase class definition
-
 class QBase : public ReferenceCountedObject<QBase>
 {
 protected:

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -28,14 +28,12 @@
 namespace libMesh
 {
 
-
-
-
 /**
  * This class creates a gaussian quadrature rule duplicated for each
  * subelement of a Clough-Tocher divided macroelement.
  *
- * @author Roy Stogner, 2005.
+ * \author Roy Stogner
+ * \date 2005
  */
 class QClough : public QBase
 {

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -34,11 +34,9 @@ namespace libMesh
 /**
  * This class creates a gaussian quadrature rule duplicated for each
  * subelement of a Clough-Tocher divided macroelement.
+ *
+ * @author Roy Stogner, 2005.
  */
-
-// ------------------------------------------------------------
-// QClough class definition
-
 class QClough : public QBase
 {
 public:

--- a/include/quadrature/quadrature_composite.h
+++ b/include/quadrature/quadrature_composite.h
@@ -41,10 +41,9 @@ namespace libMesh
  * applying the base rule on each subelement.  This class uses the
  * ElemCutter, which is only available if libmesh is configured with
  * --disable-strict-lgpl.
+ *
+ * @author Benjamin Kirk, 2013.
  */
-
-// ------------------------------------------------------------
-// QComposite class definition
 template <class QSubCell>
 class QComposite : public QSubCell
 {

--- a/include/quadrature/quadrature_composite.h
+++ b/include/quadrature/quadrature_composite.h
@@ -42,7 +42,8 @@ namespace libMesh
  * ElemCutter, which is only available if libmesh is configured with
  * --disable-strict-lgpl.
  *
- * @author Benjamin Kirk, 2013.
+ * \author Benjamin Kirk
+ * \date 2013
  */
 template <class QSubCell>
 class QComposite : public QSubCell

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -28,15 +28,14 @@
 namespace libMesh
 {
 
-
-
-
 /**
  * This class implemenets specific orders of Gauss quadrature.
  * Gauss quadrature rules of Order \p p have the property of
  * integrating polynomials of degree \p p exactly.
  *
- * @author Benjamin Kirk and John W. Peterson, 2003.
+ * \author Benjamin Kirk
+ * \author John W. Peterson
+ * \date 2003
  */
 class QGauss : public QBase
 {

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -35,11 +35,9 @@ namespace libMesh
  * This class implemenets specific orders of Gauss quadrature.
  * Gauss quadrature rules of Order \p p have the property of
  * integrating polynomials of degree \p p exactly.
+ *
+ * @author Benjamin Kirk and John W. Peterson, 2003.
  */
-
-// ------------------------------------------------------------
-// QGauss class definition
-
 class QGauss : public QBase
 {
 public:

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -92,7 +92,8 @@ namespace libMesh
  * Reference LGPL Fortran90 code by John Burkardt can be found here:
  * http://people.scs.fsu.edu/~burkardt/f_src/gm_rules/gm_rules.html
  *
- * @author John W. Peterson, 2008
+ * \author John W. Peterson
+ * \date 2008
  */
 class QGrundmann_Moller : public QBase
 {

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -28,9 +28,6 @@
 namespace libMesh
 {
 
-
-
-
 /**
  * This class creates quadrature points on a uniform grid, with
  * order+1 points on an edge.
@@ -45,7 +42,8 @@ namespace libMesh
  * functions which have discontinuities or discontinuous derivatives
  * on scales smaller than your element size.
  *
- * @author Roy Stogner, 2005.
+ * \author Roy Stogner
+ * \date 2005
  */
 class QGrid : public QBase
 {

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -44,11 +44,9 @@ namespace libMesh
  * This quadrature type may be useful iff you are integrating
  * functions which have discontinuities or discontinuous derivatives
  * on scales smaller than your element size.
+ *
+ * @author Roy Stogner, 2005.
  */
-
-// ------------------------------------------------------------
-// QGrid class definition
-
 class QGrid : public QBase
 {
 public:

--- a/include/quadrature/quadrature_jacobi.h
+++ b/include/quadrature/quadrature_jacobi.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_jacobi.h
+++ b/include/quadrature/quadrature_jacobi.h
@@ -44,7 +44,8 @@ namespace libMesh
  * Still, this class is particularly helpful: check \p QGauss
  * for triangles and tetrahedra, with orders beyond \p THIRTIETH.
  *
- * @author John W. Peterson, 2003
+ * \author John W. Peterson
+ * \date 2003
  */
 class QJacobi : public QBase
 {

--- a/include/quadrature/quadrature_jacobi.h
+++ b/include/quadrature/quadrature_jacobi.h
@@ -28,11 +28,6 @@
 namespace libMesh
 {
 
-
-// ------------------------------------------------------------
-// QJacobi class definition
-
-
 /**
  * This class implements two (for now) Jacobi-Gauss quadrature
  * rules.  These rules have the same order of accuracy as the
@@ -48,6 +43,8 @@ namespace libMesh
  * since it only provides 1D rules, weighted, as described before.
  * Still, this class is particularly helpful: check \p QGauss
  * for triangles and tetrahedra, with orders beyond \p THIRTIETH.
+ *
+ * @author John W. Peterson, 2003
  */
 class QJacobi : public QBase
 {

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -28,9 +28,6 @@
 namespace libMesh
 {
 
-
-
-
 /**
  * This class defines alternate quadrature rules on
  * "tensor-product" elements (QUADs and HEXes) which can be
@@ -58,10 +55,9 @@ namespace libMesh
  * We also provide the original reference for each rule, as available,
  * in the source code file.
  *
- * @author John W. Peterson, 2008
+ * \author John W. Peterson
+ * \date 2008
  */
-
-
 class QMonomial : public QBase
 {
 public:

--- a/include/quadrature/quadrature_rules.h
+++ b/include/quadrature/quadrature_rules.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -28,15 +28,13 @@
 namespace libMesh
 {
 
-
-
-
 /**
  * This class implemenets Simpson quadrature.
  * This is the same thing as Newton-Cotes quadrature with three points.
  * Simpson's rule can integrate polynomials of degree three exactly.
  *
- * @author John W. Peterson, 2003
+ * \author John W. Peterson
+ * \date 2003
  */
 class QSimpson : public QBase
 {

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -38,10 +38,6 @@ namespace libMesh
  *
  * @author John W. Peterson, 2003
  */
-
-// ------------------------------------------------------------
-// QSimpson class definition
-
 class QSimpson : public QBase
 {
 public:

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -33,7 +33,8 @@ namespace libMesh
  * as Newton-Cotes quadrature with two points.  These rules sample at
  * the corners and will integrate linears exactly.
  *
- * @author Benjamin Kirk, 2003.
+ * \author Benjamin Kirk
+ * \date 2003
  */
 class QTrap : public QBase
 {

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -28,15 +28,12 @@
 namespace libMesh
 {
 
-
-// ------------------------------------------------------------
-// QTrap class definition
-
-
 /**
- * This class implemenets trapezoidal quadratue.  Sometimes
- * also known as Newton-Cotes quadrature with two points.  These rules
- * sample at the corners and will integrate linears exactly.
+ * This class implemenets trapezoidal quadratue.  Sometimes also known
+ * as Newton-Cotes quadrature with two points.  These rules sample at
+ * the corners and will integrate linears exactly.
+ *
+ * @author Benjamin Kirk, 2003.
  */
 class QTrap : public QBase
 {

--- a/include/reduced_basis/rb_assembly_expansion.h
+++ b/include/reduced_basis/rb_assembly_expansion.h
@@ -37,9 +37,6 @@ namespace libMesh
  *
  * @author David J. Knezevic, 2011
  */
-
-// ------------------------------------------------------------
-// RBAssemblyExpansion class definition
 class RBAssemblyExpansion : public ReferenceCountedObject<RBAssemblyExpansion>
 {
 public:

--- a/include/reduced_basis/rb_assembly_expansion.h
+++ b/include/reduced_basis/rb_assembly_expansion.h
@@ -35,7 +35,8 @@ namespace libMesh
  * This class stores the set of ElemAssembly functor objects that define
  * the "parameter-independent expansion" of a PDE.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class RBAssemblyExpansion : public ReferenceCountedObject<RBAssemblyExpansion>
 {

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -49,11 +49,6 @@ class RBAssemblyExpansion;
  *
  * @author David J. Knezevic, 2009
  */
-
-
-// ------------------------------------------------------------
-// RBConstruction class definition
-
 class RBConstruction : public RBConstructionBase<LinearImplicitSystem>
 {
 public:

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -47,7 +47,8 @@ class RBAssemblyExpansion;
  * of the certified reduced basis method for
  * steady-state elliptic parametrized PDEs.
  *
- * @author David J. Knezevic, 2009
+ * \author David J. Knezevic
+ * \date 2009
  */
 class RBConstruction : public RBConstructionBase<LinearImplicitSystem>
 {

--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -47,7 +47,8 @@ namespace libMesh
  * for standard reduced basis, EigenSystem for SCM)
  * at compile time.
  *
- * @author David J. Knezevic, 2009
+ * \author David J. Knezevic
+ * \date 2009
  */
 template<class Base>
 class RBConstructionBase : public Base, public RBParametrized

--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -49,10 +49,6 @@ namespace libMesh
  *
  * @author David J. Knezevic, 2009
  */
-
-
-// ------------------------------------------------------------
-// RBConstructionBase class definition
 template<class Base>
 class RBConstructionBase : public Base, public RBParametrized
 {

--- a/include/reduced_basis/rb_eim_assembly.h
+++ b/include/reduced_basis/rb_eim_assembly.h
@@ -41,9 +41,9 @@ class RBEIMConstruction;
  * object that arises from an "Empirical Interpolation Method" (EIM)
  * approximation.
  *
- * @author David J. Knezevic, 2012
+ * \author David J. Knezevic
+ * \date 2012
  */
-
 class RBEIMAssembly : public ElemAssembly
 {
 public:

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -42,7 +42,8 @@ namespace libMesh
  * generate an affine approximation to non-affine
  * operators.
  *
- * @author David J. Knezevic, 2010
+ * \author David J. Knezevic
+ * \date 2010
  */
 class RBEIMConstruction : public RBConstruction
 {

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -44,10 +44,6 @@ namespace libMesh
  *
  * @author David J. Knezevic, 2010
  */
-
-// ------------------------------------------------------------
-// RBEIMConstruction class definition
-
 class RBEIMConstruction : public RBConstruction
 {
 public:

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -43,7 +43,8 @@ class RBParametrizedFunction;
  * to perform "online" evaluations for
  * EIM approximations.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class RBEIMEvaluation : public RBEvaluation
 {

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -45,10 +45,6 @@ class RBParametrizedFunction;
  *
  * @author David J. Knezevic, 2011
  */
-
-// ------------------------------------------------------------
-// RBEIMEvaluation class definition
-
 class RBEIMEvaluation : public RBEvaluation
 {
 public:

--- a/include/reduced_basis/rb_eim_theta.h
+++ b/include/reduced_basis/rb_eim_theta.h
@@ -36,9 +36,9 @@ class RBParameters;
  * object that arises from an "Empirical Interpolation Method" (EIM)
  * approximation.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
-
 class RBEIMTheta : public RBTheta
 {
 public:

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -44,7 +44,8 @@ template <typename T> class NumericVector;
  * RBEvaluation encapsulates the functionality required
  * to _evaluate_ a given reduced basis model.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class RBEvaluation : public RBParametrized,
                      public ParallelObject

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -46,9 +46,6 @@ template <typename T> class NumericVector;
  *
  * @author David J. Knezevic, 2011
  */
-
-// ------------------------------------------------------------
-// RBEvaluation class definition
 class RBEvaluation : public RBParametrized,
                      public ParallelObject
 {

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -36,7 +36,8 @@ namespace libMesh
  *
  * This class defines a set of parameters index by strings.
  *
- * @author David J. Knezevic, 2012
+ * \author David J. Knezevic
+ * \date 2012
  */
 class RBParameters
 {

--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -38,8 +38,6 @@ namespace libMesh
  *
  * @author David J. Knezevic, 2012
  */
-// ------------------------------------------------------------
-// RBParameters class definition
 class RBParameters
 {
 public:

--- a/include/reduced_basis/rb_parametrized.h
+++ b/include/reduced_basis/rb_parametrized.h
@@ -38,7 +38,8 @@ namespace libMesh
  * This class defines basic functionality of
  * a parametrized object.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class RBParametrized : public ReferenceCountedObject<RBParametrized>
 {

--- a/include/reduced_basis/rb_parametrized.h
+++ b/include/reduced_basis/rb_parametrized.h
@@ -40,8 +40,6 @@ namespace libMesh
  *
  * @author David J. Knezevic, 2011
  */
-// ------------------------------------------------------------
-// RBParametrized class definition
 class RBParametrized : public ReferenceCountedObject<RBParametrized>
 {
 public:

--- a/include/reduced_basis/rb_scm_construction.h
+++ b/include/reduced_basis/rb_scm_construction.h
@@ -47,10 +47,6 @@ namespace libMesh
  *
  * @author David J. Knezevic 2009
  */
-
-// ------------------------------------------------------------
-// RBSCMConstruction class definition
-
 class RBSCMConstruction : public RBConstructionBase<CondensedEigenSystem>
 {
 public:

--- a/include/reduced_basis/rb_scm_construction.h
+++ b/include/reduced_basis/rb_scm_construction.h
@@ -45,7 +45,8 @@ namespace libMesh
  * RBSCMConstruction implements the the Successive Constraint Method (SCM)
  * for computing rigorous lower bounds for stability constants.
  *
- * @author David J. Knezevic 2009
+ * \author David J. Knezevic
+ * \date 2009
  */
 class RBSCMConstruction : public RBConstructionBase<CondensedEigenSystem>
 {

--- a/include/reduced_basis/rb_scm_evaluation.h
+++ b/include/reduced_basis/rb_scm_evaluation.h
@@ -47,10 +47,6 @@ namespace libMesh
  *
  * @author David J. Knezevic, 2011
  */
-
-// ------------------------------------------------------------
-// RBSCMEvaluation class definition
-
 class RBSCMEvaluation : public RBParametrized,
                         public ParallelObject
 {

--- a/include/reduced_basis/rb_scm_evaluation.h
+++ b/include/reduced_basis/rb_scm_evaluation.h
@@ -45,7 +45,8 @@ namespace libMesh
  * to _evaluate_ the Successive Constraint Method for
  * associated with a reduced basis model.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class RBSCMEvaluation : public RBParametrized,
                         public ParallelObject

--- a/include/reduced_basis/rb_theta.h
+++ b/include/reduced_basis/rb_theta.h
@@ -40,7 +40,8 @@ class RBParameters;
  * for the PDE decomposition employed by the Reduced
  * Basis method.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class RBTheta : public ReferenceCountedObject<RBTheta>
 {

--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -40,9 +40,6 @@ class RBParameters;
  *
  * @author David J. Knezevic, 2011
  */
-
-// ------------------------------------------------------------
-// RBThetaExpansion class definition
 class RBThetaExpansion : public ReferenceCountedObject<RBThetaExpansion>
 {
 public:

--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -38,7 +38,8 @@ class RBParameters;
  * This class stores the set of RBTheta functor objects that define
  * the "parameter-dependent expansion" of a PDE.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class RBThetaExpansion : public ReferenceCountedObject<RBThetaExpansion>
 {

--- a/include/reduced_basis/transient_rb_assembly_expansion.h
+++ b/include/reduced_basis/transient_rb_assembly_expansion.h
@@ -34,7 +34,8 @@ namespace libMesh
  * This just requires an extra set of ElemAssembly functors
  * for the time-derivative term.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class TransientRBAssemblyExpansion : public RBAssemblyExpansion
 {

--- a/include/reduced_basis/transient_rb_assembly_expansion.h
+++ b/include/reduced_basis/transient_rb_assembly_expansion.h
@@ -36,9 +36,6 @@ namespace libMesh
  *
  * @author David J. Knezevic, 2011
  */
-
-// ------------------------------------------------------------
-// TransientRBAssemblyExpansion class definition
 class TransientRBAssemblyExpansion : public RBAssemblyExpansion
 {
 public:

--- a/include/reduced_basis/transient_rb_construction.h
+++ b/include/reduced_basis/transient_rb_construction.h
@@ -44,10 +44,6 @@ namespace libMesh
  *
  * @author David J. Knezevic 2009
  */
-
-// ------------------------------------------------------------
-// TransientRBConstruction class definition
-
 class TransientRBConstruction : public TransientSystem<RBConstruction>, public RBTemporalDiscretization
 {
 public:

--- a/include/reduced_basis/transient_rb_construction.h
+++ b/include/reduced_basis/transient_rb_construction.h
@@ -42,7 +42,8 @@ namespace libMesh
  * We can handle time controls on the RHS as h(t)*f(x,\mu).
  * See Martin Grepl's thesis for more details.
  *
- * @author David J. Knezevic 2009
+ * \author David J. Knezevic
+ * \date 2009
  */
 class TransientRBConstruction : public TransientSystem<RBConstruction>, public RBTemporalDiscretization
 {

--- a/include/reduced_basis/transient_rb_evaluation.h
+++ b/include/reduced_basis/transient_rb_evaluation.h
@@ -44,7 +44,8 @@ class TransientRBThetaExpansion;
  * We can handle time controls on the RHS as h(t)*f(x,\mu).
  * See Martin Grepl's thesis for more details.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class TransientRBEvaluation : public RBEvaluation, public RBTemporalDiscretization
 {

--- a/include/reduced_basis/transient_rb_evaluation.h
+++ b/include/reduced_basis/transient_rb_evaluation.h
@@ -46,11 +46,6 @@ class TransientRBThetaExpansion;
  *
  * @author David J. Knezevic, 2011
  */
-
-
-// ------------------------------------------------------------
-// TransientRBEvaluation class definition
-
 class TransientRBEvaluation : public RBEvaluation, public RBTemporalDiscretization
 {
 public:

--- a/include/reduced_basis/transient_rb_theta_expansion.h
+++ b/include/reduced_basis/transient_rb_theta_expansion.h
@@ -37,9 +37,6 @@ namespace libMesh
  *
  * @author David J. Knezevic, 2011
  */
-
-// ------------------------------------------------------------
-// TransientRBThetaExpansion class definition
 class TransientRBThetaExpansion : public RBThetaExpansion
 {
 public:

--- a/include/reduced_basis/transient_rb_theta_expansion.h
+++ b/include/reduced_basis/transient_rb_theta_expansion.h
@@ -35,7 +35,8 @@ namespace libMesh
  * This class stores the set of RBTheta functor objects that define
  * the "parameter-dependent expansion" of a PDE.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class TransientRBThetaExpansion : public RBThetaExpansion
 {

--- a/include/solution_transfer/direct_solution_transfer.h
+++ b/include/solution_transfer/direct_solution_transfer.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solution_transfer/dtk_adapter.h
+++ b/include/solution_transfer/dtk_adapter.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solution_transfer/dtk_evaluator.h
+++ b/include/solution_transfer/dtk_evaluator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solution_transfer/dtk_solution_transfer.h
+++ b/include/solution_transfer/dtk_solution_transfer.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solution_transfer/meshfree_interpolation.h
+++ b/include/solution_transfer/meshfree_interpolation.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solution_transfer/meshfree_solution_transfer.h
+++ b/include/solution_transfer/meshfree_solution_transfer.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solution_transfer/radial_basis_functions.h
+++ b/include/solution_transfer/radial_basis_functions.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solution_transfer/radial_basis_interpolation.h
+++ b/include/solution_transfer/radial_basis_interpolation.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solution_transfer/solution_transfer.h
+++ b/include/solution_transfer/solution_transfer.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/adaptive_time_solver.h
+++ b/include/solvers/adaptive_time_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/adaptive_time_solver.h
+++ b/include/solvers/adaptive_time_solver.h
@@ -45,9 +45,6 @@ class System;
  *
  * @author Roy H. Stogner 2007
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class AdaptiveTimeSolver : public FirstOrderUnsteadySolver
 {
 public:

--- a/include/solvers/adaptive_time_solver.h
+++ b/include/solvers/adaptive_time_solver.h
@@ -43,7 +43,8 @@ class System;
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2007
+ * \author Roy H. Stogner
+ * \date 2007
  */
 class AdaptiveTimeSolver : public FirstOrderUnsteadySolver
 {

--- a/include/solvers/diff_solver.h
+++ b/include/solvers/diff_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/diff_solver.h
+++ b/include/solvers/diff_solver.h
@@ -62,9 +62,6 @@ inline LinearSolutionMonitor::~LinearSolutionMonitor() {}
  *
  * @author Roy H. Stogner 2006-2010
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class DiffSolver : public ReferenceCountedObject<DiffSolver>,
                    public ParallelObject
 {

--- a/include/solvers/diff_solver.h
+++ b/include/solvers/diff_solver.h
@@ -60,7 +60,8 @@ inline LinearSolutionMonitor::~LinearSolutionMonitor() {}
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2006-2010
+ * \author Roy H. Stogner
+ * \date 2006-2010
  */
 class DiffSolver : public ReferenceCountedObject<DiffSolver>,
                    public ParallelObject

--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/eigen_sparse_linear_solver.h
+++ b/include/solvers/eigen_sparse_linear_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/eigen_sparse_linear_solver.h
+++ b/include/solvers/eigen_sparse_linear_solver.h
@@ -36,14 +36,13 @@
 namespace libMesh
 {
 
-
-
 /**
  * This class provides an interface to Eigen
  * iterative solvers that is compatible with the \p libMesh
  * \p LinearSolver<>
  *
- * @author Benjamin Kirk, 2013
+ * \author Benjamin Kirk
+ * \date 2013
  */
 template <typename T>
 class EigenSparseLinearSolver : public LinearSolver<T>

--- a/include/solvers/eigen_time_solver.h
+++ b/include/solvers/eigen_time_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/eigen_time_solver.h
+++ b/include/solvers/eigen_time_solver.h
@@ -60,10 +60,9 @@ template <typename T> class EigenSolver;
  * interface for EigenValue software.  The only current concrete implementation
  * is a SLEPc-based eigensolver class, which we make use of here as well.
  *
- * @author John W. Peterson 2007
+ * \author John W. Peterson
+ * \date 2007
  */
-
-
 class EigenTimeSolver : public TimeSolver
 {
 public:

--- a/include/solvers/euler2_solver.h
+++ b/include/solvers/euler2_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/euler2_solver.h
+++ b/include/solvers/euler2_solver.h
@@ -44,9 +44,6 @@ namespace libMesh
  *
  * @author Roy H. Stogner 2006
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class Euler2Solver : public FirstOrderUnsteadySolver
 {
 public:

--- a/include/solvers/euler2_solver.h
+++ b/include/solvers/euler2_solver.h
@@ -42,7 +42,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class Euler2Solver : public FirstOrderUnsteadySolver
 {

--- a/include/solvers/euler_solver.h
+++ b/include/solvers/euler_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/euler_solver.h
+++ b/include/solvers/euler_solver.h
@@ -39,9 +39,6 @@ namespace libMesh
  *
  * @author Roy H. Stogner 2006
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class EulerSolver : public FirstOrderUnsteadySolver
 {
 public:

--- a/include/solvers/euler_solver.h
+++ b/include/solvers/euler_solver.h
@@ -37,7 +37,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class EulerSolver : public FirstOrderUnsteadySolver
 {

--- a/include/solvers/first_order_unsteady_solver.h
+++ b/include/solvers/first_order_unsteady_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/first_order_unsteady_solver.h
+++ b/include/solvers/first_order_unsteady_solver.h
@@ -32,7 +32,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Paul T. Bauman 2015
+ * \author Paul T. Bauman
+ * \date 2015
  */
 class FirstOrderUnsteadySolver : public UnsteadySolver
 {

--- a/include/solvers/laspack_linear_solver.h
+++ b/include/solvers/laspack_linear_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/laspack_linear_solver.h
+++ b/include/solvers/laspack_linear_solver.h
@@ -40,14 +40,13 @@
 namespace libMesh
 {
 
-
-
 /**
  * This class provides an interface to Laspack
  * iterative solvers that is compatible with the \p libMesh
  * \p LinearSolver<>
  *
- * @author Benjamin Kirk, 2002-2007
+ * \author Benjamin Kirk
+ * \date 2002-2007
  */
 template <typename T>
 class LaspackLinearSolver : public LinearSolver<T>

--- a/include/solvers/linear.h
+++ b/include/solvers/linear.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/linear.h
+++ b/include/solvers/linear.h
@@ -37,10 +37,6 @@ namespace libMesh
  *
  * @author Benjamin S. Kirk, 2003-2004.
  */
-
-// ------------------------------------------------------------
-// Linear class definition
-
 template <class T = Solver>
 class Linear : public T
 {

--- a/include/solvers/linear.h
+++ b/include/solvers/linear.h
@@ -35,7 +35,8 @@ namespace libMesh
  * simulation.  A user can define a linear by deriving from this
  * class and implementing certain functions.
  *
- * @author Benjamin S. Kirk, 2003-2004.
+ * \author Benjamin S. Kirk
+ * \date 2003-2004
  */
 template <class T = Solver>
 class Linear : public T

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -52,9 +52,9 @@ class System;
  * class is overloaded to provide linear solvers from different packages
  * like PETSC or LASPACK.
  *
- * @author Benjamin Kirk, 2003
+ * \author Benjamin Kirk
+ * \date 2003
  */
-
 template <typename T>
 class LinearSolver : public ReferenceCountedObject<LinearSolver<T> >,
                      public ParallelObject

--- a/include/solvers/memory_solution_history.h
+++ b/include/solvers/memory_solution_history.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/newmark_solver.h
+++ b/include/solvers/newmark_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/newmark_solver.h
+++ b/include/solvers/newmark_solver.h
@@ -40,9 +40,6 @@ namespace libMesh
  *
  * @author Paul T. Bauman 2015
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class NewmarkSolver : public SecondOrderUnsteadySolver
 {
 public:

--- a/include/solvers/newmark_solver.h
+++ b/include/solvers/newmark_solver.h
@@ -38,7 +38,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Paul T. Bauman 2015
+ * \author Paul T. Bauman
+ * \date 2015
  */
 class NewmarkSolver : public SecondOrderUnsteadySolver
 {

--- a/include/solvers/newton_solver.h
+++ b/include/solvers/newton_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/newton_solver.h
+++ b/include/solvers/newton_solver.h
@@ -42,9 +42,6 @@ namespace libMesh
  *
  * @author Roy H. Stogner 2006
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class NewtonSolver : public DiffSolver
 {
 public:

--- a/include/solvers/newton_solver.h
+++ b/include/solvers/newton_solver.h
@@ -40,7 +40,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class NewtonSolver : public DiffSolver
 {

--- a/include/solvers/nlopt_optimization_solver.h
+++ b/include/solvers/nlopt_optimization_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/nlopt_optimization_solver.h
+++ b/include/solvers/nlopt_optimization_solver.h
@@ -62,7 +62,9 @@ void __libmesh_nlopt_inequality_constraints(unsigned m,
  * This class provides an interface to the NLopt optimization solvers.
  * http://ab-initio.mit.edu/wiki/index.php/NLopt
  *
- * @author David Knezevic and John Peterson, 2015
+ * \author David Knezevic
+ * \author John Peterson
+ * \date 2015
  */
 template <typename T>
 class NloptOptimizationSolver : public OptimizationSolver<T>

--- a/include/solvers/no_solution_history.h
+++ b/include/solvers/no_solution_history.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/no_solution_history.h
+++ b/include/solvers/no_solution_history.h
@@ -48,7 +48,7 @@ public:
     return UniquePtr<SolutionHistory >
       (new NoSolutionHistory());}
 
-}; // end NoSolutionHistory class definition
+};
 
 } // end namespace libMesh
 

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -45,7 +45,8 @@ template <typename T> class Preconditioner;
  * class is overloaded to provide nonlinear solvers from different packages
  * like PETSC.
  *
- * @author Benjamin Kirk, 2005
+ * \author Benjamin Kirk
+ * \date 2005
  */
 template <typename T>
 class NonlinearSolver : public ReferenceCountedObject<NonlinearSolver<T> >,

--- a/include/solvers/optimization_solver.h
+++ b/include/solvers/optimization_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/optimization_solver.h
+++ b/include/solvers/optimization_solver.h
@@ -44,7 +44,8 @@ template <typename T> class Preconditioner;
  * This class provides a uniform interface for optimization solvers.  This base
  * class is overloaded to provide optimization solvers from different packages.
  *
- * @author David Knezevic, 2015
+ * \author David Knezevic
+ * \date 2015
  */
 template <typename T>
 class OptimizationSolver : public ReferenceCountedObject<OptimizationSolver<T> >,

--- a/include/solvers/petsc_auto_fieldsplit.h
+++ b/include/solvers/petsc_auto_fieldsplit.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -48,9 +48,6 @@ namespace libMesh
  *
  * @author Roy H. Stogner 2008
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class PetscDiffSolver : public DiffSolver
 {
 public:

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -46,7 +46,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2008
+ * \author Roy H. Stogner
+ * \date 2008
  */
 class PetscDiffSolver : public DiffSolver
 {

--- a/include/solvers/petsc_linear_solver.h
+++ b/include/solvers/petsc_linear_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/petsc_linear_solver.h
+++ b/include/solvers/petsc_linear_solver.h
@@ -91,9 +91,9 @@ template <typename T> class PetscMatrix;
  * iterative solvers that is compatible with the \p libMesh
  * \p LinearSolver<>
  *
- * @author Benjamin Kirk, 2002-2007
+ * \author Benjamin Kirk
+ * \date 2002-2007
  */
-
 template <typename T>
 class PetscLinearSolver : public LinearSolver<T>
 {

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -64,9 +64,9 @@ extern "C"
  * iterative solvers that is compatible with the \p libMesh
  * \p NonlinearSolver<>
  *
- * @author Benjamin Kirk, 2002-2007
+ * \author Benjamin Kirk
+ * \date 2002-2007
  */
-
 template <typename T>
 class PetscNonlinearSolver : public NonlinearSolver<T>
 {

--- a/include/solvers/second_order_unsteady_solver.h
+++ b/include/solvers/second_order_unsteady_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/second_order_unsteady_solver.h
+++ b/include/solvers/second_order_unsteady_solver.h
@@ -32,7 +32,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Paul T. Bauman 2015
+ * \author Paul T. Bauman
+ * \date 2015
  */
 class SecondOrderUnsteadySolver : public UnsteadySolver
 {

--- a/include/solvers/slepc_eigen_solver.h
+++ b/include/solvers/slepc_eigen_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/slepc_macro.h
+++ b/include/solvers/slepc_macro.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/solution_history.h
+++ b/include/solvers/solution_history.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/solution_history.h
+++ b/include/solvers/solution_history.h
@@ -60,7 +60,7 @@ protected:
   // vectors at a given time or not
   bool overwrite_previously_stored;
 
-}; // end SolutionHistory class definition
+};
 
 } // end namespace libMesh
 

--- a/include/solvers/solver.h
+++ b/include/solvers/solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/solver.h
+++ b/include/solvers/solver.h
@@ -39,7 +39,8 @@ class Solver;
  * simulation.  A user can define a solver by deriving from this
  * class and implementing certain functions.
  *
- * @author Benjamin S. Kirk, 2003-2004.
+ * \author Benjamin S. Kirk
+ * \date 2003-2004
  */
 class Solver : public ReferenceCountedObject<Solver>
 {

--- a/include/solvers/solver.h
+++ b/include/solvers/solver.h
@@ -41,9 +41,6 @@ class Solver;
  *
  * @author Benjamin S. Kirk, 2003-2004.
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class Solver : public ReferenceCountedObject<Solver>
 {
 protected:

--- a/include/solvers/solver_configuration.h
+++ b/include/solvers/solver_configuration.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/solver_configuration.h
+++ b/include/solvers/solver_configuration.h
@@ -32,9 +32,9 @@ namespace libMesh
  * configure_solver() in order to provide specific behavior for
  * particular types of solvers (e.g. LinearSolver, EigenSolver, etc).
  *
- * @author David Knezevic, 2015.
+ * \author David Knezevic
+ * \date 2015
  */
-
 class SolverConfiguration : public ReferenceCountedObject<SolverConfiguration>
 {
 public:

--- a/include/solvers/steady_solver.h
+++ b/include/solvers/steady_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/steady_solver.h
+++ b/include/solvers/steady_solver.h
@@ -41,7 +41,8 @@ class TimeSolver;
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class SteadySolver : public TimeSolver
 {

--- a/include/solvers/steady_solver.h
+++ b/include/solvers/steady_solver.h
@@ -43,9 +43,6 @@ class TimeSolver;
  *
  * @author Roy H. Stogner 2006
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class SteadySolver : public TimeSolver
 {
 public:

--- a/include/solvers/tao_optimization_solver.h
+++ b/include/solvers/tao_optimization_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/tao_optimization_solver.h
+++ b/include/solvers/tao_optimization_solver.h
@@ -55,9 +55,9 @@ extern "C"
 /**
  * This class provides an interface to the Tao optimization solvers.
  *
- * @author David Knezevic, 2015
+ * \author David Knezevic
+ * \date 2015
  */
-
 template <typename T>
 class TaoOptimizationSolver : public OptimizationSolver<T>
 {

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -52,7 +52,8 @@ class SystemNorm;
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class TimeSolver : public ReferenceCountedObject<TimeSolver>
 {

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -54,9 +54,6 @@ class SystemNorm;
  *
  * @author Roy H. Stogner 2006
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class TimeSolver : public ReferenceCountedObject<TimeSolver>
 {
 public:

--- a/include/solvers/trilinos_aztec_linear_solver.h
+++ b/include/solvers/trilinos_aztec_linear_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/trilinos_aztec_linear_solver.h
+++ b/include/solvers/trilinos_aztec_linear_solver.h
@@ -44,9 +44,9 @@ namespace libMesh
  * iterative solvers that is compatible with the \p libMesh
  * \p LinearSolver<>
  *
- * @author Benjamin Kirk, 2002-2008
+ * \author Benjamin Kirk
+ * \date 2002-2008
  */
-
 template <typename T>
 class AztecLinearSolver : public LinearSolver<T>
 {

--- a/include/solvers/trilinos_nox_nonlinear_solver.h
+++ b/include/solvers/trilinos_nox_nonlinear_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/trilinos_nox_nonlinear_solver.h
+++ b/include/solvers/trilinos_nox_nonlinear_solver.h
@@ -49,9 +49,9 @@ class Problem_Interface;
  * iterative solvers that is compatible with the \p libMesh
  * \p NonlinearSolver<>
  *
- * @author Chris Newman, 2008
+ * \author Chris Newman
+ * \date 2008
  */
-
 template <typename T>
 class NoxNonlinearSolver : public NonlinearSolver<T>
 {

--- a/include/solvers/twostep_time_solver.h
+++ b/include/solvers/twostep_time_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/twostep_time_solver.h
+++ b/include/solvers/twostep_time_solver.h
@@ -46,9 +46,6 @@ class System;
  *
  * @author Roy H. Stogner 2007
  */
-
-// ------------------------------------------------------------
-// Solver class definition
 class TwostepTimeSolver : public AdaptiveTimeSolver
 {
 public:

--- a/include/solvers/twostep_time_solver.h
+++ b/include/solvers/twostep_time_solver.h
@@ -44,7 +44,8 @@ class System;
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2007
+ * \author Roy H. Stogner
+ * \date 2007
  */
 class TwostepTimeSolver : public AdaptiveTimeSolver
 {

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -44,9 +44,6 @@ namespace libMesh
  *
  * @author Roy H. Stogner 2008
  */
-
-// ------------------------------------------------------------
-// UnsteadySolver class definition
 class UnsteadySolver : public TimeSolver
 {
 public:

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -42,7 +42,8 @@ namespace libMesh
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2008
+ * \author Roy H. Stogner
+ * \date 2008
  */
 class UnsteadySolver : public TimeSolver
 {

--- a/include/systems/condensed_eigen_system.h
+++ b/include/systems/condensed_eigen_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/condensed_eigen_system.h
+++ b/include/systems/condensed_eigen_system.h
@@ -41,10 +41,6 @@ namespace libMesh
  * This is useful, for example, in the case that one wants to solve
  * eigenvalue problems with Dirichlet boundary conditions.
  */
-
-// ------------------------------------------------------------
-// CondensedEigenSystem class definition
-
 class CondensedEigenSystem : public EigenSystem
 {
 public:

--- a/include/systems/continuation_system.h
+++ b/include/systems/continuation_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/continuation_system.h
+++ b/include/systems/continuation_system.h
@@ -49,7 +49,8 @@ class NewtonSolver;
  * }
  * \endverbatim
  *
- * @author John W. Peterson 2007
+ * \author John W. Peterson
+ * \date 2007
  */
 class ContinuationSystem : public FEMSystem
 {

--- a/include/systems/dg_fem_context.h
+++ b/include/systems/dg_fem_context.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/dg_fem_context.h
+++ b/include/systems/dg_fem_context.h
@@ -32,10 +32,6 @@ namespace libMesh
  * required to perform local element residual and Jacobian assembly
  * in the case of a discontinuous Galerkin (DG) discretization.
  */
-
-// ------------------------------------------------------------
-// DGFEMContext class definition
-
 class DGFEMContext : public FEMContext
 {
 public:

--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -48,7 +48,8 @@ class System;
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2009
+ * \author Roy H. Stogner
+ * \date 2009
  */
 class DiffContext
 {

--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -50,10 +50,6 @@ class System;
  *
  * @author Roy H. Stogner 2009
  */
-
-// ------------------------------------------------------------
-// DifferentiableSystem class definition
-
 class DiffContext
 {
 public:

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -49,10 +49,6 @@ template <typename T> class NumericVector;
  *
  * @author Roy H. Stogner 2006
  */
-
-// ------------------------------------------------------------
-// DifferentiableSystem class definition
-
 class DifferentiableSystem : public ImplicitSystem,
                              public virtual DifferentiablePhysics,
                              public virtual DifferentiableQoI

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -47,7 +47,8 @@ template <typename T> class NumericVector;
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class DifferentiableSystem : public ImplicitSystem,
                              public virtual DifferentiablePhysics,

--- a/include/systems/eigen_system.h
+++ b/include/systems/eigen_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/eigen_system.h
+++ b/include/systems/eigen_system.h
@@ -46,10 +46,6 @@ template <typename T> class SparseMatrix;
  * \p A*x=lambda*x  and generalited eigenvalue problems
  * \p A*x=lambda*B*x.
  */
-
-// ------------------------------------------------------------
-// EigenSystem class definition
-
 class EigenSystem : public System
 {
 public:

--- a/include/systems/elem_assembly.h
+++ b/include/systems/elem_assembly.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/elem_assembly.h
+++ b/include/systems/elem_assembly.h
@@ -32,7 +32,8 @@ class FEMContext;
  * ElemAssembly provides a per-element (interior and boundary) assembly
  * functionality.
  *
- * @author David J. Knezevic, 2011
+ * \author David J. Knezevic
+ * \date 2011
  */
 class ElemAssembly : public ReferenceCountedObject<ElemAssembly>
 {

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -62,9 +62,6 @@ class MeshBase;
  *
  * @author Benjamin S. Kirk, 2002-2007
  */
-
-// ------------------------------------------------------------
-// EquationSystems class definition
 class EquationSystems : public ReferenceCountedObject<EquationSystems>,
                         public ParallelObject
 

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -60,7 +60,8 @@ class MeshBase;
  * may be handled.  Also other features, like flags,
  * parameters, I/O etc are provided.
  *
- * @author Benjamin S. Kirk, 2002-2007
+ * \author Benjamin S. Kirk
+ * \date 2002-2007
  */
 class EquationSystems : public ReferenceCountedObject<EquationSystems>,
                         public ParallelObject

--- a/include/systems/explicit_system.h
+++ b/include/systems/explicit_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/explicit_system.h
+++ b/include/systems/explicit_system.h
@@ -39,10 +39,6 @@ namespace libMesh
  * that still additional vectors/matrices may be added,
  * as offered in the parent class \p System.
  */
-
-// ------------------------------------------------------------
-// ExplicitSystem class definition
-
 class ExplicitSystem : public System
 {
 public:

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -55,7 +55,8 @@ template <typename T> class NumericVector;
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2009
+ * \author Roy H. Stogner
+ * \date 2009
  */
 class FEMContext : public DiffContext
 {

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -57,10 +57,6 @@ template <typename T> class NumericVector;
  *
  * @author Roy H. Stogner 2009
  */
-
-// ------------------------------------------------------------
-// FEMContext class definition
-
 class FEMContext : public DiffContext
 {
 public:

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -46,7 +46,8 @@ class FEMContext;
  * which is still experimental.  Users of this framework should
  * beware of bugs and future API changes.
  *
- * @author Roy H. Stogner 2006
+ * \author Roy H. Stogner
+ * \date 2006
  */
 class FEMSystem : public DifferentiableSystem,
                   public FEMPhysics

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -48,10 +48,6 @@ class FEMContext;
  *
  * @author Roy H. Stogner 2006
  */
-
-// ------------------------------------------------------------
-// FEMSystem class definition
-
 class FEMSystem : public DifferentiableSystem,
                   public FEMPhysics
 {

--- a/include/systems/frequency_system.h
+++ b/include/systems/frequency_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/frequency_system.h
+++ b/include/systems/frequency_system.h
@@ -35,9 +35,6 @@
 namespace libMesh
 {
 
-
-
-
 /**
  * \p FrequencySystem provides a specific system class
  * for frequency-dependent (linear) systems.
@@ -60,7 +57,8 @@ namespace libMesh
  *   of \p EquationSystems<FrequencySystem> named \p current \p frequency.
  *   For this to work, only provide @e one frequency.
  *
- * \author Daniel Dreyer, 2003
+ * \author Daniel Dreyer
+ * \date 2003
  */
 class FrequencySystem : public LinearImplicitSystem
 {

--- a/include/systems/frequency_system.h
+++ b/include/systems/frequency_system.h
@@ -62,10 +62,6 @@ namespace libMesh
  *
  * \author Daniel Dreyer, 2003
  */
-
-// ------------------------------------------------------------
-// FrequencySystem class definition
-
 class FrequencySystem : public LinearImplicitSystem
 {
 public:

--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -42,10 +42,6 @@ template <typename T> class SparseMatrix;
  * that still additional vectors/matrices may be added,
  * as offered in the parent class \p ExplicitSystem.
  */
-
-// ------------------------------------------------------------
-// ImplicitSystem class definition
-
 class ImplicitSystem : public ExplicitSystem
 {
 public:

--- a/include/systems/linear_implicit_system.h
+++ b/include/systems/linear_implicit_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/linear_implicit_system.h
+++ b/include/systems/linear_implicit_system.h
@@ -42,7 +42,8 @@ template <typename T> class ShellMatrix;
  * that still additional vectors/matrices may be added,
  * as offered in the parent class \p ExplicitSystem.
  *
- * @author Benjamin Kirk, 2005
+ * \author Benjamin Kirk
+ * \date 2005
  */
 class LinearImplicitSystem : public ImplicitSystem
 {

--- a/include/systems/linear_implicit_system.h
+++ b/include/systems/linear_implicit_system.h
@@ -41,11 +41,9 @@ template <typename T> class ShellMatrix;
  * the essentials needed to solve a system.  Note
  * that still additional vectors/matrices may be added,
  * as offered in the parent class \p ExplicitSystem.
+ *
+ * @author Benjamin Kirk, 2005
  */
-
-// ------------------------------------------------------------
-// LinearImplicitSystem class definition
-
 class LinearImplicitSystem : public ImplicitSystem
 {
 public:

--- a/include/systems/newmark_system.h
+++ b/include/systems/newmark_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/newmark_system.h
+++ b/include/systems/newmark_system.h
@@ -47,10 +47,6 @@ namespace libMesh
  * used for time integration are provided.
  * For details refer to the examples section.
  */
-
-// ------------------------------------------------------------
-// NewmarkSystem class definition
-
 class NewmarkSystem : public LinearImplicitSystem
 {
 public:

--- a/include/systems/nonlinear_implicit_system.h
+++ b/include/systems/nonlinear_implicit_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/optimization_system.h
+++ b/include/systems/optimization_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/optimization_system.h
+++ b/include/systems/optimization_system.h
@@ -37,7 +37,8 @@ template<typename T> class OptimizationSolver;
  * This System subclass enables us to assemble an objective function,
  * gradient, Hessian and bounds for optimization problems.
  *
- * @author David Knezevic, 2015
+ * \author David Knezevic
+ * \date 2015
  */
 class OptimizationSystem : public ImplicitSystem
 {

--- a/include/systems/optimization_system.h
+++ b/include/systems/optimization_system.h
@@ -36,11 +36,9 @@ template<typename T> class OptimizationSolver;
 /**
  * This System subclass enables us to assemble an objective function,
  * gradient, Hessian and bounds for optimization problems.
+ *
+ * @author David Knezevic, 2015
  */
-
-// ------------------------------------------------------------
-// OptimizationSystem class definition
-
 class OptimizationSystem : public ImplicitSystem
 {
 public:

--- a/include/systems/parameter_accessor.h
+++ b/include/systems/parameter_accessor.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/parameter_multiaccessor.h
+++ b/include/systems/parameter_multiaccessor.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/parameter_multipointer.h
+++ b/include/systems/parameter_multipointer.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/parameter_pointer.h
+++ b/include/systems/parameter_pointer.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/parameter_vector.h
+++ b/include/systems/parameter_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/qoi_set.h
+++ b/include/systems/qoi_set.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/sensitivity_data.h
+++ b/include/systems/sensitivity_data.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/steady_system.h
+++ b/include/systems/steady_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -73,9 +73,6 @@ class SystemSubset;
  *
  * @author Benjamin S. Kirk, 2003-2004.
  */
-
-// ------------------------------------------------------------
-// System class definition
 class System : public ReferenceCountedObject<System>,
                public ParallelObject
 {

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -71,7 +71,8 @@ class SystemSubset;
  * one or more of the children of this class.
  * Note that templating \p EqnSystems relaxes the use of virtual members.
  *
- * @author Benjamin S. Kirk, 2003-2004.
+ * \author Benjamin S. Kirk
+ * \date 2003-2004
  */
 class System : public ReferenceCountedObject<System>,
                public ParallelObject

--- a/include/systems/system_norm.h
+++ b/include/systems/system_norm.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/system_norm.h
+++ b/include/systems/system_norm.h
@@ -39,7 +39,8 @@ namespace libMesh
  * Discrete vector norms and weighted l2 combinations of Sobolev norms and
  * seminorms are representable.
  *
- * @author Roy H. Stogner 2008
+ * \author Roy H. Stogner
+ * \date 2008
  */
 class SystemNorm
 {

--- a/include/systems/system_norm.h
+++ b/include/systems/system_norm.h
@@ -41,9 +41,6 @@ namespace libMesh
  *
  * @author Roy H. Stogner 2008
  */
-
-// ------------------------------------------------------------
-// SystemNorm class definition
 class SystemNorm
 {
 public:

--- a/include/systems/system_subset.h
+++ b/include/systems/system_subset.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/system_subset.h
+++ b/include/systems/system_subset.h
@@ -36,7 +36,8 @@ class System;
  * This is a base class for classes which represent subsets of the
  * dofs of a \p System.
  *
- * @author Tim Kroeger, 2010.
+ * \author Tim Kroeger
+ * \date 2010
  */
 class SystemSubset : public ReferenceCountedObject<SystemSubset>
 {
@@ -47,8 +48,6 @@ public:
    */
   explicit
   SystemSubset (const System& system);
-
-public:
 
   /**
    * Destructor.

--- a/include/systems/system_subset.h
+++ b/include/systems/system_subset.h
@@ -38,9 +38,6 @@ class System;
  *
  * @author Tim Kroeger, 2010.
  */
-
-// ------------------------------------------------------------
-// SystemSubset class definition
 class SystemSubset : public ReferenceCountedObject<SystemSubset>
 {
 public:

--- a/include/systems/system_subset_by_subdomain.h
+++ b/include/systems/system_subset_by_subdomain.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/system_subset_by_subdomain.h
+++ b/include/systems/system_subset_by_subdomain.h
@@ -41,9 +41,6 @@ namespace libMesh
  *
  * @author Tim Kroeger, 2010.
  */
-
-// ------------------------------------------------------------
-// SystemSubset class definition
 class SystemSubsetBySubdomain : public SystemSubset,
                                 public ParallelObject
 {

--- a/include/systems/system_subset_by_subdomain.h
+++ b/include/systems/system_subset_by_subdomain.h
@@ -39,7 +39,8 @@ namespace libMesh
  * by the \p subdomain_id and possible the variable numbers.  The dofs
  * in the subset will be sorted.
  *
- * @author Tim Kroeger, 2010.
+ * \author Tim Kroeger
+ * \date 2010
  */
 class SystemSubsetBySubdomain : public SystemSubset,
                                 public ParallelObject

--- a/include/systems/transient_system.h
+++ b/include/systems/transient_system.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/systems/transient_system.h
+++ b/include/systems/transient_system.h
@@ -41,9 +41,6 @@ class ExplicitSystem;
  * that still additional vectors/matrices may be added,
  * as offered in the parent classes.
  */
-
-// ------------------------------------------------------------
-// TransientSystem class definition
 template <class Base>
 class TransientSystem : public Base
 {

--- a/include/utils/compare_types.h
+++ b/include/utils/compare_types.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/error_vector.h
+++ b/include/utils/error_vector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/error_vector.h
+++ b/include/utils/error_vector.h
@@ -29,9 +29,6 @@
 namespace libMesh
 {
 
-// Now defined in libmesh_common.h:
-// typedef float ErrorVectorReal;
-
 // Forward Declarations
 class MeshBase;
 class Mesh;
@@ -47,11 +44,11 @@ class Mesh;
  * the statistics.  Since the error is a positive quantity this class
  * assumes it contains positive data (i.e. min_val >= 0.).
  *
- * @author Benjamin S. Kirk, 2003.
+ * \author Benjamin S. Kirk
+ * \date 2003
  */
 class ErrorVector : public StatisticsVector<ErrorVectorReal>
 {
-
 public:
 
   /**

--- a/include/utils/hashword.h
+++ b/include/utils/hashword.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/hashword.h
+++ b/include/utils/hashword.h
@@ -35,7 +35,9 @@
 namespace
 {
 // Rotate x by k bits
-// @author Bob Jenkins, May 2006, Public Domain.
+// \author Bob Jenkins
+// \date May 2006
+// \copyright Public Domain
 // http://burtleburtle.net/bob/hash/index.html
 inline
 uint32_t rot(uint32_t x, uint32_t k)
@@ -46,7 +48,9 @@ uint32_t rot(uint32_t x, uint32_t k)
 
 
 // mix 3 32-bit values reversibly
-// @author Bob Jenkins, May 2006, Public Domain.
+// \author Bob Jenkins
+// \date May 2006
+// \copyright Public Domain
 // http://burtleburtle.net/bob/hash/index.html
 inline
 void mix(uint32_t& a, uint32_t& b, uint32_t& c)
@@ -61,7 +65,9 @@ void mix(uint32_t& a, uint32_t& b, uint32_t& c)
 
 
 // 'final' mixing of 3 32-bit numbers, result is stored in c.
-// @author Bob Jenkins, May 2006, Public Domain.
+// \author Bob Jenkins
+// \date May 2006
+// \copyright Public Domain
 // http://burtleburtle.net/bob/hash/index.html
 inline
 void final(uint32_t& a, uint32_t& b, uint32_t& c)
@@ -126,7 +132,9 @@ namespace Utility
 {
 // The hashword function takes an array of uint32_t's of length 'length'
 // and computes a single key from it.
-// @author Bob Jenkins, May 2006, Public Domain.
+// \author Bob Jenkins
+// \date May 2006
+// \copyright Public Domain
 // http://burtleburtle.net/bob/hash/index.html
 inline
 uint32_t hashword(const uint32_t *k, size_t length, uint32_t initval=0)
@@ -164,7 +172,9 @@ uint32_t hashword(const uint32_t *k, size_t length, uint32_t initval=0)
 
 
 // This is a hard-coded version of hashword for hashing exactly 2 numbers
-// @author Bob Jenkins, May 2006, Public Domain.
+// \author Bob Jenkins
+// \date May 2006
+// \copyright Public Domain
 // http://burtleburtle.net/bob/hash/index.html
 inline
 uint32_t hashword2(const uint32_t& first, const uint32_t& second, uint32_t initval=0)

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/location_maps.h
+++ b/include/utils/location_maps.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/mapvector.h
+++ b/include/utils/mapvector.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/null_output_iterator.h
+++ b/include/utils/null_output_iterator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/number_lookups.h
+++ b/include/utils/number_lookups.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/ostream_proxy.h
+++ b/include/utils/ostream_proxy.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/ostream_proxy.h
+++ b/include/utils/ostream_proxy.h
@@ -35,7 +35,8 @@ namespace libMesh
  *
  * It is up to the user to ensure that the target ostream remains valid.
  *
- * @author Roy Stogner, 2010.
+ * \author Roy Stogner
+ * \date 2010
  */
 template <typename charT=char, typename traits=std::char_traits<charT> >
 class BasicOStreamProxy

--- a/include/utils/ostream_proxy.h
+++ b/include/utils/ostream_proxy.h
@@ -25,27 +25,18 @@
 // C++ includes
 #include <iostream>
 
-// Local Includes
-// We don't use anything libMesh-specific here (yet)
-// #include "libmesh/libmesh_common.h"
-
-
 namespace libMesh
 {
 
-// Forward Declarations
-
-
-
-// ------------------------------------------------------------
-// OStreamProxy class definition
-//
-// This class is intended to be reseatable like a pointer-to-ostream
-// for flexibility, but to look like a reference when used to produce
-// less awkward user code.
-//
-// It is up to the user to ensure that the target ostream
-
+/**
+ * This class is intended to be reseatable like a pointer-to-ostream
+ * for flexibility, but to look like a reference when used to produce
+ * less awkward user code.
+ *
+ * It is up to the user to ensure that the target ostream remains valid.
+ *
+ * @author Roy Stogner, 2010.
+ */
 template <typename charT=char, typename traits=std::char_traits<charT> >
 class BasicOStreamProxy
 {

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -57,9 +57,6 @@ void print_helper(std::ostream& os, const std::vector<P>* param);
  * \author Benjamin S. Kirk
  * \date 2004
  */
-
-// ------------------------------------------------------------
-// Parameters class definition
 class Parameters
 {
 public:

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -39,7 +39,8 @@ namespace libMesh
  * The \p PerfData class simply contains the performance
  * data that is recorded for individual events.
  *
- * @author Benjamin Kirk, 2003.
+ * \author Benjamin Kirk
+ * \date 2003
  */
 class PerfData
 {
@@ -115,7 +116,8 @@ protected:
  * This class is particulary useful for finding performance
  * bottlenecks.
  *
- * @author Benjamin Kirk, 2003.
+ * \author Benjamin Kirk
+ * \date 2003
  */
 class PerfLog
 {

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -38,10 +38,9 @@ namespace libMesh
 /**
  * The \p PerfData class simply contains the performance
  * data that is recorded for individual events.
+ *
+ * @author Benjamin Kirk, 2003.
  */
-
-// ------------------------------------------------------------
-// PerfData class definition
 class PerfData
 {
 public:
@@ -116,13 +115,10 @@ protected:
  * This class is particulary useful for finding performance
  * bottlenecks.
  *
+ * @author Benjamin Kirk, 2003.
  */
-
-// ------------------------------------------------------------
-// PerfLog class definition
 class PerfLog
 {
-
 public:
 
   /**

--- a/include/utils/perfmon.h
+++ b/include/utils/perfmon.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/plt_loader.h
+++ b/include/utils/plt_loader.h
@@ -36,7 +36,8 @@ namespace libMesh
  * are for use with Amtec's <a href="http://www.tecplot.com">Tecplot</a>
  * visualization package.
  *
- * @author Benjamin S. Kirk, 2004.
+ * \author Benjamin S. Kirk
+ * \date 2004
  */
 class PltLoader
 {

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -49,7 +49,8 @@ class Elem;
  * points in space: given a mesh they return the element
  * and local coordinates for a given point in global coordinates.
  *
- * @author Daniel Dreyer, 2003
+ * \author Daniel Dreyer
+ * \date 2003
  */
 class PointLocatorBase : public ReferenceCountedObject<PointLocatorBase>
 {

--- a/include/utils/point_locator_list.h
+++ b/include/utils/point_locator_list.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/point_locator_list.h
+++ b/include/utils/point_locator_list.h
@@ -60,7 +60,8 @@ class Elem;
  * Use \p PointLocatorBase::build() to create objects
  * of this type at run time.
  *
- * @author Daniel Dreyer, 2003
+ * \author Daniel Dreyer
+ * \date 2003
  */
 class PointLocatorList : public PointLocatorBase
 {

--- a/include/utils/point_locator_tree.h
+++ b/include/utils/point_locator_tree.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/point_locator_tree.h
+++ b/include/utils/point_locator_tree.h
@@ -44,7 +44,8 @@ class Elem;
  * Use \p PointLocatorBase::build() to create objects of this
  * type at run time.
  *
- * @author Daniel Dreyer, 2003
+ * \author Daniel Dreyer
+ * \date 2003
  */
 class PointLocatorTree : public PointLocatorBase
 {

--- a/include/utils/pool_allocator.h
+++ b/include/utils/pool_allocator.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/statistics.h
+++ b/include/utils/statistics.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/statistics.h
+++ b/include/utils/statistics.h
@@ -68,7 +68,8 @@ namespace libMesh
  * implemented in order to avoid possible problems with
  * buffer overruns.
  *
- * @author John W. Peterson, 2002
+ * \author John W. Peterson
+ * \date 2002
  */
 template <typename T>
 class StatisticsVector : public std::vector<T>

--- a/include/utils/statistics.h
+++ b/include/utils/statistics.h
@@ -70,9 +70,6 @@ namespace libMesh
  *
  * @author John W. Peterson, 2002
  */
-
-// ------------------------------------------------------------
-// StatisticsVector class definition
 template <typename T>
 class StatisticsVector : public std::vector<T>
 {

--- a/include/utils/string_to_enum.h
+++ b/include/utils/string_to_enum.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/timestamp.h
+++ b/include/utils/timestamp.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/topology_map.h
+++ b/include/utils/topology_map.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -36,7 +36,8 @@ class MeshBase;
  * This class defines a tree that may be used for fast point
  * location in space.
  *
- * @author Benjamin S. Kirk, 2002
+ * \author Benjamin S. Kirk
+ * \date 2002
  */
 template <unsigned int N>
 class Tree : public TreeBase

--- a/include/utils/tree_base.h
+++ b/include/utils/tree_base.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/vectormap.h
+++ b/include/utils/vectormap.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -61,7 +61,8 @@ namespace libMesh
  * created to handle equation system output as a replacement for
  * XdrIO since that is somewhat limited.
  *
- * @author Benjamin Kirk, 2003.
+ * \author Benjamin Kirk
+ * \date 2003
  */
 class Xdr
 {

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -54,19 +54,15 @@ const unsigned int xdr_MAX_STRING_LENGTH=256;
 namespace libMesh
 {
 
-
-
-//--------------------------------------------------------------
-// Xdr class definition
-
 /**
  * This class implements a C++ interface to the XDR
  * (eXternal Data Representation) format.  XDR is useful for
  * creating platform-independent binary files.  This class was
  * created to handle equation system output as a replacement for
  * XdrIO since that is somewhat limited.
+ *
+ * @author Benjamin Kirk, 2003.
  */
-
 class Xdr
 {
 

--- a/src/apps/amr.C
+++ b/src/apps/amr.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/calculator.C
+++ b/src/apps/calculator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/compare.C
+++ b/src/apps/compare.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/grid2grid.C
+++ b/src/apps/grid2grid.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/meshavg.C
+++ b/src/apps/meshavg.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/meshbcid.C
+++ b/src/apps/meshbcid.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/meshdiff.C
+++ b/src/apps/meshdiff.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/meshid.C
+++ b/src/apps/meshid.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/meshtool.C
+++ b/src/apps/meshtool.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/output_libmesh_version.C
+++ b/src/apps/output_libmesh_version.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/projection.C
+++ b/src/apps/projection.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/apps/solution_components.C
+++ b/src/apps/solution_components.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/libmesh_common.C
+++ b/src/base/libmesh_common.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/periodic_boundaries.C
+++ b/src/base/periodic_boundaries.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/periodic_boundary.C
+++ b/src/base/periodic_boundary.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/periodic_boundary_base.C
+++ b/src/base/periodic_boundary_base.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/reference_counted_object.C
+++ b/src/base/reference_counted_object.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/reference_counter.C
+++ b/src/base/reference_counter.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/adjoint_residual_error_estimator.C
+++ b/src/error_estimation/adjoint_residual_error_estimator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/discontinuity_measure.C
+++ b/src/error_estimation/discontinuity_measure.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/error_estimator.C
+++ b/src/error_estimation/error_estimator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/fourth_error_estimators.C
+++ b/src/error_estimation/fourth_error_estimators.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/hp_selector.C
+++ b/src/error_estimation/hp_selector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/hp_singular.C
+++ b/src/error_estimation/hp_singular.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/kelly_error_estimator.C
+++ b/src/error_estimation/kelly_error_estimator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/error_estimation/weighted_patch_recovery_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_estimator.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_bernstein_shape_0D.C
+++ b/src/fe/fe_bernstein_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_bernstein_shape_1D.C
+++ b/src/fe/fe_bernstein_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_clough.C
+++ b/src/fe/fe_clough.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_clough_shape_0D.C
+++ b/src/fe/fe_clough_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_clough_shape_1D.C
+++ b/src/fe/fe_clough_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_clough_shape_2D.C
+++ b/src/fe/fe_clough_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_clough_shape_3D.C
+++ b/src/fe/fe_clough_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_compute_data.C
+++ b/src/fe/fe_compute_data.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hermite.C
+++ b/src/fe/fe_hermite.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hermite_shape_0D.C
+++ b/src/fe/fe_hermite_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hermite_shape_1D.C
+++ b/src/fe/fe_hermite_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hierarchic_shape_0D.C
+++ b/src/fe/fe_hierarchic_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hierarchic_shape_1D.C
+++ b/src/fe/fe_hierarchic_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_hierarchic_shape_0D.C
+++ b/src/fe/fe_l2_hierarchic_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_hierarchic_shape_1D.C
+++ b/src/fe/fe_l2_hierarchic_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_hierarchic_shape_2D.C
+++ b/src/fe/fe_l2_hierarchic_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_hierarchic_shape_3D.C
+++ b/src/fe/fe_l2_hierarchic_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_lagrange.C
+++ b/src/fe/fe_l2_lagrange.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_lagrange_shape_0D.C
+++ b/src/fe/fe_l2_lagrange_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_lagrange_shape_1D.C
+++ b/src/fe/fe_l2_lagrange_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_lagrange_shape_2D.C
+++ b/src/fe/fe_l2_lagrange_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_l2_lagrange_shape_3D.C
+++ b/src/fe/fe_l2_lagrange_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_lagrange_shape_0D.C
+++ b/src/fe/fe_lagrange_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_lagrange_vec.C
+++ b/src/fe/fe_lagrange_vec.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_monomial.C
+++ b/src/fe/fe_monomial.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_monomial_shape_0D.C
+++ b/src/fe/fe_monomial_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_monomial_shape_1D.C
+++ b/src/fe/fe_monomial_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_monomial_shape_2D.C
+++ b/src/fe/fe_monomial_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_monomial_shape_3D.C
+++ b/src/fe/fe_monomial_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_scalar.C
+++ b/src/fe/fe_scalar.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_scalar_shape_0D.C
+++ b/src/fe/fe_scalar_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_scalar_shape_1D.C
+++ b/src/fe/fe_scalar_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_scalar_shape_2D.C
+++ b/src/fe/fe_scalar_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_scalar_shape_3D.C
+++ b/src/fe/fe_scalar_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_szabab.C
+++ b/src/fe/fe_szabab.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_szabab_shape_0D.C
+++ b/src/fe/fe_szabab_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_szabab_shape_1D.C
+++ b/src/fe/fe_szabab_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_szabab_shape_2D.C
+++ b/src/fe/fe_szabab_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_szabab_shape_3D.C
+++ b/src/fe/fe_szabab_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_transformation_base.C
+++ b/src/fe/fe_transformation_base.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_type.C
+++ b/src/fe/fe_type.C
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_xyz_boundary.C
+++ b/src/fe/fe_xyz_boundary.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_xyz_map.C
+++ b/src/fe/fe_xyz_map.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_xyz_shape_0D.C
+++ b/src/fe/fe_xyz_shape_0D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_xyz_shape_1D.C
+++ b/src/fe/fe_xyz_shape_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/hcurl_fe_transformation.C
+++ b/src/fe/hcurl_fe_transformation.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe_base_radial.C
+++ b/src/fe/inf_fe_base_radial.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe_jacobi_20_00_eval.C
+++ b/src/fe/inf_fe_jacobi_20_00_eval.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe_jacobi_30_00_eval.C
+++ b/src/fe/inf_fe_jacobi_30_00_eval.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe_lagrange_eval.C
+++ b/src/fe/inf_fe_lagrange_eval.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe_legendre_eval.C
+++ b/src/fe/inf_fe_legendre_eval.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe_map_eval.C
+++ b/src/fe/inf_fe_map_eval.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell.C
+++ b/src/geom/cell.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_inf.C
+++ b/src/geom/cell_inf.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/edge_edge2.C
+++ b/src/geom/edge_edge2.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/edge_edge4.C
+++ b/src/geom/edge_edge4.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/edge_inf_edge2.C
+++ b/src/geom/edge_inf_edge2.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/elem_quality.C
+++ b/src/geom/elem_quality.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/elem_refinement.C
+++ b/src/geom/elem_refinement.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/elem_type.C
+++ b/src/geom/elem_type.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face.C
+++ b/src/geom/face.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_tri3_subdivision.C
+++ b/src/geom/face_tri3_subdivision.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/node.C
+++ b/src/geom/node.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/node_elem.C
+++ b/src/geom/node_elem.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/plane.C
+++ b/src/geom/plane.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/point.C
+++ b/src/geom/point.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/remote_elem.C
+++ b/src/geom/remote_elem.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/sphere.C
+++ b/src/geom/sphere.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/geom/surface.C
+++ b/src/geom/surface.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/boundary_mesh.C
+++ b/src/mesh/boundary_mesh.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/diva_io.C
+++ b/src/mesh/diva_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/fro_io.C
+++ b/src/mesh/fro_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/gnuplot_io.C
+++ b/src/mesh/gnuplot_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/legacy_xdr_io.C
+++ b/src/mesh/legacy_xdr_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/matlab_io.C
+++ b/src/mesh/matlab_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/medit_io.C
+++ b/src/mesh/medit_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_data.C
+++ b/src/mesh/mesh_data.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_data_tetgen_support.C
+++ b/src/mesh/mesh_data_tetgen_support.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_data_unv_support.C
+++ b/src/mesh/mesh_data_unv_support.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_data_xdr_support.C
+++ b/src/mesh/mesh_data_xdr_support.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_iterators.C
+++ b/src/mesh/mesh_iterators.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_refinement_smoothing.C
+++ b/src/mesh/mesh_refinement_smoothing.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_serializer.C
+++ b/src/mesh/mesh_serializer.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_smoother.C
+++ b/src/mesh/mesh_smoother.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_smoother_laplace.C
+++ b/src/mesh/mesh_smoother_laplace.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_tetgen_wrapper.C
+++ b/src/mesh/mesh_tetgen_wrapper.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_triangle_holes.C
+++ b/src/mesh/mesh_triangle_holes.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_triangle_interface.C
+++ b/src/mesh/mesh_triangle_interface.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/mesh_triangle_wrapper.C
+++ b/src/mesh/mesh_triangle_wrapper.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/off_io.C
+++ b/src/mesh/off_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/patch.C
+++ b/src/mesh/patch.C
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/postscript_io.C
+++ b/src/mesh/postscript_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/tecplot_io.C
+++ b/src/mesh/tecplot_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/tetgen_io.C
+++ b/src/mesh/tetgen_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/xdr_head.C
+++ b/src/mesh/xdr_head.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/xdr_mesh.C
+++ b/src/mesh/xdr_mesh.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/xdr_mgf.C
+++ b/src/mesh/xdr_mgf.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/mesh/xdr_soln.C
+++ b/src/mesh/xdr_soln.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/analytic_function.C
+++ b/src/numerics/analytic_function.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/coupling_matrix.C
+++ b/src/numerics/coupling_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/dense_matrix.C
+++ b/src/numerics/dense_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/dense_matrix_base.C
+++ b/src/numerics/dense_matrix_base.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/dense_matrix_blas_lapack.C
+++ b/src/numerics/dense_matrix_blas_lapack.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/dense_submatrix.C
+++ b/src/numerics/dense_submatrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/dense_subvector.C
+++ b/src/numerics/dense_subvector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/dense_vector.C
+++ b/src/numerics/dense_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/dense_vector_base.C
+++ b/src/numerics/dense_vector_base.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/eigen_preconditioner.C
+++ b/src/numerics/eigen_preconditioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/eigen_sparse_vector.C
+++ b/src/numerics/eigen_sparse_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/function_base.C
+++ b/src/numerics/function_base.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/laspack_matrix.C
+++ b/src/numerics/laspack_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/laspack_vector.C
+++ b/src/numerics/laspack_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/preconditioner.C
+++ b/src/numerics/preconditioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/sparse_shell_matrix.C
+++ b/src/numerics/sparse_shell_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/sum_shell_matrix.C
+++ b/src/numerics/sum_shell_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/tensor_shell_matrix.C
+++ b/src/numerics/tensor_shell_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/tensor_tools.C
+++ b/src/numerics/tensor_tools.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/trilinos_preconditioner.C
+++ b/src/numerics/trilinos_preconditioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/type_tensor.C
+++ b/src/numerics/type_tensor.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/numerics/type_vector.C
+++ b/src/numerics/type_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/parallel/parallel_bin_sorter.C
+++ b/src/parallel/parallel_bin_sorter.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/parallel/parallel_histogram.C
+++ b/src/parallel/parallel_histogram.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/parallel/parallel_sort.C
+++ b/src/parallel/parallel_sort.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/parallel/threads.C
+++ b/src/parallel/threads.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/partitioning/centroid_partitioner.C
+++ b/src/partitioning/centroid_partitioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/partitioning/linear_partitioner.C
+++ b/src/partitioning/linear_partitioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/partitioning/partitioner_factory.C
+++ b/src/partitioning/partitioner_factory.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/partitioning/sfc_partitioner.C
+++ b/src/partitioning/sfc_partitioner.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/physics/diff_physics.C
+++ b/src/physics/diff_physics.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/physics/diff_qoi.C
+++ b/src/physics/diff_qoi.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/physics/fem_physics.C
+++ b/src/physics/fem_physics.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_build.C
+++ b/src/quadrature/quadrature_build.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_clough.C
+++ b/src/quadrature/quadrature_clough.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_clough_1D.C
+++ b/src/quadrature/quadrature_clough_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_clough_2D.C
+++ b/src/quadrature/quadrature_clough_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_clough_3D.C
+++ b/src/quadrature/quadrature_clough_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_conical_2D.C
+++ b/src/quadrature/quadrature_conical_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_conical_3D.C
+++ b/src/quadrature/quadrature_conical_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gauss.C
+++ b/src/quadrature/quadrature_gauss.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gauss_1D.C
+++ b/src/quadrature/quadrature_gauss_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gauss_lobatto.C
+++ b/src/quadrature/quadrature_gauss_lobatto.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gauss_lobatto_1D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gauss_lobatto_2D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gauss_lobatto_3D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gm.C
+++ b/src/quadrature/quadrature_gm.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gm_2D.C
+++ b/src/quadrature/quadrature_gm_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_gm_3D.C
+++ b/src/quadrature/quadrature_gm_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_grid.C
+++ b/src/quadrature/quadrature_grid.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_grid_1D.C
+++ b/src/quadrature/quadrature_grid_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_grid_2D.C
+++ b/src/quadrature/quadrature_grid_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_grid_3D.C
+++ b/src/quadrature/quadrature_grid_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_jacobi.C
+++ b/src/quadrature/quadrature_jacobi.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_jacobi_1D.C
+++ b/src/quadrature/quadrature_jacobi_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_monomial.C
+++ b/src/quadrature/quadrature_monomial.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_monomial_1D.C
+++ b/src/quadrature/quadrature_monomial_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_rules.C
+++ b/src/quadrature/quadrature_rules.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_simpson.C
+++ b/src/quadrature/quadrature_simpson.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_simpson_1D.C
+++ b/src/quadrature/quadrature_simpson_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_simpson_2D.C
+++ b/src/quadrature/quadrature_simpson_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_simpson_3D.C
+++ b/src/quadrature/quadrature_simpson_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_trap.C
+++ b/src/quadrature/quadrature_trap.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_trap_1D.C
+++ b/src/quadrature/quadrature_trap_1D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_trap_2D.C
+++ b/src/quadrature/quadrature_trap_2D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/quadrature/quadrature_trap_3D.C
+++ b/src/quadrature/quadrature_trap_3D.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solution_transfer/direct_solution_transfer.C
+++ b/src/solution_transfer/direct_solution_transfer.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solution_transfer/dtk_adapter.C
+++ b/src/solution_transfer/dtk_adapter.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solution_transfer/dtk_solution_transfer.C
+++ b/src/solution_transfer/dtk_solution_transfer.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solution_transfer/meshfree_solution_transfer.C
+++ b/src/solution_transfer/meshfree_solution_transfer.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solution_transfer/meshfunction_solution_transfer.C
+++ b/src/solution_transfer/meshfunction_solution_transfer.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solution_transfer/radial_basis_interpolation.C
+++ b/src/solution_transfer/radial_basis_interpolation.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solution_transfer/solution_transfer.C
+++ b/src/solution_transfer/solution_transfer.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/adaptive_time_solver.C
+++ b/src/solvers/adaptive_time_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/diff_solver.C
+++ b/src/solvers/diff_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/eigen_solver.C
+++ b/src/solvers/eigen_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/eigen_time_solver.C
+++ b/src/solvers/eigen_time_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/euler2_solver.C
+++ b/src/solvers/euler2_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/euler_solver.C
+++ b/src/solvers/euler_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/laspack_linear_solver.C
+++ b/src/solvers/laspack_linear_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/newmark_solver.C
+++ b/src/solvers/newmark_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/newton_solver.C
+++ b/src/solvers/newton_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/nlopt_optimization_solver.C
+++ b/src/solvers/nlopt_optimization_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/nonlinear_solver.C
+++ b/src/solvers/nonlinear_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/optimization_solver.C
+++ b/src/solvers/optimization_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/petsc_auto_fieldsplit.C
+++ b/src/solvers/petsc_auto_fieldsplit.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/second_order_unsteady_solver.C
+++ b/src/solvers/second_order_unsteady_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/steady_solver.C
+++ b/src/solvers/steady_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/trilinos_aztec_linear_solver.C
+++ b/src/solvers/trilinos_aztec_linear_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/trilinos_nox_nonlinear_solver.C
+++ b/src/solvers/trilinos_nox_nonlinear_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/twostep_time_solver.C
+++ b/src/solvers/twostep_time_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/solvers/unsteady_solver.C
+++ b/src/solvers/unsteady_solver.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/continuation_system.C
+++ b/src/systems/continuation_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/dg_fem_context.C
+++ b/src/systems/dg_fem_context.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/diff_context.C
+++ b/src/systems/diff_context.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/eigen_system.C
+++ b/src/systems/eigen_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/equation_systems_io.C
+++ b/src/systems/equation_systems_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/explicit_system.C
+++ b/src/systems/explicit_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/newmark_system.C
+++ b/src/systems/newmark_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/optimization_system.C
+++ b/src/systems/optimization_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/parameter_vector.C
+++ b/src/systems/parameter_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/qoi_set.C
+++ b/src/systems/qoi_set.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/steady_system.C
+++ b/src/systems/steady_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/system_subset.C
+++ b/src/systems/system_subset.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/system_subset_by_subdomain.C
+++ b/src/systems/system_subset_by_subdomain.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/systems/transient_system.C
+++ b/src/systems/transient_system.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/hashword.C
+++ b/src/utils/hashword.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/libmesh_version.C
+++ b/src/utils/libmesh_version.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/location_maps.C
+++ b/src/utils/location_maps.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/number_lookups.C
+++ b/src/utils/number_lookups.C
@@ -1,6 +1,6 @@
 
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/statistics.C
+++ b/src/utils/statistics.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/timestamp.C
+++ b/src/utils/timestamp.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/utility.C
+++ b/src/utils/utility.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -1,5 +1,5 @@
 // The libMesh Finite Element Library.
-// Copyright (C) 2002-2014 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
* Update copyright notice for 2015.
* Update and unify copyright and license header in examples.  Consistently list example authors. 
* Expand `\author Bob, 2012` documentation to 
```
\author Bob
\date 2012
```
since Doxygen supports both pieces of metadata.