### PR TITLE
Add DenseMatrix::svd_solve().

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -395,6 +395,26 @@ public:
    */
   void svd(DenseVector<T>& sigma, DenseMatrix<T>& U, DenseMatrix<T>& VT);
 
+  /**
+   * Solve the system of equations A*x = rhs for x in the
+   * least-squares sense. $A$ may be non-square and/or rank-deficient.
+   * You can control which singular values are treated as zero by
+   * changing the "rcond" parameter.  Singular values S(i) for which
+   * S(i) <= rcond*S(1) are treated as zero for purposes of the solve.
+   * Passing a negative number for rcond forces a "machine precision"
+   * value to be used instead.
+   *
+   * This function is marked const, since due to various
+   * implementation details, we do not need to modify the contents of
+   * A in order to compute the SVD (a copy is made internally
+   * instead).
+   *
+   * Requires PETSc >= 3.1 since this was the first version to provide
+   * the LAPACKgelss_ wrapper.
+   */
+  void svd_solve(const DenseVector<T> & rhs,
+                 DenseVector<T> & x,
+                 Real rcond=std::numeric_limits<Real>::epsilon()) const;
 
   /**
    * Compute the eigenvalues (both real and imaginary parts) of a general matrix.
@@ -531,6 +551,13 @@ private:
   void _svd_lapack(DenseVector<T>& sigma,
                    DenseMatrix<T>& U,
                    DenseMatrix<T>& VT);
+
+  /**
+   * Called by svd_solve(rhs).
+   */
+  void _svd_solve_lapack(const DenseVector<T> & rhs,
+                         DenseVector<T> & x,
+                         Real rcond) const;
 
   /**
    * Helper function that actually performs the SVD.

--- a/src/numerics/dense_matrix.C
+++ b/src/numerics/dense_matrix.C
@@ -789,6 +789,16 @@ void DenseMatrix<T>::svd (DenseVector<T>& sigma, DenseMatrix<T>& U, DenseMatrix<
 
 
 template<typename T>
+void DenseMatrix<T>::svd_solve(const DenseVector<T> & rhs,
+                               DenseVector<T> & x,
+                               Real rcond) const
+{
+  _svd_solve_lapack(rhs, x, rcond);
+}
+
+
+
+template<typename T>
 void DenseMatrix<T>::evd (DenseVector<T>& lambda_real, DenseVector<T>& lambda_imag)
 {
   // We use the LAPACK eigenvalue problem implementation


### PR DESCRIPTION
This function fills a missing requirement in the DenseMatrix classes,
allowing us to solve non-square systems of equations in a
least-squares sense.  The user can pass a tolerance to svd_solve()
which determines the cutoff for small singular values. svd_solve() is
a const member function: we make a copy internally instead of allowing
Lapack to modify A.

Note that Eigen also has the capability to solve non-square systems of
equations, but it is relatively slow, as discussed in this thread:
https://forum.kde.org/viewtopic.php?f=74&t=102088, so having our own
Lapack-based implementation is worthwhile.