### PR TITLE
Cache derivatives and remove a byte code round trip for FPOptimization

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -425,7 +425,7 @@ int FunctionParserADBase<Value_t>::AutoDiff(const std::string& var_name)
 
       // try to open cache file
       std::ifstream istr;
-      istr.open(cache_file, std::ios::in | std::ios::binary);
+      istr.open(cache_file.c_str(), std::ios::in | std::ios::binary);
       if (istr)
       {
         Unserialize(istr);
@@ -449,7 +449,7 @@ int FunctionParserADBase<Value_t>::AutoDiff(const std::string& var_name)
         // save to a temporary name and rename only when the file is fully written
         std::string cache_file_tmp = cache_file + ".tmp";
         std::ofstream ostr;
-        ostr.open(cache_file_tmp, std::ios::out | std::ios::binary);
+        ostr.open(cache_file_tmp.c_str(), std::ios::out | std::ios::binary);
         if (ostr)
         {
           Serialize(ostr);

--- a/contrib/fparser/fparser_ad.hh
+++ b/contrib/fparser/fparser_ad.hh
@@ -18,7 +18,7 @@ public:
   /**
    * auto-differentiate for var
    */
-  int AutoDiff(const std::string & var_name);
+  int AutoDiff(const std::string & var_name, bool cached = false);
 
   /**
    * add another variable
@@ -56,6 +56,16 @@ public:
    * the compilation after Optimization
    */
   void Optimize();
+
+  /**
+   * write the full state of the current FParser object to a stream
+   */
+  void Serialize(std::ostream &);
+
+  /**
+   * restore the full state of the current FParser object from a stream
+   */
+  void Unserialize(std::istream &);
 
 #if LIBMESH_HAVE_FPARSER_JIT
   /**
@@ -114,6 +124,9 @@ private:
   class UnknownVariable : public std::exception {
     virtual const char* what() const throw() { return "Unknown variable"; }
   } UnknownVariableException;
+  class UnknownSerializationVersion : public std::exception {
+    virtual const char* what() const throw() { return "Unknown serialization file version"; }
+  } UnknownSerializationVersionException;
 };
 
 

--- a/contrib/fparser/fparser_ad.hh
+++ b/contrib/fparser/fparser_ad.hh
@@ -18,7 +18,7 @@ public:
   /**
    * auto-differentiate for var
    */
-  int AutoDiff(const std::string & var_name, bool cached = false);
+  int AutoDiff(const std::string & var_name);
 
   /**
    * add another variable
@@ -38,10 +38,41 @@ public:
    */
   void setZero();
 
+  // feature flags for this parser
+  enum ADFlags {
+    /**
+     * In certain applications derivatives are built proactively and may never be used.
+     * We silence all AutoDiff exceptions in that case to avoid confusing the user.
+     */
+    ADSilenceErrors = 1,
+    /**
+     * Immediately apply the optimizer grammars to the derivative tree structure.
+     * This saves a round trip to byte code.
+     */
+    ADAutoOptimize = 2,
+    /**
+     * Use cached JIT compiled function files, This bypasses the compilation stage
+     * for all further runs, after the JIT compilation ran successfully at least once.
+     */
+    ADJITCache = 4,
+    /**
+     * Use cached bytecode for the derivatives. This bypasses the automatic differentiation,
+     * (optimization), and byte code synthesis.
+     */
+    ADCacheDerivatives = 8
+  };
+
   /**
-   * Do not report any error messages to the console
+   * Set the feature flags for this parser (this way gives us better control over default values)
    */
-  void silenceAutoDiffErrors(bool _silence = true) { mSilenceErrors = _silence; }
+  void SetADFlags(int flags, bool turnon = true) {
+    if (turnon)
+      mADFlags |= flags;
+    else
+      mADFlags &= ~flags;
+  }
+  void UnsetADFlags(int flags) { mADFlags &= ~flags; }
+  void ClearADFlags() { mADFlags = 0; }
 
   /**
    * compile the current function, or load a previously compiled copy.
@@ -49,7 +80,7 @@ public:
    *          the previously JIT compiled function will continue to be Evaled until the
    *          JITCompile method is called again.
    */
-  bool JITCompile(bool cacheFunction = true);
+  bool JITCompile();
 
   /**
    * wrap Optimize of the parent class to check for a JIT compiled version and redo
@@ -88,7 +119,7 @@ public:
 
 private:
   /// helper function to perform the JIT compilation (needs the Value_t typename as a string)
-  bool JITCompileHelper(const std::string &, bool);
+  bool JITCompileHelper(const std::string &);
 
   /// JIT function pointer
   Value_t (*compiledFunction)(const Value_t *, const Value_t *, const Value_t);
@@ -96,17 +127,14 @@ private:
   /// pointer to the mImmed values (or NULL if the mImmed vector is empty)
   Value_t * pImmed;
 
-  /**
-   * In certain applications derivatives are built proactively and may never be used.
-   * We silence all AutoDiff exceptions in that case to avoid confusing the user.
-   */
-  bool mSilenceErrors;
-
   // user function plog
   static Value_t fp_plog(const Value_t * params);
 
   // function ID for the plog function
   unsigned int mFPlog;
+
+  // flags that control cache bahavior, optimization, and error reporting
+  int mADFlags;
 
   // registered derivative table, and entry structure
   struct VariableDerivative {

--- a/contrib/fparser/fpoptimizer/instantiate_for_ad.hh
+++ b/contrib/fparser/fpoptimizer/instantiate_for_ad.hh
@@ -19,3 +19,12 @@ namespace FPoptimizer_CodeTree
 
 }
 
+namespace FPoptimizer_Optimize
+{
+
+#define FP_INSTANTIATE(type) \
+    template void ApplyGrammars<type>(FPoptimizer_CodeTree::CodeTree<type>&);
+    FPOPTIMIZER_EXPLICITLY_INSTANTIATE(FP_INSTANTIATE)
+#undef FP_INSTANTIATE
+
+}

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -494,37 +494,35 @@ ParsedFunction<Output,OutputGradient>::partial_reparse (const std::string& expre
 
       // use of derivatives is optional. suppress error output on the console
       // use the has_derivatives() method to check if AutoDiff was successful.
-      fp.silenceAutoDiffErrors();
+      // also enable immediate optimization
+      fp.SetADFlags(FunctionParserADBase<Output>::ADSilenceErrors |
+                    FunctionParserADBase<Output>::ADAutoOptimize);
+
+      // optimize original function
+      fp.Optimize();
+      parsers.push_back(fp);
 
       // generate derivatives through automatic differentiation
       FunctionParserADBase<Output> dx_fp(fp);
       if (dx_fp.AutoDiff("x") != -1) // -1 for success
         _valid_derivatives = false;
-      dx_fp.Optimize();
       dx_parsers.push_back(dx_fp);
 #if LIBMESH_DIM > 1
       FunctionParserADBase<Output> dy_fp(fp);
       if (dy_fp.AutoDiff("y") != -1) // -1 for success
         _valid_derivatives = false;
-      dy_fp.Optimize();
       dy_parsers.push_back(dy_fp);
 #endif
 #if LIBMESH_DIM > 2
       FunctionParserADBase<Output> dz_fp(fp);
       if (dz_fp.AutoDiff("z") != -1) // -1 for success
         _valid_derivatives = false;
-      dz_fp.Optimize();
       dz_parsers.push_back(dz_fp);
 #endif
       FunctionParserADBase<Output> dt_fp(fp);
       if (dt_fp.AutoDiff("t") != -1) // -1 for success
         _valid_derivatives = false;
-      dt_fp.Optimize();
       dt_parsers.push_back(dt_fp);
-
-      // now optimise original function (after derivatives are taken)
-      fp.Optimize();
-      parsers.push_back(fp);
 
       // If at end, use nextstart=maxSize.  Else start at next
       // character.


### PR DESCRIPTION
This adds a caching mechanism for derivatives that provides a _substantial_ speed up for long function expressions (such as free energies from thermodynamic databases where it can cut _minutes_ of byte code synthesis down to sub second cache loads).

I've also added an optional immediate FPOptimizer call that operates on the freshly generated derivative tree, thus eliminating a roundtrip `-> tree -> byte code`. And I added a feature flag system to avoid having an API where the user needs to pass in multiple bools into several functions (which makes default arguments difficult).

<s>This will need a MOOSE update!</s> (actually MOOSE builds fine with those changes)

Closes #745  