### PR TITLE
Write nodal unique_id values to xda/xdr files

### DIFF
--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -128,8 +128,8 @@ XdrIO::XdrIO (MeshBase & mesh, const bool binary_in) :
 #else
   _write_unique_id    (false),
 #endif
-  _field_width        (4),   // In 0.7.0, all fields are 4 bytes, in 0.9.2 they can vary
-  _version            ("libMesh-0.9.2+"),
+  _field_width        (4),   // In 0.7.0, all fields are 4 bytes, in 0.9.2+ they can vary
+  _version            ("libMesh-0.9.6+"),
   _bc_file_name       ("n/a"),
   _partition_map_file ("n/a"),
   _subdomain_map_file ("n/a"),
@@ -679,8 +679,14 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
   std::vector<Real> xfer_coords;
   std::vector<Real> & coords=xfer_coords;
 
-  std::vector<std::vector<dof_id_type> > recv_ids   (this->n_processors());;
+  std::vector<std::vector<dof_id_type> > recv_ids   (this->n_processors());
   std::vector<std::vector<Real> >         recv_coords(this->n_processors());
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  std::vector<xdr_id_type> xfer_unique_ids; 
+  std::vector<xdr_id_type> & unique_ids=xfer_unique_ids;
+  std::vector<std::vector<xdr_id_type> > recv_unique_ids (this->n_processors());
+#endif // LIBMESH_ENABLE_UNIQUE_ID
 
   std::size_t n_written=0;
 
@@ -694,13 +700,20 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
         it  = mesh.local_nodes_begin(),
         end = mesh.local_nodes_end();
 
-      xfer_ids.clear(); xfer_coords.clear();
+      xfer_ids.clear();
+      xfer_coords.clear();
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+      xfer_unique_ids.clear();
+#endif // LIBMESH_ENABLE_UNIQUE_ID
 
       for (; it!=end; ++it)
         if (((*it)->id() >= first_node) && // node in [first_node, last_node)
             ((*it)->id() <  last_node))
           {
             xfer_ids.push_back((*it)->id());
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+            xfer_unique_ids.push_back((*it)->unique_id());
+#endif // LIBMESH_ENABLE_UNIQUE_ID
             const Point & p = **it;
             xfer_coords.push_back(p(0));
 #if LIBMESH_DIM > 1
@@ -713,28 +726,26 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
 
       //-------------------------------------
       // Send the xfer buffers to processor 0
-      std::vector<std::size_t> ids_size, coords_size;
+      std::vector<std::size_t> ids_size;
 
       const std::size_t my_ids_size = xfer_ids.size();
 
       // explicitly gather ids_size
       this->comm().gather (0, my_ids_size, ids_size);
 
-      // infer coords_size on processor 0
-      if (this->processor_id() == 0)
-        {
-          coords_size.reserve(this->n_processors());
-          for (std::size_t p=0; p<ids_size.size(); p++)
-            coords_size.push_back(LIBMESH_DIM*ids_size[p]);
-        }
-
       // We will have lots of simultaneous receives if we are
       // processor 0, so let's use nonblocking receives.
       std::vector<Parallel::Request>
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+        unique_id_request_handles(this->n_processors()-1),
+#endif // LIBMESH_ENABLE_UNIQUE_ID
         id_request_handles(this->n_processors()-1),
         coord_request_handles(this->n_processors()-1);
 
       Parallel::MessageTag
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+        unique_id_tag = mesh.comm().get_unique_tag(1233),
+#endif // LIBMESH_ENABLE_UNIQUE_ID
         id_tag    = mesh.comm().get_unique_tag(1234),
         coord_tag = mesh.comm().get_unique_tag(1235);
 
@@ -744,12 +755,18 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
           for (unsigned int pid=0; pid<this->n_processors(); pid++)
             {
               recv_ids[pid].resize(ids_size[pid]);
-              recv_coords[pid].resize(coords_size[pid]);
+              recv_coords[pid].resize(ids_size[pid]*LIBMESH_DIM);
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+              recv_unique_ids[pid].resize(ids_size[pid]);
+#endif // LIBMESH_ENABLE_UNIQUE_ID
 
               if (pid == 0)
                 {
                   recv_ids[0] = xfer_ids;
                   recv_coords[0] = xfer_coords;
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+                  recv_unique_ids[0] = xfer_unique_ids;
+#endif // LIBMESH_ENABLE_UNIQUE_ID
                 }
               else
                 {
@@ -759,6 +776,9 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
                   this->comm().receive (pid, recv_coords[pid],
                                         coord_request_handles[pid-1],
                                         coord_tag);
+                  this->comm().receive (pid, recv_unique_ids[pid],
+                                        unique_id_request_handles[pid-1],
+                                        unique_id_tag);
                 }
             }
         }
