### PR TITLE
Prevent duplicate entries in BoundaryInfo

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -636,44 +636,6 @@ private:
    */
   std::map<boundary_id_type, std::string> _ns_id_to_name;
 
-
-  //   /**
-  //    * Functor class for printing a single node's info
-  //    * To be used with "for_each".
-  //    */
-  //   class PrintNodeInfo
-  //   {
-  //   public:
-  //     inline
-  //     void operator() (const std::pair<const Node*, short int>& np) const
-  //     {
-  //       libMesh::out << "  (" << np.first->id()
-  //      << ", "  << np.second
-  //      << ")"  << std::endl;
-  //     }
-  //   };
-
-
-  //   /**
-  //    * Functor class for printing a single side's info.
-  //    * To be used with "for_each".
-  //    */
-  //   class PrintSideInfo
-  //   {
-  //   public:
-  //     PrintSideInfo() {}
-  //     inline
-  //     void operator() (const std::pair<const Elem*, std::pair<unsigned short int,short int> >& sp) const
-  //     {
-  //       libMesh::out << "  (" << sp.first->id()
-  //      << ", "  << sp.second.first
-  //      << ", "  << sp.second.second
-  //      << ")"   << std::endl;
-  //     }
-  //   };
-
-
-
   /**
    * Functor class for initializing a map.
    * The entries being added to the map

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -153,9 +153,18 @@ public:
   /**
    * Add \p Node \p node with boundary ids \p ids to the boundary
    * information data structure.
+   *
+   * This function is now deprecated, call the version which takes a
+   * reference to a std::set instead.
    */
   void add_node (const Node* node,
                  const std::vector<boundary_id_type>& ids);
+
+  /**
+   * Non-deprecated version of the add_node() function taking a set of ids.
+   */
+  void add_node (const Node* node,
+                 const std::set<boundary_id_type>& ids_set);
 
   /**
    * Clears all the boundary information from all of the nodes in the mesh
@@ -184,10 +193,20 @@ public:
    * Add edge \p edge of element \p elem with boundary ids \p ids
    * to the boundary information data structure.
    * Edge-based boundary IDs should only be used in 3D.
+   *
+   * This function is now deprecated, call the version which takes a
+   * reference to a std::set instead.
    */
   void add_edge (const Elem* elem,
                  const unsigned short int edge,
                  const std::vector<boundary_id_type>& ids);
+
+  /**
+   * Non-deprecated version of the add_side() function taking a set of ids.
+   */
+  void add_edge (const Elem* elem,
+                 const unsigned short int edge,
+                 const std::set<boundary_id_type>& ids_set);
 
   /**
    * Add side \p side of element number \p elem with boundary id \p id
@@ -208,10 +227,20 @@ public:
   /**
    * Add side \p side of element \p elem with boundary ids \p ids
    * to the boundary information data structure.
+   *
+   * This function is now deprecated, call the version which takes a
+   * reference to a std::set instead.
    */
   void add_side (const Elem* elem,
                  const unsigned short int side,
                  const std::vector<boundary_id_type>& ids);
+
+  /**
+   * Non-deprecated version of the add_side() function taking a set of ids.
+   */
+  void add_side (const Elem* elem,
+                 const unsigned short int side,
+                 const std::set<boundary_id_type>& ids_set);
 
   /**
    * Removes the boundary conditions associated with node \p node,

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -563,6 +563,11 @@ private:
                 boundary_id_type> _boundary_node_id;
 
   /**
+   * Typdef for iterators into the _boundary_node_id container.
+   */
+  typedef std::multimap<const Node*, boundary_id_type>::const_iterator boundary_node_iter;
+
+  /**
    * Data structure that maps edges of elements
    * to boundary ids. This is only relevant in 3D.
    */
@@ -571,12 +576,24 @@ private:
   _boundary_edge_id;
 
   /**
+   * Typdef for iterators into the _boundary_edge_id container.
+   */
+  typedef std::multimap<const Elem*,
+                        std::pair<unsigned short int, boundary_id_type> >::const_iterator boundary_edge_iter;
+
+  /**
    * Data structure that maps sides of elements
    * to boundary ids.
    */
   std::multimap<const Elem*,
                 std::pair<unsigned short int, boundary_id_type> >
   _boundary_side_id;
