### PR TITLE
Add Elem::key(), refactor Gmsh reader to use it

### DIFF
--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -176,6 +176,11 @@ public:
   std::pair<Real, Real> min_and_max_angle() const;
 
   /**
+   * Don't hide Tet::key(side) defined in the base class.
+   */
+  using Tet::key;
+
+  /**
    * @returns an id associated with the global node ids of this
    * element.  The id is not necessariy unique, but should be
    * close.

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -175,6 +175,13 @@ public:
    */
   std::pair<Real, Real> min_and_max_angle() const;
 
+  /**
+   * @returns an id associated with the global node ids of this
+   * element.  The id is not necessariy unique, but should be
+   * close.
+   */
+  virtual dof_id_type key () const libmesh_override;
+
 protected:
 
   /**

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -136,6 +136,11 @@ public:
 #endif
 
   /**
+   * Don't hide Edge::key(side) defined in the base class.
+   */
+  using Edge::key;
+
+  /**
    * @returns an id associated with the global node ids of this
    * element.  The id is not necessariy unique, but should be
    * close.

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -135,6 +135,12 @@ public:
 
 #endif
 
+  /**
+   * @returns an id associated with the global node ids of this
+   * element.  The id is not necessariy unique, but should be
+   * close.
+   */
+  virtual dof_id_type key () const libmesh_override;
 
 protected:
 

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -164,6 +164,13 @@ public:
 
 #endif
 
+  /**
+   * @returns an id associated with the global node ids of this
+   * element.  The id is not necessariy unique, but should be
+   * close.
+   */
+  virtual dof_id_type key () const libmesh_override;
+
 
 protected:
 

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -165,6 +165,11 @@ public:
 #endif
 
   /**
+   * Don't hide Edge::key(side) defined in the base class.
+   */
+  using Edge::key;
+
+  /**
    * @returns an id associated with the global node ids of this
    * element.  The id is not necessariy unique, but should be
    * close.

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -145,6 +145,11 @@ public:
 #endif
 
   /**
+   * Don't hide Edge::key(side) defined in the base class.
+   */
+  using Edge::key;
+
+  /**
    * @returns an id associated with the global node ids of this
    * element.  The id is not necessariy unique, but should be
    * close.

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -144,6 +144,12 @@ public:
 
 #endif
 
+  /**
+   * @returns an id associated with the global node ids of this
+   * element.  The id is not necessariy unique, but should be
+   * close.
+   */
+  virtual dof_id_type key () const libmesh_override;
 
 protected:
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -206,6 +206,14 @@ public:
   virtual dof_id_type key (const unsigned int s) const = 0;
 
   /**
+   * @returns an id associated with the global node ids of this
+   * element.  The id is not necessariy unique, but should be
+   * close. Uses the same hash as the key(s) function, so for example
+   * if "tri3" is side 0 of "tet4", then tri3->key()==tet4->key(0).
+   */
+  virtual dof_id_type key () const;
+
+  /**
    * @returns true if two elements are identical, false otherwise.
    * This is true if the elements are connected to identical global
    * nodes, regardless of how those nodes might be numbered local

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -128,6 +128,13 @@ public:
    */
   virtual Real volume () const libmesh_override;
 
+  /**
+   * @returns an id associated with the global node ids of this
+   * element.  The id is not necessariy unique, but should be
+   * close.
+   */
+  virtual dof_id_type key () const libmesh_override;
+
 protected:
 
   /**

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -129,6 +129,11 @@ public:
   virtual Real volume () const libmesh_override;
 
   /**
+   * Don't hide Quad::key(side) defined in the base class.
+   */
+  using Quad::key;
+
+  /**
    * @returns an id associated with the global node ids of this
    * element.  The id is not necessariy unique, but should be
    * close.

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -144,6 +144,13 @@ public:
    */
   std::pair<Real, Real> min_and_max_angle() const;
 
