### PR TITLE
Removing pthread_unique_id() from Threads

### DIFF
--- a/src/parallel/threads.C
+++ b/src/parallel/threads.C
@@ -28,26 +28,10 @@
 namespace libMesh
 {
 
-#if !defined(LIBMESH_HAVE_TBB_API) && defined(LIBMESH_HAVE_PTHREAD)
-std::map<pthread_t, unsigned int> Threads::_pthread_unique_ids;
-Threads::spin_mutex Threads::_pthread_unique_id_mutex;
-
-unsigned int Threads::pthread_unique_id()
-{
-#if LIBMESH_HAVE_OPENMP
-  return omp_get_thread_num();
-#else
-  spin_mutex::scoped_lock lock(_pthread_unique_id_mutex);
-  return _pthread_unique_ids[pthread_self()];
-#endif
-}
-#endif
-
 //-------------------------------------------------------------------------
 // Threads:: object instantiation
 Threads::spin_mutex Threads::spin_mtx;
 Threads::recursive_mutex Threads::recursive_mtx;
 bool Threads::in_threads = false;
-
 
 } // namespace libMesh


### PR DESCRIPTION
This method is buggy and unused by libMesh
it should simply be removed. I have a patch in MOOSE (https://github.com/idaholab/moose/pull/6246) that will remove the need to call this method.

Additionally, I believe we should cleanup these thread defines. We have at least four that I can see but there are already a few places where we have "else" clauses floating around without testing very many of these defines. For now, I thought I'd be more explicit about what case we are talking about. In the future we should consider a more robust model that allows us to turn on several configurations at the same time and choose which configuration to use at runtime!

closes #801