### PR TITLE
NewmarkSolver::set_initial_accel_avail

### DIFF
--- a/include/solvers/newmark_solver.h
+++ b/include/solvers/newmark_solver.h
@@ -93,6 +93,14 @@ public:
   void project_initial_accel( FunctionBase<Number> *f, FunctionBase<Gradient> *g = NULL );
 
   /**
+   * Allow the user to (re)set whether the initial acceleration is available.
+   * This is not needed if either compute_initial_accel() or project_initial_accel()
+   * are called. This is useful is the user is restarting a calculation and the acceleration
+   * is available from the restart.
+   */
+  void set_initial_accel_avail( bool initial_accel_set );
+
+  /**
    * Error convergence order: 2 for \f$\gamma=0.5\f$, 1 otherwise
    */
   virtual Real error_order() const libmesh_override;

--- a/src/solvers/newmark_solver.C
+++ b/src/solvers/newmark_solver.C
@@ -126,7 +126,7 @@ void NewmarkSolver::compute_initial_accel()
   // We're done, so no longer doing an acceleration solve
   this->_is_accel_solve = false;
 
-  _initial_accel_set = true;
+  this->set_initial_accel_avail(true);
 }
 
 void NewmarkSolver::project_initial_accel( FunctionBase<Number> *f, FunctionBase<Gradient> *g )
@@ -136,7 +136,7 @@ void NewmarkSolver::project_initial_accel( FunctionBase<Number> *f, FunctionBase
 
   _system.project_vector( old_solution_accel, f, g );
 
-  _initial_accel_set = true;
+  this->set_initial_accel_avail(true);
 }
 
 void NewmarkSolver::set_initial_accel_avail( bool initial_accel_set )

--- a/src/solvers/newmark_solver.C
+++ b/src/solvers/newmark_solver.C
@@ -139,6 +139,11 @@ void NewmarkSolver::project_initial_accel( FunctionBase<Number> *f, FunctionBase
   _initial_accel_set = true;
 }
 
+void NewmarkSolver::set_initial_accel_avail( bool initial_accel_set )
+{
+  _initial_accel_set = initial_accel_set;
+}
+
 void NewmarkSolver::solve ()
 {
   // First, check that the initial accel was set one way or another


### PR DESCRIPTION
This adds the function `NewmarkSolver::set_initial_accel_avail` allowing the user to indicate the acceleration vector is already loaded and thus, don't need to either compute it or project onto it. The intended use for this function is for the case when the user is restarting, having used  `libMesh::EquationSystems::WRITE_ADDITIONAL_DATA` so that the acceleration vector (among others) was written to the restart file, and shouldn't recompute the initial acceleration.

I'm not really thrilled with this solution, but I can't come up with a different way of doing this other than checking the norm of the acceleration vector. But then we have to introduce a tolerance, and then a knob for that tolerance. I feel like the user controls when they're restarting so they should be able to discern when to compute the initial acceleration vs. knowing it was read from a restart. But I'm all ears on this.