### PR TITLE
Add -Wno-unknown-pragmas to GCC flags.

### DIFF
--- a/configure
+++ b/configure
@@ -7438,11 +7438,17 @@ fi
 
     # GCC 4.6.3 warns about variadic macros but supports them just
     # fine, so let's turn off that warning.
+    # GCC also warns about an "unknown pragma" on every file that
+    # includes threads.h when you configure with --disable-openmp.
+    # This is really annoying if you know what you are doing, and
+    # really don't want openmp enabled.  It's also a little unexpected
+    # for a pragma, presumably the compiler silently ignores unknown
+    # ones all the time...
     case "$GXX_VERSION" in
       gcc4.6 | gcc5)
-        CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
-        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
-        CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"
+        CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros -Wno-unknown-pragmas"
+        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros -Wno-unknown-pragmas"
+        CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros -Wno-unknown-pragmas"
         ;;
 
       *)

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -741,11 +741,17 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
 
     # GCC 4.6.3 warns about variadic macros but supports them just
     # fine, so let's turn off that warning.
+    # GCC also warns about an "unknown pragma" on every file that
+    # includes threads.h when you configure with --disable-openmp.
+    # This is really annoying if you know what you are doing, and
+    # really don't want openmp enabled.  It's also a little unexpected
+    # for a pragma, presumably the compiler silently ignores unknown
+    # ones all the time...
     case "$GXX_VERSION" in
       gcc4.6 | gcc5)
-        CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
-        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
-        CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"
+        CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros -Wno-unknown-pragmas"
+        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros -Wno-unknown-pragmas"
+        CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros -Wno-unknown-pragmas"
         ;;
 
       *)


### PR DESCRIPTION
Otherwise, every file emits the following two warnings from threads.h:
```
../include/libmesh/threads.h:539:0: warning: ignoring #pragma omp parallel [-Wunknown-pragmas]
../include/libmesh/threads.h:640:0: warning: ignoring #pragma omp parallel [-Wunknown-pragmas]
```

I also tried disabling the warnings "in place" with yet more pragmas:
```
#pragma GCC diagnostic ignored "-Wunknown-pragmas"
...
#pragma GCC diagnostic warning "-Wunknown-pragmas"
```
but this seemed to have no effect, only adding the compiler flag (and it has to appear *after* `-Wall` in the list of flags) made the warning go away.
