### PR TITLE
Updated BoundaryInfo::sync

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -124,6 +124,15 @@ public:
 
 
   /**
+   * Same as above, except in this case we fill \p node_id_map and \p side_id_map.
+   */
+  void sync (const std::set<boundary_id_type> &requested_boundary_ids,
+             UnstructuredMesh& boundary_mesh,
+             std::map<dof_id_type, dof_id_type>& node_id_map,
+             std::map<std::pair<dof_id_type, unsigned char>, dof_id_type>& side_id_map);
+
+
+  /**
    * Generates \p elements along the boundary of our _mesh, which
    * use pre-existing nodes on the boundary_mesh, and which have
    * interior_parent values properly defined.
@@ -509,6 +518,17 @@ public:
 
 
 private:
+
+  /**
+   * Helper method for that actually performs the syncing between the interior
+   * mesh and the boundary mesh.
+   */
+  void sync_helper (const std::set<boundary_id_type> &requested_boundary_ids,
+                    UnstructuredMesh& boundary_mesh,
+                    MeshData* boundary_mesh_data,
+                    MeshData* this_mesh_data,
+                    std::map<dof_id_type, dof_id_type>* node_id_map_ptr,
+                    std::map<std::pair<dof_id_type, unsigned char>, dof_id_type>* side_id_map_ptr);
 
   /**
    * Helper method for finding consistent maps of interior to boundary


### PR DESCRIPTION
I wanted to be able to use the node and side id maps that are used internally when doing BoundaryInfo::sync(). This small PR gives us access to this data.