### PR TITLE
Fix deprecation warning in unit tests.

### DIFF
--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -232,10 +232,7 @@ void EquationSystems::reinit ()
 
   // FIXME: Where should the user set maintain_level_one now??
   // Don't override previous settings, for now
-
   MeshRefinement mesh_refine(_mesh);
-
-  mesh_refine.face_level_mismatch_limit() = false;
 
   // Try to coarsen the mesh, then restrict each system's vectors
   // if necessary


### PR DESCRIPTION
face_level_mismatch_limit() is supposed to set the value of an
unsigned char, but this line of code was assigning it the value of
"false", which is equivalent to 0, which is equivalent to unlimited
mismatch, which triggered the deprecation warning.  Based on the
nearby comment, we don't want to override any settings anyway, so I
think this is the right fix.