### PR TITLE
Skip lower-dimensional elements in System::calculate_norm()

### DIFF
--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1557,6 +1557,13 @@ Real System::calculate_norm(const NumericVector<Number> & v,
         {
           const Elem * elem = *el;
 
+          if(elem->dim() < dim)
+          {
+            // Skip lower-dimensional elements since they do
+            // not contribute to the norm
+            continue;
+          }
+
           fe->reinit (elem);
 
           this->get_dof_map().dof_indices (elem, dof_indices, var);


### PR DESCRIPTION
System::calculate_norm() currently assumes that all elements have the same dimension, and hence fails on mixed-dimension meshes. A simple fix is to just ignore the lower-dimensional elements, since they have zero measure on a dim-dimensional mesh.