### PR TITLE
Hilbert + unique_id sorting

### DIFF
--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.C
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.C
@@ -288,8 +288,6 @@ int main (int argc, char** argv)
 
 
 #ifdef LIBMESH_HAVE_EXODUS_API
-  // We want to write the file in the ExodusII format, but we don't
-  // yet support mixed-dimension meshes there?
   ExodusII_IO(mesh).write_equation_systems
     ("out.e", equation_systems);
 #endif // #ifdef LIBMESH_HAVE_EXODUS_API

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -262,6 +262,14 @@ public:
   virtual dof_id_type max_elem_id () const = 0;
 
   /**
+   * Returns a number greater than or equal to the maximum unique_id in the
+   * mesh.
+   */
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  virtual unique_id_type parallel_max_unique_id () const = 0;
+#endif
+
+  /**
    * Reserves space for a known number of elements.
    * Note that this method may or may not do anything, depending
    * on the actual \p Mesh implementation.  If you know the number

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -979,14 +979,6 @@ public:
 protected:
 
   /**
-   * Assign globally unique IDs to all DOF objects (Elements and Nodes)
-   * if the library has been configured with unique_id support.
-   */
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
-  virtual void assign_unique_ids() = 0;
-#endif
-
-  /**
    * Returns a writeable reference to the number of partitions.
    */
   unsigned int & set_n_partitions ()

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -171,7 +171,7 @@ public:
    */
   void make_elems_parallel_consistent (MeshBase &);
 
-   /**
+  /**
    * Assuming all ids on local nodes are globally unique, and
    * assuming all processor ids are parallel consistent, this function makes
    * all other ids parallel consistent.

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -171,12 +171,19 @@ public:
    */
   void make_elems_parallel_consistent (MeshBase &);
 
-  /**
+   /**
    * Assuming all ids on local nodes are globally unique, and
    * assuming all processor ids are parallel consistent, this function makes
    * all other ids parallel consistent.
    */
   void make_node_ids_parallel_consistent (MeshBase &);
+
+ /**
+   * Assuming all unique_ids on local nodes are globally unique, and
+   * assuming all processor ids are parallel consistent, this function makes
+   * all ghost unique_ids parallel consistent.
+   */
+  void make_node_unique_ids_parallel_consistent (MeshBase &);
 
   /**
    * Assuming all processor ids on nodes touching local elements

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -446,8 +446,13 @@ void libmesh_assert_valid_refinement_tree (const MeshBase & mesh);
  * element is a neighbor of or descendant of a neighbor of its neighbors)
  * and consistent (each neighbor link goes to either the same neighbor
  * or to a RemoteElem on each processor)
+ *
+ * If assert_valid_remote_elems is set to false, then no error will be
+ * thrown for neighbor links where a remote_elem should exist but NULL
+ * exists instead.
  */
-void libmesh_assert_valid_neighbors (const MeshBase & mesh);
+void libmesh_assert_valid_neighbors (const MeshBase & mesh,
+                                     bool assert_valid_remote_elems=true);
 #endif
 
 // There is no reason for users to call functions in the MeshTools::Private namespace.

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -409,6 +409,15 @@ void libmesh_assert_connected_nodes (const MeshBase & mesh);
  */
 void libmesh_assert_valid_dof_ids (const MeshBase & mesh);
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+/**
+ * A function for verifying that unique ids match across processors.
+ *
+ * FIXME: we ought to check for uniqueness too.
+ */
+void libmesh_assert_valid_unique_ids (const MeshBase &mesh);
+#endif
+
 /**
  * A function for verifying that processor assignment is
  * self-consistent on nodes (each node part of an active element on

--- a/include/mesh/parallel_mesh.h
+++ b/include/mesh/parallel_mesh.h
@@ -194,7 +194,7 @@ public:
   dof_id_type parallel_max_elem_id () const;
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-  unique_id_type parallel_max_unique_id () const;
+  virtual unique_id_type parallel_max_unique_id () const libmesh_override;
 #endif
 
   virtual const Point & point (const dof_id_type i) const libmesh_override;

--- a/include/mesh/parallel_mesh.h
+++ b/include/mesh/parallel_mesh.h
@@ -407,14 +407,6 @@ public:
 protected:
 
   /**
-   * Assign globally unique IDs to all DOF objects (Elements and Nodes)
-   * if the library has been configured with unique_id support.
-   */
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
-  virtual void assign_unique_ids() libmesh_override;
-#endif
-
-  /**
    * The verices (spatial coordinates) of the mesh.
    */
   mapvector<Node *, dof_id_type> _nodes;

--- a/include/mesh/parallel_mesh.h
+++ b/include/mesh/parallel_mesh.h
@@ -193,6 +193,10 @@ public:
   virtual dof_id_type parallel_n_elem () const libmesh_override;
   dof_id_type parallel_max_elem_id () const;
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  unique_id_type parallel_max_unique_id () const;
+#endif
+
   virtual const Point & point (const dof_id_type i) const libmesh_override;
 
   virtual const Node &  node  (const dof_id_type i) const libmesh_override;
@@ -438,6 +442,13 @@ protected:
     _next_free_local_elem_id;
   dof_id_type _next_free_unpartitioned_node_id,
     _next_free_unpartitioned_elem_id;
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  /**
+   * The next available unique id for assigning ids to unpartitioned DOF objects
+   */
+  unique_id_type _next_unpartitioned_unique_id;
+#endif
 
   /**
    * These are extra ghost elements that we want to make sure

--- a/include/mesh/serial_mesh.h
+++ b/include/mesh/serial_mesh.h
@@ -377,14 +377,6 @@ public:
 
 protected:
 
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
-  /**
-   * Assign globally unique IDs to all DOF objects (Elements and Nodes)
-   * if the library has been configured with unique_id support.
-   */
-  virtual void assign_unique_ids() libmesh_override;
-#endif
-
   /**
    * The verices (spatial coordinates) of the mesh.
    */

--- a/include/mesh/serial_mesh.h
+++ b/include/mesh/serial_mesh.h
@@ -116,6 +116,11 @@ public:
   virtual dof_id_type max_elem_id () const libmesh_override
   { return cast_int<dof_id_type>(_elements.size()); }
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  virtual unique_id_type parallel_max_unique_id () const libmesh_override
+  { return _next_unique_id; }
+#endif
+
   virtual void reserve_elem (const dof_id_type ne) libmesh_override
   { _elements.reserve (ne); }
 

--- a/include/mesh/serial_mesh.h
+++ b/include/mesh/serial_mesh.h
@@ -117,15 +117,13 @@ public:
   { return cast_int<dof_id_type>(_elements.size()); }
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-  virtual unique_id_type parallel_max_unique_id () const libmesh_override
-  { return _next_unique_id; }
+  virtual unique_id_type parallel_max_unique_id () const libmesh_override;
 #endif
 
   virtual void reserve_elem (const dof_id_type ne) libmesh_override
   { _elements.reserve (ne); }
 
-  // SerialMesh has no caches to update
-  virtual void update_parallel_id_counts () libmesh_override {}
+  virtual void update_parallel_id_counts () libmesh_override;
 
   virtual const Point & point (const dof_id_type i) const libmesh_override;
 

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -58,6 +58,17 @@ public:
     _datatype = _static_type;
   }
 };
