### PR TITLE
Auto set interior parent/update mixed dim tests

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -958,6 +958,12 @@ public:
    */
   void cache_elem_dims();
 
+  /**
+   * Search the mesh for elements that have a neighboring element
+   * of dim+1 and set that element as the interior parent
+   */
+  void detect_interior_parents();
+
 
   /**
    * This class holds the boundary information.  It can store nodes, edges,

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -591,10 +591,10 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
               e_it != neighbors_0.end(); e_it++)
             {
               found_interior_parents=false;
-              dof_id_type int_prnt = *e_it;
+              dof_id_type interior_parent_id = *e_it;
               for(dof_id_type n=1; n < element->n_vertices(); n++)
                 {
-                  if(neighbors[n].find(int_prnt)!=neighbors[n].end())
+                  if(neighbors[n].find(interior_parent_id)!=neighbors[n].end())
                     {
                       found_interior_parents=true;
                     }
@@ -606,7 +606,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                 }
               if(found_interior_parents)
               {
-                element->set_interior_parent(this->elem(int_prnt));
+                element->set_interior_parent(this->elem(interior_parent_id));
                 break;
               }
             }

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -566,6 +566,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
     {
       Elem * element = *it;
 
+      //Ignore an 3D element or an element that already has an interior parent
       if(element->dim()>=LIBMESH_DIM || element->interior_parent())
         continue;
 
@@ -589,10 +590,18 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
             }
           else
             {
+              // We have found an empty set, no reason to continue
+              // Ensure we set this flag to false before the break since it could have
+              // been set to true for previous vertex
               found_interior_parents = false;
               break;
             }
         }
+
+      // If we have successfully generated a set of elements for each vertex, we will compare
+      // the set for vertex 0 will the sets for the vertices until we find a id that exists in
+      // all sets.  If found, this is our an interior parent id.  The interior parent id found
+      // will be the lowest element id if there is potential for multiple interior parents.
       if(found_interior_parents)
         {
           std::set<dof_id_type> &neighbors_0 = neighbors[0];

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -882,10 +882,10 @@ protected:
                   Elem* hex = _mesh->add_elem( new Hex8 );
                   hex->set_node(0) = _mesh->node_ptr(x+4*y    +16*z        );
                   hex->set_node(1) = _mesh->node_ptr(x+4*y    +16*z     + 1);
-                  hex->set_node(2) = _mesh->node_ptr(x+4*y    +16*(z+1) + 1);
-                  hex->set_node(3) = _mesh->node_ptr(x+4*y    +16*(z+1)    );
-                  hex->set_node(4) = _mesh->node_ptr(x+4*(y+1)+16*z        );
-                  hex->set_node(5) = _mesh->node_ptr(x+4*(y+1)+16*z     + 1);
+                  hex->set_node(2) = _mesh->node_ptr(x+4*(y+1)+16*z     + 1);
+                  hex->set_node(3) = _mesh->node_ptr(x+4*(y+1)+16*z        );
+                  hex->set_node(4) = _mesh->node_ptr(x+4*y    +16*(z+1)    );
+                  hex->set_node(5) = _mesh->node_ptr(x+4*y    +16*(z+1) + 1);
                   hex->set_node(6) = _mesh->node_ptr(x+4*(y+1)+16*(z+1) + 1);
                   hex->set_node(7) = _mesh->node_ptr(x+4*(y+1)+16*(z+1)    );
               }
@@ -936,52 +936,52 @@ public:
     CPPUNIT_ASSERT_EQUAL( (dof_id_type)113, _mesh->n_nodes() );
 
     // QUAD4,id=53 should have same nodes as a face in HEX8, id=39
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(0), _mesh->elem(39)->node(3) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(1), _mesh->elem(39)->node(2) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(2), _mesh->elem(39)->node(6) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(3), _mesh->elem(39)->node(7) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(0), _mesh->elem(41)->node(4) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(1), _mesh->elem(41)->node(5) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(2), _mesh->elem(41)->node(6) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(3), _mesh->elem(41)->node(7) );
 
     // QUAD4,id=53 should have same nodes as a face in HEX8, id=45
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(0), _mesh->elem(45)->node(0) );
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(1), _mesh->elem(45)->node(1) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(2), _mesh->elem(45)->node(5) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(3), _mesh->elem(45)->node(4) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(2), _mesh->elem(45)->node(2) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(3), _mesh->elem(45)->node(3) );
 
-    // QUAD4,id=54 should have same nodes as a face in HEX8, id=40
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(0), _mesh->elem(40)->node(3) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(1), _mesh->elem(40)->node(2) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(2), _mesh->elem(40)->node(6) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(3), _mesh->elem(40)->node(7) );
+    // QUAD4,id=54 should have same nodes as a face in HEX8, id=42
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(0), _mesh->elem(42)->node(4) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(1), _mesh->elem(42)->node(5) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(2), _mesh->elem(42)->node(6) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(3), _mesh->elem(42)->node(7) );
 
     // QUAD4,id=54 should have same nodes as a face in HEX8, id=46
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(0), _mesh->elem(46)->node(0) );
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(1), _mesh->elem(46)->node(1) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(2), _mesh->elem(46)->node(5) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(3), _mesh->elem(46)->node(4) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(2), _mesh->elem(46)->node(2) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->node(3), _mesh->elem(46)->node(3) );
 
     // QUAD4,id=55 should have same nodes as a face in HEX8, id=43
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(0), _mesh->elem(43)->node(3) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(1), _mesh->elem(43)->node(2) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(0), _mesh->elem(43)->node(4) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(1), _mesh->elem(43)->node(5) );
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(2), _mesh->elem(43)->node(6) );
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(3), _mesh->elem(43)->node(7) );
 
-    // QUAD4,id=55 should have same nodes as a face in HEX8, id=49
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(0), _mesh->elem(49)->node(0) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(1), _mesh->elem(49)->node(1) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(2), _mesh->elem(49)->node(5) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(3), _mesh->elem(49)->node(4) );
+    // QUAD4,id=55 should have same nodes as a face in HEX8, id=47
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(0), _mesh->elem(47)->node(0) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(1), _mesh->elem(47)->node(1) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(2), _mesh->elem(47)->node(2) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->node(3), _mesh->elem(47)->node(3) );
 
     // QUAD4,id=56 should have same nodes as a face in HEX8, id=44
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(0), _mesh->elem(44)->node(3) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(1), _mesh->elem(44)->node(2) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(0), _mesh->elem(44)->node(4) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(1), _mesh->elem(44)->node(5) );
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(2), _mesh->elem(44)->node(6) );
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(3), _mesh->elem(44)->node(7) );
 
-    // QUAD4,id=56 should have same nodes as a face in HEX8, id=50
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(0), _mesh->elem(50)->node(0) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(1), _mesh->elem(50)->node(1) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(2), _mesh->elem(50)->node(5) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(3), _mesh->elem(50)->node(4) );
+    // QUAD4,id=56 should have same nodes as a face in HEX8, id=48
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(0), _mesh->elem(48)->node(0) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(1), _mesh->elem(48)->node(1) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(2), _mesh->elem(48)->node(2) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->node(3), _mesh->elem(48)->node(3) );
 
     // Shared node between the QUAD4 elements should have the same global id
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->node(1), _mesh->elem(54)->node(0) );
@@ -1000,8 +1000,8 @@ public:
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->parent(), _mesh->elem(36) );
 
     // QUAD4 child elements should have the correct interior_parent
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->interior_parent(), _mesh->elem(39) );
-    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->interior_parent(), _mesh->elem(40) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(53)->interior_parent(), _mesh->elem(41) );
+    CPPUNIT_ASSERT_EQUAL( _mesh->elem(54)->interior_parent(), _mesh->elem(42) );
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(55)->interior_parent(), _mesh->elem(43) );
     CPPUNIT_ASSERT_EQUAL( _mesh->elem(56)->interior_parent(), _mesh->elem(44) );
 
@@ -1019,93 +1019,93 @@ public:
     DofMap& dof_map = es.get_system("TestDofSystem").get_dof_map();
 
     //Elements to the left of the QUAD4 elements
-    std::vector<dof_id_type> elem43_dof_indices, elem44_dof_indices, elem49_dof_indices, elem50_dof_indices;
+    std::vector<dof_id_type> elem41_dof_indices, elem42_dof_indices, elem43_dof_indices, elem44_dof_indices;
     //Elements to the right of the QUAD4 elements
-    std::vector<dof_id_type> elem39_dof_indices, elem40_dof_indices, elem45_dof_indices, elem46_dof_indices;
+    std::vector<dof_id_type> elem45_dof_indices, elem46_dof_indices, elem47_dof_indices, elem48_dof_indices;
     //QUAD4 elements
     std::vector<dof_id_type> elem53_dof_indices, elem54_dof_indices, elem55_dof_indices, elem56_dof_indices;
 
+    dof_map.dof_indices( _mesh->elem(41), elem41_dof_indices );
+    dof_map.dof_indices( _mesh->elem(42), elem42_dof_indices );
     dof_map.dof_indices( _mesh->elem(43), elem43_dof_indices );
     dof_map.dof_indices( _mesh->elem(44), elem44_dof_indices );
-    dof_map.dof_indices( _mesh->elem(49), elem49_dof_indices );
-    dof_map.dof_indices( _mesh->elem(50), elem50_dof_indices );
-    dof_map.dof_indices( _mesh->elem(39), elem39_dof_indices );
-    dof_map.dof_indices( _mesh->elem(40), elem40_dof_indices );
     dof_map.dof_indices( _mesh->elem(45), elem45_dof_indices );
     dof_map.dof_indices( _mesh->elem(46), elem46_dof_indices );
+    dof_map.dof_indices( _mesh->elem(47), elem47_dof_indices );
+    dof_map.dof_indices( _mesh->elem(48), elem48_dof_indices );
+    dof_map.dof_indices( _mesh->elem(53), elem53_dof_indices );
     dof_map.dof_indices( _mesh->elem(54), elem54_dof_indices );
     dof_map.dof_indices( _mesh->elem(55), elem55_dof_indices );
-    dof_map.dof_indices( _mesh->elem(53), elem53_dof_indices );
     dof_map.dof_indices( _mesh->elem(56), elem56_dof_indices );
 
     /* The dofs for the QUAD4 (ids = 53, 54, 55, and 56) element should be the same
-       as the face of the HEX8 elements HEX8 (id=39, 40, 43, and 44) left of the
+       as the face of the HEX8 elements HEX8 (id=41, 42, 43, and 44) left of the
        QUAD4 elements. */
