### PR TITLE
Proposed packed_range refactor

### DIFF
--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -526,80 +526,55 @@ inline void wait (std::vector<Request> &r)
 
 
 /**
- * Define the data type to be used for data arrays whne encoding
- * a potentially-variable-size object of type T.
+ * Define data types and (un)serialization functions for use when
+ * encoding a potentially-variable-size object of type T.
+ *
+ * Users will need to specialize this class for their particular data
+ * types.
  */
 template <typename T>
-struct BufferType;
+class Packing {
+public:
+  // Should be an MPI sendable type in specializations, e.g.
+  // typedef char buffer_type;
+  // typedef unsigned int buffer_type;
 
-/**
- * Encoding non-const T* always uses the same buffer type as
- * encoding const T*, so other classes only have to specialize the
- * latter.
- */
-template <typename T>
-struct BufferType<T*> {
-  typedef typename BufferType<const T*>::type type;
+  // Should copy an encoding of the provided object into the provided
+  // output iterator (which is of type buffer_type)
+  template <typename OutputIter, typename Context>
+  static void pack(const T& object,
+                   OutputIter data_out,
+                   const Context* context);
+
+  // Should return the number of array entries (of type buffer_type)
+  // required to encode the provided object
+  template <typename Context>
+  static unsigned int packable_size(const T& object,
+                                    const Context* context);
+
+  // Should return the number of array entries which were used to
+  // encode the provided serialization of an object which begins at
+  // \p iter
+  template <typename BufferIter>
+  static unsigned int packed_size(BufferIter iter);
+
+  // Decode a potentially-variable-size object from a subsequence of a
+  // data array, returning a heap-allocated pointer to the result.
+  template <typename BufferIter, typename Context>
+  static T unpack(BufferIter in, Context* ctx);
 };
 
-/**
- * Encode a potentially-variable-size object at the end of a data
- * array.
- *
- * Parallel::pack() has no default implementation, and must be
- * specialized for each class which is to be communicated via packed
- * ranges.
- */
-template <typename T, typename buffertype, typename Context>
-void pack(const T* object,
-          typename std::vector<buffertype>& data,
-          const Context* context);
-
-/**
- * Output the number of integers required to encode a
- * potentially-variable-size object into a data array.
- *
- * Parallel::packable_size() has no default implementation, and must
- * be specialized for each class which is to be communicated via
- * packed ranges.
- */
-template <typename T, typename Context>
-unsigned int packable_size(const T*, const Context*);
-
-/**
- * Output the number of integers that were used to encode the next
- * variable-size object in the data array.
- *
- * Parallel::packed_size() has no default implementation, and must
- * be specialized for each class which is to be communicated via
- * packed ranges.
- *
- * The output of this method should be based *only* on the data
- * array; the T* argument is solely for function specialization.
- */
-template <typename T, typename BufferIter>
-unsigned int packed_size(const T*,
-                         BufferIter);
-
-/**
- * Decode a potentially-variable-size object from a subsequence of a
- * data array.
- *
- * Parallel::unpack() has no default implementation, and must be
- * specialized for each class which is to be communicated via packed
- * ranges.
- */
-template <typename T, typename BufferIter, typename Context>
-void unpack(BufferIter in, T** out, Context* ctx);
 
 /**
  * Decode a range of potentially-variable-size objects from a data
  * array.
  */
-template <typename Context, typename buffertype, typename OutputIter>
+template <typename Context, typename buffertype, typename OutputIter,
+          typename T>
 inline void unpack_range (const typename std::vector<buffertype>& buffer,
                           Context *context,
-                          OutputIter out);
+                          OutputIter out,
+                          T * output_type /* used only to infer T */);
 
 /**
  * Encode a range of potentially-variable-size objects to a data
@@ -976,10 +951,11 @@ public:
    *                                    vector<int>::const_iterator)
    * is used to advance to the beginning of the next object's data.
    */
-  template <typename Context, typename OutputIter>
+  template <typename Context, typename OutputIter, typename T>
   void receive_packed_range (const unsigned int dest_processor_id,
                              Context *context,
                              OutputIter out,
+                             T *output_type, // used only to infer T
                              const MessageTag &tag=any_tag) const;
 
   /**
@@ -1041,7 +1017,8 @@ public:
    *                                    vector<int>::const_iterator)
    * is used to advance to the beginning of the next object's data.
    */
-  template <typename Context1, typename RangeIter, typename Context2, typename OutputIter>
+  template <typename Context1, typename RangeIter, typename Context2,
+           typename OutputIter, typename T>
   void send_receive_packed_range(const unsigned int dest_processor_id,
                                  const Context1* context1,
                                  RangeIter send_begin,
@@ -1049,6 +1026,7 @@ public:
                                  const unsigned int source_processor_id,
                                  Context2* context2,
                                  OutputIter out,
+                                 T * output_type,
                                  const MessageTag &send_tag = no_tag,
                                  const MessageTag &recv_tag = any_tag) const;
 
@@ -1242,12 +1220,15 @@ private:
 };
 
 // PostWaitWork specialization for unpacking received buffers.
