### PR TITLE
Make Elem::key() implementations consistent with Elem::key(side)

### DIFF
--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -120,7 +120,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -139,7 +139,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
    * We reimplemenet this method here for the \p Hex27 since we can

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -116,7 +116,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -152,7 +152,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
    * We reimplemenet this method here for the \p InfHex18 since we can

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -115,7 +115,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -111,7 +111,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -141,7 +141,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
    * We reimplemenet this method here for the \p Prism18 since we can

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -112,7 +112,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -138,6 +138,22 @@ public:
   virtual Order default_order() const libmesh_override { return SECOND; }
 
   /**
+   * Don't hide Pyramid::key() defined in the base class.
+   */
+  using Pyramid::key;
+
+  /**
+   * @returns an id associated with the \p s side of this element.
+   * The id is not necessarily unique, but should be close.  This is
+   * particularly useful in the \p MeshBase::find_neighbors() routine.
+   *
+   * We reimplemenet this method here for the \p Pyramid14 since we can
+   * use the center node of the base face to provide a perfect (unique)
+   * key.
+   */
+  virtual dof_id_type key (const unsigned int s) const libmesh_override;
+
+  /**
    * Builds a \p QUAD9 or \p TRI6 coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -99,7 +99,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -182,7 +182,7 @@ public:
 
   /**
    * @returns an id associated with the global node ids of this
-   * element.  The id is not necessariy unique, but should be
+   * element.  The id is not necessarily unique, but should be
    * close.
    */
   virtual dof_id_type key () const libmesh_override;

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -127,7 +127,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -142,7 +142,7 @@ public:
 
   /**
    * @returns an id associated with the global node ids of this
-   * element.  The id is not necessariy unique, but should be
+   * element.  The id is not necessarily unique, but should be
    * close.
    */
   virtual dof_id_type key () const libmesh_override;

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -170,9 +170,10 @@ public:
   using Edge::key;
 
   /**
-   * @returns an id associated with the global node ids of this
-   * element.  The id is not necessariy unique, but should be
-   * close.
+   * Compute a unique key for this element which is suitable for
+   * hashing (not necessarily unique, but close).  The key is based
+   * solely on the mid-edge node's global id, to be consistent with 2D
+   * elements that have Edge3 sides (Quad9, Quad8, etc.).
    */
   virtual dof_id_type key () const libmesh_override;
 

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -151,7 +151,7 @@ public:
 
   /**
    * @returns an id associated with the global node ids of this
-   * element.  The id is not necessariy unique, but should be
+   * element.  The id is not necessarily unique, but should be
    * close.
    */
   virtual dof_id_type key () const libmesh_override;

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -200,14 +200,14 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const = 0;
 
   /**
    * @returns an id associated with the global node ids of this
-   * element.  The id is not necessariy unique, but should be
+   * element.  The id is not necessarily unique, but should be
    * close. Uses the same hash as the key(s) function, so for example
    * if "tri3" is side 0 of "tet4", then tri3->key()==tet4->key(0).
    */

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -135,7 +135,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -113,6 +113,16 @@ public:
   virtual Order default_order() const libmesh_override { return SECOND; }
 
   /**
+   * @returns an id associated with the \p s side of this element.
+   * The id is not necessarily unique, but should be close.  This is
+   * particularly useful in the \p MeshBase::find_neighbors() routine.
+   *
+   * We override this function to return a key for the Edge3 side
+   * which is consistent which Edge3::key().
+   */
+  virtual dof_id_type key (const unsigned int s) const libmesh_override;
+
+  /**
    * Creates and returns an \p Edge3 for the base (0) side, and an \p InfEdge2 for
    * the sides 1, 2.
    */

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -131,7 +131,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -137,6 +137,13 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * @returns an id associated with the global node ids of this
+   * element.  The id is not necessarily unique, but should be
+   * close.
+   */
+  virtual dof_id_type key () const libmesh_override;
+
+  /**
    * @returns a primitive (2-noded) edge for
    * edge i.
    */

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -135,7 +135,7 @@ public:
 
   /**
    * @returns an id associated with the global node ids of this
-   * element.  The id is not necessariy unique, but should be
+   * element.  The id is not necessarily unique, but should be
    * close.
    */
   virtual dof_id_type key () const libmesh_override;

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -128,18 +128,6 @@ public:
    */
   virtual Real volume () const libmesh_override;
 