-    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[0], elem39_dof_indices[3] );
-    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[1], elem39_dof_indices[2] );
-    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[2], elem39_dof_indices[6] );
-    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[3], elem39_dof_indices[7] );
+    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[0], elem41_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[1], elem41_dof_indices[5] );
+    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[2], elem41_dof_indices[6] );
+    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[3], elem41_dof_indices[7] );
 
-    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[0], elem40_dof_indices[3] );
-    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[1], elem40_dof_indices[2] );
-    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[2], elem40_dof_indices[6] );
-    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[3], elem40_dof_indices[7] );
+    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[0], elem42_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[1], elem42_dof_indices[5] );
+    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[2], elem42_dof_indices[6] );
+    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[3], elem42_dof_indices[7] );
 
-    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[0], elem43_dof_indices[3] );
-    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[1], elem43_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[0], elem43_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[1], elem43_dof_indices[5] );
     CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[2], elem43_dof_indices[6] );
     CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[3], elem43_dof_indices[7] );
 
-    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[0], elem44_dof_indices[3] );
-    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[1], elem44_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[0], elem44_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[1], elem44_dof_indices[5] );
     CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[2], elem44_dof_indices[6] );
     CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[3], elem44_dof_indices[7] );
 
     /* The dofs for the QUAD4 (ids = 53, 54, 55, and 56) element should be the same
-       as the face of the HEX8 elements HEX8 (id=45, 46, 49, and 50) left of the
+       as the face of the HEX8 elements HEX8 (id=45, 46, 47, and 49) left of the
        QUAD4 elements. */
     CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[0], elem45_dof_indices[0] );
     CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[1], elem45_dof_indices[1] );