-template <typename Container, typename Context, typename OutputIter>
+template <typename Container, typename Context, typename OutputIter,
+          typename T>
 struct PostWaitUnpackBuffer : public PostWaitWork {
   PostWaitUnpackBuffer(const Container& buffer, Context *context, OutputIter out) :
     _buf(buffer), _context(context), _out(out) {}
 
-  virtual void run() libmesh_override { Parallel::unpack_range(_buf, _context, _out); }
+  virtual void run() libmesh_override {
+    Parallel::unpack_range(_buf, _context, _out, (T*)NULL);
+  }
 
 private:
   const Container& _buf;

--- a/include/parallel/parallel_elem.h
+++ b/include/parallel/parallel_elem.h
@@ -28,17 +28,59 @@
 
 namespace libMesh {
 namespace Parallel {
-// BufferType<> specializations to return a buffer datatype
-// to handle communication of Elems
-template <>
-struct BufferType<const Elem*> {
-  typedef largest_id_type type;
-};
+
 
 template <>
-struct BufferType<Elem> {
-  typedef largest_id_type type;
+class Packing<const Elem*> {
+public:
+  typedef largest_id_type buffer_type;
+
+  template <typename OutputIter, typename Context>
+  static void pack(const Elem* const & object,
+                   OutputIter data_out,
+                   const Context* context);
+
+  template <typename Context>
+  static unsigned int packable_size(const Elem* const & object,
+                                    const Context* context);
+
+  template <typename BufferIter>
+  static unsigned int packed_size(BufferIter iter);
+
+  template <typename BufferIter, typename Context>
+  static const Elem* unpack(BufferIter in, Context* ctx);
 };
+
+
+template <>
+class Packing<Elem*> {
+public:
+  typedef largest_id_type buffer_type;
+
+  template <typename OutputIter, typename Context>
+  static void pack(Elem* const & object,
+                   OutputIter data_out,
+                   const Context* context)
+  { return Packing<const Elem*>::pack(object, data_out, context); }
+
+  template <typename Context>
+  static unsigned int packable_size(Elem* const & object,
+                                    const Context* context)
+  { return Packing<const Elem*>::packable_size(object, context); }
+
+  template <typename BufferIter>
+  static unsigned int packed_size(BufferIter iter)
+  { return Packing<const Elem*>::packed_size(iter); }
+
+  template <typename BufferIter, typename Context>
+  static Elem* unpack(BufferIter in, Context* ctx);
+};
+
+
+template <typename BufferIter, typename Context>
+inline const Elem*
+Packing<const Elem*>::unpack(BufferIter in, Context* ctx)
+{ return Packing<Elem*>::unpack(in, ctx); }
 
 } // namespace Parallel
 } // namespace libMesh

--- a/include/parallel/parallel_node.h
+++ b/include/parallel/parallel_node.h
@@ -28,17 +28,61 @@
 
 namespace libMesh {
 namespace Parallel {
-// BufferType<> specialization to return a buffer datatype
-// to handle communication of Nodes
-template <>
-struct BufferType<const Node*> {
-  typedef largest_id_type type;
-};
+
 
 template <>
-struct BufferType<Node> {
-  typedef largest_id_type type;
+class Packing<const Node*> {
+public:
+  typedef largest_id_type buffer_type;
+
+  template <typename OutputIter, typename Context>
+  static void pack(const Node* const & object,
+                   OutputIter data_out,
+                   const Context* context);
+
+  template <typename Context>
+  static unsigned int packable_size(const Node* const & object,
+                                    const Context* context);
+
+  template <typename BufferIter>
+  static unsigned int packed_size(BufferIter iter);
+
+  template <typename BufferIter, typename Context>
+  static const Node* unpack(BufferIter in, Context* ctx);
 };
+
+
+template <>
+class Packing<Node*> {
+public:
+  typedef largest_id_type buffer_type;
+
+  template <typename OutputIter, typename Context>
+  static void pack(Node* const & object,
+                   OutputIter data_out,
+                   const Context* context)
+  { return Packing<const Node*>::pack(object, data_out, context); }
+
+  template <typename Context>
+  static unsigned int packable_size(Node* const & object,
+                                    const Context* context)
+  { return Packing<const Node*>::packable_size(object, context); }
+
+  template <typename BufferIter>
+  static unsigned int packed_size(BufferIter iter)
+  { return Packing<const Node*>::packed_size(iter); }
+
+  template <typename BufferIter, typename Context>
+  static Node* unpack(BufferIter in, Context* ctx);
+};
+
+
+template <typename BufferIter, typename Context>
+inline const Node*
+Packing<const Node*>::unpack(BufferIter in, Context* ctx)
+{ return Packing<Node*>::unpack(in, ctx); }
+
+
 
 } // namespace Parallel
 } // namespace libMesh

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3072,7 +3072,8 @@ void DofMap::allgather_recursive_constraints(MeshBase& mesh)
           if (!mesh.is_serial())
             this->comm().send_receive_packed_range
               (procdown, &mesh, nodes_requested.begin(), nodes_requested.end(),
-               procup,   &mesh, mesh_inserter_iterator<Node>(mesh));
+               procup,   &mesh, mesh_inserter_iterator<Node>(mesh),
+               (Node**)NULL);
 
 #endif // LIBMESH_ENABLE_NODE_CONSTRAINTS
           libmesh_assert_equal_to (dof_filled_keys.size(), requested_dof_ids[procup].size());
@@ -3466,7 +3467,8 @@ void DofMap::scatter_constraints(MeshBase& mesh)
       if (!mesh.is_serial())
         this->comm().send_receive_packed_range
           (procup, &mesh, pushed_nodes.begin(), pushed_nodes.end(),
-           procdown, &mesh, mesh_inserter_iterator<Node>(mesh));
+           procdown, &mesh, mesh_inserter_iterator<Node>(mesh),
+           (Node**)NULL);
 
       libmesh_assert_equal_to (pushed_node_ids_to_me.size(), pushed_node_keys_to_me.size());
       libmesh_assert_equal_to (pushed_node_ids_to_me.size(), pushed_node_vals_to_me.size());

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -359,6 +359,7 @@ void MeshCommunication::redistribute (ParallelMesh &mesh) const
     mesh.comm().receive_packed_range (Parallel::any_source,
                                       &mesh,
                                       mesh_inserter_iterator<Node>(mesh),
+                                      (Node**)NULL,
                                       nodestag);
 
   // Receive elements.
@@ -368,6 +369,7 @@ void MeshCommunication::redistribute (ParallelMesh &mesh) const
     mesh.comm().receive_packed_range (Parallel::any_source,
                                       &mesh,
                                       mesh_inserter_iterator<Elem>(mesh),
+                                      (Elem**)NULL,
                                       elemstag);
 
   // Wait for all sends to complete
@@ -715,6 +717,7 @@ void MeshCommunication::gather_neighboring_elements (ParallelMesh &mesh) const
           mesh.comm().receive_packed_range (source_pid_idx,
                                             &mesh,
                                             mesh_inserter_iterator<Node>(mesh),
+                                            (Node**)NULL,
                                             element_neighbors_tag);
         }
       //------------------------------------------------------------------
