### PR TITLE
Fix memory leak in vector_fe_ex{2,3,4}

### DIFF
--- a/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
+++ b/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
@@ -113,11 +113,12 @@ int main (int argc, char** argv)
 
   ExactSolution exact_sol(equation_systems);
 
-  std::vector<FunctionBase<Number> *> sols;
-  std::vector<FunctionBase<Gradient> *> grads;
+  SolutionFunction soln_func(system.variable_number("u"));
+  SolutionGradient soln_grad(system.variable_number("u"));
 
-  sols.push_back(new SolutionFunction(system.variable_number("u")));
-  grads.push_back(new SolutionGradient(system.variable_number("u")));
+  // Build FunctionBase* containers to attach to the ExactSolution object.
+  std::vector<FunctionBase<Number> *> sols(1, &soln_func);
+  std::vector<FunctionBase<Gradient> *> grads(1, &soln_grad);
 
   exact_sol.attach_exact_values(sols);
   exact_sol.attach_exact_derivs(grads);

--- a/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
+++ b/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
@@ -119,11 +119,12 @@ int main (int argc, char ** argv)
 
   ExactSolution exact_sol(equation_systems);
 
-  std::vector<FunctionBase<Number> *> sols;
-  std::vector<FunctionBase<Gradient> *> grads;
+  SolutionFunction soln_func(system.variable_number("u"));
+  SolutionGradient soln_grad(system.variable_number("u"));
 
-  sols.push_back(new SolutionFunction(system.variable_number("u")));
-  grads.push_back(new SolutionGradient(system.variable_number("u")));
+  // Build FunctionBase* containers to attach to the ExactSolution object.
+  std::vector<FunctionBase<Number> *> sols(1, &soln_func);
+  std::vector<FunctionBase<Gradient> *> grads(1, &soln_grad);
 
   exact_sol.attach_exact_values(sols);
   exact_sol.attach_exact_derivs(grads);

--- a/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
+++ b/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
@@ -122,11 +122,12 @@ int main (int argc, char ** argv)
 
   ExactSolution exact_sol(equation_systems);
 
-  std::vector<FunctionBase<Number> *> sols;
-  std::vector<FunctionBase<Gradient> *> grads;
+  SolutionFunction soln_func(system.variable_number("u"));
+  SolutionGradient soln_grad(system.variable_number("u"));
 
-  sols.push_back(new SolutionFunction(system.variable_number("u")));
-  grads.push_back(new SolutionGradient(system.variable_number("u")));
+  // Build FunctionBase* containers to attach to the ExactSolution object.
+  std::vector<FunctionBase<Number> *> sols(1, &soln_func);
+  std::vector<FunctionBase<Gradient> *> grads(1, &soln_grad);
 
   exact_sol.attach_exact_values(sols);
   exact_sol.attach_exact_derivs(grads);

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -89,7 +89,7 @@ public:
    * Clone and attach arbitrary functors which compute the exact
    * values of the EquationSystems' solutions at any point.
    */
-  void attach_exact_values (std::vector<FunctionBase<Number> *> f);
+  void attach_exact_values (const std::vector<FunctionBase<Number> *> & f);
 
   /**
    * Clone and attach an arbitrary functor which computes the exact
@@ -111,7 +111,7 @@ public:
    * Clone and attach arbitrary functors which compute the exact
    * gradients of the EquationSystems' solutions at any point.
    */
-  void attach_exact_derivs (std::vector<FunctionBase<Gradient> *> g);
+  void attach_exact_derivs (const std::vector<FunctionBase<Gradient> *> & g);
 
   /**
    * Clone and attach an arbitrary functor which computes the exact

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -120,7 +120,7 @@ void ExactSolution::attach_exact_value (Number fptr(const Point & p,
 }
 
 
-void ExactSolution::attach_exact_values (std::vector<FunctionBase<Number> *> f)
+void ExactSolution::attach_exact_values (const std::vector<FunctionBase<Number> *> & f)
 {
   // Clear out any previous _exact_values entries, then add a new
   // entry for each system.
@@ -174,7 +174,7 @@ void ExactSolution::attach_exact_deriv (Gradient gptr(const Point & p,
 }
 
 
-void ExactSolution::attach_exact_derivs (std::vector<FunctionBase<Gradient> *> g)
+void ExactSolution::attach_exact_derivs (const std::vector<FunctionBase<Gradient> *> & g)
 {
   // Clear out any previous _exact_derivs entries, then add a new
   // entry for each system.


### PR DESCRIPTION
`ExactSolution::attach_exact_{values,derivs}` can also take a constant reference to a vector, since it copies the objects internally.