### PR TITLE
Assert no repeated calls to System::init()

### DIFF
--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -227,6 +227,10 @@ void System::clear ()
 
 void System::init ()
 {
+  // Calling init() twice on the same system currently works evil
+  // magic, whether done directly or via EquationSystems::read()
+  libmesh_assert(!this->is_initialized());
+
   // First initialize any required data:
   // either only the basic System data
   if (_basic_system_only)


### PR DESCRIPTION
This isn't hard to do by accident (e.g. first manually calling
EquationSystems::init() and later calling EquationSystems::read() with
read_headers on), and even in dbg mode it may result in no saner error
than "suddenly PETSc LU is finding zero pivots on Poisson matrices".

Apologies to @vikramvgarg for the aforementioned insane error.