### PR TITLE
Implement fixes suggested by cppclean

### DIFF
--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -64,6 +64,7 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/getpot.h"
+#include "libmesh/elem.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/fem_system/fem_system_ex1/naviersystem.C
+++ b/examples/fem_system/fem_system_ex1/naviersystem.C
@@ -28,6 +28,7 @@
 #include "libmesh/quadrature.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/zero_function.h"
+#include "libmesh/elem.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/fem_system/fem_system_ex2/solid_system.C
+++ b/examples/fem_system/fem_system_ex2/solid_system.C
@@ -34,6 +34,8 @@
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/steady_solver.h"
 #include "libmesh/transient_system.h"
+#include "libmesh/node.h"
+#include "libmesh/elem.h"
 
 #include "nonlinear_neohooke_cc.h"
 #include "solid_system.h"

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -43,6 +43,7 @@
 #include "libmesh/diff_solver.h"
 #include "libmesh/newmark_solver.h"
 #include "libmesh/steady_solver.h"
+#include "libmesh/elem.h"
 
 #define x_scaling 1.3
 

--- a/examples/fem_system/fem_system_ex4/heatsystem.C
+++ b/examples/fem_system/fem_system_ex4/heatsystem.C
@@ -10,6 +10,7 @@
 #include "libmesh/quadrature.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/zero_function.h"
+#include "libmesh/elem.h"
 
 using namespace libMesh;
 

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic.h
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic.h
@@ -4,6 +4,7 @@
 #include "libmesh/equation_systems.h"
 #include "libmesh/serial_mesh.h"
 #include "libmesh/exodusII_io.h"
+#include "libmesh/mesh_refinement.h"
 
 // Bring in bits from the libMesh namespace.
 // Just the bits we're using, since this is a header.

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
@@ -9,6 +9,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/periodic_boundary.h"
+#include "libmesh/elem.h"
 
 // Example includes
 #include "biharmonic_jr.h"

--- a/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
+++ b/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
@@ -33,6 +33,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/tecplot_io.h"
 #include "libmesh/threads.h"
+#include "libmesh/node.h"
 #include "meshless_interpolation_function.h"
 
 // C++ includes

--- a/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
+++ b/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
@@ -3,6 +3,7 @@
 
 // libMesh includes
 #include "libmesh/linear_implicit_system.h"
+#include "libmesh/elem.h"
 
 using namespace libMesh;
 

--- a/examples/reduced_basis/reduced_basis_ex1/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex1/rb_classes.h
@@ -22,6 +22,7 @@
 
 #include "libmesh/rb_construction.h"
 #include "libmesh/fe_base.h"
+#include "libmesh/rb_evaluation.h"
 
 // local include
 #include "assembly.h"

--- a/examples/reduced_basis/reduced_basis_ex2/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex2/rb_classes.h
@@ -26,6 +26,8 @@
 #include "libmesh/rb_scm_construction.h"
 #include "libmesh/fe_base.h"
 #include "libmesh/auto_ptr.h"
+#include "libmesh/rb_evaluation.h"
+#include "libmesh/rb_scm_evaluation.h"
 
 // Bring in bits from the libMesh namespace.
 // Just the bits we're using, since this is a header.

--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -3,6 +3,7 @@
 
 // local includes
 #include "libmesh/rb_eim_construction.h"
+#include "libmesh/rb_eim_evaluation.h"
 #include "assembly.h"
 
 // Bring in bits from the libMesh namespace.

--- a/examples/reduced_basis/reduced_basis_ex5/assembly.C
+++ b/examples/reduced_basis/reduced_basis_ex5/assembly.C
@@ -15,6 +15,7 @@
 #include "libmesh/elem_assembly.h"
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/boundary_info.h"
+#include "libmesh/node.h"
 
 // Bring in bits from the libMesh namespace.
 // Just the bits we're using, since this is a header.

--- a/examples/reduced_basis/reduced_basis_ex5/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex5/assembly.h
@@ -6,6 +6,7 @@
 #include "libmesh/rb_theta.h"
 #include "libmesh/rb_theta_expansion.h"
 #include "libmesh/rb_assembly_expansion.h"
+#include "libmesh/elem_assembly.h"
 
 // Bring in bits from the libMesh namespace.
 // Just the bits we're using, since this is a header.

--- a/examples/reduced_basis/reduced_basis_ex5/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex5/rb_classes.h
@@ -6,6 +6,7 @@
 
 // rbOOmit includes
 #include "libmesh/rb_construction.h"
+#include "libmesh/rb_evaluation.h"
 
 // libMesh includes
 #include "libmesh/fe_base.h"

--- a/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
@@ -22,6 +22,7 @@
 
 #include "libmesh/rb_construction.h"
 #include "libmesh/fe_base.h"
+#include "libmesh/rb_evaluation.h"
 
 // local include
 #include "assembly.h"

--- a/examples/reduced_basis/reduced_basis_ex7/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex7/rb_classes.h
@@ -23,6 +23,7 @@
 #include "libmesh/rb_construction.h"
 #include "libmesh/fe_base.h"
 #include "libmesh/auto_ptr.h"
+#include "libmesh/rb_evaluation.h"
 
 // local include
 #include "assembly.h"