@@ -767,6 +787,9 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
           // Send -- do this on all other processors.
           this->comm().send(0, xfer_ids,    id_tag);
           this->comm().send(0, xfer_coords, coord_tag);
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+          this->comm().send(0, xfer_unique_ids, unique_id_tag);
+#endif // LIBMESH_ENABLE_UNIQUE_ID
         }
 
       // -------------------------------------------------------
@@ -778,29 +801,43 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
           // buffer sizes.
           Parallel::wait (id_request_handles);
           Parallel::wait (coord_request_handles);
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+          Parallel::wait (unique_id_request_handles);
+#endif // LIBMESH_ENABLE_UNIQUE_ID
 
           // Write the coordinates in this block.
           std::size_t tot_id_size=0;
-#ifndef NDEBUG
-          std::size_t tot_coord_size=0;
-#endif
+
           for (unsigned int pid=0; pid<this->n_processors(); pid++)
             {
               tot_id_size    += recv_ids[pid].size();
-#ifndef NDEBUG
-              tot_coord_size += recv_coords[pid].size();
-#endif
+              libmesh_assert_equal_to(recv_coords[pid].size(),
+                                      recv_ids[pid].size()*LIBMESH_DIM);
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+              libmesh_assert_equal_to
+                (recv_ids[pid].size(), recv_unique_ids[pid].size());
+#endif // LIBMESH_ENABLE_UNIQUE_ID
             }
 
           libmesh_assert_less_equal
             (tot_id_size, std::min(io_blksize, std::size_t(n_nodes)));
-          libmesh_assert_equal_to (tot_coord_size, LIBMESH_DIM*tot_id_size);
 
           coords.resize (3*tot_id_size);
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+          unique_ids.resize(tot_id_size);
+#endif
+
           for (unsigned int pid=0; pid<this->n_processors(); pid++)
             for (std::size_t idx=0; idx<recv_ids[pid].size(); idx++)
               {
                 const std::size_t local_idx = recv_ids[pid][idx] - first_node;
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+                libmesh_assert_less (local_idx, unique_ids.size());
+
+                unique_ids[local_idx] = recv_unique_ids[pid][idx];
+#endif
+
                 libmesh_assert_less ((3*local_idx+2), coords.size());
                 libmesh_assert_less ((LIBMESH_DIM*idx+LIBMESH_DIM-1), recv_coords[pid].size());
 
@@ -821,6 +858,19 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
 
           io.data_stream (coords.empty() ? NULL : &coords[0],
                           cast_int<unsigned int>(coords.size()), 3);
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+          // XDR unsigned char doesn't work as anticipated
+          unsigned short write_unique_ids = 1;
+
+          io.data (write_unique_ids, "# presence of unique ids");
+          io.data_stream (unique_ids.empty() ? NULL : &unique_ids[0],
+                          cast_int<unsigned int>(unique_ids.size()), 1);
+#else
+          unsigned short write_unique_ids = 0;
+
+          io.data_stream (&write_unique_ids, 1, 1);
+#endif
         }
     }
   if (this->processor_id() == 0)
@@ -1072,7 +1122,9 @@ void XdrIO::read (const std::string & name)
   // type_size, uid_size, pid_size, sid_size, p_level_size, eid_size, side_size, bid_size;
   header_id_type pos=0;
 
