### PR TITLE
(Reduced Basis change) Optimized the EIM construction code

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -64,11 +64,25 @@ public:
    */
   virtual void init_data()
   {
-    u_var = this->add_variable ("f_EIM", libMesh::FIRST);
-
     Parent::init_data();
 
     set_inner_product_assembly(ip);
+  }
+
+  /**
+   * Initialize the implicit system that is used to perform L2 projections.
+   */
+  virtual void init_implicit_system()
+  {
+    this->add_variable ("L2_proj_var", libMesh::FIRST);
+  }
+
+  /**
+   * Initialize the explicit system that is used to store the basis functions.
+   */
+  virtual void init_explicit_system()
+  {
+    u_var = get_explicit_system().add_variable ("f_EIM", libMesh::FIRST);
   }
 
   /**

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -172,8 +172,10 @@ int main (int argc, char ** argv)
       if (store_basis_functions)
         {
           // Write out the basis functions
-          eim_construction.get_rb_evaluation().write_out_basis_functions(eim_construction, "eim_data");
-          rb_construction.get_rb_evaluation().write_out_basis_functions(rb_construction, "rb_data");
+          eim_construction.get_rb_evaluation().write_out_basis_functions(
+            eim_construction.get_explicit_system(), "eim_data");
+          rb_construction.get_rb_evaluation().write_out_basis_functions(
+            rb_construction, "rb_data");
         }
     }
   else
@@ -211,7 +213,7 @@ int main (int argc, char ** argv)
       if (store_basis_functions)
         {
           // read in the data from files
-          eim_rb_eval.read_in_basis_functions(eim_construction, "eim_data");
+          eim_rb_eval.read_in_basis_functions(eim_construction.get_explicit_system(), "eim_data");
           rb_eval.read_in_basis_functions(rb_construction, "rb_data");
 
           eim_construction.load_rb_solution();

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -401,35 +401,25 @@ struct Ex6InnerProduct : ElemAssembly
 
 struct Ex6EIMInnerProduct : ElemAssembly
 {
-  // Use the L2 norm to find the best fit
+  // Use the L2 inner product to find the best fit
   virtual void interior_assembly(FEMContext & c)
   {
-    const unsigned int Gx_var = 0;
-    const unsigned int Gy_var = 1;
-    const unsigned int Gz_var = 2;
-
     FEBase * elem_fe = NULL;
-    c.get_element_fe(Gx_var, elem_fe);
+    c.get_element_fe(0, elem_fe);
 
     const std::vector<Real> & JxW = elem_fe->get_JxW();
 
     const std::vector<std::vector<Real> > & phi = elem_fe->get_phi();
 
-    const unsigned int n_u_dofs = c.get_dof_indices(Gx_var).size();
+    const unsigned int n_dofs = c.get_dof_indices().size();
 
     unsigned int n_qpoints = c.get_element_qrule().n_points();
 
-    DenseSubMatrix<Number> & Kxx = c.get_elem_jacobian(Gx_var, Gx_var);
-    DenseSubMatrix<Number> & Kyy = c.get_elem_jacobian(Gy_var, Gy_var);
-    DenseSubMatrix<Number> & Kzz = c.get_elem_jacobian(Gz_var, Gz_var);
-
     for (unsigned int qp=0; qp != n_qpoints; qp++)
-      for (unsigned int i=0; i != n_u_dofs; i++)
-        for (unsigned int j=0; j != n_u_dofs; j++)
+      for (unsigned int i=0; i != n_dofs; i++)
+        for (unsigned int j=0; j != n_dofs; j++)
           {
-            Kxx(i,j) += JxW[qp] * phi[j][qp]*phi[i][qp];
-            Kyy(i,j) += JxW[qp] * phi[j][qp]*phi[i][qp];
-            Kzz(i,j) += JxW[qp] * phi[j][qp]*phi[i][qp];
+            c.get_elem_jacobian()(i,j) += JxW[qp] * phi[j][qp]*phi[i][qp];
           }
   }
 };

--- a/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
@@ -70,13 +70,27 @@ public:
    */
   virtual void init_data()
   {
-    Gx_var = this->add_variable ("x_comp_of_G", libMesh::FIRST);
-    Gy_var = this->add_variable ("y_comp_of_G", libMesh::FIRST);
-    Gz_var = this->add_variable ("z_comp_of_G", libMesh::FIRST);
-
     Parent::init_data();
 
     set_inner_product_assembly(eim_ip);
+  }
+
+  /**
+   * Initialize the implicit system that is used to perform L2 projections.
+   */
+  virtual void init_implicit_system()
+  {
+    this->add_variable ("L2_proj_var", libMesh::FIRST);
+  }
+
+  /**
+   * Initialize the explicit system that is used to store the basis functions.
+   */
+  virtual void init_explicit_system()
+  {
+    Gx_var = get_explicit_system().add_variable ("x_comp_of_G", libMesh::FIRST);
+    Gy_var = get_explicit_system().add_variable ("y_comp_of_G", libMesh::FIRST);
+    Gz_var = get_explicit_system().add_variable ("z_comp_of_G", libMesh::FIRST);
   }
 
   /**

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -234,8 +234,10 @@ int main (int argc, char ** argv)
       if (store_basis_functions)
         {
           // Write out the basis functions
-          eim_construction.get_rb_evaluation().write_out_basis_functions(eim_construction, "eim_data");
-          rb_construction.get_rb_evaluation().write_out_basis_functions(rb_construction, "rb_data");
+          eim_construction.get_rb_evaluation().write_out_basis_functions(
+            eim_construction.get_explicit_system(), "eim_data");
+          rb_construction.get_rb_evaluation().write_out_basis_functions(
+            rb_construction, "rb_data");
         }
     }
   else // Perform the Online stage of the RB method
@@ -275,7 +277,8 @@ int main (int argc, char ** argv)
       if (store_basis_functions)
         {
           // read in the data from files
-          eim_rb_eval.read_in_basis_functions(eim_construction, "eim_data");
+          eim_rb_eval.read_in_basis_functions(
+            eim_construction.get_explicit_system(), "eim_data");
           rb_eval.read_in_basis_functions(rb_construction, "rb_data");
 
           eim_construction.load_rb_solution();

--- a/include/reduced_basis/rb_eim_assembly.h
+++ b/include/reduced_basis/rb_eim_assembly.h
@@ -79,16 +79,16 @@ public:
   NumericVector<Number> & get_ghosted_basis_function();
 
   /**
-   * Retrieve the FE object associated with variable \p var.
+   * Retrieve the FE object.
    */
