### PR TITLE
Add missing overrides.

### DIFF
--- a/include/error_estimation/kelly_error_estimator.h
+++ b/include/error_estimation/kelly_error_estimator.h
@@ -96,20 +96,20 @@ protected:
    * An initialization function, for requesting specific data from the FE
    * objects
    */
-  virtual void init_context(FEMContext &c);
+  virtual void init_context(FEMContext &c) libmesh_override;
 
   /**
    * The function which calculates a normal derivative jump based error
    * term on an internal side
    */
-  virtual void internal_side_integration();
+  virtual void internal_side_integration() libmesh_override;
 
   /**
    * The function which calculates a normal derivative jump based error
    * term on a boundary side.
    * Returns true if the flux bc function is in fact defined on the current side.
    */
-  virtual bool boundary_side_integration();
+  virtual bool boundary_side_integration() libmesh_override;
 
   /**
    * Pointer to function that returns BC information.

--- a/include/error_estimation/weighted_patch_recovery_error_estimator.h
+++ b/include/error_estimation/weighted_patch_recovery_error_estimator.h
@@ -81,7 +81,7 @@ public:
   */
   std::vector<FEMFunctionBase<Number>*> weight_functions;
 
-  virtual ErrorEstimatorType type() const
+  virtual ErrorEstimatorType type() const libmesh_override
   { return WEIGHTED_PATCH_RECOVERY;}
 
 private:

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2263,7 +2263,7 @@ Elem::side_iterator : variant_filter_iterator<Elem::Predicate, Elem*>
 #define LIBMESH_ENABLE_TOPOLOGY_CACHES                                  \
   virtual                                                               \
   std::vector<std::vector<std::vector<std::vector<std::pair<unsigned char, unsigned char> > > > > & \
-  _get_bracketing_node_cache() const                                    \
+  _get_bracketing_node_cache() const libmesh_override                   \
   {                                                                     \
     static std::vector<std::vector<std::vector<std::vector<std::pair<unsigned char, unsigned char> > > > > c; \
     return c;                                                           \
@@ -2271,7 +2271,7 @@ Elem::side_iterator : variant_filter_iterator<Elem::Predicate, Elem*>
                                                                         \
   virtual                                                               \
   std::vector<std::vector<std::vector<signed char> > > &                \
-  _get_parent_indices_cache() const                                     \
+  _get_parent_indices_cache() const libmesh_override                    \
   {                                                                     \
     static std::vector<std::vector<std::vector<signed char> > > c;      \
     return c;                                                           \

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -140,9 +140,9 @@ public:
   /**
    * Write out a nodal solution.
    */
-  void write_nodal_data (const std::string&,
-                         const std::vector<Number>&,
-                         const std::vector<std::string>&);
+  virtual void write_nodal_data (const std::string&,
+                                 const std::vector<Number>&,
+                                 const std::vector<std::string>&) libmesh_override;
 
   /**
    * Write out a discontinuous nodal solution.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -620,7 +620,8 @@ public:
    * Interfaces for reading/writing a mesh to/from a file.  Must be
    * implemented in derived classes.
    */
-  virtual void read  (const std::string& name, MeshData* mesh_data=NULL,
+  virtual void read  (const std::string& name,
+                      MeshData* mesh_data=NULL,
                       bool skip_renumber_nodes_and_elements=false) = 0;
   virtual void write (const std::string& name, MeshData* mesh_data=NULL) = 0;
 

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -120,7 +120,7 @@ public:
    * \p p and for \p time, which defaults to zero.
    */
   Number operator() (const Point& p,
-                     const Real time=0.);
+                     const Real time=0.) libmesh_override;
 
   /**
    * @returns the first derivatives of variable 0 at point
@@ -146,7 +146,7 @@ public:
    */
   void operator() (const Point& p,
                    const Real time,
-                   DenseVector<Number>& output);
+                   DenseVector<Number>& output) libmesh_override;
 
   /**
    * Computes values at coordinate \p p and for time \p time,

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -86,7 +86,9 @@ public:
   /**
    * Output a nodal solution.
    */
-  void write_nodal_data (const std::string& fname, const std::vector<Number>& soln, const std::vector<std::string>& names);
+  virtual void write_nodal_data (const std::string& fname,
+                                 const std::vector<Number>& soln,
+                                 const std::vector<std::string>& names) libmesh_override;
 
   /**
    * Set the flag indicationg if we should be verbose.

--- a/include/mesh/parallel_mesh.h
+++ b/include/mesh/parallel_mesh.h
@@ -128,7 +128,7 @@ public:
    * nodes containers.
    * Calls libmesh_assert() on each possible failure.
    */
-  virtual void libmesh_assert_valid_parallel_ids() const;
+  virtual void libmesh_assert_valid_parallel_ids() const libmesh_override;
 
   /**
    * Verify refinement_flag and p_refinement_flag consistency of our

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -85,9 +85,9 @@ public:
    * The skip_renumber_nodes_and_elements argument is now deprecated -
    * to disallow renumbering, set \p MeshBase::allow_renumbering(false)
    */
-  void read (const std::string& name,
-             MeshData* mesh_data=NULL,
-             bool skip_renumber_nodes_and_elements=false);
+  virtual void read (const std::string& name,
+                     MeshData* mesh_data=NULL,
+                     bool skip_renumber_nodes_and_elements=false) libmesh_override;
   /**
    * Write the file specified by \p name.  Attempts to figure out the
    * proper method by the file extension.
@@ -96,8 +96,8 @@ public:
    * also pass a separate pointer to the MeshData object you have been
    * using with this mesh, since these write methods expect it.
    */
-  void write (const std::string& name,
-              MeshData* mesh_data=NULL);
+  virtual void write (const std::string& name,
+                      MeshData* mesh_data=NULL) libmesh_override;
 
   /**
    * Write to the file specified by \p name.  Attempts to figure out the

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -381,7 +381,7 @@ protected:
   virtual void _get_submatrix(SparseMatrix<T>& submatrix,
                               const std::vector<numeric_index_type>& rows,
                               const std::vector<numeric_index_type>& cols,
-                              const bool reuse_submatrix) const;
+                              const bool reuse_submatrix) const libmesh_override;
 
 private:
 

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -61,11 +61,11 @@ public:
 private:
 
   void init_1D (const ElemType _type=INVALID_ELEM,
-                unsigned int p_level=0);
+                unsigned int p_level=0) libmesh_override;
   void init_2D (const ElemType _type=INVALID_ELEM,
-                unsigned int p_level=0);
+                unsigned int p_level=0) libmesh_override;
   void init_3D (const ElemType _type=INVALID_ELEM,
-                unsigned int p_level=0);
+                unsigned int p_level=0) libmesh_override;
 };
 
 } // namespace libMesh

--- a/include/solvers/adaptive_time_solver.h
+++ b/include/solvers/adaptive_time_solver.h
@@ -70,7 +70,7 @@ public:
 
   virtual void reinit() libmesh_override;
 
-  virtual void solve() = 0;
+  virtual void solve() libmesh_override = 0;
 
   virtual void advance_timestep() libmesh_override;
 

--- a/include/solvers/second_order_unsteady_solver.h
+++ b/include/solvers/second_order_unsteady_solver.h
@@ -50,7 +50,7 @@ public:
    */
   virtual ~SecondOrderUnsteadySolver ();
 
-  virtual unsigned int time_order() const
+  virtual unsigned int time_order() const libmesh_override
   { return 2; }
 
   /**

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -123,7 +123,7 @@ public:
    */
   virtual void assembly (bool get_residual,
                          bool get_jacobian,
-                         bool apply_heterogeneous_constraints = false) = 0;
+                         bool apply_heterogeneous_constraints = false) libmesh_override = 0;
 
   /**
    * Invokes the solver associated with the system.  For steady state
@@ -142,7 +142,7 @@ public:
   /**
    * We don't allow systems to be attached to each other
    */
