### PR TITLE
Add rpath flags for TBB to link line.

### DIFF
--- a/configure
+++ b/configure
@@ -33396,6 +33396,11 @@ fi
       TBB_LIBRARY="-L$TBB_LIBS -ltbb -ltbbmalloc"
       TBB_INCLUDE=-I$TBB_INCLUDE_PATH
 
+            if (test "x$RPATHFLAG" != "x" -a -d $TBB_LIBS); then
+        TBB_LIBRARY="${RPATHFLAG}${TBB_LIBS} $TBB_LIBRARY"
+      fi
+
+
 
 
 $as_echo "#define USING_THREADS 1" >>confdefs.h

--- a/m4/tbb.m4
+++ b/m4/tbb.m4
@@ -41,6 +41,12 @@ AC_DEFUN([CONFIGURE_TBB],
     if (test -r $TBB_INCLUDE_PATH/tbb/task_scheduler_init.h) ; then
       TBB_LIBRARY="-L$TBB_LIBS -ltbb -ltbbmalloc"
       TBB_INCLUDE=-I$TBB_INCLUDE_PATH
+
+      dnl Add rpath flags to the link line.
+      if (test "x$RPATHFLAG" != "x" -a -d $TBB_LIBS); then
+        TBB_LIBRARY="${RPATHFLAG}${TBB_LIBS} $TBB_LIBRARY"
+      fi
+
       AC_SUBST(TBB_LIBRARY)
       AC_SUBST(TBB_INCLUDE)
       AC_DEFINE(USING_THREADS, 1,


### PR DESCRIPTION
This was apparently an oversight, we were already doing it for pretty much every other package we link to.  This issue is apparently going be more important in OSX El Capitan, as they are changing the way DYLD_LIBRARY_PATH is handled there.