### PR TITLE
Set SLEPc solver options for eigenproblems_ex3

### DIFF
--- a/examples/eigenproblems/eigenproblems_ex3/run.sh
+++ b/examples/eigenproblems/eigenproblems_ex3/run.sh
@@ -8,8 +8,9 @@ example_name=eigenproblems_ex3
 
 example_dir=examples/eigenproblems/$example_name
 
-options="-n_evals 5 -mesh_name drum1 -plotting_index 2"
-run_example "$example_name" "$options"
+slepc_options="-st_ksp_type gmres -st_pc_type bjacobi -st_sub_pc_type ilu"
+options="-n_evals 5 -mesh_name drum1 -plotting_index 2 $slepc_options"
+run_example_no_extra_options "$example_name" "$options"
 
-options="-n_evals 5 -mesh_name drum2 -plotting_index 2"
-run_example "$example_name" "$options"
+options="-n_evals 5 -mesh_name drum2 -plotting_index 2 $slepc_options"
+run_example_no_extra_options "$example_name" "$options"


### PR DESCRIPTION
Without these, I get a "No support for this operation with this object
type" error when running in parallel with PETSc 3.6