-  virtual UniquePtr<DifferentiablePhysics> clone_physics()
+  virtual UniquePtr<DifferentiablePhysics> clone_physics() libmesh_override
   {
     libmesh_not_implemented();
     // dummy
@@ -152,7 +152,7 @@ public:
   /**
    * We don't allow systems to be attached to each other
    */
-  virtual UniquePtr<DifferentiableQoI> clone()
+  virtual UniquePtr<DifferentiableQoI> clone() libmesh_override
   {
     libmesh_not_implemented();
     // dummy

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -130,7 +130,7 @@ public:
    * Most FEMSystem-based problems will need to reimplement this in order to
    * call FE::get_*() as their particular physics requires.
    */
-  virtual void init_context(DiffContext &);
+  virtual void init_context(DiffContext &) libmesh_override;
 
   /**
    * Runs a postprocessing loop over all elements, and if

--- a/include/utils/tree.h
+++ b/include/utils/tree.h
@@ -81,10 +81,9 @@ public:
    * optionally restricted to a set of allowed subdomains,
    * optionally using a non-zero relative tolerance for searches.
    */
-  const Elem* find_element(const Point& p,
-                           const std::set<subdomain_id_type>
-                           *allowed_subdomains = NULL,
-                           Real relative_tol = TOLERANCE) const;
+  virtual const Elem* find_element(const Point& p,
+                                   const std::set<subdomain_id_type> *allowed_subdomains = NULL,
+                                   Real relative_tol = TOLERANCE) const libmesh_override;
 
   /**
    * @returns a pointer to the element containing point p,

--- a/include/utils/tree_base.h
+++ b/include/utils/tree_base.h
@@ -94,8 +94,7 @@ public:
    * optionally using a non-zero relative tolerance for searches.
    */
   virtual const Elem* find_element(const Point& p,
-                                   const std::set<subdomain_id_type>
-                                   *allowed_subdomains = NULL,
+                                   const std::set<subdomain_id_type> *allowed_subdomains = NULL,
                                    Real relative_tol = TOLERANCE) const = 0;
 
 protected:


### PR DESCRIPTION
Clang 3.7.0 apparently has -Winconsistent-missing-override turned on
by default, and warned me about a bunch of overrides I missed.  Note
also that you can use the `override` keyword when virtual functions are
overridden to become pure virtual.

Refs #655.