### PR TITLE
Avoid clear() in DiffSystem class destructors

### DIFF
--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -78,12 +78,6 @@ public:
   typedef DifferentiableSystem Parent;
 
   /**
-   * Clear all the data structures associated with
-   * the system.
-   */
-  virtual void clear () libmesh_override;
-
-  /**
    * Prepares \p matrix or \p rhs for matrix assembly.
    * Users may reimplement this to add pre- or post-assembly
    * code before or after calling FEMSystem::assembly()

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -50,7 +50,13 @@ DifferentiableSystem::DifferentiableSystem
 
 DifferentiableSystem::~DifferentiableSystem ()
 {
-  this->clear();
+  // If we had an attached Physics object, delete it.
+  if (this->_diff_physics != this)
+    delete this->_diff_physics;
+
+  // If we had an attached QoI object, delete it.
+  if (this->diff_qoi != this)
+    delete this->diff_qoi;
 }
 
 

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -830,14 +830,6 @@ FEMSystem::FEMSystem (EquationSystems& es,
 
 FEMSystem::~FEMSystem ()
 {
-  this->clear();
-}
-
-
-
-void FEMSystem::clear()
-{
-  Parent::clear();
 }
 
 


### PR DESCRIPTION
The previous code doesn't do what it might be expected to do.  Since
the methods called by clear are virtual, and any subclasses have been
partially-destructed down to the base class at this point, and the
base class implementations of physics and qoi clearing are no-ops,
calling those functions does nothing.  If clearing of subclass data
needs to be done then it needs to be done in the subclasses'
destructor.

On Intel 16 in opt mode, those virtual function calls give me a
segfault, which I'm pretty sure is a compiler bug, but since fixing my
stupid code also avoids the segfault I'm not complaining too hard.