### PR TITLE
Add configure tests for unordered_multiset variants

### DIFF
--- a/configure
+++ b/configure
@@ -27993,6 +27993,336 @@ fi
 
 
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports std::unordered_multiset" >&5
+$as_echo_n "checking whether the compiler supports std::unordered_multiset... " >&6; }
+if ${ac_cv_cxx_unordered_multiset+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <unordered_set>
+int
+main ()
+{
+
+  std::unordered_multiset<int> s;
+  s.insert(1);
+  s.insert(1);
+  if (s.size() != 2) return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_cv_cxx_unordered_multiset=yes
+else
+  ac_cv_cxx_unordered_multiset=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_unordered_multiset" >&5
+$as_echo "$ac_cv_cxx_unordered_multiset" >&6; }
+if test "$ac_cv_cxx_unordered_multiset" = yes; then
+
+$as_echo "#define HAVE_STD_UNORDERED_MULTISET 1" >>confdefs.h
+
+
+$as_echo "#define BEST_UNORDERED_MULTISET std::unordered_multiset" >>confdefs.h
+
+
+$as_echo "#define INCLUDE_UNORDERED_MULTISET <unordered_set>" >>confdefs.h
+
+  if test "$ac_cv_cxx_hash_specializations" != yes; then
+
+$as_echo "#define DEFINE_HASH_STRING /**/" >>confdefs.h
+
+
+$as_echo "#define DEFINE_HASH_POINTERS /**/" >>confdefs.h
+
+  fi
+
+else
+  false
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports std::tr1::unordered_multiset" >&5
+$as_echo_n "checking whether the compiler supports std::tr1::unordered_multiset... " >&6; }
+if ${ac_cv_cxx_tr1_unordered_multiset+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <tr1/unordered_set>
+int
+main ()
+{
+
+  std::tr1::unordered_multiset<int> s;
+  s.insert(1);
+  s.insert(1);
+  if (s.size() != 2) return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_cv_cxx_tr1_unordered_multiset=yes
+else
+  ac_cv_cxx_tr1_unordered_multiset=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_tr1_unordered_multiset" >&5
+$as_echo "$ac_cv_cxx_tr1_unordered_multiset" >&6; }
+if test "$ac_cv_cxx_tr1_unordered_multiset" = yes; then
+
+$as_echo "#define HAVE_TR1_UNORDERED_MULTISET 1" >>confdefs.h
+
+
+$as_echo "#define BEST_UNORDERED_MULTISET std::tr1::unordered_multiset" >>confdefs.h
+
+
+$as_echo "#define INCLUDE_UNORDERED_MULTISET <tr1/unordered_set>" >>confdefs.h
+
+  if test "$ac_cv_cxx_hash_specializations" != yes; then
+
+$as_echo "#define DEFINE_HASH_STRING /**/" >>confdefs.h
+
+
+$as_echo "#define DEFINE_HASH_POINTERS /**/" >>confdefs.h
+
+  fi
+
+else
+  false
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports __gnu_cxx::hash_multiset" >&5
+$as_echo_n "checking whether the compiler supports __gnu_cxx::hash_multiset... " >&6; }
+if ${ac_cv_cxx_ext_hash_multiset+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <ext/hash_set>
+int
+main ()
+{
+
+  __gnu_cxx::hash_multiset<int> s;
+  s.insert(1);
+  s.insert(1);
+  if (s.size() != 2) return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_cv_cxx_ext_hash_multiset=yes
+else
+  ac_cv_cxx_ext_hash_multiset=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_ext_hash_multiset" >&5
+$as_echo "$ac_cv_cxx_ext_hash_multiset" >&6; }
+if test "$ac_cv_cxx_ext_hash_multiset" = yes; then
+
+$as_echo "#define HAVE_EXT_HASH_MULTISET 1" >>confdefs.h
+
+
+$as_echo "#define BEST_UNORDERED_MULTISET __gnu_cxx::hash_multiset" >>confdefs.h
+
+
+$as_echo "#define INCLUDE_UNORDERED_MULTISET <ext/hash_set>" >>confdefs.h
+
+
+$as_echo "#define DEFINE_HASH_STRING namespace __gnu_cxx {template<> struct hash<std::string>{size_t operator()(const std::string& s)const{return hash<const char*>()(s.c_str());}};}" >>confdefs.h
+
+
+$as_echo "#define DEFINE_HASH_POINTERS namespace __gnu_cxx {template<typename T> struct hash<T*>{size_t operator()(const T* p)const{return hash<size_t>()(reinterpret_cast<size_t>(p));}};}" >>confdefs.h
+
+  ac_cv_cxx_hash_specializations=yes
+
+else
+  false
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports std::hash_multiset" >&5
+$as_echo_n "checking whether the compiler supports std::hash_multiset... " >&6; }
+if ${ac_cv_cxx_hash_multiset+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <hash_set>
+int
+main ()
+{
+
+  std::hash_multiset<int> s;
+  s.insert(1);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_cv_cxx_hash_multiset=yes
+else
+  ac_cv_cxx_hash_multiset=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_hash_multiset" >&5
+$as_echo "$ac_cv_cxx_hash_multiset" >&6; }
+if test "$ac_cv_cxx_hash_multiset" = yes; then
+
+$as_echo "#define HAVE_HASH_MULTISET 1" >>confdefs.h
+
+
+$as_echo "#define BEST_UNORDERED_MULTISET std::hash_multiset" >>confdefs.h
+
+
+$as_echo "#define INCLUDE_UNORDERED_MULTISET <hash_set>" >>confdefs.h
+
+  if test "$ac_cv_cxx_hash_specializations" != yes; then
+
+$as_echo "#define DEFINE_HASH_STRING /**/" >>confdefs.h
+
+
+$as_echo "#define DEFINE_HASH_POINTERS /**/" >>confdefs.h
+
+  fi
+
+else
+  false
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports std::multiset" >&5
+$as_echo_n "checking whether the compiler supports std::multiset... " >&6; }
+if ${ac_cv_cxx_multiset+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <set>
+int
+main ()
+{
+
+  std::multiset<int, int> s;
+  m.insert(1);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_cv_cxx_multiset=yes
+else
+  ac_cv_cxx_multiset=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_multiset" >&5
+$as_echo "$ac_cv_cxx_multiset" >&6; }
+if test "$ac_cv_cxx_multiset" = yes; then
+
+$as_echo "#define BEST_UNORDERED_MULTISET std::multiset" >>confdefs.h
+
+
+$as_echo "#define INCLUDE_UNORDERED_MULTISET <set>" >>confdefs.h
+
+  if test "$ac_cv_cxx_hash_specializations" != yes; then
+
+$as_echo "#define DEFINE_HASH_STRING /**/" >>confdefs.h
+
+
+$as_echo "#define DEFINE_HASH_POINTERS /**/" >>confdefs.h
+
+  fi
+
+else
+  false
+
+fi
+
+fi
+
+fi
+
+fi
+
+fi
+
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports std::unordered_set" >&5
 $as_echo_n "checking whether the compiler supports std::unordered_set... " >&6; }
 if ${ac_cv_cxx_unordered_set+:} false; then :
