### PR TITLE
Widen NewtonSolver immediate-convergence test

### DIFF
--- a/src/solvers/newton_solver.C
+++ b/src/solvers/newton_solver.C
@@ -324,24 +324,29 @@ unsigned int NewtonSolver::solve()
           continue;
         }
 
-      if (current_residual == 0)
+      if (current_residual <= absolute_residual_tolerance)
         {
           if (verbose)
-            libMesh::out << "Linear solve unnecessary; residual = 0"
+            libMesh::out << "Linear solve unnecessary; residual "
+                         << current_residual
+                         << " meets absolute tolerance "
+                         << absolute_residual_tolerance
                          << std::endl;
 
           // We're not doing a solve, but other code may reuse this
           // matrix.
           matrix.close();
 
-          if (absolute_residual_tolerance > 0)
-            _solve_result |= CONVERGED_ABSOLUTE_RESIDUAL;
-          if (relative_residual_tolerance > 0)
-            _solve_result |= CONVERGED_RELATIVE_RESIDUAL;
-          if (absolute_step_tolerance > 0)
-            _solve_result |= CONVERGED_ABSOLUTE_STEP;
-          if (relative_step_tolerance > 0)
-            _solve_result |= CONVERGED_RELATIVE_STEP;
+          _solve_result |= CONVERGED_ABSOLUTE_RESIDUAL;
+          if (current_residual == 0)
+            {
+              if (relative_residual_tolerance > 0)
+                _solve_result |= CONVERGED_RELATIVE_RESIDUAL;
+              if (absolute_step_tolerance > 0)
+                _solve_result |= CONVERGED_ABSOLUTE_STEP;
+              if (relative_step_tolerance > 0)
+                _solve_result |= CONVERGED_RELATIVE_STEP;
+            }
 
           break;
         }


### PR DESCRIPTION
Not only should we converge on our initial iterate if it has a zero
residual, we should converge if it has a residual under our
absolute_residual_tolerance.

This should fix the cases where we try to re-solve an oversolved
solution and we tell PETSc to use a linear tolerance above 1.0

I haven't finished compiling and testing this myself yet; just wanted to get it out there for @pbauman to try ASAP.