-    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[2], elem45_dof_indices[5] );
-    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[3], elem45_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[2], elem45_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem53_dof_indices[3], elem45_dof_indices[3] );
 
     CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[0], elem46_dof_indices[0] );
     CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[1], elem46_dof_indices[1] );
-    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[2], elem46_dof_indices[5] );
-    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[3], elem46_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[2], elem46_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem54_dof_indices[3], elem46_dof_indices[3] );
 
-    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[0], elem49_dof_indices[0] );
-    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[1], elem49_dof_indices[1] );
-    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[2], elem49_dof_indices[5] );
-    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[3], elem49_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[0], elem47_dof_indices[0] );
+    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[1], elem47_dof_indices[1] );
+    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[2], elem47_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem55_dof_indices[3], elem47_dof_indices[3] );
 
-    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[0], elem50_dof_indices[0] );
-    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[1], elem50_dof_indices[1] );
-    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[2], elem50_dof_indices[5] );
-    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[3], elem50_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[0], elem48_dof_indices[0] );
+    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[1], elem48_dof_indices[1] );
+    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[2], elem48_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem56_dof_indices[3], elem48_dof_indices[3] );
 
-    /* The dofs for the HEX8 elements (id=39, 40, 43, and 44) should be the same
-       on the left side of the QUAD4 elements as the HEX8 elements (id=45, 46, 49, and 50)
+    /* The dofs for the HEX8 elements (id=41, 42, 43, and 44) should be the same
+       on the left side of the QUAD4 elements as the HEX8 elements (id=45, 46, 47, and 48)
        on the right as QUAD4 elements. */