-  const bool is_version_0_9_2 = this->version().find("0.9.2") != std::string::npos ? true : false;
+  const bool exceeds_version_0_9_2 =
+    (this->version().find("0.9.2") != std::string::npos) ||
+    (this->version().find("0.9.6") != std::string::npos);
 
   if (this->processor_id() == 0)
     {
@@ -1083,7 +1135,7 @@ void XdrIO::read (const std::string & name)
       io.data (this->partition_map_file_name());      // libMesh::out << "pid_file=" << this->partition_map_file_name()      << std::endl;
       io.data (this->polynomial_level_file_name());   // libMesh::out << "pl_file="  << this->polynomial_level_file_name()   << std::endl;
 
-      if (is_version_0_9_2)
+      if (exceeds_version_0_9_2)
         {
           io.data (meta_data[pos++], "# type size");
           io.data (meta_data[pos++], "# uid size");
@@ -1121,7 +1173,7 @@ void XdrIO::read (const std::string & name)
    * TODO: All types are stored as the same size. Use the size information to pack things efficiently.
    * For now we will assume that "type size" is how the entire file will be encoded.
    */
-  if (is_version_0_9_2)
+  if (exceeds_version_0_9_2)
     _field_width = meta_data[2];
 
   if (_field_width == 4)
@@ -1140,7 +1192,7 @@ void XdrIO::read (const std::string & name)
       // read the boundary conditions
       this->read_serialized_bcs (io, type_size);
 
-      if (is_version_0_9_2)
+      if (exceeds_version_0_9_2)
         // read the nodesets
         this->read_serialized_nodesets (io, type_size);
     }
@@ -1160,7 +1212,7 @@ void XdrIO::read (const std::string & name)
       // read the boundary conditions
       this->read_serialized_bcs (io, type_size);
 
-      if (is_version_0_9_2)
+      if (exceeds_version_0_9_2)
         // read the nodesets
         this->read_serialized_nodesets (io, type_size);
     }
