### PR TITLE
Refactor Elem::key(), side() implementations

### DIFF
--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -89,60 +89,8 @@ UniquePtr<Elem> Hex::side (const unsigned int i) const
 
   Elem* face = new Quad4;
 
-  // Think of a unit cube: (-1,1) x (-1,1) x (-1,1)
-  switch (i)
-    {
-    case 0:  // the face at z = -1
-      {
-        face->set_node(0) = this->get_node(0);
-        face->set_node(1) = this->get_node(3);
-        face->set_node(2) = this->get_node(2);
-        face->set_node(3) = this->get_node(1);
-        break;
-      }
-    case 1:  // the face at y = -1
-      {
-        face->set_node(0) = this->get_node(0);
-        face->set_node(1) = this->get_node(1);
-        face->set_node(2) = this->get_node(5);
-        face->set_node(3) = this->get_node(4);
-        break;
-      }
-    case 2:  // the face at x = 1
-      {
-        face->set_node(0) = this->get_node(1);
-        face->set_node(1) = this->get_node(2);
-        face->set_node(2) = this->get_node(6);
-        face->set_node(3) = this->get_node(5);
-        break;
-      }
-    case 3: // the face at y = 1
-      {
-        face->set_node(0) = this->get_node(2);
-        face->set_node(1) = this->get_node(3);
-        face->set_node(2) = this->get_node(7);
-        face->set_node(3) = this->get_node(6);
-        break;
-      }
-    case 4: // the face at x = -1
-      {
-        face->set_node(0) = this->get_node(3);
-        face->set_node(1) = this->get_node(0);
-        face->set_node(2) = this->get_node(4);
-        face->set_node(3) = this->get_node(7);
-        break;
-      }
-    case 5: // the face at z = 1
-      {
-        face->set_node(0) = this->get_node(4);
-        face->set_node(1) = this->get_node(5);
-        face->set_node(2) = this->get_node(6);
-        face->set_node(3) = this->get_node(7);
-        break;
-      }
-    default:
-      libmesh_error_msg("Unsupported side i = " << i);
-    }
+  for (unsigned n=0; n<face->n_nodes(); ++n)
+    face->set_node(n) = this->get_node(Hex8::side_nodes_map[i][n]);
 
   return UniquePtr<Elem>(face);
 }

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -75,63 +75,10 @@ dof_id_type Hex::key (const unsigned int s) const
 {
   libmesh_assert_less (s, this->n_sides());
 
-  // Think of a unit cube: (-1,1) x (-1,1)x (-1,1)
-  switch (s)
-    {
-    case 0:  // the face at z = -1
-
-      return
-        this->compute_key (this->node(0),
-                           this->node(3),
-                           this->node(2),
-                           this->node(1));
-
-    case 1:  // the face at y = -1
-
-      return
-        this->compute_key (this->node(0),
-                           this->node(1),
-                           this->node(5),
-                           this->node(4));
-
-    case 2:  // the face at x = 1
-
-      return
-        this->compute_key (this->node(1),
-                           this->node(2),
-                           this->node(6),
-                           this->node(5));
-
-    case 3: // the face at y = 1
-
-      return
-        this->compute_key (this->node(2),
-                           this->node(3),
-                           this->node(7),
-                           this->node(6));
-
-    case 4: // the face at x = -1
-
-      return
-        this->compute_key (this->node(3),
-                           this->node(0),
-                           this->node(4),
-                           this->node(7));
-
-    case 5: // the face at z = 1
-
-      return
-        this->compute_key (this->node(4),
-                           this->node(5),
-                           this->node(6),
-                           this->node(7));
-
-    default:
-      libmesh_error_msg("Invalid s = " << s);
-    }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
+  return this->compute_key(this->node(Hex8::side_nodes_map[s][0]),
+                           this->node(Hex8::side_nodes_map[s][1]),
+                           this->node(Hex8::side_nodes_map[s][2]),
+                           this->node(Hex8::side_nodes_map[s][3]));
 }
 
 

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -96,64 +96,29 @@ UniquePtr<Elem> Prism::side (const unsigned int i) const
 
   Elem* face = NULL;
 