@@ -28492,6 +28822,69 @@ $as_echo "#define BEST_UNORDERED_SET std::set" >>confdefs.h
 
 
 $as_echo "#define INCLUDE_UNORDERED_SET <set>" >>confdefs.h
+
+  if test "$ac_cv_cxx_hash_specializations" != yes; then
+
+$as_echo "#define DEFINE_HASH_STRING /**/" >>confdefs.h
+
+
+$as_echo "#define DEFINE_HASH_POINTERS /**/" >>confdefs.h
+
+  fi
+
+else
+  false
+
+fi
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports std::multiset" >&5
+$as_echo_n "checking whether the compiler supports std::multiset... " >&6; }
+if ${ac_cv_cxx_multiset+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <set>
+int
+main ()
+{
+
+  std::multiset<int, int> s;
+  m.insert(1);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_cv_cxx_multiset=yes
+else
+  ac_cv_cxx_multiset=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_multiset" >&5
+$as_echo "$ac_cv_cxx_multiset" >&6; }
+if test "$ac_cv_cxx_multiset" = yes; then
+
+$as_echo "#define BEST_UNORDERED_MULTISET std::multiset" >>confdefs.h
+
+
+$as_echo "#define INCLUDE_UNORDERED_MULTISET <set>" >>confdefs.h
 
   if test "$ac_cv_cxx_hash_specializations" != yes; then
 

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -632,6 +632,7 @@ include_HEADERS = \
         geom/edge_inf_edge2.h \
         geom/elem.h \
         geom/elem_cutter.h \
+        geom/elem_hash.h \
         geom/elem_quality.h \
         geom/elem_range.h \
         geom/elem_type.h \

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1381,39 +1381,6 @@ protected:
 };
 
 