+  /**
+   * @returns an id associated with the global node ids of this
+   * element.  The id is not necessariy unique, but should be
+   * close.
+   */
+  virtual dof_id_type key () const libmesh_override;
+
 protected:
 
   /**

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -145,6 +145,11 @@ public:
   std::pair<Real, Real> min_and_max_angle() const;
 
   /**
+   * Don't hide Tri::key(side) defined in the base class.
+   */
+  using Tri::key;
+
+  /**
    * @returns an id associated with the global node ids of this
    * element.  The id is not necessariy unique, but should be
    * close.

--- a/include/utils/hashword.h
+++ b/include/utils/hashword.h
@@ -28,6 +28,7 @@
 // http://stackoverflow.com/questions/237370/does-stdsize-t-make-sense-in-c
 #include <stddef.h>
 #include <stdint.h> // uint32_t, uint64_t
+#include <vector>
 
 #include "libmesh_common.h" // libmesh_error_msg()
 
@@ -171,6 +172,14 @@ uint32_t hashword(const uint32_t *k, size_t length, uint32_t initval=0)
 }
 
 
+
+// Calls function above with slightly more convenient std::vector interface.
+inline
+uint32_t hashword(const std::vector<uint32_t> & keys, uint32_t initval=0)
+{
+  return hashword(&keys[0], keys.size(), initval);
+}
+
 // This is a hard-coded version of hashword for hashing exactly 2 numbers
 // \author Bob Jenkins
 // \date May 2006
@@ -215,6 +224,15 @@ inline
 uint64_t hashword(const uint64_t *k, size_t length)
 {
   return fnv_64_buf(k, 8*length);
+}
+
+
+
+// Calls function above with slightly more convenient std::vector interface.
+inline
+uint64_t hashword(const std::vector<uint64_t> & keys)
+{
+  return hashword(&keys[0], keys.size());
 }
 
 // In a personal communication from Bob Jenkins, he recommended using

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -400,6 +400,13 @@ float Tet4::embedding_matrix (const unsigned int i,
 
 
 
+dof_id_type Tet4::key () const
+{
+  return this->compute_key(this->node(0),
+                           this->node(1),
+                           this->node(2),
+                           this->node(3));
+}
 
 
 

--- a/src/geom/edge_edge2.C
+++ b/src/geom/edge_edge2.C
@@ -114,4 +114,12 @@ Real Edge2::volume () const
   return (this->point(1) - this->point(0)).size();
 }
 
+
+
+dof_id_type Edge2::key () const
+{
+  return this->compute_key(this->node(0),
+                           this->node(1));
+}
+
 } // namespace libMesh

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -196,4 +196,14 @@ Real Edge3::volume () const
                            );
 }
 
+
+
+dof_id_type Edge3::key () const
+{
+  return this->compute_key(this->node(0),
+                           this->node(1),
+                           this->node(2));
+}
+
+
 } // namespace libMesh

--- a/src/geom/edge_edge4.C
+++ b/src/geom/edge_edge4.C
@@ -162,4 +162,14 @@ void Edge4::connectivity(const unsigned int sc,
     }
 }
 
+
+
+dof_id_type Edge4::key () const
+{
+  return this->compute_key(this->node(0),
+                           this->node(1),
+                           this->node(2),
+                           this->node(3));
+}
+
 } // namespace libMesh

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -463,6 +463,22 @@ Real Elem::length(const unsigned int n1,
 
 
 
+dof_id_type Elem::key () const
+{
+  std::vector<dof_id_type> node_ids(this->n_nodes());
+
+  for (unsigned n=0; n<this->n_nodes(); n++)
+    node_ids[n] = this->node(n);
+
+  // Always sort, so that different local node numberings hash to the
+  // same value.
+  std::sort (node_ids.begin(), node_ids.end());
+
+  return Utility::hashword(node_ids);
+}
+
+
+
 bool Elem::operator == (const Elem& rhs) const
 {
 

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -276,4 +276,14 @@ Real Quad4::volume () const
     }
 }
 
+
+
+dof_id_type Quad4::key () const
+{
+  return this->compute_key(this->node(0),
+                           this->node(1),
+                           this->node(2),
+                           this->node(3));
+}
+
 } // namespace libMesh

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -227,4 +227,13 @@ std::pair<Real, Real> Tri3::min_and_max_angle() const
                         std::max(theta0, std::max(theta1,theta2)));
 }
 
+
+
+dof_id_type Tri3::key () const
+{
+  return this->compute_key(this->node(0),
+                           this->node(1),
+                           this->node(2));
+}
+
 } // namespace libMesh


### PR DESCRIPTION
This PR adds the ability to generate a "key" for an element, which is based on its global node ids, in a similar manner to the way you could get a key for an element's sides.  This is then used to refactor and simplify the GmshIO class, which uses these keys to set boundary information in libmesh.