### PR TITLE
Fix obscure issue with errno_t not being defined.

### DIFF
--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -23,6 +23,16 @@
 #include "libmesh/libmesh_config.h"
 #include "libmesh/libmesh_common.h"  // for libmesh_assert
 
+// We ran across a very strange issue with hand-built GCC 5.2.0 on OSX
+// with C++11 disabled, in which the "errno_t" type was not defined.
+// This is an attempt to fix that issue without unduly affecting other
+// compilers and build configurations.
+#if !defined(LIBMESH_HAVE_CXX11) && defined(__APPLE__) && defined(__GNUC__)
+# if (__GNUC__ == 5 && __GNUC_MINOR__ >= 2 && __GNUC_PATCHLEVEL__ >= 0)
+typedef int errno_t;
+# endif
+#endif
+
 // Threading building blocks includes
 #ifdef LIBMESH_HAVE_TBB_API
 #  include "libmesh/libmesh_logging.h" // only mess with the perflog if we are really multithreaded


### PR DESCRIPTION
This seems to currently only affect the following very specific configuration:
.) OSX with command line tools installed.
.) C++11 disabled.
.) GCC == 5.2.0.

The exact error message was:
In file included from /opt/moose/gcc_5.2.0/include/c++/5.2.0/cstring:42:0,
                 from /opt/moose/tbb/include/tbb/tbb_allocator.h:36,
                 from /opt/moose/tbb/include/tbb/tbb_exception.h:123,
                 from /opt/moose/tbb/include/tbb/parallel_for.h:28,
                 from ./include/libmesh/threads.h:31,
                 from ./include/libmesh/reference_counter.h:25,
                 from ./include/libmesh/reference_counted_object.h:24,
                 from ./include/libmesh/dof_object.h:28,
                 from ./include/libmesh/elem.h:25,
                 from ../src/mesh/exodusII_io_helper.C:31:
/usr/include/string.h:145:1: error: ‘errno_t’ does not name a type
 errno_t memset_s(void *, rsize_t, int, rsize_t) __OSX_AVAILABLE_STARTING(__MAC_10_9, __IPHONE_7_0);