-    CPPUNIT_ASSERT_EQUAL( elem39_dof_indices[3], elem45_dof_indices[0] );
-    CPPUNIT_ASSERT_EQUAL( elem39_dof_indices[2], elem45_dof_indices[1] );
-    CPPUNIT_ASSERT_EQUAL( elem39_dof_indices[6], elem45_dof_indices[5] );
-    CPPUNIT_ASSERT_EQUAL( elem39_dof_indices[7], elem45_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem41_dof_indices[4], elem45_dof_indices[0] );
+    CPPUNIT_ASSERT_EQUAL( elem41_dof_indices[5], elem45_dof_indices[1] );
+    CPPUNIT_ASSERT_EQUAL( elem41_dof_indices[6], elem45_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem41_dof_indices[7], elem45_dof_indices[3] );
 
-    CPPUNIT_ASSERT_EQUAL( elem40_dof_indices[3], elem46_dof_indices[0] );
-    CPPUNIT_ASSERT_EQUAL( elem40_dof_indices[2], elem46_dof_indices[1] );
-    CPPUNIT_ASSERT_EQUAL( elem40_dof_indices[6], elem46_dof_indices[5] );
-    CPPUNIT_ASSERT_EQUAL( elem40_dof_indices[7], elem46_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem42_dof_indices[4], elem46_dof_indices[0] );
+    CPPUNIT_ASSERT_EQUAL( elem42_dof_indices[5], elem46_dof_indices[1] );
+    CPPUNIT_ASSERT_EQUAL( elem42_dof_indices[6], elem46_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem42_dof_indices[7], elem46_dof_indices[3] );
 