+
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  typedef
+  std::pair<Hilbert::HilbertIndices, unique_id_type> DofObjectKey;
+#else
+  typedef
+  Hilbert::HilbertIndices DofObjectKey;
+#endif
+
+
 } // namespace Parallel
 } // namespace libMesh
 

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -70,6 +70,24 @@ public:
 
 
 } // namespace Parallel
+
+
+
+// This has to be in libMesh namespace for Koenig lookup to work
+// g++ doesn't find it if it's in the global namespace.
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+inline
+std::ostream&
+operator <<
+  (std::ostream& os,
+   const libMesh::Parallel::DofObjectKey & hilbert_pair)
+{
+  os << '(' << hilbert_pair.first << ',' << hilbert_pair.second << ')' << std::endl;
+  return os;
+}
+#endif
+
+
 } // namespace libMesh
 
 #endif // LIBMESH_HAVE_LIBHILBERT && LIBMESH_HAVE_MPI

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -114,7 +114,7 @@ void dofobjectkey_min_op (libMesh::Parallel::DofObjectKey *in,
   // When (*in >= *inout), then inout already contains min(*in,*inout)
   // Otherwise we need to copy from in.
   for (int i=0; i<*len; i++, in++, inout++)
-    if (*inout > *in)
+    if (*in < *inout)
       *inout = *in;
 }
 

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -90,6 +90,34 @@ operator <<
 
 } // namespace libMesh
 
+
+// Appropriate operator< definitions for std::pair let the same code handle
+// both DofObjectKey types
+
+inline
+void dofobjectkey_max_op (libMesh::Parallel::DofObjectKey *in,
+                          libMesh::Parallel::DofObjectKey *inout,
+                          int *len, void *)
+{
+  // When (*in <= *inout), then inout already contains max(*in,*inout)
+  // Otherwise we need to copy from in.
+  for (int i=0; i<*len; i++, in++, inout++)
+    if (*inout < *in)
+      *inout = *in;
+}
+
+inline
+void dofobjectkey_min_op (libMesh::Parallel::DofObjectKey *in,
+                          libMesh::Parallel::DofObjectKey *inout,
+                          int *len, void *)
+{
+  // When (*in >= *inout), then inout already contains min(*in,*inout)
+  // Otherwise we need to copy from in.
+  for (int i=0; i<*len; i++, in++, inout++)
+    if (*inout > *in)
+      *inout = *in;
+}
+
 #endif // LIBMESH_HAVE_LIBHILBERT && LIBMESH_HAVE_MPI
 
 #endif // LIBMESH_PARALLEL_HILBERT_H

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -2764,12 +2764,15 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
       return;
     }
 
+  const T* example = sendvec.empty() ?
+                     (recv.empty() ? NULL : &recv[0]) : &sendvec[0];
+
   // Call the user-defined type version with automatic
   // type conversion based on template argument:
   this->send_receive (dest_processor_id, sendvec,
-                      StandardType<T>(sendvec.empty() ? NULL : &sendvec[0]),
+                      StandardType<T>(example),
                       source_processor_id, recv,
-                      StandardType<T>(recv.empty() ? NULL : &recv[0]),
+                      StandardType<T>(example),
                       send_tag, recv_tag);
 }
 

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -118,7 +118,9 @@ public:
   explicit
   StandardType(const std::pair<T1, T2> * example = NULL) {
     // We need an example for MPI_Address to use
-    libmesh_assert(example);
+    static const std::pair<T1, T2> p;
+    if (!example)
+      example = &p;
 
     // _static_type never gets freed, but it only gets committed once
     // per T, so it's not a *huge* memory leak...

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -384,6 +384,10 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
           }
     }
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  unique_id_type old_max_unique_id = boundary_mesh.parallel_max_unique_id();
+#endif
+
   for (side_container::const_iterator it = sides_to_add.begin();
        it != sides_to_add.end(); ++it)
     {
@@ -402,7 +406,13 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
 
       libmesh_assert(side_id_map.count(side_pair));
 
-      side->set_id(side_id_map[side_pair]);
+      const dof_id_type new_side_id = side_id_map[side_pair];
+
+      side->set_id(new_side_id);
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+      side->set_unique_id() = old_max_unique_id + new_side_id;
+#endif
 
       // Add the side
       Elem * new_elem = boundary_mesh.add_elem(side.release());

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -30,6 +30,7 @@
 #include "libmesh/boundary_info.h"
 #include "libmesh/elem.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/mesh_tools.h"
 #include "libmesh/parallel.h"
 #include "libmesh/partitioner.h"
 #include "libmesh/point_locator_base.h"
@@ -191,6 +192,10 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
 
   // The mesh is now prepared for use.
   _is_prepared = true;
+
+#if defined(DEBUG) && defined(LIBMESH_ENABLE_UNIQUE_ID)
+  MeshTools::libmesh_assert_valid_unique_ids(*this);
+#endif
 }
 
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -30,6 +30,7 @@
 #include "libmesh/boundary_info.h"
 #include "libmesh/elem.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/mesh_communication.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/parallel.h"
 #include "libmesh/partitioner.h"
@@ -176,6 +177,16 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
   // Search the mesh for elements that have a neighboring element
   // of dim+1 and set that element as the interior parent
   this->detect_interior_parents();
+
+  // Fix up node unique ids in case mesh generation code didn't take
+  // exceptional care to do so.
+//  MeshCommunication().make_node_unique_ids_parallel_consistent(*this);
+
+  // We're going to still require that mesh generation code gets
+  // element unique ids consistent.
+#if defined(DEBUG) && defined(LIBMESH_ENABLE_UNIQUE_ID)
+  MeshTools::libmesh_assert_valid_unique_ids(*this);
+#endif
 
   // Partition the mesh.
   this->partition();

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -182,11 +182,6 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
   // If we're using ParallelMesh, we'll want it parallelized.
   this->delete_remote_elements();
 
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
-  // Assign DOF object unique ids
-  this->assign_unique_ids();
-#endif
-
   if(!_skip_renumber_nodes_and_elements)
     this->renumber_nodes_and_elements();
 

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -75,26 +75,7 @@ void get_hilbert_coords (const Point & p,
 
 
 
-// Compute the hilbert index
-template <typename T>
-Hilbert::HilbertIndices
-get_hilbert_index (const T * p,
-                   const MeshTools::BoundingBox & bbox)
-{
-  static const unsigned int sizeof_inttype = sizeof(Hilbert::inttype);
-
-  Hilbert::HilbertIndices index;
-  CFixBitVec icoords[3];
-  Hilbert::BitVecType bv;
-  get_hilbert_coords (*p, bbox, icoords);
-  Hilbert::coordsToIndex (icoords, 8*sizeof_inttype, 3, bv);
-  index = bv;
-
-  return index;
-}
-
-template <>
-Hilbert::HilbertIndices
+Parallel::DofObjectKey
 get_hilbert_index (const Elem * e,
                    const MeshTools::BoundingBox & bbox)
 {
@@ -107,14 +88,18 @@ get_hilbert_index (const Elem * e,
   Hilbert::coordsToIndex (icoords, 8*sizeof_inttype, 3, bv);
   index = bv;
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  return std::make_pair(index, e->unique_id());
+#else
   return index;
+#endif
 }
 
 
 
 // Compute the hilbert index
-Hilbert::HilbertIndices
-get_hilbert_index (const Point & p,
+Parallel::DofObjectKey
+get_hilbert_index (const Node * n,
                    const MeshTools::BoundingBox & bbox)
 {
   static const unsigned int sizeof_inttype = sizeof(Hilbert::inttype);
@@ -122,11 +107,15 @@ get_hilbert_index (const Point & p,
   Hilbert::HilbertIndices index;
   CFixBitVec icoords[3];
   Hilbert::BitVecType bv;
-  get_hilbert_coords (p, bbox, icoords);
+  get_hilbert_coords (*n, bbox, icoords);
   Hilbert::coordsToIndex (icoords, 8*sizeof_inttype, 3, bv);
   index = bv;
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  return std::make_pair(index, n->unique_id());
+#else
   return index;
+#endif
 }
 
 // Helper class for threaded Hilbert key computation
@@ -134,7 +123,7 @@ class ComputeHilbertKeys
 {
 public:
   ComputeHilbertKeys (const MeshTools::BoundingBox & bbox,
-                      std::vector<Hilbert::HilbertIndices> & keys) :
+                      std::vector<Parallel::DofObjectKey> & keys) :
     _bbox(bbox),
     _keys(keys)
   {}
@@ -148,7 +137,7 @@ public:
         const Node * node = (*it);
         libmesh_assert(node);
         libmesh_assert_less (pos, _keys.size());
-        _keys[pos++] = get_hilbert_index (*node, _bbox);
+        _keys[pos++] = get_hilbert_index (node, _bbox);
       }
   }
 
@@ -161,13 +150,13 @@ public:
         const Elem * elem = (*it);
         libmesh_assert(elem);
         libmesh_assert_less (pos, _keys.size());
-        _keys[pos++] = get_hilbert_index (elem->centroid(), _bbox);
+        _keys[pos++] = get_hilbert_index (elem, _bbox);
       }
   }
 
 private:
   const MeshTools::BoundingBox & _bbox;