@@ -1176,7 +1228,9 @@ void XdrIO::read (const std::string & name)
 
 void XdrIO::read_serialized_subdomain_names(Xdr & io)
 {
-  const bool read_entity_info = this->version().find("0.9.2") != std::string::npos ? true : false;
+  const bool read_entity_info =
+    (this->version().find("0.9.2") != std::string::npos) ||
+    (this->version().find("0.9.6") != std::string::npos);
   if (read_entity_info)
     {
       MeshBase & mesh = MeshInput<MeshBase>::mesh();
@@ -1244,8 +1298,10 @@ void XdrIO::read_serialized_connectivity (Xdr & io, const dof_id_type n_elem, st
 
   // Version 0.9.2+ introduces unique ids
   const size_t unique_id_size_index = 3;
-  const bool read_unique_id = this->version().find("0.9.2") != std::string::npos &&
-    sizes[unique_id_size_index] ? true : false;
+  const bool read_unique_id =
+    ((this->version().find("0.9.2") != std::string::npos) ||
+     (this->version().find("0.9.6") != std::string::npos)) &&
+    sizes[unique_id_size_index];
 
   T n_elem_at_level=0, n_processed_at_level=0;
   for (dof_id_type blk=0, first_elem=0, last_elem=0;
@@ -1414,11 +1470,16 @@ void XdrIO::read_serialized_nodes (Xdr & io, const dof_id_type n_nodes)
 
   // At this point the elements have been read from file and placeholder nodes
   // have been assigned.  These nodes, however, do not have the proper (x,y,z)
-  // locations.  This method will read all the nodes from disk, and each processor
-  // can then grab the individual values it needs.
+  // locations or unique_id values.  This method will read all the
+  // nodes from disk, and each processor can then grab the individual
+  // values it needs.
+
+  // If the file includes unique ids for nodes (as indicated by a
+  // flag in 0.9.6+ files), those will be read next.
 
   // build up a list of the nodes contained in our local mesh.  These are the nodes
-  // stored on the local processor whose (x,y,z) values need to be corrected.
+  // stored on the local processor whose (x,y,z) and unique_id values
+  // need to be corrected.
   std::vector<dof_id_type> needed_nodes; needed_nodes.reserve (mesh.n_nodes());
   {
     MeshBase::node_iterator
@@ -1440,6 +1501,7 @@ void XdrIO::read_serialized_nodes (Xdr & io, const dof_id_type n_nodes)
             std::vector<dof_id_type>::iterator> pos;
   pos.first = needed_nodes.begin();
 
+  // Broadcast node coordinates
   for (std::size_t blk=0, first_node=0, last_node=0; last_node<n_nodes; blk++)
     {
       first_node = blk*io_blksize;
@@ -1472,6 +1534,76 @@ void XdrIO::read_serialized_nodes (Xdr & io, const dof_id_type n_nodes)
                        coords[idx+2]);
 
             }
+        }
+    }
+
+  const bool exceeds_version_0_9_6 =
+    (this->version().find("0.9.6") != std::string::npos);
+
+  if (exceeds_version_0_9_6)
+    {
+      // Check for node unique ids
+      unsigned short read_unique_ids;
+
+      if (this->processor_id() == 0)
+        io.data (read_unique_ids);
+
+      this->comm().broadcast (read_unique_ids);
+
+      // If no unique ids are in the file, we're done.
+      if (!read_unique_ids)
+        return;
+
+      std::vector<uint32_t> unique_32;
+      std::vector<uint64_t> unique_64;
+
+      for (std::size_t blk=0, first_node=0, last_node=0; last_node<n_nodes; blk++)
+        {
+          first_node = blk*io_blksize;
+          last_node  = std::min((blk+1)*io_blksize, std::size_t(n_nodes));
+
+          libmesh_assert((_field_width == 8) || (_field_width == 4));
+
+          if (_field_width == 8)
+            unique_64.resize(last_node - first_node);
+          else
+            unique_32.resize(last_node - first_node);
+
+          if (this->processor_id() == 0)
+            {
+              if (_field_width == 8)
+                io.data_stream (unique_64.empty() ? NULL : &unique_64[0],
+                                cast_int<unsigned int>(unique_64.size()));
+              else
+                io.data_stream (unique_32.empty() ? NULL : &unique_32[0],
+                                cast_int<unsigned int>(unique_32.size()));
+            }
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+          if (_field_width == 8)
+            this->comm().broadcast (unique_64);
+          else
+            this->comm().broadcast (unique_32);
+
+          for (std::size_t n=first_node, idx=0; n<last_node; n++, idx++)
+            {
+              // first see if we need this node.  use pos.first as a smart lower
+              // bound, this will ensure that the size of the searched range
+              // decreases as we match nodes.
+              pos = std::equal_range (pos.first, needed_nodes.end(), n);
+
+              if (pos.first != pos.second) // we need this node.
+                {
+                  libmesh_assert_equal_to (*pos.first, n);
+                  if (_field_width == 8)
+                    mesh.node(cast_int<dof_id_type>(n)).set_unique_id()
+                      = unique_64[idx];
+                  else
+                    mesh.node(cast_int<dof_id_type>(n)).set_unique_id()
+                      = unique_32[idx];
+                }
+            }
+#endif // LIBMESH_ENABLE_UNIQUE_ID
         }
     }
 }
@@ -1635,7 +1767,9 @@ void XdrIO::read_serialized_nodesets (Xdr & io, T)
 
 void XdrIO::read_serialized_bc_names(Xdr & io, BoundaryInfo & info, bool is_sideset)
 {
-  const bool read_entity_info = this->version().find("0.9.2") != std::string::npos ? true : false;
+  const bool read_entity_info =
+    (this->version().find("0.9.2") != std::string::npos) ||
+    (this->version().find("0.9.6") != std::string::npos);
   if (read_entity_info)
     {
       header_id_type n_boundary_names = 0;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,6 +23,7 @@ unit_tests_sources = \
 	mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C \
 	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -173,7 +173,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
 	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C numerics/composite_function_test.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -200,6 +201,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT) \
+	mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-distributed_vector_test.$(OBJEXT) \
@@ -235,7 +237,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
 	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C numerics/composite_function_test.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -261,6 +264,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_extruder.$(OBJEXT) \
+	mesh/unit_tests_devel-slit_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_devel-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT) \
@@ -294,7 +298,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
 	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C numerics/composite_function_test.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -320,6 +325,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT) \
+	mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT) \
@@ -353,7 +359,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
 	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C numerics/composite_function_test.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -379,6 +386,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_extruder.$(OBJEXT) \
+	mesh/unit_tests_opt-slit_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_opt-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT) \
@@ -410,7 +418,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	geom/node_test.C geom/point_test.C geom/point_test.h \
 	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C numerics/composite_function_test.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -436,6 +445,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_prof-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_extruder.$(OBJEXT) \
