### PR TITLE
Add Type{Vector,Tensor}::norm(), norm_sq().

### DIFF
--- a/include/geom/sphere.h
+++ b/include/geom/sphere.h
@@ -205,7 +205,7 @@ Point Sphere::surface_coords (const Point & cart) const
   // phi: special care, so that it gives 0..2pi results
   const Real phi = std::atan2(c(1), c(0));
 
-  return Point(/* radius */ c.size(),
+  return Point(/* radius */ c.norm(),
                /* theta  */ std::atan2( std::sqrt( c(0)*c(0) + c(1)*c(1) ), c(2) ),
                /* phi    */ ( (phi < 0)  ?  2.*libMesh::pi+phi  :  phi ) );
 }

--- a/include/numerics/tensor_tools.h
+++ b/include/numerics/tensor_tools.h
@@ -76,12 +76,12 @@ T norm_sq(std::complex<T> a) { return std::norm(a); }
 template <typename T>
 inline
 Real norm_sq(const TypeVector<T> & a)
-{return a.size_sq();}
+{return a.norm_sq();}
 
 template <typename T>
 inline
 Real norm_sq(const VectorValue<T> & a)
-{return a.size_sq();}
+{return a.norm_sq();}
 
 // Any tensor-rank-independent code will need to include
 // tensor_tools.h, so we define rank-increasing and real-to-number type

--- a/include/numerics/type_n_tensor.h
+++ b/include/numerics/type_n_tensor.h
@@ -155,7 +155,13 @@ public:
    * Returns the Frobenius norm of the tensor squared, i.e.  sum of the
    * element magnitudes squared.
    */
-  Real size_sq() const { return 0.;}
+  Real size_sq() const { libmesh_deprecated(); return 0.;}
+
+  /**
+   * Returns the Frobenius norm of the tensor squared, i.e.  sum of the
+   * element magnitudes squared.
+   */
+  Real norm_sq() const { return 0.;}
 
   /**
    * @returns \p true if two tensors are equal valued.

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -291,15 +291,29 @@ public:
 
   /**
    * Returns the Frobenius norm of the tensor, i.e. the square-root of
-   * the sum of the elements squared.
+   * the sum of the elements squared.  This function is deprecated,
+   * used norm() instead.
    */
   Real size() const;
+
+  /**
+   * Returns the Frobenius norm of the tensor, i.e. the square-root of
+   * the sum of the elements squared.
+   */
+  Real norm() const;
+
+  /**
+   * Returns the Frobenius norm of the tensor squared, i.e.  sum of the
+   * element magnitudes squared.  This function is deprecated,
+   * used norm() instead.
+   */
+  Real size_sq() const;
 
   /**
    * Returns the Frobenius norm of the tensor squared, i.e.  sum of the
    * element magnitudes squared.
    */
-  Real size_sq() const;
+  Real norm_sq() const;
 
   /**
    * Returns the determinant of the tensor.  Because these are 3x3
@@ -1077,7 +1091,17 @@ template <typename T>
 inline
 Real TypeTensor<T>::size() const
 {
-  return std::sqrt(this->size_sq());
+  libmesh_deprecated();
+  return this->norm();
+}
+
+
+
+template <typename T>
+inline
+Real TypeTensor<T>::norm() const
+{
+  return std::sqrt(this->norm_sq());
 }
 
 
@@ -1135,6 +1159,16 @@ void TypeTensor<T>::zero()
 template <typename T>
 inline
 Real TypeTensor<T>::size_sq () const
+{
+  libmesh_deprecated();
+  return this->norm_sq();
+}
+
+
+
+template <typename T>
+inline
+Real TypeTensor<T>::norm_sq () const
 {
   Real sum = 0.;
   for (unsigned int i=0; i<LIBMESH_DIM*LIBMESH_DIM; i++)

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -267,15 +267,29 @@ public:
 
   /**
    * Returns the magnitude of the vector, i.e. the square-root of the
-   * sum of the elements squared.
+   * sum of the elements squared.  This function is deprecated, instead
+   * call norm().
    */
   Real size() const;
 
   /**
-   * Returns the magnitude of the vector squared, i.e. the sum of the element
-   * magnitudes squared.
+   * Returns the magnitude of the vector, i.e. the square-root of the
+   * sum of the elements squared.
+   */
+  Real norm() const;
+
+  /**
+   * Returns the magnitude of the vector squared, i.e. the sum of the
+   * element magnitudes squared.  This function is deprecated, instead
+   * call norm_sq().
    */
   Real size_sq() const;