-    CPPUNIT_ASSERT_EQUAL( elem43_dof_indices[3], elem49_dof_indices[0] );
-    CPPUNIT_ASSERT_EQUAL( elem43_dof_indices[2], elem49_dof_indices[1] );
-    CPPUNIT_ASSERT_EQUAL( elem43_dof_indices[6], elem49_dof_indices[5] );
-    CPPUNIT_ASSERT_EQUAL( elem43_dof_indices[7], elem49_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem43_dof_indices[4], elem47_dof_indices[0] );
+    CPPUNIT_ASSERT_EQUAL( elem43_dof_indices[5], elem47_dof_indices[1] );
+    CPPUNIT_ASSERT_EQUAL( elem43_dof_indices[6], elem47_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem43_dof_indices[7], elem47_dof_indices[3] );
 
-    CPPUNIT_ASSERT_EQUAL( elem44_dof_indices[3], elem50_dof_indices[0] );
-    CPPUNIT_ASSERT_EQUAL( elem44_dof_indices[2], elem50_dof_indices[1] );
-    CPPUNIT_ASSERT_EQUAL( elem44_dof_indices[6], elem50_dof_indices[5] );
-    CPPUNIT_ASSERT_EQUAL( elem44_dof_indices[7], elem50_dof_indices[4] );
+    CPPUNIT_ASSERT_EQUAL( elem44_dof_indices[4], elem48_dof_indices[0] );
+    CPPUNIT_ASSERT_EQUAL( elem44_dof_indices[5], elem48_dof_indices[1] );
+    CPPUNIT_ASSERT_EQUAL( elem44_dof_indices[6], elem48_dof_indices[2] );
+    CPPUNIT_ASSERT_EQUAL( elem44_dof_indices[7], elem48_dof_indices[3] );
 
     /* The dofs for the QUAD4 elements (ids = 53, 54, 55, and 56) should be the
        same for shared nodes. */

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -133,7 +133,7 @@ public:
 
     // We didn't set an interior_parent on the edge element, so it
     // should default to NULL
-    CPPUNIT_ASSERT( !_mesh->elem(2)->interior_parent() );
+    CPPUNIT_ASSERT( _mesh->elem(2)->interior_parent() );
   }
 
   void testDofOrdering()

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -268,9 +268,6 @@ public:
      */
     this->build_mesh();
 
-    // Let's set an interior_parent() this time for testing
-    _mesh->elem(2)->set_interior_parent(_mesh->elem(0));
-
 #ifdef LIBMESH_ENABLE_AMR
     MeshRefinement(*_mesh).uniformly_refine(1);
 #endif
@@ -494,13 +491,11 @@ protected:
       edge->subdomain_id() = 1;
     }
 
-    // Let's set an interior_parent() this time for testing
-    _mesh->elem(4)->set_interior_parent(_mesh->elem(0));
-
     // libMesh will renumber, but we numbered according to its scheme
     // anyway. We do this because when we call uniformly_refine subsequenly,
     // it's going use skip_renumber=false.
     _mesh->prepare_for_use(false /*skip_renumber*/);
+
 
 #ifdef LIBMESH_ENABLE_AMR
     //Flag the bottom element for refinement
@@ -711,10 +706,6 @@ protected:
     // it's going use skip_renumber=false.
     _mesh->prepare_for_use(false /*skip_renumber*/);
 
-    // Let's set an interior_parent() this time for testing
-    _mesh->elem(4)->set_interior_parent(_mesh->elem(0));
-
-
 #ifdef LIBMESH_ENABLE_AMR
     //Flag the bottom element for refinement
     _mesh->elem(4)->set_refinement_flag(Elem::REFINE);
@@ -910,9 +901,6 @@ protected:
       // 2D elements will have subdomain id 0, this one will have 1
       quad->subdomain_id() = 1;
     }
-
-    // Let's set an interior_parent() this time for testing
-    _mesh->elem(36)->set_interior_parent(_mesh->elem(13));
 
     // libMesh will renumber, but we numbered according to its scheme
     // anyway. We do this because when we call uniformly_refine subsequently,


### PR DESCRIPTION
Added an algorithm to auto set interior parents.  Placed it in find_neighbors since it handles setting the interior parent of child elements when the parent has an interior parent.  Also, removed the manual setting of the interior parent in the mixed dim refinement tests since it is handled by find_neighbors.