### PR TITLE
Prevent user-supplied mesh dimension from being ignored

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1052,6 +1052,11 @@ protected:
   std::map<subdomain_id_type, std::string> _block_id_to_name;
 
   /**
+   * User-supplied mesh dimension.
+   */
+  unsigned char _user_dim;
+
+  /**
    * We cache the dimension of the elements present in the mesh.
    * So, if we have a mesh with 1D and 2D elements, this structure
    * will contain 1 and 2.

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -56,9 +56,10 @@ MeshBase::MeshBase (const Parallel::Communicator &comm_in,
   _next_unique_id(DofObject::invalid_unique_id),
 #endif
   _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
-  _skip_renumber_nodes_and_elements(false)
+  _skip_renumber_nodes_and_elements(false),
+  _user_dim(d)
 {
-  _elem_dims.insert(d);
+  _elem_dims.insert(_user_dim);
   libmesh_assert_less_equal (LIBMESH_DIM, 3);
   libmesh_assert_greater_equal (LIBMESH_DIM, d);
   libmesh_assert (libMesh::initialized());
@@ -77,9 +78,10 @@ MeshBase::MeshBase (unsigned char d) :
   _next_unique_id(DofObject::invalid_unique_id),
 #endif
   _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
-  _skip_renumber_nodes_and_elements(false)
+  _skip_renumber_nodes_and_elements(false),
+  _user_dim(d)
 {
-  _elem_dims.insert(d);
+  _elem_dims.insert(_user_dim);
   libmesh_assert_less_equal (LIBMESH_DIM, 3);
   libmesh_assert_greater_equal (LIBMESH_DIM, d);
   libmesh_assert (libMesh::initialized());
@@ -100,6 +102,7 @@ MeshBase::MeshBase (const MeshBase& other_mesh) :
 #endif
   _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false),
+  _user_dim(other_mesh._user_dim),
   _elem_dims(other_mesh._elem_dims)
 {
   if(other_mesh._partitioner.get())
@@ -510,6 +513,9 @@ void MeshBase::cache_elem_dims()
   // Need to clear _elem_dims first in case all elements of a
   // particular dimension have been deleted.
   _elem_dims.clear();
+
+  //Insert the user-supplied mesh dimension
+  _elem_dims.insert(_user_dim);
 
   const_element_iterator el  = this->active_elements_begin();
   const_element_iterator end = this->active_elements_end();


### PR DESCRIPTION
The mesh dimension supplied in the constructors to MeshBase currently gets put into _elem_dims, but when prepare_for_use() gets called, that gets cleared, and it gets lost.  As a result, if the user asked for a mesh with dimension 3, but it only contains elements of dimension 1 or 2, the mesh dimension is reported as the lower number.  This fixes that issue.

My interest in doing this is that I'm trying to use a 3d or 2d truss mesh composed only of line elements.  The elements themselves are 1d, but the nodal coordinates are 2d or 3d.  With this fix, I can pass a 3 in to the constructor, and then the mesh dimension is reported as 3, and my MOOSE job runs happily.  I should note that this patch breaks many MOOSE tests because it currently passes 3 in to the MeshBase constructor, which then gets ignored. Passing in 1 instead by default from the MOOSE side fixes that.

Ideally, I'd like to not have to tell it that it's a 3d mesh and have that be detected. I see that there is a spatial dimension and a mesh dimension.  I might have the terminology wrong, but I think what I have here is a mesh that is spatially 3D, but topologically 1D.  If that's correct, I think what I really need is a way to get the spatial dimension of my mesh. The spatial dimension is hardcoded to LIBMESH_DIM, so that isn't useful for the application to figure out what the actual dimension of the current mesh is.