+	mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT) \
 	numerics/unit_tests_prof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT) \
@@ -885,7 +895,8 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	geom/point_test.C geom/point_test.h mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C numerics/composite_function_test.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -1015,6 +1026,8 @@ mesh/unit_tests_dbg-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/$(am__dirstamp):
 	@$(MKDIR_P) numerics
 	@: > numerics/$(am__dirstamp)
@@ -1114,6 +1127,8 @@ mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-coupling_matrix_test.$(OBJEXT):  \
@@ -1176,6 +1191,8 @@ mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT):  \
 mesh/unit_tests_oprof-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -1240,6 +1257,8 @@ mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-coupling_matrix_test.$(OBJEXT):  \
@@ -1302,6 +1321,8 @@ mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT):  \
 mesh/unit_tests_prof-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -1398,30 +1419,35 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po@am__quote@
@@ -1690,6 +1716,20 @@ mesh/unit_tests_dbg-mesh_extruder.obj: mesh/mesh_extruder.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_extruder.C' object='mesh/unit_tests_dbg-mesh_extruder.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_extruder.obj `if test -f 'mesh/mesh_extruder.C'; then $(CYGPATH_W) 'mesh/mesh_extruder.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_extruder.C'; fi`
+
+mesh/unit_tests_dbg-slit_mesh_test.o: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Tpo -c -o mesh/unit_tests_dbg-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_dbg-slit_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+
+mesh/unit_tests_dbg-slit_mesh_test.obj: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-slit_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Tpo -c -o mesh/unit_tests_dbg-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_dbg-slit_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
 
 numerics/unit_tests_dbg-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Tpo -c -o numerics/unit_tests_dbg-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
@@ -2111,6 +2151,20 @@ mesh/unit_tests_devel-mesh_extruder.obj: mesh/mesh_extruder.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_extruder.obj `if test -f 'mesh/mesh_extruder.C'; then $(CYGPATH_W) 'mesh/mesh_extruder.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_extruder.C'; fi`
 
+mesh/unit_tests_devel-slit_mesh_test.o: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Tpo -c -o mesh/unit_tests_devel-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_devel-slit_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+
+mesh/unit_tests_devel-slit_mesh_test.obj: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-slit_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Tpo -c -o mesh/unit_tests_devel-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_devel-slit_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
+
 numerics/unit_tests_devel-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Tpo -c -o numerics/unit_tests_devel-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po
@@ -2530,6 +2584,20 @@ mesh/unit_tests_oprof-mesh_extruder.obj: mesh/mesh_extruder.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_extruder.C' object='mesh/unit_tests_oprof-mesh_extruder.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_extruder.obj `if test -f 'mesh/mesh_extruder.C'; then $(CYGPATH_W) 'mesh/mesh_extruder.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_extruder.C'; fi`
+
+mesh/unit_tests_oprof-slit_mesh_test.o: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Tpo -c -o mesh/unit_tests_oprof-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_oprof-slit_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+
+mesh/unit_tests_oprof-slit_mesh_test.obj: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-slit_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Tpo -c -o mesh/unit_tests_oprof-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_oprof-slit_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
 
 numerics/unit_tests_oprof-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Tpo -c -o numerics/unit_tests_oprof-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
@@ -2951,6 +3019,20 @@ mesh/unit_tests_opt-mesh_extruder.obj: mesh/mesh_extruder.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_extruder.obj `if test -f 'mesh/mesh_extruder.C'; then $(CYGPATH_W) 'mesh/mesh_extruder.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_extruder.C'; fi`
 
+mesh/unit_tests_opt-slit_mesh_test.o: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Tpo -c -o mesh/unit_tests_opt-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_opt-slit_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+
+mesh/unit_tests_opt-slit_mesh_test.obj: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-slit_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Tpo -c -o mesh/unit_tests_opt-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_opt-slit_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
+
 numerics/unit_tests_opt-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Tpo -c -o numerics/unit_tests_opt-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po
