### PR TITLE
Fix a few unit tests for complex-enabled builds.

### DIFF
--- a/tests/numerics/laspack_vector_test.C
+++ b/tests/numerics/laspack_vector_test.C
@@ -9,7 +9,8 @@
 
 using namespace libMesh;
 
-class LaspackVectorTest : public NumericVectorTest<LaspackVector<Real> > {
+class LaspackVectorTest : public NumericVectorTest<LaspackVector<Number> >
+{
 public:
   void setUp()
   {

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -67,9 +67,9 @@ public:
     for (Real x = 0.1; x < 1; x += 0.2)
       {
         Point p(x);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL
-          (sys.point_value(0,p),
-           cubic_test(p,es.parameters,"",""), TOLERANCE*TOLERANCE);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
+                                     libmesh_real(cubic_test(p,es.parameters,"","")),
+                                     TOLERANCE*TOLERANCE);
       }
   }
 
@@ -95,9 +95,9 @@ public:
       for (Real y = 0.1; y < 1; y += 0.2)
         {
           Point p(x,y);
-          CPPUNIT_ASSERT_DOUBLES_EQUAL
-            (sys.point_value(0,p),
-             cubic_test(p,es.parameters,"",""), TOLERANCE*TOLERANCE);
+          CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
+                                       libmesh_real(cubic_test(p,es.parameters,"","")),
+                                       TOLERANCE*TOLERANCE);
         }
   }
 
@@ -123,9 +123,9 @@ public:
         for (Real z = 0.1; z < 1; z += 0.2)
           {
             Point p(x,y,z);
-            CPPUNIT_ASSERT_DOUBLES_EQUAL
-              (sys.point_value(0,p),
-               cubic_test(p,es.parameters,"",""), TOLERANCE*TOLERANCE);
+            CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
+                                         libmesh_real(cubic_test(p,es.parameters,"","")),
+                                         TOLERANCE*TOLERANCE);
           }
   }
 


### PR DESCRIPTION
Not sure if these are exactly right but they make the tests compile and pass.  If this doesn't break Real-valued builds and @roystgnr signs off on it, it can be merged any time and should also probably be cherry-picked onto 0.9.5.