### PR TITLE
Absolute values for error_per_cell in the elementwise adjoint refinement error estimator

### DIFF
--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -417,7 +417,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
               // FIXME: we're throwing away information in the
               // --enable-complex case
               error_per_cell[e_id] += static_cast<ErrorVectorReal>
-                (libmesh_real(local_contribution));
+                (std::abs(local_contribution));
 
             } // End loop over elements
 


### PR DESCRIPTION
We werent putting absolute values on the error per cells from the adjoint refinement estimator earlier. Compiles and fixes the problem I was having in GRINS because of this.