--- a/examples/subdomains/subdomains_ex3/subdomains_ex3.C
+++ b/examples/subdomains/subdomains_ex3/subdomains_ex3.C
@@ -35,6 +35,7 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/quadrature_composite.h"
 #include "libmesh/fe.h"
+#include "libmesh/elem.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/systems_of_equations/systems_of_equations_ex8/augment_sparsity_on_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/augment_sparsity_on_contact.C
@@ -4,6 +4,7 @@
 // libMesh includes
 #include "libmesh/linear_implicit_system.h"
 #include LIBMESH_INCLUDE_UNORDERED_SET
+#include "libmesh/elem.h"
 
 using namespace libMesh;
 

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -53,10 +53,8 @@ class DofObject;
 class Elem;
 class FEType;
 class MeshBase;
-class Mesh;
 class PeriodicBoundaryBase;
 class PeriodicBoundaries;
-namespace SparsityPattern { class Build; }
 class System;
 template <typename T> class DenseVectorBase;
 template <typename T> class DenseVector;

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -32,6 +32,7 @@
 #include "libmesh/elem_range.h"
 #include "libmesh/sparsity_pattern.h"
 #include "libmesh/parallel_object.h"
+#include "libmesh/point.h"
 
 // C++ Includes   -----------------------------------
 #include <algorithm>

--- a/include/fe/fe_base.h
+++ b/include/fe/fe_base.h
@@ -27,7 +27,6 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/fe_abstract.h"
 #include "libmesh/fe_transformation_base.h"
-#include "libmesh/fe_type.h"
 #include "libmesh/point.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/tensor_tools.h"
@@ -54,6 +53,7 @@ class MeshBase;
 template <typename T> class NumericVector;
 class QBase;
 template <typename T> class FETransformationBase;
