### PR TITLE
Extract TBB_VERSION_{MAJOR,MINOR} from tbb_stddef.h

### DIFF
--- a/configure
+++ b/configure
@@ -35055,6 +35055,22 @@ fi
         TBB_LIBRARY="${RPATHFLAG}${TBB_LIBS} $TBB_LIBRARY"
       fi
 
+                        tbbmajor=`grep "define TBB_VERSION_MAJOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MAJOR[ ]*//g"`
+      tbbminor=`grep "define TBB_VERSION_MINOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MINOR[ ]*//g"`
+
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_TBB_VERSION_MAJOR $tbbmajor
+_ACEOF
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_TBB_VERSION_MINOR $tbbminor
+_ACEOF
+
+
+
 
 
 

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -82,6 +82,12 @@
 /* PETSc's subminor version number, as detected by petsc.m4 */
 #undef DETECTED_PETSC_VERSION_SUBMINOR
 
+/* TBB's major version number, as detected by tbb.m4 */
+#undef DETECTED_TBB_VERSION_MAJOR
+
+/* TBB's minor version number, as detected by tbb.m4 */
+#undef DETECTED_TBB_VERSION_MINOR
+
 /* VTK's major version number, as detected by vtk.m4 */
 #undef DETECTED_VTK_VERSION_MAJOR
 

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -35,6 +35,10 @@
 #  include "tbb/spin_mutex.h"
 #  include "tbb/recursive_mutex.h"
 #  include "tbb/atomic.h"
+
+#define TBB_VERSION_LESS_THAN(major,minor)                              \
+  ((LIBMESH_DETECTED_TBB_VERSION_MAJOR < (major) ||                     \
+    (LIBMESH_DETECTED_TBB_VERSION_MAJOR == (major) && (LIBMESH_DETECTED_TBB_VERSION_MINOR < (minor)))) ? 1 : 0)
 #endif
 
 // C++ includes

--- a/m4/tbb.m4
+++ b/m4/tbb.m4
@@ -47,6 +47,19 @@ AC_DEFUN([CONFIGURE_TBB],
         TBB_LIBRARY="${RPATHFLAG}${TBB_LIBS} $TBB_LIBRARY"
       fi
 
+      dnl Extract TBB_VERSION_MAJOR and TBB_VERSION_MINOR from
+      dnl tbb_stddef.h.  This will allow us to set up a
+      dnl TBB_VERSION_LESS_THAN macro.
+      tbbmajor=`grep "define TBB_VERSION_MAJOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MAJOR[ ]*//g"`
+      tbbminor=`grep "define TBB_VERSION_MINOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MINOR[ ]*//g"`
+
+      AC_DEFINE_UNQUOTED(DETECTED_TBB_VERSION_MAJOR, [$tbbmajor],
+        [TBB's major version number, as detected by tbb.m4])
+
+      AC_DEFINE_UNQUOTED(DETECTED_TBB_VERSION_MINOR, [$tbbminor],
+        [TBB's minor version number, as detected by tbb.m4])
+
+
       AC_SUBST(TBB_LIBRARY)
       AC_SUBST(TBB_INCLUDE)
       AC_DEFINE(USING_THREADS, 1,


### PR DESCRIPTION
Also, add a `TBB_VERSION_LESS_THAN` macro that uses them.  We need this specifically for something in MOOSE, but it may also eventually be useful in libmesh if someone wants to play with more advanced TBB features while maintaining backwards compatibility.