### PR TITLE
GetPot fixes when libmesh is absent

### DIFF
--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -96,6 +96,7 @@ extern "C" {
 #else // !USE_LIBMESH
 
 // Currently threaded GetPot use is only supported via libMesh Threads
+#define GETPOT_DISABLE_MUTEX
 #define SCOPED_MUTEX
 #define GETPOT_MUTEX_DECLARE
 

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -68,8 +68,10 @@ extern "C" {
 #if !defined(GETPOT_DISABLE_MUTEX)
 #include "libmesh/threads.h"
 #define SCOPED_MUTEX  libMesh::Threads::spin_mutex::scoped_lock lock(_getpot_mtx)
+#define GETPOT_MUTEX_DECLARE mutable libMesh::Threads::spin_mutex _getpot_mtx
 #else
 #define SCOPED_MUTEX
+#define GETPOT_MUTEX_DECLARE
 #endif
 
 #define getpot_cerr libMesh::err
@@ -95,6 +97,7 @@ extern "C" {
 
 // Currently threaded GetPot use is only supported via libMesh Threads
 #define SCOPED_MUTEX
+#define GETPOT_MUTEX_DECLARE
 
 #define getpot_cerr std::cerr
 #define getpot_error() throw std::runtime_error(std::string("GetPot Error"))
@@ -529,9 +532,7 @@ private:
    * multiple threads at once, so we'll wrap access to
    * mutable objects in a mutex.
    */
-#if !defined(GETPOT_DISABLE_MUTEX)
-  mutable libMesh::Threads::spin_mutex _getpot_mtx;
-#endif
+  GETPOT_MUTEX_DECLARE;
 
   /**
    * some functions return a char pointer to a string created on the fly.

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -880,7 +880,7 @@ GetPot::parse_input_file(const std::string& FileName,
   std::ifstream input(FileName.c_str());
 
   if (!input)
-    libmesh_file_error(FileName);
+    getpot_file_error(FileName);
 
   this->parse_input_stream(input,FileName,CommentStart,CommentEnd,FieldSeparator);
 }


### PR DESCRIPTION
I fix two bugs here:

1.  The declaration of the mutex when libmesh is not present (`#undef USE_LIBMESH`)
2.  Using the libmesh-independent `getpot_file_error` macro instead of the `libmesh_file_error` macro

Feedback welcome.