### PR TITLE
Add an operator bool() to AutoPtr.

### DIFF
--- a/include/base/auto_ptr.h
+++ b/include/base/auto_ptr.h
@@ -376,7 +376,11 @@ public:
    * Forward compatibility with newer smart pointer types.  This
    * allows code like if (!foo) to work with AutoPtr.
    */
-  explicit operator bool() const
+#ifdef LIBMESH_HAVE_CXX11
+  // Conversion operators can only be marked explicit in C++11.
+  explicit
+#endif
+  operator bool() const
   { return (this->get() != NULL); }
 
   /**

--- a/include/base/auto_ptr.h
+++ b/include/base/auto_ptr.h
@@ -373,6 +373,13 @@ public:
   }
 
   /**
+   * Forward compatibility with newer smart pointer types.  This
+   * allows code like if (!foo) to work with AutoPtr.
+   */
+  explicit operator bool() const
+  { return (this->get() != NULL); }
+
+  /**
    * op() for AutoPtrRef<Tp1>.  Calls the release member.
    */
   template<typename Tp1>


### PR DESCRIPTION
I don't think this changes the inner workings of AutoPtr in any way,
and allows us to be more compatible with newer smart pointer types.

This fixes the compile error we encountered in #694, so presumably once this is merged we can invalidate that one and it will make it a bit further...