+
+  /**
+   * Typdef for iterators into the _boundary_side_id container.
+   */
+  typedef std::multimap<const Elem*,
+                        std::pair<unsigned short int, boundary_id_type> >::const_iterator boundary_side_iter;
 
   /**
    * A collection of user-specified boundary ids for sides, edges and nodes.

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -527,12 +527,18 @@ void BoundaryInfo::add_node(const Node* node,
   // A convenient typedef
   typedef std::multimap<const Node*, boundary_id_type>::const_iterator Iter;
 
+  // The following logic requires that the entries in the ids vector
+  // be unique, so guarantee that's the case by constructing a
+  // std::set.
+  std::set<boundary_id_type> ids_set(ids.begin(), ids.end());
+
   // Don't add the same ID twice
   std::pair<Iter, Iter> pos = _boundary_node_id.equal_range(node);
 
-  for (unsigned int i=0; i!= ids.size(); ++i)
+  std::set<boundary_id_type>::iterator it = ids_set.begin();
+  for (; it != ids_set.end(); ++it)
     {
-      boundary_id_type id=ids[i];
+      boundary_id_type id = *it;
 
       if (id == invalid_id)
         libmesh_error_msg("ERROR: You may not set a boundary ID of "    \
@@ -549,9 +555,7 @@ void BoundaryInfo::add_node(const Node* node,
       if (already_inserted)
         continue;
 
-      std::pair<const Node*, boundary_id_type> kv (node, id);
-
-      _boundary_node_id.insert(kv);
+      _boundary_node_id.insert(std::make_pair(node,id));
       _boundary_ids.insert(id);
       _node_boundary_ids.insert(id); // Also add this ID to the set of node boundary IDs
     }
@@ -720,12 +724,18 @@ void BoundaryInfo::add_side(const Elem* elem,
   typedef std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
     const_iterator Iter;
 
+  // The following logic requires that the entries in the ids vector
+  // be unique, so guarantee that's the case by constructing a
+  // std::set.
+  std::set<boundary_id_type> ids_set(ids.begin(), ids.end());
+
   // Don't add the same ID twice
   std::pair<Iter, Iter> pos = _boundary_side_id.equal_range(elem);
 
-  for (unsigned int i=0; i!= ids.size(); ++i)
+  std::set<boundary_id_type>::iterator it = ids_set.begin();
+  for (; it != ids_set.end(); ++it)
     {
-      boundary_id_type id=ids[i];
+      boundary_id_type id = *it;
 
       if (id == invalid_id)
         libmesh_error_msg("ERROR: You may not set a boundary ID of "    \
@@ -733,9 +743,8 @@ void BoundaryInfo::add_side(const Elem* elem,
                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
-      for (Iter p = pos.first;p != pos.second; ++p)
-        if (p->second.first == side &&
-            p->second.second == id)
+      for (Iter p = pos.first; p != pos.second; ++p)
+        if (p->second.first == side && p->second.second == id)
           {
             already_inserted = true;
             break;
@@ -743,11 +752,7 @@ void BoundaryInfo::add_side(const Elem* elem,
       if (already_inserted)
         continue;
 
-      std::pair<unsigned short int, boundary_id_type> p(side,id);
-      std::pair<const Elem*, std::pair<unsigned short int, boundary_id_type> >
-        kv (elem, p);
-
-      _boundary_side_id.insert(kv);
+      _boundary_side_id.insert(std::make_pair(elem, std::make_pair(side, id)));
       _boundary_ids.insert(id);
       _side_boundary_ids.insert(id); // Also add this ID to the set of side boundary IDs
     }

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -61,10 +61,10 @@ BoundaryInfo& BoundaryInfo::operator=(const BoundaryInfo& other_boundary_info)
 
   // Copy node boundary info
   {
-    std::multimap<const Node*, boundary_id_type>::const_iterator it = other_boundary_info._boundary_node_id.begin();
-    const std::multimap<const Node*, boundary_id_type>::const_iterator end = other_boundary_info._boundary_node_id.end();
+    boundary_node_iter it = other_boundary_info._boundary_node_id.begin();
+    const boundary_node_iter end = other_boundary_info._boundary_node_id.end();
 
-    for(; it != end; ++it)
+    for (; it != end; ++it)
       {
         const Node * other_node = it->first;
         _boundary_node_id.insert
@@ -75,12 +75,10 @@ BoundaryInfo& BoundaryInfo::operator=(const BoundaryInfo& other_boundary_info)
 
   // Copy edge boundary info
   {
-    std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-      const_iterator it = other_boundary_info._boundary_edge_id.begin();
-    const std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-      const_iterator end = other_boundary_info._boundary_edge_id.end();
+    boundary_edge_iter it = other_boundary_info._boundary_edge_id.begin();
+    const boundary_edge_iter end = other_boundary_info._boundary_edge_id.end();
 
-    for(; it != end; ++it)
+    for (; it != end; ++it)
       {
         const Elem * other_elem = it->first;
         _boundary_edge_id.insert
@@ -91,12 +89,10 @@ BoundaryInfo& BoundaryInfo::operator=(const BoundaryInfo& other_boundary_info)
 
   // Copy side boundary info
   {
-    std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-      const_iterator it = other_boundary_info._boundary_side_id.begin();
-    const std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-      const_iterator end = other_boundary_info._boundary_side_id.end();
+    boundary_side_iter it = other_boundary_info._boundary_side_id.begin();
+    const boundary_side_iter end = other_boundary_info._boundary_side_id.end();
 
-    for(; it != end; ++it)
+    for (; it != end; ++it)
       {
         const Elem * other_elem = it->first;
         _boundary_side_id.insert
@@ -298,13 +294,8 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> &requested_boun
             // Get the top-level parent for this element
             const Elem* top_parent = elem->top_parent();
 
-            // A convenient typedef
-            typedef
-              std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-              const_iterator Iter;
-
             // Find the right id number for that side
-            std::pair<Iter, Iter> pos = _boundary_side_id.equal_range(top_parent);
+            std::pair<boundary_side_iter, boundary_side_iter> pos = _boundary_side_id.equal_range(top_parent);
 
             bool add_this_side = false;
             boundary_id_type this_bcid = invalid_id;
@@ -499,13 +490,10 @@ void BoundaryInfo::add_node(const Node* node,
                       << invalid_id                                \
                       << "\n That is reserved for internal use.");
 
-  // A convenient typedef
-  typedef std::multimap<const Node*, boundary_id_type>::const_iterator Iter;
-
   // Don't add the same ID twice
-  std::pair<Iter, Iter> pos = _boundary_node_id.equal_range(node);
+  std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
 
-  for (;pos.first != pos.second; ++pos.first)
+  for (; pos.first != pos.second; ++pos.first)
     if (pos.first->second == id)
       return;
 
@@ -535,11 +523,8 @@ void BoundaryInfo::add_node(const Node* node,
 
   libmesh_assert(node);
 
-  // A convenient typedef
-  typedef std::multimap<const Node*, boundary_id_type>::const_iterator Iter;
-
   // Don't add the same ID twice
-  std::pair<Iter, Iter> pos = _boundary_node_id.equal_range(node);
+  std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
 
   std::set<boundary_id_type>::iterator it = ids_set.begin();
   for (; it != ids_set.end(); ++it)
@@ -552,7 +537,7 @@ void BoundaryInfo::add_node(const Node* node,
                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
-      for (Iter p = pos.first;p != pos.second; ++p)
+      for (boundary_node_iter p = pos.first; p != pos.second; ++p)
         if (p->second == id)
           {
             already_inserted = true;
@@ -597,14 +582,10 @@ void BoundaryInfo::add_edge(const Elem* elem,
                       << invalid_id                                     \
                       << "\n That is reserved for internal use.");
 
-  // A convenient typedef
-  typedef std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-    const_iterator Iter;
-
   // Don't add the same ID twice
-  std::pair<Iter, Iter> pos = _boundary_edge_id.equal_range(elem);
+  std::pair<boundary_edge_iter, boundary_edge_iter> pos = _boundary_edge_id.equal_range(elem);
 
-  for (;pos.first != pos.second; ++pos.first)
+  for (; pos.first != pos.second; ++pos.first)
     if (pos.first->second.first == edge &&
         pos.first->second.second == id)
       return;
@@ -642,12 +623,8 @@ void BoundaryInfo::add_edge(const Elem* elem,
   // Only add BCs for level-0 elements.
   libmesh_assert_equal_to (elem->level(), 0);
 
-  // A convenient typedef
-  typedef std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-    const_iterator Iter;
-
   // Don't add the same ID twice
-  std::pair<Iter, Iter> pos = _boundary_edge_id.equal_range(elem);
+  std::pair<boundary_edge_iter, boundary_edge_iter> pos = _boundary_edge_id.equal_range(elem);
 
   std::set<boundary_id_type>::iterator it = ids_set.begin();
   for (; it != ids_set.end(); ++it)
@@ -660,7 +637,7 @@ void BoundaryInfo::add_edge(const Elem* elem,
                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
-      for (Iter p = pos.first;p != pos.second; ++p)
+      for (boundary_edge_iter p = pos.first; p != pos.second; ++p)
         if (p->second.first == edge &&
             p->second.second == id)
           {
@@ -701,14 +678,10 @@ void BoundaryInfo::add_side(const Elem* elem,
                       << invalid_id                                     \
                       << "\n That is reserved for internal use.");
 
-  // A convenient typedef
-  typedef std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-    const_iterator Iter;
-
   // Don't add the same ID twice
-  std::pair<Iter, Iter> pos = _boundary_side_id.equal_range(elem);
+  std::pair<boundary_side_iter, boundary_side_iter> pos = _boundary_side_id.equal_range(elem);
 
-  for (;pos.first != pos.second; ++pos.first)
+  for (; pos.first != pos.second; ++pos.first)
     if (pos.first->second.first == side &&
         pos.first->second.second == id)
       return;
@@ -746,12 +719,8 @@ void BoundaryInfo::add_side(const Elem* elem,
   // Only add BCs for level-0 elements.
   libmesh_assert_equal_to (elem->level(), 0);
 
-  // A convenient typedef
-  typedef std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-    const_iterator Iter;
-
   // Don't add the same ID twice
-  std::pair<Iter, Iter> pos = _boundary_side_id.equal_range(elem);
+  std::pair<boundary_side_iter, boundary_side_iter> pos = _boundary_side_id.equal_range(elem);
 
   std::set<boundary_id_type>::iterator it = ids_set.begin();
   for (; it != ids_set.end(); ++it)
@@ -764,7 +733,7 @@ void BoundaryInfo::add_side(const Elem* elem,
                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
-      for (Iter p = pos.first; p != pos.second; ++p)
+      for (boundary_side_iter p = pos.first; p != pos.second; ++p)
         if (p->second.first == side && p->second.second == id)
           {
             already_inserted = true;
@@ -784,12 +753,9 @@ void BoundaryInfo::add_side(const Elem* elem,
 bool BoundaryInfo::has_boundary_id(const Node* const node,
                                    const boundary_id_type id) const
 {
-  // A convenient typedef
-  typedef std::multimap<const Node*, boundary_id_type>::const_iterator Iter;
+  std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
 
-  std::pair<Iter, Iter> pos = _boundary_node_id.equal_range(node);
-
-  for (;pos.first != pos.second; ++pos.first)
+  for (; pos.first != pos.second; ++pos.first)
     if (pos.first->second == id)
       return true;
 
@@ -802,12 +768,9 @@ std::vector<boundary_id_type> BoundaryInfo::boundary_ids(const Node* node) const
 {
   std::vector<boundary_id_type> ids;
 
-  // A convenient typedef
-  typedef std::multimap<const Node*, boundary_id_type>::const_iterator Iter;
+  std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
 
-  std::pair<Iter, Iter> pos = _boundary_node_id.equal_range(node);
-
-  for (;pos.first != pos.second; ++pos.first)
+  for (; pos.first != pos.second; ++pos.first)
     ids.push_back(pos.first->second);
 
   return ids;
@@ -817,13 +780,9 @@ std::vector<boundary_id_type> BoundaryInfo::boundary_ids(const Node* node) const
 
 unsigned int BoundaryInfo::n_boundary_ids(const Node* node) const
 {
-  // A convenient typedef
-  typedef std::multimap<const Node*, boundary_id_type>::const_iterator Iter;
+  std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
 
-  std::pair<Iter, Iter> pos = _boundary_node_id.equal_range(node);
-
-  return cast_int<unsigned int>
-    (std::distance(pos.first, pos.second));
+  return cast_int<unsigned int>(std::distance(pos.first, pos.second));
 }
 
 
@@ -845,7 +804,7 @@ std::vector<boundary_id_type> BoundaryInfo::edge_boundary_ids (const Elem* const
       // side, then this must be a boundary edge. In that case, we just use the
       // top-level parent.
       bool found_boundary_edge = false;
-      for(unsigned int side=0; side<elem->n_sides(); side++)
+      for (unsigned int side=0; side<elem->n_sides(); side++)
         {
           if(elem->is_edge_on_side(edge,side))
             {
@@ -858,7 +817,7 @@ std::vector<boundary_id_type> BoundaryInfo::edge_boundary_ids (const Elem* const
             }
         }
 
-      if(!found_boundary_edge)
+      if (!found_boundary_edge)
         {
           // Child element is not on external edge, but it may have internal
           // "boundary" IDs.  We will walk up the tree, at each level checking that
@@ -875,10 +834,7 @@ std::vector<boundary_id_type> BoundaryInfo::edge_boundary_ids (const Elem* const
     }
 #endif
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator >
+  std::pair<boundary_edge_iter, boundary_edge_iter>
     e = _boundary_edge_id.equal_range(searched_elem);
 
   // elem not in the data structure
@@ -943,10 +899,7 @@ unsigned int BoundaryInfo::n_edge_boundary_ids (const Elem* const elem,
     }
 #endif
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator >
+  std::pair<boundary_edge_iter, boundary_edge_iter>
     e = _boundary_edge_id.equal_range(searched_elem);
 
   unsigned int n_ids = 0;
@@ -973,10 +926,7 @@ std::vector<boundary_id_type> BoundaryInfo::raw_edge_boundary_ids (const Elem* c
   if (elem->parent())
     return ids;
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator >
+  std::pair<boundary_edge_iter, boundary_edge_iter>
     e = _boundary_edge_id.equal_range(elem);
 
   // Check any occurrences
@@ -1029,10 +979,7 @@ boundary_id_type BoundaryInfo::boundary_id(const Elem* const elem,
 #endif
     }
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator >
+  std::pair<boundary_side_iter, boundary_side_iter>
     e = _boundary_side_id.equal_range(searched_elem);
 
   // elem not in the data structure
@@ -1078,10 +1025,7 @@ bool BoundaryInfo::has_boundary_id(const Elem* const elem,
 #endif
     }
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator >
+  std::pair<boundary_side_iter, boundary_side_iter>
     e = _boundary_side_id.equal_range(searched_elem);
 
   // elem is there, maybe multiple occurrences
@@ -1122,10 +1066,7 @@ std::vector<boundary_id_type> BoundaryInfo::boundary_ids (const Elem* const elem
 #endif
     }
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator >
+  std::pair<boundary_side_iter, boundary_side_iter>
     e = _boundary_side_id.equal_range(searched_elem);
 
   // elem not in the data structure
@@ -1152,7 +1093,7 @@ unsigned int BoundaryInfo::n_boundary_ids (const Elem* const elem,
 
   // Only level-0 elements store BCs.  If this is not a level-0
   // element get its level-0 parent and infer the BCs.
-  const Elem*  searched_elem = elem;
+  const Elem* searched_elem = elem;
   if (elem->level() != 0)
     {
       if (elem->neighbor(side) == NULL)
@@ -1169,10 +1110,7 @@ unsigned int BoundaryInfo::n_boundary_ids (const Elem* const elem,
 #endif
     }
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator >
+  std::pair<boundary_side_iter, boundary_side_iter>
     e = _boundary_side_id.equal_range(searched_elem);
 
   unsigned int n_ids = 0;
@@ -1199,10 +1137,7 @@ std::vector<boundary_id_type> BoundaryInfo::raw_boundary_ids (const Elem* const 
   if (elem->parent())
     return ids;
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator >
+  std::pair<boundary_side_iter, boundary_side_iter>
     e = _boundary_side_id.equal_range(elem);
 
   // Check any occurrences
@@ -1227,10 +1162,7 @@ void BoundaryInfo::remove_edge (const Elem* elem,
   // id
   libmesh_assert_equal_to (elem->level(), 0);
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::iterator >
+  std::pair<boundary_edge_iter, boundary_edge_iter>
     e = _boundary_edge_id.equal_range(elem);
 
   // elem may be there, maybe multiple occurrences
@@ -1260,10 +1192,7 @@ void BoundaryInfo::remove_edge (const Elem* elem,
   // id
   libmesh_assert_equal_to (elem->level(), 0);
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::iterator >
+  std::pair<boundary_edge_iter, boundary_edge_iter>
     e = _boundary_edge_id.equal_range(elem);
 
   // elem may be there, maybe multiple occurrences
@@ -1291,10 +1220,7 @@ void BoundaryInfo::remove_side (const Elem* elem,
   // id
   libmesh_assert_equal_to (elem->level(), 0);
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::iterator >
+  std::pair<boundary_side_iter, boundary_side_iter>
     e = _boundary_side_id.equal_range(elem);
 
   // elem may be there, maybe multiple occurrences
@@ -1322,12 +1248,7 @@ void BoundaryInfo::remove_side (const Elem* elem,
 
   // The user shouldn't be trying to remove only one child's boundary
   // id
-  libmesh_assert_equal_to (elem->level(), 0);
-
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::iterator >
+  std::pair<boundary_side_iter, boundary_side_iter>
     e = _boundary_side_id.equal_range(elem);
 
   // elem may be there, maybe multiple occurrences
@@ -1355,10 +1276,7 @@ unsigned int BoundaryInfo::side_with_boundary_id(const Elem* const elem,
   if (elem->level() != 0)
     searched_elem = elem->top_parent();
 
-  std::pair<std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator,
-            std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator >
+  std::pair<boundary_side_iter, boundary_side_iter>
     e = _boundary_side_id.equal_range(searched_elem);
 
   // elem may have zero or multiple occurrences
@@ -1405,14 +1323,12 @@ BoundaryInfo::build_node_boundary_ids(std::vector<boundary_id_type> &b_ids) cons
 {
   b_ids.clear();
 
-  std::multimap<const Node*, boundary_id_type>::const_iterator pos
-    = _boundary_node_id.begin();
-
+  boundary_node_iter pos = _boundary_node_id.begin();
   for (; pos != _boundary_node_id.end(); ++pos)
     {
       boundary_id_type id = pos->second;
 
-      if(std::find(b_ids.begin(),b_ids.end(),id) == b_ids.end())
+      if (std::find(b_ids.begin(),b_ids.end(),id) == b_ids.end())
         b_ids.push_back(id);
     }
 }
@@ -1422,14 +1338,12 @@ BoundaryInfo::build_side_boundary_ids(std::vector<boundary_id_type> &b_ids) cons
 {
   b_ids.clear();
 
-  std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::const_iterator pos
-    = _boundary_side_id.begin();
-
+  boundary_side_iter pos = _boundary_side_id.begin();
   for (; pos != _boundary_side_id.end(); ++pos)
     {
       boundary_id_type id = pos->second.second;
 
-      if(std::find(b_ids.begin(),b_ids.end(),id) == b_ids.end())
+      if (std::find(b_ids.begin(),b_ids.end(),id) == b_ids.end())
         b_ids.push_back(id);
     }
 }
@@ -1446,11 +1360,8 @@ std::size_t BoundaryInfo::n_boundary_conds () const
 
   std::size_t nbcs=0;
 
-  std::multimap<const Elem*,
-                std::pair<unsigned short int,
-                          boundary_id_type> >::const_iterator pos;
-
-  for (pos=_boundary_side_id.begin(); pos != _boundary_side_id.end(); ++pos)
+  boundary_side_iter pos = _boundary_side_id.begin();
+  for (; pos != _boundary_side_id.end(); ++pos)
     if (pos->first->processor_id() == this->processor_id())
       nbcs++;
 
@@ -1471,11 +1382,8 @@ std::size_t BoundaryInfo::n_edge_conds () const
 
   std::size_t n_edge_bcs=0;
 
-  std::multimap<const Elem*,
-                std::pair<unsigned short int,
-                          boundary_id_type> >::const_iterator pos;
-
-  for (pos=_boundary_edge_id.begin(); pos != _boundary_edge_id.end(); ++pos)
+  boundary_edge_iter pos = _boundary_edge_id.begin();
+  for (; pos != _boundary_edge_id.end(); ++pos)
     if (pos->first->processor_id() == this->processor_id())
       n_edge_bcs++;
 
@@ -1497,9 +1405,8 @@ std::size_t BoundaryInfo::n_nodeset_conds () const
 
   std::size_t n_nodesets=0;
 
-  std::multimap<const Node*, boundary_id_type>::const_iterator pos;
-
-  for (pos=_boundary_node_id.begin(); pos != _boundary_node_id.end(); ++pos)
+  boundary_node_iter pos = _boundary_node_id.begin();
+  for (; pos != _boundary_node_id.end(); ++pos)
     if (pos->first->processor_id() == this->processor_id())
       n_nodesets++;
 
@@ -1517,9 +1424,7 @@ void BoundaryInfo::build_node_list (std::vector<dof_id_type>& nl,
   nl.reserve (_boundary_node_id.size());
   il.reserve (_boundary_node_id.size());
 
-  std::multimap<const Node*, boundary_id_type>::const_iterator pos
-    = _boundary_node_id.begin();
-
+  boundary_node_iter pos = _boundary_node_id.begin();
   for (; pos != _boundary_node_id.end(); ++pos)
     {
       nl.push_back (pos->first->id());
@@ -1531,38 +1436,31 @@ void BoundaryInfo::build_node_list (std::vector<dof_id_type>& nl,
 void
 BoundaryInfo::build_node_list_from_side_list()
 {
-  std::multimap<const Elem*,
-                std::pair<unsigned short int,
-                          boundary_id_type> >::const_iterator pos;
-
-  //Loop over the side list
-  for (pos=_boundary_side_id.begin(); pos != _boundary_side_id.end(); ++pos)
+  // Loop over the side list
+  boundary_side_iter pos = _boundary_side_id.begin();
+  for (; pos != _boundary_side_id.end(); ++pos)
     {
       // Don't add remote sides
-      if(pos->first->is_remote())
+      if (pos->first->is_remote())
         continue;
 
-      //Need to loop over the sides of any possible children
-      std::vector< const Elem * > family;
+      // Need to loop over the sides of any possible children
+      std::vector<const Elem *> family;
 #ifdef LIBMESH_ENABLE_AMR
       pos->first->active_family_tree_by_side (family, pos->second.first);
 #else
       family.push_back(pos->first);
 #endif
 
-      for(std::size_t elem_it=0; elem_it < family.size(); elem_it++)
+      for (std::size_t elem_it=0; elem_it < family.size(); elem_it++)
         {
           const Elem * cur_elem = family[elem_it];
 
           UniquePtr<Elem> side = cur_elem->build_side(pos->second.first);
 
-          //Add each node node on the side with the side's boundary id
-          for(unsigned int i=0; i<side->n_nodes(); i++)
-            {
-              Node * node = side->get_node(i);
-
-              this->add_node(node, pos->second.second);
-            }
+          // Add each node node on the side with the side's boundary id
+          for (unsigned int i=0; i<side->n_nodes(); i++)
+            this->add_node(side->get_node(i), pos->second.second);
         }
     }
 }
@@ -1578,13 +1476,6 @@ void BoundaryInfo::build_side_list_from_node_list()
       libMesh::out << "No boundary node IDs have been added: cannot build side list!" << std::endl;
       return;
     }
-
-  // typedef for less typing!
-  typedef std::multimap<const Node*, boundary_id_type>::const_iterator iterator_t;
-
-  // Return value and iterator for equal_range()
-  iterator_t pos;
-  std::pair<iterator_t, iterator_t> range;
 
   MeshBase::const_element_iterator el = _mesh.active_elements_begin();
   const MeshBase::const_element_iterator end_el = _mesh.active_elements_end();
@@ -1602,11 +1493,12 @@ void BoundaryInfo::build_side_list_from_node_list()
           for (unsigned node_num=0; node_num < side_elem->n_nodes(); ++node_num)
             {
               Node* node = side_elem->get_node(node_num);
-              range = _boundary_node_id.equal_range(node);
+              std::pair<boundary_node_iter, boundary_node_iter>
+                range = _boundary_node_id.equal_range(node);
 
               // For each nodeset that this node is a member of, increment the associated
               // nodeset ID count
-              for (pos = range.first; pos != range.second; ++pos)
+              for (boundary_node_iter pos = range.first; pos != range.second; ++pos)
                 nodesets_node_count[pos->second]++;
             }
 
@@ -1642,12 +1534,8 @@ void BoundaryInfo::build_side_list (std::vector<dof_id_type>&        el,
   sl.reserve (_boundary_side_id.size());
   il.reserve (_boundary_side_id.size());
 
-  std::multimap<const Elem*,
-                std::pair<unsigned short int,
-                          boundary_id_type> >::const_iterator pos;
-
-  for (pos=_boundary_side_id.begin(); pos != _boundary_side_id.end();
-       ++pos)
+  boundary_side_iter pos = _boundary_side_id.begin();
+  for (; pos != _boundary_side_id.end(); ++pos)
     {
       el.push_back (pos->first->id());
       sl.push_back (pos->second.first);
@@ -1659,12 +1547,8 @@ void BoundaryInfo::build_active_side_list (std::vector<dof_id_type>&        el,
                                            std::vector<unsigned short int>& sl,
                                            std::vector<boundary_id_type>&   il) const
 {
-  std::multimap<const Elem*,
-                std::pair<unsigned short int,
-                          boundary_id_type> >::const_iterator pos;
-
-  for (pos=_boundary_side_id.begin(); pos != _boundary_side_id.end();
-       ++pos)
+  boundary_side_iter pos = _boundary_side_id.begin();
+  for (; pos != _boundary_side_id.end(); ++pos)
     {
       // Don't add remote sides
       if (pos->first->is_remote())
@@ -1698,12 +1582,8 @@ void BoundaryInfo::build_edge_list (std::vector<dof_id_type>&        el,
   sl.reserve (_boundary_side_id.size());
   il.reserve (_boundary_side_id.size());
 
-  std::multimap<const Elem*,
-                std::pair<unsigned short int,
-                          boundary_id_type> >::const_iterator pos;
-
-  for (pos=_boundary_edge_id.begin(); pos != _boundary_edge_id.end();
-       ++pos)
+  boundary_edge_iter pos = _boundary_edge_id.begin();
+  for (; pos != _boundary_edge_id.end(); ++pos)
     {
       el.push_back (pos->first->id());
       sl.push_back (pos->second.first);
@@ -1721,12 +1601,8 @@ void BoundaryInfo::print_info(std::ostream& out_stream) const
                  << "--------------------------" << std::endl
                  << "  (Node No., ID)               " << std::endl;
 
-      //       std::for_each(_boundary_node_id.begin(),
-      //    _boundary_node_id.end(),
-      //    PrintNodeInfo());
-
-      std::multimap<const Node*, boundary_id_type>::const_iterator it        = _boundary_node_id.begin();
-      const std::multimap<const Node*, boundary_id_type>::const_iterator end = _boundary_node_id.end();
+      boundary_node_iter it        = _boundary_node_id.begin();
+      const boundary_node_iter end = _boundary_node_id.end();
 
       for (; it != end; ++it)
         out_stream << "  (" << (*it).first->id()
@@ -1742,14 +1618,8 @@ void BoundaryInfo::print_info(std::ostream& out_stream) const
                  << "-------------------------" << std::endl
                  << "  (Elem No., Edge No., ID)      " << std::endl;
 
-      //       std::for_each(_boundary_edge_id.begin(),
-      //    _boundary_edge_id.end(),
-      //    PrintSideInfo());
-
-      std::multimap<const Elem*,
-                    std::pair<unsigned short int, boundary_id_type> >::const_iterator it = _boundary_edge_id.begin();
-      const std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator end = _boundary_edge_id.end();
+      boundary_edge_iter it = _boundary_edge_id.begin();
+      const boundary_edge_iter end = _boundary_edge_id.end();
 
       for (; it != end; ++it)
         out_stream << "  (" << (*it).first->id()
@@ -1766,14 +1636,8 @@ void BoundaryInfo::print_info(std::ostream& out_stream) const
                  << "-------------------------" << std::endl
                  << "  (Elem No., Side No., ID)      " << std::endl;
 
-      //       std::for_each(_boundary_side_id.begin(),
-      //    _boundary_side_id.end(),
-      //    PrintSideInfo());
-
-      std::multimap<const Elem*,
-                    std::pair<unsigned short int, boundary_id_type> >::const_iterator it = _boundary_side_id.begin();
-      const std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator end = _boundary_side_id.end();
+      boundary_side_iter it = _boundary_side_id.begin();
+      const boundary_side_iter end = _boundary_side_id.end();
 
       for (; it != end; ++it)
         out_stream << "  (" << (*it).first->id()
@@ -1796,8 +1660,8 @@ void BoundaryInfo::print_summary(std::ostream& out_stream) const
 
       std::map<boundary_id_type, std::size_t> ID_counts;
 
-      std::multimap<const Node*, boundary_id_type>::const_iterator it        = _boundary_node_id.begin();
-      const std::multimap<const Node*, boundary_id_type>::const_iterator end = _boundary_node_id.end();
+      boundary_node_iter it        = _boundary_node_id.begin();
+      const boundary_node_iter end = _boundary_node_id.end();
 
       for (; it != end; ++it)
         ID_counts[(*it).second]++;
@@ -1821,10 +1685,8 @@ void BoundaryInfo::print_summary(std::ostream& out_stream) const
 
       std::map<boundary_id_type, std::size_t> ID_counts;
 
-      std::multimap<const Elem*,
-                    std::pair<unsigned short int, boundary_id_type> >::const_iterator it = _boundary_edge_id.begin();
-      const std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator end = _boundary_edge_id.end();
+      boundary_edge_iter it = _boundary_edge_id.begin();
+      const boundary_edge_iter end = _boundary_edge_id.end();
 
       for (; it != end; ++it)
         ID_counts[(*it).second.second]++;
@@ -1848,10 +1710,8 @@ void BoundaryInfo::print_summary(std::ostream& out_stream) const
 
       std::map<boundary_id_type, std::size_t> ID_counts;
 
-      std::multimap<const Elem*,
-                    std::pair<unsigned short int, boundary_id_type> >::const_iterator it = _boundary_side_id.begin();
-      const std::multimap<const Elem*,
-                          std::pair<unsigned short int, boundary_id_type> >::const_iterator end = _boundary_side_id.end();
+      boundary_side_iter it = _boundary_side_id.begin();
+      const boundary_side_iter end = _boundary_side_id.end();
 
       for (; it != end; ++it)
         ID_counts[(*it).second.second]++;
@@ -1985,13 +1845,8 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> &requested_bou
             // Get the top-level parent for this element
             const Elem* top_parent = elem->top_parent();
 
-            // A convenient typedef
-            typedef
-              std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
-              const_iterator Iter;
-
             // Find the right id number for that side
-            std::pair<Iter, Iter> pos = _boundary_side_id.equal_range(top_parent);
+            std::pair<boundary_side_iter, boundary_side_iter> pos = _boundary_side_id.equal_range(top_parent);
 
             bool add_this_side = false;
             boundary_id_type this_bcid = invalid_id;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -67,9 +67,8 @@ BoundaryInfo& BoundaryInfo::operator=(const BoundaryInfo& other_boundary_info)
     for (; it != end; ++it)
       {
         const Node * other_node = it->first;
-        _boundary_node_id.insert
-          (std::pair<const Node*, boundary_id_type>
-           (_mesh.node_ptr(other_node->id()), it->second) );
+        _boundary_node_id.insert(std::make_pair(_mesh.node_ptr(other_node->id()),
+                                                it->second));
       }
   }
 
@@ -81,9 +80,8 @@ BoundaryInfo& BoundaryInfo::operator=(const BoundaryInfo& other_boundary_info)
     for (; it != end; ++it)
       {
         const Elem * other_elem = it->first;
-        _boundary_edge_id.insert
-          (std::pair<const Elem*, std::pair<unsigned short int, boundary_id_type> >
-           (_mesh.elem(other_elem->id()), it->second) );
+        _boundary_edge_id.insert(std::make_pair(_mesh.elem(other_elem->id()),
+                                                it->second));
       }
   }
 
@@ -95,9 +93,8 @@ BoundaryInfo& BoundaryInfo::operator=(const BoundaryInfo& other_boundary_info)
     for (; it != end; ++it)
       {
         const Elem * other_elem = it->first;
-        _boundary_side_id.insert
-          (std::pair<const Elem*, std::pair<unsigned short int, boundary_id_type> >
-           (_mesh.elem(other_elem->id()), it->second) );
+        _boundary_side_id.insert(std::make_pair(_mesh.elem(other_elem->id()),
+                                                it->second));
       }
   }
 
@@ -497,9 +494,7 @@ void BoundaryInfo::add_node(const Node* node,
     if (pos.first->second == id)
       return;
 
-  std::pair<const Node*, boundary_id_type> kv (node, id);
-
-  _boundary_node_id.insert(kv);
+  _boundary_node_id.insert(std::make_pair(node, id));
   _boundary_ids.insert(id);
   _node_boundary_ids.insert(id); // Also add this ID to the set of node boundary IDs
 }
@@ -590,11 +585,7 @@ void BoundaryInfo::add_edge(const Elem* elem,
         pos.first->second.second == id)
       return;
 
-  std::pair<unsigned short int, boundary_id_type> p(edge,id);
-  std::pair<const Elem*, std::pair<unsigned short int, boundary_id_type> >
-    kv (elem, p);
-
-  _boundary_edge_id.insert(kv);
+  _boundary_edge_id.insert(std::make_pair(elem, std::make_pair(edge, id)));
   _boundary_ids.insert(id);
   _edge_boundary_ids.insert(id); // Also add this ID to the set of edge boundary IDs
 }
@@ -686,11 +677,7 @@ void BoundaryInfo::add_side(const Elem* elem,
         pos.first->second.second == id)
       return;
 
-  std::pair<unsigned short int, boundary_id_type> p(side,id);
-  std::pair<const Elem*, std::pair<unsigned short int, boundary_id_type> >
-    kv (elem, p);
-
-  _boundary_side_id.insert(kv);
+  _boundary_side_id.insert(std::make_pair(elem, std::make_pair(side, id)));
   _boundary_ids.insert(id);
   _side_boundary_ids.insert(id); // Also add this ID to the set of side boundary IDs
 }

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -516,21 +516,27 @@ void BoundaryInfo::add_node(const Node* node,
   _node_boundary_ids.insert(id); // Also add this ID to the set of node boundary IDs
 }
 
+
+
 void BoundaryInfo::add_node(const Node* node,
                             const std::vector<boundary_id_type>& ids)
 {
-  if (ids.empty())
+  libmesh_deprecated();
+  this->add_node(node, std::set<boundary_id_type>(ids.begin(), ids.end()));
+}
+
+
+
+void BoundaryInfo::add_node(const Node* node,
+                            const std::set<boundary_id_type>& ids_set)
+{
+  if (ids_set.empty())
     return;
 
   libmesh_assert(node);
 
   // A convenient typedef
   typedef std::multimap<const Node*, boundary_id_type>::const_iterator Iter;
-
-  // The following logic requires that the entries in the ids vector
-  // be unique, so guarantee that's the case by constructing a
-  // std::set.
-  std::set<boundary_id_type> ids_set(ids.begin(), ids.end());
 
   // Don't add the same ID twice
   std::pair<Iter, Iter> pos = _boundary_node_id.equal_range(node);
@@ -560,6 +566,7 @@ void BoundaryInfo::add_node(const Node* node,
       _node_boundary_ids.insert(id); // Also add this ID to the set of node boundary IDs
     }
 }
+
 
 
 void BoundaryInfo::clear_boundary_node_ids()
@@ -617,7 +624,17 @@ void BoundaryInfo::add_edge(const Elem* elem,
                             const unsigned short int edge,
                             const std::vector<boundary_id_type>& ids)
 {
-  if (ids.empty())
+  libmesh_deprecated();
+  this->add_edge(elem, edge, std::set<boundary_id_type>(ids.begin(), ids.end()));
+}
+
+
+
+void BoundaryInfo::add_edge(const Elem* elem,
+                            const unsigned short int edge,
+                            const std::set<boundary_id_type>& ids_set)
+{
+  if (ids_set.empty())
     return;
 
   libmesh_assert(elem);
@@ -632,9 +649,10 @@ void BoundaryInfo::add_edge(const Elem* elem,
   // Don't add the same ID twice
   std::pair<Iter, Iter> pos = _boundary_edge_id.equal_range(elem);
 
-  for (unsigned int i=0; i!= ids.size(); ++i)
+  std::set<boundary_id_type>::iterator it = ids_set.begin();
+  for (; it != ids_set.end(); ++it)
     {
-      boundary_id_type id=ids[i];
+      boundary_id_type id = *it;
 
       if (id == invalid_id)
         libmesh_error_msg("ERROR: You may not set a boundary ID of "   \
@@ -652,15 +670,13 @@ void BoundaryInfo::add_edge(const Elem* elem,
       if (already_inserted)
         continue;
 
-      std::pair<unsigned short int, boundary_id_type> p(edge,id);
-      std::pair<const Elem*, std::pair<unsigned short int, boundary_id_type> >
-        kv (elem, p);
-
-      _boundary_edge_id.insert(kv);
+      _boundary_edge_id.insert(std::make_pair(elem, std::make_pair(edge, id)));
       _boundary_ids.insert(id);
       _edge_boundary_ids.insert(id); // Also add this ID to the set of edge boundary IDs
     }
 }
+
+
 
 void BoundaryInfo::add_side(const dof_id_type e,
                             const unsigned short int side,
@@ -712,7 +728,17 @@ void BoundaryInfo::add_side(const Elem* elem,
                             const unsigned short int side,
                             const std::vector<boundary_id_type>& ids)
 {
-  if (ids.empty())
+  libmesh_deprecated();
+  this->add_side(elem, side, std::set<boundary_id_type>(ids.begin(), ids.end()));
+}
+
+
+
+void BoundaryInfo::add_side(const Elem* elem,
+                            const unsigned short int side,
+                            const std::set<boundary_id_type>& ids_set)
+{
+  if (ids_set.empty())
     return;
 
   libmesh_assert(elem);
@@ -723,11 +749,6 @@ void BoundaryInfo::add_side(const Elem* elem,
   // A convenient typedef
   typedef std::multimap<const Elem*, std::pair<unsigned short int, boundary_id_type> >::
     const_iterator Iter;
-
-  // The following logic requires that the entries in the ids vector
-  // be unique, so guarantee that's the case by constructing a
-  // std::set.
-  std::set<boundary_id_type> ids_set(ids.begin(), ids.end());
 
   // Don't add the same ID twice
   std::pair<Iter, Iter> pos = _boundary_side_id.equal_range(elem);

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2001,7 +2001,9 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh& mesh,
           const std::vector<boundary_id_type> ids_to_copy =
             cross_section_boundary_info.boundary_ids(node);
 
-          boundary_info.add_node(new_node, ids_to_copy);
+          boundary_info.add_node(new_node,
+                                 std::set<boundary_id_type>(ids_to_copy.begin(),
+                                                            ids_to_copy.end()));
         }
     }
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -388,7 +388,10 @@ void UnstructuredMesh::all_first_order ()
           const std::vector<boundary_id_type> boundary_ids =
             this->get_boundary_info().raw_boundary_ids (so_elem, s);
 
-          this->get_boundary_info().add_side (lo_elem, s, boundary_ids);
+          this->get_boundary_info().add_side (lo_elem,
+                                              s,
+                                              std::set<boundary_id_type>(boundary_ids.begin(),
+                                                                         boundary_ids.end()));
         }
 
       /*
@@ -676,7 +679,10 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
           const std::vector<boundary_id_type> boundary_ids =
             this->get_boundary_info().raw_boundary_ids (lo_elem, s);
 
-          this->get_boundary_info().add_side (so_elem, s, boundary_ids);
+          this->get_boundary_info().add_side (so_elem,
+                                              s,
+                                              std::set<boundary_id_type>(boundary_ids.begin(),
+                                                                         boundary_ids.end()));
 
           if (lo_elem->neighbor(s) == remote_elem)
             so_elem->set_neighbor(s, const_cast<RemoteElem*>(remote_elem));
@@ -1505,8 +1511,10 @@ void MeshTools::Modification::change_boundary_id (MeshBase& mesh,
             mesh.get_boundary_info().boundary_ids(elem->get_node(n));
           if (std::find(old_ids.begin(), old_ids.end(), old_id) != old_ids.end())
             {
-              std::vector<boundary_id_type> new_ids(old_ids);
-              std::replace(new_ids.begin(), new_ids.end(), old_id, new_id);
+              std::set<boundary_id_type> new_ids(old_ids.begin(), old_ids.end());
+              // Replace the old_id, if it exists, with the new ID.
+              if (new_ids.erase(old_id))
+                new_ids.insert(new_id);
               mesh.get_boundary_info().remove(elem->get_node(n));
               mesh.get_boundary_info().add_node(elem->get_node(n), new_ids);
             }
@@ -1519,8 +1527,10 @@ void MeshTools::Modification::change_boundary_id (MeshBase& mesh,
             mesh.get_boundary_info().edge_boundary_ids(elem, edge);
           if (std::find(old_ids.begin(), old_ids.end(), old_id) != old_ids.end())
             {
-              std::vector<boundary_id_type> new_ids(old_ids);
-              std::replace(new_ids.begin(), new_ids.end(), old_id, new_id);
+              std::set<boundary_id_type> new_ids(old_ids.begin(), old_ids.end());
+              // Replace the old_id, if it exists, with the new ID.
+              if (new_ids.erase(old_id))
+                new_ids.insert(new_id);
               mesh.get_boundary_info().remove_edge(elem, edge);
               mesh.get_boundary_info().add_edge(elem, edge, new_ids);
             }
@@ -1533,8 +1543,10 @@ void MeshTools::Modification::change_boundary_id (MeshBase& mesh,
             mesh.get_boundary_info().boundary_ids(elem, s);
           if (std::find(old_ids.begin(), old_ids.end(), old_id) != old_ids.end())
             {
-              std::vector<boundary_id_type> new_ids(old_ids);
-              std::replace(new_ids.begin(), new_ids.end(), old_id, new_id);
+              std::set<boundary_id_type> new_ids(old_ids.begin(), old_ids.end());
+              // Replace the old_id, if it exists, with the new ID.
+              if (new_ids.erase(old_id))
+                new_ids.insert(new_id);
               mesh.get_boundary_info().remove_side(elem, s);
               mesh.get_boundary_info().add_side(elem, s, new_ids);
             }

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -1248,10 +1248,9 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
             {
               const std::vector<boundary_id_type>& ids =
                 other_mesh->get_boundary_info().boundary_ids(other_elem->get_node(n));
-              if (!ids.empty())
-                {
-                  this->get_boundary_info().add_node(this_elem->get_node(n), ids);
-                }
+              this->get_boundary_info().add_node(this_elem->get_node(n),
+                                                 std::set<boundary_id_type>(ids.begin(),
+                                                                            ids.end()));
             }
 
           // Copy edge boundary info
@@ -1260,10 +1259,10 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
             {
               const std::vector<boundary_id_type>& ids =
                 other_mesh->get_boundary_info().edge_boundary_ids(other_elem, edge);
-              if (!ids.empty())
-                {
-                  this->get_boundary_info().add_edge( this_elem, edge, ids);
-                }
+              this->get_boundary_info().add_edge(this_elem,
+                                                 edge,
+                                                 std::set<boundary_id_type>(ids.begin(),
+                                                                            ids.end()));
             }
 
           unsigned int n_sides = other_elem->n_sides();
@@ -1271,10 +1270,10 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
             {
               const std::vector<boundary_id_type>& ids =
                 other_mesh->get_boundary_info().boundary_ids(other_elem, s);
-              if (!ids.empty())
-                {
-                  this->get_boundary_info().add_side( this_elem, s, ids);
-                }
+              this->get_boundary_info().add_side(this_elem,
+                                                 s,
+                                                 std::set<boundary_id_type>(ids.begin(),
+                                                                            ids.end()));
             }
 
         }
@@ -1311,7 +1310,9 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
 
           el->set_node(local_node_index) = &target_node;
 
-          this->get_boundary_info().add_node(&target_node, ids);
+          this->get_boundary_info().add_node(&target_node,
+                                             std::set<boundary_id_type>(ids.begin(),
+                                                                        ids.end()));
         }
     }
 


### PR DESCRIPTION
This fixes the bug reported in #706, plus refactors a few things for readability.