### PR TITLE
Restore old EXTERN_C_FOR_PETSC_ macros

### DIFF
--- a/include/numerics/petsc_macro.h
+++ b/include/numerics/petsc_macro.h
@@ -50,6 +50,13 @@
 
 #endif
 
+// We used to have workarounds for missing extern "C" in old PETSc
+// versions.  We no longer support PETSc versions so old, but we do
+// still support libMesh applications old enough to have used these
+// macros.
+#define EXTERN_C_FOR_PETSC_BEGIN
+#define EXTERN_C_FOR_PETSC_END
+
 // Petsc include files
 #include <petsc.h>
 


### PR DESCRIPTION
We've got some application codes that use them, and it doesn't cost us
more than a few lines to retain that support.

This should restore backwards compatibility enough to fix the breakage in https://github.com/idaholab/moose/pull/6358