### PR TITLE
Update API in GetPot

### DIFF
--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -278,13 +278,13 @@ public:
    *   ii) from inside, use '_set_variable()' below
    */
   template<typename T>
-  inline void set(const char* VarName, const T& Value, const bool Requested = true);
+  inline void set(const char* VarName, const T& Value, const bool Requested = true, const bool Overridden = true);
 
   template<typename T>
-  inline void set(const std::string& VarName, const T& Value, const bool Requested = true);
+  inline void set(const std::string& VarName, const T& Value, const bool Requested = true, const bool Overridden = true);
 
-  inline void set(const char* VarName, const char* Value, const bool Requested = true);
-  inline void set(const std::string& VarName, const char* Value, const bool Requested = true);
+  inline void set(const char* VarName, const char* Value, const bool Requested = true, const bool Overridden = true);
+  inline void set(const std::string& VarName, const char* Value, const bool Requested = true, const bool Overridden = true);
 
   inline unsigned vector_variable_size(const char* VarName) const;
   inline unsigned vector_variable_size(const std::string& VarName) const;
@@ -539,7 +539,8 @@ private:
    */
   inline void _set_variable(const std::string& VarName,
                             const std::string& Value,
-                            const bool Requested);
+                            const bool Requested,
+                            const bool Overridden);
 
   /**
    * produce three basic data vectors:
@@ -1113,7 +1114,7 @@ GetPot::_parse_argument_vector(const STRING_VECTOR& ARGV)
           // => arg (from start to '=') = Name of variable
           //        (from '=' to end)   = value of variable
           _set_variable(arg.substr(0,equals_pos),
-                        arg.substr(equals_pos+1), false);
+                        arg.substr(equals_pos+1), false, true);
         }
     }
 }
@@ -2406,7 +2407,7 @@ GetPot::_record_variable_request(const std::string& Name) const
 //     arguments => append an argument in the argument vector that reflects the addition
 inline void
 GetPot::_set_variable(const std::string& VarName,
-                      const std::string& Value, const bool Requested /* = true */)
+                      const std::string& Value, const bool Requested /* = true */, const bool Overridden /* = true */)
 {
   const GetPot::variable* Var = Requested ?
     _request_variable(VarName.c_str()) :
@@ -2415,7 +2416,8 @@ GetPot::_set_variable(const std::string& VarName,
     variables.push_back(variable(VarName.c_str(), Value.c_str(), _field_separator.c_str()));
   else
     {
-      overridden_vars.insert(VarName.c_str());
+      if (Overridden)
+        overridden_vars.insert(VarName.c_str());
       (const_cast<GetPot::variable*>(Var))->take(Value.c_str(), _field_separator.c_str());
     }
 }
@@ -2424,36 +2426,36 @@ GetPot::_set_variable(const std::string& VarName,
 
 template <typename T>
 inline void
-GetPot::set(const char* VarName, const T& Value, const bool Requested /* = true */)
+GetPot::set(const char* VarName, const T& Value, const bool Requested /* = true */, const bool Overridden /* = true */)
 {
   std::ostringstream string_value;
   string_value << Value;
-  _set_variable(VarName, string_value.str().c_str(), Requested);
+  _set_variable(VarName, string_value.str().c_str(), Requested, Overridden);
 }
 
 
 
 template <typename T>
 inline void
-GetPot::set(const std::string& VarName, const T& Value, const bool Requested /* = true */)
+GetPot::set(const std::string& VarName, const T& Value, const bool Requested /* = true */, const bool Overridden /* = true */)
 {
-  set(VarName.c_str(), Value, Requested);
+  set(VarName.c_str(), Value, Requested, Overridden);
 }
 
 
 
 inline void
-GetPot::set(const char* VarName, const char* Value, const bool Requested /* = true */)
+GetPot::set(const char* VarName, const char* Value, const bool Requested /* = true */, const bool Overridden /* = true */)
 {
-  _set_variable(VarName, Value, Requested);
+  _set_variable(VarName, Value, Requested, Overridden);
 }
 
 
 
 inline void
-GetPot::set(const std::string& VarName, const char* Value, const bool Requested /* = true */)
+GetPot::set(const std::string& VarName, const char* Value, const bool Requested /* = true */, const bool Overridden /* = true */)
 {
-  set(VarName.c_str(), Value, Requested);
+  set(VarName.c_str(), Value, Requested, Overridden);
 }
 
 


### PR DESCRIPTION
TL;DR;
There appears to be no way to set a variable externally (that may already exist)
without having it marked as overridden. This API change allows the user to
choose which variables appear overridden and which do not.

Full Details
I would like to support the ability for users to supply variables right in their input files that may be replaced by user-defined logic (See https://github.com/idaholab/moose/issues/4840 and https://github.com/idaholab/moose/issues/5649). This would look like the following in a normal MOOSE input file:

```
[Outputs]
  file_base = 'heat_conduction_$DATE$'
  ...
[]
```

The Parser would then give the user the opportunity to replace these variables with a callback supplying various other pieces of information from the input file or system. Some of these variables would be system defined like `$DATE$` while others would be user-defined like `$TRANSPORT_METHOD$`. To avoid the explosion of new template functions, my implementation works by peaking at each raw variable value as a string type and allowing the user to replace the value as another string type. The normal templated GetPot extraction methods would then be used to convert the input as normal. The only hitch to this whole plan is the fact that the current implementation of the private method `_set_variable()` in GetPot automatically marks all existing parameters as overridden which I am already making use of for error checking in GetPot files, specifically for these types of cases:

```
[Outputs]
   file_base = foobar.e
[]

...

[Outputs]
  file_base = junk.e  # Perfectly legal in GetPot but causes confusion
[]
```

I'd like these "replacements" to happen without triggering this override behavior. I propose either this PR which simply piggybacks on the existing `sets()` methods or adding a new group of methods called `replace()` that will do the same thing.  Any objects, comments?