### PR TITLE
(not quite) fix std::string non-blocking send/receive

### DIFF
--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -2402,13 +2402,13 @@ inline void Communicator::receive (const unsigned int src_processor_id,
   req.add_post_wait_work
     (new Parallel::PostWaitCopyBuffer<std::vector<T>,
      std::back_insert_iterator<std::basic_string<T> > >
-     (tempbuf, std::back_inserter(buf)));
+     (*tempbuf, std::back_inserter(buf)));
 
   // Make the Request::wait() then handle deleting the buffer
   req.add_post_wait_work
     (new Parallel::PostWaitDeleteBuffer<std::vector<T> >(tempbuf));
 
-  this->receive(src_processor_id, tempbuf, req, tag);
+  this->receive(src_processor_id, *tempbuf, req, tag);
 }
 
 

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -25,6 +25,7 @@ public:
   CPPUNIT_TEST( testIsendRecv );
   CPPUNIT_TEST( testIrecvSend );
   CPPUNIT_TEST( testSemiVerify );
+  CPPUNIT_TEST( testDerek );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -225,7 +226,7 @@ public:
     if (TestCommWorld->size() > 1)
       {
         // Default communication
-        TestCommWorld->send_mode(Parallel::Communicator::DEFAULT);
+//        TestCommWorld->send_mode(Parallel::Communicator::DEFAULT);
 
         TestCommWorld->receive (procdown,
                                 recv_val,
@@ -242,7 +243,7 @@ public:
           CPPUNIT_ASSERT_EQUAL( src_val[i] , recv_val[i] );
 
         // Synchronous communication
-        TestCommWorld->send_mode(Parallel::Communicator::SYNCHRONOUS);
+//       TestCommWorld->send_mode(Parallel::Communicator::SYNCHRONOUS);
         std::fill (recv_val.begin(), recv_val.end(), 0);
 
 
@@ -261,11 +262,36 @@ public:
           CPPUNIT_ASSERT_EQUAL( src_val[i] , recv_val[i] );
 
         // Restore default communication
-        TestCommWorld->send_mode(Parallel::Communicator::DEFAULT);
+//        TestCommWorld->send_mode(Parallel::Communicator::DEFAULT);
       }
   }
 
 
+  void testDerek ()
+  {
+    if (TestCommWorld->rank() == 0)
+    {
+      std::vector<int> vector_data;
+      vector_data.push_back(4);
+
+      Parallel::Request request;
+      TestCommWorld->send(1, vector_data, request);
+      request.wait();
+    }
+
+    if (TestCommWorld->rank() == 1)
+    {
+      Parallel::Request request;
+      std::vector<int> vector_data;
+      TestCommWorld->receive(0, vector_data, request);
+      request.wait();
+
+      std::cerr<<"vector_data.size(): "<<vector_data.size()<<std::endl;
+
+      CPPUNIT_ASSERT_EQUAL((int)vector_data.size(), 1);
+      CPPUNIT_ASSERT_EQUAL(vector_data[0], 4);
+    }
+  }
 
   void testSemiVerify ()
   {


### PR DESCRIPTION
It looks like no one has actually tried to use a non-blocking receive of a `std::string` yet... because it doesn't compile.

This change gets it to compile: BUT IT DOES NOT WORK!

I cannot at all see why the hell not though.  I can see that the `PostWaitCopyBuffer` is getting called after `Request::wait()` is called by my code... but the buffer to copy is simply of size 0.  So, the code doesn't crash or hang or anything... it's just that nothing comes through.

If I change line 2411 there to a _blocking_ receive then this code works: the right data comes through.  (similarly, just calling the blocking form of `receive()` directly with a `std::string` works fine).

@roystgnr could I get a little help here?