### PR TITLE
Disable curl by default.

### DIFF
--- a/configure
+++ b/configure
@@ -1975,7 +1975,7 @@ Optional Features:
                           Build fparser with bytecode debugging functions
   --disable-cppunit       Build without cppunit C++ unit testing support
   --disable-nanoflann     build without nanoflann KD-tree suppport
-  --disable-curl          build without curl support
+  --enable-curl           link against libcurl, for using the cURL API
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -38102,7 +38102,7 @@ if test "${enable_curl+set}" = set; then :
                   *)  as_fn_error $? "bad value ${enableval} for --enable-curl" "$LINENO" 5 ;;
                 esac
 else
-  enablecurl=$enableoptional
+  enablecurl=no
 fi
 
 

--- a/m4/curl.m4
+++ b/m4/curl.m4
@@ -2,14 +2,14 @@
 AC_DEFUN([CONFIGURE_CURL],
 [
   AC_ARG_ENABLE(curl,
-                AS_HELP_STRING([--disable-curl],
-                               [build without curl support]),
+                AS_HELP_STRING([--enable-curl],
+                               [link against libcurl, for using the cURL API]),
                 [case "${enableval}" in
                   yes)  enablecurl=yes ;;
                   no)  enablecurl=no ;;
                   *)  AC_MSG_ERROR(bad value ${enableval} for --enable-curl) ;;
                 esac],
-                [enablecurl=$enableoptional])
+                [enablecurl=no])
 
   if (test $enablecurl = yes); then
 


### PR DESCRIPTION
As we decided over [here](https://github.com/libMesh/libmesh/commit/c2a9713596c3b098e714332a285e3307700a222e#commitcomment-13914389) it can be dangerous to enable this by default.