### PR TITLE
Refactor UCDIO slightly, read/write subdomain id

### DIFF
--- a/include/mesh/ucd_io.h
+++ b/include/mesh/ucd_io.h
@@ -21,11 +21,13 @@
 #define LIBMESH_UCD_IO_H
 
 // C++ includes
+#include <map>
 
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/mesh_input.h"
 #include "libmesh/mesh_output.h"
+#include "libmesh/enum_elem_type.h"
 
 namespace libMesh
 {
@@ -127,6 +129,20 @@ private:
                   const MeshBase& mesh,
                   const std::vector<std::string>& names,
                   const std::vector<Number>& soln);
+
+  // Static map from libmesh ElementType -> UCD description string for
+  // use during writing.
+  static std::map<ElemType, std::string> _writing_element_map;
+
+  // Static map from libmesh UCD description string -> ElementType for
+  // use during reading.
+  static std::map<std::string, ElemType> _reading_element_map;
+
+  // Static function used to build the _writing_element_map.
+  static std::map<ElemType, std::string> build_writing_element_map();
+
+  // Static function used to build the _reading_element_map.
+  static std::map<std::string, ElemType> build_reading_element_map();
 };
 
 } // namespace libMesh

--- a/include/mesh/ucd_io.h
+++ b/include/mesh/ucd_io.h
@@ -26,7 +26,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/mesh_input.h"
 #include "libmesh/mesh_output.h"
-#include "libmesh/boundary_info.h"
 
 namespace libMesh
 {
@@ -50,14 +49,19 @@ public:
    * This is the constructor required to read a mesh.
    */
   explicit
-  UCDIO (MeshBase&);
+  UCDIO (MeshBase& mesh) :
+    MeshInput<MeshBase> (mesh),
+    MeshOutput<MeshBase>(mesh)
+  {}
 
   /**
    * Constructor.  Takes a reference to a constant mesh object.
    * This constructor will only allow us to write the mesh.
    */
   explicit
-  UCDIO (const MeshBase&);
+  UCDIO (const MeshBase& mesh) :
+    MeshOutput<MeshBase> (mesh)
+  {}
 
   /**
    * This method implements reading a mesh from a specified file
@@ -99,47 +103,31 @@ private:
   /**
    * Write UCD format header
    */
-  void write_header(std::ostream& out, const MeshBase& mesh,
-                    dof_id_type n_elems, unsigned int n_vars );
+  void write_header(std::ostream& out,
+                    const MeshBase& mesh,
+                    dof_id_type n_elems,
+                    unsigned int n_vars);
 
   /**
    * Write node information
    */
-  void write_nodes(std::ostream& out, const MeshBase& mesh);
+  void write_nodes(std::ostream& out,
+                   const MeshBase& mesh);
 
   /**
    * Write element information
    */
-  void write_interior_elems(std::ostream& out, const MeshBase& mesh);
+  void write_interior_elems(std::ostream& out,
+                            const MeshBase& mesh);
 
   /**
    * Writes all nodal solution variables
    */
-  void write_soln(std::ostream& out, const MeshBase& mesh,
+  void write_soln(std::ostream& out,
+                  const MeshBase& mesh,
                   const std::vector<std::string>& names,
-                  const std::vector<Number>&soln);
-
+                  const std::vector<Number>& soln);
 };
-
-
-
-// ------------------------------------------------------------
-// UCDIO inline members
-inline
-UCDIO::UCDIO (MeshBase& mesh) :
-  MeshInput<MeshBase> (mesh),
-  MeshOutput<MeshBase>(mesh)
-{
-}
-
-
-
-inline
-UCDIO::UCDIO (const MeshBase& mesh) :
-  MeshOutput<MeshBase> (mesh)
-{
-}
-
 
 } // namespace libMesh
 

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -180,7 +180,7 @@ void UCDIO::read_implementation (std::istream& in)
 
         // The cell type can be either tri, quad, tet, hex, or prism.
         in >> dummy        // Cell number, means nothing to us
-           >> material_id  // doesn't mean anything at present, might later
+           >> material_id  // We'll use this for the element subdomain id.
            >> type;        // string describing cell type
 
         // Convert the UCD type string to a libmesh ElementType
@@ -205,6 +205,9 @@ void UCDIO::read_implementation (std::istream& in)
           }
 
         elems_of_dimension[elem->dim()] = true;
+
+        // Set the element's subdomain ID based on the material_id.
+        elem->subdomain_id() = cast_int<subdomain_id_type>(material_id);
 
         // Add the element to the mesh
         elem->set_id(i);
@@ -315,7 +318,8 @@ void UCDIO::write_interior_elems(std::ostream& out_stream,
       if (it == _writing_element_map.end())
         libmesh_error_msg("Error: Unsupported ElemType " << etype << " for UCDIO.");
 
-      out_stream << e++ << " 0 " << it->second << "\t";
+      // Write the element's subdomain ID as the UCD "material_id".
+      out_stream << e++ << " " << elem->subdomain_id() << " " << it->second << "\t";
       elem->write_connectivity(out_stream, UCD);
     }
 }


### PR DESCRIPTION
Someone on the MOOSE users mailing list discovered that we were just throwing away the "material_id" from UCD files so I fixed that and also refactored the class in some separate commits.