### PR TITLE
Don't use LIBMESH_OPTIONS in reduced basis ex5

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex5/run.sh
+++ b/examples/reduced_basis/reduced_basis_ex5/run.sh
@@ -9,7 +9,7 @@ example_name=reduced_basis_ex5
 example_dir=examples/reduced_basis/$example_name
 
 options="-online_mode 0 -ksp_type cg"
-run_example "$example_name" "$options"
+run_example_no_extra_options "$example_name" "$options"
 
 options="-online_mode 1"
-run_example "$example_name" "$options"
+run_example_no_extra_options "$example_name" "$options"


### PR DESCRIPTION
I could swear that my usual "block Jacobi + ILU4" combo has been
working fine here for years, but today I just get a convergence
failure with DIVERGED_INDEFINITE_PC.

Regressing libMesh a ways doesn't seem to help.  @pbauman is trying to
hunt down some PETSc behavior changes that hopefully will explain this
too, but in the meantime the default preconditioner settings work fine
and we should just use them.