### PR TITLE
Set #defines if PETSc is built with SuperLU_dist and/or MUMPS support.

### DIFF
--- a/configure
+++ b/configure
@@ -32070,6 +32070,12 @@ $as_echo "<<< PETSc 2.x detected and \"\$PETSC_ARCH\" not set.  PETSc disabled. 
       # We look for petscconf.h in both $PETSC_DIR/include and
       # $PETSC_DIR/$PETSC_ARCH/include, since it can appear in either.
       petsc_use_debug=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_USE_DEBUG`
+      petsc_have_superlu_dist=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_SUPERLU_DIST`
+      petsc_have_mumps=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_MUMPS`
+
+      # We have had a slightly different way of checking for Hypre for
+      # quite some time, see below.
+      # petsc_have_hypre=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_HYPRE`
 
     else # petscversion.h was not readable
         enablepetsc=no
@@ -34423,6 +34429,27 @@ _ACEOF
 $as_echo "#define PETSC_USE_DEBUG 1" >>confdefs.h
 
     fi
+
+    # Set a #define if PETSc was built with SuperLU_dist support
+    if (test $petsc_have_superlu_dist -gt 0) ; then
+
+$as_echo "#define PETSC_HAVE_SUPERLU_DIST 1" >>confdefs.h
+
+    fi
+
+    # Set a #define if PETSc was built with MUMPS support
+    if (test $petsc_have_mumps -gt 0) ; then
+
+$as_echo "#define PETSC_HAVE_MUMPS 1" >>confdefs.h
+
+    fi
+
+    # Set a #define if PETSc was built with Hypre support.  We have
+    # been using the slightly different "LIBMESH_HAVE_PETSC_HYPRE" for
+    # quite a while, I may update this in a future branch.
+    # if (test $petsc_have_hypre -gt 0) ; then
+    #   AC_DEFINE(PETSC_HAVE_HYPRE, 1, [Flag indicating whether or not PETSc was configured with Hypre support])
+    # fi
 
      # Note: may be empty...
 

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -586,6 +586,13 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
+/* Flag indicating whether or not PETSc was configured with MUMPS support */
+#undef PETSC_HAVE_MUMPS
+
+/* Flag indicating whether or not PETSc was configured with SuperLU_dist
+   support */
+#undef PETSC_HAVE_SUPERLU_DIST
+
 /* Flag indicating whether or not PETSc was configured with debugging enabled
    */
 #undef PETSC_USE_DEBUG

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -76,6 +76,12 @@ AC_DEFUN([CONFIGURE_PETSC],
       # We look for petscconf.h in both $PETSC_DIR/include and
       # $PETSC_DIR/$PETSC_ARCH/include, since it can appear in either.
       petsc_use_debug=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_USE_DEBUG`
+      petsc_have_superlu_dist=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_SUPERLU_DIST`
+      petsc_have_mumps=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_MUMPS`
+
+      # We have had a slightly different way of checking for Hypre for
+      # quite some time, see below.
+      # petsc_have_hypre=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_HYPRE`
 
     else # petscversion.h was not readable
         enablepetsc=no
@@ -328,6 +334,23 @@ AC_DEFUN([CONFIGURE_PETSC],
     if (test $petsc_use_debug -gt 0) ; then
       AC_DEFINE(PETSC_USE_DEBUG, 1, [Flag indicating whether or not PETSc was configured with debugging enabled])
     fi
+
+    # Set a #define if PETSc was built with SuperLU_dist support
+    if (test $petsc_have_superlu_dist -gt 0) ; then
+      AC_DEFINE(PETSC_HAVE_SUPERLU_DIST, 1, [Flag indicating whether or not PETSc was configured with SuperLU_dist support])
+    fi
+
+    # Set a #define if PETSc was built with MUMPS support
+    if (test $petsc_have_mumps -gt 0) ; then
+      AC_DEFINE(PETSC_HAVE_MUMPS, 1, [Flag indicating whether or not PETSc was configured with MUMPS support])
+    fi
+
+    # Set a #define if PETSc was built with Hypre support.  We have
+    # been using the slightly different "LIBMESH_HAVE_PETSC_HYPRE" for
+    # quite a while, I may update this in a future branch.
+    # if (test $petsc_have_hypre -gt 0) ; then
+    #   AC_DEFINE(PETSC_HAVE_HYPRE, 1, [Flag indicating whether or not PETSc was configured with Hypre support])
+    # fi
 
     AC_SUBST(PETSC_ARCH) # Note: may be empty...
     AC_SUBST(PETSC_DIR)


### PR DESCRIPTION
I think for now, we'll go on detecting Hypre the way we have for years, but for consistency, it might be good to change this to the way we detect the other #defines, which I believe have been in petscconf.h for a long time...