### PR TITLE
Add API to Detect Time-Dependence in FunctionBase Objects

### DIFF
--- a/include/numerics/composite_function.h
+++ b/include/numerics/composite_function.h
@@ -75,6 +75,20 @@ public:
         reverse_index_map[index_map[j]] =
           std::make_pair(subfunction_index, j);
       }
+
+    // Now check for time dependence
+    // We only check the function we just added instead of researching all subfunctions
+    // If this is the first subfunction, then that determines the time-dependence.
+    if( subfunctions.size() == 1 )
+      this->_is_time_dependent = subfunctions[0]->is_time_dependent();
+
+    // Otherwise, we have more than 1 function already.
+    // If _is_time_dependent is true, then one of the previous
+    // subfunctions is time-dependent and thus this CompositeFunction
+    // time-dependent. If _is_time_dependent is false, then the subfunction
+    // just added determines the time-dependence.
+    else if( !this->_is_time_dependent )
+      this->_is_time_dependent = (subfunctions.back())->is_time_dependent();
   }
 
   virtual Output operator() (const Point & p,

--- a/include/numerics/const_function.h
+++ b/include/numerics/const_function.h
@@ -34,7 +34,8 @@ class ConstFunction : public FunctionBase<Output>
 {
 public:
   explicit
-  ConstFunction (const Output & c) : _c(c) { this->_initialized = true; }
+  ConstFunction (const Output & c) : _c(c) { this->_initialized = true;
+                                             this->_is_time_dependent = false;}
 
   virtual Output operator() (const Point &,
                              const Real = 0) libmesh_override

--- a/include/numerics/function_base.h
+++ b/include/numerics/function_base.h
@@ -147,6 +147,19 @@ public:
    */
   bool initialized () const;
 
+  /**
+   * Function to set whether this is a time-dependent function or not.
+   * This is intended to be only used by subclasses who cannot natively
+   * determine time-dependence. In such a case, this function should
+   * be used immediately following construction.
+   */
+  void set_is_time_dependent( bool is_time_dependent);
+
+  /**
+   * @returns \p true when the function this object represents
+   * is actually time-dependent, \p false otherwise.
+   */
+  bool is_time_dependent() const;
 
 protected:
 
@@ -164,6 +177,11 @@ protected:
    */
   bool _initialized;
 
+  /**
+   * Cache whether or not this function is actually time-dependent.
+   */
+  bool _is_time_dependent;
+
 };
 
 
@@ -174,7 +192,8 @@ template<typename Output>
 inline
 FunctionBase<Output>::FunctionBase (const FunctionBase * master) :
   _master             (master),
-  _initialized        (false)
+  _initialized        (false),
+  _is_time_dependent  (true) // Assume we are time-dependent until the user says otherwise
 {
 }
 
@@ -195,6 +214,19 @@ bool FunctionBase<Output>::initialized() const
   return (this->_initialized);
 }
 
+template <typename Output>
+inline
+void FunctionBase<Output>::set_is_time_dependent( bool is_time_dependent )
+{
+  this->_is_time_dependent = is_time_dependent;
+}
+
+template <typename Output>
+inline
+bool FunctionBase<Output>::is_time_dependent() const
+{
+  return (this->_is_time_dependent);
+}
 
 
 template <typename Output>

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -115,6 +115,9 @@ protected:
   std::size_t find_name (const std::string & varname,
                          const std::string & expr) const;
 
+  // Helper function for determining time-dependence of expression
+  bool expression_is_time_dependent( const std::string & expression ) const;
+
 private:
   // Set the _spacetime argument vector
   void set_spacetime(const Point & p,
@@ -163,6 +166,7 @@ ParsedFunction<Output,OutputGradient>::ParsedFunction (const std::string & expre
   _additional_vars (additional_vars ? *additional_vars : std::vector<std::string>()),
   _initial_vals (initial_vals ? *initial_vals : std::vector<Output>())
 {
+  // time-dependence established in reparse function
   this->reparse(expression);
   this->_initialized = true;
 }
@@ -195,6 +199,8 @@ ParsedFunction<Output,OutputGradient>::reparse (const std::string & expression)
     }
 
   this->partial_reparse(expression);
+
+  this->_is_time_dependent = this->expression_is_time_dependent(expression);
 }
 
 template <typename Output, typename OutputGradient>
@@ -554,7 +560,20 @@ ParsedFunction<Output,OutputGradient>::find_name (const std::string & varname,
 
   return varname_i;
 }
+template <typename Output, typename OutputGradient>
+inline
+bool
+ParsedFunction<Output,OutputGradient>::expression_is_time_dependent( const std::string & expression ) const
+{
+  bool is_time_dependent = false;
 
+  // By definition, time is "t" for FunctionBase-based objects, so we just need to
+  // see if this expression has the variable "t" in it.
+  if( this->find_name( std::string("t"), expression ) != std::string::npos )
+    is_time_dependent = true;
+
+  return is_time_dependent;
+}
 
 // Set the _spacetime argument vector
 template <typename Output, typename OutputGradient>

--- a/tests/numerics/parsed_function_test.C
+++ b/tests/numerics/parsed_function_test.C
@@ -31,6 +31,7 @@ public:
   CPPUNIT_TEST(testValues);
   CPPUNIT_TEST(testInlineGetter);
   CPPUNIT_TEST(testInlineSetter);
+  CPPUNIT_TEST(testTimeDependence);
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -96,6 +97,21 @@ private:
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL
       (libmesh_real(cxy8.get_inline_value("c")), 3.5, TOLERANCE*TOLERANCE);
+  }
+
+  void testTimeDependence()
+  {
+    ParsedFunction<Number> no_t("x*2+y^2-tanh(z)+atan(x-y)");
+    CPPUNIT_ASSERT(!no_t.is_time_dependent());
+
+    ParsedFunction<Number> xyt("x+y+t");
+    CPPUNIT_ASSERT(xyt.is_time_dependent());
+
+    ParsedFunction<Number> x2y2t2("x*2+y^2+t^2");
+    CPPUNIT_ASSERT(x2y2t2.is_time_dependent());
+
+    ParsedFunction<Number> ztanht("z*tanh(t)");
+    CPPUNIT_ASSERT(ztanht.is_time_dependent());
   }
 
 };


### PR DESCRIPTION
The use case I have in mind here is to be able to query the `FunctionBase` in a `DirichletBoundary` object to see if we need to `reinit_constraints` or not. `FunctionBase` is assumed to be `f(x,y,z,t)` so there already is a notion of time. I've added functionality for `ParsedFunction` (which can just look for variable "t" in the expression), `CompositeFunction` (look at the subfunctions and see if any are time-dependent), and `ConstFunction` (never time-dependent).

I took a crack at `AnalyticFunction`, but I'm not sure how `init()` and `clear()` are typically used. I at least put a crack at the changes as the last commit to show what I was thinking. Can update it accordingly based on discussion. And `WrappedFunction` seems to not even assume time-dependence? I wasn't really sure what the "right thing" was to do there.

Labeling as do not merge until there's some discussion/consensus. I realize there may not even be interest in having this, but it was quick to do, so I just did it to throw it out there for thoughts.