### PR TITLE
Slit mesh restarts may fail without unique_id

### DIFF
--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -26,7 +26,7 @@ public:
 
   ~SlitFunc () {}
 
-  virtual void init_context (const FEMContext &) {}
+  virtual void init_context (const FEMContext &) libmesh_override {}
 
   virtual UniquePtr<FEMFunctionBase<Number> >
   clone () const libmesh_override

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -244,7 +244,9 @@ public:
 
   CPPUNIT_TEST( testSystem );
 
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
   CPPUNIT_TEST( testRestart );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
And *do* fail on this particular mesh, according to @jwpeterson

So let's only enable this test when we know it should succeed.