### PR TITLE
Deprecate PointLocatorList.

### DIFF
--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -40,11 +40,11 @@ PointLocatorList::PointLocatorList (const MeshBase & mesh,
   PointLocatorBase (mesh,master),
   _list            (NULL)
 {
-  // This code will only work if your mesh is the Voroni mesh of it's
+  // This code will only work if your mesh is the Voronoi mesh of its
   // own elements' centroids.  If your mesh is that regular you might
   // as well hand-code an O(1) algorithm for locating points within
   // it. - RHS
-  libmesh_experimental();
+  libmesh_deprecated();
 
   this->init();
 }

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -30,7 +30,6 @@ public:
 
   CPPUNIT_TEST( testMesh );
   CPPUNIT_TEST( testDofOrdering );
-  CPPUNIT_TEST( testPointLocatorList );
   CPPUNIT_TEST( testPointLocatorTree );
 
   CPPUNIT_TEST_SUITE_END();


### PR DESCRIPTION
Based on Roy's scathing analysis, I don't think we want it any more.

// This code will only work if your mesh is the Voronoi mesh of it's
// own elements' centroids.  If your mesh is that regular you might
// as well hand-code an O(1) algorithm for locating points within
// it. - RHS

Also remove unit testing of this class.