### PR TITLE
Expose requested variables in GetPot

### DIFF
--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -390,6 +390,13 @@ public:
   inline STRING_VECTOR unidentified_nominuses() const;
 
   /**
+   * Accessors for requested variables
+   */
+  std::set<std::string> get_requested_arguments() const;
+  std::set<std::string> get_requested_variables() const;
+  std::set<std::string> get_requested_sections() const;
+
+  /**
    * output
    */
 
@@ -3728,6 +3735,36 @@ GetPot::unidentified_nominuses(const std::set<std::string>& Knowns) const
         ufos.push_back(*it);
     }
   return ufos;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// (*) Accessors for requested types
+//.............................................................................
+
+inline
+std::set<std::string>
+GetPot::get_requested_arguments() const
+{
+  return _requested_arguments;
+}
+
+
+
+inline
+std::set<std::string>
+GetPot::get_requested_variables() const
+{
+  return _requested_variables;
+}
+
+
+
+inline
+std::set<std::string>
+GetPot::get_requested_sections() const
+{
+  return _requested_sections;
 }
 
 


### PR DESCRIPTION
Adding accessors so that we can perform checks on used or overridden
variables outside of the internal GetPot routines.