-  /**
-   * Don't hide Quad::key(side) defined in the base class.
-   */
-  using Quad::key;
-
-  /**
-   * @returns an id associated with the global node ids of this
-   * element.  The id is not necessarily unique, but should be
-   * close.
-   */
-  virtual dof_id_type key () const libmesh_override;
-
 protected:
 
   /**

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -127,7 +127,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
    * We reimplemenet this method here for the \p Quad8 since we can

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -126,7 +126,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
    * We reimplemenet this method here for the \p Quad9 since we can
@@ -134,6 +134,14 @@ public:
    * key.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
+
+  /**
+   * Compute a unique key for this element which is suitable for
+   * hashing (not necessarily unique, but close).  The key is based
+   * solely on the mid-face node's global id, to be consistent with 3D
+   * elements that have Quad9 faces (Hex27, Prism18, etc.).
+   */
+  virtual dof_id_type key () const libmesh_override;
 
   virtual UniquePtr<Elem> build_side (const unsigned int i,
                                       bool proxy) const libmesh_override;

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -128,6 +128,13 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * @returns an id associated with the global node ids of this
+   * element.  The id is not necessarily unique, but should be
+   * close.
+   */
+  virtual dof_id_type key () const libmesh_override;
+
+  /**
    * @returns a primitive (2-noded) edge for
    * edge i.
    */

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -122,7 +122,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -144,18 +144,6 @@ public:
    */
   std::pair<Real, Real> min_and_max_angle() const;
 
