### PR TITLE
add locking to PetscVector::_get_array

### DIFF
--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -34,7 +34,8 @@
 namespace libMesh
 {
 
-
+// Mutex for Petsc vector thread safety
+Threads::spin_mutex petsc_vector_mutex;
 
 //-----------------------------------------------------------------------
 // PetscVector members
@@ -1320,50 +1321,55 @@ void PetscVector<T>::_get_array() const
   libmesh_assert (this->initialized());
   if(!_array_is_present)
     {
-      PetscErrorCode ierr=0;
-      if(this->type() != GHOSTED)
+      Threads::spin_mutex::scoped_lock lock(petsc_vector_mutex);
+
+      if (!_array_is_present)
         {
+          PetscErrorCode ierr=0;
+          if(this->type() != GHOSTED)
+            {
 #if PETSC_VERSION_LESS_THAN(3,2,0)
-          // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
-          // have an older PETSc than that, we'll do an ugly
-          // const_cast and call VecGetArray() instead.
-          ierr = VecGetArray(_vec, const_cast<PetscScalar **>(&_values));
+              // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
+              // have an older PETSc than that, we'll do an ugly
+              // const_cast and call VecGetArray() instead.
+              ierr = VecGetArray(_vec, const_cast<PetscScalar **>(&_values));
 #else
-          ierr = VecGetArrayRead(_vec, &_values);
+              ierr = VecGetArrayRead(_vec, &_values);
 #endif
-          LIBMESH_CHKERR(ierr);
-        }
-      else
-        {
-          ierr = VecGhostGetLocalForm (_vec,&_local_form);
-          LIBMESH_CHKERR(ierr);
+              LIBMESH_CHKERR(ierr);
+            }
+          else
+            {
+              ierr = VecGhostGetLocalForm (_vec,&_local_form);
+              LIBMESH_CHKERR(ierr);
 
 #if PETSC_VERSION_LESS_THAN(3,2,0)
-          // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
-          // have an older PETSc than that, we'll do an ugly
-          // const_cast and call VecGetArray() instead.
-          ierr = VecGetArray(_local_form, const_cast<PetscScalar **>(&_values));
+              // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
+              // have an older PETSc than that, we'll do an ugly
+              // const_cast and call VecGetArray() instead.
+              ierr = VecGetArray(_local_form, const_cast<PetscScalar **>(&_values));
 #else
-          ierr = VecGetArrayRead(_local_form, &_values);
+              ierr = VecGetArrayRead(_local_form, &_values);
 #endif
-          LIBMESH_CHKERR(ierr);
+              LIBMESH_CHKERR(ierr);
 #ifndef NDEBUG
-          PetscInt my_local_size = 0;
-          ierr = VecGetLocalSize(_local_form, &my_local_size);
-          LIBMESH_CHKERR(ierr);
-          _local_size = static_cast<numeric_index_type>(my_local_size);
+              PetscInt my_local_size = 0;
+              ierr = VecGetLocalSize(_local_form, &my_local_size);
+              LIBMESH_CHKERR(ierr);
+              _local_size = static_cast<numeric_index_type>(my_local_size);
 #endif
+            }
+
+          { // cache ownership range
+            PetscInt petsc_first=0, petsc_last=0;
+            ierr = VecGetOwnershipRange (_vec, &petsc_first, &petsc_last);
+            LIBMESH_CHKERR(ierr);
+            _first = static_cast<numeric_index_type>(petsc_first);
+            _last = static_cast<numeric_index_type>(petsc_last);
+          }
+
+          _array_is_present = true;
         }
-
-      { // cache ownership range
-        PetscInt petsc_first=0, petsc_last=0;
-        ierr = VecGetOwnershipRange (_vec, &petsc_first, &petsc_last);
-        LIBMESH_CHKERR(ierr);
-        _first = static_cast<numeric_index_type>(petsc_first);
-        _last = static_cast<numeric_index_type>(petsc_last);
-      }
-
-      _array_is_present = true;
     }
 }
 
@@ -1375,41 +1381,45 @@ void PetscVector<T>::_restore_array() const
   libmesh_assert (this->initialized());
   if(_array_is_present)
     {
-      PetscErrorCode ierr=0;
-      if(this->type() != GHOSTED)
+      Threads::spin_mutex::scoped_lock lock(petsc_vector_mutex);
+      if(_array_is_present)
         {
+          PetscErrorCode ierr=0;
+          if(this->type() != GHOSTED)
+            {
 #if PETSC_VERSION_LESS_THAN(3,2,0)
-          // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
-          // have an older PETSc than that, we'll do an ugly
-          // const_cast and call VecRestoreArray() instead.
-          ierr = VecRestoreArray (_vec, const_cast<PetscScalar **>(&_values));
+              // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
+              // have an older PETSc than that, we'll do an ugly
+              // const_cast and call VecRestoreArray() instead.
+              ierr = VecRestoreArray (_vec, const_cast<PetscScalar **>(&_values));
 #else
-          ierr = VecRestoreArrayRead (_vec, &_values);
+              ierr = VecRestoreArrayRead (_vec, &_values);
 #endif
 
-          LIBMESH_CHKERR(ierr);
-          _values = libmesh_nullptr;
-        }
-      else
-        {
+              LIBMESH_CHKERR(ierr);
+              _values = libmesh_nullptr;
+            }
+          else
+            {
 #if PETSC_VERSION_LESS_THAN(3,2,0)
-          // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
-          // have an older PETSc than that, we'll do an ugly
-          // const_cast and call VecRestoreArray() instead.
-          ierr = VecRestoreArray (_local_form, const_cast<PetscScalar **>(&_values));
+              // Vec{Get,Restore}ArrayRead were introduced in PETSc 3.2.0.  If you
+              // have an older PETSc than that, we'll do an ugly
+              // const_cast and call VecRestoreArray() instead.
+              ierr = VecRestoreArray (_local_form, const_cast<PetscScalar **>(&_values));
 #else
-          ierr = VecRestoreArrayRead (_local_form, &_values);
+              ierr = VecRestoreArrayRead (_local_form, &_values);
 #endif
-          LIBMESH_CHKERR(ierr);
-          _values = libmesh_nullptr;
-          ierr = VecGhostRestoreLocalForm (_vec,&_local_form);
-          LIBMESH_CHKERR(ierr);
-          _local_form = libmesh_nullptr;
+              LIBMESH_CHKERR(ierr);
+              _values = libmesh_nullptr;
+              ierr = VecGhostRestoreLocalForm (_vec,&_local_form);
+              LIBMESH_CHKERR(ierr);
+              _local_form = libmesh_nullptr;
 #ifndef NDEBUG
-          _local_size = 0;
+              _local_size = 0;
 #endif
+            }
+          _array_is_present = false;
         }
-      _array_is_present = false;
     }
 }
 


### PR DESCRIPTION
Uses a doubly-checked scoped lock to efficiently protect against a race condition on setting the `_values` pointer.

fixes idaholab/moose#6436