-  FEBase & get_fe(unsigned int var);
+  FEBase & get_fe();
 
 private:
 
   /**
-   * Initialize the FE objects in _fe_var.
+   * Initialize the FE object.
    */
-  void initialize_fe_objects();
+  void initialize_fe();
 
   /**
    * The RBEIMConstruction object that this RBEIMAssembly is based on.
@@ -108,16 +108,10 @@ private:
   UniquePtr<NumericVector<Number> > _ghosted_basis_function;
 
   /**
-   * We store an FE object for each variable in _rb_eim_con. This is used
-   * in evaluate_basis_function. Note that by storing the FE objects (rather
-   * than recreating them each time) we benefit from caching in fe.reinit().
+   * We store an FE object and an associated quadrature rule.
    */
-  std::vector<FEBase *> _fe_var;
-
-  /**
-   * We also store the quadrature rule associated with each FE object.
-   */
-  std::vector<QBase *> _fe_qrule;
+  FEBase * _fe;
+  QBase * _qrule;
 
 };
 

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -440,16 +440,18 @@ void RBConstruction::zero_constrained_dofs_on_vector(NumericVector<Number> & vec
 void RBConstruction::initialize_rb_construction(bool skip_matrix_assembly,
                                                 bool skip_vector_assembly)
 {
-  // Check that the theta and assembly objects are consistently sized
-  libmesh_assert_equal_to (get_rb_theta_expansion().get_n_A_terms(), get_rb_assembly_expansion().get_n_A_terms());
-  libmesh_assert_equal_to (get_rb_theta_expansion().get_n_F_terms(), get_rb_assembly_expansion().get_n_F_terms());
-  libmesh_assert_equal_to (get_rb_theta_expansion().get_n_outputs(), get_rb_assembly_expansion().get_n_outputs());
-  for(unsigned int i=0; i<get_rb_theta_expansion().get_n_outputs(); i++)
+  if(!skip_matrix_assembly && !skip_vector_assembly)
     {
-      libmesh_assert_equal_to (get_rb_theta_expansion().get_n_output_terms(i),
-                               get_rb_assembly_expansion().get_n_output_terms(i));
+      // Check that the theta and assembly objects are consistently sized
+      libmesh_assert_equal_to (get_rb_theta_expansion().get_n_A_terms(), get_rb_assembly_expansion().get_n_A_terms());
+      libmesh_assert_equal_to (get_rb_theta_expansion().get_n_F_terms(), get_rb_assembly_expansion().get_n_F_terms());
+      libmesh_assert_equal_to (get_rb_theta_expansion().get_n_outputs(), get_rb_assembly_expansion().get_n_outputs());
+      for(unsigned int i=0; i<get_rb_theta_expansion().get_n_outputs(); i++)
+        {
+          libmesh_assert_equal_to (get_rb_theta_expansion().get_n_output_terms(i),
+                                   get_rb_assembly_expansion().get_n_output_terms(i));
+        }
     }
-
 
   // Perform the initialization
   allocate_data_structures();

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -35,46 +35,38 @@ RBEIMAssembly::RBEIMAssembly(RBEIMConstruction & rb_eim_con_in,
                              unsigned int basis_function_index_in)
   : _rb_eim_con(rb_eim_con_in),
     _basis_function_index(basis_function_index_in),
-    _ghosted_basis_function(NumericVector<Number>::build(rb_eim_con_in.system().comm()))
+    _ghosted_basis_function(NumericVector<Number>::build(
+      rb_eim_con_in.get_explicit_system().comm())),
+    _fe(NULL),
+    _qrule(NULL)
 {
   // localize the vector that stores the basis function for this assembly object,
   // i.e. the vector that is used in evaluate_basis_function_at_quad_pts
 #ifdef LIBMESH_ENABLE_GHOSTED
-  _ghosted_basis_function->init (_rb_eim_con.n_dofs(), _rb_eim_con.n_local_dofs(),
-                                 _rb_eim_con.get_dof_map().get_send_list(), false, GHOSTED);
+  _ghosted_basis_function->init (_rb_eim_con.get_explicit_system().n_dofs(),
+                                 _rb_eim_con.get_explicit_system().n_local_dofs(),
+                                 _rb_eim_con.get_explicit_system().get_dof_map().get_send_list(),
+                                 false,
+                                 GHOSTED);
   _rb_eim_con.get_rb_evaluation().get_basis_function(_basis_function_index).
-    localize(*_ghosted_basis_function, _rb_eim_con.get_dof_map().get_send_list());
+    localize(*_ghosted_basis_function,
+              _rb_eim_con.get_explicit_system().get_dof_map().get_send_list());
 #else
-  _ghosted_basis_function->init (_rb_eim_con.n_dofs(), false, SERIAL);
+  _ghosted_basis_function->init (_rb_eim_con.get_explicit_system().n_dofs(), false, SERIAL);
   _rb_eim_con.get_rb_evaluation().get_basis_function(_basis_function_index).
     localize(*_ghosted_basis_function);
 #endif
 
-  initialize_fe_objects();
-
-  // Also, declare fe_qrule. Just set entries to NULL for now.
-  _fe_qrule.resize(_fe_var.size());
-  for(unsigned int var=0; var<_fe_qrule.size(); var++)
-    {
-      _fe_qrule[var] = NULL;
-    }
+  initialize_fe();
 }
 
 RBEIMAssembly::~RBEIMAssembly()
 {
-  for(unsigned int var=0; var<_fe_var.size(); var++)
-    {
-      delete _fe_var[var];
-      _fe_var[var] = NULL;
-    }
-  _fe_var.clear();
+  delete _fe;
+  _fe = NULL;
 
-  for(unsigned int var=0; var<_fe_qrule.size(); var++)
-    {
-      delete _fe_qrule[var];
-      _fe_qrule[var] = NULL;
-    }
-  _fe_qrule.clear();
+  delete _qrule;
+  _qrule = NULL;
 }
 
 void RBEIMAssembly::evaluate_basis_function(unsigned int var,
@@ -85,42 +77,42 @@ void RBEIMAssembly::evaluate_basis_function(unsigned int var,
   START_LOG("evaluate_basis_function", "RBEIMAssembly");
 
   bool repeated_qrule = false;
-  if(_fe_qrule[var] != NULL)
+  if(_qrule != NULL)
     {
       repeated_qrule =
-        ( (element_qrule.type()      == _fe_qrule[var]->type()) &&
-          (element_qrule.get_dim()   == _fe_qrule[var]->get_dim()) &&
-          (element_qrule.get_order() == _fe_qrule[var]->get_order()) );
+        ( (element_qrule.type()      == _qrule->type()) &&
+          (element_qrule.get_dim()   == _qrule->get_dim()) &&
+          (element_qrule.get_order() == _qrule->get_order()) );
     }
 
   // If the qrule is not repeated, then we need to make a new copy of element_qrule.
   if (!repeated_qrule)
     {
       // First, possibly delete the old qrule
-      delete _fe_qrule[var];
+      delete _qrule;
 
-      _fe_qrule[var] =
+      _qrule =
         QBase::build(element_qrule.type(),
                      element_qrule.get_dim(),
                      element_qrule.get_order()).release();
 
-      get_fe(var).attach_quadrature_rule (_fe_qrule[var]);
+      get_fe().attach_quadrature_rule (_qrule);
     }
 
-  const std::vector<std::vector<Real> > & phi = get_fe(var).get_phi();
+  const std::vector<std::vector<Real> > & phi = get_fe().get_phi();
 
   // The FE object caches data, hence we recompute as little as
   // possible on the call to reinit.
-  get_fe(var).reinit (&element);
+  get_fe().reinit (&element);
 
   std::vector<dof_id_type> dof_indices_var;
 
-  DofMap & dof_map = get_rb_eim_construction().get_dof_map();
+  DofMap & dof_map = get_rb_eim_construction().get_explicit_system().get_dof_map();
   dof_map.dof_indices (&element, dof_indices_var, var);
 
   libmesh_assert(dof_indices_var.size() == phi.size());
 
-  unsigned int n_qpoints = _fe_qrule[var]->n_points();
+  unsigned int n_qpoints = _qrule->n_points();
   values.resize(n_qpoints);
 
   for(unsigned int qp=0; qp<n_qpoints; qp++)
@@ -143,33 +135,23 @@ NumericVector<Number> & RBEIMAssembly::get_ghosted_basis_function()
   return *_ghosted_basis_function;
 }
 
-FEBase & RBEIMAssembly::get_fe(unsigned int var)
+FEBase & RBEIMAssembly::get_fe()
 {
-  libmesh_assert_less(var, _fe_var.size());
-
-  return *_fe_var[var];
+  return *_fe;
 }
 
-void RBEIMAssembly::initialize_fe_objects()
+void RBEIMAssembly::initialize_fe()
 {
-  libmesh_assert_equal_to(_fe_var.size(), 0);
-
-  DofMap & dof_map = get_rb_eim_construction().get_dof_map();
+  DofMap & dof_map = get_rb_eim_construction().get_explicit_system().get_dof_map();
 
   const unsigned int dim =
     get_rb_eim_construction().get_mesh().mesh_dimension();
 
-  _fe_var.resize(get_rb_eim_construction().n_vars());
-  for(unsigned int var=0; var<get_rb_eim_construction().n_vars(); var++)
-    {
-      FEType fe_type = dof_map.variable_type(var);
-      FEBase * fe = (FEBase::build(dim, fe_type)).release();
+  FEType fe_type = dof_map.variable_type(0);
+  _fe = (FEBase::build(dim, fe_type)).release();
 
-      _fe_var[var] = fe;
-
-      // Pre-request the shape function for efficieny's sake
-      fe->get_phi();
-    }
+  // Pre-request the shape function for efficieny's sake
+  _fe->get_phi();
 }
 
 }


### PR DESCRIPTION
Before we did multiple L2 projections for all variables in one big system. Now we do a separate L2 projection for each variable. This gives the same results as before but uses less memory.