-// This struct defines functions used for the "Hash" and "Pred" template arguments
-// of the various "unordered" containers, e.g.
-// template <class Key,                         // unordered_multiset::key_type/value_type
-//           class Hash = hash<Key>,            // unordered_multiset::hasher
-//           class Pred = equal_to<Key>,        // unordered_multiset::key_equal
-//           class Alloc = allocator<Key>       // unordered_multiset::allocator_type
-//           > class unordered_multiset;
-//
-// You would use this to declare the type of set as e.g.
-// LIBMESH_BEST_UNORDERED_MULTISET<Elem*, ElemHashUtils, ElemHashUtils>
-struct ElemHashUtils
-{
-public:
-  // A custom hash functor that can be used with the "unordered"
-  // container types.  Simply returns elem->key() as the hash.
-  inline
-  std::size_t operator()(const Elem* elem) const
-  {
-    return cast_int<std::size_t>(elem->key());
-  }
-
-  // A binary predicate that takes two arguments of the same type as
-  // the elements and returns a bool.  We need to specify this in
-  // order to use the unordered_multiset, otherwise it just uses
-  // std::equal_to to compare two pointers...
-  inline
-  bool operator()(const Elem * lhs, const Elem * rhs) const
-  {
-    return lhs->key() == rhs->key();
-  }
-};
-
-
 
 // ------------------------------------------------------------
 // global Elem functions

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1380,6 +1380,41 @@ protected:
 #endif
 };
 
+
+// This struct defines functions used for the "Hash" and "Pred" template arguments
+// of the various "unordered" containers, e.g.
+// template <class Key,                         // unordered_multiset::key_type/value_type
+//           class Hash = hash<Key>,            // unordered_multiset::hasher
+//           class Pred = equal_to<Key>,        // unordered_multiset::key_equal
+//           class Alloc = allocator<Key>       // unordered_multiset::allocator_type
+//           > class unordered_multiset;
+//
+// You would use this to declare the type of set as e.g.
+// LIBMESH_BEST_UNORDERED_MULTISET<Elem*, ElemHashUtils, ElemHashUtils>
+struct ElemHashUtils
+{
+public:
+  // A custom hash functor that can be used with the "unordered"
+  // container types.  Simply returns elem->key() as the hash.
+  inline
+  std::size_t operator()(const Elem* elem) const
+  {
+    return cast_int<std::size_t>(elem->key());
+  }
+
+  // A binary predicate that takes two arguments of the same type as
+  // the elements and returns a bool.  We need to specify this in
+  // order to use the unordered_multiset, otherwise it just uses
+  // std::equal_to to compare two pointers...
+  inline
+  bool operator()(const Elem * lhs, const Elem * rhs) const
+  {
+    return lhs->key() == rhs->key();
+  }
+};
+
+
+
 // ------------------------------------------------------------
 // global Elem functions
 

--- a/include/geom/elem_hash.h
+++ b/include/geom/elem_hash.h
@@ -1,0 +1,67 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2015 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_ELEM_HASH_H
+#define LIBMESH_ELEM_HASH_H
+
+#include "elem.h"
+#include LIBMESH_INCLUDE_UNORDERED_MAP
+#include LIBMESH_INCLUDE_UNORDERED_SET
+
+// This header defines some typedefs that are useful for working with
+// "unordered" containers of Elem* that use Elem::key() as a hash
+// function.
+namespace libMesh
+{
+
+// The ElemHashUtils struct defines functions used for the "Hash" and
+// "Pred" template arguments of the various "unordered" containers,
+// e.g.
+// template <class Key,                         // unordered_multiset::key_type/value_type
+//           class Hash = hash<Key>,            // unordered_multiset::hasher
+//           class Pred = equal_to<Key>,        // unordered_multiset::key_equal
+//           class Alloc = allocator<Key>       // unordered_multiset::allocator_type
+//           > class unordered_multiset;
+struct ElemHashUtils
+{
+public:
+  // The "Hash" template argument.  A custom hash functor that can be
+  // used with the "unordered" container types.  Simply returns
+  // elem->key() as the hash.
+  inline
+  std::size_t operator()(const Elem* elem) const
+  {
+    return cast_int<std::size_t>(elem->key());
+  }
+
+  // The "Pred" template argument.  A binary predicate that takes two
+  // arguments of the same type as the elements and returns a bool.
+  // We need to specify this in order to use the unordered_multiset,
+  // otherwise it just uses std::equal_to to compare two pointers...
+  inline
+  bool operator()(const Elem * lhs, const Elem * rhs) const
+  {
+    return lhs->key() == rhs->key();
+  }
+};
+
+// A convenient type for working with unordered_multiset<Elem*>
+typedef LIBMESH_BEST_UNORDERED_MULTISET<Elem*, ElemHashUtils, ElemHashUtils> unordered_multiset_elem;
+
+}
+
+#endif

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -126,6 +126,7 @@ include_HEADERS =  \
         geom/edge_inf_edge2.h \
         geom/elem.h \
         geom/elem_cutter.h \
+        geom/elem_hash.h \
         geom/elem_quality.h \
         geom/elem_range.h \
         geom/elem_type.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -115,6 +115,7 @@ BUILT_SOURCES = \
         edge_inf_edge2.h \
         elem.h \
         elem_cutter.h \