+class FEType;
 
 #ifdef LIBMESH_ENABLE_NODE_CONSTRAINTS
 class NodeConstraints;

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -26,13 +26,13 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/auto_ptr.h"
-#include "libmesh/node.h"
 
 namespace libMesh
 {
 
 // forward declarations
 class Elem;
+class Node;
 
 class FEMap
 {

--- a/include/fe/fe_transformation_base.h
+++ b/include/fe/fe_transformation_base.h
@@ -19,7 +19,6 @@
 #define LIBMESH_FE_TRANSFORMATION_BASE_H
 
 #include "libmesh/fe_base.h"
-#include "libmesh/fe_type.h"
 
 namespace libMesh
 {
@@ -28,6 +27,7 @@ namespace libMesh
 template< typename T > class FEGenericBase;
 template< typename T > class H1FETransformation;
 template< typename T > class HCurlFETransformation;
+class FEType;
 
 /**
  * This class handles the computation of the shape functions in the physical domain.

--- a/include/fe/fe_xyz_map.h
+++ b/include/fe/fe_xyz_map.h
@@ -22,10 +22,12 @@
 
 #include "libmesh/fe_map.h"
 #include "libmesh/libmesh_logging.h"
-#include "libmesh/elem.h"
 
 namespace libMesh
 {
+
+// Forward declarations
+class Elem;
 
 class FEXYZMap : public FEMap
 {

--- a/include/fe/h1_fe_transformation.h
+++ b/include/fe/h1_fe_transformation.h
@@ -20,10 +20,12 @@
 
 #include "libmesh/fe_transformation_base.h"
 #include "libmesh/compare_types.h"
-#include "libmesh/elem.h"
 
 namespace libMesh
 {
+
+// Forward declarations
+class Elem;
 
 /**
  * This class handles the computation of the shape functions in the

--- a/include/geom/elem_range.h
+++ b/include/geom/elem_range.h
@@ -21,12 +21,14 @@
 #define LIBMESH_ELEM_RANGE_H
 
 // Local includes
-#include "libmesh/elem.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/stored_range.h"
 
 namespace libMesh
 {
+
+// Forward declarations
+class Elem;
 
 typedef StoredRange<MeshBase::element_iterator,             Elem*>      ElemRange;
 typedef StoredRange<MeshBase::const_element_iterator, const Elem*> ConstElemRange;

--- a/include/geom/node_range.h
+++ b/include/geom/node_range.h
@@ -22,13 +22,15 @@
 
 // Local includes
 #include "libmesh/mesh_base.h"
-#include "libmesh/node.h"
 #include "libmesh/stored_range.h"
 
 // C++ includes
 
 namespace libMesh
 {
+
+// Forward declarations
+class Node;
 
 typedef StoredRange<MeshBase::node_iterator,             Node*>      NodeRange;
 typedef StoredRange<MeshBase::const_node_iterator, const Node*> ConstNodeRange;

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -34,10 +34,7 @@
 namespace libMesh
 {
 // Forward declarations
-class MeshBase;
-class MeshData;
 class Xdr;
-class Elem;
 
 /**
  * The CheckpointIO class can be used to write simplified restart

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -23,9 +23,9 @@
 #ifdef LIBMESH_HAVE_EXODUS_API
 
 // Local includes
-#include "libmesh/mesh_base.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/point.h"
+#include "libmesh/elem_type.h"
 
 // C++ includes
 #include <iostream>
@@ -52,6 +52,8 @@
 namespace libMesh
 {
 
+// Forward declarations
+class MeshBase;
 
 namespace exII {
 extern "C" {

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -34,7 +34,6 @@ namespace libMesh
 // Forward declarations
 class MeshBase;
 class ParallelMesh;
-class BoundaryInfo;
 
 /**
  * This is the \p MeshCommunication class.  It handles all the details

--- a/include/mesh/mesh_generation.h
+++ b/include/mesh/mesh_generation.h
@@ -21,11 +21,12 @@
 #define LIBMESH_MESH_GENERATION_H
 
 // Local Includes -----------------------------------
-// #include "libmesh/libmesh_common.h" // needed for Real
 #include "libmesh/libmesh.h"
 #include "libmesh/enum_elem_type.h"
-#include "libmesh/mesh_triangle_interface.h"
 #include "libmesh/vector_value.h"
+#ifdef LIBMESH_HAVE_TRIANGLE
+#include "libmesh/mesh_triangle_interface.h"
+#endif
 
 // C++ Includes   -----------------------------------
 #include <cstddef>
@@ -38,7 +39,6 @@ namespace libMesh
 class MeshBase;
 class UnstructuredMesh;
 class Elem;
-
 
 
 // ------------------------------------------------------------

--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -30,8 +30,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh.h" // libMesh::invalid_uint
 #include "libmesh/topology_map.h"
-#include "libmesh/elem.h"
-#include "libmesh/point_locator_base.h"
 #include "libmesh/parallel_object.h"
 
 // C++ Includes   -----------------------------------
@@ -46,6 +44,8 @@ class Point;
 class Node;
 class ErrorVector;
 class PeriodicBoundaries;
+class Elem;
+class PointLocatorBase;
 
 /**
  * This is the \p MeshRefinement class.  This class implements

--- a/include/mesh/mesh_smoother_vsmoother.h
+++ b/include/mesh/mesh_smoother_vsmoother.h
@@ -24,8 +24,8 @@
 #ifdef LIBMESH_ENABLE_VSMOOTHER
 
 // Local Includes -----------------------------------
+#include "libmesh/libmesh_common.h"
 #include "libmesh/mesh_smoother.h"
-#include "libmesh/unstructured_mesh.h"
 
 // C++ Includes   -----------------------------------
 #include <cstddef>
@@ -35,6 +35,9 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class UnstructuredMesh;
 
 /**
  * This is an implementation of Larisa Branets' smoothing algorithms.

--- a/include/mesh/mesh_subdivision_support.h
+++ b/include/mesh/mesh_subdivision_support.h
@@ -24,7 +24,6 @@
 
 // Local Includes -----------------------------------
 #include "libmesh/libmesh.h"
-#include "libmesh/mesh_base.h"
 #include "libmesh/face_tri3_subdivision.h"
 #include "libmesh/elem.h"
 
@@ -32,6 +31,9 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class MeshBase;
 
 // ------------------------------------------------------------
 // MeshTools::Subdivision namespace

--- a/include/mesh/mesh_tetgen_interface.h
+++ b/include/mesh/mesh_tetgen_interface.h
@@ -24,7 +24,6 @@
 
 
 // Local includes
-#include "libmesh/elem.h"
 #include "libmesh/mesh_serializer.h"
 #include "libmesh/point.h" // used for specifying holes
 
@@ -39,6 +38,7 @@ namespace libMesh
 // Forward Declarations
 class UnstructuredMesh;
 class TetGenWrapper;
+class Elem;
 
 /**
  * Class \p TetGenMeshInterface provides an interface for

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -39,8 +39,6 @@ namespace libMesh
 {
 
 // forward declarations
-class SerialMesh;
-class ParallelMesh;
 class Sphere;
 class Elem;
 

--- a/include/mesh/xdr_io.h
+++ b/include/mesh/xdr_io.h
@@ -35,8 +35,6 @@ namespace libMesh
 {
 
 // Forward declarations
-class MeshBase;
-class MeshData;
 class Xdr;
 class Elem;
 

--- a/include/mesh/xdr_mhead.h
+++ b/include/mesh/xdr_mhead.h
@@ -20,7 +20,6 @@
 
 // Local includes
 #include "libmesh/xdr_head.h" // for base class
-#include "libmesh/xdr_mesh.h" // for friend
 #include "libmesh/enum_elem_type.h" // for ElemType
 
 // C++ includes
@@ -28,6 +27,9 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class XdrMESH;
 
 /**
  * The \p XdrMHEAD class.

--- a/include/mesh/xdr_shead.h
+++ b/include/mesh/xdr_shead.h
@@ -20,12 +20,14 @@
 
 // Local includes
 #include "libmesh/xdr_head.h" // for base class
-#include "libmesh/xdr_soln.h" // for friend
 
 // C++ includes
 
 namespace libMesh
 {
+
+// Forward declarations
+class XdrSOLN;
 
 /**
  * The \p XdrSHEAD class.  This class is responsible for

--- a/include/numerics/const_fem_function.h
+++ b/include/numerics/const_fem_function.h
@@ -22,9 +22,12 @@
 
 #include "libmesh/dense_vector.h"
 #include "libmesh/fem_function_base.h"
-#include "libmesh/point.h"
 
-namespace libMesh {
+namespace libMesh
+{
+
+// Forward declarations
+class Point;
 
 template <typename Output=Number>
 class ConstFEMFunction : public FEMFunctionBase<Output>

--- a/include/numerics/parsed_fem_function_parameter.h
+++ b/include/numerics/parsed_fem_function_parameter.h
@@ -24,11 +24,12 @@
 // Local Includes -----------------------------------
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parameter_accessor.h"
-#include "libmesh/parsed_function.h"
-#include "libmesh/parsed_fem_function.h"
 
 namespace libMesh
 {
+
+// Forward declarations
+template <typename T> class ParsedFEMFunction;
 
 /**
  * Accessor object allowing reading and modification of the

--- a/include/numerics/parsed_function_parameter.h
+++ b/include/numerics/parsed_function_parameter.h
@@ -24,11 +24,10 @@
 // Local Includes -----------------------------------
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parameter_accessor.h"
+#include "libmesh/parsed_function.h"
 
 namespace libMesh
 {
-
-template <typename T> class ParsedFunction;
 
 /**
  * Accessor object allowing reading and modification of the

--- a/include/numerics/parsed_function_parameter.h
+++ b/include/numerics/parsed_function_parameter.h
@@ -24,10 +24,11 @@
 // Local Includes -----------------------------------
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parameter_accessor.h"
-#include "libmesh/parsed_function.h"
 
 namespace libMesh
 {
+
+template <typename T> class ParsedFunction;
 
 /**
  * Accessor object allowing reading and modification of the

--- a/include/physics/diff_physics.h
+++ b/include/physics/diff_physics.h
@@ -24,7 +24,6 @@
 // Local Includes
 #include "libmesh/libmesh.h"
 #include "libmesh/auto_ptr.h"
-#include "libmesh/diff_context.h"
 
 // C++ includes
 #include <vector>
@@ -34,9 +33,7 @@ namespace libMesh
 
 // Forward Declarations
 class System;
-class TimeSolver;
-
-template <typename T> class NumericVector;
+class DiffContext;
 
 /**
  * This class provides a specific system class.  It aims

--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -22,8 +22,6 @@
 #define LIBMESH_DIFF_QOI_H
 
 // Local Includes
-#include "libmesh/diff_context.h"
-#include "libmesh/qoi_set.h"
 #include "libmesh/auto_ptr.h"
 #include "libmesh/parallel.h"
 
@@ -31,6 +29,10 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class DiffContext;
+class QoISet;
 
 /**
  * This class provides a specific system class.  It aims

--- a/include/reduced_basis/rb_assembly_expansion.h
+++ b/include/reduced_basis/rb_assembly_expansion.h
@@ -21,7 +21,6 @@
 #define LIBMESH_RB_ASSEMBLY_EXPANSION_H
 
 // libMesh includes
-#include "libmesh/elem_assembly.h"
 #include "libmesh/reference_counted_object.h"
 
 // C++ includes
@@ -30,6 +29,10 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class ElemAssembly;
+class FEMContext;
 
 /**
  * This class stores the set of ElemAssembly functor objects that define

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -22,14 +22,12 @@
 
 // rbOOmit includes
 #include "libmesh/rb_construction_base.h"
-#include "libmesh/rb_evaluation.h"
 
 // libMesh includes
 #include "libmesh/linear_implicit_system.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dg_fem_context.h"
-#include "libmesh/elem_assembly.h"
 #include "libmesh/dirichlet_boundaries.h"
 
 // C++ includes
@@ -39,6 +37,8 @@ namespace libMesh
 
 class RBThetaExpansion;
 class RBAssemblyExpansion;
+class RBEvaluation;
+class ElemAssembly;
 
 /**
  * This class is part of the rbOOmit framework.

--- a/include/reduced_basis/rb_data_deserialization.h
+++ b/include/reduced_basis/rb_data_deserialization.h
@@ -1,3 +1,22 @@
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010, 2015 David J. Knezevic
+
+// This file is part of rbOOmit.
+
+// rbOOmit is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// rbOOmit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
 #ifndef RB_DATA_DESERIALIZATION_H
 #define RB_DATA_DESERIALIZATION_H
 
@@ -6,9 +25,6 @@
 #if defined(LIBMESH_HAVE_CAPNPROTO)
 
 // libMesh/reduced_basis includes
-#include "libmesh/transient_rb_evaluation.h"
-#include "libmesh/rb_eim_evaluation.h"
-#include "libmesh/rb_scm_evaluation.h"
 #include "libmesh/rb_data.capnp.h"
 
 // Cap'n'Proto includes
@@ -18,6 +34,12 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class RBEvaluation;
+class TransientRBEvaluation;
+class RBEIMEvaluation;
+class RBSCMEvaluation;
 
 namespace RBDataDeserialization
 {

--- a/include/reduced_basis/rb_data_serialization.h
+++ b/include/reduced_basis/rb_data_serialization.h
@@ -1,3 +1,22 @@
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010, 2015 David J. Knezevic
+
+// This file is part of rbOOmit.
+
+// rbOOmit is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// rbOOmit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
 #ifndef RB_DATA_SERIALIZATION_H
 #define RB_DATA_SERIALIZATION_H
 
@@ -8,10 +27,6 @@
 #include <string>
 
 // libMesh/reduced_basis includes
-#include "libmesh/rb_evaluation.h"
-#include "libmesh/transient_rb_evaluation.h"
-#include "libmesh/rb_eim_evaluation.h"
-#include "libmesh/rb_scm_evaluation.h"
 #include "libmesh/rb_data.capnp.h"
 
 // Cap'n'Proto includes
@@ -19,6 +34,15 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class RBEvaluation;
+class TransientRBEvaluation;
+class RBEIMEvaluation;
+class RBSCMEvaluation;
+class RBParametrized;
+class Point;
+class Elem;
 
 namespace RBDataSerialization
 {
@@ -213,7 +237,7 @@ void add_point_to_builder(const Point& point,
 /**
  * Helper function that adds element data.
  */
-void add_elem_to_builder(const libMesh::Elem& elem,
+void add_elem_to_builder(const Elem& elem,
                          RBData::MeshElem::Builder mesh_elem_builder);
 
 } // namespace RBDataSerialization

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -24,8 +24,8 @@
 #include "libmesh/auto_ptr.h"
 #include "libmesh/point.h"
 #include "libmesh/rb_evaluation.h"
-#include "libmesh/elem.h"
 #include "libmesh/serial_mesh.h"
+#include "libmesh/rb_theta_expansion.h"
 
 // C++ includes
 
@@ -34,6 +34,8 @@ namespace libMesh
 
 class RBParameters;
 class RBParametrizedFunction;
+class Elem;
+class RBTheta;
 
 /**
  * This class is part of the rbOOmit framework.

--- a/include/reduced_basis/rb_eim_theta.h
+++ b/include/reduced_basis/rb_eim_theta.h
@@ -22,7 +22,6 @@
 
 // rbOOmit includes
 #include "libmesh/rb_theta.h"
-#include "libmesh/rb_eim_evaluation.h"
 
 // C++ includes
 
@@ -30,6 +29,7 @@ namespace libMesh
 {
 
 class RBParameters;
+class RBEIMEvaluation;
 
 /**
  * This class provides functionality required to define an RBTheta

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -22,7 +22,6 @@
 
 // rbOOmit includes
 #include "libmesh/rb_parametrized.h"
-#include "libmesh/rb_theta_expansion.h"
 
 // libMesh includes
 #include "libmesh/dense_matrix.h"
@@ -37,6 +36,7 @@ namespace libMesh
 
 class System;
 template <typename T> class NumericVector;
+class RBThetaExpansion;
 
 /**
  * This class is part of the rbOOmit framework.

--- a/include/reduced_basis/rb_scm_construction.h
+++ b/include/reduced_basis/rb_scm_construction.h
@@ -29,7 +29,6 @@
 
 // rbOOmit includes
 #include "libmesh/rb_construction_base.h"
-#include "libmesh/rb_scm_evaluation.h"
 
 // libMesh includes
 #include "libmesh/condensed_eigen_system.h"
@@ -38,6 +37,9 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class RBSCMEvaluation;
 
 /**
  * This class is part of the rbOOmit framework.

--- a/include/reduced_basis/rb_scm_evaluation.h
+++ b/include/reduced_basis/rb_scm_evaluation.h
@@ -28,7 +28,6 @@
 
 // rbOOmit includes
 #include "libmesh/rb_parametrized.h"
-#include "libmesh/rb_theta_expansion.h"
 
 // libMesh includes
 #include "libmesh/parallel_object.h"
@@ -37,6 +36,9 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class RBThetaExpansion;
 
 /**
  * This class is part of the rbOOmit framework.

--- a/include/solution_transfer/dtk_evaluator.h
+++ b/include/solution_transfer/dtk_evaluator.h
@@ -25,9 +25,7 @@
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
-#include "libmesh/equation_systems.h"
 #include "libmesh/mesh.h"
-#include "libmesh/system.h"
 
 #include <DTK_MeshContainer.hpp>
 #include <DTK_FieldEvaluator.hpp>
@@ -40,6 +38,10 @@
 
 namespace libMesh
 {
+
+// Forward declarations
+class EquationSystems;
+class System;
 
 /**
  * Implements the evaluate() function to compute FE solution values at

--- a/include/solution_transfer/meshfree_solution_transfer.h
+++ b/include/solution_transfer/meshfree_solution_transfer.h
@@ -24,10 +24,13 @@
 
 #include <string>
 
-namespace libMesh {
+namespace libMesh
+{
 
 /**
- * Implementation of a SolutionTransfer object that utilizes the MeshfreeInterpolation system to interpolate one solution to another.
+ * Implementation of a SolutionTransfer object that utilizes the
+ * MeshfreeInterpolation system to interpolate one solution to
+ * another.
  */
 class MeshfreeSolutionTransfer : public SolutionTransfer
 {

--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -32,7 +32,6 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/auto_ptr.h"
-#include "libmesh/solver_configuration.h"
 
 // C++ includes
 
@@ -43,7 +42,7 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class ShellMatrix;
 template <typename T> class NumericVector;
-
+class SolverConfiguration;
 
 /**
  * This class provides an interface to solvers for eigenvalue

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -31,7 +31,6 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/auto_ptr.h"
-#include "libmesh/solver_configuration.h"
 
 // C++ includes
 #include <cstddef>
@@ -46,6 +45,7 @@ template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
 template <typename T> class Preconditioner;
 class System;
+class SolverConfiguration;
 
 /**
  * This class provides a uniform interface for linear solvers.  This base

--- a/include/systems/elem_assembly.h
+++ b/include/systems/elem_assembly.h
@@ -19,14 +19,13 @@
 #define LIBMESH_ELEM_ASSEMBLY_H
 
 #include "libmesh/reference_counted_object.h"
-#include "libmesh/system.h"
-#include "libmesh/node.h"
-
 
 namespace libMesh
 {
 
 class FEMContext;
+class System;
+class Node;
 
 /**
  * ElemAssembly provides a per-element (interior and boundary) assembly

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -27,13 +27,11 @@
 #include "libmesh/enum_xdr_mode.h"
 #include "libmesh/enum_subset_solve_mode.h"
 #include "libmesh/enum_parallel_type.h"
-#include "libmesh/fe_type.h"
 #include "libmesh/fem_function_base.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/qoi_set.h"
 #include "libmesh/reference_counted_object.h"
-#include "libmesh/system_norm.h" // for implicit conversion
 #include "libmesh/tensor_value.h" // For point_hessian
 #include "libmesh/variable.h"
 
@@ -61,6 +59,8 @@ template <typename T> class VectorValue;
 typedef VectorValue<Number> NumberVectorValue;
 typedef NumberVectorValue Gradient;
 class SystemSubset;
+class FEType;
+class SystemNorm;
 
 /**
  * This is the base class for classes which contain

--- a/src/apps/solution_components.C
+++ b/src/apps/solution_components.C
@@ -25,6 +25,7 @@
 #include "libmesh/mesh.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/id_types.h"
+#include "libmesh/elem.h"
 
 unsigned char dim = 2; // This gets overridden by most mesh formats
 

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -36,6 +36,7 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/threads.h"
+#include "libmesh/fe_type.h"
 
 // Anonymous namespace, for a helper function for periodic boundary
 // constraint calculations

--- a/src/fe/fe_transformation_base.C
+++ b/src/fe/fe_transformation_base.C
@@ -18,6 +18,7 @@
 #include "libmesh/fe_transformation_base.h"
 #include "libmesh/h1_fe_transformation.h"
 #include "libmesh/hcurl_fe_transformation.h"
+#include "libmesh/fe_type.h"
 
 namespace libMesh
 {

--- a/src/fe/fe_xyz_map.C
+++ b/src/fe/fe_xyz_map.C
@@ -16,8 +16,10 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/fe_xyz_map.h"
+#include "libmesh/elem.h"
 
-namespace libMesh {
+namespace libMesh
+{
 
 void FEXYZMap::compute_face_map(int dim, const std::vector<Real>& qw, const Elem* side)
 {

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -18,6 +18,7 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/h1_fe_transformation.h"
 #include "libmesh/tensor_value.h"
+#include "libmesh/elem.h"
 
 namespace libMesh
 {

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -31,6 +31,7 @@
 #include "libmesh/partitioner.h"
 #include "libmesh/remote_elem.h"
 #include "libmesh/unstructured_mesh.h"
+#include "libmesh/elem.h"
 
 namespace libMesh
 {

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -30,7 +30,7 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/system.h"
-
+#include "libmesh/elem.h"
 
 namespace libMesh
 {

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -32,6 +32,7 @@
 #include "libmesh/fe_compute_data.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/point.h"
+#include "libmesh/elem.h"
 
 namespace libMesh
 {

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -25,7 +25,6 @@
 // Local includes
 #include "libmesh/mesh_generation.h"
 #include "libmesh/unstructured_mesh.h"
-// #include "libmesh/elem.h"
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/edge_edge3.h"

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -27,6 +27,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/parallel.h"
+#include "libmesh/mesh_base.h"
 
 #if defined(LIBMESH_HAVE_NEMESIS_API) && defined(LIBMESH_HAVE_EXODUS_API)
 

--- a/src/reduced_basis/rb_assembly_expansion.C
+++ b/src/reduced_basis/rb_assembly_expansion.C
@@ -19,6 +19,7 @@
 
 // rbOOmit includes
 #include "libmesh/rb_assembly_expansion.h"
+#include "libmesh/elem_assembly.h"
 
 namespace libMesh
 {

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -20,6 +20,8 @@
 // rbOOmit includes
 #include "libmesh/rb_construction.h"
 #include "libmesh/rb_assembly_expansion.h"
+#include "libmesh/rb_evaluation.h"
+#include "libmesh/elem_assembly.h"
 
 // LibMesh includes
 #include "libmesh/numeric_vector.h"

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -1,3 +1,22 @@
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010, 2015 David J. Knezevic
+
+// This file is part of rbOOmit.
+
+// rbOOmit is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// rbOOmit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
 #include "libmesh/libmesh_config.h"
 #if defined(LIBMESH_HAVE_CAPNPROTO)
 
@@ -8,6 +27,9 @@
 #include "libmesh/mesh.h"
 #include "libmesh/rb_data_deserialization.h"
 #include "libmesh/transient_rb_theta_expansion.h"
+#include "libmesh/transient_rb_evaluation.h"
+#include "libmesh/rb_eim_evaluation.h"
+#include "libmesh/rb_scm_evaluation.h"
 
 // Cap'n'Proto includes
 #include "capnp/serialize.h"

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -1,3 +1,22 @@
+// rbOOmit: An implementation of the Certified Reduced Basis method.
+// Copyright (C) 2009, 2010, 2015 David J. Knezevic
+
+// This file is part of rbOOmit.
+
+// rbOOmit is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// rbOOmit is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
 #include "libmesh/libmesh_config.h"
 #if defined(LIBMESH_HAVE_CAPNPROTO)
 
@@ -6,6 +25,11 @@
 #include "libmesh/rb_eim_evaluation.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/transient_rb_theta_expansion.h"
+#include "libmesh/rb_evaluation.h"
+#include "libmesh/transient_rb_evaluation.h"
+#include "libmesh/rb_eim_evaluation.h"
+#include "libmesh/rb_scm_evaluation.h"
+#include "libmesh/elem.h"
 
 // Cap'n'Proto includes
 #include <capnp/serialize.h>

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -20,6 +20,7 @@
 // rbOOmit includes
 #include "libmesh/rb_eim_assembly.h"
 #include "libmesh/rb_eim_construction.h"
+#include "libmesh/rb_evaluation.h"
 
 // libMesh includes
 #include "libmesh/fem_context.h"

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -17,6 +17,10 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+// C++ includes
+#include <fstream>
+#include <sstream>
+
 // LibMesh includes
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/numeric_vector.h"
@@ -33,10 +37,9 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/fe_compute_data.h"
 #include "libmesh/getpot.h"
-#include <fstream>
-#include <sstream>
 #include "libmesh/exodusII_io.h"
 #include "libmesh/fem_context.h"
+#include "libmesh/elem.h"
 
 #include "libmesh/rb_eim_construction.h"
 #include "libmesh/rb_eim_evaluation.h"

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -30,6 +30,7 @@
 #include "libmesh/xdr_cxx.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/serial_mesh.h"
+#include "libmesh/elem.h"
 
 namespace libMesh
 {

--- a/src/reduced_basis/rb_eim_theta.C
+++ b/src/reduced_basis/rb_eim_theta.C
@@ -19,6 +19,7 @@
 
 #include "libmesh/rb_eim_theta.h"
 #include "libmesh/rb_parameters.h"
+#include "libmesh/rb_eim_evaluation.h"
 
 namespace libMesh
 {

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -19,6 +19,7 @@
 
 // rbOOmit includes
 #include "libmesh/rb_evaluation.h"
+#include "libmesh/rb_theta_expansion.h"
 
 // libMesh includes
 #include "libmesh/libmesh_version.h"

--- a/src/reduced_basis/rb_scm_construction.C
+++ b/src/reduced_basis/rb_scm_construction.C
@@ -26,6 +26,7 @@
 
 #include "libmesh/rb_scm_construction.h"
 #include "libmesh/rb_construction.h"
+#include "libmesh/rb_scm_evaluation.h"
 
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/numeric_vector.h"

--- a/src/reduced_basis/rb_scm_evaluation.C
+++ b/src/reduced_basis/rb_scm_evaluation.C
@@ -26,6 +26,7 @@
 
 // rbOOmit includes
 #include "libmesh/rb_scm_evaluation.h"
+#include "libmesh/rb_theta_expansion.h"
 
 // libMesh includes
 #include "libmesh/libmesh_logging.h"

--- a/src/reduced_basis/transient_rb_assembly_expansion.C
+++ b/src/reduced_basis/transient_rb_assembly_expansion.C
@@ -19,6 +19,7 @@
 
 // rbOOmit includes
 #include "libmesh/transient_rb_assembly_expansion.h"
+#include "libmesh/elem_assembly.h"
 
 namespace libMesh
 {

--- a/src/solution_transfer/dtk_evaluator.C
+++ b/src/solution_transfer/dtk_evaluator.C
@@ -25,6 +25,8 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/fe_compute_data.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/system.h"
 
 #include <string>
 

--- a/src/solution_transfer/meshfree_solution_transfer.C
+++ b/src/solution_transfer/meshfree_solution_transfer.C
@@ -25,11 +25,13 @@
 #include "libmesh/threads.h"
 #include "libmesh/meshfree_interpolation.h"
 #include "libmesh/function_base.h"
+#include "libmesh/node.h"
 
 // C++ includes
 #include <cstddef>
 
-namespace libMesh {
+namespace libMesh
+{
 
 // Forward Declarations
 template <typename T>
@@ -123,9 +125,11 @@ MeshfreeSolutionTransfer::transfer(const Variable & from_var, const Variable & t
   // We have only set local values - prepare for use by gathering remote gata
   idi.prepare_for_use();
 
-  // Create a MeshlessInterpolationFunction that uses our InverseDistanceInterpolation
-  // object.  Since each MeshlessInterpolationFunction shares the same InverseDistanceInterpolation
-  // object in a threaded environment we must also provide a locking mechanism.
+  // Create a MeshlessInterpolationFunction that uses our
+  // InverseDistanceInterpolation object.  Since each
+  // MeshlessInterpolationFunction shares the same
+  // InverseDistanceInterpolation object in a threaded environment we
+  // must also provide a locking mechanism.
   Threads::spin_mutex mutex;
   MeshlessInterpolationFunction mif(idi, mutex);
 

--- a/src/solution_transfer/meshfunction_solution_transfer.C
+++ b/src/solution_transfer/meshfunction_solution_transfer.C
@@ -22,8 +22,10 @@
 #include "libmesh/system.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/mesh_function.h"
+#include "libmesh/node.h"
 
-namespace libMesh {
+namespace libMesh
+{
 
 MeshFunctionSolutionTransfer::MeshFunctionSolutionTransfer(const libMesh::Parallel::Communicator &comm_in) :
   SolutionTransfer(comm_in)
@@ -54,7 +56,8 @@ MeshFunctionSolutionTransfer::transfer(const Variable & from_var, const Variable
   NumericVector<Number> * serialized_solution = NumericVector<Number>::build(from_sys->get_mesh().comm()).release();
   serialized_solution->init(from_sys->n_dofs(), false, SERIAL);
 
-  // Need to pull down a full copy of this vector on every processor so we can get values in parallel
+  // Need to pull down a full copy of this vector on every processor
+  // so we can get values in parallel
   from_sys->solution->localize(*serialized_solution);
 
   MeshFunction from_func(from_es, *serialized_solution, from_sys->get_dof_map(), to_var_num);

--- a/src/solvers/eigen_solver.C
+++ b/src/solvers/eigen_solver.C
@@ -24,6 +24,7 @@
 // Local Includes
 #include "libmesh/eigen_solver.h"
 #include "libmesh/slepc_eigen_solver.h"
+#include "libmesh/solver_configuration.h"
 
 namespace libMesh
 {

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -30,6 +30,7 @@
 #include "libmesh/preconditioner.h"
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/solver_configuration.h"
 
 namespace libMesh
 {

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -34,6 +34,7 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/system.h"
 #include "libmesh/petsc_auto_fieldsplit.h"
+#include "libmesh/solver_configuration.h"
 
 namespace libMesh
 {

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -21,6 +21,7 @@
 #include "libmesh/petscdmlibmesh.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/preconditioner.h"
+#include "libmesh/elem.h"
 
 
 using namespace libMesh;

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -31,6 +31,7 @@
 #include "libmesh/slepc_eigen_solver.h"
 #include "libmesh/shell_matrix.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/solver_configuration.h"
 
 namespace libMesh
 {

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -35,6 +35,8 @@
 #include "libmesh/system.h"
 #include "libmesh/system_norm.h"
 #include "libmesh/utility.h"
+#include "libmesh/elem.h"
+#include "libmesh/fe_type.h"
 
 // includes for calculate_norm, point_*
 #include "libmesh/fe_base.h"

--- a/src/systems/system_subset_by_subdomain.C
+++ b/src/systems/system_subset_by_subdomain.C
@@ -25,6 +25,7 @@
 #include "libmesh/system.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/parallel.h"
+#include "libmesh/elem.h"
 
 namespace libMesh
 {

--- a/tests/numerics/laspack_vector_test.C
+++ b/tests/numerics/laspack_vector_test.C
@@ -9,7 +9,8 @@
 
 using namespace libMesh;
 
-class LaspackVectorTest : public NumericVectorTest<LaspackVector<Real> > {
+class LaspackVectorTest : public NumericVectorTest<LaspackVector<Number> >
+{
 public:
   void setUp()
   {

--- a/tests/systems/equation_systems_test.C
+++ b/tests/systems/equation_systems_test.C
@@ -8,6 +8,7 @@
 #include <libmesh/mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/serial_mesh.h>
+#include <libmesh/elem.h>
 
 #include "test_comm.h"
 

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -67,9 +67,9 @@ public:
     for (Real x = 0.1; x < 1; x += 0.2)
       {
         Point p(x);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL
-          (sys.point_value(0,p),
-           cubic_test(p,es.parameters,"",""), TOLERANCE*TOLERANCE);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
+                                     libmesh_real(cubic_test(p,es.parameters,"","")),
+                                     TOLERANCE*TOLERANCE);
       }
   }
 
@@ -95,9 +95,9 @@ public:
       for (Real y = 0.1; y < 1; y += 0.2)
         {
           Point p(x,y);
-          CPPUNIT_ASSERT_DOUBLES_EQUAL
-            (sys.point_value(0,p),
-             cubic_test(p,es.parameters,"",""), TOLERANCE*TOLERANCE);
+          CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
+                                       libmesh_real(cubic_test(p,es.parameters,"","")),
+                                       TOLERANCE*TOLERANCE);
         }
   }
 
@@ -123,9 +123,9 @@ public:
         for (Real z = 0.1; z < 1; z += 0.2)
           {
             Point p(x,y,z);
-            CPPUNIT_ASSERT_DOUBLES_EQUAL
-              (sys.point_value(0,p),
-               cubic_test(p,es.parameters,"",""), TOLERANCE*TOLERANCE);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
+                                         libmesh_real(cubic_test(p,es.parameters,"","")),
+                                         TOLERANCE*TOLERANCE);
           }
   }
 


### PR DESCRIPTION
This is primarily changing several #includes to forward declarations as suggested by [cppclean](https://github.com/myint/cppclean).  This tool also produces quite a few false positives and crashes on some files, but I think the changes I've made in this PR are valid.  

I've already tested MOOSE, and it doesn't seem to have any issues, but several of the libmesh examples actually had to have #includes added in order to compile.  I've tested with most of the optional stuff enabled, major exceptions being complex number and GLPK support, but it would be great if some other app developers could try this branch as well and make sure it doesn't cause them too much heartburn.  I *don't* plan to merge this into the 0.9.5/1.0.0 branch, since it can potentially break previously-compiling code.
