### PR TITLE
System::calculate_norm() now works with mixed-dimension meshes

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1204,14 +1204,16 @@ public:
    */
   Real calculate_norm(const NumericVector<Number> & v,
                       unsigned int var,
-                      FEMNormType norm_type) const;
+                      FEMNormType norm_type,
+                      std::set<unsigned int> * skip_dimensions=NULL) const;
 
   /**
    * @returns a norm of the vector \p v, using \p component_norm and \p
    * component_scale to choose and weight the norms of each variable.
    */
   Real calculate_norm(const NumericVector<Number> & v,
-                      const SystemNorm & norm) const;
+                      const SystemNorm & norm,
+                      std::set<unsigned int> * skip_dimensions=NULL) const;
 
   /**
    * Reads the basic data header for this System.


### PR DESCRIPTION
This follows the approach used in ExactSolution::compute_error, where we initialize FE objects for each dimension and then pick out the right one on each element. We can also now skip specific dimensions by setting the skip_dimensions set (by default we calculate contributions from all dimensions in the mesh).