### PR TITLE
Add BoundaryInfo::remove_id()

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -115,7 +115,7 @@ public:
    * pass a pointer to both the boundary_mesh's MeshData object,
    * and the MeshData object used for this mesh.
    */
-  void sync (const std::set<boundary_id_type> &requested_boundary_ids,
+  void sync (const std::set<boundary_id_type>& requested_boundary_ids,
              UnstructuredMesh& boundary_mesh,
              MeshData* boundary_mesh_data=NULL,
              MeshData* this_mesh_data=NULL);
@@ -146,7 +146,7 @@ public:
    *
    * Only boundary elements with the specified ids are created.
    */
-  void add_elements (const std::set<boundary_id_type> &requested_boundary_ids,
+  void add_elements (const std::set<boundary_id_type>& requested_boundary_ids,
                      UnstructuredMesh& boundary_mesh);
 
   /**
@@ -450,12 +450,12 @@ public:
   /**
    * Builds the list of unique node boundary ids.
    */
-  void build_node_boundary_ids(std::vector<boundary_id_type> &b_ids) const;
+  void build_node_boundary_ids(std::vector<boundary_id_type>& b_ids) const;
 
   /**
    * Builds the list of unique side boundary ids.
    */
-  void build_side_boundary_ids(std::vector<boundary_id_type> &b_ids) const;
+  void build_side_boundary_ids(std::vector<boundary_id_type>& b_ids) const;
 
   /**
    * @returns the number of element-side-based boundary conditions.
@@ -492,13 +492,13 @@ public:
   void build_side_list_from_node_list();
 
   /**
-   * Creates a list of element numbers, sides, and  and ids for those sides.
+   * Creates a list of element numbers, sides, and ids for those sides.
    */
   void build_side_list (std::vector<dof_id_type>&        element_id_list,
                         std::vector<unsigned short int>& side_list,
                         std::vector<boundary_id_type>&   bc_id_list) const;
   /**
-   * Creates a list of active element numbers, sides, and  and ids for those sides.
+   * Creates a list of active element numbers, sides, and ids for those sides.
    */
   void build_active_side_list (std::vector<dof_id_type>&        element_id_list,
                                std::vector<unsigned short int>& side_list,
@@ -608,7 +608,7 @@ private:
    * dof_object ids.  Either node_id_map or side_id_map can be NULL,
    * in which case it will not be filled.
    */
-  void _find_id_maps (const std::set<boundary_id_type> &requested_boundary_ids,
+  void _find_id_maps (const std::set<boundary_id_type>& requested_boundary_ids,
                       dof_id_type first_free_node_id,
                       std::map<dof_id_type, dof_id_type> * node_id_map,
                       dof_id_type first_free_elem_id,

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -713,35 +713,6 @@ private:
    * this is only implemented for ExodusII
    */
   std::map<boundary_id_type, std::string> _ns_id_to_name;
-
-  /**
-   * Functor class for initializing a map.
-   * The entries being added to the map
-   * increase by exactly one each time.
-   * The desctructor also inserts the
-   * invalid_id entry.
-   */
-  class Fill
-  {
-  public:
-    Fill(std::map<boundary_id_type, dof_id_type>& im) : id_map(im), cnt(0) {}
-
-    ~Fill()
-    {
-      id_map[invalid_id] = cnt;
-    }
-
-    inline
-    void operator() (const boundary_id_type& pos)
-    {
-      id_map[pos] = cnt++;
-    }
-
-  private:
-    std::map<boundary_id_type, dof_id_type>& id_map;
-    dof_id_type cnt;
-  };
-
 };
 
 

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -269,6 +269,16 @@ public:
                     const boundary_id_type id);
 
   /**
+   * Removes all entities (nodes, sides, edges) with boundary id \p id
+   * from their respective containers and erases any record of \p id's
+   * existence from the BoundaryInfo object.  That is, after calling
+   * remove_id(), \p id will no longer be in the sets returned by
+   * get_boundary_ids(), get_side_boundary_ids(), etc., and will not
+   * be in the bc_id_list vector returned by build_side_list(), etc.
+   */
+  void remove_id (boundary_id_type id);
+
+  /**
    * Returns the number of user-specified boundary ids.
    */
   std::size_t n_boundary_ids () const { return _boundary_ids.size(); }
@@ -620,6 +630,13 @@ private:
    * Typdef for iterators into the _boundary_node_id container.
    */
   typedef std::multimap<const Node*, boundary_id_type>::const_iterator boundary_node_iter;
+
+  /**
+   * Some older compilers don't support erasing from a map with
+   * const_iterators, so we need to use a non-const iterator in those
+   * situations.
+   */
+  typedef std::multimap<const Node*, boundary_id_type>::iterator boundary_node_erase_iter;
 
   /**
    * Data structure that maps edges of elements

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -715,34 +715,6 @@ private:
   std::map<boundary_id_type, std::string> _ns_id_to_name;
 };
 
-
-
-
-
-
-// ------------------------------------------------------------
-// BoundaryInfo inline methods
-inline
-void BoundaryInfo::remove (const Node* node)
-{
-  libmesh_assert(node);
-
-  // Erase everything associated with node
-  _boundary_node_id.erase (node);
-}
-
-
-
-inline
-void BoundaryInfo::remove (const Elem* elem)
-{
-  libmesh_assert(elem);
-
-  // Erase everything associated with elem
-  _boundary_edge_id.erase (elem);
-  _boundary_side_id.erase (elem);
-}
-
 } // namespace libMesh
 
 #endif // LIBMESH_BOUNDARY_INFO_H

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1095,6 +1095,27 @@ void BoundaryInfo::raw_boundary_ids (const Elem* const elem,
 
 
 
+void BoundaryInfo::remove (const Node* node)
+{
+  libmesh_assert(node);
+
+  // Erase everything associated with node
+  _boundary_node_id.erase (node);
+}
+
+
+
+void BoundaryInfo::remove (const Elem* elem)
+{
+  libmesh_assert(elem);
+
+  // Erase everything associated with elem
+  _boundary_edge_id.erase (elem);
+  _boundary_side_id.erase (elem);
+}
+
+
+
 void BoundaryInfo::remove_edge (const Elem* elem,
                                 const unsigned short int edge)
 {

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1427,6 +1427,11 @@ std::size_t BoundaryInfo::n_nodeset_conds () const
 void BoundaryInfo::build_node_list (std::vector<dof_id_type>& nl,
                                     std::vector<boundary_id_type>&    il) const
 {
+  // Clear the input vectors, just in case they were used for
+  // something else recently...
+  nl.clear();
+  il.clear();
+
   // Reserve the size, then use push_back
   nl.reserve (_boundary_node_id.size());
   il.reserve (_boundary_node_id.size());
@@ -1536,6 +1541,12 @@ void BoundaryInfo::build_side_list (std::vector<dof_id_type>&        el,
                                     std::vector<unsigned short int>& sl,
                                     std::vector<boundary_id_type>&   il) const
 {
+  // Clear the input vectors, just in case they were used for
+  // something else recently...
+  el.clear();
+  sl.clear();
+  il.clear();
+
   // Reserve the size, then use push_back
   el.reserve (_boundary_side_id.size());
   sl.reserve (_boundary_side_id.size());
@@ -1554,6 +1565,12 @@ void BoundaryInfo::build_active_side_list (std::vector<dof_id_type>&        el,
                                            std::vector<unsigned short int>& sl,
                                            std::vector<boundary_id_type>&   il) const
 {
+  // Clear the input vectors, just in case they were used for
+  // something else recently...
+  el.clear();
+  sl.clear();
+  il.clear();
+
   boundary_side_iter pos = _boundary_side_id.begin();
   for (; pos != _boundary_side_id.end(); ++pos)
     {
@@ -1584,6 +1601,12 @@ void BoundaryInfo::build_edge_list (std::vector<dof_id_type>&        el,
                                     std::vector<unsigned short int>& sl,
                                     std::vector<boundary_id_type>&   il) const
 {
+  // Clear the input vectors, just in case they were used for
+  // something else recently...
+  el.clear();
+  sl.clear();
+  il.clear();
+
   // Reserve the size, then use push_back
   el.reserve (_boundary_side_id.size());
   sl.reserve (_boundary_side_id.size());

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1217,6 +1217,44 @@ void BoundaryInfo::remove_side (const Elem* elem,
 
 
 
+void BoundaryInfo::remove_id (boundary_id_type id)
+{
+  // Erase id from ids containers
+  _boundary_ids.erase(id);
+  _side_boundary_ids.erase(id);
+  _edge_boundary_ids.erase(id);
+  _node_boundary_ids.erase(id);
+  _ss_id_to_name.erase(id);
+  _ns_id_to_name.erase(id);
+
+  // Erase pointers to geometric entities with this id.
+  for (boundary_node_erase_iter it = _boundary_node_id.begin(); it != _boundary_node_id.end(); /*below*/)
+    {
+      if (it->second == id)
+        _boundary_node_id.erase(it++);
+      else
+        ++it;
+    }
+
+  for (erase_iter it = _boundary_edge_id.begin(); it != _boundary_edge_id.end(); /*below*/)
+    {
+      if (it->second.second == id)
+        _boundary_edge_id.erase(it++);
+      else
+        ++it;
+    }
+
+  for (erase_iter it = _boundary_side_id.begin(); it != _boundary_side_id.end(); /*below*/)
+    {
+      if (it->second.second == id)
+        _boundary_side_id.erase(it++);
+      else
+        ++it;
+    }
+}
+
+
+
 unsigned int BoundaryInfo::side_with_boundary_id(const Elem* const elem,
                                                  const boundary_id_type boundary_id_in) const
 {

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -315,7 +315,7 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh& boundary_mesh,
 }
 
 
-void BoundaryInfo::add_elements(const std::set<boundary_id_type> &requested_boundary_ids,
+void BoundaryInfo::add_elements(const std::set<boundary_id_type>& requested_boundary_ids,
                                 UnstructuredMesh& boundary_mesh)
 {
   START_LOG("add_elements()", "BoundaryInfo");
@@ -1424,8 +1424,8 @@ std::size_t BoundaryInfo::n_nodeset_conds () const
 
 
 
-void BoundaryInfo::build_node_list (std::vector<dof_id_type>& nl,
-                                    std::vector<boundary_id_type>&    il) const
+void BoundaryInfo::build_node_list (std::vector<dof_id_type>&      nl,
+                                    std::vector<boundary_id_type>& il) const
 {
   // Clear the input vectors, just in case they were used for
   // something else recently...

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1594,6 +1594,10 @@ void MeshTools::Modification::change_boundary_id (MeshBase& mesh,
           bi.add_side(elem, side, bndry_ids);
         }
   }
+
+  // Remove any remaining references to the old_id so it does not show
+  // up in lists of boundary ids, etc.
+  bi.remove_id(old_id);
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,6 +18,7 @@ unit_tests_sources = \
 	geom/point_test.C \
 	geom/point_test.h \
 	mesh/boundary_mesh.C \
+	mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -169,9 +169,9 @@ PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	numerics/composite_function_test.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -193,6 +193,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	geom/unit_tests_dbg-node_test.$(OBJEXT) \
 	geom/unit_tests_dbg-point_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-boundary_mesh.$(OBJEXT) \
+	mesh/unit_tests_dbg-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT) \
@@ -229,9 +230,9 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	numerics/composite_function_test.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -252,6 +253,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	geom/unit_tests_devel-node_test.$(OBJEXT) \
 	geom/unit_tests_devel-point_test.$(OBJEXT) \
 	mesh/unit_tests_devel-boundary_mesh.$(OBJEXT) \
+	mesh/unit_tests_devel-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_extruder.$(OBJEXT) \
@@ -286,9 +288,9 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	numerics/composite_function_test.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -309,6 +311,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	geom/unit_tests_oprof-node_test.$(OBJEXT) \
 	geom/unit_tests_oprof-point_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-boundary_mesh.$(OBJEXT) \
+	mesh/unit_tests_oprof-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT) \
@@ -343,9 +346,9 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	numerics/composite_function_test.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -366,6 +369,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	geom/unit_tests_opt-node_test.$(OBJEXT) \
 	geom/unit_tests_opt-point_test.$(OBJEXT) \
 	mesh/unit_tests_opt-boundary_mesh.$(OBJEXT) \
+	mesh/unit_tests_opt-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_extruder.$(OBJEXT) \
@@ -398,9 +402,9 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/boundary_mesh.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	numerics/composite_function_test.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -421,6 +425,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	geom/unit_tests_prof-node_test.$(OBJEXT) \
 	geom/unit_tests_prof-point_test.$(OBJEXT) \
 	mesh/unit_tests_prof-boundary_mesh.$(OBJEXT) \
+	mesh/unit_tests_prof-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_prof-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_extruder.$(OBJEXT) \
@@ -871,8 +876,9 @@ AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
 	geom/point_test.C geom/point_test.h mesh/boundary_mesh.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C numerics/composite_function_test.C \
+	mesh/boundary_info.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -993,6 +999,8 @@ mesh/$(DEPDIR)/$(am__dirstamp):
 	@: > mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1088,6 +1096,8 @@ geom/unit_tests_devel-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1146,6 +1156,8 @@ geom/unit_tests_oprof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 geom/unit_tests_oprof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1206,6 +1218,8 @@ geom/unit_tests_opt-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1264,6 +1278,8 @@ geom/unit_tests_prof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 geom/unit_tests_prof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1360,22 +1376,27 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@
@@ -1578,6 +1599,20 @@ mesh/unit_tests_dbg-boundary_mesh.obj: mesh/boundary_mesh.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_mesh.C' object='mesh/unit_tests_dbg-boundary_mesh.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-boundary_mesh.obj `if test -f 'mesh/boundary_mesh.C'; then $(CYGPATH_W) 'mesh/boundary_mesh.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_mesh.C'; fi`
+
+mesh/unit_tests_dbg-boundary_info.o: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-boundary_info.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-boundary_info.Tpo -c -o mesh/unit_tests_dbg-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_dbg-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_dbg-boundary_info.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+
+mesh/unit_tests_dbg-boundary_info.obj: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-boundary_info.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-boundary_info.Tpo -c -o mesh/unit_tests_dbg-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_dbg-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_dbg-boundary_info.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
 
 mesh/unit_tests_dbg-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_dbg-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
@@ -1971,6 +2006,20 @@ mesh/unit_tests_devel-boundary_mesh.obj: mesh/boundary_mesh.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-boundary_mesh.obj `if test -f 'mesh/boundary_mesh.C'; then $(CYGPATH_W) 'mesh/boundary_mesh.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_mesh.C'; fi`
 
+mesh/unit_tests_devel-boundary_info.o: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-boundary_info.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Tpo -c -o mesh/unit_tests_devel-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_devel-boundary_info.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+
+mesh/unit_tests_devel-boundary_info.obj: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-boundary_info.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Tpo -c -o mesh/unit_tests_devel-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_devel-boundary_info.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
+
 mesh/unit_tests_devel-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_devel-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
@@ -2362,6 +2411,20 @@ mesh/unit_tests_oprof-boundary_mesh.obj: mesh/boundary_mesh.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_mesh.C' object='mesh/unit_tests_oprof-boundary_mesh.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-boundary_mesh.obj `if test -f 'mesh/boundary_mesh.C'; then $(CYGPATH_W) 'mesh/boundary_mesh.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_mesh.C'; fi`
+
+mesh/unit_tests_oprof-boundary_info.o: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-boundary_info.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Tpo -c -o mesh/unit_tests_oprof-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_oprof-boundary_info.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+
+mesh/unit_tests_oprof-boundary_info.obj: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-boundary_info.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Tpo -c -o mesh/unit_tests_oprof-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_oprof-boundary_info.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
 
 mesh/unit_tests_oprof-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_oprof-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
@@ -2755,6 +2818,20 @@ mesh/unit_tests_opt-boundary_mesh.obj: mesh/boundary_mesh.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-boundary_mesh.obj `if test -f 'mesh/boundary_mesh.C'; then $(CYGPATH_W) 'mesh/boundary_mesh.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_mesh.C'; fi`
 
+mesh/unit_tests_opt-boundary_info.o: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-boundary_info.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Tpo -c -o mesh/unit_tests_opt-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_opt-boundary_info.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+
+mesh/unit_tests_opt-boundary_info.obj: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-boundary_info.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Tpo -c -o mesh/unit_tests_opt-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_opt-boundary_info.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
+
 mesh/unit_tests_opt-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_opt-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
@@ -3146,6 +3223,20 @@ mesh/unit_tests_prof-boundary_mesh.obj: mesh/boundary_mesh.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_mesh.C' object='mesh/unit_tests_prof-boundary_mesh.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-boundary_mesh.obj `if test -f 'mesh/boundary_mesh.C'; then $(CYGPATH_W) 'mesh/boundary_mesh.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_mesh.C'; fi`
+
+mesh/unit_tests_prof-boundary_info.o: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-boundary_info.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Tpo -c -o mesh/unit_tests_prof-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_prof-boundary_info.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-boundary_info.o `test -f 'mesh/boundary_info.C' || echo '$(srcdir)/'`mesh/boundary_info.C
+
+mesh/unit_tests_prof-boundary_info.obj: mesh/boundary_info.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-boundary_info.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Tpo -c -o mesh/unit_tests_prof-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Tpo mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/boundary_info.C' object='mesh/unit_tests_prof-boundary_info.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-boundary_info.obj `if test -f 'mesh/boundary_info.C'; then $(CYGPATH_W) 'mesh/boundary_info.C'; else $(CYGPATH_W) '$(srcdir)/mesh/boundary_info.C'; fi`
 
 mesh/unit_tests_prof-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_prof-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C

--- a/tests/base/auto_ptr_test.C
+++ b/tests/base/auto_ptr_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/fparser/autodiff.C
+++ b/tests/fparser/autodiff.C
@@ -1,6 +1,6 @@
 #include "libmesh/fparser_ad.hh"
 
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/geom/node_test.C
+++ b/tests/geom/node_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/geom/point_test.C
+++ b/tests/geom/point_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -1,0 +1,89 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/mesh.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/boundary_info.h>
+
+#include "test_comm.h"
+
+using namespace libMesh;
+
+class BoundaryInfoTest : public CppUnit::TestCase {
+  /**
+   * This test ensures various aspects of the BoundaryInfo class work as expected.
+   */
+public:
+  CPPUNIT_TEST_SUITE( BoundaryInfoTest );
+
+  CPPUNIT_TEST( testMesh );
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+
+  Mesh* _mesh;
+
+  void build_mesh()
+  {
+    _mesh = new Mesh(*TestCommWorld);
+
+    MeshTools::Generation::build_square(*_mesh,
+                                        2, 2,
+                                        0., 1.,
+                                        0., 1.,
+                                        QUAD4);
+  }
+
+public:
+  void setUp()
+  {
+    this->build_mesh();
+  }
+
+  void tearDown()
+  {
+    delete _mesh;
+  }
+
+  void testMesh()
+  {
+    // build_square adds boundary_ids 0,1,2,3 for the bottom, right,
+    // top, and left sides, respectively.  Let's test that we can
+    // remove them successfully.
+    BoundaryInfo & bi = _mesh->get_boundary_info();
+    bi.remove_id(0);
+
+    // Check that there are now only 3 boundary ids total on the Mesh.
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(3), bi.n_boundary_ids());
+
+    // Build the side list
+    std::vector<dof_id_type> element_id_list;
+    std::vector<unsigned short int> side_list;
+    std::vector<boundary_id_type> bc_id_list;
+    bi.build_side_list (element_id_list, side_list, bc_id_list);
+
+    // Check that there are now exactly 6 sides left in the BoundaryInfo
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(6), element_id_list.size());
+
+    // Remove the same id again, make sure nothing changes.
+    bi.remove_id(0);
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(3), bi.n_boundary_ids());
+
+    // Remove the remaining IDs, verify that we have no sides left and
+    // that we can safely reuse the same vectors in the
+    // build_side_list() call.
+    bi.remove_id(1);
+    bi.remove_id(2);
+    bi.remove_id(3);
+    bi.build_side_list (element_id_list, side_list, bc_id_list);
+
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(0), bi.n_boundary_ids());
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(0), element_id_list.size());
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( BoundaryInfoTest );

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/mesh/mesh_extruder.C
+++ b/tests/mesh/mesh_extruder.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/mesh/nodal_neighbors.C
+++ b/tests/mesh/nodal_neighbors.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/numerics/composite_function_test.C
+++ b/tests/numerics/composite_function_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/numerics/coupling_matrix_test.C
+++ b/tests/numerics/coupling_matrix_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/numerics/parsed_function_test.C
+++ b/tests/numerics/parsed_function_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/numerics/type_tensor_test.C
+++ b/tests/numerics/type_tensor_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/numerics/vector_value_test.C
+++ b/tests/numerics/vector_value_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/parallel/parallel_point_test.C
+++ b/tests/parallel/parallel_point_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/quadrature/quadrature_test.C
+++ b/tests/quadrature/quadrature_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/systems/equation_systems_test.C
+++ b/tests/systems/equation_systems_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -1,4 +1,4 @@
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>

--- a/tests/utils/vectormap_test.C
+++ b/tests/utils/vectormap_test.C
@@ -1,6 +1,6 @@
 #include "libmesh/vectormap.h"
 
-// Ignore unused parameter warnings coming from cppuint headers
+// Ignore unused parameter warnings coming from cppunit headers
 #include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>


### PR DESCRIPTION
It is already possible to remove sides/edges/nodes from the BoundaryInfo, but if, for example, you remove *all* of the geometric entities with a given ID, that ID may still appear in the following `BoundaryInfo` data structures:
```
_ss_id_to_name
_ns_id_to_name
_boundary_ids
_side_boundary_ids
_edge_boundary_ids
_node_boundary_ids
```

This can lead to slightly confusing behavior in calls to `n_boundary_ids()` and other functions.  This fixes a minor issue over in idaholab/moose#3554, where a boundary id is updated due to Mesh extrusion.

The branch also adds a unit test of the new capability.