+  // Set up the type of element
   switch (i)
     {
-    case 0:  // the triangular face at z=0
-      {
-        face = new Tri3;
-
-        face->set_node(0) = this->get_node(0);
-        face->set_node(1) = this->get_node(2);
-        face->set_node(2) = this->get_node(1);
-
-        break;
-      }
-    case 1:  // the quad face at y=0
-      {
-        face = new Quad4;
-
-        face->set_node(0) = this->get_node(0);
-        face->set_node(1) = this->get_node(1);
-        face->set_node(2) = this->get_node(4);
-        face->set_node(3) = this->get_node(3);
-
-        break;
-      }
-    case 2:  // the other quad face
-      {
-        face = new Quad4;
-
-        face->set_node(0) = this->get_node(1);
-        face->set_node(1) = this->get_node(2);
-        face->set_node(2) = this->get_node(5);
-        face->set_node(3) = this->get_node(4);
-
-        break;
-      }
-    case 3: // the quad face at x=0
-      {
-        face = new Quad4;
-
-        face->set_node(0) = this->get_node(2);
-        face->set_node(1) = this->get_node(0);
-        face->set_node(2) = this->get_node(3);
-        face->set_node(3) = this->get_node(5);
-
-        break;
-      }
+    case 0: // the triangular face at z=0
     case 4: // the triangular face at z=1
       {
         face = new Tri3;
-
-        face->set_node(0) = this->get_node(3);
-        face->set_node(1) = this->get_node(4);
-        face->set_node(2) = this->get_node(5);
-
+        break;
+      }
+    case 1: // the quad face at y=0
+    case 2: // the other quad face
+    case 3: // the quad face at x=0
+      {
+        face = new Quad4;
         break;
       }
     default:
       libmesh_error_msg("Invalid side i = " << i);
     }
