### PR TITLE
Bugfix for DofMap::constrain_element_matrix

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1755,18 +1755,26 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
   row_dofs = orig_row_dofs;
   col_dofs = orig_col_dofs;
 
+  // K_constrained = R^T K C
+
+  if ((R.m() == matrix.m()) &&
+      (R.n() == row_dofs.size()))
+    {
+      matrix.left_multiply_transpose  (R);
+    }
+
+  if ((C.m() == matrix.n()) &&
+      (C.n() == col_dofs.size()))
+    {
+      matrix.right_multiply (C);
+    }
 
   // It is possible that the matrix is not constrained at all.
   if ((R.m() == matrix.m()) &&
       (R.n() == row_dofs.size()) &&
       (C.m() == matrix.n()) &&
-      (C.n() == col_dofs.size())) // If the matrix is constrained
+      (C.n() == col_dofs.size()))  // If the matrix is constrained
     {
-      // K_constrained = R^T K C
-      matrix.left_multiply_transpose  (R);
-      matrix.right_multiply (C);
-
-
       libmesh_assert_equal_to (matrix.m(), row_dofs.size());
       libmesh_assert_equal_to (matrix.n(), col_dofs.size());
 


### PR DESCRIPTION
DofMap::constrain_element_matrix (the 4 argument asymmetric version) was
returning incorrect element matrices when the row_dofs have a constraint and
the col_dofs do not.

The initial if condition in the routine was too stringent and missed the XOR case.