### PR TITLE
Revert some of boundary_ids() refactoring

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -94,9 +94,9 @@ struct AssemblyA0 : ElemAssemblyWithConstruction
 {
   virtual void boundary_assembly(FEMContext &c)
   {
-    std::set<boundary_id_type> bc_ids;
+    std::vector<boundary_id_type> bc_ids;
     rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
-    for (std::set<boundary_id_type>::const_iterator b =
+    for (std::vector<boundary_id_type>::const_iterator b =
            bc_ids.begin(); b != bc_ids.end(); ++b)
       if( *b == 1 || *b == 2 || *b == 3 || *b == 4 )
         {
@@ -135,9 +135,9 @@ struct AssemblyA1 : ElemAssemblyWithConstruction
 {
   virtual void boundary_assembly(FEMContext &c)
   {
-    std::set<boundary_id_type> bc_ids;
+    std::vector<boundary_id_type> bc_ids;
     rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
-    for (std::set<boundary_id_type>::const_iterator b =
+    for (std::vector<boundary_id_type>::const_iterator b =
            bc_ids.begin(); b != bc_ids.end(); ++b)
       if( *b == 1 || *b == 3 ) // y == -0.2, y == 0.2
         {
@@ -182,9 +182,9 @@ struct AssemblyA2 : ElemAssemblyWithConstruction
 {
   virtual void boundary_assembly(FEMContext &c)
   {
-    std::set<boundary_id_type> bc_ids;
+    std::vector<boundary_id_type> bc_ids;
     rb_con->get_mesh().get_boundary_info().boundary_ids (&c.get_elem(), c.side, bc_ids);
-    for (std::set<boundary_id_type>::const_iterator b =
+    for (std::vector<boundary_id_type>::const_iterator b =
            bc_ids.begin(); b != bc_ids.end(); ++b)
       if( *b == 2 || *b == 4) // x == 0.2, x == -0.2
         {

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -330,7 +330,7 @@ void assemble_elasticity(EquationSystems& es,
         }
 
       {
-        std::set<boundary_id_type> bc_ids;
+        std::vector<boundary_id_type> bc_ids;
         for (unsigned int side=0; side<elem->n_sides(); side++)
           if (elem->neighbor(side) == NULL)
             {
@@ -341,7 +341,7 @@ void assemble_elasticity(EquationSystems& es,
 
               fe_face->reinit(elem, side);
 
-              for (std::set<boundary_id_type>::const_iterator b =
+              for (std::vector<boundary_id_type>::const_iterator b =
                      bc_ids.begin(); b != bc_ids.end(); ++b)
                 {
                   const boundary_id_type bc_id = *b;

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -240,20 +240,10 @@ public:
   /**
    * Add side \p side of element \p elem with boundary ids \p ids
    * to the boundary information data structure.
-   *
-   * This function is now deprecated, call the version which takes a
-   * reference to a std::set instead.
    */
   void add_side (const Elem* elem,
                  const unsigned short int side,
                  const std::vector<boundary_id_type>& ids);
-
-  /**
-   * Non-deprecated version of the add_side() function taking a set of ids.
-   */
-  void add_side (const Elem* elem,
-                 const unsigned short int side,
-                 const std::set<boundary_id_type>& ids_set);
 
   /**
    * Removes the boundary conditions associated with node \p node,

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -197,20 +197,10 @@ public:
    * Add edge \p edge of element \p elem with boundary ids \p ids
    * to the boundary information data structure.
    * Edge-based boundary IDs should only be used in 3D.
-   *
-   * This function is now deprecated, call the version which takes a
-   * reference to a std::set instead.
    */
   void add_edge (const Elem* elem,
                  const unsigned short int edge,
                  const std::vector<boundary_id_type>& ids);
-
-  /**
-   * Non-deprecated version of the add_side() function taking a set of ids.
-   */
-  void add_edge (const Elem* elem,
-                 const unsigned short int edge,
-                 const std::set<boundary_id_type>& ids_set);
 
   /**
    * Add side \p side of element number \p elem with boundary id \p id

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -315,7 +315,7 @@ public:
    * Edge-based boundary IDs should only be used in 3D.
    *
    * This function has been deprecated.  Instead, use the version of
-   * this function that fills a std::set.
+   * this function that fills a std::vector.
    */
   std::vector<boundary_id_type> edge_boundary_ids (const Elem* const elem,
                                                    const unsigned short int edge) const;
@@ -329,7 +329,7 @@ public:
    */
   void edge_boundary_ids (const Elem* const elem,
                           const unsigned short int edge,
-                          std::set<boundary_id_type> & set_to_fill) const;
+                          std::vector<boundary_id_type> & vec_to_fill) const;
 
   /**
    * Returns the list of raw boundary ids associated with the \p edge

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -339,7 +339,7 @@ public:
    * Edge-based boundary IDs should only be used in 3D.
    *
    * This function has been deprecated.  Instead, use the version of
-   * this function that fills a std::set.
+   * this function that fills a std::vector.
    */
   std::vector<boundary_id_type> raw_edge_boundary_ids (const Elem* const elem,
                                                        const unsigned short int edge) const;
@@ -355,7 +355,7 @@ public:
    */
   void raw_edge_boundary_ids (const Elem* const elem,
                               const unsigned short int edge,
-                              std::set<boundary_id_type> & set_to_fill) const;
+                              std::vector<boundary_id_type> & vec_to_fill) const;
 
   /**
    * Returns true iff the given side of the given element is

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -283,7 +283,7 @@ public:
    * Returns the boundary ids associated with \p Node \p node.
    *
    * This function has been deprecated.  Instead, use the version of
-   * this function that fills a std::set.
+   * this function that fills a std::vector.
    */
   std::vector<boundary_id_type> boundary_ids (const Node* node) const;
 
@@ -294,7 +294,7 @@ public:
    * This is the non-deprecated version of the function.
    */
   void boundary_ids (const Node* node,
-                     std::set<boundary_id_type> & set_to_fill) const;
+                     std::vector<boundary_id_type> & vec_to_fill) const;
 
   /**
    * Returns the number of boundary ids associated with \p Node \p node.

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -166,18 +166,9 @@ public:
   /**
    * Add \p Node \p node with boundary ids \p ids to the boundary
    * information data structure.
-   *
-   * This function is now deprecated, call the version which takes a
-   * reference to a std::set instead.
    */
   void add_node (const Node* node,
                  const std::vector<boundary_id_type>& ids);
-
-  /**
-   * Non-deprecated version of the add_node() function taking a set of ids.
-   */
-  void add_node (const Node* node,
-                 const std::set<boundary_id_type>& ids_set);
 
   /**
    * Clears all the boundary information from all of the nodes in the mesh

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -387,7 +387,7 @@ public:
    * element \p elem.
    *
    * This function has been deprecated.  Instead, use the version of
-   * this function that fills a std::set.
+   * this function that fills a std::vector.
    */
   std::vector<boundary_id_type> boundary_ids (const Elem* const elem,
                                               const unsigned short int side) const;
@@ -400,7 +400,7 @@ public:
    */
   void boundary_ids (const Elem* const elem,
                      const unsigned short int side,
-                     std::set<boundary_id_type> & set_to_fill) const;
+                     std::vector<boundary_id_type> & vec_to_fill) const;
 
   /**
    * Returns the list of raw boundary ids associated with the \p side

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -288,7 +288,7 @@ public:
   std::vector<boundary_id_type> boundary_ids (const Node* node) const;
 
   /**
-   * Fills a user-provided std::set with the boundary ids associated
+   * Fills a user-provided std::vector with the boundary ids associated
    * with \p Node \p node.
    *
    * This is the non-deprecated version of the function.
@@ -409,7 +409,7 @@ public:
    * its ancestors' boundary id.
    *
    * This function has been deprecated.  Instead, use the version of
-   * this function that fills a std::set.
+   * this function that fills a std::vector.
    */
   std::vector<boundary_id_type> raw_boundary_ids (const Elem* const elem,
                                                   const unsigned short int side) const;
@@ -424,7 +424,7 @@ public:
    */
   void raw_boundary_ids (const Elem* const elem,
                          const unsigned short int side,
-                         std::set<boundary_id_type> & set_to_fill) const;
+                         std::vector<boundary_id_type> & vec_to_fill) const;
 
   /**
    * Returns a side of element \p elem whose associated boundary id is

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -89,7 +89,7 @@ public:
   /**
    * As above, but fills in the std::set provided by the user.
    */
-  void side_boundary_ids(std::set<boundary_id_type> & set_to_fill) const;
+  void side_boundary_ids(std::vector<boundary_id_type> & vec_to_fill) const;
 
   /**
    * Returns the value of the solution variable \p var at the quadrature

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -485,11 +485,10 @@ private:
         // also independently check whether the edges have been requested
         for (unsigned short e=0; e != elem->n_edges(); ++e)
           {
-            std::set<boundary_id_type> ids_set;
-            boundary_info.edge_boundary_ids (elem, e, ids_set);
+            boundary_info.edge_boundary_ids (elem, e, ids_vec);
 
-            for (std::set<boundary_id_type>::iterator bc_it = ids_set.begin();
-                 bc_it != ids_set.end(); ++bc_it)
+            for (std::vector<boundary_id_type>::iterator bc_it = ids_vec.begin();
+                 bc_it != ids_vec.end(); ++bc_it)
               if (b.count(*bc_it))
                 is_boundary_edge[e] = true;
           }

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -470,11 +470,10 @@ private:
         // also independently check whether the nodes have been requested
         for (unsigned int n=0; n != elem->n_nodes(); ++n)
           {
-            std::set<boundary_id_type> ids_set;
-            boundary_info.boundary_ids (elem->get_node(n), ids_set);
+            boundary_info.boundary_ids (elem->get_node(n), ids_vec);
 
-            for (std::set<boundary_id_type>::iterator bc_it = ids_set.begin();
-                 bc_it != ids_set.end(); ++bc_it)
+            for (std::vector<boundary_id_type>::iterator bc_it = ids_vec.begin();
+                 bc_it != ids_vec.end(); ++bc_it)
               if (b.count(*bc_it))
                 {
                   is_boundary_node[n] = true;

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -437,16 +437,16 @@ private:
 
         // Container to catch boundary ids handed back for sides,
         // nodes, and edges in the loops below.
-        std::set<boundary_id_type> ids_set;
+        std::vector<boundary_id_type> ids_vec;
 
         for (unsigned char s=0; s != elem->n_sides(); ++s)
           {
             // First see if this side has been requested
-            boundary_info.boundary_ids (elem, s, ids_set);
+            boundary_info.boundary_ids (elem, s, ids_vec);
 
             bool do_this_side = false;
-            for (std::set<boundary_id_type>::iterator bc_it = ids_set.begin();
-                 bc_it != ids_set.end(); ++bc_it)
+            for (std::vector<boundary_id_type>::iterator bc_it = ids_vec.begin();
+                 bc_it != ids_vec.end(); ++bc_it)
               if (b.count(*bc_it))
                 {
                   do_this_side = true;
@@ -470,6 +470,7 @@ private:
         // also independently check whether the nodes have been requested
         for (unsigned int n=0; n != elem->n_nodes(); ++n)
           {
+            std::set<boundary_id_type> ids_set;
             boundary_info.boundary_ids (elem->get_node(n), ids_set);
 
             for (std::set<boundary_id_type>::iterator bc_it = ids_set.begin();
@@ -485,6 +486,7 @@ private:
         // also independently check whether the edges have been requested
         for (unsigned short e=0; e != elem->n_edges(); ++e)
           {
+            std::set<boundary_id_type> ids_set;
             boundary_info.edge_boundary_ids (elem, e, ids_set);
 
             for (std::set<boundary_id_type>::iterator bc_it = ids_set.begin();

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -953,14 +953,14 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints &constraints
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
-  std::set<boundary_id_type> bc_ids;
+  std::vector<boundary_id_type> bc_ids;
   for (unsigned short int s=0; s<elem->n_sides(); s++)
     {
       if (elem->neighbor(s))
         continue;
 
       mesh.get_boundary_info().boundary_ids (elem, s, bc_ids);
-      for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+      for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
         {
           const boundary_id_type boundary_id = *id_it;
           const PeriodicBoundaryBase *periodic = boundaries.boundary(boundary_id);

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -56,7 +56,7 @@ const Elem* primary_boundary_point_neighbor
   const Elem *primary = elem;
 
   // Container to catch boundary IDs passed back by BoundaryInfo.
-  std::set<boundary_id_type> bc_ids;
+  std::vector<boundary_id_type> bc_ids;
 
   std::set<const Elem*> point_neighbors;
   elem->find_point_neighbors(p, point_neighbors);
@@ -87,7 +87,7 @@ const Elem* primary_boundary_point_neighbor
           bool on_relevant_boundary = false;
           for (std::set<boundary_id_type>::const_iterator i =
                  boundary_ids.begin(); i != boundary_ids.end(); ++i)
-            if (bc_ids.count(*i))
+            if (std::find(bc_ids.begin(), bc_ids.end(), *i) != bc_ids.end())
               on_relevant_boundary = true;
 
           if (!on_relevant_boundary)
@@ -123,7 +123,7 @@ const Elem* primary_boundary_edge_neighbor
   elem->find_edge_neighbors(p1, p2, edge_neighbors);
 
   // Container to catch boundary IDs handed back by BoundaryInfo
-  std::set<boundary_id_type> bc_ids;
+  std::vector<boundary_id_type> bc_ids;
 
   for (std::set<const Elem*>::const_iterator edge_neighbors_iter =
          edge_neighbors.begin();
@@ -152,7 +152,7 @@ const Elem* primary_boundary_edge_neighbor
           bool on_relevant_boundary = false;
           for (std::set<boundary_id_type>::const_iterator i =
                  boundary_ids.begin(); i != boundary_ids.end(); ++i)
-            if (bc_ids.count(*i))
+            if (std::find(bc_ids.begin(), bc_ids.end(), *i) != bc_ids.end())
               on_relevant_boundary = true;
 
           if (!on_relevant_boundary)
@@ -1725,7 +1725,7 @@ compute_periodic_constraints (DofConstraints &constraints,
   std::vector<DenseVector<Real> > Ue;
 
   // Container to catch the boundary ids that BoundaryInfo hands us.
-  std::set<boundary_id_type> bc_ids;
+  std::vector<boundary_id_type> bc_ids;
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
@@ -1736,7 +1736,7 @@ compute_periodic_constraints (DofConstraints &constraints,
 
       mesh.get_boundary_info().boundary_ids (elem, s, bc_ids);
 
-      for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+      for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
         {
           const boundary_id_type boundary_id = *id_it;
           const PeriodicBoundaryBase *periodic = boundaries.boundary(boundary_id);
@@ -1928,7 +1928,7 @@ compute_periodic_constraints (DofConstraints &constraints,
                   std::set<dof_id_type> my_constrained_dofs;
 
                   // Container to catch boundary IDs handed back by BoundaryInfo.
-                  std::set<boundary_id_type> new_bc_ids;
+                  std::vector<boundary_id_type> new_bc_ids;
 
                   for (unsigned int n = 0; n != elem->n_nodes(); ++n)
                     {
@@ -1952,7 +1952,7 @@ compute_periodic_constraints (DofConstraints &constraints,
 
                               mesh.get_boundary_info().boundary_ids (elem, s, new_bc_ids);
 
-                              for (std::set<boundary_id_type>::const_iterator
+                              for (std::vector<boundary_id_type>::const_iterator
                                      new_id_it=new_bc_ids.begin(); new_id_it!=new_bc_ids.end(); ++new_id_it)
                                 {
                                   const boundary_id_type new_boundary_id = *new_id_it;
@@ -2097,7 +2097,7 @@ compute_periodic_constraints (DofConstraints &constraints,
                               // We're reusing the new_bc_ids vector created outside the loop over nodes.
                               mesh.get_boundary_info().boundary_ids (elem, s, new_bc_ids);
 
-                              for (std::set<boundary_id_type>::const_iterator
+                              for (std::vector<boundary_id_type>::const_iterator
                                      new_id_it=new_bc_ids.begin(); new_id_it!=new_bc_ids.end(); ++new_id_it)
                                 {
                                   const boundary_id_type new_boundary_id = *new_id_it;

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1054,9 +1054,9 @@ Elem* Elem::topological_neighbor (const unsigned int i,
       // Since the neighbor is NULL it must be on a boundary. We need
       // see if this is a periodic boundary in which case it will have a
       // topological neighbor
-      std::set<boundary_id_type> bc_ids;
+      std::vector<boundary_id_type> bc_ids;
       mesh.get_boundary_info().boundary_ids(this, cast_int<unsigned short>(i), bc_ids);
-      for (std::set<boundary_id_type>::iterator j = bc_ids.begin(); j != bc_ids.end(); ++j)
+      for (std::vector<boundary_id_type>::iterator j = bc_ids.begin(); j != bc_ids.end(); ++j)
         if (pb->boundary(*j))
           {
             // Since the point locator inside of periodic boundaries
@@ -1092,9 +1092,9 @@ const Elem* Elem::topological_neighbor (const unsigned int i,
       // Since the neighbor is NULL it must be on a boundary. We need
       // see if this is a periodic boundary in which case it will have a
       // topological neighbor
-      std::set<boundary_id_type> bc_ids;
+      std::vector<boundary_id_type> bc_ids;
       mesh.get_boundary_info().boundary_ids(this, cast_int<unsigned short>(i), bc_ids);
-      for (std::set<boundary_id_type>::iterator j = bc_ids.begin(); j != bc_ids.end(); ++j)
+      for (std::vector<boundary_id_type>::iterator j = bc_ids.begin(); j != bc_ids.end(); ++j)
         if (pb->boundary(*j))
           {
             // Since the point locator inside of periodic boundaries

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -852,21 +852,21 @@ std::vector<boundary_id_type> BoundaryInfo::edge_boundary_ids (const Elem* const
 {
   libmesh_deprecated();
 
-  std::set<boundary_id_type> ids_set;
-  this->edge_boundary_ids(elem, edge, ids_set);
-  return std::vector<boundary_id_type>(ids_set.begin(), ids_set.end());
+  std::vector<boundary_id_type> ids;
+  this->edge_boundary_ids(elem, edge, ids);
+  return ids;
 }
 
 
 
 void BoundaryInfo::edge_boundary_ids (const Elem* const elem,
                                       const unsigned short int edge,
-                                      std::set<boundary_id_type> & set_to_fill) const
+                                      std::vector<boundary_id_type> & vec_to_fill) const
 {
   libmesh_assert(elem);
 
   // Clear out any previous contents
-  set_to_fill.clear();
+  vec_to_fill.clear();
 
   // Only level-0 elements store BCs.  If this is not a level-0
   // element get its level-0 parent and infer the BCs.
@@ -914,7 +914,7 @@ void BoundaryInfo::edge_boundary_ids (const Elem* const elem,
   // Check each element in the range to see if its edge matches the requested edge.
   for (; e.first != e.second; ++e.first)
     if (e.first->second.first == edge)
-      set_to_fill.insert(e.first->second.second);
+      vec_to_fill.push_back(e.first->second.second);
 }
 
 
@@ -922,9 +922,9 @@ void BoundaryInfo::edge_boundary_ids (const Elem* const elem,
 unsigned int BoundaryInfo::n_edge_boundary_ids (const Elem* const elem,
                                                 const unsigned short int edge) const
 {
-  std::set<boundary_id_type> ids_set;
-  this->edge_boundary_ids(elem, edge, ids_set);
-  return ids_set.size();
+  std::vector<boundary_id_type> ids;
+  this->edge_boundary_ids(elem, edge, ids);
+  return ids.size();
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -192,11 +192,9 @@ void BoundaryInfo::sync (const std::set<boundary_id_type> &requested_boundary_id
         boundary_mesh.add_point(*node, node_id_map[node_id], node->processor_id());
 
         // Copy over all the node's boundary IDs to boundary_mesh
-        std::vector<boundary_id_type> node_boundary_ids =
-          this->boundary_ids(node);
-        for(unsigned int index=0;
-            index<node_boundary_ids.size();
-            index++)
+        std::vector<boundary_id_type> node_boundary_ids;
+        this->boundary_ids(node, node_boundary_ids);
+        for (unsigned int index=0; index<node_boundary_ids.size(); index++)
           {
             boundary_mesh.boundary_info->add_node(
               node_id_map[node_id], node_boundary_ids[index]);

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1066,21 +1066,21 @@ std::vector<boundary_id_type> BoundaryInfo::raw_boundary_ids (const Elem* const 
 {
   libmesh_deprecated();
 
-  std::set<boundary_id_type> ids_set;
-  this->raw_boundary_ids(elem, side, ids_set);
-  return std::vector<boundary_id_type>(ids_set.begin(), ids_set.end());
+  std::vector<boundary_id_type> ids;
+  this->raw_boundary_ids(elem, side, ids);
+  return ids;
 }
 
 
 
 void BoundaryInfo::raw_boundary_ids (const Elem* const elem,
                                      const unsigned short int side,
-                                     std::set<boundary_id_type> & set_to_fill) const
+                                     std::vector<boundary_id_type> & vec_to_fill) const
 {
   libmesh_assert(elem);
 
   // Clear out any previous contents
-  set_to_fill.clear();
+  vec_to_fill.clear();
 
   // Only level-0 elements store BCs.
   if (elem->parent())
@@ -1092,7 +1092,7 @@ void BoundaryInfo::raw_boundary_ids (const Elem* const elem,
   // Check each element in the range to see if its side matches the requested side.
   for (; e.first != e.second; ++e.first)
     if (e.first->second.first == side)
-      set_to_fill.insert(e.first->second.second);
+      vec_to_fill.push_back(e.first->second.second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -816,24 +816,24 @@ std::vector<boundary_id_type> BoundaryInfo::boundary_ids(const Node* node) const
 {
   libmesh_deprecated();
 
-  std::set<boundary_id_type> ids_set;
-  this->boundary_ids(node, ids_set);
-  return std::vector<boundary_id_type>(ids_set.begin(), ids_set.end());
+  std::vector<boundary_id_type> ids;
+  this->boundary_ids(node, ids);
+  return ids;
 }
 
 
 
 void BoundaryInfo::boundary_ids (const Node* node,
-                                 std::set<boundary_id_type> & set_to_fill) const
+                                 std::vector<boundary_id_type> & vec_to_fill) const
 {
   // Clear out any previous contents
-  set_to_fill.clear();
+  vec_to_fill.clear();
 
   std::pair<boundary_node_iter, boundary_node_iter>
     pos = _boundary_node_id.equal_range(node);
 
   for (; pos.first != pos.second; ++pos.first)
-    set_to_fill.insert(pos.first->second);
+    vec_to_fill.push_back(pos.first->second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -657,17 +657,7 @@ void BoundaryInfo::add_edge(const Elem* elem,
                             const unsigned short int edge,
                             const std::vector<boundary_id_type>& ids)
 {
-  libmesh_deprecated();
-  this->add_edge(elem, edge, std::set<boundary_id_type>(ids.begin(), ids.end()));
-}
-
-
-
-void BoundaryInfo::add_edge(const Elem* elem,
-                            const unsigned short int edge,
-                            const std::set<boundary_id_type>& ids_set)
-{
-  if (ids_set.empty())
+  if (ids.empty())
     return;
 
   libmesh_assert(elem);
@@ -678,8 +668,18 @@ void BoundaryInfo::add_edge(const Elem* elem,
   // Don't add the same ID twice
   std::pair<boundary_edge_iter, boundary_edge_iter> pos = _boundary_edge_id.equal_range(elem);
 
-  std::set<boundary_id_type>::iterator it = ids_set.begin();
-  for (; it != ids_set.end(); ++it)
+  // The entries in the ids vector may be non-unique.  If we expected
+  // *lots* of ids, it might be fastest to construct a std::set from
+  // the entries, but for a small number of entries, which is more
+  // typical, it is probably faster to copy the vector and do sort+unique.
+  // http://stackoverflow.com/questions/1041620/whats-the-most-efficient-way-to-erase-duplicates-and-sort-a-vector
+  std::vector<boundary_id_type> unique_ids(ids.begin(), ids.end());
+  std::sort(unique_ids.begin(), unique_ids.end());
+  std::vector<boundary_id_type>::iterator new_end =
+    std::unique(unique_ids.begin(), unique_ids.end());
+
+  std::vector<boundary_id_type>::iterator it = unique_ids.begin();
+  for (; it != new_end; ++it)
     {
       boundary_id_type id = *it;
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -564,16 +564,7 @@ void BoundaryInfo::add_node(const Node* node,
 void BoundaryInfo::add_node(const Node* node,
                             const std::vector<boundary_id_type>& ids)
 {
-  libmesh_deprecated();
-  this->add_node(node, std::set<boundary_id_type>(ids.begin(), ids.end()));
-}
-
-
-
-void BoundaryInfo::add_node(const Node* node,
-                            const std::set<boundary_id_type>& ids_set)
-{
-  if (ids_set.empty())
+  if (ids.empty())
     return;
 
   libmesh_assert(node);
@@ -581,8 +572,18 @@ void BoundaryInfo::add_node(const Node* node,
   // Don't add the same ID twice
   std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
 
-  std::set<boundary_id_type>::iterator it = ids_set.begin();
-  for (; it != ids_set.end(); ++it)
+  // The entries in the ids vector may be non-unique.  If we expected
+  // *lots* of ids, it might be fastest to construct a std::set from
+  // the entries, but for a small number of entries, which is more
+  // typical, it is probably faster to copy the vector and do sort+unique.
+  // http://stackoverflow.com/questions/1041620/whats-the-most-efficient-way-to-erase-duplicates-and-sort-a-vector
+  std::vector<boundary_id_type> unique_ids(ids.begin(), ids.end());
+  std::sort(unique_ids.begin(), unique_ids.end());
+  std::vector<boundary_id_type>::iterator new_end =
+    std::unique(unique_ids.begin(), unique_ids.end());
+
+  std::vector<boundary_id_type>::iterator it = unique_ids.begin();
+  for (; it != new_end; ++it)
     {
       boundary_id_type id = *it;
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -974,16 +974,16 @@ boundary_id_type BoundaryInfo::boundary_id(const Elem* const elem,
   // instead.
   libmesh_deprecated();
 
-  std::set<boundary_id_type> ids_set;
-  this->boundary_ids(elem, side, ids_set);
+  std::vector<boundary_id_type> ids;
+  this->boundary_ids(elem, side, ids);
 
   // If the set is empty, return invalid_id
-  if (ids_set.empty())
+  if (ids.empty())
     return invalid_id;
 
   // Otherwise, just return the first id we came across for this
   // element on this side.
-  return *(ids_set.begin());
+  return *(ids.begin());
 }
 
 
@@ -992,9 +992,9 @@ bool BoundaryInfo::has_boundary_id(const Elem* const elem,
                                    const unsigned short int side,
                                    const boundary_id_type id) const
 {
-  std::set<boundary_id_type> ids_set;
-  this->boundary_ids(elem, side, ids_set);
-  return (ids_set.find(id) != ids_set.end());
+  std::vector<boundary_id_type> ids;
+  this->boundary_ids(elem, side, ids);
+  return (std::find(ids.begin(), ids.end(), id) != ids.end());
 }
 
 
@@ -1004,21 +1004,21 @@ std::vector<boundary_id_type> BoundaryInfo::boundary_ids (const Elem* const elem
 {
   libmesh_deprecated();
 
-  std::set<boundary_id_type> ids_set;
-  this->boundary_ids(elem, side, ids_set);
-  return std::vector<boundary_id_type>(ids_set.begin(), ids_set.end());
+  std::vector<boundary_id_type> ids;
+  this->boundary_ids(elem, side, ids);
+  return ids;
 }
 
 
 
 void BoundaryInfo::boundary_ids (const Elem* const elem,
                                  const unsigned short int side,
-                                 std::set<boundary_id_type> & set_to_fill) const
+                                 std::vector<boundary_id_type> & vec_to_fill) const
 {
   libmesh_assert(elem);
 
   // Clear out any previous contents
-  set_to_fill.clear();
+  vec_to_fill.clear();
 
   // Only level-0 elements store BCs.  If this is not a level-0
   // element get its level-0 parent and infer the BCs.
@@ -1045,7 +1045,7 @@ void BoundaryInfo::boundary_ids (const Elem* const elem,
   // Check each element in the range to see if its side matches the requested side.
   for (; e.first != e.second; ++e.first)
     if (e.first->second.first == side)
-      set_to_fill.insert(e.first->second.second);
+      vec_to_fill.push_back(e.first->second.second);
 }
 
 
@@ -1054,9 +1054,9 @@ void BoundaryInfo::boundary_ids (const Elem* const elem,
 unsigned int BoundaryInfo::n_boundary_ids (const Elem* const elem,
                                            const unsigned short int side) const
 {
-  std::set<boundary_id_type> ids_set;
-  this->boundary_ids(elem, side, ids_set);
-  return ids_set.size();
+  std::vector<boundary_id_type> ids;
+  this->boundary_ids(elem, side, ids);
+  return ids.size();
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -934,21 +934,21 @@ std::vector<boundary_id_type> BoundaryInfo::raw_edge_boundary_ids (const Elem* c
 {
   libmesh_deprecated();
 
-  std::set<boundary_id_type> ids_set;
-  this->raw_edge_boundary_ids(elem, edge, ids_set);
-  return std::vector<boundary_id_type>(ids_set.begin(), ids_set.end());
+  std::vector<boundary_id_type> ids;
+  this->raw_edge_boundary_ids(elem, edge, ids);
+  return ids;
 }
 
 
 
 void BoundaryInfo::raw_edge_boundary_ids (const Elem* const elem,
                                           const unsigned short int edge,
-                                          std::set<boundary_id_type> & set_to_fill) const
+                                          std::vector<boundary_id_type> & vec_to_fill) const
 {
   libmesh_assert(elem);
 
   // Clear out any previous contents
-  set_to_fill.clear();
+  vec_to_fill.clear();
 
   // Only level-0 elements store BCs.
   if (elem->parent())
@@ -960,7 +960,7 @@ void BoundaryInfo::raw_edge_boundary_ids (const Elem* const elem,
   // Check each element in the range to see if its edge matches the requested edge.
   for (; e.first != e.second; ++e.first)
     if (e.first->second.first == edge)
-      set_to_fill.insert(e.first->second.second);
+      vec_to_fill.push_back(e.first->second.second);
 }
 
 

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1984,7 +1984,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh& mesh,
   mesh.reserve_nodes((order*nz+1)*orig_nodes);
 
   // Container to catch the boundary IDs handed back by the BoundaryInfo object
-  std::set<boundary_id_type> ids_to_copy;
+  std::vector<boundary_id_type> ids_to_copy;
 
   MeshBase::const_node_iterator       nd  = cross_section.nodes_begin();
   const MeshBase::const_node_iterator nend = cross_section.nodes_end();
@@ -2000,7 +2000,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh& mesh,
                            node->id() + (k * orig_nodes),
                            node->processor_id());
 
-          cross_section_boundary_info.boundary_ids(node, ids_to_copy);
+          ids_to_copy = cross_section_boundary_info.boundary_ids(node);
           boundary_info.add_node(new_node, ids_to_copy);
         }
     }
@@ -2149,7 +2149,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh& mesh,
           // Copy any old boundary ids on all sides
           for (unsigned short s = 0; s != elem->n_sides(); ++s)
             {
-              cross_section_boundary_info.boundary_ids(elem, s, ids_to_copy);
+              ids_to_copy = cross_section_boundary_info.boundary_ids(elem, s);
 
               if (new_elem->dim() == 3)
                 {

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2000,7 +2000,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh& mesh,
                            node->id() + (k * orig_nodes),
                            node->processor_id());
 
-          ids_to_copy = cross_section_boundary_info.boundary_ids(node);
+          cross_section_boundary_info.boundary_ids(node, ids_to_copy);
           boundary_info.add_node(new_node, ids_to_copy);
         }
     }
@@ -2149,7 +2149,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh& mesh,
           // Copy any old boundary ids on all sides
           for (unsigned short s = 0; s != elem->n_sides(); ++s)
             {
-              ids_to_copy = cross_section_boundary_info.boundary_ids(elem, s);
+              cross_section_boundary_info.boundary_ids(elem, s, ids_to_copy);
 
               if (new_elem->dim() == 3)
                 {

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -386,7 +386,7 @@ void UnstructuredMesh::all_first_order ()
       std::vector<boundary_id_type> bndry_ids;
       for (unsigned short s=0; s<so_elem->n_sides(); s++)
         {
-          bndry_ids = this->get_boundary_info().raw_boundary_ids (so_elem, s);
+          this->get_boundary_info().raw_boundary_ids (so_elem, s, bndry_ids);
           this->get_boundary_info().add_side (lo_elem, s, bndry_ids);
         }
 
@@ -673,7 +673,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
       std::vector<boundary_id_type> bndry_ids;
       for (unsigned short s=0; s<lo_elem->n_sides(); s++)
         {
-          bndry_ids = this->get_boundary_info().raw_boundary_ids (lo_elem, s);
+          this->get_boundary_info().raw_boundary_ids (lo_elem, s, bndry_ids);
           this->get_boundary_info().add_side (so_elem, s, bndry_ids);
 
           if (lo_elem->neighbor(s) == remote_elem)

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1514,7 +1514,7 @@ void MeshTools::Modification::change_boundary_id (MeshBase& mesh,
           const Node * node = mesh.node_ptr(node_list[idx]);
 
           // Get all the current IDs for this node.
-          bndry_ids = bi.boundary_ids(node);
+          bi.boundary_ids(node, bndry_ids);
 
           // Update the IDs accordingly
           std::replace(bndry_ids.begin(), bndry_ids.end(), old_id, new_id);
@@ -1548,7 +1548,7 @@ void MeshTools::Modification::change_boundary_id (MeshBase& mesh,
           unsigned short int edge = edge_list[idx];
 
           // Get all the current IDs for the edge in question.
-          bndry_ids = bi.edge_boundary_ids(elem, edge);
+          bi.edge_boundary_ids(elem, edge, bndry_ids);
 
           // Update the IDs accordingly
           std::replace(bndry_ids.begin(), bndry_ids.end(), old_id, new_id);
@@ -1582,7 +1582,7 @@ void MeshTools::Modification::change_boundary_id (MeshBase& mesh,
           unsigned short int side = side_list[idx];
 
           // Get all the current IDs for the side in question.
-          bndry_ids = bi.boundary_ids(elem, side);
+          bi.boundary_ids(elem, side, bndry_ids);
 
           // Update the IDs accordingly
           std::replace(bndry_ids.begin(), bndry_ids.end(), old_id, new_id);

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -931,13 +931,13 @@ void MeshTools::Modification::all_tri (MeshBase& mesh)
             if (mesh_has_boundary_data)
               {
                 // Container to catch the boundary IDs handed back by the BoundaryInfo object.
-                std::set<boundary_id_type> bc_ids;
+                std::vector<boundary_id_type> bc_ids;
 
                 for (unsigned short sn=0; sn<elem->n_sides(); ++sn)
                   {
                     mesh.get_boundary_info().boundary_ids(*el, sn, bc_ids);
 
-                    for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+                    for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
                       {
                         const boundary_id_type b_id = *id_it;
 
@@ -1375,7 +1375,7 @@ void MeshTools::Modification::flatten(MeshBase& mesh)
   std::vector<unsigned short int> saved_bc_sides;
 
   // Container to catch boundary ids passed back by BoundaryInfo
-  std::set<boundary_id_type> bc_ids;
+  std::vector<boundary_id_type> bc_ids;
 
   // Reserve a reasonable amt. of space for each
   new_elements.reserve(mesh.n_active_elem());
@@ -1414,7 +1414,7 @@ void MeshTools::Modification::flatten(MeshBase& mesh)
               copy->set_neighbor(s, const_cast<RemoteElem*>(remote_elem));
 
             mesh.get_boundary_info().boundary_ids(elem, s, bc_ids);
-            for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+            for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
               {
                 const boundary_id_type bc_id = *id_it;
 

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -1232,7 +1232,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
         }
 
       // Container to catch boundary IDs passed back from BoundaryInfo.
-      std::set<boundary_id_type> bc_ids;
+      std::vector<boundary_id_type> bc_ids;
 
       elem_it  = other_mesh->elements_begin();
       elem_end = other_mesh->elements_end();
@@ -1250,7 +1250,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
           unsigned int other_n_nodes = other_elem->n_nodes();
           for (unsigned int n=0; n != other_n_nodes; ++n)
             {
-              other_mesh->get_boundary_info().boundary_ids(other_elem->get_node(n), bc_ids);
+              bc_ids = other_mesh->get_boundary_info().boundary_ids(other_elem->get_node(n));
               this->get_boundary_info().add_node(this_elem->get_node(n), bc_ids);
             }
 
@@ -1258,14 +1258,14 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
           unsigned int n_edges = other_elem->n_edges();
           for (unsigned short edge=0; edge != n_edges; ++edge)
             {
-              other_mesh->get_boundary_info().edge_boundary_ids(other_elem, edge, bc_ids);
+              bc_ids = other_mesh->get_boundary_info().edge_boundary_ids(other_elem, edge);
               this->get_boundary_info().add_edge(this_elem, edge, bc_ids);
             }
 
           unsigned int n_sides = other_elem->n_sides();
           for (unsigned short s=0; s != n_sides; ++s)
             {
-              other_mesh->get_boundary_info().boundary_ids(other_elem, s, bc_ids);
+              bc_ids = other_mesh->get_boundary_info().boundary_ids(other_elem, s);
               this->get_boundary_info().add_side(this_elem, s, bc_ids);
             }
         }

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -966,10 +966,9 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                           if(el->is_edge_on_side(edge_id, side_id))
                             {
                               // Get *all* boundary IDs on this edge, not just the first one!
-                              std::set<boundary_id_type> bc_ids_set;
-                              mesh_array[i]->get_boundary_info().edge_boundary_ids (el, edge_id, bc_ids_set);
+                              mesh_array[i]->get_boundary_info().edge_boundary_ids (el, edge_id, bc_ids);
 
-                              if (bc_ids_set.count(id_array[i]))
+                              if (std::find(bc_ids.begin(), bc_ids.end(), id_array[i]) != bc_ids.end())
                                 {
                                   UniquePtr<Elem> edge (el->build_edge(edge_id));
                                   for (unsigned int node_id=0; node_id<edge->n_nodes(); ++node_id)

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -1250,7 +1250,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
           unsigned int other_n_nodes = other_elem->n_nodes();
           for (unsigned int n=0; n != other_n_nodes; ++n)
             {
-              bc_ids = other_mesh->get_boundary_info().boundary_ids(other_elem->get_node(n));
+              other_mesh->get_boundary_info().boundary_ids(other_elem->get_node(n), bc_ids);
               this->get_boundary_info().add_node(this_elem->get_node(n), bc_ids);
             }
 
@@ -1258,14 +1258,14 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
           unsigned int n_edges = other_elem->n_edges();
           for (unsigned short edge=0; edge != n_edges; ++edge)
             {
-              bc_ids = other_mesh->get_boundary_info().edge_boundary_ids(other_elem, edge);
+              other_mesh->get_boundary_info().edge_boundary_ids(other_elem, edge, bc_ids);
               this->get_boundary_info().add_edge(this_elem, edge, bc_ids);
             }
 
           unsigned int n_sides = other_elem->n_sides();
           for (unsigned short s=0; s != n_sides; ++s)
             {
-              bc_ids = other_mesh->get_boundary_info().boundary_ids(other_elem, s);
+              other_mesh->get_boundary_info().boundary_ids(other_elem, s, bc_ids);
               this->get_boundary_info().add_side(this_elem, s, bc_ids);
             }
         }
@@ -1301,7 +1301,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
 
           // We also need to copy over the nodeset info here,
           // because the node will get deleted below
-          bc_ids = this->get_boundary_info().boundary_ids(el->get_node(local_node_index));
+          this->get_boundary_info().boundary_ids(el->get_node(local_node_index), bc_ids);
           el->set_node(local_node_index) = &target_node;
           this->get_boundary_info().add_node(&target_node, bc_ids);
         }

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -914,7 +914,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
               }
 
             // Container to catch boundary IDs passed back from BoundaryInfo.
-            std::set<boundary_id_type> bc_ids;
+            std::vector<boundary_id_type> bc_ids;
 
             MeshBase::element_iterator elem_it  = mesh_array[i]->elements_begin();
             MeshBase::element_iterator elem_end = mesh_array[i]->elements_end();
@@ -929,7 +929,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                       // Get *all* boundary IDs on this side, not just the first one!
                       mesh_array[i]->get_boundary_info().boundary_ids (el, side_id, bc_ids);
 
-                      if (bc_ids.count(id_array[i]))
+                      if (std::find(bc_ids.begin(), bc_ids.end(), id_array[i]) != bc_ids.end())
                         {
                           UniquePtr<Elem> side (el->build_side(side_id));
                           for (unsigned int node_id=0; node_id<side->n_nodes(); ++node_id)
@@ -966,9 +966,10 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                           if(el->is_edge_on_side(edge_id, side_id))
                             {
                               // Get *all* boundary IDs on this edge, not just the first one!
-                              mesh_array[i]->get_boundary_info().edge_boundary_ids (el, edge_id, bc_ids);
+                              std::set<boundary_id_type> bc_ids_set;
+                              mesh_array[i]->get_boundary_info().edge_boundary_ids (el, edge_id, bc_ids_set);
 
-                              if (bc_ids.count(id_array[i]))
+                              if (bc_ids_set.count(id_array[i]))
                                 {
                                   UniquePtr<Elem> edge (el->build_edge(edge_id));
                                   for (unsigned int node_id=0; node_id<edge->n_nodes(); ++node_id)
@@ -1424,7 +1425,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
   if(clear_stitched_boundary_ids)
     {
       // Container to catch boundary IDs passed back from BoundaryInfo.
-      std::set<boundary_id_type> bc_ids;
+      std::vector<boundary_id_type> bc_ids;
 
       MeshBase::element_iterator elem_it  = this->elements_begin();
       MeshBase::element_iterator elem_end = this->elements_end();
@@ -1440,8 +1441,8 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
                   // this_mesh_boundary_id or other_mesh_boundary_id.
                   this->get_boundary_info().boundary_ids (el, side_id, bc_ids);
 
-                  if (bc_ids.count(this_mesh_boundary_id) ||
-                      bc_ids.count(other_mesh_boundary_id))
+                  if (std::find(bc_ids.begin(), bc_ids.end(), this_mesh_boundary_id) != bc_ids.end() ||
+                      std::find(bc_ids.begin(), bc_ids.end(), other_mesh_boundary_id) != bc_ids.end())
                     this->get_boundary_info().remove_side(el, side_id);
                 }
             }

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -1280,7 +1280,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
   // duplicate nodes that came from other_mesh.
 
   // Container to catch boundary IDs passed back from BoundaryInfo.
-  std::set<boundary_id_type> bc_ids;
+  std::vector<boundary_id_type> bc_ids;
 
   std::map<dof_id_type, std::vector<dof_id_type> >::iterator elem_map_it     = node_to_elems_map.begin();
   std::map<dof_id_type, std::vector<dof_id_type> >::iterator elem_map_it_end = node_to_elems_map.end();
@@ -1301,7 +1301,7 @@ void SerialMesh::stitching_helper (SerialMesh* other_mesh,
 
           // We also need to copy over the nodeset info here,
           // because the node will get deleted below
-          this->get_boundary_info().boundary_ids(el->get_node(local_node_index), bc_ids);
+          bc_ids = this->get_boundary_info().boundary_ids(el->get_node(local_node_index));
           el->set_node(local_node_index) = &target_node;
           this->get_boundary_info().add_node(&target_node, bc_ids);
         }

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -736,7 +736,7 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh& new_mesh,
       // Maybe add boundary conditions for this element
       for (unsigned short s=0; s<old_elem->n_sides(); s++)
         {
-          bc_ids = this->get_boundary_info().boundary_ids(old_elem, s);
+          this->get_boundary_info().boundary_ids(old_elem, s, bc_ids);
           new_mesh.get_boundary_info().add_side (new_elem, s, bc_ids);
         }
     } // end loop over elements

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -699,7 +699,7 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh& new_mesh,
   libmesh_assert_not_equal_to (this->n_elem(), 0);
 
   // Container to catch boundary IDs handed back by BoundaryInfo
-  std::set<boundary_id_type> bc_ids;
+  std::vector<boundary_id_type> bc_ids;
 
   for (; it != it_end; ++it)
     {
@@ -736,7 +736,7 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh& new_mesh,
       // Maybe add boundary conditions for this element
       for (unsigned short s=0; s<old_elem->n_sides(); s++)
         {
-          this->get_boundary_info().boundary_ids(old_elem, s, bc_ids);
+          bc_ids = this->get_boundary_info().boundary_ids(old_elem, s);
           new_mesh.get_boundary_info().add_side (new_elem, s, bc_ids);
         }
     } // end loop over elements

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -857,7 +857,7 @@ void XdrIO::write_serialized_bcs (Xdr &io, const header_id_type n_bcs) const
     end = mesh.local_level_elements_end(0);
 
   // Container to catch boundary IDs handed back by BoundaryInfo
-  std::set<boundary_id_type> bc_ids;
+  std::vector<boundary_id_type> bc_ids;
 
   dof_id_type n_local_level_0_elem=0;
   for (; it!=end; ++it, n_local_level_0_elem++)
@@ -867,7 +867,7 @@ void XdrIO::write_serialized_bcs (Xdr &io, const header_id_type n_bcs) const
       for (unsigned short s=0; s<elem->n_sides(); s++)
         {
           boundary_info.boundary_ids (elem, s, bc_ids);
-          for (std::set<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
+          for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
             {
               const boundary_id_type bc_id = *id_it;
               if (bc_id != BoundaryInfo::invalid_id)

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -940,7 +940,7 @@ void XdrIO::write_serialized_nodesets (Xdr &io, const header_id_type n_nodesets)
   std::vector<std::size_t> bc_sizes(this->n_processors());
 
   // Container to catch boundary IDs handed back by BoundaryInfo
-  std::set<boundary_id_type> nodeset_ids;
+  std::vector<boundary_id_type> nodeset_ids;
 
   MeshBase::const_node_iterator
     it  = mesh.local_nodes_begin(),
@@ -951,7 +951,7 @@ void XdrIO::write_serialized_nodesets (Xdr &io, const header_id_type n_nodesets)
     {
       const Node *node = *it;
       boundary_info.boundary_ids (node, nodeset_ids);
-      for (std::set<boundary_id_type>::const_iterator id_it=nodeset_ids.begin(); id_it!=nodeset_ids.end(); ++id_it)
+      for (std::vector<boundary_id_type>::const_iterator id_it=nodeset_ids.begin(); id_it!=nodeset_ids.end(); ++id_it)
         {
           const boundary_id_type bc_id = *id_it;
           if (bc_id != BoundaryInfo::invalid_id)

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -278,15 +278,14 @@ void pack (const Elem* elem,
             data.push_back(*bc_it);
         }
 
-      std::set<boundary_id_type> bcs_set;
       for (unsigned short e = 0; e != elem->n_edges(); ++e)
         {
-          mesh->get_boundary_info().edge_boundary_ids(elem, e, bcs_set);
+          mesh->get_boundary_info().edge_boundary_ids(elem, e, bcs);
 
-          data.push_back(bcs_set.size());
+          data.push_back(bcs.size());
 
-          for (std::set<boundary_id_type>::iterator bc_it=bcs_set.begin();
-               bc_it != bcs_set.end(); ++bc_it)
+          for (std::vector<boundary_id_type>::iterator bc_it=bcs.begin();
+               bc_it != bcs.end(); ++bc_it)
             data.push_back(*bc_it);
         }
     }

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -266,26 +266,27 @@ void pack (const Elem* elem,
   // Add any element side boundary condition ids
   if (elem->level() == 0)
     {
-      std::set<boundary_id_type> bcs;
+      std::vector<boundary_id_type> bcs;
       for (unsigned short s = 0; s != elem->n_sides(); ++s)
         {
           mesh->get_boundary_info().boundary_ids(elem, s, bcs);
 
           data.push_back(bcs.size());
 
-          for (std::set<boundary_id_type>::iterator bc_it=bcs.begin();
+          for (std::vector<boundary_id_type>::iterator bc_it=bcs.begin();
                bc_it != bcs.end(); ++bc_it)
             data.push_back(*bc_it);
         }
 
+      std::set<boundary_id_type> bcs_set;
       for (unsigned short e = 0; e != elem->n_edges(); ++e)
         {
-          mesh->get_boundary_info().edge_boundary_ids(elem, e, bcs);
+          mesh->get_boundary_info().edge_boundary_ids(elem, e, bcs_set);
 
-          data.push_back(bcs.size());
+          data.push_back(bcs_set.size());
 
-          for (std::set<boundary_id_type>::iterator bc_it=bcs.begin();
-               bc_it != bcs.end(); ++bc_it)
+          for (std::set<boundary_id_type>::iterator bc_it=bcs_set.begin();
+               bc_it != bcs_set.end(); ++bc_it)
             data.push_back(*bc_it);
         }
     }

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -162,14 +162,14 @@ void pack (const Node* node,
                            data.size() - start_indices);
 
   // Add any nodal boundary condition ids
-  std::set<boundary_id_type> bcs;
+  std::vector<boundary_id_type> bcs;
   mesh->get_boundary_info().boundary_ids(node, bcs);
 
   libmesh_assert(bcs.size() < std::numeric_limits<largest_id_type>::max());
 
   data.push_back(bcs.size());
 
-  for (std::set<boundary_id_type>::iterator bc_it=bcs.begin();
+  for (std::vector<boundary_id_type>::iterator bc_it=bcs.begin();
        bc_it != bcs.end(); ++bc_it)
     data.push_back(*bc_it);
 }

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -187,9 +187,9 @@ std::vector<boundary_id_type> FEMContext::side_boundary_ids() const
 }
 
 
-void FEMContext::side_boundary_ids(std::set<boundary_id_type> & set_to_fill) const
+void FEMContext::side_boundary_ids(std::vector<boundary_id_type> & vec_to_fill) const
 {
-  _boundary_info.boundary_ids(&(this->get_elem()), side, set_to_fill);
+  _boundary_info.boundary_ids(&(this->get_elem()), side, vec_to_fill);
 }
 
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -2067,7 +2067,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange &range) const
       std::vector<unsigned int> side_dofs;
 
       // Container to catch IDs passed back from BoundaryInfo.
-      std::set<boundary_id_type> bc_ids;
+      std::vector<boundary_id_type> bc_ids;
 
       // Iterate over all the elements in the range
       for (ConstElemRange::const_iterator elem_it=range.begin(); elem_it != range.end(); ++elem_it)
@@ -2089,7 +2089,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange &range) const
               // First see if this side has been requested
               boundary_info.boundary_ids (elem, s, bc_ids);
               bool do_this_side = false;
-              for (std::set<boundary_id_type>::iterator i=bc_ids.begin();
+              for (std::vector<boundary_id_type>::iterator i=bc_ids.begin();
                    i!=bc_ids.end(); ++i)
                 if (b.count(*i))
                   {


### PR DESCRIPTION
The `std::set` interfaces added in #711 were found to be less efficient (see discussion below the line) than the old `std::vector` based ones, especially for elements with lots of boundary ids, so this PR reverts some of those changes. I am still deprecating the original boundary_ids() interfaces which returned std::vectors by value in favor of interfaces that can be passed std::vectors by reference and filled up.  Since this function is frequently called inside of loops, it is hoped that allowing the id storage to be reused in this way will have more favorable memory access characteristics...

---


I created a little test case [here](https://gist.github.com/jwpeterson/ef68cf5c4bee0e9b2096) that measures how long it takes to call `boundary_ids()` on a mesh of 1000 HEX8's where every side of every element has  `n` boundary ids, both before and after the recent refactoring.  The old method which created a vector at every invocation was faster across the entire range of different values of `n`:

| n | set | vector |
|--------|--------|-----|
| 10  | .0110826  | .0050758 |
| 20  | .0220908  | .0080900 |
| 40  | .0406006  | .0125184 |
| 80  | .0837440  | .0241320 |
| 160 | .1733694  | .0444768 |


