### PR TITLE
Updated systems_of_equations_ex8.

### DIFF
--- a/examples/systems_of_equations/systems_of_equations_ex8/augment_sparsity_on_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/augment_sparsity_on_contact.C
@@ -14,32 +14,16 @@ AugmentSparsityOnContact::AugmentSparsityOnContact(
   _sys(sys)
 {}
 
-void AugmentSparsityOnContact::clear_contact_element_map()
+void AugmentSparsityOnContact::clear_contact_node_map()
 {
-  _contact_element_map.clear();
+  _contact_node_map.clear();
 }
 
-void AugmentSparsityOnContact::add_contact_element(
-  dof_id_type element_id,
-  dof_id_type other_element_id)
+void AugmentSparsityOnContact::add_contact_node(
+  dof_id_type lower_node_id,
+  dof_id_type upper_node_id)
 {
-  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, std::set<dof_id_type> >::iterator it =
-    _contact_element_map.find(element_id);
-
-  if(it == _contact_element_map.end())
-  {
-    std::set<dof_id_type> new_set;
-    new_set.insert(other_element_id);
-
-    _contact_element_map[element_id] = new_set;
-  }
-  else
-  {
-    std::set<dof_id_type> existing_set = it->second;
-    existing_set.insert(other_element_id);
-
-    _contact_element_map[element_id] = existing_set;
-  }
+  _contact_node_map[lower_node_id] = upper_node_id;
 }
 
 void AugmentSparsityOnContact::augment_sparsity_pattern(
@@ -50,95 +34,63 @@ void AugmentSparsityOnContact::augment_sparsity_pattern(
   // get a constant reference to the mesh object
   const MeshBase& mesh = _sys.get_mesh();
 
-  const DofMap& dof_map = _sys.get_dof_map();
-
-  // Create a set that will have the DoF numbers we need to augment the sparsity pattern
-  LIBMESH_BEST_UNORDERED_SET<dof_id_type> local_coupled_dofs, remote_coupled_dofs;
-
-  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, std::set<dof_id_type> >::iterator it     = _contact_element_map.begin();
-  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, std::set<dof_id_type> >::iterator it_end = _contact_element_map.end();
+  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, dof_id_type>::iterator it     = _contact_node_map.begin();
+  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, dof_id_type>::iterator it_end = _contact_node_map.end();
 
   for( ; it != it_end; ++it)
   {
-    const Elem* this_elem = mesh.elem(it->first);
-    std::set<dof_id_type> neighbor_elem_ids = it->second;
+    const Node& this_node = mesh.node(it->first);
+    const Node& other_node = mesh.node(it->second);
 
-    local_coupled_dofs.clear();
-    remote_coupled_dofs.clear();
-
-    std::set<dof_id_type>::iterator set_it = neighbor_elem_ids.begin();
-    std::set<dof_id_type>::iterator set_it_end = neighbor_elem_ids.end();
-    for( ; set_it != set_it_end; ++set_it)
-    {
-      const Elem* neighbor_elem = mesh.elem( *set_it );
-
-      // Now loop over the nodes and get the DoFs on neighbor_elem.
-      // These will be used to augment the sparsity pattern.
-      // Note, we should also account for element-based dofs,
-      // but for now we're just being lazy and considering only
-      // node-based dofs.
-      for(unsigned int var_num=0; var_num<_sys.n_vars(); var_num++)
-      {
-        for (unsigned int n=0; n<neighbor_elem->n_nodes(); n++)
-        {
-          unsigned int var_dofs_on_node =
-            neighbor_elem->get_node(n)->n_dofs(_sys.number(), var_num);
-
-          if(var_dofs_on_node > 0)
-          {
-            const dof_id_type global_dof_number =
-              neighbor_elem->get_node(n)->dof_number(_sys.number(),var_num,0);
-
-            // and finally insert it into one of the sets
-            if ((global_dof_number <  dof_map.first_dof()) ||
-                (global_dof_number >= dof_map.end_dof()))
-            {
-              remote_coupled_dofs.insert(global_dof_number);
-            }
-            else
-            {
-              local_coupled_dofs.insert(global_dof_number);
-            }
-          }
-        } // end loop over nodes on neighbor element
-      }
-    }
-
-    // Conservatively increase the preallocation for the implicit matrix contribution
-    // to account for remote_coupled_dofs and local_coupled_dofs.
-    for(unsigned int var_num=0; var_num<_sys.n_vars(); var_num++)
-    {
-      for (unsigned int nl=0; nl<this_elem->n_nodes(); nl++)
-      {
-        const dof_id_type
-          global_dof_number = this_elem->get_node(nl)->dof_number(_sys.number(),var_num,0),
-          n_local_dofs      = dof_map.n_local_dofs(),
-          n_remote_dofs     = dof_map.n_dofs() - n_local_dofs;
-
-        // Only monkey with the sparsity pattern for local dofs!
-        // The other dofs will be handled on other processors.
-        if ((global_dof_number >= dof_map.first_dof()) &&
-            (global_dof_number  < dof_map.end_dof()))
-        {
-          const dof_id_type
-            dof_offset = global_dof_number - dof_map.first_dof();
-
-          libmesh_assert_less (dof_offset, n_nz.size());
-          libmesh_assert_less (dof_offset, n_oz.size());
-
-          // TODO: This factor of 5 should not be needed. We must be making
-          // a mistake somewhere with keeping track of the dof coupling.
-          n_nz[dof_offset] += 5*local_coupled_dofs.size();
-          n_oz[dof_offset] += 5*remote_coupled_dofs.size();
-
-          // for crazy coarse problems on many processors we need to impose sane limits
-          // since we shouldn't allow n_nz > n_local_dofs, for example
-          n_nz[dof_offset] = std::min(n_nz[dof_offset], n_local_dofs);
-          n_oz[dof_offset] = std::min(n_oz[dof_offset], n_remote_dofs);
-        }
-      }
-    }
-
+    set_sparsity_values(this_node, other_node, n_nz, n_oz);
+    set_sparsity_values(other_node, this_node, n_nz, n_oz);
   }
 
+}
+
+void AugmentSparsityOnContact::set_sparsity_values(
+  const Node& this_node, const Node& other_node,
+  std::vector<dof_id_type> & n_nz,
+  std::vector<dof_id_type> & n_oz)
+{
+  const DofMap& dof_map = _sys.get_dof_map();
+
+  for(unsigned int var_i=0; var_i<3; var_i++)
+  {
+    dof_id_type dof_index_on_this_node =
+      this_node.dof_number(_sys.number(),var_i,0);
+
+    unsigned int n_local_coupled_dofs = 0;
+    unsigned int n_remote_coupled_dofs = 0;
+
+    for(unsigned int var_j=0; var_j<3; var_j++)
+    {
+      dof_id_type dof_index_on_other_node =
+        other_node.dof_number(_sys.number(),var_j,0);
+
+      if ((dof_index_on_other_node >= dof_map.first_dof()) &&
+          (dof_index_on_other_node  < dof_map.end_dof()))
+      {
+        n_local_coupled_dofs++;
+      }
+      else
+      {
+        n_remote_coupled_dofs++;
+      }
+    }
+
+    // only monkey with the sparsity pattern for local dofs!
+    if ((dof_index_on_this_node >= dof_map.first_dof()) &&
+        (dof_index_on_this_node  < dof_map.end_dof()))
+    {
+      const unsigned int
+        dof_offset = dof_index_on_this_node - dof_map.first_dof();
+
+      libmesh_assert_less (dof_offset, n_nz.size());
+      libmesh_assert_less (dof_offset, n_oz.size());
+
+      n_nz[dof_offset] += n_local_coupled_dofs;
+      n_oz[dof_offset] += n_remote_coupled_dofs;
+    }
+  }
 }

--- a/examples/systems_of_equations/systems_of_equations_ex8/augment_sparsity_on_contact.h
+++ b/examples/systems_of_equations/systems_of_equations_ex8/augment_sparsity_on_contact.h
@@ -7,24 +7,12 @@
 
 using libMesh::DofMap;
 using libMesh::System;
+using libMesh::Node;
 using libMesh::dof_id_type;
 using libMesh::boundary_id_type;
 
 class AugmentSparsityOnContact : public DofMap::AugmentSparsityPattern
 {
-private:
-
-  /**
-   * The System object that we're using here.
-   */
-  System& _sys;
-
-  /**
-   * This maps from element --> elements it is in contact with.
-   * We use a set as the value to enfore uniqueness of the values.
-   */
-  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, std::set<dof_id_type> > _contact_element_map;
-
 public:
 
   /**
@@ -36,16 +24,14 @@ public:
   /**
    * Clear the contact element map.
    */
-  void clear_contact_element_map();
+  void clear_contact_node_map();
 
   /**
-   * Add a new entry to the multimap that defines
-   * which elements element \p element_id is in
-   * contact with.
+   * Add a new entry to _contact_node_map.
    */
-  void add_contact_element(
-    dof_id_type element_id,
-    dof_id_type other_element_id);
+  void add_contact_node(
+    dof_id_type lower_node_id,
+    dof_id_type upper_node_id);
 
   /**
    * User-defined function to augment the sparsity pattern.
@@ -54,6 +40,24 @@ public:
     libMesh::SparsityPattern::Graph & ,
     std::vector<dof_id_type> & n_nz,
     std::vector<dof_id_type> & n_oz);
+
+  /**
+   * Helper function that actually sets the sparsity values.
+   */
+  void set_sparsity_values(
+    const Node& this_node, const Node& other_node,
+    std::vector<dof_id_type> & n_nz,
+    std::vector<dof_id_type> & n_oz);
+
+  /**
+   * The System object that we're using here.
+   */
+  System& _sys;
+
+  /**
+   * This provides a map between contact nodes.
+   */
+  LIBMESH_BEST_UNORDERED_MAP<dof_id_type, dof_id_type> _contact_node_map;
 
 };
 

--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.h
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.h
@@ -26,129 +26,6 @@ using libMesh::NumericVector;
 using libMesh::SparseMatrix;
 
 /**
- * Convenient class to encapsulate (element,side,qp) data.
- */
-class QuadraturePointOnSideId
-{
-public:
-
-  /**
-   * Need a default constructor so that we can use this class in STL containers.
-   */
-  QuadraturePointOnSideId()
-  :
-    _element_id(0),
-    _side_index(0),
-    _qp(0)
-  {}
-
-  /**
-   * Constructor to set the members.
-   */
-  QuadraturePointOnSideId(
-    dof_id_type element_id,
-    unsigned char side_index,
-    unsigned int qp)
-  :
-    _element_id(element_id),
-    _side_index(side_index),
-    _qp(qp)
-  {
-  }
-
-  /**
-   * The element ID for this quadrature point.
-   */
-  dof_id_type _element_id;
-
-  /**
-   * The side of the element that this quadrature point belongs to.
-   */
-  unsigned char _side_index;
-
-  /**
-   * The quadrature point index on the side.
-   */
-  unsigned int _qp;
-};
-
-/**
- * Need operator< for QuadraturePointOnSideId so that we can use it as
- * the key in a map.
- */
-bool operator< (QuadraturePointOnSideId const& a, QuadraturePointOnSideId const& b);
-
-/**
- * Convenient class to encapsulate data related to the
- * line that defines the distance between elements in contact.
- */
-class IntersectionPointData
-{
-public:
-
-  /**
-   * Need a default constructor so that we can use this class in STL containers.
-   */
-  IntersectionPointData()
-  :
-    _neighbor_element_id(0),
-    _neighbor_side_index(0)
-  {}
-
-  /**
-   * Constructor to set the members.
-   */
-  IntersectionPointData(
-    dof_id_type neighbor_element_id,
-    unsigned char neighbor_side_index,
-    Point intersection_point,
-    Point inverse_mapped_intersection_point,
-    Point line_point,
-    Point line_direction)
-  :
-    _neighbor_element_id(neighbor_element_id),
-    _neighbor_side_index(neighbor_side_index),
-    _intersection_point(intersection_point),
-    _inverse_mapped_intersection_point(inverse_mapped_intersection_point),
-    _line_point(line_point),
-    _line_direction(line_direction)
-  {
-  }
-
-  /**
-   * The element ID for this intersection point.
-   */
-  dof_id_type _neighbor_element_id;
-
-  /**
-   * The side of the element that this intersection point belongs to.
-   */
-  unsigned char _neighbor_side_index;
-
-  /**
-   * The intersection point.
-   */
-  Point _intersection_point;
-
-  /**
-   * The intersection point mapped back to the reference element.
-   */
-  Point _inverse_mapped_intersection_point;
-
-  /**
-   * The point on the "master" element.
-   */
-  Point _line_point;
-
-  /**
-   * The normal on the "master" element, which
-   * defines the direction of the line
-   */
-  Point _line_direction;
-
-};
-
-/**
  * This class encapsulate all functionality required for assembling
  * and solving a linear elastic model with contact.
  */
@@ -163,31 +40,26 @@ private:
   NonlinearImplicitSystem& _sys;
 
   /**
+   * The object that handles augmenting the sparsity pattern.
+   */
+  AugmentSparsityOnContact _augment_sparsity;
+
+  /**
    * Penalize overlapping elements.
    */
   Real _contact_penalty;
 
   /**
-   * Tolerance relative to element size for detecting nearby elements
-   * which might be in contact.
+   * Store the intermediate values of lambda plus penalty. The dof IDs refer
+   * to the nodes on the upper contact surface.
    */
-  Real _contact_proximity_tol;
+  std::map<dof_id_type, Real> _lambda_plus_penalty_values;
 
   /**
-   * Tolerance relative to element size for detecting if a point
-   * is inside an element.
+   * Augmented Lagrangian values at each contact node. The dof IDs refer
+   * to the nodes on the upper contact surface.
    */
-  Real _contains_point_tol;
-
-  /**
-   * This maps from (element ID,side,qp) to the corresponding IntersectionPointData.
-   */
-  std::map<QuadraturePointOnSideId, IntersectionPointData> _contact_intersection_data;
-
-  /**
-   * The object that handles augmenting the sparsity pattern.
-   */
-  AugmentSparsityOnContact _augment_sparsity;
+  std::map<dof_id_type, Real> _lambdas;
 
 public:
 
@@ -196,8 +68,7 @@ public:
    */
   LinearElasticityWithContact(
     NonlinearImplicitSystem &sys_in,
-    Real contact_penalty_in,
-    Real contact_proximity_tol);
+    Real contact_penalty_in);
 
   /**
    * @return a reference to the object for augmenting the sparsity pattern.
@@ -213,38 +84,6 @@ public:
    * Get the penalty parameter.
    */
   Real get_contact_penalty() const;
-
-  /**
-   * Clear the non-zero contact forces from a previous iteration.
-   */
-  void clear_contact_data();
-
-  /**
-   * Set non-zero contact force for the specified element, side, quadrature point.
-   * Also store the "nearest point" on the other element.
-   */
-  void set_contact_data(
-    dof_id_type element_id,
-    unsigned char side_index,
-    unsigned int qp,
-    IntersectionPointData intersection_pt_data);
-
-  /**
-   * @return true is we have detected contact for the specified element,side,qp.
-   */
-  bool is_contact_detected(
-    dof_id_type element_id,
-    unsigned char side_index,
-    unsigned int qp);
-
-  /**
-   * Get an entry from the contact intersection point data structure.
-   * Throw an error if the entry doesn't exist.
-   */
-  IntersectionPointData get_contact_data(
-    dof_id_type element_id,
-    unsigned char side_index,
-    unsigned int qp);
 
   /**
    * Kronecker delta function.
@@ -273,6 +112,11 @@ public:
     const NumericVector<Number>& input_solution);
 
   /**
+   * Set up the load paths on the contact surfaces.
+   */
+  void initialize_contact_load_paths();
+
+  /**
    * Evaluate the Jacobian of the nonlinear system.
    */
   virtual void residual_and_jacobian (
@@ -285,6 +129,19 @@ public:
    * Compute the Cauchy stress for the current solution.
    */
   void compute_stresses();
+
+  /**
+   * Update the lambda parameters in the augmented Lagrangian
+   * method.
+   * @return the largest change in the lambdas, and the largest
+   * lambda value.
+   */
+  std::pair<Real,Real> update_lambdas();
+
+  /**
+   * @return the least and max gap function values for the current solution.
+   */
+  std::pair<Real,Real> get_least_and_max_gap_function();
 
 };
 

--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
@@ -17,33 +17,22 @@
 
 
 
-// <h1> Systems Example 8 - Linear elasticity with contact. </h1>
+// <h1> Systems Example 8 - "Small-sliding" contact. </h1>
 // \author David Knezevic
 // \date 2015
 //
-// In this example, we consider a linear elastic model with contact. This is a nonlinear
-// problem due to the contact condition.
+// In this example, we consider a linear elastic model with contact. We restrict ourselves
+// to considering "small sliding", which means that we set the contact "load transfer" between
+// surfaces up front, based on the undeformed mesh, and retain that load transfer throughout
+// the solve. Even though we consider linear elasticity here, this is a nonlinear problem due
+// to the contact condition.
 //
-// This example borrows from systems_of_equations_ex6 (linear elastic
-// constitutive law) and systems_of_equations_ex7 (NonlinearImplicitSystem to
-// handle nonlinearities). Note that this example could be extended to large
-// deformation elasticity by using the constitutive law from systems_of_equations_ex7.
+// The contact condition is imposed using the augmented Lagrangian method, e.g. see
+// Simo & Laursen (1992). For the sake of simplicity, in this example we assume that contact
+// nodes are perfectly aligned (this assumption can be eliminated relatively easily).
 //
-// The contact condition is imposed using a penalty method. Consider two contact surfaces,
-// "master" and "slave". For each quadrature point qp on "master", we define a line in the normal
-// direction and see where that line intersects slave. This gives us the normal distance,
-// which we refer to as the "signed_distance", since if this value is negative it means
-// we detected overlap between master and slave qp, and we impose a normal force (i.e.
-// contact force) of magnitude penalty * signed_distance. If there is no overlap at qp,
-// then the contact force is zero. We repeat this for all quadrature points on both sides
-// of the contact surface.
-//
-// We also have to augment the sparsity pattern to handle the contributions to the Jacobian
-// from the "other" side of the contact surface, and we use a similar approach to
-// miscellanoues_ex9 for this.
-//
-// Note that the contact penalty term is non-smooth, which can cause convergence problems
-// for a nonlinear solver. This is a widely recognized issue in contact simulation.
+// The mesh in this example consists of two disconnected cylinders. We impose a displacement
+// boundary condition of -1 in the z-direction on the top cylinder in order to impose contact.
 
 // C++ include files that we need
 #include <iostream>
@@ -87,16 +76,12 @@ int main (int argc, char** argv)
 
   const Real young_modulus = infile("Young_modulus", 1.0);
   const Real poisson_ratio = infile("poisson_ratio", 0.3);
-  const Real initial_forcing_magnitude = infile("initial_forcing_magnitude", 0.001);
 
   const Real nonlinear_abs_tol = infile("nonlinear_abs_tol", 1.e-8);
   const Real nonlinear_rel_tol = infile("nonlinear_rel_tol", 1.e-8);
   const unsigned int nonlinear_max_its = infile("nonlinear_max_its", 50);
   const Real contact_penalty = infile("contact_penalty", 1.e2);
-  const Real contact_proximity_tol = infile("contact_proximity_tol",0.1);
-
-  const unsigned int n_solves = infile("n_solves", 10);
-  const Real force_increment = infile("force_increment", 0.001);
+  const Real gap_function_tol = infile("gap_function_tol", 1.e-8);
 
   Mesh mesh(init.comm());
   mesh.read("systems_of_equations_ex8.exo");
@@ -108,7 +93,7 @@ int main (int argc, char** argv)
   NonlinearImplicitSystem& system =
     equation_systems.add_system<NonlinearImplicitSystem> ("NonlinearElasticity");
 
-  LinearElasticityWithContact le(system, contact_penalty, contact_proximity_tol);
+  LinearElasticityWithContact le(system, contact_penalty);
 
   unsigned int u_var = system.add_variable("u",
                       Utility::string_to_enum<Order>   (approx_order),
@@ -139,68 +124,93 @@ int main (int argc, char** argv)
 
   equation_systems.parameters.set<Real>("young_modulus") = young_modulus;
   equation_systems.parameters.set<Real>("poisson_ratio") = poisson_ratio;
-  equation_systems.parameters.set<Real>("forcing_magnitude") = initial_forcing_magnitude;
 
   // Attach Dirichlet boundary conditions
-  std::set<boundary_id_type> clamped_boundaries;
-  clamped_boundaries.insert(MIN_Z_BOUNDARY);
-  clamped_boundaries.insert(MAX_Z_BOUNDARY);
+  {
+    std::set<boundary_id_type> clamped_boundaries;
+    clamped_boundaries.insert(MIN_Z_BOUNDARY);
 
-  std::vector<unsigned int> uvw;
-  uvw.push_back(u_var);
-  uvw.push_back(v_var);
-  uvw.push_back(w_var);
+    std::vector<unsigned int> uvw;
+    uvw.push_back(u_var);
+    uvw.push_back(v_var);
+    uvw.push_back(w_var);
 
-  ZeroFunction<Number> zero;
+    ZeroFunction<Number> zero;
 
-  system.get_dof_map().add_dirichlet_boundary
-    (DirichletBoundary (clamped_boundaries, uvw, &zero));
+    system.get_dof_map().add_dirichlet_boundary
+      (DirichletBoundary (clamped_boundaries, uvw, &zero));
+  }
+  {
+    std::set<boundary_id_type> clamped_boundaries;
+    clamped_boundaries.insert(MAX_Z_BOUNDARY);
 
+    std::vector<unsigned int> uv;
+    uv.push_back(u_var);
+    uv.push_back(v_var);
+
+    ZeroFunction<Number> zero;
+
+    system.get_dof_map().add_dirichlet_boundary
+      (DirichletBoundary (clamped_boundaries, uv, &zero));
+  }
+  {
+    std::set<boundary_id_type> clamped_boundaries;
+    clamped_boundaries.insert(MAX_Z_BOUNDARY);
+
+    std::vector<unsigned int> w;
+    w.push_back(w_var);
+
+    ConstFunction<Number> neg_one(-1.);
+
+    system.get_dof_map().add_dirichlet_boundary
+      (DirichletBoundary (clamped_boundaries, w, &neg_one));
+  }
+
+  le.initialize_contact_load_paths();
+
+  // The augment_sparsity object was initialized in initialize_contact_load_paths.
   system.get_dof_map().attach_extra_sparsity_object(le.get_augment_sparsity());
 
   equation_systems.init();
   equation_systems.print_info();
 
-  // Provide a loop here so that we can do a sequence of solves
-  // where solve n gives a good starting guess for solve n+1.
-  // This "continuation" approach is helpful for solving for
-  // large values of "forcing_magnitude".
-  for(unsigned int count=0; count<n_solves; count++)
-  {
-    libMesh::out << "Performing solve " << (count+1) << ", forcing_magnitude: "
-      << equation_systems.parameters.get<Real>("forcing_magnitude")
-      << ", contact_penalty: " << contact_penalty << std::endl;
+  libMesh::out << "Contact penalty: " << contact_penalty  << std::endl << std::endl;
 
+  Real current_max_gap_function = std::numeric_limits<Real>::max();
+
+  unsigned int outer_iteration = 0;
+  while( current_max_gap_function > gap_function_tol )
+  {
+    libMesh::out << "Starting outer iteration " << outer_iteration << std::endl;
+
+    // Perform inner iteration (i.e. Newton's method loop)
     system.solve();
     system.nonlinear_solver->print_converged_reason();
 
-    libMesh::out << "System solved at nonlinear iteration "
-      << system.n_nonlinear_iterations()
-      << " , final nonlinear residual norm: "
-      << system.final_nonlinear_residual()
-      << std::endl << std::endl;
+    // Perform augmented Lagrangian update
+    le.update_lambdas();
 
-    libMesh::out << "Solution l2 norm: " << system.solution->l2_norm()
-      << std::endl << std::endl;
+    std::pair<Real,Real> least_and_max_gap_function = le.get_least_and_max_gap_function();
+    Real least_gap_fn = least_and_max_gap_function.first;
+    Real max_gap_fn = least_and_max_gap_function.second;
+    libMesh::out << "Finished outer iteration, least gap function: "
+      << least_gap_fn << ", max gap function: "
+      << max_gap_fn << std::endl << std::endl;
 
-    libMesh::out << "Computing stresses..." << std::endl;
+    current_max_gap_function = std::max( std::abs(least_gap_fn), std::abs(max_gap_fn) );
 
-    le.compute_stresses();
-
-    std::stringstream filename;
-    filename << "solution_" << count << ".exo";
-    ExodusII_IO (mesh).write_equation_systems(
-      filename.str(),
-      equation_systems);
-
-    {
-      // Increment the forcing magnitude
-      Real previous_forcing =
-        equation_systems.parameters.get<Real>("forcing_magnitude");
-      equation_systems.parameters.set<Real>("forcing_magnitude") =
-        previous_forcing + force_increment;
-    }
+    outer_iteration++;
   }
+
+  libMesh::out << "Computing stresses..." << std::endl;
+
+  le.compute_stresses();
+
+  std::stringstream filename;
+  filename << "solution.exo";
+  ExodusII_IO (mesh).write_equation_systems(
+    filename.str(),
+    equation_systems);
 
   return 0;
 }

--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.in
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.in
@@ -4,15 +4,10 @@ fe_family = LAGRANGE
 young_modulus = 1.
 poisson_ratio = 0.3
 
-# Note: The contact penalty should be larger (about 100), we turn it down to make the
-# problem easier to solve in the regression test setting.
-contact_penalty = 1.e-1
-contact_proximity_tol = 0.1
+contact_penalty = 10.0
 
 nonlinear_abs_tol = 1.e-12
 nonlinear_rel_tol = 1.e-3
 nonlinear_max_its = 5
 
-n_solves = 1
-initial_forcing_magnitude = 0.001
-force_increment = 0.0005
+gap_function_tol = 1.e-8


### PR DESCRIPTION
The previous version of systems_of_equations_ex8 was unnecessarily complicated for the sake of an example, and didn't converge very well. In this updated version, we restrict to "small sliding" contact,
and we use the augmented Lagrangian method to achieve high accuracy in the contact solve.

One issue I haven't figured out yet is the sparsity pattern augmentation. The augment_sparsity_pattern
code in this example seems to have no effect. Any insights into this would be appreciated. Does
sparsity pattern augmentation not work for NonlinearImplicitSystems, perhaps?

In the meantime, I've turned off PETSc's sparsity pattern check (see
LinearElasticityWithContact::residual_and_jacobian).