+        elem_hash.h \
         elem_quality.h \
         elem_range.h \
         elem_type.h \
@@ -847,6 +848,9 @@ elem.h: $(top_srcdir)/include/geom/elem.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 elem_cutter.h: $(top_srcdir)/include/geom/elem_cutter.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+elem_hash.h: $(top_srcdir)/include/geom/elem_hash.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 elem_quality.h: $(top_srcdir)/include/geom/elem_quality.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -481,33 +481,34 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	cell_prism6.h cell_pyramid.h cell_pyramid13.h cell_pyramid14.h \
 	cell_pyramid5.h cell_tet.h cell_tet10.h cell_tet4.h edge.h \
 	edge_edge2.h edge_edge3.h edge_edge4.h edge_inf_edge2.h elem.h \
-	elem_cutter.h elem_quality.h elem_range.h elem_type.h face.h \
-	face_inf_quad.h face_inf_quad4.h face_inf_quad6.h face_quad.h \
-	face_quad4.h face_quad8.h face_quad9.h face_tri.h face_tri3.h \
-	face_tri3_subdivision.h face_tri6.h node.h node_elem.h \
-	node_range.h plane.h point.h reference_elem.h remote_elem.h \
-	side.h sphere.h stored_range.h surface.h abaqus_io.h \
-	boundary_info.h boundary_mesh.h checkpoint_io.h diva_io.h \
-	ensight_io.h exodusII_io.h exodusII_io_helper.h fro_io.h \
-	gmsh_io.h gmv_io.h gnuplot_io.h inf_elem_builder.h \
-	legacy_xdr_io.h matlab_io.h medit_io.h mesh.h mesh_base.h \
-	mesh_communication.h mesh_data.h mesh_function.h \
-	mesh_generation.h mesh_input.h mesh_inserter_iterator.h \
-	mesh_modification.h mesh_output.h mesh_refinement.h \
-	mesh_serializer.h mesh_smoother.h mesh_smoother_laplace.h \
-	mesh_smoother_vsmoother.h mesh_subdivision_support.h \
-	mesh_tetgen_interface.h mesh_tetgen_wrapper.h mesh_tools.h \
-	mesh_triangle_holes.h mesh_triangle_interface.h \
-	mesh_triangle_wrapper.h namebased_io.h nemesis_io.h \
-	nemesis_io_helper.h off_io.h parallel_mesh.h patch.h \
-	postscript_io.h serial_mesh.h tecplot_io.h tetgen_io.h \
-	ucd_io.h unstructured_mesh.h unv_io.h vtk_io.h xdr_head.h \
-	xdr_io.h xdr_mesh.h xdr_mgf.h xdr_mhead.h xdr_shead.h \
-	xdr_soln.h analytic_function.h composite_fem_function.h \
-	composite_function.h const_fem_function.h const_function.h \
-	coupling_matrix.h dense_matrix.h dense_matrix_base.h \
-	dense_submatrix.h dense_subvector.h dense_vector.h \
-	dense_vector_base.h distributed_vector.h eigen_core_support.h \
+	elem_cutter.h elem_hash.h elem_quality.h elem_range.h \
+	elem_type.h face.h face_inf_quad.h face_inf_quad4.h \
+	face_inf_quad6.h face_quad.h face_quad4.h face_quad8.h \
+	face_quad9.h face_tri.h face_tri3.h face_tri3_subdivision.h \
+	face_tri6.h node.h node_elem.h node_range.h plane.h point.h \
+	reference_elem.h remote_elem.h side.h sphere.h stored_range.h \
+	surface.h abaqus_io.h boundary_info.h boundary_mesh.h \
+	checkpoint_io.h diva_io.h ensight_io.h exodusII_io.h \
+	exodusII_io_helper.h fro_io.h gmsh_io.h gmv_io.h gnuplot_io.h \
+	inf_elem_builder.h legacy_xdr_io.h matlab_io.h medit_io.h \
+	mesh.h mesh_base.h mesh_communication.h mesh_data.h \
+	mesh_function.h mesh_generation.h mesh_input.h \
+	mesh_inserter_iterator.h mesh_modification.h mesh_output.h \
+	mesh_refinement.h mesh_serializer.h mesh_smoother.h \
+	mesh_smoother_laplace.h mesh_smoother_vsmoother.h \
+	mesh_subdivision_support.h mesh_tetgen_interface.h \
+	mesh_tetgen_wrapper.h mesh_tools.h mesh_triangle_holes.h \
+	mesh_triangle_interface.h mesh_triangle_wrapper.h \
+	namebased_io.h nemesis_io.h nemesis_io_helper.h off_io.h \
+	parallel_mesh.h patch.h postscript_io.h serial_mesh.h \
+	tecplot_io.h tetgen_io.h ucd_io.h unstructured_mesh.h unv_io.h \
+	vtk_io.h xdr_head.h xdr_io.h xdr_mesh.h xdr_mgf.h xdr_mhead.h \
+	xdr_shead.h xdr_soln.h analytic_function.h \
+	composite_fem_function.h composite_function.h \
+	const_fem_function.h const_function.h coupling_matrix.h \
+	dense_matrix.h dense_matrix_base.h dense_submatrix.h \
+	dense_subvector.h dense_vector.h dense_vector_base.h \
+	distributed_vector.h eigen_core_support.h \
 	eigen_preconditioner.h eigen_sparse_matrix.h \
 	eigen_sparse_vector.h fem_function_base.h function_base.h \
 	laspack_matrix.h laspack_vector.h numeric_vector.h \
