### PR TITLE
PETSc 3.6.3 still has old TaoSetTolerances options

### DIFF
--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -500,8 +500,8 @@ void TaoOptimizationSolver<T>::solve ()
   // ||g(X)|| / ||g(X0)||                <= gttol
   // Command line equivalents: -tao_fatol, -tao_frtol, -tao_gatol, -tao_grtol, -tao_gttol
   ierr = TaoSetTolerances(_tao,
-#if PETSC_RELEASE_LESS_THAN(3,6,3)
-                          // Releases up to 3.6.2 had fatol and frtol, after that they were removed.
+#if PETSC_RELEASE_LESS_THAN(3,6,4)
+                          // Releases up to 3.6.3 had fatol and frtol, after that they were removed.
                           /*fatol=*/PETSC_DEFAULT,
                           /*frtol=*/PETSC_DEFAULT,
 #endif


### PR DESCRIPTION
With this change, I can build libMesh with the PETSc 3.6.3 release.