### PR TITLE
Fix to ignore "unused typedef"

### DIFF
--- a/contrib/unique_ptr/unique_ptr.hpp
+++ b/contrib/unique_ptr/unique_ptr.hpp
@@ -21,6 +21,11 @@
 #include <boost/static_assert.hpp>
 #include <boost/mpl/if.hpp>
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
+
 namespace boost
 {
 
@@ -531,5 +536,9 @@ operator>=(const unique_ptr<T1, D1>& x, const unique_ptr<T2, D2>& y)
 }
 
 }  // boost
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #endif  // UNIQUE_PTR_HPP


### PR DESCRIPTION
present in clang 3.7.0 when not using C++11 with METHOD=dbg.