+
+  // Set the nodes
+  for (unsigned n=0; n<face->n_nodes(); ++n)
+    face->set_node(n) = this->get_node(Prism6::side_nodes_map[i][n]);
 
   return UniquePtr<Elem>(face);
 }

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -66,42 +66,19 @@ dof_id_type Prism::key (const unsigned int s) const
 
   switch (s)
     {
-    case 0:  // the triangular face at z=0
-
-      return
-        this->compute_key (this->node(0),
-                           this->node(2),
-                           this->node(1));
-
-    case 1:  // the quad face at y=0
-
-      return
-        this->compute_key (this->node(0),
-                           this->node(1),
-                           this->node(4),
-                           this->node(3));
-
-    case 2:  // the other quad face
-
-      return
-        this->compute_key (this->node(1),
-                           this->node(2),
-                           this->node(5),
-                           this->node(4));
-
-    case 3: // the quad face at x=0
-
-      return
-        this->compute_key (this->node(2),
-                           this->node(0),
-                           this->node(3),
-                           this->node(5));
+    case 0: // the triangular face at z=0
     case 4: // the triangular face at z=1
+      return this->compute_key (this->node(Prism6::side_nodes_map[s][0]),
+                                this->node(Prism6::side_nodes_map[s][1]),
+                                this->node(Prism6::side_nodes_map[s][2]));
 
-      return
-        this->compute_key (this->node(3),
-                           this->node(4),
-                           this->node(5));
+    case 1: // the quad face at y=0
+    case 2: // the other quad face
+    case 3: // the quad face at x=0
+      return this->compute_key (this->node(Prism6::side_nodes_map[s][0]),
+                                this->node(Prism6::side_nodes_map[s][1]),
+                                this->node(Prism6::side_nodes_map[s][2]),
+                                this->node(Prism6::side_nodes_map[s][3]));
 
     default:
       libmesh_error_msg("Invalid side " << s);

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -91,62 +91,29 @@ UniquePtr<Elem> Pyramid::side (const unsigned int i) const
   // To be returned wrapped in an UniquePtr
   Elem* face = NULL;
 
+  // Set up the type of element
   switch (i)
     {
-    case 0:  // triangular face 1
+    case 0: // triangular face 1
+    case 1: // triangular face 2
+    case 2: // triangular face 3
+    case 3: // triangular face 4
       {
         face = new Tri3;
-
-        face->set_node(0) = this->get_node(0);
-        face->set_node(1) = this->get_node(1);
-        face->set_node(2) = this->get_node(4);
-
-        break;
-      }
-    case 1:  // triangular face 2
-      {
-        face = new Tri3;
-
-        face->set_node(0) = this->get_node(1);
-        face->set_node(1) = this->get_node(2);
-        face->set_node(2) = this->get_node(4);
-
-        break;
-      }
-    case 2:  // triangular face 3
-      {
-        face = new Tri3;
-
-        face->set_node(0) = this->get_node(2);
-        face->set_node(1) = this->get_node(3);
-        face->set_node(2) = this->get_node(4);
-
-        break;
-      }
-    case 3:  // triangular face 4
-      {
-        face = new Tri3;
-
-        face->set_node(0) = this->get_node(3);
-        face->set_node(1) = this->get_node(0);
-        face->set_node(2) = this->get_node(4);
-
         break;
       }
     case 4:  // the quad face at z=0
       {
         face = new Quad4;
-
-        face->set_node(0) = this->get_node(0);
-        face->set_node(1) = this->get_node(3);
-        face->set_node(2) = this->get_node(2);
-        face->set_node(3) = this->get_node(1);
-
         break;
       }
     default:
       libmesh_error_msg("Invalid side i = " << i);
     }
+
+  // Set the nodes
+  for (unsigned n=0; n<face->n_nodes(); ++n)
+    face->set_node(n) = this->get_node(Pyramid5::side_nodes_map[i][n]);
 
   return UniquePtr<Elem>(face);
 }

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -60,41 +60,19 @@ dof_id_type Pyramid::key (const unsigned int s) const
 
   switch (s)
     {
-    case 0:  // triangular face 1
-
-      return
-        this->compute_key (this->node(0),
-                           this->node(1),
-                           this->node(4));
-
-    case 1:  // triangular face 2
-
-      return
-        this->compute_key (this->node(1),
-                           this->node(2),
-                           this->node(4));
-
-    case 2:  // triangular face 3
-
-      return
-        this->compute_key (this->node(2),
-                           this->node(3),
-                           this->node(4));
-
-    case 3:  // triangular face 4
-
-      return
-        this->compute_key (this->node(3),
-                           this->node(0),
-                           this->node(4));
+    case 0: // triangular face 1
+    case 1: // triangular face 2
+    case 2: // triangular face 3
+    case 3: // triangular face 4
+      return this->compute_key (this->node(Pyramid5::side_nodes_map[s][0]),
+                                this->node(Pyramid5::side_nodes_map[s][1]),
+                                this->node(Pyramid5::side_nodes_map[s][2]));
 
     case 4:  // the quad face at z=0
-
-      return
-        this->compute_key (this->node(0),
-                           this->node(3),
-                           this->node(2),
-                           this->node(1));
+      return this->compute_key (this->node(Pyramid5::side_nodes_map[s][0]),
+                                this->node(Pyramid5::side_nodes_map[s][1]),
+                                this->node(Pyramid5::side_nodes_map[s][2]),
+                                this->node(Pyramid5::side_nodes_map[s][3]));
 
     default:
       libmesh_error_msg("Invalid side s = " << s);

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -69,39 +69,8 @@ UniquePtr<Elem> Tet::side (const unsigned int i) const
 
   Elem* face = new Tri3;
 
-  switch (i)
-    {
-    case 0:
-      {
-        face->set_node(0) = this->get_node(0);
-        face->set_node(1) = this->get_node(2);
-        face->set_node(2) = this->get_node(1);
-        break;
-      }
-    case 1:
-      {
-        face->set_node(0) = this->get_node(0);
-        face->set_node(1) = this->get_node(1);
-        face->set_node(2) = this->get_node(3);
-        break;
-      }
-    case 2:
-      {
-        face->set_node(0) = this->get_node(1);
-        face->set_node(1) = this->get_node(2);
-        face->set_node(2) = this->get_node(3);
-        break;
-      }
-    case 3:
-      {
-        face->set_node(0) = this->get_node(2);
-        face->set_node(1) = this->get_node(0);
-        face->set_node(2) = this->get_node(3);
-        break;
-      }
-    default:
-      libmesh_error_msg("Invalid side i = " << i);
-    }
+  for (unsigned n=0; n<face->n_nodes(); ++n)
+    face->set_node(n) = this->get_node(Tet4::side_nodes_map[i][n]);
 
   return UniquePtr<Elem>(face);
 }

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -56,38 +56,9 @@ dof_id_type Tet::key (const unsigned int s) const
 {
   libmesh_assert_less (s, this->n_sides());
 
-  switch (s)
-    {
-    case 0:
-      return
-        this->compute_key (this->node(0),
-                           this->node(2),
-                           this->node(1));
-
-    case 1:
-      return
-        this->compute_key (this->node(0),
-                           this->node(1),
-                           this->node(3));
-
-    case 2:
-      return
-        this->compute_key (this->node(1),
-                           this->node(2),
-                           this->node(3));
-
-    case 3:
-      return
-        this->compute_key (this->node(2),
-                           this->node(0),
-                           this->node(3));
-
-    default:
-      libmesh_error_msg("Invalid side s = " << s);
-    }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
+  return this->compute_key(this->node(Tet4::side_nodes_map[s][0]),
+                           this->node(Tet4::side_nodes_map[s][1]),
+                           this->node(Tet4::side_nodes_map[s][2]));
 }
 
 

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -66,35 +66,8 @@ UniquePtr<Elem> Quad::side (const unsigned int i) const
 
   Elem* edge = new Edge2;
 