@@ -3370,6 +3452,20 @@ mesh/unit_tests_prof-mesh_extruder.obj: mesh/mesh_extruder.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_extruder.C' object='mesh/unit_tests_prof-mesh_extruder.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_extruder.obj `if test -f 'mesh/mesh_extruder.C'; then $(CYGPATH_W) 'mesh/mesh_extruder.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_extruder.C'; fi`
+
+mesh/unit_tests_prof-slit_mesh_test.o: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-slit_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Tpo -c -o mesh/unit_tests_prof-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_prof-slit_mesh_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-slit_mesh_test.o `test -f 'mesh/slit_mesh_test.C' || echo '$(srcdir)/'`mesh/slit_mesh_test.C
+
+mesh/unit_tests_prof-slit_mesh_test.obj: mesh/slit_mesh_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-slit_mesh_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Tpo -c -o mesh/unit_tests_prof-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/slit_mesh_test.C' object='mesh/unit_tests_prof-slit_mesh_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-slit_mesh_test.obj `if test -f 'mesh/slit_mesh_test.C'; then $(CYGPATH_W) 'mesh/slit_mesh_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/slit_mesh_test.C'; fi`
 
 numerics/unit_tests_prof-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Tpo -c -o numerics/unit_tests_prof-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -343,7 +343,9 @@ public:
     SlitFunc slitfunc;
 
     _mesh->write("slit_mesh.xda");
