### PR TITLE
Fix in Threads::parallel_for().

### DIFF
--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -549,7 +549,7 @@ void parallel_for (const Range & range, const Body & body)
 #endif
     }
 
-#if LIBMESH_HAVE_PTHREAD
+#if !LIBMESH_HAVE_OPENMP
   // Wait for them to finish
 
   // The use of 'int' instead of unsigned for the iteration variable


### PR DESCRIPTION
This reverts a regression introduced by bca60c6aa, but is not the
complete overhaul of threads.h that is discussed in #838. It fixes
a definite issue with parallel_for() when both OpenMP and pthreads are
active at the same time.