### PR TITLE
fatol and frtol are going away in the next PETSc release

### DIFF
--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -500,8 +500,11 @@ void TaoOptimizationSolver<T>::solve ()
   // ||g(X)|| / ||g(X0)||                <= gttol
   // Command line equivalents: -tao_fatol, -tao_frtol, -tao_gatol, -tao_grtol, -tao_gttol
   ierr = TaoSetTolerances(_tao,
+#if PETSC_RELEASE_LESS_THAN(3,6,3)
+                          // Releases up to 3.6.2 had fatol and frtol, after that they were removed.
                           /*fatol=*/PETSC_DEFAULT,
                           /*frtol=*/this->objective_function_relative_tolerance,
+#endif
                           /*gatol=*/PETSC_DEFAULT,
                           /*grtol=*/PETSC_DEFAULT,
                           /*gttol=*/PETSC_DEFAULT);

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -415,7 +415,7 @@ template <typename T>
 TaoOptimizationSolver<T>::TaoOptimizationSolver (OptimizationSystem& system_in)
   :
   OptimizationSolver<T>(system_in),
-  _reason(TAO_CONVERGED_FATOL/*==0*/) // Arbitrary initial value...
+  _reason(TAO_CONVERGED_USER) // Arbitrary initial value...
 {
 }
 


### PR DESCRIPTION
@dknez, looks like we currently set `frtol`, should we maybe change to setting `grtol`?

Relevant [diff](https://bitbucket.org/petsc/petsc/diff/include/petsctao.h?diff2=e52336cb213e).

Closes #723.