-  /**
-   * Don't hide Tri::key(side) defined in the base class.
-   */
-  using Tri::key;
-
-  /**
-   * @returns an id associated with the global node ids of this
-   * element.  The id is not necessarily unique, but should be
-   * close.
-   */
-  virtual dof_id_type key () const libmesh_override;
-
 protected:
 
   /**

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -151,7 +151,7 @@ public:
 
   /**
    * @returns an id associated with the global node ids of this
-   * element.  The id is not necessariy unique, but should be
+   * element.  The id is not necessarily unique, but should be
    * close.
    */
   virtual dof_id_type key () const libmesh_override;

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -127,7 +127,7 @@ public:
 
   /**
    * @returns an id associated with the \p s side of this element.
-   * The id is not necessariy unique, but should be close.  This is
+   * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
    * We reimplemenet this method here for the \p Quad8 since we can

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -103,6 +103,8 @@ bool InfHex18::is_node_on_edge(const unsigned int n,
   return false;
 }
 
+
+
 dof_id_type InfHex18::key (const unsigned int s) const
 {
   libmesh_assert_less (s, this->n_sides());
@@ -111,42 +113,14 @@ dof_id_type InfHex18::key (const unsigned int s) const
   switch (s)
     {
     case 0: // the base face
+      return this->compute_key (this->node(16));
 
-      return
-        this->compute_key (this->node(16));
-
-
-    case 1:  // the face at y = -1
-
-      return
-        this->compute_key (this->node(0),
-                           this->node(1),
-                           this->node(5),
-                           this->node(4));
-
-    case 2:  // the face at x = 1
-
-      return
-        this->compute_key (this->node(1),
-                           this->node(2),
-                           this->node(6),
-                           this->node(5));
-
+    case 1: // the face at y = -1
+    case 2: // the face at x = 1
     case 3: // the face at y = 1
-
-      return
-        this->compute_key (this->node(2),
-                           this->node(3),
-                           this->node(7),
-                           this->node(6));
-
     case 4: // the face at x = -1
+      return InfHex::key(s);
 
-      return
-        this->compute_key (this->node(3),
-                           this->node(0),
-                           this->node(4),
-                           this->node(7));
     default:
       libmesh_error_msg("Invalid side s = " << s);
     }

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -119,6 +119,31 @@ bool Pyramid14::has_affine_map() const
 
 
 
+dof_id_type Pyramid14::key (const unsigned int s) const
+{
+  libmesh_assert_less (s, this->n_sides());
+
+  switch (s)
+    {
+    case 0: // triangular face 1
+    case 1: // triangular face 2
+    case 2: // triangular face 3
+    case 3: // triangular face 4
+      return Pyramid::key(s);
+
+    case 4:  // the quad face at z=0
+      return this->compute_key (this->node(13));
+
+    default:
+      libmesh_error_msg("Invalid side s = " << s);
+    }
+
+  libmesh_error_msg("We'll never get here!");
+  return 0;
+}
+
+
+
 UniquePtr<Elem> Pyramid14::build_side (const unsigned int i, bool proxy) const
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -200,9 +200,7 @@ Real Edge3::volume () const
 
 dof_id_type Edge3::key () const
 {
-  return this->compute_key(this->node(0),
-                           this->node(1),
-                           this->node(2));
+  return this->compute_key(this->node(2));
 }
 
 

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -108,6 +108,31 @@ const float InfQuad6::_embedding_matrix[2][6][6] =
 
 
 
+dof_id_type InfQuad6::key (const unsigned int s) const
+{
+  libmesh_assert_less (s, this->n_sides());
+
+  switch (s)
+    {
+      // Edge3 side
+    case 0:
+      return this->compute_key (this->node(4));
+
+      // InfEdge
+    case 1:
+    case 2:
+      return InfQuad::key(s);
+
+    default:
+      libmesh_error_msg("Invalid side s = " << s);
+    }
+
+  libmesh_error_msg("We'll never get here!");
+  return 0;
+}
+
+
+
 UniquePtr<Elem> InfQuad6::build_side (const unsigned int i,
                                       bool proxy) const
 {

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -60,6 +60,16 @@ dof_id_type Quad::key (const unsigned int s) const
 
 
 
+dof_id_type Quad::key () const
+{
+  return this->compute_key(this->node(0),
+                           this->node(1),
+                           this->node(2),
+                           this->node(3));
+}
+
+
+
 UniquePtr<Elem> Quad::side (const unsigned int i) const
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -250,14 +250,4 @@ Real Quad4::volume () const
     }
 }
 
-
-
-dof_id_type Quad4::key () const
-{
-  return this->compute_key(this->node(0),
-                           this->node(1),
-                           this->node(2),
-                           this->node(3));
-}
-
 } // namespace libMesh

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -201,6 +201,13 @@ dof_id_type Quad9::key (const unsigned int s) const
 
 
 
+dof_id_type Quad9::key () const
+{
+  return this->compute_key(this->node(8));
+}
+
+
+
 UniquePtr<Elem> Quad9::build_side (const unsigned int i,
                                    bool proxy) const
 {

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -59,6 +59,15 @@ dof_id_type Tri::key (const unsigned int s) const
 
 
 
+dof_id_type Tri::key () const
+{
+  return this->compute_key(this->node(0),
+                           this->node(1),
+                           this->node(2));
+}
+
+
+
 UniquePtr<Elem> Tri::side (const unsigned int i) const
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -207,13 +207,4 @@ std::pair<Real, Real> Tri3::min_and_max_angle() const
                         std::max(theta0, std::max(theta1,theta2)));
 }
 
-
-
-dof_id_type Tri3::key () const
-{
-  return this->compute_key(this->node(0),
-                           this->node(1),
-                           this->node(2));
-}
-
 } // namespace libMesh


### PR DESCRIPTION
The key computed for the quadratic side of an element should be consistent with the key computed for the lower-dimensional element itself.  Also, a few of the infinite element types did not follow the convention of using mid-edge/face nodes for computing keys, so fixed those.