### PR TITLE
Update and deprecate several variants of BoundaryInfo::boundary_ids()

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -94,9 +94,9 @@ struct AssemblyA0 : ElemAssemblyWithConstruction
 {
   virtual void boundary_assembly(FEMContext &c)
   {
-    const std::vector<boundary_id_type> bc_ids =
-      rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(),c.side);
-    for (std::vector<boundary_id_type>::const_iterator b =
+    std::set<boundary_id_type> bc_ids;
+    rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
+    for (std::set<boundary_id_type>::const_iterator b =
            bc_ids.begin(); b != bc_ids.end(); ++b)
       if( *b == 1 || *b == 2 || *b == 3 || *b == 4 )
         {
@@ -135,9 +135,9 @@ struct AssemblyA1 : ElemAssemblyWithConstruction
 {
   virtual void boundary_assembly(FEMContext &c)
   {
-    const std::vector<boundary_id_type> bc_ids =
-      rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(),c.side);
-    for (std::vector<boundary_id_type>::const_iterator b =
+    std::set<boundary_id_type> bc_ids;
+    rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
+    for (std::set<boundary_id_type>::const_iterator b =
            bc_ids.begin(); b != bc_ids.end(); ++b)
       if( *b == 1 || *b == 3 ) // y == -0.2, y == 0.2
         {
@@ -182,9 +182,9 @@ struct AssemblyA2 : ElemAssemblyWithConstruction
 {
   virtual void boundary_assembly(FEMContext &c)
   {
-    const std::vector<boundary_id_type> bc_ids =
-      rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(),c.side);
-    for (std::vector<boundary_id_type>::const_iterator b =
+    std::set<boundary_id_type> bc_ids;
+    rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
+    for (std::set<boundary_id_type>::const_iterator b =
            bc_ids.begin(); b != bc_ids.end(); ++b)
       if( *b == 2 || *b == 4) // x == 0.2, x == -0.2
         {

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -330,18 +330,18 @@ void assemble_elasticity(EquationSystems& es,
         }
 
       {
+        std::set<boundary_id_type> bc_ids;
         for (unsigned int side=0; side<elem->n_sides(); side++)
           if (elem->neighbor(side) == NULL)
             {
-              const std::vector<boundary_id_type> bc_ids =
-                mesh.get_boundary_info().boundary_ids (elem,side);
+              mesh.get_boundary_info().boundary_ids (elem, side, bc_ids);
 
               const std::vector<std::vector<Real> >&  phi_face = fe_face->get_phi();
               const std::vector<Real>& JxW_face = fe_face->get_JxW();
 
               fe_face->reinit(elem, side);
 
-              for (std::vector<boundary_id_type>::const_iterator b =
+              for (std::set<boundary_id_type>::const_iterator b =
                      bc_ids.begin(); b != bc_ids.end(); ++b)
                 {
                   const boundary_id_type bc_id = *b;

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -50,8 +50,6 @@ class MeshData;
  * element faces and nodes with ids useful for identifying the
  * type of boundary condtion.  It can also build a mesh that
  * just includes boundary elements/faces.
- *
- * TODO[JWP]: Generalize this to work with MeshBase again.
  */
 class BoundaryInfo : public ParallelObject
 {

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -420,9 +420,24 @@ public:
    * side of element \p elem.  These ids are ``raw'' because they
    * exclude ids which are implicit, such as a child's inheritance of
    * its ancestors' boundary id.
+   *
+   * This function has been deprecated.  Instead, use the version of
+   * this function that fills a std::set.
    */
   std::vector<boundary_id_type> raw_boundary_ids (const Elem* const elem,
                                                   const unsigned short int side) const;
+
+  /**
+   * Returns the list of raw boundary ids associated with the \p side
+   * side of element \p elem.  These ids are ``raw'' because they
+   * exclude ids which are implicit, such as a child's inheritance of
+   * its ancestors' boundary id.
+   *
+   * This is the non-deprecated version of the function.
+   */
+  void raw_boundary_ids (const Elem* const elem,
+                         const unsigned short int side,
+                         std::set<boundary_id_type> & set_to_fill) const;
 
   /**
    * Returns a side of element \p elem whose associated boundary id is

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -310,8 +310,19 @@ public:
 
   /**
    * Returns the boundary ids associated with \p Node \p node.
+   *
+   * This function has been deprecated.  See instead: boundary_ids_set(const Node*).
    */
   std::vector<boundary_id_type> boundary_ids (const Node* node) const;
+
+  /**
+   * Fills a user-provided std::set with the boundary ids associated
+   * with \p Node \p node.
+   *
+   * This is the non-deprecated version of the function.
+   */
+  void boundary_ids (const Node* node,
+                     std::set<boundary_id_type> & set_to_fill) const;
 
   /**
    * Returns the number of boundary ids associated with \p Node \p node.

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -311,7 +311,8 @@ public:
   /**
    * Returns the boundary ids associated with \p Node \p node.
    *
-   * This function has been deprecated.  See instead: boundary_ids_set(const Node*).
+   * This function has been deprecated.  Instead, use the version of
+   * this function that fills a std::set.
    */
   std::vector<boundary_id_type> boundary_ids (const Node* node) const;
 
@@ -341,9 +342,23 @@ public:
    * Returns the list of boundary ids associated with the \p edge edge of
    * element \p elem.
    * Edge-based boundary IDs should only be used in 3D.
+   *
+   * This function has been deprecated.  Instead, use the version of
+   * this function that fills a std::set.
    */
   std::vector<boundary_id_type> edge_boundary_ids (const Elem* const elem,
                                                    const unsigned short int edge) const;
+
+  /**
+   * Returns the list of boundary ids associated with the \p edge edge of
+   * element \p elem.
+   * Edge-based boundary IDs should only be used in 3D.
+   *
+   * This is the non-deprecated version of the function.
+   */
+  void edge_boundary_ids (const Elem* const elem,
+                          const unsigned short int edge,
+                          std::set<boundary_id_type> & set_to_fill) const;
 
   /**
    * Returns the list of raw boundary ids associated with the \p edge

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -398,9 +398,22 @@ public:
   /**
    * Returns the list of boundary ids associated with the \p side side of
    * element \p elem.
+   *
+   * This function has been deprecated.  Instead, use the version of
+   * this function that fills a std::set.
    */
   std::vector<boundary_id_type> boundary_ids (const Elem* const elem,
                                               const unsigned short int side) const;
+
+  /**
+   * Returns the list of boundary ids associated with the \p side side of
+   * element \p elem.
+   *
+   * This is the non-deprecated version of the function.
+   */
+  void boundary_ids (const Elem* const elem,
+                     const unsigned short int side,
+                     std::set<boundary_id_type> & set_to_fill) const;
 
   /**
    * Returns the list of raw boundary ids associated with the \p side

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -366,9 +366,25 @@ public:
    * exclude ids which are implicit, such as a child's inheritance of
    * its ancestors' boundary id.
    * Edge-based boundary IDs should only be used in 3D.
+   *
+   * This function has been deprecated.  Instead, use the version of
+   * this function that fills a std::set.
    */
   std::vector<boundary_id_type> raw_edge_boundary_ids (const Elem* const elem,
                                                        const unsigned short int edge) const;
+
+  /**
+   * Returns the list of raw boundary ids associated with the \p edge
+   * edge of element \p elem.  These ids are ``raw'' because they
+   * exclude ids which are implicit, such as a child's inheritance of
+   * its ancestors' boundary id.
+   * Edge-based boundary IDs should only be used in 3D.
+   *
+   * This is the non-deprecated version of the function.
+   */
+  void raw_edge_boundary_ids (const Elem* const elem,
+                              const unsigned short int edge,
+                              std::set<boundary_id_type> & set_to_fill) const;
 
   /**
    * Returns true iff the given side of the given element is

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -80,8 +80,16 @@ public:
 
   /**
    * Lists the boundary ids found on the current side
+   *
+   * This function is now deprecated. Instead, use the version that
+   * takes a reference to a std::set.
    */
   std::vector<boundary_id_type> side_boundary_ids() const;
+
+  /**
+   * As above, but fills in the std::set provided by the user.
+   */
+  void side_boundary_ids(std::set<boundary_id_type> & set_to_fill) const;
 
   /**
    * Returns the value of the solution variable \p var at the quadrature

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -434,14 +434,20 @@ private:
 
         // We also maintain a separate list of nodeset-based boundary nodes
         std::vector<bool> is_boundary_nodeset(elem->n_nodes(), false);
+
+        // Container to catch boundary ids handed back for sides,
+        // nodes, and edges in the loops below.
+        std::set<boundary_id_type> ids_set;
+
         for (unsigned char s=0; s != elem->n_sides(); ++s)
           {
             // First see if this side has been requested
-            const std::vector<boundary_id_type>& bc_ids =
-              boundary_info.boundary_ids (elem, s);
+            boundary_info.boundary_ids (elem, s, ids_set);
+
             bool do_this_side = false;
-            for (std::size_t i=0; i != bc_ids.size(); ++i)
-              if (b.count(bc_ids[i]))
+            for (std::set<boundary_id_type>::iterator bc_it = ids_set.begin();
+                 bc_it != ids_set.end(); ++bc_it)
+              if (b.count(*bc_it))
                 {
                   do_this_side = true;
                   break;
@@ -464,11 +470,11 @@ private:
         // also independently check whether the nodes have been requested
         for (unsigned int n=0; n != elem->n_nodes(); ++n)
           {
-            const std::vector<boundary_id_type>& bc_ids =
-              boundary_info.boundary_ids (elem->get_node(n));
+            boundary_info.boundary_ids (elem->get_node(n), ids_set);
 
-            for (std::size_t i=0; i != bc_ids.size(); ++i)
-              if (b.count(bc_ids[i]))
+            for (std::set<boundary_id_type>::iterator bc_it = ids_set.begin();
+                 bc_it != ids_set.end(); ++bc_it)
+              if (b.count(*bc_it))
                 {
                   is_boundary_node[n] = true;
                   is_boundary_nodeset[n] = true;
@@ -479,11 +485,11 @@ private:
         // also independently check whether the edges have been requested
         for (unsigned short e=0; e != elem->n_edges(); ++e)
           {
-            const std::vector<boundary_id_type>& bc_ids =
-              boundary_info.edge_boundary_ids (elem, e);
+            boundary_info.edge_boundary_ids (elem, e, ids_set);
 
-            for (std::size_t i=0; i != bc_ids.size(); ++i)
-              if (b.count(bc_ids[i]))
+            for (std::set<boundary_id_type>::iterator bc_it = ids_set.begin();
+                 bc_it != ids_set.end(); ++bc_it)
+              if (b.count(*bc_it))
                 is_boundary_edge[e] = true;
           }
 

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -953,14 +953,14 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints &constraints
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
+  std::set<boundary_id_type> bc_ids;
   for (unsigned short int s=0; s<elem->n_sides(); s++)
     {
       if (elem->neighbor(s))
         continue;
 
-      const std::vector<boundary_id_type>& bc_ids =
-        mesh.get_boundary_info().boundary_ids (elem, s);
-      for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+      mesh.get_boundary_info().boundary_ids (elem, s, bc_ids);
+      for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
         {
           const boundary_id_type boundary_id = *id_it;
           const PeriodicBoundaryBase *periodic = boundaries.boundary(boundary_id);

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -55,6 +55,9 @@ const Elem* primary_boundary_point_neighbor
   // provided the primary element
   const Elem *primary = elem;
 
+  // Container to catch boundary IDs passed back by BoundaryInfo.
+  std::set<boundary_id_type> bc_ids;
+
   std::set<const Elem*> point_neighbors;
   elem->find_point_neighbors(p, point_neighbors);
   for (std::set<const Elem*>::const_iterator point_neighbors_iter =
@@ -79,14 +82,12 @@ const Elem* primary_boundary_point_neighbor
       for (unsigned short int ns = 0;
            ns != pt_neighbor->n_sides(); ++ns)
         {
-          const std::vector<boundary_id_type> bc_ids =
-            boundary_info.boundary_ids (pt_neighbor, ns);
+          boundary_info.boundary_ids (pt_neighbor, ns, bc_ids);
 
           bool on_relevant_boundary = false;
           for (std::set<boundary_id_type>::const_iterator i =
                  boundary_ids.begin(); i != boundary_ids.end(); ++i)
-            if (std::find(bc_ids.begin(), bc_ids.end(), *i)
-                != bc_ids.end())
+            if (bc_ids.count(*i))
               on_relevant_boundary = true;
 
           if (!on_relevant_boundary)

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -120,6 +120,10 @@ const Elem* primary_boundary_edge_neighbor
 
   std::set<const Elem*> edge_neighbors;
   elem->find_edge_neighbors(p1, p2, edge_neighbors);
+
+  // Container to catch boundary IDs handed back by BoundaryInfo
+  std::set<boundary_id_type> bc_ids;
+
   for (std::set<const Elem*>::const_iterator edge_neighbors_iter =
          edge_neighbors.begin();
        edge_neighbors_iter != edge_neighbors.end(); ++edge_neighbors_iter)
@@ -142,14 +146,12 @@ const Elem* primary_boundary_edge_neighbor
       for (unsigned short int ns = 0;
            ns != e_neighbor->n_sides(); ++ns)
         {
-          const std::vector<boundary_id_type>& bc_ids =
-            boundary_info.boundary_ids (e_neighbor, ns);
+          boundary_info.boundary_ids (e_neighbor, ns, bc_ids);
 
           bool on_relevant_boundary = false;
           for (std::set<boundary_id_type>::const_iterator i =
                  boundary_ids.begin(); i != boundary_ids.end(); ++i)
-            if (std::find(bc_ids.begin(), bc_ids.end(), *i)
-                != bc_ids.end())
+            if (bc_ids.count(*i))
               on_relevant_boundary = true;
 
           if (!on_relevant_boundary)

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -1723,6 +1723,9 @@ compute_periodic_constraints (DofConstraints &constraints,
   DenseVector<Real> Fe;
   std::vector<DenseVector<Real> > Ue;
 
+  // Container to catch the boundary ids that BoundaryInfo hands us.
+  std::set<boundary_id_type> bc_ids;
+
   // Look at the element faces.  Check to see if we need to
   // build constraints.
   for (unsigned short int s=0; s<elem->n_sides(); s++)
@@ -1730,9 +1733,9 @@ compute_periodic_constraints (DofConstraints &constraints,
       if (elem->neighbor(s))
         continue;
 
-      const std::vector<boundary_id_type>& bc_ids =
-        mesh.get_boundary_info().boundary_ids (elem, s);
-      for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+      mesh.get_boundary_info().boundary_ids (elem, s, bc_ids);
+
+      for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
         {
           const boundary_id_type boundary_id = *id_it;
           const PeriodicBoundaryBase *periodic = boundaries.boundary(boundary_id);
@@ -1923,6 +1926,9 @@ compute_periodic_constraints (DofConstraints &constraints,
                   // intersect.
                   std::set<dof_id_type> my_constrained_dofs;
 
+                  // Container to catch boundary IDs handed back by BoundaryInfo.
+                  std::set<boundary_id_type> new_bc_ids;
+
                   for (unsigned int n = 0; n != elem->n_nodes(); ++n)
                     {
                       if (!elem->is_node_on_side(n,s))
@@ -1943,9 +1949,9 @@ compute_periodic_constraints (DofConstraints &constraints,
                               if (!elem->is_node_on_side(n,new_s))
                                 continue;
 
-                              const std::vector<boundary_id_type> new_bc_ids =
-                                mesh.get_boundary_info().boundary_ids (elem, s);
-                              for (std::vector<boundary_id_type>::const_iterator
+                              mesh.get_boundary_info().boundary_ids (elem, s, new_bc_ids);
+
+                              for (std::set<boundary_id_type>::const_iterator
                                      new_id_it=new_bc_ids.begin(); new_id_it!=new_bc_ids.end(); ++new_id_it)
                                 {
                                   const boundary_id_type new_boundary_id = *new_id_it;
@@ -2087,9 +2093,10 @@ compute_periodic_constraints (DofConstraints &constraints,
                               if (!elem->is_node_on_side(n,new_s))
                                 continue;
 
-                              const std::vector<boundary_id_type>& new_bc_ids =
-                                mesh.get_boundary_info().boundary_ids (elem, s);
-                              for (std::vector<boundary_id_type>::const_iterator
+                              // We're reusing the new_bc_ids vector created outside the loop over nodes.
+                              mesh.get_boundary_info().boundary_ids (elem, s, new_bc_ids);
+
+                              for (std::set<boundary_id_type>::const_iterator
                                      new_id_it=new_bc_ids.begin(); new_id_it!=new_bc_ids.end(); ++new_id_it)
                                 {
                                   const boundary_id_type new_boundary_id = *new_id_it;

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1054,10 +1054,9 @@ Elem* Elem::topological_neighbor (const unsigned int i,
       // Since the neighbor is NULL it must be on a boundary. We need
       // see if this is a periodic boundary in which case it will have a
       // topological neighbor
-
-      std::vector<boundary_id_type> boundary_ids =
-        mesh.get_boundary_info().boundary_ids(this, cast_int<unsigned short>(i));
-      for (std::vector<boundary_id_type>::iterator j = boundary_ids.begin(); j != boundary_ids.end(); ++j)
+      std::set<boundary_id_type> bc_ids;
+      mesh.get_boundary_info().boundary_ids(this, cast_int<unsigned short>(i), bc_ids);
+      for (std::set<boundary_id_type>::iterator j = bc_ids.begin(); j != bc_ids.end(); ++j)
         if (pb->boundary(*j))
           {
             // Since the point locator inside of periodic boundaries
@@ -1093,10 +1092,9 @@ const Elem* Elem::topological_neighbor (const unsigned int i,
       // Since the neighbor is NULL it must be on a boundary. We need
       // see if this is a periodic boundary in which case it will have a
       // topological neighbor
-
-      std::vector<boundary_id_type> boundary_ids =
-        mesh.get_boundary_info().boundary_ids(this, cast_int<unsigned short>(i));
-      for (std::vector<boundary_id_type>::iterator j = boundary_ids.begin(); j != boundary_ids.end(); ++j)
+      std::set<boundary_id_type> bc_ids;
+      mesh.get_boundary_info().boundary_ids(this, cast_int<unsigned short>(i), bc_ids);
+      for (std::set<boundary_id_type>::iterator j = bc_ids.begin(); j != bc_ids.end(); ++j)
         if (pb->boundary(*j))
           {
             // Since the point locator inside of periodic boundaries

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -813,14 +813,26 @@ bool BoundaryInfo::has_boundary_id(const Node* const node,
 
 std::vector<boundary_id_type> BoundaryInfo::boundary_ids(const Node* node) const
 {
-  std::vector<boundary_id_type> ids;
+  libmesh_deprecated();
 
-  std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
+  std::set<boundary_id_type> ids_set;
+  this->boundary_ids(node, ids_set);
+  return std::vector<boundary_id_type>(ids_set.begin(), ids_set.end());
+}
+
+
+
+void BoundaryInfo::boundary_ids (const Node* node,
+                                 std::set<boundary_id_type> & set_to_fill) const
+{
+  // Clear out any previous contents
+  set_to_fill.clear();
+
+  std::pair<boundary_node_iter, boundary_node_iter>
+    pos = _boundary_node_id.equal_range(node);
 
   for (; pos.first != pos.second; ++pos.first)
-    ids.push_back(pos.first->second);
-
-  return ids;
+    set_to_fill.insert(pos.first->second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1054,28 +1054,37 @@ unsigned int BoundaryInfo::n_boundary_ids (const Elem* const elem,
 std::vector<boundary_id_type> BoundaryInfo::raw_boundary_ids (const Elem* const elem,
                                                               const unsigned short int side) const
 {
+  libmesh_deprecated();
+
+  std::set<boundary_id_type> ids_set;
+  this->raw_boundary_ids(elem, side, ids_set);
+  return std::vector<boundary_id_type>(ids_set.begin(), ids_set.end());
+}
+
+
+
+void BoundaryInfo::raw_boundary_ids (const Elem* const elem,
+                                     const unsigned short int side,
+                                     std::set<boundary_id_type> & set_to_fill) const
+{
   libmesh_assert(elem);
 
-  std::vector<boundary_id_type> ids;
+  // Clear out any previous contents
+  set_to_fill.clear();
 
   // Only level-0 elements store BCs.
   if (elem->parent())
-    return ids;
+    return;
 
   std::pair<boundary_side_iter, boundary_side_iter>
     e = _boundary_side_id.equal_range(elem);
 
-  // Check any occurrences
+  // Check each element in the range to see if its side matches the requested side.
   for (; e.first != e.second; ++e.first)
-    // if this is true we found the requested side of the element
     if (e.first->second.first == side)
-      ids.push_back(e.first->second.second);
-
-  // if nothing got pushed back, we didn't find elem in the data
-  // structure with the requested side, so return the default empty
-  // vector
-  return ids;
+      set_to_fill.insert(e.first->second.second);
 }
+
 
 
 void BoundaryInfo::remove_edge (const Elem* elem,

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -921,60 +921,9 @@ void BoundaryInfo::edge_boundary_ids (const Elem* const elem,
 unsigned int BoundaryInfo::n_edge_boundary_ids (const Elem* const elem,
                                                 const unsigned short int edge) const
 {
-  libmesh_assert(elem);
-
-  // Only level-0 elements store BCs.  If this is not a level-0
-  // element get its level-0 parent and infer the BCs.
-  const Elem* searched_elem = elem;
-#ifdef LIBMESH_ENABLE_AMR
-  if (elem->level() != 0)
-    {
-      // Find all the sides that contain edge. If one of those is a boundary
-      // side, then this must be a boundary edge. In that case, we just use the
-      // top-level parent.
-      bool found_boundary_edge = false;
-      for(unsigned int side=0; side<elem->n_sides(); side++)
-        {
-          if(elem->is_edge_on_side(edge,side))
-            {
-              if (elem->neighbor(side) == NULL)
-                {
-                  searched_elem = elem->top_parent ();
-                  found_boundary_edge = true;
-                  break;
-                }
-            }
-        }
-
-      if(!found_boundary_edge)
-        {
-          // Child element is not on external edge, but it may have internal
-          // "boundary" IDs.  We will walk up the tree, at each level checking that
-          // the current child is actually on the same edge of the parent that is
-          // currently being searched for (i.e. that was passed in as "edge").
-          while (searched_elem->parent() != NULL)
-            {
-              const Elem * parent = searched_elem->parent();
-              if (parent->is_child_on_edge(parent->which_child_am_i(searched_elem), edge) == false)
-                return 0;
-              searched_elem = parent;
-            }
-        }
-    }
-#endif
-
-  std::pair<boundary_edge_iter, boundary_edge_iter>
-    e = _boundary_edge_id.equal_range(searched_elem);
-
-  unsigned int n_ids = 0;
-
-  // elem is there, maybe multiple occurrences
-  for (; e.first != e.second; ++e.first)
-    // if this is true we found the requested edge of the element
-    if (e.first->second.first == edge)
-      n_ids++;
-
-  return n_ids;
+  std::set<boundary_id_type> ids_set;
+  this->edge_boundary_ids(elem, edge, ids_set);
+  return ids_set.size();
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -931,28 +931,37 @@ unsigned int BoundaryInfo::n_edge_boundary_ids (const Elem* const elem,
 std::vector<boundary_id_type> BoundaryInfo::raw_edge_boundary_ids (const Elem* const elem,
                                                                    const unsigned short int edge) const
 {
+  libmesh_deprecated();
+
+  std::set<boundary_id_type> ids_set;
+  this->raw_edge_boundary_ids(elem, edge, ids_set);
+  return std::vector<boundary_id_type>(ids_set.begin(), ids_set.end());
+}
+
+
+
+void BoundaryInfo::raw_edge_boundary_ids (const Elem* const elem,
+                                          const unsigned short int edge,
+                                          std::set<boundary_id_type> & set_to_fill) const
+{
   libmesh_assert(elem);
 
-  std::vector<boundary_id_type> ids;
+  // Clear out any previous contents
+  set_to_fill.clear();
 
   // Only level-0 elements store BCs.
   if (elem->parent())
-    return ids;
+    return;
 
   std::pair<boundary_edge_iter, boundary_edge_iter>
     e = _boundary_edge_id.equal_range(elem);
 
-  // Check any occurrences
+  // Check each element in the range to see if its edge matches the requested edge.
   for (; e.first != e.second; ++e.first)
-    // if this is true we found the requested edge of the element
     if (e.first->second.first == edge)
-      ids.push_back(e.first->second.second);
-
-  // if nothing got pushed back, we didn't find elem in the data
-  // structure with the requested edge, so return the default empty
-  // vector
-  return ids;
+      set_to_fill.insert(e.first->second.second);
 }
+
 
 
 boundary_id_type BoundaryInfo::boundary_id(const Elem* const elem,

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1159,39 +1159,9 @@ void BoundaryInfo::boundary_ids (const Elem* const elem,
 unsigned int BoundaryInfo::n_boundary_ids (const Elem* const elem,
                                            const unsigned short int side) const
 {
-  libmesh_assert(elem);
-
-  // Only level-0 elements store BCs.  If this is not a level-0
-  // element get its level-0 parent and infer the BCs.
-  const Elem* searched_elem = elem;
-  if (elem->level() != 0)
-    {
-      if (elem->neighbor(side) == NULL)
-        searched_elem = elem->top_parent ();
-#ifdef LIBMESH_ENABLE_AMR
-      else
-        while (searched_elem->parent() != NULL)
-          {
-            const Elem * parent = searched_elem->parent();
-            if (parent->is_child_on_side(parent->which_child_am_i(searched_elem), side) == false)
-              return 0;
-            searched_elem = parent;
-          }
-#endif
-    }
-
-  std::pair<boundary_side_iter, boundary_side_iter>
-    e = _boundary_side_id.equal_range(searched_elem);
-
-  unsigned int n_ids = 0;
-
-  // elem is there, maybe multiple occurrences
-  for (; e.first != e.second; ++e.first)
-    // if this is true we found the requested side of the element
-    if (e.first->second.first == side)
-      n_ids++;
-
-  return n_ids;
+  std::set<boundary_id_type> ids_set;
+  this->boundary_ids(elem, side, ids_set);
+  return ids_set.size();
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1017,38 +1017,9 @@ bool BoundaryInfo::has_boundary_id(const Elem* const elem,
                                    const unsigned short int side,
                                    const boundary_id_type id) const
 {
-  libmesh_assert(elem);
-
-  // Only level-0 elements store BCs.  If this is not a level-0
-  // element get its level-0 parent and infer the BCs.
-  const Elem*  searched_elem = elem;
-  if (elem->level() != 0)
-    {
-      if (elem->neighbor(side) == NULL)
-        searched_elem = elem->top_parent ();
-#ifdef LIBMESH_ENABLE_AMR
-      else
-        while (searched_elem->parent() != NULL)
-          {
-            const Elem * parent = searched_elem->parent();
-            if (parent->is_child_on_side(parent->which_child_am_i(searched_elem), side) == false)
-              return false;
-            searched_elem = parent;
-          }
-#endif
-    }
-
-  std::pair<boundary_side_iter, boundary_side_iter>
-    e = _boundary_side_id.equal_range(searched_elem);
-
-  // elem is there, maybe multiple occurrences
-  for (; e.first != e.second; ++e.first)
-    // if this is true we found the requested id on this side of the element
-    if (e.first->second.first == side &&
-        e.first->second.second == id)
-      return true;
-
-  return false;
+  std::set<boundary_id_type> ids_set;
+  this->boundary_ids(elem, side, ids_set);
+  return (ids_set.find(id) != ids_set.end());
 }
 
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1526,16 +1526,15 @@ void MeshTools::Modification::change_boundary_id (MeshBase& mesh,
       unsigned int n_edges = elem->n_edges();
       for (unsigned short edge=0; edge != n_edges; ++edge)
         {
-          const std::vector<boundary_id_type>& old_ids =
-            mesh.get_boundary_info().edge_boundary_ids(elem, edge);
-          if (std::find(old_ids.begin(), old_ids.end(), old_id) != old_ids.end())
+          mesh.get_boundary_info().edge_boundary_ids(elem, edge, bndry_ids);
+
+          // If the old ID was present, erase it, insert the new one,
+          // and update the BoundaryInfo accordingly.
+          if (bndry_ids.erase(old_id))
             {
-              std::set<boundary_id_type> new_ids(old_ids.begin(), old_ids.end());
-              // Replace the old_id, if it exists, with the new ID.
-              if (new_ids.erase(old_id))
-                new_ids.insert(new_id);
+              bndry_ids.insert(new_id);
               mesh.get_boundary_info().remove_edge(elem, edge);
-              mesh.get_boundary_info().add_edge(elem, edge, new_ids);
+              mesh.get_boundary_info().add_edge(elem, edge, bndry_ids);
             }
         }
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -930,11 +930,14 @@ void MeshTools::Modification::all_tri (MeshBase& mesh)
 
             if (mesh_has_boundary_data)
               {
+                // Container to catch the boundary IDs handed back by the BoundaryInfo object.
+                std::set<boundary_id_type> bc_ids;
+
                 for (unsigned short sn=0; sn<elem->n_sides(); ++sn)
                   {
-                    const std::vector<boundary_id_type>& bc_ids =
-                      mesh.get_boundary_info().boundary_ids(*el, sn);
-                    for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+                    mesh.get_boundary_info().boundary_ids(*el, sn, bc_ids);
+
+                    for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
                       {
                         const boundary_id_type b_id = *id_it;
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -383,15 +383,11 @@ void UnstructuredMesh::all_first_order ()
        */
       libmesh_assert_equal_to (lo_elem->n_sides(), so_elem->n_sides());
 
+      std::set<boundary_id_type> bndry_ids;
       for (unsigned short s=0; s<so_elem->n_sides(); s++)
         {
-          const std::vector<boundary_id_type> boundary_ids =
-            this->get_boundary_info().raw_boundary_ids (so_elem, s);
-
-          this->get_boundary_info().add_side (lo_elem,
-                                              s,
-                                              std::set<boundary_id_type>(boundary_ids.begin(),
-                                                                         boundary_ids.end()));
+          this->get_boundary_info().raw_boundary_ids (so_elem, s, bndry_ids);
+          this->get_boundary_info().add_side (lo_elem, s, bndry_ids);
         }
 
       /*
@@ -674,15 +670,11 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
        */
       libmesh_assert_equal_to (lo_elem->n_sides(), so_elem->n_sides());
 
+      std::set<boundary_id_type> bndry_ids;
       for (unsigned short s=0; s<lo_elem->n_sides(); s++)
         {
-          const std::vector<boundary_id_type> boundary_ids =
-            this->get_boundary_info().raw_boundary_ids (lo_elem, s);
-
-          this->get_boundary_info().add_side (so_elem,
-                                              s,
-                                              std::set<boundary_id_type>(boundary_ids.begin(),
-                                                                         boundary_ids.end()));
+          this->get_boundary_info().raw_boundary_ids (lo_elem, s, bndry_ids);
+          this->get_boundary_info().add_side (so_elem, s, bndry_ids);
 
           if (lo_elem->neighbor(s) == remote_elem)
             so_elem->set_neighbor(s, const_cast<RemoteElem*>(remote_elem));

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1374,6 +1374,9 @@ void MeshTools::Modification::flatten(MeshBase& mesh)
   std::vector<boundary_id_type>   saved_bc_ids;
   std::vector<unsigned short int> saved_bc_sides;
 
+  // Container to catch boundary ids passed back by BoundaryInfo
+  std::set<boundary_id_type> bc_ids;
+
   // Reserve a reasonable amt. of space for each
   new_elements.reserve(mesh.n_active_elem());
   saved_boundary_elements.reserve(mesh.get_boundary_info().n_boundary_conds());
@@ -1410,9 +1413,8 @@ void MeshTools::Modification::flatten(MeshBase& mesh)
             if (elem->neighbor(s) == remote_elem)
               copy->set_neighbor(s, const_cast<RemoteElem*>(remote_elem));
 
-            const std::vector<boundary_id_type>& bc_ids =
-              mesh.get_boundary_info().boundary_ids(elem,s);
-            for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+            mesh.get_boundary_info().boundary_ids(elem, s, bc_ids);
+            for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
               {
                 const boundary_id_type bc_id = *id_it;
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1541,16 +1541,15 @@ void MeshTools::Modification::change_boundary_id (MeshBase& mesh,
       unsigned int n_sides = elem->n_sides();
       for (unsigned short s=0; s != n_sides; ++s)
         {
-          const std::vector<boundary_id_type>& old_ids =
-            mesh.get_boundary_info().boundary_ids(elem, s);
-          if (std::find(old_ids.begin(), old_ids.end(), old_id) != old_ids.end())
+          mesh.get_boundary_info().boundary_ids(elem, s, bndry_ids);
+
+          // If the old ID was present, erase it, insert the new one,
+          // and update the BoundaryInfo accordingly.
+          if (bndry_ids.erase(old_id))
             {
-              std::set<boundary_id_type> new_ids(old_ids.begin(), old_ids.end());
-              // Replace the old_id, if it exists, with the new ID.
-              if (new_ids.erase(old_id))
-                new_ids.insert(new_id);
+              bndry_ids.insert(new_id);
               mesh.get_boundary_info().remove_side(elem, s);
-              mesh.get_boundary_info().add_side(elem, s, new_ids);
+              mesh.get_boundary_info().add_side(elem, s, bndry_ids);
             }
         }
     }

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -913,6 +913,9 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                   }
               }
 
+            // Container to catch boundary IDs passed back from BoundaryInfo.
+            std::set<boundary_id_type> bc_ids;
+
             MeshBase::element_iterator elem_it  = mesh_array[i]->elements_begin();
             MeshBase::element_iterator elem_end = mesh_array[i]->elements_end();
             for ( ; elem_it != elem_end; ++elem_it)
@@ -924,10 +927,9 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                   if (el->neighbor(side_id) == NULL)
                     {
                       // Get *all* boundary IDs on this side, not just the first one!
-                      std::vector<boundary_id_type> bc_ids =
-                        mesh_array[i]->get_boundary_info().boundary_ids (el, side_id);
+                      mesh_array[i]->get_boundary_info().boundary_ids (el, side_id, bc_ids);
 
-                      if (std::count(bc_ids.begin(), bc_ids.end(), id_array[i]))
+                      if (bc_ids.count(id_array[i]))
                         {
                           UniquePtr<Elem> side (el->build_side(side_id));
                           for (unsigned int node_id=0; node_id<side->n_nodes(); ++node_id)
@@ -964,10 +966,9 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                           if(el->is_edge_on_side(edge_id, side_id))
                             {
                               // Get *all* boundary IDs on this edge, not just the first one!
-                              std::vector<boundary_id_type> edge_bc_ids =
-                                mesh_array[i]->get_boundary_info().edge_boundary_ids (el, edge_id);
+                              mesh_array[i]->get_boundary_info().edge_boundary_ids (el, edge_id, bc_ids);
 
-                              if (std::count(edge_bc_ids.begin(), edge_bc_ids.end(), id_array[i]))
+                              if (bc_ids.count(id_array[i]))
                                 {
                                   UniquePtr<Elem> edge (el->build_edge(edge_id));
                                   for (unsigned int node_id=0; node_id<edge->n_nodes(); ++node_id)
@@ -1230,6 +1231,9 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
           nd->set_id(new_id);
         }
 
+      // Container to catch boundary IDs passed back from BoundaryInfo.
+      std::set<boundary_id_type> bc_ids;
+
       elem_it  = other_mesh->elements_begin();
       elem_end = other_mesh->elements_end();
       for (; elem_it != elem_end; ++elem_it)
@@ -1246,36 +1250,24 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
           unsigned int other_n_nodes = other_elem->n_nodes();
           for (unsigned int n=0; n != other_n_nodes; ++n)
             {
-              const std::vector<boundary_id_type>& ids =
-                other_mesh->get_boundary_info().boundary_ids(other_elem->get_node(n));
-              this->get_boundary_info().add_node(this_elem->get_node(n),
-                                                 std::set<boundary_id_type>(ids.begin(),
-                                                                            ids.end()));
+              other_mesh->get_boundary_info().boundary_ids(other_elem->get_node(n), bc_ids);
+              this->get_boundary_info().add_node(this_elem->get_node(n), bc_ids);
             }
 
           // Copy edge boundary info
           unsigned int n_edges = other_elem->n_edges();
           for (unsigned short edge=0; edge != n_edges; ++edge)
             {
-              const std::vector<boundary_id_type>& ids =
-                other_mesh->get_boundary_info().edge_boundary_ids(other_elem, edge);
-              this->get_boundary_info().add_edge(this_elem,
-                                                 edge,
-                                                 std::set<boundary_id_type>(ids.begin(),
-                                                                            ids.end()));
+              other_mesh->get_boundary_info().edge_boundary_ids(other_elem, edge, bc_ids);
+              this->get_boundary_info().add_edge(this_elem, edge, bc_ids);
             }
 
           unsigned int n_sides = other_elem->n_sides();
           for (unsigned short s=0; s != n_sides; ++s)
             {
-              const std::vector<boundary_id_type>& ids =
-                other_mesh->get_boundary_info().boundary_ids(other_elem, s);
-              this->get_boundary_info().add_side(this_elem,
-                                                 s,
-                                                 std::set<boundary_id_type>(ids.begin(),
-                                                                            ids.end()));
+              other_mesh->get_boundary_info().boundary_ids(other_elem, s, bc_ids);
+              this->get_boundary_info().add_side(this_elem, s, bc_ids);
             }
-
         }
 
     } // end if(other_mesh)
@@ -1286,6 +1278,10 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
   // from this mesh, rather than from other_mesh.
   // Then we iterate over node_to_node_map and delete the
   // duplicate nodes that came from other_mesh.
+
+  // Container to catch boundary IDs passed back from BoundaryInfo.
+  std::set<boundary_id_type> bc_ids;
+
   std::map<dof_id_type, std::vector<dof_id_type> >::iterator elem_map_it     = node_to_elems_map.begin();
   std::map<dof_id_type, std::vector<dof_id_type> >::iterator elem_map_it_end = node_to_elems_map.end();
   for( ; elem_map_it != elem_map_it_end; ++elem_map_it)
@@ -1305,14 +1301,9 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
 
           // We also need to copy over the nodeset info here,
           // because the node will get deleted below
-          const std::vector<boundary_id_type>& ids =
-            this->get_boundary_info().boundary_ids(el->get_node(local_node_index));
-
+          this->get_boundary_info().boundary_ids(el->get_node(local_node_index), bc_ids);
           el->set_node(local_node_index) = &target_node;
-
-          this->get_boundary_info().add_node(&target_node,
-                                             std::set<boundary_id_type>(ids.begin(),
-                                                                        ids.end()));
+          this->get_boundary_info().add_node(&target_node, bc_ids);
         }
     }
 
@@ -1432,6 +1423,9 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
   // faces that are now internal to the mesh
   if(clear_stitched_boundary_ids)
     {
+      // Container to catch boundary IDs passed back from BoundaryInfo.
+      std::set<boundary_id_type> bc_ids;
+
       MeshBase::element_iterator elem_it  = this->elements_begin();
       MeshBase::element_iterator elem_end = this->elements_end();
       for (; elem_it != elem_end; ++elem_it)
@@ -1444,17 +1438,15 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                 {
                   // Completely remove the side from the boundary_info object if it has either
                   // this_mesh_boundary_id or other_mesh_boundary_id.
-                  std::vector<boundary_id_type> bc_ids =
-                    this->get_boundary_info().boundary_ids (el, side_id);
+                  this->get_boundary_info().boundary_ids (el, side_id, bc_ids);
 
-                  if (std::count(bc_ids.begin(), bc_ids.end(), this_mesh_boundary_id) ||
-                      std::count(bc_ids.begin(), bc_ids.end(), other_mesh_boundary_id))
+                  if (bc_ids.count(this_mesh_boundary_id) ||
+                      bc_ids.count(other_mesh_boundary_id))
                     this->get_boundary_info().remove_side(el, side_id);
                 }
             }
         }
     }
-
 }
 
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -698,6 +698,9 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh& new_mesh,
   libmesh_assert_not_equal_to (this->n_nodes(), 0);
   libmesh_assert_not_equal_to (this->n_elem(), 0);
 
+  // Container to catch boundary IDs handed back by BoundaryInfo
+  std::set<boundary_id_type> bc_ids;
+
   for (; it != it_end; ++it)
     {
       const Elem* old_elem = *it;
@@ -732,25 +735,14 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh& new_mesh,
 
       // Maybe add boundary conditions for this element
       for (unsigned short s=0; s<old_elem->n_sides(); s++)
-        // We're supporting boundary ids on internal sides now
-        //if (old_elem->neighbor(s) == NULL)
         {
-          const std::vector<boundary_id_type>& bc_ids =
-            this->get_boundary_info().boundary_ids(old_elem, s);
-          for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
-            {
-              const boundary_id_type bc_id = *id_it;
-              if (bc_id != this->get_boundary_info().invalid_id)
-                new_mesh.get_boundary_info().add_side (new_elem, s,
-                                                       bc_id);
-            }
+          this->get_boundary_info().boundary_ids(old_elem, s, bc_ids);
+          new_mesh.get_boundary_info().add_side (new_elem, s, bc_ids);
         }
     } // end loop over elements
 
-
   // Prepare the new_mesh for use
   new_mesh.prepare_for_use(/*skip_renumber =*/false);
-
 }
 
 

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -939,6 +939,9 @@ void XdrIO::write_serialized_nodesets (Xdr &io, const header_id_type n_nodesets)
   std::vector<xdr_id_type> xfer_bcs, recv_bcs;
   std::vector<std::size_t> bc_sizes(this->n_processors());
 
+  // Container to catch boundary IDs handed back by BoundaryInfo
+  std::set<boundary_id_type> nodeset_ids;
+
   MeshBase::const_node_iterator
     it  = mesh.local_nodes_begin(),
     end = mesh.local_nodes_end();
@@ -947,9 +950,8 @@ void XdrIO::write_serialized_nodesets (Xdr &io, const header_id_type n_nodesets)
   for (; it!=end; ++it)
     {
       const Node *node = *it;
-      const std::vector<boundary_id_type>& nodeset_ids =
-        boundary_info.boundary_ids (node);
-      for (std::vector<boundary_id_type>::const_iterator id_it=nodeset_ids.begin(); id_it!=nodeset_ids.end(); ++id_it)
+      boundary_info.boundary_ids (node, nodeset_ids);
+      for (std::set<boundary_id_type>::const_iterator id_it=nodeset_ids.begin(); id_it!=nodeset_ids.end(); ++id_it)
         {
           const boundary_id_type bc_id = *id_it;
           if (bc_id != BoundaryInfo::invalid_id)

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -856,18 +856,18 @@ void XdrIO::write_serialized_bcs (Xdr &io, const header_id_type n_bcs) const
     it  = mesh.local_level_elements_begin(0),
     end = mesh.local_level_elements_end(0);
 
+  // Container to catch boundary IDs handed back by BoundaryInfo
+  std::set<boundary_id_type> bc_ids;
+
   dof_id_type n_local_level_0_elem=0;
   for (; it!=end; ++it, n_local_level_0_elem++)
     {
       const Elem *elem = *it;
 
       for (unsigned short s=0; s<elem->n_sides(); s++)
-        // We're supporting boundary ids on internal sides now
-        //if (elem->neighbor(s) == NULL)
         {
-          const std::vector<boundary_id_type>& bc_ids =
-            boundary_info.boundary_ids (elem, s);
-          for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+          boundary_info.boundary_ids (elem, s, bc_ids);
+          for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
             {
               const boundary_id_type bc_id = *id_it;
               if (bc_id != BoundaryInfo::invalid_id)

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -266,26 +266,27 @@ void pack (const Elem* elem,
   // Add any element side boundary condition ids
   if (elem->level() == 0)
     {
+      std::set<boundary_id_type> bcs;
       for (unsigned short s = 0; s != elem->n_sides(); ++s)
         {
-          std::vector<boundary_id_type> bcs =
-            mesh->get_boundary_info().boundary_ids(elem, s);
+          mesh->get_boundary_info().boundary_ids(elem, s, bcs);
 
           data.push_back(bcs.size());
 
-          for(unsigned int bc_it=0; bc_it < bcs.size(); bc_it++)
-            data.push_back(bcs[bc_it]);
+          for (std::set<boundary_id_type>::iterator bc_it=bcs.begin();
+               bc_it != bcs.end(); ++bc_it)
+            data.push_back(*bc_it);
         }
 
       for (unsigned short e = 0; e != elem->n_edges(); ++e)
         {
-          std::vector<boundary_id_type> bcs =
-            mesh->get_boundary_info().edge_boundary_ids(elem, e);
+          mesh->get_boundary_info().edge_boundary_ids(elem, e, bcs);
 
           data.push_back(bcs.size());
 
-          for(unsigned int bc_it=0; bc_it < bcs.size(); bc_it++)
-            data.push_back(bcs[bc_it]);
+          for (std::set<boundary_id_type>::iterator bc_it=bcs.begin();
+               bc_it != bcs.end(); ++bc_it)
+            data.push_back(*bc_it);
         }
     }
 }

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -162,15 +162,16 @@ void pack (const Node* node,
                            data.size() - start_indices);
 
   // Add any nodal boundary condition ids
-  std::vector<boundary_id_type> bcs =
-    mesh->get_boundary_info().boundary_ids(node);
+  std::set<boundary_id_type> bcs;
+  mesh->get_boundary_info().boundary_ids(node, bcs);
 
   libmesh_assert(bcs.size() < std::numeric_limits<largest_id_type>::max());
 
   data.push_back(bcs.size());
 
-  for (std::size_t bc_it=0; bc_it < bcs.size(); bc_it++)
-    data.push_back(bcs[bc_it]);
+  for (std::set<boundary_id_type>::iterator bc_it=bcs.begin();
+       bc_it != bcs.end(); ++bc_it)
+    data.push_back(*bc_it);
 }
 
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -182,7 +182,14 @@ bool FEMContext::has_side_boundary_id(boundary_id_type id) const
 
 std::vector<boundary_id_type> FEMContext::side_boundary_ids() const
 {
+  libmesh_deprecated();
   return _boundary_info.boundary_ids(&(this->get_elem()), side);
+}
+
+
+void FEMContext::side_boundary_ids(std::set<boundary_id_type> & set_to_fill) const
+{
+  _boundary_info.boundary_ids(&(this->get_elem()), side, set_to_fill);
 }
 
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -2066,6 +2066,9 @@ void BoundaryProjectSolution::operator()(const ConstElemRange &range) const
       // Side/edge DOF indices
       std::vector<unsigned int> side_dofs;
 
+      // Container to catch IDs passed back from BoundaryInfo.
+      std::set<boundary_id_type> bc_ids;
+
       // Iterate over all the elements in the range
       for (ConstElemRange::const_iterator elem_it=range.begin(); elem_it != range.end(); ++elem_it)
         {
@@ -2084,11 +2087,11 @@ void BoundaryProjectSolution::operator()(const ConstElemRange &range) const
           for (unsigned char s=0; s != elem->n_sides(); ++s)
             {
               // First see if this side has been requested
-              const std::vector<boundary_id_type>& bc_ids =
-                boundary_info.boundary_ids (elem, s);
+              boundary_info.boundary_ids (elem, s, bc_ids);
               bool do_this_side = false;
-              for (unsigned int i=0; i != bc_ids.size(); ++i)
-                if (b.count(bc_ids[i]))
+              for (std::set<boundary_id_type>::iterator i=bc_ids.begin();
+                   i!=bc_ids.end(); ++i)
+                if (b.count(*i))
                   {
                     do_this_side = true;
                     break;


### PR DESCRIPTION
This is a continuation of the work in #707 where the BoundaryInfo::add_{side,node,edge} interfaces that took std::vectors were upgraded to take std::sets instead.

I believe the new versions of boundary_ids() are potentially more efficient, especially when used in loops, because they don't create brand new containers to return to the user, they just fill up a passed-in container with IDs.

I've also converted library and examples code over to using these new interfaces.  These last patches could all be squashed down together if someone wants, but I opted to keep them separate for bisecting, just in case a bug was introduced during the refactoring.