@@ -726,6 +729,7 @@ void MeshCommunication::gather_neighboring_elements (ParallelMesh &mesh) const
           mesh.comm().receive_packed_range (source_pid_idx,
                                             &mesh,
                                             mesh_inserter_iterator<Elem>(mesh),
+                                            (Elem**)NULL,
                                             element_neighbors_tag);
         }
       //------------------------------------------------------------------

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -54,8 +54,9 @@ namespace Parallel
 {
 
 template <>
-unsigned int packed_size (const Elem*,
-                          std::vector<largest_id_type>::const_iterator in)
+template <>
+unsigned int Packing<const Elem*>::packed_size 
+  (std::vector<largest_id_type>::const_iterator in)
 {
 #ifndef NDEBUG
   const largest_id_type packed_header = *in++;
@@ -120,16 +121,19 @@ unsigned int packed_size (const Elem*,
 
 
 template <>
-unsigned int packed_size (const Elem* e,
-                          std::vector<largest_id_type>::iterator in)
+template <>
+unsigned int Packing<const Elem*>::packed_size
+  (std::vector<largest_id_type>::iterator in)
 {
-  return packed_size(e, std::vector<largest_id_type>::const_iterator(in));
+  return packed_size(std::vector<largest_id_type>::const_iterator(in));
 }
 
 
 
 template <>
-unsigned int packable_size (const Elem* elem, const MeshBase* mesh)
+template <>
+unsigned int Packing<const Elem*>::packable_size
+  (const Elem* const & elem, const MeshBase* mesh)
 {
   unsigned int total_packed_bcs = 0;
   if (elem->level() == 0)
@@ -157,7 +161,9 @@ unsigned int packable_size (const Elem* elem, const MeshBase* mesh)
 
 
 template <>
-unsigned int packable_size (const Elem* elem, const ParallelMesh* mesh)
+template <>
+unsigned int Packing<const Elem*>::packable_size
+  (const Elem* const & elem, const ParallelMesh* mesh)
 {
   return packable_size(elem, static_cast<const MeshBase*>(mesh));
 }
@@ -165,22 +171,21 @@ unsigned int packable_size (const Elem* elem, const ParallelMesh* mesh)
 
 
 template <>
-void pack (const Elem* elem,
-           std::vector<largest_id_type>& data,
-           const MeshBase* mesh)
+template <>
+void Packing<const Elem*>::pack
+  (const Elem* const & elem,
+   std::back_insert_iterator<std::vector<largest_id_type> > data_out,
+   const MeshBase* mesh)
 {
   libmesh_assert(elem);
 
-  // This should be redundant when used with Parallel::pack_range()
-  // data.reserve (data.size() + Parallel::packable_size(elem, mesh));
-
 #ifndef NDEBUG
-  data.push_back (elem_magic_header);
+  *data_out++ = elem_magic_header;
 #endif
 
 #ifdef LIBMESH_ENABLE_AMR
-  data.push_back (static_cast<largest_id_type>(elem->level()));
-  data.push_back (static_cast<largest_id_type>(elem->p_level()));
+  *data_out++ = (static_cast<largest_id_type>(elem->level()));
+  *data_out++ = (static_cast<largest_id_type>(elem->p_level()));
 
   // Encode both the refinement flag and whether the element has
   // children together.  This coding is unambiguous because our
@@ -191,76 +196,65 @@ void pack (const Elem* elem,
   if (elem->has_children())
     refinement_info +=
       static_cast<largest_id_type>(Elem::INVALID_REFINEMENTSTATE) + 1;
-  data.push_back (refinement_info);
+  *data_out++ = (refinement_info);
 
-  data.push_back (static_cast<largest_id_type>(elem->p_refinement_flag()));
+  *data_out++ = (static_cast<largest_id_type>(elem->p_refinement_flag()));
 #else
-  data.push_back (0);
-  data.push_back (0);
-  data.push_back (0);
-  data.push_back (0);
+  *data_out++ = (0);
+  *data_out++ = (0);
+  *data_out++ = (0);
+  *data_out++ = (0);
 #endif
-  data.push_back (static_cast<largest_id_type>(elem->type()));
-  data.push_back (elem->processor_id());
-  data.push_back (elem->subdomain_id());
-  data.push_back (elem->id());
+  *data_out++ = (static_cast<largest_id_type>(elem->type()));
+  *data_out++ = (elem->processor_id());
+  *data_out++ = (elem->subdomain_id());
+  *data_out++ = (elem->id());
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   if (elem->valid_unique_id())
-    data.push_back (static_cast<largest_id_type>(elem->unique_id()));
+    *data_out++ = (static_cast<largest_id_type>(elem->unique_id()));
   else
     // OK to send invalid unique id, we must not own this DOF
-    data.push_back (static_cast<largest_id_type>(DofObject::invalid_unique_id));
+    *data_out++ = (static_cast<largest_id_type>(DofObject::invalid_unique_id));
 #endif
 
 #ifdef LIBMESH_ENABLE_AMR
   // use parent_ID of invalid_id to indicate a level 0 element
   if (elem->level() == 0)
     {
-      data.push_back(DofObject::invalid_id);
-      data.push_back(DofObject::invalid_id);
+      *data_out++ =(DofObject::invalid_id);
+      *data_out++ =(DofObject::invalid_id);
     }
   else
     {
-      data.push_back(elem->parent()->id());
-      data.push_back(elem->parent()->which_child_am_i(elem));
+      *data_out++ =(elem->parent()->id());
+      *data_out++ =(elem->parent()->which_child_am_i(elem));
     }
 #else
-  data.push_back (DofObject::invalid_id);
-  data.push_back (DofObject::invalid_id);
+  *data_out++ = (DofObject::invalid_id);
+  *data_out++ = (DofObject::invalid_id);
 #endif
 
   if ((elem->dim() < LIBMESH_DIM) &&
       elem->interior_parent())
-    data.push_back(elem->interior_parent()->id());
+    *data_out++ =(elem->interior_parent()->id());
   else
-    data.push_back(DofObject::invalid_id);
+    *data_out++ =(DofObject::invalid_id);
 
   for (unsigned int n=0; n<elem->n_nodes(); n++)
-    data.push_back (elem->node(n));
+    *data_out++ = (elem->node(n));
 
   for (unsigned int n=0; n<elem->n_neighbors(); n++)
     {
       const Elem *neigh = elem->neighbor(n);
       if (neigh)
-        data.push_back (neigh->id());
+        *data_out++ = (neigh->id());
       else
-        data.push_back (DofObject::invalid_id);
+        *data_out++ = (DofObject::invalid_id);
     }
 
-#ifndef NDEBUG
-  const std::size_t start_indices = data.size();
-#endif
   // Add any DofObject indices
-  elem->pack_indexing(std::back_inserter(data));
-
-  libmesh_assert(elem->packed_indexing_size() ==
-                 DofObject::unpackable_indexing_size(data.begin() +
-                                                     start_indices));
-
-  libmesh_assert_equal_to (elem->packed_indexing_size(),
-                           data.size() - start_indices);
-
+  elem->pack_indexing(data_out);
 
   // If this is a coarse element,
   // Add any element side boundary condition ids
@@ -271,22 +265,22 @@ void pack (const Elem* elem,
         {
           mesh->get_boundary_info().boundary_ids(elem, s, bcs);
 
-          data.push_back(bcs.size());
+          *data_out++ =(bcs.size());
 
           for (std::vector<boundary_id_type>::iterator bc_it=bcs.begin();
                bc_it != bcs.end(); ++bc_it)
-            data.push_back(*bc_it);
+            *data_out++ =(*bc_it);
         }
 
       for (unsigned short e = 0; e != elem->n_edges(); ++e)
         {
           mesh->get_boundary_info().edge_boundary_ids(elem, e, bcs);
 
-          data.push_back(bcs.size());
+          *data_out++ =(bcs.size());
 
           for (std::vector<boundary_id_type>::iterator bc_it=bcs.begin();
                bc_it != bcs.end(); ++bc_it)
-            data.push_back(*bc_it);
+            *data_out++ =(*bc_it);
         }
     }
 }
@@ -294,20 +288,23 @@ void pack (const Elem* elem,
 
 
 template <>
-void pack (const Elem* elem,
-           std::vector<largest_id_type>& data,
-           const ParallelMesh* mesh)
+template <>
+void Packing<const Elem*>::pack
+  (const Elem* const & elem,
+   std::back_insert_iterator<std::vector<largest_id_type> > data_out,
+   const ParallelMesh* mesh)
 {
-  pack(elem, data, static_cast<const MeshBase*>(mesh));
+  pack(elem, data_out, static_cast<const MeshBase*>(mesh));
 }
 
 
 
 // FIXME - this needs serious work to be 64-bit compatible
 template <>
-void unpack(std::vector<largest_id_type>::const_iterator in,
-            Elem** out,
-            MeshBase* mesh)
+template <>
+Elem* Packing<Elem*>::unpack
+  (std::vector<largest_id_type>::const_iterator in,
+   MeshBase* mesh)
 {
 #ifndef NDEBUG
   const std::vector<largest_id_type>::const_iterator original_in = in;
@@ -717,17 +714,18 @@ void unpack(std::vector<largest_id_type>::const_iterator in,
     }
 
   // Return the new element
-  *out = elem;
+  return elem;
 }
 
 
 
 template <>
-void unpack(std::vector<largest_id_type>::const_iterator in,
-            Elem** out,
-            ParallelMesh* mesh)
+template <>
+Elem* Packing<Elem*>::unpack
+  (std::vector<largest_id_type>::const_iterator in,
+   ParallelMesh* mesh)
 {
-  unpack(in, out, static_cast<MeshBase*>(mesh));
+  return unpack(in, static_cast<MeshBase*>(mesh));
 }
 
 } // namespace Parallel

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -57,7 +57,8 @@ namespace Parallel
 {
 
 template <>
-unsigned int packable_size (const Node* node, const MeshBase* mesh)
+template <>
+unsigned int Packing<const Node*>::packable_size (const Node* const & node, const MeshBase* mesh)
 {
   return
 #ifndef NDEBUG
@@ -71,8 +72,9 @@ unsigned int packable_size (const Node* node, const MeshBase* mesh)
 
 
 template <>
-unsigned int packed_size (const Node*,
-                          const std::vector<largest_id_type>::const_iterator in)
+template <>
+unsigned int Packing<const Node*>::packed_size
+  (const std::vector<largest_id_type>::const_iterator in)
 {
   const unsigned int pre_indexing_size =
 #ifndef NDEBUG
@@ -93,16 +95,19 @@ unsigned int packed_size (const Node*,
 
 
 template <>
-unsigned int packed_size (const Node* n,
-                          const std::vector<largest_id_type>::iterator in)
+template <>
+unsigned int Packing<const Node*>::packed_size
+  (const std::vector<largest_id_type>::iterator in)
 {
-  return packed_size(n, std::vector<largest_id_type>::const_iterator(in));
+  return packed_size(std::vector<largest_id_type>::const_iterator(in));
 }
 
 
 
 template <>
-unsigned int packable_size (const Node* node, const ParallelMesh* mesh)
+template <>
+unsigned int Packing<const Node*>::packable_size
+  (const Node* const & node, const ParallelMesh* mesh)
 {
   return packable_size(node, static_cast<const MeshBase*>(mesh));
 }
@@ -110,28 +115,27 @@ unsigned int packable_size (const Node* node, const ParallelMesh* mesh)
 
 
 template <>
-void pack (const Node* node,
-           std::vector<largest_id_type>& data,
-           const MeshBase* mesh)
+template <>
+void Packing<const Node*>::pack
+  (const Node* const & node,
+   std::back_insert_iterator<std::vector<largest_id_type> > data_out,
+   const MeshBase* mesh)
 {
   libmesh_assert(node);
 
-  // This should be redundant when used with Parallel::pack_range()
-  // data.reserve (data.size() + Parallel::packable_size(node, mesh));
-
 #ifndef NDEBUG
-  data.push_back (node_magic_header);
+  *data_out++ = (node_magic_header);
 #endif
 
-  data.push_back (static_cast<largest_id_type>(node->processor_id()));
-  data.push_back (static_cast<largest_id_type>(node->id()));
+  *data_out++ = (static_cast<largest_id_type>(node->processor_id()));
+  *data_out++ = (static_cast<largest_id_type>(node->id()));
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   if (node->valid_unique_id())
-    data.push_back (static_cast<largest_id_type>(node->unique_id()));
+    *data_out++ = (static_cast<largest_id_type>(node->unique_id()));
   else
     // OK to send invalid unique id, we must not own this DOF
-    data.push_back (static_cast<largest_id_type>(DofObject::invalid_unique_id));
+    *data_out++ = (static_cast<largest_id_type>(DofObject::invalid_unique_id));
 #endif
 
   // use "(a+b-1)/b" trick to get a/b to round up
@@ -144,22 +148,12 @@ void pack (const Node* node,
         reinterpret_cast<const largest_id_type*>(&((*node)(i)));
       for (unsigned int j=0; j != idtypes_per_Real; ++j)
         {
-          data.push_back(Real_as_idtypes[j]);
+          *data_out++ =(Real_as_idtypes[j]);
         }
     }
 
-#ifndef NDEBUG
-  const std::size_t start_indices = data.size();
-#endif
   // Add any DofObject indices
-  node->pack_indexing(std::back_inserter(data));
-
-  libmesh_assert(node->packed_indexing_size() ==
-                 DofObject::unpackable_indexing_size(data.begin() +
-                                                     start_indices));
-
-  libmesh_assert_equal_to (node->packed_indexing_size(),
-                           data.size() - start_indices);
+  node->pack_indexing(data_out);
 
   // Add any nodal boundary condition ids
   std::vector<boundary_id_type> bcs;
@@ -167,29 +161,32 @@ void pack (const Node* node,
 
   libmesh_assert(bcs.size() < std::numeric_limits<largest_id_type>::max());
 
-  data.push_back(bcs.size());
+  *data_out++ =(bcs.size());
 
   for (std::vector<boundary_id_type>::iterator bc_it=bcs.begin();
        bc_it != bcs.end(); ++bc_it)
-    data.push_back(*bc_it);
+    *data_out++ =(*bc_it);
 }
 
 
 
 template <>
-void pack (const Node* node,
-           std::vector<largest_id_type>& data,
-           const ParallelMesh* mesh)
+template <>
+void Packing<const Node*>::pack
+  (const Node* const & node,
+   std::back_insert_iterator<std::vector<largest_id_type> > data_out,
+   const ParallelMesh* mesh)
 {
-  pack(node, data, static_cast<const MeshBase*>(mesh));
+  pack(node, data_out, static_cast<const MeshBase*>(mesh));
 }
 
 
 
 template <>
-void unpack (std::vector<largest_id_type>::const_iterator in,
-             Node** out,
-             MeshBase* mesh)
+template <>
+Node* Packing<Node*>::unpack
+  (std::vector<largest_id_type>::const_iterator in,
+   MeshBase* mesh)
 {
 #ifndef NDEBUG
   const std::vector<largest_id_type>::const_iterator original_in = in;
@@ -245,8 +242,6 @@ void unpack (std::vector<largest_id_type>::const_iterator in,
           // the encoded indexing is consistent
           in += DofObject::unpackable_indexing_size(in);
         }
-
-      *out = node;
     }
   else
     {
@@ -283,23 +278,24 @@ void unpack (std::vector<largest_id_type>::const_iterator in,
     mesh->get_boundary_info().add_node
       (node, cast_int<boundary_id_type>(*in++));
 
-  *out = node;
-
 #ifndef NDEBUG
   libmesh_assert (in - original_in ==
                   cast_int<int>
-                  (Parallel::packed_size(node, original_in)));
+                  (Parallel::Packing<const Node*>::packed_size(original_in)));
 #endif
+
+  return node;
 }
 
 
 
 template <>
-void unpack (std::vector<largest_id_type>::const_iterator in,
-             Node** out,
-             ParallelMesh* mesh)
+template <>
+Node* Packing<Node*>::unpack
+  (std::vector<largest_id_type>::const_iterator in,
+   ParallelMesh* mesh)
 {
-  unpack(in, out, static_cast<MeshBase*>(mesh));
+  return unpack(in, static_cast<MeshBase*>(mesh));
 }
 
 } // namespace Parallel

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,6 +35,7 @@ unit_tests_sources = \
 	numerics/vector_value_test.C \
 	numerics/type_tensor_test.C \
 	numerics/dense_matrix_test.C \
+	parallel/packed_range_test.C \
 	parallel/parallel_test.C \
 	parallel/parallel_point_test.C \
 	quadrature/quadrature_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -144,10 +144,10 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	quadrature/quadrature_test.C systems/equation_systems_test.C \
-	systems/systems_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	parallel/packed_range_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C quadrature/quadrature_test.C \
+	systems/equation_systems_test.C systems/systems_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 am__dirstamp = $(am__leading_dot)dirstamp
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_1 = fparser/unit_tests_dbg-autodiff.$(OBJEXT)
 am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
@@ -171,6 +171,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	numerics/unit_tests_dbg-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_dbg-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_point_test.$(OBJEXT) \
 	quadrature/unit_tests_dbg-quadrature_test.$(OBJEXT) \
@@ -204,10 +205,10 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	quadrature/quadrature_test.C systems/equation_systems_test.C \
-	systems/systems_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	parallel/packed_range_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C quadrature/quadrature_test.C \
+	systems/equation_systems_test.C systems/systems_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_3 = fparser/unit_tests_devel-autodiff.$(OBJEXT)
 am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	base/unit_tests_devel-getpot_test.$(OBJEXT) \
@@ -230,6 +231,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	numerics/unit_tests_devel-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_devel-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_devel-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_devel-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_point_test.$(OBJEXT) \
 	quadrature/unit_tests_devel-quadrature_test.$(OBJEXT) \
@@ -261,10 +263,10 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	quadrature/quadrature_test.C systems/equation_systems_test.C \
-	systems/systems_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	parallel/packed_range_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C quadrature/quadrature_test.C \
+	systems/equation_systems_test.C systems/systems_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_5 = fparser/unit_tests_oprof-autodiff.$(OBJEXT)
 am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	base/unit_tests_oprof-getpot_test.$(OBJEXT) \
@@ -287,6 +289,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	numerics/unit_tests_oprof-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_oprof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_point_test.$(OBJEXT) \
 	quadrature/unit_tests_oprof-quadrature_test.$(OBJEXT) \
@@ -318,10 +321,10 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	quadrature/quadrature_test.C systems/equation_systems_test.C \
-	systems/systems_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	parallel/packed_range_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C quadrature/quadrature_test.C \
+	systems/equation_systems_test.C systems/systems_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_7 = fparser/unit_tests_opt-autodiff.$(OBJEXT)
 am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	base/unit_tests_opt-getpot_test.$(OBJEXT) \
@@ -344,6 +347,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	numerics/unit_tests_opt-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_opt-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_opt-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_opt-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_point_test.$(OBJEXT) \
 	quadrature/unit_tests_opt-quadrature_test.$(OBJEXT) \
@@ -373,10 +377,10 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	quadrature/quadrature_test.C systems/equation_systems_test.C \
-	systems/systems_test.C utils/vectormap_test.C \
-	fparser/autodiff.C
+	parallel/packed_range_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C quadrature/quadrature_test.C \
+	systems/equation_systems_test.C systems/systems_test.C \
+	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_9 = fparser/unit_tests_prof-autodiff.$(OBJEXT)
 am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	base/unit_tests_prof-getpot_test.$(OBJEXT) \
@@ -399,6 +403,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	numerics/unit_tests_prof-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_prof-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_prof-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_prof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_point_test.$(OBJEXT) \
 	quadrature/unit_tests_prof-quadrature_test.$(OBJEXT) \
@@ -826,9 +831,10 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	quadrature/quadrature_test.C systems/equation_systems_test.C \
-	systems/systems_test.C utils/vectormap_test.C $(am__append_1)
+	parallel/packed_range_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C quadrature/quadrature_test.C \
+	systems/equation_systems_test.C systems/systems_test.C \
+	utils/vectormap_test.C $(am__append_1)
 EXTRA_DIST = base/getpot_test_input.in
 @LIBMESH_OPT_MODE_TRUE@unit_tests_opt_SOURCES = $(unit_tests_sources)
 @LIBMESH_OPT_MODE_TRUE@unit_tests_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
@@ -980,6 +986,8 @@ parallel/$(am__dirstamp):
 parallel/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) parallel/$(DEPDIR)
 	@: > parallel/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_dbg-packed_range_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_dbg-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_dbg-parallel_point_test.$(OBJEXT):  \
@@ -1062,6 +1070,8 @@ numerics/unit_tests_devel-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_devel-packed_range_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-parallel_point_test.$(OBJEXT):  \
@@ -1120,6 +1130,8 @@ numerics/unit_tests_oprof-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_oprof-packed_range_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_oprof-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_oprof-parallel_point_test.$(OBJEXT):  \
@@ -1178,6 +1190,8 @@ numerics/unit_tests_opt-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_opt-packed_range_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-parallel_point_test.$(OBJEXT):  \
@@ -1236,6 +1250,8 @@ numerics/unit_tests_prof-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_prof-packed_range_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_prof-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_prof-parallel_point_test.$(OBJEXT):  \
@@ -1380,14 +1396,19 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-vector_value_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_dbg-parallel_point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_dbg-parallel_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_devel-parallel_point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_devel-parallel_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_oprof-parallel_point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_oprof-parallel_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_opt-parallel_point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_opt-parallel_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-parallel_point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-parallel_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@quadrature/$(DEPDIR)/unit_tests_dbg-quadrature_test.Po@am__quote@
@@ -1728,6 +1749,20 @@ numerics/unit_tests_dbg-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/dense_matrix_test.C' object='numerics/unit_tests_dbg-dense_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
+
+parallel/unit_tests_dbg-packed_range_test.o: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Tpo -c -o parallel/unit_tests_dbg-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_dbg-packed_range_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_dbg-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+
+parallel/unit_tests_dbg-packed_range_test.obj: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-packed_range_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Tpo -c -o parallel/unit_tests_dbg-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_dbg-packed_range_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_dbg-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
 
 parallel/unit_tests_dbg-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-parallel_test.Tpo -c -o parallel/unit_tests_dbg-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C
@@ -2121,6 +2156,20 @@ numerics/unit_tests_devel-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+parallel/unit_tests_devel-packed_range_test.o: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Tpo -c -o parallel/unit_tests_devel-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_devel-packed_range_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_devel-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+
+parallel/unit_tests_devel-packed_range_test.obj: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-packed_range_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Tpo -c -o parallel/unit_tests_devel-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_devel-packed_range_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_devel-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
+
 parallel/unit_tests_devel-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-parallel_test.Tpo -c -o parallel/unit_tests_devel-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-parallel_test.Tpo parallel/$(DEPDIR)/unit_tests_devel-parallel_test.Po
@@ -2512,6 +2561,20 @@ numerics/unit_tests_oprof-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/dense_matrix_test.C' object='numerics/unit_tests_oprof-dense_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
+
+parallel/unit_tests_oprof-packed_range_test.o: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Tpo -c -o parallel/unit_tests_oprof-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_oprof-packed_range_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_oprof-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+
+parallel/unit_tests_oprof-packed_range_test.obj: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-packed_range_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Tpo -c -o parallel/unit_tests_oprof-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_oprof-packed_range_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_oprof-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
 
 parallel/unit_tests_oprof-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-parallel_test.Tpo -c -o parallel/unit_tests_oprof-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C
@@ -2905,6 +2968,20 @@ numerics/unit_tests_opt-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+parallel/unit_tests_opt-packed_range_test.o: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Tpo -c -o parallel/unit_tests_opt-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_opt-packed_range_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_opt-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+
+parallel/unit_tests_opt-packed_range_test.obj: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-packed_range_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Tpo -c -o parallel/unit_tests_opt-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_opt-packed_range_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_opt-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
+
 parallel/unit_tests_opt-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-parallel_test.Tpo -c -o parallel/unit_tests_opt-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-parallel_test.Tpo parallel/$(DEPDIR)/unit_tests_opt-parallel_test.Po
@@ -3296,6 +3373,20 @@ numerics/unit_tests_prof-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/dense_matrix_test.C' object='numerics/unit_tests_prof-dense_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
+
+parallel/unit_tests_prof-packed_range_test.o: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Tpo -c -o parallel/unit_tests_prof-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_prof-packed_range_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_prof-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
+
+parallel/unit_tests_prof-packed_range_test.obj: parallel/packed_range_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-packed_range_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Tpo -c -o parallel/unit_tests_prof-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/packed_range_test.C' object='parallel/unit_tests_prof-packed_range_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_prof-packed_range_test.obj `if test -f 'parallel/packed_range_test.C'; then $(CYGPATH_W) 'parallel/packed_range_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/packed_range_test.C'; fi`
 
 parallel/unit_tests_prof-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-parallel_test.Tpo -c -o parallel/unit_tests_prof-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C

--- a/tests/parallel/packed_range_test.C
+++ b/tests/parallel/packed_range_test.C
@@ -1,0 +1,129 @@
+#include "test_comm.h"
+
+// Ignore unused parameter warnings coming from cppuint headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/parallel.h>
+#include <libmesh/null_output_iterator.h>
+
+#include <vector>
+
+namespace libMesh {
+namespace Parallel {
+template <typename T>
+class Packing<std::basic_string<T> > {
+public:
+
+  static const unsigned int size_bytes = 4;
+
+  typedef T buffer_type;
+
+static unsigned int get_string_len
+  (typename std::vector<T>::const_iterator in)
+{
+  unsigned int string_len = in[size_bytes-1];
+  for (signed int i=size_bytes-2; i >= 0; --i)
+    {
+      string_len *= 256;
+      string_len += in[i];
+    }
+  return string_len;
+}
+
+
+static unsigned int packed_size
+  (typename std::vector<T>::const_iterator in)
+{
+  return get_string_len(in) + size_bytes;
+}
+
+static unsigned int packable_size
+  (const std::basic_string<T> & s,
+   const void *)
+{
+  return s.size() + size_bytes;
+}
+
+
+template <typename Iter>
+static void pack (const std::basic_string<T> & b, Iter data_out,
+                  const void * f)
+{
+  unsigned int string_len = b.size();
+  for (unsigned int i=0; i != size_bytes; ++i)
+    {
+      *data_out++ = (string_len % 256);
+      string_len /= 256;
+    }
+  std::copy(b.begin(), b.end(), data_out);
+}
+
+static std::basic_string<T> unpack
+  (typename std::vector<T>::const_iterator in, void * f)
+{
+  unsigned int string_len = get_string_len(in);
+
+  std::ostringstream oss;
+  for (unsigned int i = 0; i < string_len; ++i)
+    oss << static_cast<char>(in[i+size_bytes]);
+
+  in += size_bytes + string_len;
+
+//  std::cout << oss.str() << std::endl;
+  return std::string(oss.str());
+}
+
+};
+
+
+} // namespace Parallel
+
+} // namespace libMesh
+
+
+
+using namespace libMesh;
+
+class PackedRangeTest : public CppUnit::TestCase {
+public:
+  CPPUNIT_TEST_SUITE( PackedRangeTest );
+
+  CPPUNIT_TEST( testNullAllGather );
+//  CPPUNIT_TEST( testNullSendReceive );
+//  CPPUNIT_TEST( testAdapterSendReceive );
+//  CPPUNIT_TEST( testPointerAdapterSendReceive );
+
+  CPPUNIT_TEST_SUITE_END();
+
+private:
+
+public:
+  void setUp()
+  {}
+
+  void tearDown()
+  {}
+
+
+
+  void testNullAllGather()
+  {
+    std::vector<processor_id_type> vals;
+
+    std::vector<std::string> send(1);
+    if (TestCommWorld->rank() == 0)
+      send[0].assign("Hello");
+    else
+      send[0].assign("Goodbye");
+
+    TestCommWorld->allgather_packed_range
+      ((void *)(NULL), send.begin(), send.end(),
+       libMesh::null_output_iterator<std::string>());
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( PackedRangeTest );

--- a/tests/parallel/packed_range_test.C
+++ b/tests/parallel/packed_range_test.C
@@ -50,7 +50,7 @@ static unsigned int packable_size
 
 template <typename Iter>
 static void pack (const std::basic_string<T> & b, Iter data_out,
-                  const void * f)
+                  const void *)
 {
   unsigned int string_len = b.size();
   for (unsigned int i=0; i != size_bytes; ++i)
@@ -62,7 +62,7 @@ static void pack (const std::basic_string<T> & b, Iter data_out,
 }
 
 static std::basic_string<T> unpack
-  (typename std::vector<T>::const_iterator in, void * f)
+  (typename std::vector<T>::const_iterator in, void *)
 {
   unsigned int string_len = get_string_len(in);
 

--- a/tests/parallel/packed_range_test.C
+++ b/tests/parallel/packed_range_test.C
@@ -92,7 +92,8 @@ public:
   CPPUNIT_TEST_SUITE( PackedRangeTest );
 
   CPPUNIT_TEST( testNullAllGather );
-//  CPPUNIT_TEST( testNullSendReceive );
+  CPPUNIT_TEST( testNullSendReceive );
+  CPPUNIT_TEST( testContainerSendReceive );
 //  CPPUNIT_TEST( testAdapterSendReceive );
 //  CPPUNIT_TEST( testPointerAdapterSendReceive );
 
@@ -122,6 +123,68 @@ public:
     TestCommWorld->allgather_packed_range
       ((void *)(NULL), send.begin(), send.end(),
        libMesh::null_output_iterator<std::string>());
+  }
+
+
+  void testNullSendReceive()
+  {
+    std::vector<processor_id_type> vals;
+
+    std::vector<std::string> send(1);
+    const unsigned int my_rank = TestCommWorld->rank();
+    const unsigned int dest_rank =
+      (my_rank + 1) % TestCommWorld->size();
+    const unsigned int source_rank =
+      (my_rank + TestCommWorld->size() - 1) % TestCommWorld->size();
+
+    {
+      std::ostringstream os;
+      os << my_rank;
+      send[0] = os.str();
+    }
+
+    TestCommWorld->send_receive_packed_range
+      (dest_rank, (void *)(NULL), send.begin(), send.end(),
+       source_rank, (void *)(NULL),
+       libMesh::null_output_iterator<std::string>(),
+       (std::string*)NULL);
+  }
+
+
+  void testContainerSendReceive()
+  {
+    std::vector<processor_id_type> vals;
+
+    std::vector<std::string> send(1), recv;
+
+    const unsigned int my_rank = TestCommWorld->rank();
+    const unsigned int dest_rank =
+      (my_rank + 1) % TestCommWorld->size();
+    const unsigned int source_rank =
+      (my_rank + TestCommWorld->size() - 1) % TestCommWorld->size();
+
+    {
+      std::ostringstream os;
+      os << my_rank;
+      send[0] = os.str();
+    }
+
+    TestCommWorld->send_receive_packed_range
+      (dest_rank, (void *)(NULL), send.begin(), send.end(),
+       source_rank, (void *)(NULL),
+       std::back_inserter(recv),
+       (std::string*)NULL);
+
+    CPPUNIT_ASSERT_EQUAL(recv.size(), std::size_t(1));
+
+    std::string check;
+    {
+      std::ostringstream os;
+      os << source_rank;
+      check = os.str();
+    }
+
+    CPPUNIT_ASSERT_EQUAL(recv[0], check);
   }
 
 };


### PR DESCRIPTION
Make functions into class static methods, so we can do partial template specialization on the class.

pack() can take an output iterator for future flexibility (although for Elem and Node we'll only instantiate the methods which take a back_inserter)

Use references to T rather than pointers to T.  This still lets us use references-to-pointers-to-heap-objects in the Elem* and Node* cases, but lets us manipulate objects on the stack if we prefer in other specializations, and (given the proper Packing<Foo> and Packing<Foo*> specializations) should even let us mix and match between the two options when sending and receiving.

Use a return value rather than a return parameter in unpack

Remove the now-redundant function specialization argument from packed_size

Add a function specialization argument to receive_packed_range and send_receive_packed_range, so we can now use standard output iterators whose underlying type can't be inferred from traits.

Use the new Packing API with Node* and Elem* types

Add unit tests with std::string


This is based on the discussion and advice from @permcody in #728 and emails.

This PR changes the packed_range code from "a neat refactoring of internal DofObject communications" to "intended for public specialization and general use", so now is the time for complaints, suggestions, etc. about the new API.