-    _es->write("slit_solution.xda");
+    _es->write("slit_solution.xda",
+               EquationSystems::WRITE_DATA |
+               EquationSystems::WRITE_SERIAL_FILES);
 
     Mesh mesh2(*TestCommWorld);
     mesh2.read("slit_mesh.xda");

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -1,0 +1,179 @@
+// Ignore unused parameter warnings coming from cppuint headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/equation_systems.h>
+#include <libmesh/mesh.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/edge_edge2.h>
+#include <libmesh/face_quad4.h>
+#include <libmesh/cell_hex8.h>
+#include <libmesh/dof_map.h>
+#include <libmesh/linear_implicit_system.h>
+#include <libmesh/mesh_refinement.h>
+
+#include "test_comm.h"
+
+using namespace libMesh;
+
+class SlitMeshTest : public CppUnit::TestCase {
+  /**
+   * The goal of this test is to ensure that a 2D mesh with nodes overlapping
+   * on opposite sides of an internal, "slit" edge is useable.
+   */
+public:
+  CPPUNIT_TEST_SUITE( SlitMeshTest );
+
+  CPPUNIT_TEST( testMesh );
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+
+  Mesh* _mesh;
+
+  void build_mesh()
+  {
+    _mesh = new Mesh(*TestCommWorld);
+
+    /*
+      (0,1)           (1,1)           (2,1)
+        x---------------x---------------x
+        |               |               |
+        |               |               |
+        |               |               |
+        |               |               |
+        |               |               |
+        x---------------x---------------x
+       (0,0)           (1,0)          (2,0)
+        |               |               |
+        |               |               |
+        |               |               |
+        |               |               |
+        x---------------x---------------x
+       (0,-1)          (1,-1)         (2,-1)
+     */
+
+    _mesh->set_mesh_dimension(2);
+
+    _mesh->add_point( Point(0.0, 0.0), 0 );
+    _mesh->add_point( Point(1.0, 0.0), 1 );
+    _mesh->add_point( Point(1.0, 1.0), 2 );
+    _mesh->add_point( Point(0.0, 1.0), 3 );
+    _mesh->add_point( Point(0.0,-1.0), 4 );
+    _mesh->add_point( Point(1.0,-1.0), 5 );
+    _mesh->add_point( Point(0.0, 0.0), 6 );
+    _mesh->add_point( Point(2.0, 0.0), 7 );
+    _mesh->add_point( Point(2.0, 1.0), 8 );
+    _mesh->add_point( Point(2.0,-1.0), 9 );
+
+    {
+      Elem* elem_top_left = _mesh->add_elem( new Quad4 );
+      elem_top_left->set_node(0) = _mesh->node_ptr(0);
+      elem_top_left->set_node(1) = _mesh->node_ptr(1);
+      elem_top_left->set_node(2) = _mesh->node_ptr(2);
+      elem_top_left->set_node(3) = _mesh->node_ptr(3);
+
+      Elem* elem_bottom_left = _mesh->add_elem( new Quad4 );
+      elem_bottom_left->set_node(0) = _mesh->node_ptr(4);
+      elem_bottom_left->set_node(1) = _mesh->node_ptr(5);
+      elem_bottom_left->set_node(2) = _mesh->node_ptr(6);
+      elem_bottom_left->set_node(3) = _mesh->node_ptr(0);
+
+      Elem* elem_top_right = _mesh->add_elem( new Quad4 );
+      elem_top_right->set_node(0) = _mesh->node_ptr(1);
+      elem_top_right->set_node(1) = _mesh->node_ptr(7);
+      elem_top_right->set_node(2) = _mesh->node_ptr(8);
+      elem_top_right->set_node(3) = _mesh->node_ptr(2);
+
+      Elem* elem_bottom_right = _mesh->add_elem( new Quad4 );
+      elem_bottom_right->set_node(0) = _mesh->node_ptr(5);
+      elem_bottom_right->set_node(1) = _mesh->node_ptr(9);
+      elem_bottom_right->set_node(2) = _mesh->node_ptr(7);
+      elem_bottom_right->set_node(3) = _mesh->node_ptr(6);
+    }
+
+    // libMesh shouldn't renumber, or our based-on-initial-id
+    // assertions later may fail.
+    _mesh->prepare_for_use(true /*skip_renumber*/);
+  }
+
+public:
+  void setUp()
+  {
+    this->build_mesh();
+  }
+
+  void tearDown()
+  {
+    delete _mesh;
+   }
+
+  void testMesh()
+  {
+    // There'd better be 4 elements
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)4, _mesh->n_elem() );
+
+    // There'd better still be a full 10 nodes
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)10, _mesh->n_nodes() );
+
+    /* The middle nodes should still be distinct between the top and
+     * bottom elements */
+    if (_mesh->query_elem(0) && _mesh->query_elem(1))
+      CPPUNIT_ASSERT( _mesh->elem(0)->node(1) != _mesh->elem(1)->node(2) );
+    if (_mesh->query_elem(2) && _mesh->query_elem(3))
+      CPPUNIT_ASSERT( _mesh->elem(2)->node(0) != _mesh->elem(3)->node(3) );
+
+    /* The middle nodes should still be shared between left and right
+     * elements on top and bottom */
+    if (_mesh->query_elem(0) && _mesh->query_elem(2))
+      CPPUNIT_ASSERT_EQUAL( _mesh->elem(0)->node(1), _mesh->elem(2)->node(0) );
+    if (_mesh->query_elem(1) && _mesh->query_elem(3))
+      CPPUNIT_ASSERT_EQUAL( _mesh->elem(1)->node(2), _mesh->elem(3)->node(3) );
+  }
+
+};
+
+class SlitMeshRefinedMeshTest : public SlitMeshTest {
+  /**
+   * The goal of this test is the same as the previous, but now we do a
+   * uniform refinement and make sure the result mesh is consistent. i.e.
+   * the new node shared between the 1D elements is the same as the node
+   * shared on the underlying quads, and so on.
+   */
+public:
+  CPPUNIT_TEST_SUITE( SlitMeshRefinedMeshTest );
+
+  CPPUNIT_TEST( testMesh );
+
+  CPPUNIT_TEST_SUITE_END();
+
+  // Yes, this is necessary. Somewhere in those macros is a protected/private
+public:
+
+  void setUp()
+  {
+    this->build_mesh();
+
+#ifdef LIBMESH_ENABLE_AMR
+    MeshRefinement(*_mesh).uniformly_refine(1);
+#endif
+  }
+
+  void testMesh()
+  {
+#ifdef LIBMESH_ENABLE_AMR
+    // We should have 20 total and 16 active elements.
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)20, _mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)16, _mesh->n_active_elem() );
+
+    // We should have 28 nodes, not 25 or 26
+    CPPUNIT_ASSERT_EQUAL( (dof_id_type)28, _mesh->n_nodes() );
+#endif
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( SlitMeshTest );
+CPPUNIT_TEST_SUITE_REGISTRATION( SlitMeshRefinedMeshTest );


### PR DESCRIPTION
Increment the file version number to 0.9.6+ to signify the format change.

This rebases (and replaces) #765 

I need to add more test coverage before we merge.

This probably shouldn't be left in limbo too long, though; now that #719 has fixed slit mesh (and other collocated mesh) uses, we need to make sure there aren't any lingering bugs w.r.t. restarts with such meshes.