-  std::vector<Hilbert::HilbertIndices> & _keys;
+  std::vector<Parallel::DofObjectKey> & _keys;
 };
 }
 #endif
@@ -175,7 +164,6 @@ private:
 
 namespace libMesh
 {
-
 
 // ------------------------------------------------------------
 // MeshCommunication class members
@@ -202,7 +190,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
 
   //-------------------------------------------------------------
   // (1) compute Hilbert keys
-  std::vector<Hilbert::HilbertIndices>
+  std::vector<Parallel::DofObjectKey>
     node_keys, elem_keys;
 
   {
@@ -267,14 +255,14 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
                     (**elemj) << " centroid " <<
                     (*elemj)->centroid() << " has HilbertIndices " <<
                     elem_keys[j] << " or " <<
-                    get_hilbert_index((*elemj)->centroid(), bbox) <<
+                    get_hilbert_index((*elemj), bbox) <<
                     std::endl;
                   libMesh::err <<
                     "level " << (*elemi)->level() << " elem\n" <<
                     (**elemi) << " centroid " <<
                     (*elemi)->centroid() << " has HilbertIndices " <<
                     elem_keys[i] << " or " <<
-                    get_hilbert_index((*elemi)->centroid(), bbox) <<
+                    get_hilbert_index((*elemi), bbox) <<
                     std::endl;
                   libmesh_error_msg("Error: level " << (*elemi)->level() << " elements with duplicate Hilbert keys!");
                 }
@@ -288,34 +276,34 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
 
   //-------------------------------------------------------------
   // (2) parallel sort the Hilbert keys
-  Parallel::Sort<Hilbert::HilbertIndices> node_sorter (communicator,
-                                                       node_keys);
+  Parallel::Sort<Parallel::DofObjectKey> node_sorter (communicator,
+                                                      node_keys);
   node_sorter.sort(); /* done with node_keys */ //node_keys.clear();
 
-  const std::vector<Hilbert::HilbertIndices> & my_node_bin =
+  const std::vector<Parallel::DofObjectKey> & my_node_bin =
     node_sorter.bin();
 
-  Parallel::Sort<Hilbert::HilbertIndices> elem_sorter (communicator,
-                                                       elem_keys);
+  Parallel::Sort<Parallel::DofObjectKey> elem_sorter (communicator,
+                                                      elem_keys);
   elem_sorter.sort(); /* done with elem_keys */ //elem_keys.clear();
 
-  const std::vector<Hilbert::HilbertIndices> & my_elem_bin =
+  const std::vector<Parallel::DofObjectKey> & my_elem_bin =
     elem_sorter.bin();
 
 
 
   //-------------------------------------------------------------
   // (3) get the max value on each processor
-  std::vector<Hilbert::HilbertIndices>
+  std::vector<Parallel::DofObjectKey>
     node_upper_bounds(communicator.size()),
     elem_upper_bounds(communicator.size());
 
   { // limit scope of temporaries
-    std::vector<Hilbert::HilbertIndices> recvbuf(2*communicator.size());
+    std::vector<Parallel::DofObjectKey> recvbuf(2*communicator.size());
     std::vector<unsigned short int> /* do not use a vector of bools here since it is not always so! */
       empty_nodes (communicator.size()),
       empty_elem  (communicator.size());
-    std::vector<Hilbert::HilbertIndices> my_max(2);
+    std::vector<Parallel::DofObjectKey> my_max(2);
 
     communicator.allgather (static_cast<unsigned short int>(my_node_bin.empty()), empty_nodes);
     communicator.allgather (static_cast<unsigned short int>(my_elem_bin.empty()),  empty_elem);
@@ -351,7 +339,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
     // Nodes first -- all nodes, not just local ones
     {
       // Request sets to send to each processor
-      std::vector<std::vector<Hilbert::HilbertIndices> >
+      std::vector<std::vector<Parallel::DofObjectKey> >
         requested_ids (communicator.size());
       // Results to gather from each processor
       std::vector<std::vector<dof_id_type> >
@@ -366,8 +354,8 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
           {
             const Node * node = (*it);
             libmesh_assert(node);
-            const Hilbert::HilbertIndices hi =
-              get_hilbert_index (*node, bbox);
+            const Parallel::DofObjectKey hi =
+              get_hilbert_index (node, bbox);
             const processor_id_type pid =
               cast_int<processor_id_type>
               (std::distance (node_upper_bounds.begin(),
@@ -400,7 +388,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
             ((communicator.size() + communicator.rank() - pid) %
              communicator.size());
 
-          std::vector<Hilbert::HilbertIndices> request_to_fill;
+          std::vector<Parallel::DofObjectKey> request_to_fill;
           communicator.send_receive(procup, requested_ids[procup],
                                     procdown, request_to_fill);
 
@@ -408,11 +396,11 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
           std::vector<dof_id_type> global_ids; /**/ global_ids.reserve(request_to_fill.size());
           for (std::size_t idx=0; idx<request_to_fill.size(); idx++)
             {
-              const Hilbert::HilbertIndices & hi = request_to_fill[idx];
+              const Parallel::DofObjectKey & hi = request_to_fill[idx];
               libmesh_assert_less_equal (hi, node_upper_bounds[communicator.rank()]);
 
               // find the requested index in my node bin
-              std::vector<Hilbert::HilbertIndices>::const_iterator pos =
+              std::vector<Parallel::DofObjectKey>::const_iterator pos =
                 std::lower_bound (my_node_bin.begin(), my_node_bin.end(), hi);
               libmesh_assert (pos != my_node_bin.end());
               libmesh_assert_equal_to (*pos, hi);
@@ -443,8 +431,8 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
             {
               Node * node = (*it);
               libmesh_assert(node);
-              const Hilbert::HilbertIndices hi =
-                get_hilbert_index (*node, bbox);
+              const Parallel::DofObjectKey hi =
+                get_hilbert_index (node, bbox);
               const processor_id_type pid =
                 cast_int<processor_id_type>
                 (std::distance (node_upper_bounds.begin(),
@@ -469,7 +457,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
     // elements next -- all elements, not just local ones
     {
       // Request sets to send to each processor
-      std::vector<std::vector<Hilbert::HilbertIndices> >
+      std::vector<std::vector<Parallel::DofObjectKey> >
         requested_ids (communicator.size());
       // Results to gather from each processor
       std::vector<std::vector<dof_id_type> >
@@ -483,8 +471,8 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
           {
             const Elem * elem = (*it);
             libmesh_assert(elem);
-            const Hilbert::HilbertIndices hi =
-              get_hilbert_index (elem->centroid(), bbox);
+            const Parallel::DofObjectKey hi =
+              get_hilbert_index (elem, bbox);
             const processor_id_type pid =
               cast_int<processor_id_type>
               (std::distance (elem_upper_bounds.begin(),
@@ -517,7 +505,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
             ((communicator.size() + communicator.rank() - pid) %
              communicator.size());
 
-          std::vector<Hilbert::HilbertIndices> request_to_fill;
+          std::vector<Parallel::DofObjectKey> request_to_fill;
           communicator.send_receive(procup, requested_ids[procup],
                                     procdown, request_to_fill);
 
@@ -525,11 +513,11 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
           std::vector<dof_id_type> global_ids; /**/ global_ids.reserve(request_to_fill.size());
           for (std::size_t idx=0; idx<request_to_fill.size(); idx++)
             {
-              const Hilbert::HilbertIndices & hi = request_to_fill[idx];
+              const Parallel::DofObjectKey & hi = request_to_fill[idx];
               libmesh_assert_less_equal (hi, elem_upper_bounds[communicator.rank()]);
 
               // find the requested index in my elem bin
-              std::vector<Hilbert::HilbertIndices>::const_iterator pos =
+              std::vector<Parallel::DofObjectKey>::const_iterator pos =
                 std::lower_bound (my_elem_bin.begin(), my_elem_bin.end(), hi);
               libmesh_assert (pos != my_elem_bin.end());
               libmesh_assert_equal_to (*pos, hi);
@@ -560,8 +548,8 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
             {
               Elem * elem = (*it);
               libmesh_assert(elem);
-              const Hilbert::HilbertIndices hi =
-                get_hilbert_index (elem->centroid(), bbox);
+              const Parallel::DofObjectKey hi =
+                get_hilbert_index (elem, bbox);
               const processor_id_type pid =
                 cast_int<processor_id_type>
                 (std::distance (elem_upper_bounds.begin(),
@@ -601,7 +589,7 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase & mesh) con
   MeshTools::BoundingBox bbox =
     MeshTools::bounding_box (mesh);
 
-  std::vector<Hilbert::HilbertIndices>
+  std::vector<Parallel::DofObjectKey>
     node_keys, elem_keys;
 
   {
@@ -663,14 +651,14 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase & mesh) con
                     (**elemj) << " centroid " <<
                     (*elemj)->centroid() << " has HilbertIndices " <<
                     elem_keys[j] << " or " <<
-                    get_hilbert_index((*elemj)->centroid(), bbox) <<
+                    get_hilbert_index((*elemj), bbox) <<
                     std::endl;
                   libMesh::err <<
                     "level " << (*elemi)->level() << " elem\n" <<
                     (**elemi) << " centroid " <<
                     (*elemi)->centroid() << " has HilbertIndices " <<
                     elem_keys[i] << " or " <<
-                    get_hilbert_index((*elemi)->centroid(), bbox) <<
+                    get_hilbert_index((*elemi), bbox) <<
                     std::endl;
                   libmesh_error_msg("Error: level " << (*elemi)->level() << " elements with duplicate Hilbert keys!");
                 }
@@ -715,7 +703,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
   // These aren't trivial to compute, and we will need them again.
   // But the binsort will sort the input vector, trashing the order
   // that we'd like to rely on.  So, two vectors...
-  std::vector<Hilbert::HilbertIndices>
+  std::vector<Parallel::DofObjectKey>
     sorted_hilbert_keys,
     hilbert_keys;
   sorted_hilbert_keys.reserve(n_objects);
@@ -724,7 +712,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
     START_LOG("compute_hilbert_indices()", "MeshCommunication");
     for (ForwardIterator it=begin; it!=end; ++it)
       {
-        const Hilbert::HilbertIndices hi(get_hilbert_index (*it, bbox));
+        const Parallel::DofObjectKey hi(get_hilbert_index (*it, bbox));
         hilbert_keys.push_back(hi);
 
         if ((*it)->processor_id() == communicator.rank())
@@ -741,11 +729,11 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
   //-------------------------------------------------------------
   // (2) parallel sort the Hilbert keys
   START_LOG ("parallel_sort()", "MeshCommunication");
-  Parallel::Sort<Hilbert::HilbertIndices> sorter (communicator,
+  Parallel::Sort<Parallel::DofObjectKey> sorter (communicator,
                                                   sorted_hilbert_keys);
   sorter.sort();
   STOP_LOG ("parallel_sort()", "MeshCommunication");
-  const std::vector<Hilbert::HilbertIndices> & my_bin = sorter.bin();
+  const std::vector<Parallel::DofObjectKey> & my_bin = sorter.bin();
 
   // The number of objects in my_bin on each processor
   std::vector<unsigned int> bin_sizes(communicator.size());
@@ -758,7 +746,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
 
   //-------------------------------------------------------------
   // (3) get the max value on each processor
-  std::vector<Hilbert::HilbertIndices>
+  std::vector<Parallel::DofObjectKey>
     upper_bounds(1);
 
   if (!my_bin.empty())
@@ -781,25 +769,27 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
     // all objects, not just local ones
 
     // Request sets to send to each processor
-    std::vector<std::vector<Hilbert::HilbertIndices> >
+    std::vector<std::vector<Parallel::DofObjectKey> >
       requested_ids (communicator.size());
     // Results to gather from each processor
     std::vector<std::vector<dof_id_type> >
       filled_request (communicator.size());
 
     // build up list of requests
-    std::vector<Hilbert::HilbertIndices>::const_iterator hi =
+    std::vector<Parallel::DofObjectKey>::const_iterator hi =
       hilbert_keys.begin();
 
     for (ForwardIterator it = begin; it != end; ++it)
       {
         libmesh_assert (hi != hilbert_keys.end());
+
+        std::vector<Parallel::DofObjectKey>::iterator lb =
+          std::lower_bound(upper_bounds.begin(), upper_bounds.end(),
+                           *hi);
+
         const processor_id_type pid =
           cast_int<processor_id_type>
-          (std::distance (upper_bounds.begin(),
-                          std::lower_bound(upper_bounds.begin(),
-                                           upper_bounds.end(),
-                                           *hi)));
+          (std::distance (upper_bounds.begin(), lb));
 
         libmesh_assert_less (pid, communicator.size());
 
@@ -812,7 +802,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
       }
 
     // start with pid=0, so that we will trade with ourself
-    std::vector<Hilbert::HilbertIndices> request_to_fill;
+    std::vector<Parallel::DofObjectKey> request_to_fill;
     std::vector<dof_id_type> global_ids;
     for (processor_id_type pid=0; pid<communicator.size(); pid++)
       {
@@ -830,11 +820,11 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
         global_ids.clear(); /**/ global_ids.reserve(request_to_fill.size());
         for (unsigned int idx=0; idx<request_to_fill.size(); idx++)
           {
-            const Hilbert::HilbertIndices & hilbert_indices = request_to_fill[idx];
+            const Parallel::DofObjectKey & hilbert_indices = request_to_fill[idx];
             libmesh_assert_less_equal (hilbert_indices, upper_bounds[communicator.rank()]);
 
             // find the requested index in my node bin
-            std::vector<Hilbert::HilbertIndices>::const_iterator pos =
+            std::vector<Parallel::DofObjectKey>::const_iterator pos =
               std::lower_bound (my_bin.begin(), my_bin.end(), hilbert_indices);
             libmesh_assert (pos != my_bin.end());
 #ifdef DEBUG
@@ -848,7 +838,11 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
                 // to BitVecType using the operator= provided by the
                 // BitVecType class. BitVecType is a CBigBitVec!
                 Hilbert::BitVecType input;
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+                input = hilbert_indices.first;
+#else
                 input = hilbert_indices;
+#endif
 
                 // Get output in a vector of CBigBitVec
                 std::vector<CBigBitVec> output(3);

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -396,6 +396,9 @@ void UnstructuredMesh::all_first_order ()
        * the second-order element.
        */
       lo_elem->set_id(so_elem->id());
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+      lo_elem->set_unique_id() = so_elem->unique_id();
+#endif
       lo_elem->processor_id() = so_elem->processor_id();
       lo_elem->subdomain_id() = so_elem->subdomain_id();
       this->insert_elem(lo_elem);
@@ -686,6 +689,9 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
        * the first-order element.
        */
       so_elem->set_id(lo_elem->id());
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+      so_elem->set_unique_id() = lo_elem->unique_id();
+#endif
       so_elem->processor_id() = lo_elem->processor_id();
       so_elem->subdomain_id() = lo_elem->subdomain_id();
       this->insert_elem(so_elem);
@@ -1112,13 +1118,25 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                   } // end if (elem->neighbor(sn) == remote_elem)
               } // end for loop over sides
 
+            // The number of elements in the original mesh before any additions
+            // or deletions.
+            const dof_id_type max_elem_id = mesh.max_elem_id();
+
             // Determine new IDs for the split elements which will be
             // the same on all processors, therefore keeping the Mesh
-            // in sync.  Note: we offset the new IDs by n_orig_elem to
-            // avoid overwriting any of the original IDs, this assumes
-            // they were contiguously-numbered to begin with...
-            tri0->set_id( n_orig_elem + 2*elem->id() + 0 );
-            tri1->set_id( n_orig_elem + 2*elem->id() + 1 );
+            // in sync.  Note: we offset the new IDs by the max of the
+            // pre-existing ids to avoid conflicting with originals.
+            tri0->set_id( max_elem_id + 2*elem->id());
+            tri1->set_id( max_elem_id + 2*elem->id() + 1 );
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+            unique_id_type max_unique_id =
+              mesh.parallel_max_unique_id();
+            tri0->set_unique_id() =
+              max_unique_id + 2*elem->unique_id();
+            tri1->set_unique_id() =
+              max_unique_id + 2*elem->unique_id() + 1;
+#endif
 
             // Add the newly-created triangles to the temporary vector of new elements.
             new_elements.push_back(tri0);
@@ -1400,9 +1418,12 @@ void MeshTools::Modification::flatten(MeshBase & mesh)
         copy->processor_id() = elem->processor_id();
         copy->subdomain_id() = elem->subdomain_id();
 
-        // Retain the original element's ID as well, otherwise ParallelMesh will
-        // try to create one for you...
+        // Retain the original element's ID(s) as well, otherwise
+        // the Mesh may try to create them for you...
         copy->set_id( elem->id() );
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+        copy->set_unique_id() = elem->unique_id();
+#endif
 
         // This element could have boundary info or ParallelMesh
         // remote_elem links as well.  We need to save the (elem,

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -703,9 +703,10 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
 
   STOP_LOG("all_second_order()", "Mesh");
 
-  // In a ParallelMesh our ghost node processor ids may be bad and
-  // the ids of nodes touching remote elements may be inconsistent.
-  // Fix them.
+  // In a ParallelMesh our ghost node processor ids may be bad,
+  // the ids of nodes touching remote elements may be inconsistent,
+  // and unique_ids of newly added non-local nodes remain unset.
+  // make_nodes_parallel_consistent() will fix all this.
   if (!this->is_serial())
     MeshCommunication().make_nodes_parallel_consistent (*this);
 
@@ -739,6 +740,11 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
   std::vector<Elem *> new_bndry_elements;
   std::vector<unsigned short int> new_bndry_sides;
   std::vector<boundary_id_type> new_bndry_ids;
+
+  // We may need to add new points if we run into a 1.5th order
+  // element; if we do that on a ParallelMesh in a ghost element then
+  // we will need to fix their ids / unique_ids
+  bool added_new_ghost_point = false;
 
   // Iterate over the elements, splitting QUADS into
   // pairs of conforming triangles.
@@ -810,6 +816,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
           case QUAD8:
             {
               split_elem =  true;
+              if (elem->processor_id() != mesh.processor_id())
+                added_new_ghost_point = true;
 
               tri0 = new Tri6;
               tri1 = new Tri6;
@@ -817,7 +825,9 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               Node * new_node = mesh.add_point((mesh.node(elem->node(0)) +
                                                 mesh.node(elem->node(1)) +
                                                 mesh.node(elem->node(2)) +
-                                                mesh.node(elem->node(3)) / 4));
+                                                mesh.node(elem->node(3)) / 4),
+                                               DofObject::invalid_id,
+                                               elem->processor_id());
 
               // Check for possible edge swap
               if ((elem->point(0) - elem->point(2)).size() <
@@ -1181,6 +1191,19 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                                           new_bndry_sides[s],
                                           new_bndry_ids[s]);
     }
+
+  // In a ParallelMesh any newly added ghost node ids may be
+  // inconsistent, and unique_ids of newly added ghost nodes remain
+  // unset.
+  // make_nodes_parallel_consistent() will fix all this.
+  if (!mesh.is_serial())
+    {
+      mesh.comm().max(added_new_ghost_point);
+
+      if (added_new_ghost_point)
+        MeshCommunication().make_nodes_parallel_consistent (mesh);
+    }
+
 
 
   // Prepare the newly created mesh for use.

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1299,6 +1299,36 @@ void libmesh_assert_valid_dof_ids(const MeshBase & mesh)
                              mesh.query_node_ptr(i));
 }
 
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+void libmesh_assert_valid_unique_ids(const MeshBase &mesh)
+{
+  libmesh_parallel_only(mesh.comm());
+
+  dof_id_type pmax_elem_id = mesh.max_elem_id();
+  mesh.comm().max(pmax_elem_id);
+
+  for (dof_id_type i=0; i != pmax_elem_id; ++i)
+    {
+      const Elem *elem = mesh.query_elem(i);
+      const unique_id_type unique_id = elem ? elem->unique_id() : 0;
+      const unique_id_type * uid_ptr = elem ? &unique_id : NULL;
+      libmesh_assert(mesh.comm().semiverify(uid_ptr));
+    }
+
+  dof_id_type pmax_node_id = mesh.max_node_id();
+  mesh.comm().max(pmax_node_id);
+
+  for (dof_id_type i=0; i != pmax_node_id; ++i)
+    {
+      const Node *node = mesh.query_node_ptr(i);
+      const unique_id_type unique_id = node ? node->unique_id() : 0;
+      const unique_id_type * uid_ptr = node ? &unique_id : NULL;
+      libmesh_assert(mesh.comm().semiverify(uid_ptr));
+    }
+}
+#endif
+
 template <>
 void libmesh_assert_valid_procids<Elem>(const MeshBase & mesh)
 {

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1611,7 +1611,7 @@ void MeshTools::libmesh_assert_valid_neighbors(const MeshBase & mesh)
               if (elem->neighbor(n))
                 my_neighbor = elem->neighbor(n)->id();
             }
-          mesh.comm().semiverify(p_my_neighbor);
+          libmesh_assert(mesh.comm().semiverify(p_my_neighbor));
         }
     }
 }

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1138,6 +1138,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   // For ParallelMesh, it seems that _is_serial is true by default.  A hack to
   // make the Mesh think it's parallel might be to call:
   mesh.update_post_partitioning();
+  MeshCommunication().make_node_unique_ids_parallel_consistent(mesh);
   mesh.delete_remote_elements();
 
   // And if that didn't work, then we're actually reading into a

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -836,6 +836,9 @@ void Nemesis_IO::read (const std::string & base_filename)
           elem->subdomain_id() = subdomain_id;
           elem->processor_id() = this->processor_id();
           elem->set_id()       = my_next_elem++;
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+          elem->set_unique_id() = elem->id();
+#endif
 
           // Mark that we have seen an element of the current element's
           // dimension.

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -1409,34 +1409,5 @@ void ParallelMesh::allgather()
 #endif
 }
 
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
-void ParallelMesh::assign_unique_ids()
-{
-  {
-    elem_iterator_imp        it = _elements.begin();
-    const elem_iterator_imp end = _elements.end();
-
-    for (; it != end; ++it)
-      if ((*it) && ! (*it)->valid_unique_id() && processor_id() == (*it)->processor_id())
-        {
-          (*it)->set_unique_id() = _next_unique_id;
-          _next_unique_id += this->n_processors();
-        }
-  }
-
-  {
-    node_iterator_imp it  = _nodes.begin();
-    node_iterator_imp end = _nodes.end();
-
-    for (; it != end; ++it)
-      if ((*it) && ! (*it)->valid_unique_id() && processor_id() == (*it)->processor_id())
-        {
-          (*it)->set_unique_id() = _next_unique_id;
-          _next_unique_id += this->n_processors();
-        }
-  }
-}
-#endif
-
 
 } // namespace libMesh

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -107,6 +107,8 @@ ParallelMesh::ParallelMesh (const ParallelMesh & other_mesh) :
   _next_free_unpartitioned_elem_id =
     other_mesh._next_free_unpartitioned_elem_id;
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
+  _next_unique_id =
+    other_mesh._next_unique_id;
   _next_unpartitioned_unique_id =
     other_mesh._next_unpartitioned_unique_id;
 #endif
@@ -132,6 +134,9 @@ ParallelMesh::ParallelMesh (const UnstructuredMesh & other_mesh) :
   this->copy_nodes_and_elements(other_mesh);
   this->get_boundary_info() = other_mesh.get_boundary_info();
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  _next_unique_id = other_mesh.parallel_max_unique_id();
+#endif
   this->update_parallel_id_counts();
 }
 

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -493,6 +493,22 @@ Elem * ParallelMesh::insert_elem (Elem * e)
   if (_elements[e->id()])
     this->delete_elem(_elements[e->id()]);
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  if (!e->valid_unique_id())
+    {
+      if (processor_id() == e->processor_id())
+        {
+          e->set_unique_id() = _next_unique_id;
+          _next_unique_id += this->n_processors() + 1;
+        }
+      else
+        {
+          e->set_unique_id() = _next_unpartitioned_unique_id;
+          _next_unpartitioned_unique_id += this->n_processors() + 1;
+        }
+    }
+#endif
+
   // Try to make the cached elem data more accurate
   processor_id_type elem_procid = e->processor_id();
   if (elem_procid == this->processor_id() ||

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -638,6 +638,29 @@ void SerialMesh::clear ()
 
 
 
+void SerialMesh::update_parallel_id_counts()
+{
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  _next_unique_id = this->parallel_max_unique_id();
+#endif
+}
+
+
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+unique_id_type SerialMesh::parallel_max_unique_id() const
+{
+  // This function must be run on all processors at once
+  parallel_object_only();
+
+  unique_id_type max_local = _next_unique_id;
+  this->comm().max(max_local);
+  return max_local;
+}
+#endif
+
+
+
 void SerialMesh::renumber_nodes_and_elements ()
 {
 
@@ -791,6 +814,8 @@ void SerialMesh::renumber_nodes_and_elements ()
 
   libmesh_assert_equal_to (next_free_elem, _elements.size());
   libmesh_assert_equal_to (next_free_node, _nodes.size());
+
+  this->update_parallel_id_counts();
 
   STOP_LOG("renumber_nodes_and_elem()", "Mesh");
 }

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -160,6 +160,9 @@ SerialMesh::SerialMesh (const SerialMesh & other_mesh) :
 {
   this->copy_nodes_and_elements(other_mesh);
   this->get_boundary_info() = other_mesh.get_boundary_info();
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  this->_next_unique_id = other_mesh._next_unique_id;
+#endif
 }
 
 

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -349,6 +349,11 @@ Elem * SerialMesh::add_elem (Elem * e)
 
 Elem * SerialMesh::insert_elem (Elem * e)
 {
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  if (!e->valid_unique_id())
+    e->set_unique_id() = _next_unique_id++;
+#endif
+
   dof_id_type eid = e->id();
   libmesh_assert_less (eid, _elements.size());
   Elem * oldelem = _elements[eid];
@@ -457,6 +462,11 @@ Node * SerialMesh::add_point (const Point & p,
                       cast_int<dof_id_type>(_nodes.size()-1) : id).release();
       n->processor_id() = proc_id;
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+      if (!n->valid_unique_id())
+        n->set_unique_id() = _next_unique_id++;
+#endif
+
       if (id == DofObject::invalid_id)
         _nodes.back() = n;
       else
@@ -518,6 +528,10 @@ Node * SerialMesh::insert_node(Node * n)
       _nodes.resize(n->id() + 1);
     }
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  if (!n->valid_unique_id())
+    n->set_unique_id() = _next_unique_id++;
+#endif
 
   // We have enough space and this spot isn't already occupied by
   // another node, so go ahead and add it.

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -1456,18 +1456,4 @@ dof_id_type SerialMesh::n_active_elem () const
 }
 
 
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
-void SerialMesh::assign_unique_ids()
-{
-  for (dof_id_type i=0; i<_elements.size(); ++i)
-    if (_elements[i] && ! _elements[i]->valid_unique_id())
-      _elements[i]->set_unique_id() = _next_unique_id++;
-
-  for (dof_id_type i=0; i<_nodes.size(); ++i)
-    if (_nodes[i] && ! _nodes[i]->valid_unique_id())
-      _nodes[i]->set_unique_id() = _next_unique_id++;
-}
-#endif
-
-
 } // namespace libMesh

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -97,10 +97,14 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
         const Node * oldn = *it;
 
         // Add new nodes in old node Point locations
-        /*Node *newn =*/ this->add_point(*oldn, oldn->id(), oldn->processor_id());
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+        Node *newn =
+#endif
+          this->add_point(*oldn, oldn->id(), oldn->processor_id());
 
-        // And start them off in the same subdomain
-        //        newn->processor_id() = oldn->processor_id();
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+        newn->set_unique_id() = oldn->unique_id();
+#endif
       }
   }
 
@@ -158,8 +162,12 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
         // And start it off in the same subdomain
         el->processor_id() = old->processor_id();
 
-        // Give it the same id
+        // Give it the same ids
         el->set_id(old->id());
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+        el->set_unique_id() = old->unique_id();
+#endif
 
         //Hold onto it
         if(!skip_find_neighbors)
@@ -709,6 +717,9 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh & new_mesh,
       // Copy ids for this element.
       Elem * new_elem = Elem::build(old_elem->type()).release();
       new_elem->set_id() = old_elem->id();
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+      new_elem->set_unique_id() = old_elem->unique_id();
+#endif
       new_elem->subdomain_id() = old_elem->subdomain_id();
       new_elem->processor_id() = old_elem->processor_id();
 
@@ -724,9 +735,16 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh & new_mesh,
           // Add this node to the new mesh if it's not there already
           if (!new_mesh.query_node_ptr(node_id))
             {
-              new_mesh.add_point (old_elem->point(n),
-                                  node_id,
-                                  old_elem->get_node(n)->processor_id());
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+              Node *newn =
+#endif
+                new_mesh.add_point (old_elem->point(n),
+                                    node_id,
+                                    old_elem->get_node(n)->processor_id());
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+              newn->set_unique_id() = old_elem->get_node(n)->unique_id();
+#endif
             }
 
           // Define this element's connectivity on the new mesh

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -560,7 +560,8 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
 
 
 #ifdef DEBUG
-  MeshTools::libmesh_assert_valid_neighbors(*this);
+  MeshTools::libmesh_assert_valid_neighbors(*this,
+                                            !reset_remote_elements);
   MeshTools::libmesh_assert_valid_amr_interior_parents(*this);
 #endif
 

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1321,7 +1321,10 @@ void XdrIO::read_serialized_connectivity (Xdr & io, const dof_id_type n_elem, st
         {
           const ElemType elem_type        = static_cast<ElemType>(*it); ++it;
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-          unique_id_type unique_id = DofObject::invalid_unique_id;
+          // We are on all processors here, so we can easily assign
+          // consistent unique ids if the file doesn't specify them
+          // later.
+          unique_id_type unique_id = e;
 #endif
           if (read_unique_id)
             {

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1321,7 +1321,7 @@ void XdrIO::read_serialized_connectivity (Xdr & io, const dof_id_type n_elem, st
         {
           const ElemType elem_type        = static_cast<ElemType>(*it); ++it;
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-          unique_id_type unique_id = 0;
+          unique_id_type unique_id = DofObject::invalid_unique_id;
 #endif
           if (read_unique_id)
             {

--- a/src/parallel/parallel_bin_sorter.C
+++ b/src/parallel/parallel_bin_sorter.C
@@ -21,12 +21,10 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/parallel_bin_sorter.h"
-#include "libmesh/parallel_histogram.h"
-#ifdef LIBMESH_HAVE_LIBHILBERT
-#  include "hilbert.h"
-#endif
 #include "libmesh/parallel.h"
+#include "libmesh/parallel_bin_sorter.h"
+#include "libmesh/parallel_hilbert.h"
+#include "libmesh/parallel_histogram.h"
 #include "libmesh/parallel_conversion_utils.h"
 
 namespace libMesh
@@ -126,8 +124,10 @@ void BinSorter<KeyType,IdxType>::binsort (const IdxType nbins,
 
           // Set the upper bound of the bin
           bin_bounds[b+1] = phist.upper_bound (current_histogram_bin);
-          bin_iters[b+1]  = std::lower_bound(bin_iters[b], data.end(),
-                                             Parallel::Utils::to_key_type<KeyType>(bin_bounds[b+1]));
+          bin_iters[b+1] =
+            std::lower_bound(bin_iters[b], data.end(),
+                             Parallel::Utils::Convert<KeyType>::to_key_type
+                               (bin_bounds[b+1]));
         }
 
       // Just be sure the last boundary points to the right place
@@ -145,7 +145,7 @@ void BinSorter<KeyType,IdxType>::binsort (const IdxType nbins,
 template class Parallel::BinSorter<int, unsigned int>;
 template class Parallel::BinSorter<double, unsigned int>;
 #ifdef LIBMESH_HAVE_LIBHILBERT
-template class Parallel::BinSorter<Hilbert::HilbertIndices, unsigned int>;
+template class Parallel::BinSorter<Parallel::DofObjectKey, unsigned int>;
 #endif
 
 } // namespace libMesh

--- a/src/parallel/parallel_histogram.C
+++ b/src/parallel/parallel_histogram.C
@@ -21,11 +21,9 @@
 
 // Local includes
 #include "libmesh/parallel_histogram.h"
-#ifdef LIBMESH_HAVE_LIBHILBERT
-#  include "hilbert.h"
-#endif
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_conversion_utils.h"
+#include "libmesh/parallel_hilbert.h"
 
 namespace libMesh
 {
@@ -78,8 +76,10 @@ void Histogram<KeyType,IdxType>::make_histogram (const IdxType nbins,
     {
       bin_bounds[b] = Parallel::Utils::to_double(min) + bin_width * b;
 
-      bin_iters[b]  = std::lower_bound (bin_iters[b-1], data.end(),
-                                        Parallel::Utils::to_key_type<KeyType>(bin_bounds[b]));
+      bin_iters[b] =
+        std::lower_bound (bin_iters[b-1], data.end(),
+                          Parallel::Utils::Convert<KeyType>::to_key_type
+                            (bin_bounds[b]));
     }
 
   bin_iters[nbins]  = data.end();
@@ -111,7 +111,7 @@ void Histogram<KeyType,IdxType>::build_histogram ()
 template class Parallel::Histogram<int,    unsigned int>;
 template class Parallel::Histogram<double, unsigned int>;
 #ifdef LIBMESH_HAVE_LIBHILBERT
-template class Parallel::Histogram<Hilbert::HilbertIndices, unsigned int>;
+template class Parallel::Histogram<Parallel::DofObjectKey, unsigned int>;
 #endif
 
 } // namespace libMesh

--- a/src/parallel/parallel_sort.C
+++ b/src/parallel/parallel_sort.C
@@ -26,9 +26,6 @@
 #include "libmesh/parallel_hilbert.h"
 #include "libmesh/parallel_sort.h"
 #include "libmesh/parallel_bin_sorter.h"
-#ifdef LIBMESH_HAVE_LIBHILBERT
-#  include "hilbert.h"
-#endif
 
 namespace libMesh
 {
@@ -130,18 +127,25 @@ void Sort<KeyType,IdxType>::binsort()
 // code duplication here that could potentially be consolidated with the
 // above method
 template <>
-void Sort<Hilbert::HilbertIndices,unsigned int>::binsort()
+void Sort<Parallel::DofObjectKey,unsigned int>::binsort()
 {
   // Find the global min and max from all the
   // processors.  Do this using MPI_Allreduce.
-  Hilbert::HilbertIndices
+  Parallel::DofObjectKey
     local_min,  local_max,
     global_min, global_max;
 
   if (_data.empty())
     {
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+      local_min.first.rack0 = local_min.first.rack1 = local_min.first.rack2 = static_cast<Hilbert::inttype>(-1);
+      local_min.second = std::numeric_limits<unique_id_type>::max();
+      local_max.first.rack0 = local_max.first.rack1 = local_max.first.rack2 = 0;
+      local_max.second = 0;
+#else
       local_min.rack0 = local_min.rack1 = local_min.rack2 = static_cast<Hilbert::inttype>(-1);
       local_max.rack0 = local_max.rack1 = local_max.rack2 = 0;
+#endif
     }
   else
     {
@@ -151,22 +155,22 @@ void Sort<Hilbert::HilbertIndices,unsigned int>::binsort()
 
   MPI_Op hilbert_max, hilbert_min;
 
-  MPI_Op_create       ((MPI_User_function*)__hilbert_max_op, true, &hilbert_max);
-  MPI_Op_create       ((MPI_User_function*)__hilbert_min_op, true, &hilbert_min);
+  MPI_Op_create       ((MPI_User_function*)dofobjectkey_max_op, true, &hilbert_max);
+  MPI_Op_create       ((MPI_User_function*)dofobjectkey_min_op, true, &hilbert_min);
 
   // Communicate to determine the global
   // min and max for all processors.
   MPI_Allreduce(&local_min,
                 &global_min,
                 1,
-                Parallel::StandardType<Hilbert::HilbertIndices>(),
+                Parallel::StandardType<Parallel::DofObjectKey>(&local_min),
                 hilbert_min,
                 this->comm().get());
 
   MPI_Allreduce(&local_max,
                 &global_max,
                 1,
-                Parallel::StandardType<Hilbert::HilbertIndices>(),
+                Parallel::StandardType<Parallel::DofObjectKey>(&local_max),
                 hilbert_max,
                 this->comm().get());
 
@@ -174,7 +178,7 @@ void Sort<Hilbert::HilbertIndices,unsigned int>::binsort()
   MPI_Op_free   (&hilbert_min);
 
   // Bin-Sort based on the global min and max
-  Parallel::BinSorter<Hilbert::HilbertIndices> bs(this->comm(),_data);
+  Parallel::BinSorter<Parallel::DofObjectKey> bs(this->comm(),_data);
   bs.binsort(_n_procs, global_max, global_min);
 
   // Now save the local bin sizes in a vector so
@@ -238,14 +242,16 @@ void Sort<KeyType,IdxType>::communicate_bins()
       if (sendbuf == NULL && _local_bin_sizes[i] != 0)
         libmesh_error_msg("Error: invalid MPI_Gatherv call constructed!");
 
+      KeyType example;
+
       MPI_Gatherv(sendbuf,
-                  _local_bin_sizes[i],               // How much data is in the bin being sent.
-                  Parallel::StandardType<KeyType>(), // The data type we are sorting
+                  _local_bin_sizes[i],                       // How much data is in the bin being sent.
+                  Parallel::StandardType<KeyType>(&example), // The data type we are sorting
                   recvbuf,
                   &proc_bin_size[0],          // How much is to be received from each processor
                   &displacements[0],          // Offsets into the receive buffer
-                  Parallel::StandardType<KeyType>(), // The data type we are sorting
-                  i,                                 // The root process (we do this once for each proc)
+                  Parallel::StandardType<KeyType>(&example), // The data type we are sorting
+                  i,                                         // The root process (we do this once for each proc)
                   this->comm().get());
 
       // Copy the destination buffer if it
@@ -266,7 +272,7 @@ void Sort<KeyType,IdxType>::communicate_bins()
 // code duplication here that could potentially be consolidated with the
 // above method
 template <>
-void Sort<Hilbert::HilbertIndices,unsigned int>::communicate_bins()
+void Sort<Parallel::DofObjectKey,unsigned int>::communicate_bins()
 {
   // Create storage for the global bin sizes.  This
   // is the number of keys which will be held in
@@ -288,7 +294,7 @@ void Sort<Hilbert::HilbertIndices,unsigned int>::communicate_bins()
   // Create a vector to temporarily hold the results of MPI_Gatherv
   // calls.  The vector dest  may be saved away to _my_bin depending on which
   // processor is being MPI_Gatherv'd.
-  std::vector<Hilbert::HilbertIndices> dest;
+  std::vector<Parallel::DofObjectKey> dest;
 
   unsigned int local_offset = 0;
 
@@ -332,13 +338,15 @@ void Sort<Hilbert::HilbertIndices,unsigned int>::communicate_bins()
       if (sendbuf == NULL && _local_bin_sizes[i] != 0)
         libmesh_error_msg("Error: invalid MPI_Gatherv call constructed!");
 
+      Parallel::DofObjectKey example;
+
       MPI_Gatherv(sendbuf,
                   _local_bin_sizes[i],      // How much data is in the bin being sent.
-                  Parallel::StandardType<Hilbert::HilbertIndices>(), // The data type we are sorting
+                  Parallel::StandardType<Parallel::DofObjectKey>(&example), // The data type we are sorting
                   recvbuf,
                   &proc_bin_size[0], // How much is to be received from each processor
                   &displacements[0], // Offsets into the receive buffer
-                  Parallel::StandardType<Hilbert::HilbertIndices>(), // The data type we are sorting
+                  Parallel::StandardType<Parallel::DofObjectKey>(&example), // The data type we are sorting
                   i,                        // The root process (we do this once for each proc)
                   this->comm().get());
 
@@ -383,7 +391,7 @@ const std::vector<KeyType> & Sort<KeyType,IdxType>::bin()
 template class Parallel::Sort<int, unsigned int>;
 template class Parallel::Sort<double, unsigned int>;
 #if defined(LIBMESH_HAVE_LIBHILBERT) && defined(LIBMESH_HAVE_MPI)
-template class Parallel::Sort<Hilbert::HilbertIndices, unsigned int>;
+template class Parallel::Sort<Parallel::DofObjectKey, unsigned int>;
 #endif
 
 } // namespace libMesh


### PR DESCRIPTION
If this works, it should enable slit meshes, overset meshes, and all the other fun meshes where nodes or centroids share the same location and therefore the same Hilbert indices.

This is starting to pass my own tests but is not ready to merge; even if it actually passes MooseBuild already I've still got more testing lined up.