@@ -1154,6 +1155,9 @@ elem.h: $(top_srcdir)/include/geom/elem.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 elem_cutter.h: $(top_srcdir)/include/geom/elem_cutter.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+elem_hash.h: $(top_srcdir)/include/geom/elem_hash.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 elem_quality.h: $(top_srcdir)/include/geom/elem_quality.h

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -9,6 +9,9 @@
 /* definition of the final detected unordered_multimap type */
 #undef BEST_UNORDERED_MULTIMAP
 
+/* definition of the final detected unordered_multiset type */
+#undef BEST_UNORDERED_MULTISET
+
 /* definition of the final detected unordered_set type */
 #undef BEST_UNORDERED_SET
 
@@ -249,6 +252,9 @@
 /* define if the compiler supports __gnu_cxx::hash_multimap */
 #undef HAVE_EXT_HASH_MULTIMAP
 
+/* define if the compiler supports __gnu_cxx::hash_multiset */
+#undef HAVE_EXT_HASH_MULTISET
+
 /* define if the compiler supports __gnu_cxx::hash_set */
 #undef HAVE_EXT_HASH_SET
 
@@ -298,6 +304,9 @@
 
 /* define if the compiler supports std::hash_multimap */
 #undef HAVE_HASH_MULTIMAP
+
+/* define if the compiler supports std::hash_multiset */
+#undef HAVE_HASH_MULTISET
 
 /* define if the compiler supports std::hash_set */
 #undef HAVE_HASH_SET
@@ -411,6 +420,9 @@
 /* define if the compiler supports std::unordered_multimap */
 #undef HAVE_STD_UNORDERED_MULTIMAP
 
+/* define if the compiler supports std::unordered_multiset */
+#undef HAVE_STD_UNORDERED_MULTISET
+
 /* define if the compiler supports std::unordered_set */
 #undef HAVE_STD_UNORDERED_SET
 
@@ -461,6 +473,9 @@
 /* define if the compiler supports std::tr1::unordered_multimap */
 #undef HAVE_TR1_UNORDERED_MULTIMAP
 
+/* define if the compiler supports std::tr1::unordered_multiset */
+#undef HAVE_TR1_UNORDERED_MULTISET
+
 /* define if the compiler supports std::tr1::unordered_set */
 #undef HAVE_TR1_UNORDERED_SET
 
@@ -498,6 +513,9 @@
 
 /* header file for the final detected unordered_multimap type */
 #undef INCLUDE_UNORDERED_MULTIMAP
+
+/* header file for the final detected unordered_multiset type */
+#undef INCLUDE_UNORDERED_MULTISET
 
 /* header file for the final detected unordered_set type */
 #undef INCLUDE_UNORDERED_SET

