### PR TITLE
Add EigenSparseMatrix::l1_norm(), linfty_norm().

### DIFF
--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -220,7 +220,7 @@ public:
    * to the l1-norm for vectors, i.e.
    * \f$|Mv|_1\leq |M|_1 |v|_1\f$.
    */
-  virtual Real l1_norm () const libmesh_override { libmesh_not_implemented(); return 0.; }
+  virtual Real l1_norm () const libmesh_override;
 
   /**
    * Return the linfty-norm of the
@@ -233,7 +233,7 @@ public:
    * to the linfty-norm of vectors, i.e.
    * \f$|Mv|_\infty \leq |M|_\infty |v|_\infty\f$.
    */
-  virtual Real linfty_norm () const libmesh_override { libmesh_not_implemented(); return 0.; }
+  virtual Real linfty_norm () const libmesh_override;
 
   /**
    * see if Eigen matrix has been closed

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -294,6 +294,50 @@ T EigenSparseMatrix<T>::operator () (const numeric_index_type i,
 
 
 
+template <typename T>
+Real EigenSparseMatrix<T>::l1_norm () const
+{
+  // There does not seem to be a straightforward way to iterate over
+  // the columns of an EigenSparseMatrix.  So we use some extra
+  // storage and keep track of the column sums while going over the
+  // row entries...
+  std::vector<Real> abs_col_sums(this->n());
+
+  // For a row-major Eigen SparseMatrix like we're using, the
+  // InnerIterator iterates over the non-zero entries of rows.
+  for (unsigned row=0; row<this->m(); ++row)
+    {
+      EigenSM::InnerIterator it(_mat, row);
+      for (; it; ++it)
+        abs_col_sums[it.col()] += std::abs(it.value());
+    }
+
+  return *(std::max_element(abs_col_sums.begin(), abs_col_sums.end()));
+}
+
+
+
+template <typename T>
+Real EigenSparseMatrix<T>::linfty_norm () const
+{
+  Real max_abs_row_sum = 0.;
+
+  // For a row-major Eigen SparseMatrix like we're using, the
+  // InnerIterator iterates over the non-zero entries of rows.
+  for (unsigned row=0; row<this->m(); ++row)
+    {
+      Real current_abs_row_sum = 0.;
+      EigenSM::InnerIterator it(_mat, row);
+      for (; it; ++it)
+        current_abs_row_sum += std::abs(it.value());
+
+      max_abs_row_sum = std::max(max_abs_row_sum, current_abs_row_sum);
+    }
+
+  return max_abs_row_sum;
+}
+
+
 //------------------------------------------------------------------
 // Explicit instantiations
 template class EigenSparseMatrix<Number>;


### PR DESCRIPTION
Only the Frobenius norm is implemented for Eigen::SparseMatrix, these
others were simple enough to add.