-  switch (i)
-    {
-    case 0:
-      {
-        edge->set_node(0) = this->get_node(0);
-        edge->set_node(1) = this->get_node(1);
-        break;
-      }
-    case 1:
-      {
-        edge->set_node(0) = this->get_node(1);
-        edge->set_node(1) = this->get_node(2);
-        break;
-      }
-    case 2:
-      {
-        edge->set_node(0) = this->get_node(2);
-        edge->set_node(1) = this->get_node(3);
-        break;
-      }
-    case 3:
-      {
-        edge->set_node(0) = this->get_node(3);
-        edge->set_node(1) = this->get_node(0);
-        break;
-      }
-    default:
-      libmesh_error_msg("Invalid side i = " << i);
-    }
+  for (unsigned n=0; n<edge->n_nodes(); ++n)
+    edge->set_node(n) = this->get_node(Quad4::side_nodes_map[i][n]);
 
   return UniquePtr<Elem>(edge);
 }

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -20,7 +20,7 @@
 // Local includes
 #include "libmesh/face_quad.h"
 #include "libmesh/edge_edge2.h"
-
+#include "libmesh/face_quad4.h"
 
 
 namespace libMesh
@@ -54,34 +54,8 @@ dof_id_type Quad::key (const unsigned int s) const
 {
   libmesh_assert_less (s, this->n_sides());
 
-  switch (s)
-    {
-    case 0:
-      return
-        this->compute_key (this->node(0),
-                           this->node(1));
-
-    case 1:
-      return
-        this->compute_key (this->node(1),
-                           this->node(2));
-
-    case 2:
-      return
-        this->compute_key (this->node(2),
-                           this->node(3));
-
-    case 3:
-      return
-        this->compute_key (this->node(3),
-                           this->node(0));
-
-    default:
-      libmesh_error_msg("Invalid side s = " << s);
-    }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
+  return this->compute_key(this->node(Quad4::side_nodes_map[s][0]),
+                           this->node(Quad4::side_nodes_map[s][1]));
 }
 
 

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -65,29 +65,8 @@ UniquePtr<Elem> Tri::side (const unsigned int i) const
 
   Elem* edge = new Edge2;
 
-  switch (i)
-    {
-    case 0:
-      {
-        edge->set_node(0) = this->get_node(0);
-        edge->set_node(1) = this->get_node(1);
-        break;
-      }
-    case 1:
-      {
-        edge->set_node(0) = this->get_node(1);
-        edge->set_node(1) = this->get_node(2);
-        break;
-      }
-    case 2:
-      {
-        edge->set_node(0) = this->get_node(2);
-        edge->set_node(1) = this->get_node(0);
-        break;
-      }
-    default:
-      libmesh_error_msg("Invalid side i = " << i);
-    }
+  for (unsigned n=0; n<edge->n_nodes(); ++n)
+    edge->set_node(n) = this->get_node(Tri3::side_nodes_map[i][n]);
 
   return UniquePtr<Elem>(edge);
 }

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -20,6 +20,7 @@
 // Local includes
 #include "libmesh/face_tri.h"
 #include "libmesh/edge_edge2.h"
+#include "libmesh/face_tri3.h"
 
 namespace libMesh
 {
@@ -52,28 +53,8 @@ dof_id_type Tri::key (const unsigned int s) const
 {
   libmesh_assert_less (s, this->n_sides());
 
-  switch (s)
-    {
-    case 0:
-      return
-        this->compute_key (this->node(0),
-                           this->node(1));
-
-    case 1:
-      return
-        this->compute_key (this->node(1),
-                           this->node(2));
-    case 2:
-      return
-        this->compute_key (this->node(2),
-                           this->node(0));
-
-    default:
-      libmesh_error_msg("Invalid side s = " << s);
-    }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
+  return this->compute_key(this->node(Tri3::side_nodes_map[s][0]),
+                           this->node(Tri3::side_nodes_map[s][1]));
 }
 
 


### PR DESCRIPTION
We had a lot of redundant code in these functions that should just have been using the appropriate `side_nodes_map` arrays.