--- a/m4/libmesh_compiler_features.m4
+++ b/m4/libmesh_compiler_features.m4
@@ -169,11 +169,13 @@ AC_ARG_ENABLE(unordered-containers,
     # various quasi-standard hash containers.
     ACX_BEST_UNORDERED_MULTIMAP
     ACX_BEST_UNORDERED_MAP
+    ACX_BEST_UNORDERED_MULTISET
     ACX_BEST_UNORDERED_SET
   else
     ACX_STD_MAP
     ACX_STD_MULTIMAP
     ACX_STD_SET
+    ACX_STD_MULTISET
   fi
 
 # Determine which of std::hash, std::tr1::hash, or __gnu_cxx::hash is available

--- a/m4/unordered.m4
+++ b/m4/unordered.m4
@@ -80,6 +80,48 @@ fi
 
 dnl ----------------------------------------------------------------------------
 dnl Check to see if the compiler can compile a test program using
+dnl std::tr1::unordered_multiset
+dnl ----------------------------------------------------------------------------
+AC_DEFUN([ACX_TR1_UNORDERED_MULTISET],
+[AC_CACHE_CHECK(whether the compiler supports std::tr1::unordered_multiset,
+ac_cv_cxx_tr1_unordered_multiset,
+[AC_LANG_SAVE
+ AC_LANG_CPLUSPLUS
+ AC_TRY_COMPILE([@%:@include <tr1/unordered_set>],
+[
+  std::tr1::unordered_multiset<int> s;
+  s.insert(1);
+  s.insert(1);
+  if (s.size() != 2) return 1;
+],
+ ac_cv_cxx_tr1_unordered_multiset=yes,
+ ac_cv_cxx_tr1_unordered_multiset=no)
+ AC_LANG_RESTORE
+])
+if test "$ac_cv_cxx_tr1_unordered_multiset" = yes; then
+  AC_DEFINE(HAVE_TR1_UNORDERED_MULTISET,1,
+            [define if the compiler supports std::tr1::unordered_multiset])
+  AC_DEFINE(BEST_UNORDERED_MULTISET,std::tr1::unordered_multiset,
+            [definition of the final detected unordered_multiset type])
+  AC_DEFINE(INCLUDE_UNORDERED_MULTISET,<tr1/unordered_set>,
+            [header file for the final detected unordered_multiset type])
+  if test "$ac_cv_cxx_hash_specializations" != yes; then
+    AC_DEFINE(DEFINE_HASH_STRING,,
+              [workaround for potentially missing hash<string>])
+    AC_DEFINE(DEFINE_HASH_POINTERS,,
+              [workaround for potentially missing hash<T*>])
+  fi
+  [$1]
+else
+  false
+  [$2]
+fi
+])
+
+
+
+dnl ----------------------------------------------------------------------------
+dnl Check to see if the compiler can compile a test program using
 dnl std::tr1::unordered_set
 dnl ----------------------------------------------------------------------------
 AC_DEFUN([ACX_TR1_UNORDERED_SET],
@@ -221,6 +263,48 @@ if test "$ac_cv_cxx_unordered_multimap" = yes; then
             [definition of the final detected unordered_multimap type])
   AC_DEFINE(INCLUDE_UNORDERED_MULTIMAP,<unordered_map>,
             [header file for the final detected unordered_multimap type])
+  if test "$ac_cv_cxx_hash_specializations" != yes; then
+    AC_DEFINE(DEFINE_HASH_STRING,,
+              [workaround for potentially missing hash<string>])
+    AC_DEFINE(DEFINE_HASH_POINTERS,,
+              [workaround for potentially missing hash<T*>])
+  fi
+  [$1]
+else
+  false
+  [$2]
+fi
+])
+
+
+
+dnl ----------------------------------------------------------------------------
+dnl Check to see if the compiler can compile a test program using
+dnl std::unordered_multiset
+dnl ----------------------------------------------------------------------------
+AC_DEFUN([ACX_STD_UNORDERED_MULTISET],
+[AC_CACHE_CHECK(whether the compiler supports std::unordered_multiset,
+ac_cv_cxx_unordered_multiset,
+[AC_LANG_SAVE
+ AC_LANG_CPLUSPLUS
+ AC_TRY_COMPILE([@%:@include <unordered_set>],
+[
+  std::unordered_multiset<int> s;
+  s.insert(1);
+  s.insert(1);
+  if (s.size() != 2) return 1;
+],
+ ac_cv_cxx_unordered_multiset=yes,
+ ac_cv_cxx_unordered_multiset=no)
+ AC_LANG_RESTORE
+])
+if test "$ac_cv_cxx_unordered_multiset" = yes; then
+  AC_DEFINE(HAVE_STD_UNORDERED_MULTISET,1,
+            [define if the compiler supports std::unordered_multiset])
+  AC_DEFINE(BEST_UNORDERED_MULTISET,std::unordered_multiset,
+            [definition of the final detected unordered_multiset type])
+  AC_DEFINE(INCLUDE_UNORDERED_MULTISET,<unordered_set>,
+            [header file for the final detected unordered_multiset type])
   if test "$ac_cv_cxx_hash_specializations" != yes; then
     AC_DEFINE(DEFINE_HASH_STRING,,
               [workaround for potentially missing hash<string>])
@@ -396,6 +480,47 @@ fi
 
 dnl ----------------------------------------------------------------------------
 dnl Check to see if the compiler can compile a test program using
+dnl __gnu_cxx::hash_multiset
+dnl ----------------------------------------------------------------------------
+AC_DEFUN([ACX_EXT_HASH_MULTISET],
+[AC_CACHE_CHECK(whether the compiler supports __gnu_cxx::hash_multiset,
+ac_cv_cxx_ext_hash_multiset,
+[AC_LANG_SAVE
+ AC_LANG_CPLUSPLUS
+ AC_TRY_COMPILE([@%:@include <ext/hash_set>],
+[
+  __gnu_cxx::hash_multiset<int> s;
+  s.insert(1);
+  s.insert(1);
+  if (s.size() != 2) return 1;
+],
+ ac_cv_cxx_ext_hash_multiset=yes,
+ ac_cv_cxx_ext_hash_multiset=no)
+ AC_LANG_RESTORE
+])
+if test "$ac_cv_cxx_ext_hash_multiset" = yes; then
+  AC_DEFINE(HAVE_EXT_HASH_MULTISET,1,
+            [define if the compiler supports __gnu_cxx::hash_multiset])
+  AC_DEFINE(BEST_UNORDERED_MULTISET,__gnu_cxx::hash_multiset,
+            [definition of the final detected unordered_multiset type])
+  AC_DEFINE(INCLUDE_UNORDERED_MULTISET,<ext/hash_set>,
+            [header file for the final detected unordered_multiset type])
+  AC_DEFINE(DEFINE_HASH_STRING,[namespace __gnu_cxx {template<> struct hash<std::string>{size_t operator()(const std::string& s)const{return hash<const char*>()(s.c_str());}};}],
+            [workaround for potentially missing hash<string>])
+  AC_DEFINE(DEFINE_HASH_POINTERS,[namespace __gnu_cxx {template<typename T> struct hash<T*>{size_t operator()(const T* p)const{return hash<size_t>()(reinterpret_cast<size_t>(p));}};}],
+            [workaround for potentially missing hash<T*>])
+  ac_cv_cxx_hash_specializations=yes
+  [$1]
+else
+  false
+  [$2]
+fi
+])
+
+
+
+dnl ----------------------------------------------------------------------------
+dnl Check to see if the compiler can compile a test program using
 dnl __gnu_cxx::hash_set
 dnl ----------------------------------------------------------------------------
 AC_DEFUN([ACX_EXT_HASH_SET],
@@ -549,6 +674,46 @@ fi
 
 
 dnl ----------------------------------------------------------------------------
+dnl Check to see if the compiler can compile a test program using
+dnl std::hash_multiset (This is unlikely...)
+dnl ----------------------------------------------------------------------------
+AC_DEFUN([ACX_HASH_MULTISET],
+[AC_CACHE_CHECK(whether the compiler supports std::hash_multiset,
+ac_cv_cxx_hash_multiset,
+[AC_LANG_SAVE
+ AC_LANG_CPLUSPLUS
+ AC_TRY_COMPILE([@%:@include <hash_set>],
+[
+  std::hash_multiset<int> s;
+  s.insert(1);
+],
+ ac_cv_cxx_hash_multiset=yes,
+ ac_cv_cxx_hash_multiset=no)
+ AC_LANG_RESTORE
+])
+if test "$ac_cv_cxx_hash_multiset" = yes; then
+  AC_DEFINE(HAVE_HASH_MULTISET,1,
+            [define if the compiler supports std::hash_multiset])
+  AC_DEFINE(BEST_UNORDERED_MULTISET,std::hash_multiset,
+            [definition of the final detected unordered_multiset type])
+  AC_DEFINE(INCLUDE_UNORDERED_MULTISET,<hash_set>,
+            [header file for the final detected unordered_multiset type])
+  if test "$ac_cv_cxx_hash_specializations" != yes; then
+    AC_DEFINE(DEFINE_HASH_STRING,,
+              [workaround for potentially missing hash<string>])
+    AC_DEFINE(DEFINE_HASH_POINTERS,,
+              [workaround for potentially missing hash<T*>])
+  fi
+  [$1]
+else
+  false
+  [$2]
+fi
+])
+
+
+
+dnl ----------------------------------------------------------------------------
 dnl Make sure the compiler can compile a test program using
 dnl std::set as a "fall-back" unordered_set
 dnl ----------------------------------------------------------------------------
@@ -660,6 +825,43 @@ fi
 
 dnl ----------------------------------------------------------------------------
 dnl Check to see if the compiler can compile a test program using
+dnl std::multiset as a "fall-back" unordered_multiset
+dnl ----------------------------------------------------------------------------
+AC_DEFUN([ACX_STD_MULTISET],
+[AC_CACHE_CHECK(whether the compiler supports std::multiset,
+ac_cv_cxx_multiset,
+[AC_LANG_SAVE
+ AC_LANG_CPLUSPLUS
+ AC_TRY_COMPILE([@%:@include <set>],
+[
+  std::multiset<int, int> s;
+  m.insert(1);
+],
+ ac_cv_cxx_multiset=yes, ac_cv_cxx_multiset=no)
+ AC_LANG_RESTORE
+])
+if test "$ac_cv_cxx_multiset" = yes; then
+  AC_DEFINE(BEST_UNORDERED_MULTISET,std::multiset,
+            [definition of the final detected unordered_multiset type])
+  AC_DEFINE(INCLUDE_UNORDERED_MULTISET,<set>,
+            [header file for the final detected unordered_multiset type])
+  if test "$ac_cv_cxx_hash_specializations" != yes; then
+    AC_DEFINE(DEFINE_HASH_STRING,,
+              [workaround for potentially missing hash<string>])
+    AC_DEFINE(DEFINE_HASH_POINTERS,,
+              [workaround for potentially missing hash<T*>])
+  fi
+  [$1]
+else
+  false
+  [$2]
+fi
+])
+
+
+
+dnl ----------------------------------------------------------------------------
+dnl Check to see if the compiler can compile a test program using
 dnl std::hash_set (This is unlikely...)
 dnl ----------------------------------------------------------------------------
 AC_DEFUN([ACX_HASH_SET],
@@ -735,6 +937,20 @@ ACX_TR1_UNORDERED_SET([],
 ACX_EXT_HASH_SET([],
 ACX_HASH_SET([],
 ACX_STD_SET([],[])))))
+])
+
+
+
+dnl ----------------------------------------------------------------------------
+dnl Choose the best unordered_multiset implementation available
+dnl ----------------------------------------------------------------------------
+AC_DEFUN([ACX_BEST_UNORDERED_MULTISET],
+[
+ACX_STD_UNORDERED_MULTISET([],
+ACX_TR1_UNORDERED_MULTISET([],
+ACX_EXT_HASH_MULTISET([],
+ACX_HASH_MULTISET([],
+ACX_STD_MULTISET([],[])))))
 ])
 
 

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -28,6 +28,7 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/utility.h"
+#include LIBMESH_INCLUDE_UNORDERED_MAP
 
 // Anonymous namespace to hold mapping Data for Abaqus/libMesh element types
 namespace
@@ -953,8 +954,8 @@ void AbaqusIO::assign_sideset_ids()
     // because the lower-dimensional elements can belong to more than
     // 1 sideset, and multiple lower-dimensional elements can hash to
     // the same value, but this is very rare.
-    typedef std::multimap<dof_id_type,
-                          std::pair<Elem*, boundary_id_type> > provide_bcs_t;
+    typedef LIBMESH_BEST_UNORDERED_MULTIMAP<dof_id_type,
+                                            std::pair<Elem*, boundary_id_type> > provide_bcs_t;
     provide_bcs_t provide_bcs;
 
     // The elemset_id counter assigns a logical numbering to the

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -33,6 +33,7 @@
 #include "libmesh/cell_hex20.h"
 #include "libmesh/cell_tet10.h"
 #include "libmesh/cell_prism6.h"
+#include "libmesh/elem_hash.h"
 
 // C++ includes
 #include <iomanip>
@@ -40,7 +41,6 @@
 #include <fstream>
 #include <ctype.h> // isspace
 #include <sstream> // std::istringstream
-#include LIBMESH_INCLUDE_UNORDERED_MULTISET
 
 #ifdef LIBMESH_HAVE_GZSTREAM
 # include "gzstream.h" // For reading/writing compressed streams
@@ -431,8 +431,7 @@ void UNVIO::groups_in (std::istream& in_file)
   // conditions.  We need to use a multiset and check the result when
   // searching because the hash function (while good) can't be
   // guaranteed to be perfect.
-  typedef LIBMESH_BEST_UNORDERED_MULTISET<Elem*, ElemHashUtils, ElemHashUtils> provide_bcs_t;
-  provide_bcs_t provide_bcs;
+  unordered_multiset_elem provide_bcs;
 
   // Read groups until there aren't any more to read...
   while (true)
@@ -582,12 +581,12 @@ void UNVIO::groups_in (std::istream& in_file)
                 UniquePtr<Elem> side (elem->build_side(sn));
 
                 // Look for this key in the provide_bcs map
-                std::pair<provide_bcs_t::const_iterator,
-                          provide_bcs_t::const_iterator>
+                std::pair<unordered_multiset_elem::const_iterator,
+                          unordered_multiset_elem::const_iterator>
                   range = provide_bcs.equal_range (side.get());
 
                 // Add boundary information for each side in the range.
-                for (provide_bcs_t::const_iterator iter = range.first;
+                for (unordered_multiset_elem::const_iterator iter = range.first;
                      iter != range.second; ++iter)
                   {
                     // Get a pointer to the lower-dimensional element


### PR DESCRIPTION
I initially thought I would use these in some of the IO classes (and therefore added some useful stuff in the new elem_hash.h header), but it turned out that `unordered_multimap` was faster for what I was doing.  I think `unordered_multiset<Elem*>` could be useful for other things in the future, though, so I left it in.