### PR TITLE
Add SPARSELU SolverType for Eigen.

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -52,6 +52,7 @@
 #include "libmesh/exodusII_io.h"
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/zero_function.h"
+#include "libmesh/linear_solver.h"
 
 // Eigen includes
 #ifdef LIBMESH_HAVE_EIGEN
@@ -75,10 +76,6 @@ int main (int argc, char ** argv)
 
   // Skip this 3D example if libMesh was compiled as 1D/2D-only.
   libmesh_example_requires (3 == LIBMESH_DIM, "3D support");
-
-  // This example currently produces a NaN when used with
-  // EigenSparseLinearSolver, so require PETSc solvers for now.
-  libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
 
   // This example does a bunch of linear algebra during assembly, and
   // therefore requires Eigen.
@@ -185,6 +182,12 @@ int main (int argc, char ** argv)
 
   // Print information about the system to the screen.
   equation_systems.print_info();
+
+  // This example can be run with EigenSparseLinearSolvers, but it
+  // only works with either the CG or SPARSELU types, and SparseLU
+  // turns out to be faster.
+  if (libMesh::default_solver_package() == EIGEN_SOLVERS)
+    system.get_linear_solver()->set_solver_type(SPARSELU);
 
   // Solve the linear system.
   system.solve();

--- a/include/enums/enum_solver_type.h
+++ b/include/enums/enum_solver_type.h
@@ -45,6 +45,7 @@ enum SolverType {CG=0,
                  SSOR,
                  RICHARDSON,
                  CHEBYSHEV,
+                 SPARSELU,
 
                  INVALID_SOLVER};
 }

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -158,6 +158,53 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
         break;
       }
 
+    case SPARSELU:
+      {
+        // SparseLU solver code adapted from:
+        // http://eigen.tuxfamily.org/dox-devel/classEigen_1_1SparseLU.html
+        //
+        // From Eigen docs:
+        // The input matrix A should be in a compressed and
+        // column-major form. Otherwise an expensive copy will be
+        // made. You can call the inexpensive makeCompressed() to get
+        // a compressed matrix.
+        //
+        // Note: we don't have a column-major storage format here, so
+        // I think a copy must be made in order to use SparseLU.  It
+        // appears that we also have to call makeCompressed(),
+        // otherwise you get a segfault.
+        matrix._mat.makeCompressed();
+
+        // Build the SparseLU solver object.  Note, there is one other
+        // sparse direct solver available in Eigen:
+        //
+        // Eigen::SparseQR<EigenSM, Eigen::AMDOrdering<int> > solver;
+        //
+        // I've tested it, and it works, but it is much slower than
+        // SparseLU.  The main benefit of SparseQR is that it can
+        // handle non-square matrices, but we don't allow non-square
+        // sparse matrices to be built in libmesh...
+        Eigen::SparseLU<EigenSM> solver;
+
+        // Compute the ordering permutation vector from the structural pattern of the matrix.
+        solver.analyzePattern(matrix._mat);
+
+        // Compute the numerical factorization
+        solver.factorize(matrix._mat);
+
+        // Use the factors to solve the linear system
+        solution._vec = solver.solve(rhs._vec);
+
+        // Set up the return value.  The SparseLU solver doesn't
+        // support asking for the number of iterations or the final
+        // error, so we'll just report back 1 and 0, respectively.
+        retval = std::make_pair(/*n. iterations=*/1, /*error=*/0);
+
+        // Store the success/failure reason and break out.
+        _comp_info = solver.info();
+        break;
+      }
+
       // Unknown solver, use BICGSTAB
     default:
       {


### PR DESCRIPTION
This sparse direct solver works with the new misc_ex12, and lets us
enable that example when PETSc is not available.  It is also faster
than using the Eigen CG solver, or PETSc JACOBI+CG (see table of solve
times for misc_ex12 below).  I also tested Eigen's SparseQR
implementation, but it was much slower than SparseLU, and doesn't
really buy us much flexibility over that method.

```
Solver                             | solve() time
--------------------------------------------------
PETSc -pc_type lu                  | 0.0450
Eigen SparseLU                     | 0.0774
PETSc -ksp_type cg -pc_type jacobi | 0.3371
Eigen CG                           | 0.5971
Eigen SparseQR                     | 6.2501
```