### PR TITLE
Make meshplot solution file optional

### DIFF
--- a/src/apps/meshplot.C
+++ b/src/apps/meshplot.C
@@ -24,8 +24,14 @@ int main(int argc, char ** argv)
   Mesh mesh(init.comm());
   EquationSystems es(mesh);
 
-  libMesh::out << "Usage: " << argv[0]
-               << " inputmesh inputsolution outputplot" << std::endl;
+  if (argc < 3 || argc > 4)
+    {
+      libMesh::out << "Usage: " << argv[0]
+                   << " inputmesh [inputsolution] outputplot"
+                   << std::endl;
+
+      libmesh_error();
+    }
 
   START_LOG("mesh.read()", "main");
   mesh.read(argv[1]);
@@ -33,20 +39,23 @@ int main(int argc, char ** argv)
   libMesh::out << "Loaded mesh " << argv[1] << std::endl;
   mesh.print_info();
 
-  START_LOG("es.read()", "main");
-  std::string solnname = argv[2];
+  if (argc > 3)
+    {
+      START_LOG("es.read()", "main");
+      std::string solnname = argv[2];
 
-  es.read(solnname,
-          EquationSystems::READ_HEADER |
-          EquationSystems::READ_DATA |
-          EquationSystems::READ_ADDITIONAL_DATA |
-          EquationSystems::READ_BASIC_ONLY);
-  STOP_LOG("es.read()", "main");
-  libMesh::out << "Loaded solution " << solnname << std::endl;
-  es.print_info();
+      es.read(solnname,
+              EquationSystems::READ_HEADER |
+              EquationSystems::READ_DATA |
+              EquationSystems::READ_ADDITIONAL_DATA |
+              EquationSystems::READ_BASIC_ONLY);
+      STOP_LOG("es.read()", "main");
+      libMesh::out << "Loaded solution " << solnname << std::endl;
+      es.print_info();
+    }
 
   START_LOG("write_equation_systems()", "main");
-  std::string outputname(argv[3]);
+  std::string outputname(argv[argc-1]);
 
   if (outputname.find(".gnuplot") != std::string::npos)
     GnuPlotIO(mesh).write_equation_systems (outputname, es);

--- a/src/apps/meshplot.C
+++ b/src/apps/meshplot.C
@@ -25,13 +25,10 @@ int main(int argc, char ** argv)
   EquationSystems es(mesh);
 
   if (argc < 3 || argc > 4)
-    {
-      libMesh::out << "Usage: " << argv[0]
-                   << " inputmesh [inputsolution] outputplot"
-                   << std::endl;
+    libmesh_error_msg
+      ("Usage: " << argv[0] <<
+       " inputmesh [inputsolution] outputplot");
 
-      libmesh_error();
-    }
 
   START_LOG("mesh.read()", "main");
   mesh.read(argv[1]);

--- a/src/apps/meshplot.C
+++ b/src/apps/meshplot.C
@@ -73,6 +73,14 @@ int main(int argc, char ** argv)
     ExodusII_IO(mesh).write_equation_systems (outputname, es);
   else if (outputname.find(".n") != std::string::npos)
     Nemesis_IO(mesh).write_equation_systems (outputname, es);
+  else if ((outputname.find(".xda") != std::string::npos) ||
+           (outputname.find(".xdr") != std::string::npos))
+    {
+      mesh.write(outputname);
+      es.write(outputname);
+    }
+  else
+    libmesh_error();
 
   STOP_LOG("write_equation_systems()", "main");
   libMesh::out << "Wrote output " << outputname << std::endl;

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -479,8 +479,6 @@ void EquationSystems::build_variable_names (std::vector<std::string> & var_names
                                             const FEType * type,
                                             const std::set<std::string> * system_names) const
 {
-  libmesh_assert (this->n_systems());
-
   unsigned int var_num=0;
 
   const_system_iterator       pos = _systems.begin();
@@ -674,8 +672,6 @@ void EquationSystems::build_solution_vector (std::vector<Number> & soln,
 
   // This function must be run on all processors at once
   parallel_object_only();
-
-  libmesh_assert (this->n_systems());
 
   const unsigned int dim = _mesh.mesh_dimension();
   const dof_id_type nn   = _mesh.n_nodes();


### PR DESCRIPTION
And remove a couple overzealous asserts that got in the way.

This is only tested with ExodusII; if it breaks with other formats that'll be a separate bug to fix.