+
+  /**
+   * Returns the magnitude of the vector squared, i.e. the sum of the
+   * element magnitudes squared.
+   */
+  Real norm_sq() const;
 
   /**
    * Zero the vector in any dimension.
@@ -861,7 +875,17 @@ template <typename T>
 inline
 Real TypeVector<T>::size() const
 {
-  return std::sqrt(this->size_sq());
+  libmesh_deprecated();
+  return this->norm();
+}
+
+
+
+template <typename T>
+inline
+Real TypeVector<T>::norm() const
+{
+  return std::sqrt(this->norm_sq());
 }
 
 
@@ -879,6 +903,16 @@ void TypeVector<T>::zero()
 template <typename T>
 inline
 Real TypeVector<T>::size_sq() const
+{
+  libmesh_deprecated();
+  return this->norm_sq();
+}
+
+
+
+template <typename T>
+inline
+Real TypeVector<T>::norm_sq() const
 {
 #if LIBMESH_DIM == 1
   return (TensorTools::norm_sq(_coords[0]));

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -527,7 +527,7 @@ Real ExactErrorEstimator::find_squared_element_error(const System & system,
           else if(_equation_systems_fine)
             grad_error -= fine_values->gradient(q_point[qp]);
 
-          error_val += JxW[qp]*grad_error.size_sq();
+          error_val += JxW[qp]*grad_error.norm_sq();
         }
 
 
@@ -546,7 +546,7 @@ Real ExactErrorEstimator::find_squared_element_error(const System & system,
           else if (_equation_systems_fine)
             grad2_error -= fine_values->hessian(q_point[qp]);
 
-          error_val += JxW[qp]*grad2_error.size_sq();
+          error_val += JxW[qp]*grad2_error.norm_sq();
         }
 #endif
 

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -792,7 +792,7 @@ void ExactSolution::_compute_error(const std::string & sys_name,
 
           const typename FEGenericBase<OutputShape>::OutputNumberGradient grad_error = grad_u_h - exact_grad;
 
-          error_vals[1] += JxW[qp]*grad_error.size_sq();
+          error_vals[1] += JxW[qp]*grad_error.norm_sq();
 
 
           if( FEInterface::field_type(fe_type) == TYPE_VECTOR )
@@ -863,7 +863,7 @@ void ExactSolution::_compute_error(const std::string & sys_name,
           const typename FEGenericBase<OutputShape>::OutputNumberTensor grad2_error = grad2_u_h - exact_hess;
 
           // FIXME: PB: Is this what we want for rank 3 tensors?
-          error_vals[2] += JxW[qp]*grad2_error.size_sq();
+          error_vals[2] += JxW[qp]*grad2_error.norm_sq();
 #endif
 
         } // end qp loop

--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -428,11 +428,11 @@ void HPCoarsenTest::select_refinement (System & system)
               if (cont == C_ZERO || cont == C_ONE)
                 p_error_per_cell[e_id] += static_cast<ErrorVectorReal>
                   (component_scale[var] *
-                   (*JxW)[qp] * grad_error.size_sq());
+                   (*JxW)[qp] * grad_error.norm_sq());
               if (cont == C_ONE)
                 p_error_per_cell[e_id] += static_cast<ErrorVectorReal>
                   (component_scale[var] *
-                   (*JxW)[qp] * hessian_error.size_sq());
+                   (*JxW)[qp] * hessian_error.norm_sq());
             }
 
           // Calculate this variable's contribution to the h
@@ -500,11 +500,11 @@ void HPCoarsenTest::select_refinement (System & system)
                   if (cont == C_ZERO || cont == C_ONE)
                     h_error_per_cell[e_id] += static_cast<ErrorVectorReal>
                       (component_scale[var] *
-                       (*JxW)[qp] * grad_error.size_sq());
+                       (*JxW)[qp] * grad_error.norm_sq());
                   if (cont == C_ONE)
                     h_error_per_cell[e_id] += static_cast<ErrorVectorReal>
                       (component_scale[var] *
-                       (*JxW)[qp] * hessian_error.size_sq());
+                       (*JxW)[qp] * hessian_error.norm_sq());
                 }
 
             }

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -602,7 +602,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
                       Gradient grad_error = grad_u_fine - grad_u_coarse;
 
                       H1seminormsq += JxW[qp] * system_i_norm.weight_sq(var) *
-                        grad_error.size_sq();
+                        grad_error.norm_sq();
                       libmesh_assert_greater_equal (H1seminormsq, 0.);
                     }
 
@@ -615,7 +615,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
                       Tensor grad2_error = grad2_u_fine - grad2_u_coarse;
 
                       H2seminormsq += JxW[qp] * system_i_norm.weight_sq(var) *
-                        grad2_error.size_sq();
+                        grad2_error.norm_sq();
                       libmesh_assert_greater_equal (H2seminormsq, 0.);
 #else
                       libmesh_error_msg

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -663,7 +663,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
             // curvature.  Concave-downward curves (frowns) have a
             // negative curvature.  Be sure to take that into account!
             const Real numerator   = this->d2xyzdxi2_map[p] * this->normals[p];
-            const Real denominator = this->dxyzdxi_map[p].size_sq();
+            const Real denominator = this->dxyzdxi_map[p].norm_sq();
             libmesh_assert_not_equal_to (denominator, 0);
             curvatures[p] = numerator / denominator;
           }
@@ -671,7 +671,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
         // compute the jacobian at the quadrature points
         for (unsigned int p=0; p<n_qp; p++)
           {
-            const Real the_jac = this->dxyzdxi_map[p].size();
+            const Real the_jac = this->dxyzdxi_map[p].norm();
 
             libmesh_assert_greater (the_jac, 0.);
 
@@ -747,9 +747,9 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
             const Real L  = -this->d2xyzdxi2_map[p]    * this->normals[p];
             const Real M  = -this->d2xyzdxideta_map[p] * this->normals[p];
             const Real N  = -this->d2xyzdeta2_map[p]   * this->normals[p];
-            const Real E  =  this->dxyzdxi_map[p].size_sq();
+            const Real E  =  this->dxyzdxi_map[p].norm_sq();
             const Real F  =  this->dxyzdxi_map[p]      * this->dxyzdeta_map[p];
-            const Real G  =  this->dxyzdeta_map[p].size_sq();
+            const Real G  =  this->dxyzdeta_map[p].norm_sq();
 
             const Real numerator   = E*N -2.*F*M + G*L;
             const Real denominator = E*G - F*F;

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -380,7 +380,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         // where T'= transpose of T, so
         //
         // jac = sqrt( (dx/dxi)^2 + (dy/dxi)^2 + (dz/dxi)^2 )
-        jac[p] = dxyzdxi_map[p].size();
+        jac[p] = dxyzdxi_map[p].norm();
 
         if (jac[p] <= 0.)
           {
@@ -1537,7 +1537,7 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
 
 
       //  ||P_n+1 - P_n||
-      inverse_map_error = dp.size();
+      inverse_map_error = dp.norm();
 
       //  P_n+1 = P_n + dp
       p.add (dp);
@@ -1634,11 +1634,11 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
       const Point check = FE<Dim,T>::map (elem, p);
       const Point diff  = physical_point - check;
 
-      if (diff.size() > tolerance)
+      if (diff.norm() > tolerance)
         {
           libmesh_here();
           libMesh::err << "WARNING:  diff is "
-                       << diff.size()
+                       << diff.norm()
                        << std::endl
                        << " point="
                        << physical_point;

--- a/src/fe/fe_xyz_map.C
+++ b/src/fe/fe_xyz_map.C
@@ -90,7 +90,7 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
             // curvature.  Concave-downward curves (frowns) have a
             // negative curvature.  Be sure to take that into account!
             const Real numerator   = this->d2xyzdxi2_map[p] * this->normals[p];
-            const Real denominator = this->dxyzdxi_map[p].size_sq();
+            const Real denominator = this->dxyzdxi_map[p].norm_sq();
             libmesh_assert_not_equal_to (denominator, 0);
             this->curvatures[p] = numerator / denominator;
           }
@@ -171,9 +171,9 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
             const Real L  = -this->d2xyzdxi2_map[p]    * this->normals[p];
             const Real M  = -this->d2xyzdxideta_map[p] * this->normals[p];
             const Real N  = -this->d2xyzdeta2_map[p]   * this->normals[p];
-            const Real E  =  this->dxyzdxi_map[p].size_sq();
+            const Real E  =  this->dxyzdxi_map[p].norm_sq();
             const Real F  =  this->dxyzdxi_map[p]      * this->dxyzdeta_map[p];
-            const Real G  =  this->dxyzdeta_map[p].size_sq();
+            const Real G  =  this->dxyzdeta_map[p].norm_sq();
 
             const Real numerator   = E*N -2.*F*M + G*L;
             const Real denominator = E*G - F*F;

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -146,9 +146,9 @@ void Tet::choose_diagonal() const
   // Check for uninitialized diagonal selection
   if (this->_diagonal_selection==INVALID_DIAG)
     {
-      Real diag_01_23 = (this->point(0)+this->point(1)-this->point(2)-this->point(3)).size_sq();
-      Real diag_02_13 = (this->point(0)-this->point(1)+this->point(2)-this->point(3)).size_sq();
-      Real diag_03_12 = (this->point(0)-this->point(1)-this->point(2)+this->point(3)).size_sq();
+      Real diag_01_23 = (this->point(0) + this->point(1) - this->point(2) - this->point(3)).norm_sq();
+      Real diag_02_13 = (this->point(0) - this->point(1) + this->point(2) - this->point(3)).norm_sq();
+      Real diag_03_12 = (this->point(0) - this->point(1) - this->point(2) + this->point(3)).norm_sq();
 
       this->_diagonal_selection=DIAG_02_13;
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -316,7 +316,7 @@ std::pair<Real, Real> Tet4::min_and_max_angle() const
   // Compute dihedral angles
   for (unsigned int k=0,i=0; i<4; ++i)
     for (unsigned int j=i+1; j<4; ++j,k+=1)
-      dihedral_angles[k] = std::acos(n[i]*n[j] / n[i].size() / n[j].size()); // return value is between 0 and PI
+      dihedral_angles[k] = std::acos(n[i]*n[j] / n[i].norm() / n[j].norm()); // return value is between 0 and PI
 
   // Return max/min dihedral angles
   return std::make_pair(*std::min_element(dihedral_angles, dihedral_angles+6),
@@ -455,9 +455,9 @@ dof_id_type Tet4::key () const
 
 // void Tet4::reselect_optimal_diagonal (const Diagonal exclude_this)
 // {
-//   Real diag_01_23 = (this->point(0)+this->point(1)-this->point(2)-this->point(3)).size_sq();
-//   Real diag_02_13 = (this->point(0)-this->point(1)+this->point(2)-this->point(3)).size_sq();
-//   Real diag_03_12 = (this->point(0)-this->point(1)-this->point(2)+this->point(3)).size_sq();
+//   Real diag_01_23 = (this->point(0)+this->point(1)-this->point(2)-this->point(3)).norm_sq();
+//   Real diag_02_13 = (this->point(0)-this->point(1)+this->point(2)-this->point(3)).norm_sq();
+//   Real diag_03_12 = (this->point(0)-this->point(1)-this->point(2)+this->point(3)).norm_sq();
 //
 //   Diagonal use_this = INVALID_DIAG;
 //   switch (exclude_this)

--- a/src/geom/edge_edge2.C
+++ b/src/geom/edge_edge2.C
@@ -111,7 +111,7 @@ Real Edge2::volume () const
 {
   // OK, so this is probably overkill, since it is equivalent to
   // Elem::hmax() for the Edge2, but here it is nonetheless...
-  return (this->point(1) - this->point(0)).size();
+  return (this->point(1) - this->point(0)).norm();
 }
 
 

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -174,13 +174,13 @@ Real Edge3::volume () const
   Point A = this->point(0) + this->point(1) - 2*this->point(2);
   Point B = (this->point(1) - this->point(0))/2;
 
-  const Real a = A.size_sq();
+  const Real a = A.norm_sq();
   const Real b = 2.*(A*B);
-  const Real c = B.size_sq();
+  const Real c = B.norm_sq();
 
   // Degenerate straight line case
   if (a < TOLERANCE*TOLERANCE*TOLERANCE)
-    return (this->point(1) - this->point(0)).size();
+    return (this->point(1) - this->point(0)).norm();
 
   const Real ba=b/a;
   const Real ca=c/a;

--- a/src/geom/edge_edge4.C
+++ b/src/geom/edge_edge4.C
@@ -205,7 +205,7 @@ Real Edge4::volume () const
 
   Real vol=0.;
   for (unsigned int i=0; i<N; ++i)
-    vol += w[i] * (q[i]*q[i]*a1 + q[i]*b1 + c1).size();
+    vol += w[i] * (q[i]*q[i]*a1 + q[i]*b1 + c1).norm();
 
   return vol;
 }

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -427,7 +427,7 @@ Real Elem::hmin() const
       {
         const Point diff = (this->point(n_outer) - this->point(n_inner));
 
-        h_min = std::min(h_min,diff.size_sq());
+        h_min = std::min(h_min, diff.norm_sq());
       }
 
   return std::sqrt(h_min);
@@ -444,7 +444,7 @@ Real Elem::hmax() const
       {
         const Point diff = (this->point(n_outer) - this->point(n_inner));
 
-        h_max = std::max(h_max,diff.size_sq());
+        h_max = std::max(h_max, diff.norm_sq());
       }
 
   return std::sqrt(h_max);
@@ -458,7 +458,7 @@ Real Elem::length(const unsigned int n1,
   libmesh_assert_less ( n1, this->n_vertices() );
   libmesh_assert_less ( n2, this->n_vertices() );
 
-  return (this->point(n1) - this->point(n2)).size();
+  return (this->point(n1) - this->point(n2)).norm();
 }
 
 
@@ -2330,7 +2330,7 @@ bool Elem::point_test(const Point & p, Real box_tol, Real map_tol) const
 
       // Compute the distance between the original point and the re-mapped point.
       // They should be in the same place.
-      Real dist = (xyz - p).size();
+      Real dist = (xyz - p).norm();
 
 
       // If dist is larger than some fraction of the tolerance, then return false.

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -209,7 +209,7 @@ Real Quad4::volume () const
 
   // Check for quick return for parallelogram QUAD4.
   if (a1.relative_fuzzy_equals(Point(0,0,0)))
-    return 4. * b1.cross(b2).size();
+    return 4. * b1.cross(b2).norm();
 
   // Otherwise, use 2x2 quadrature to approximate the surface area.
 
@@ -220,7 +220,7 @@ Real Quad4::volume () const
   Real vol=0.;
   for (unsigned int i=0; i<2; ++i)
     for (unsigned int j=0; j<2; ++j)
-      vol += (q[j]*a1 + b1).cross(q[i]*a2 + b2).size();
+      vol += (q[j]*a1 + b1).cross(q[i]*a2 + b2).norm();
 
   return vol;
 }

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -404,7 +404,7 @@ Real Quad8::volume () const
   for (unsigned int i=0; i<N; ++i)
     for (unsigned int j=0; j<N; ++j)
       vol += (q[j]*q[j]*a1 + q[i]*q[j]*b1 + q[i]*c1 + q[j]*d1 + e1).
-        cross(q[i]*q[i]*a2 + q[i]*q[j]*b2 + q[i]*c2 + q[j]*d2 + e2).size() * w[i] * w[j];
+        cross(q[i]*q[i]*a2 + q[i]*q[j]*b2 + q[i]*c2 + q[j]*d2 + e2).norm() * w[i] * w[j];
 
   return vol;
 }

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -391,7 +391,7 @@ Real Quad9::volume () const
   for (unsigned int i=0; i<N; ++i)
     for (unsigned int j=0; j<N; ++j)
       vol += (q[i]*q[j]*q[j]*a1 + q[j]*q[j]*b1 + q[j]*q[i]*c1 + q[i]*d1 + q[j]*e1 + f1).
-        cross(q[i]*q[i]*q[j]*a2 + q[i]*q[i]*b2 + q[j]*q[i]*c2 + q[i]*d2 + q[j]*e2 + f2).size() * w[i] * w[j];
+        cross(q[i]*q[i]*q[j]*a2 + q[i]*q[i]*b2 + q[j]*q[i]*c2 + q[i]*d2 + q[j]*e2 + f2).norm() * w[i] * w[j];
 
   return vol;
 }

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -111,9 +111,9 @@ Real Tri::quality (const ElemQuality q) const
         Point v1 = (*p2) - (*p1);
         Point v2 = (*p3) - (*p1);
         Point v3 = (*p3) - (*p2);
-        const Real l1 = v1.size();
-        const Real l2 = v2.size();
-        const Real l3 = v3.size();
+        const Real l1 = v1.norm();
+        const Real l2 = v2.norm();
+        const Real l3 = v3.norm();
 
         // if one length is 0, quality is quite bad!
         if ((l1 <=0.) || (l2 <= 0.) || (l3 <= 0.))

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -176,7 +176,7 @@ Real Tri3::volume () const
 
   Point v20 ( *(this->get_node(2)) - *(this->get_node(0)) );
 
-  return 0.5 * (v10.cross(v20)).size() ;
+  return 0.5 * (v10.cross(v20)).norm() ;
 }
 
 
@@ -188,10 +188,9 @@ std::pair<Real, Real> Tri3::min_and_max_angle() const
   Point v21 ( this->point(2) - this->point(1) );
 
   const Real
-    len_10=v10.size(),
-    len_20=v20.size(),
-    len_21=v21.size()
-    ;
+    len_10=v10.norm(),
+    len_20=v20.norm(),
+    len_21=v21.norm();
 
   const Real
     theta0=std::acos(( v10*v20)/len_10/len_20),

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -334,7 +334,7 @@ Real Tri6::volume () const
   if (a1.relative_fuzzy_equals(Point(0,0,0)) &&
       b1.relative_fuzzy_equals(Point(0,0,0)) &&
       b2.relative_fuzzy_equals(Point(0,0,0)))
-    return 0.5 * c1.cross(c2).size();
+    return 0.5 * c1.cross(c2).norm();
 
   // 7-point rule, exact for quintics.
   const unsigned int N = 7;
@@ -353,7 +353,7 @@ Real Tri6::volume () const
   // Approximate the area with quadrature
   Real vol=0.;
   for (unsigned int q=0; q<N; ++q)
-    vol += wts[q] * (xi[q]*a1 + eta[q]*b1 + c1).cross(xi[q]*a2 + eta[q]*b2 + c2).size();
+    vol += wts[q] * (xi[q]*a1 + eta[q]*b1 + c1).cross(xi[q]*a2 + eta[q]*b2 + c2).norm();
 
   return vol;
 }

--- a/src/geom/sphere.C
+++ b/src/geom/sphere.C
@@ -75,9 +75,9 @@ Sphere::Sphere(const Point & pa,
   // The points had better not be coplanar
   libmesh_assert_greater (std::abs(D), 1e-12);
 
-  Real e = 0.5*(pa.size_sq() - pd.size_sq());
-  Real f = 0.5*(pb.size_sq() - pd.size_sq());
-  Real g = 0.5*(pc.size_sq() - pd.size_sq());
+  Real e = 0.5*(pa.norm_sq() - pd.norm_sq());
+  Real f = 0.5*(pb.norm_sq() - pd.norm_sq());
+  Real g = 0.5*(pc.norm_sq() - pd.norm_sq());
 
   TensorValue<Real> T1(e,pad(1),pad(2),
                        f,pbd(1),pbd(2),
@@ -95,7 +95,7 @@ Sphere::Sphere(const Point & pa,
   Real sz = T3.det()/D;
 
   Point c(sx,sy,sz);
-  Real r = (c-pa).size();
+  Real r = (c-pa).norm();
 
   this->create_from_center_radius(c,r);
 }
@@ -130,7 +130,7 @@ Real Sphere::distance (const Sphere & other_sphere) const
   libmesh_assert_greater ( this->radius(), 0. );
   libmesh_assert_greater ( other_sphere.radius(), 0. );
 
-  const Real the_distance = (this->center() - other_sphere.center()).size();
+  const Real the_distance = (this->center() - other_sphere.center()).norm();
 
   return the_distance - (this->radius() + other_sphere.radius());
 }
@@ -144,7 +144,7 @@ bool Sphere::above_surface (const Point & p) const
   // create a vector from the center to the point.
   const Point w = p - this->center();
 
-  if (w.size() > this->radius())
+  if (w.norm() > this->radius())
     return true;
 
   return false;
@@ -170,7 +170,7 @@ bool Sphere::on_surface (const Point & p) const
 
   // if the size of that vector is the same as the radius() then
   // the point is on the surface.
-  if (std::abs(w.size() - this->radius()) < 1.e-10)
+  if (std::abs(w.norm() - this->radius()) < 1.e-10)
     return true;
 
   return false;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -284,7 +284,7 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
       for(unsigned char side=0; side<interior_parent->n_sides(); side++)
         {
           UniquePtr<Elem> interior_parent_side = interior_parent->build_side(side);
-          Real centroid_distance = (boundary_elem->centroid() - interior_parent_side->centroid()).size();
+          Real centroid_distance = (boundary_elem->centroid() - interior_parent_side->centroid()).norm();
 
           if( centroid_distance < (tolerance * boundary_elem->hmin()) )
             {

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -813,8 +813,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               subelem[1] = new Tri3;
 
               // Check for possible edge swap
-              if ((elem->point(0) - elem->point(2)).size() <
-                  (elem->point(1) - elem->point(3)).size())
+              if ((elem->point(0) - elem->point(2)).norm() <
+                  (elem->point(1) - elem->point(3)).norm())
                 {
                   subelem[0]->set_node(0) = elem->get_node(0);
                   subelem[0]->set_node(1) = elem->get_node(1);
@@ -857,8 +857,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                                                elem->processor_id());
 
               // Check for possible edge swap
-              if ((elem->point(0) - elem->point(2)).size() <
-                  (elem->point(1) - elem->point(3)).size())
+              if ((elem->point(0) - elem->point(2)).norm() <
+                  (elem->point(1) - elem->point(3)).norm())
                 {
                   subelem[0]->set_node(0) = elem->get_node(0);
                   subelem[0]->set_node(1) = elem->get_node(1);
@@ -902,8 +902,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
               subelem[1] = new Tri6;
 
               // Check for possible edge swap
-              if ((elem->point(0) - elem->point(2)).size() <
-                  (elem->point(1) - elem->point(3)).size())
+              if ((elem->point(0) - elem->point(2)).norm() <
+                  (elem->point(1) - elem->point(3)).norm())
                 {
                   subelem[0]->set_node(0) = elem->get_node(0);
                   subelem[0]->set_node(1) = elem->get_node(1);
@@ -1643,7 +1643,7 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
                             if (power > 0)
                               {
                                 Point diff = (*node0)-(*node1);
-                                node_weight = std::pow( diff.size(), power );
+                                node_weight = std::pow(diff.norm(), power);
                               }
 
                             const dof_id_type id0 = node0->id(), id1 = node1->id();

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -279,7 +279,7 @@ void MeshTools::Subdivision::add_boundary_ghosts(MeshBase & mesh)
                   Node * node = libmesh_nullptr;
                   for (unsigned int j = 0; j < ghost_nodes.size(); ++j)
                     {
-                      if ((*ghost_nodes[j] - point).size() < tol * (elem->point(k) - point).size())
+                      if ((*ghost_nodes[j] - point).norm() < tol * (elem->point(k) - point).norm())
                         {
                           node = ghost_nodes[j];
                           break;
@@ -351,7 +351,7 @@ void MeshTools::Subdivision::add_boundary_ghosts(MeshBase & mesh)
               Node * node = libmesh_nullptr;
               for (unsigned int j = 0; j < ghost_nodes.size(); ++j)
                 {
-                  if ((*ghost_nodes[j] - point).size() < tol * (elem->point(i) - point).size())
+                  if ((*ghost_nodes[j] - point).norm() < tol * (elem->point(i) - point).norm())
                     {
                       node = ghost_nodes[j];
                       break;
@@ -435,7 +435,7 @@ void MeshTools::Subdivision::add_boundary_ghosts(MeshBase & mesh)
                   Node * node = libmesh_nullptr;
                   for (unsigned int k = 0; k < ghost_nodes.size(); ++k)
                     {
-                      if ((*ghost_nodes[k] - point).size() < tol * (nb2->point(j) - point).size())
+                      if ((*ghost_nodes[k] - point).norm() < tol * (nb2->point(j) - point).norm())
                         {
                           node = ghost_nodes[k];
                           break;

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -444,7 +444,7 @@ MeshTools::bounding_sphere(const MeshBase & mesh)
 {
   BoundingBox bbox = bounding_box(mesh);
 
-  const Real  diag = (bbox.second - bbox.first).size();
+  const Real  diag = (bbox.second - bbox.first).norm();
   const Point cent = (bbox.second + bbox.first)/2;
 
   return Sphere (cent, .5*diag);
@@ -475,7 +475,7 @@ MeshTools::processor_bounding_sphere (const MeshBase & mesh,
 {
   BoundingBox bbox = processor_bounding_box(mesh,pid);
 
-  const Real  diag = (bbox.second - bbox.first).size();
+  const Real  diag = (bbox.second - bbox.first).norm();
   const Point cent = (bbox.second + bbox.first)/2;
 
   return Sphere (cent, .5*diag);
@@ -512,7 +512,7 @@ MeshTools::subdomain_bounding_sphere (const MeshBase & mesh,
 {
   BoundingBox bbox = subdomain_bounding_box(mesh,sid);
 
-  const Real  diag = (bbox.second - bbox.first).size();
+  const Real  diag = (bbox.second - bbox.first).norm();
   const Point cent = (bbox.second + bbox.first)/2;
 
   return Sphere (cent, .5*diag);

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -1142,7 +1142,7 @@ void SerialMesh::stitching_helper (SerialMesh * other_mesh,
                   dof_id_type other_node_id = *other_set_it;
                   Node & other_node = other_mesh->node(other_node_id);
 
-                  Real node_distance = (this_node - other_node).size();
+                  Real node_distance = (this_node - other_node).norm();
 
                   if(node_distance < tol*h_min)
                     {

--- a/src/numerics/type_vector.C
+++ b/src/numerics/type_vector.C
@@ -37,7 +37,7 @@ template <typename T>
 TypeVector<T> TypeVector<T>::unit() const
 {
 
-  const Real length = size();
+  const Real length = norm();
 
   libmesh_assert_not_equal_to (length, static_cast<Real>(0.));
 

--- a/src/partitioning/centroid_partitioner.C
+++ b/src/partitioning/centroid_partitioner.C
@@ -174,7 +174,7 @@ bool CentroidPartitioner::sort_z (const std::pair<Point, Elem *> & lhs,
 bool CentroidPartitioner::sort_radial (const std::pair<Point, Elem *> & lhs,
                                        const std::pair<Point, Elem *> & rhs)
 {
-  return (lhs.first.size() < rhs.first.size());
+  return (lhs.first.norm() < rhs.first.norm());
 }
 
 } // namespace libMesh

--- a/src/solution_transfer/radial_basis_interpolation.C
+++ b/src/solution_transfer/radial_basis_interpolation.C
@@ -87,7 +87,7 @@ void RadialBasisInterpolation<KDDim,RBF>::prepare_for_use()
 
   // Construct the Radial Basis Function, giving it the size of the domain
   if(_r_override < 0)
-    _r_bbox = (_src_bbox.max() - _src_bbox.min()).size();
+    _r_bbox = (_src_bbox.max() - _src_bbox.min()).norm();
   else
     _r_bbox = _r_override;
 
@@ -117,7 +117,7 @@ void RadialBasisInterpolation<KDDim,RBF>::prepare_for_use()
         {
           const Point & x_j (_src_pts[j]);
 
-          const Real r_ij = (x_j - x_i).size();
+          const Real r_ij = (x_j - x_i).norm();
 
           A(i,j) = A(j,i) = rbf(r_ij);
         }
@@ -188,7 +188,7 @@ void RadialBasisInterpolation<KDDim,RBF>::interpolate_field_data (const std::vec
         {
           const Point & x_i(_src_pts[i]);
           const Real
-            r_i   = (p - x_i).size(),
+            r_i   = (p - x_i).norm(),
             phi_i = rbf(r_i);
 
           for (unsigned int var=0; var<n_vars; var++)

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1642,7 +1642,7 @@ Real System::calculate_norm(const NumericVector<Number> & v,
                   for (unsigned int i=0; i != n_sf; ++i)
                     grad_u_h.add_scaled((*dphi)[i][qp], (*local_v)(dof_indices[i]));
                   v_norm += norm_weight_sq *
-                    JxW[qp] * grad_u_h.size_sq();
+                    JxW[qp] * grad_u_h.norm_sq();
                 }
 
               if (norm_type == W1_INF_SEMINORM)
@@ -1650,7 +1650,7 @@ Real System::calculate_norm(const NumericVector<Number> & v,
                   Gradient grad_u_h;
                   for (unsigned int i=0; i != n_sf; ++i)
                     grad_u_h.add_scaled((*dphi)[i][qp], (*local_v)(dof_indices[i]));
-                  v_norm = std::max(v_norm, norm_weight * grad_u_h.size());
+                  v_norm = std::max(v_norm, norm_weight * grad_u_h.norm());
                 }
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
@@ -1661,7 +1661,7 @@ Real System::calculate_norm(const NumericVector<Number> & v,
                   for (unsigned int i=0; i != n_sf; ++i)
                     hess_u_h.add_scaled((*d2phi)[i][qp], (*local_v)(dof_indices[i]));
                   v_norm += norm_weight_sq *
-                    JxW[qp] * hess_u_h.size_sq();
+                    JxW[qp] * hess_u_h.norm_sq();
                 }
 
               if (norm_type == W2_INF_SEMINORM)
@@ -1669,7 +1669,7 @@ Real System::calculate_norm(const NumericVector<Number> & v,
                   Tensor hess_u_h;
                   for (unsigned int i=0; i != n_sf; ++i)
                     hess_u_h.add_scaled((*d2phi)[i][qp], (*local_v)(dof_indices[i]));
-                  v_norm = std::max(v_norm, norm_weight * hess_u_h.size());
+                  v_norm = std::max(v_norm, norm_weight * hess_u_h.norm());
                 }
 #endif
             }

--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -156,7 +156,7 @@ const Elem * PointLocatorList::operator() (const Point & p,
   // element is closer, but we simply don't consider
   // it!
   //
-  // We _can_, however, use size_sq() instead of size()
+  // We _can_, however, use norm_sq() instead of norm()
   // here to avoid repeated calls to std::sqrt(), which is
   // pretty expensive.
   {
@@ -172,7 +172,7 @@ const Elem * PointLocatorList::operator() (const Point & p,
         if (!allowed_subdomains ||
             allowed_subdomains->count(my_list[n].second->subdomain_id()))
           {
-            const Real current_distance_sq = Point(my_list[n].first -p).size_sq();
+            const Real current_distance_sq = Point(my_list[n].first -p).norm_sq();
 
             if (current_distance_sq < last_distance_sq)
               {

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -200,7 +200,7 @@ bool TreeNode<N>::bounds_point (const Point & p,
   const Point & min = bounding_box.first;
   const Point & max = bounding_box.second;
 
-  const Real tol = (max - min).size() * relative_tol;
+  const Real tol = (max - min).norm() * relative_tol;
 
   if ((p(0) >= min(0) - tol)
       && (p(0) <= max(0) + tol)

--- a/tests/numerics/type_vector_test.h
+++ b/tests/numerics/type_vector_test.h
@@ -7,8 +7,8 @@
 #include <cppunit/TestCase.h>
 
 #define TYPEVECTORTEST                          \
-  CPPUNIT_TEST( testSize );                     \
-  CPPUNIT_TEST( testSizeSq );                   \
+  CPPUNIT_TEST( testNorm );                     \
+  CPPUNIT_TEST( testNormSq );                   \
                                                 \
   CPPUNIT_TEST( testValue );                    \
   CPPUNIT_TEST( testZero );                     \
@@ -29,8 +29,8 @@
   CPPUNIT_TEST( testVectorAddAssign );          \
   CPPUNIT_TEST( testVectorSubAssign );          \
                                                 \
-  CPPUNIT_TEST( testSizeBase );                 \
-  CPPUNIT_TEST( testSizeSqBase );               \
+  CPPUNIT_TEST( testNormBase );                 \
+  CPPUNIT_TEST( testNormSqBase );               \
   CPPUNIT_TEST( testValueBase );                \
   CPPUNIT_TEST( testZeroBase );                 \
                                                 \
@@ -100,14 +100,14 @@ public:
     CPPUNIT_ASSERT_EQUAL( T(0), avector(2));
   }
 
-  void testSize()
+  void testNorm()
   {
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( std::sqrt(3.0) , m_1_1_1->size() , TOLERANCE*TOLERANCE );
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( std::sqrt(3.0) , m_1_1_1->norm() , TOLERANCE*TOLERANCE );
   }
 
-  void testSizeSq()
+  void testNormSq()
   {
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 3.0 , m_1_1_1->size_sq() , TOLERANCE*TOLERANCE );
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 3.0 , m_1_1_1->norm_sq() , TOLERANCE*TOLERANCE );
   }
 
   void testEquality()
@@ -248,14 +248,14 @@ public:
     CPPUNIT_ASSERT_EQUAL( T(0), avector(2));
   }
 
-  void testSizeBase()
+  void testNormBase()
   {
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( std::sqrt(3.0) , basem_1_1_1->size() , TOLERANCE*TOLERANCE );
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( std::sqrt(3.0) , basem_1_1_1->norm() , TOLERANCE*TOLERANCE );
   }
 
-  void testSizeSqBase()
+  void testNormSqBase()
   {
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 3.0 , basem_1_1_1->size_sq() , TOLERANCE*TOLERANCE );
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 3.0 , basem_1_1_1->norm_sq() , TOLERANCE*TOLERANCE );
   }
 
   void testEqualityBase()


### PR DESCRIPTION
For the time being, I did not add an option to select the type of norm.  That would be easy enough to do if someone actually needs it.

Refs #813.