### PR TITLE
Overhaul of threads.h, add support for --with-thread-model

### DIFF
--- a/configure
+++ b/configure
@@ -36108,6 +36108,13 @@ $as_echo "$ac_cv_tls" >&6; }
       libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
       found_thread_model=tbb
     fi
+
+    # If TBB was not enabled, but the user requested it, we treat that as an error:
+    # we want to alert the user as soon as possible that their requested thread model
+    # could not be configured correctly.
+    if (test $enabletbb = no -a "x$requested_thread_model" = "xtbb"); then
+      as_fn_error $? "requested threading model, TBB, could not be found." "$LINENO" 5
+    fi
   fi
 
   # If TBB wasn't selected, try pthreads as long as the user requested it (or auto)
@@ -36552,6 +36559,13 @@ $as_echo "<<< Configuring library with pthread support >>>" >&6; }
         else
           enablepthreads=no
         fi
+      fi
+
+      # If pthreads were not enabled, but the user requested it, we treat that as an error:
+      # we want to alert the user as soon as possible that their requested thread model
+      # could not be configured correctly.
+      if (test $enablepthreads = no -a "x$requested_thread_model" = "xpthread"); then
+        as_fn_error $? "requested threading model, pthreads, could not be found." "$LINENO" 5
       fi
     fi
   fi

--- a/configure
+++ b/configure
@@ -790,6 +790,9 @@ LIBMESH_ENABLE_LASPACK_FALSE
 LIBMESH_ENABLE_LASPACK_TRUE
 LASPACK_LIB
 LASPACK_INCLUDE
+OPENMP_FFLAGS
+OPENMP_CFLAGS
+OPENMP_CXXFLAGS
 PTHREAD_CFLAGS
 PTHREAD_LIBS
 PTHREAD_CC
@@ -866,9 +869,6 @@ NODEPRECATEDFLAG
 CFLAGS_DVL
 CXXFLAGS_DVL
 GXX_VERSION
-OPENMP_FFLAGS
-OPENMP_CFLAGS
-OPENMP_CXXFLAGS
 PKG_CONFIG
 libmesh_LDFLAGS
 CXXCPP
@@ -1119,7 +1119,6 @@ enable_getpwuid
 enable_exceptions
 enable_timestamps
 enable_unordered_containers
-enable_openmp
 with_gdb_command
 enable_unique_ptr
 enable_warnings
@@ -1170,11 +1169,11 @@ with_nox
 with_ml
 with_tpetra
 with_dtk
+with_thread_model
 enable_tbb
 with_tbb
 with_tbb_lib
-enable_pthreads
-enable_cppthreads
+enable_openmp
 enable_laspack
 enable_sfc
 enable_gzstreams
@@ -1910,7 +1909,6 @@ Optional Features:
                           (helps ccache)
   --disable-unordered-containers
                           Use map/set instead of unordered_map/unordered_set
-  --disable-openmp        Build without OpenMP Support
   --enable-unique-ptr     Use a true unique_ptr implementation instead of
                           libMesh AutoPtr
   --disable-warnings      Do not warn about deprecated, experimental, or
@@ -1961,8 +1959,7 @@ Optional Features:
   --disable-trilinos      build without Trilinos support
   --disable-tbb           build without threading support via Threading
                           Building Blocks
-  --disable-pthreads      build without POSIX threading (pthreads) support
-  --disable-cppthreads    Build without C++ std::thread support
+  --disable-openmp        Build without OpenMP Support
   --disable-laspack       build without LASPACK iterative solver suppport
   --disable-sfc           build without space-filling curves suppport
   --disable-gzstreams     build without gzstreams compressed I/O suppport
@@ -2046,6 +2043,8 @@ Optional Packages:
   --with-ml=PATH          Specify the path to ML installation
   --with-tpetra=PATH      Specify the path to Tpetra installation
   --with-dtk=PATH         Specify the path to Dtk installation
+  --with-thread-model=tbb,pthread,auto,none
+                          Specify the thread model to use
   --with-tbb=PATH         Specify the path where Threading Building Blocks is
                           installed
   --with-tbb-lib=PATH     Specify the path to Threading Building Blocks
@@ -8794,7 +8793,9 @@ int
 main ()
 {
 
+        thread_local int i;
         std::thread t(my_thread_func);
+        t.join();
 
   ;
   return 0;
@@ -30149,113 +30150,6 @@ fi
 
 
 
-# -------------------------------------------------------------
-# OpenMP Support  -- enabled by default
-# -------------------------------------------------------------
-# Check whether --enable-openmp was given.
-if test "${enable_openmp+set}" = set; then :
-  enableval=$enable_openmp; enableopenmp=$enableval
-else
-  enableopenmp=yes
-fi
-
-if (test "$enableopenmp" != no) ; then
-
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for OpenMP flag of C++ compiler" >&5
-$as_echo_n "checking for OpenMP flag of C++ compiler... " >&6; }
-if ${ax_cv_cxx_openmp+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  saveCXXFLAGS=$CXXFLAGS
-ax_cv_cxx_openmp=unknown
-# Flags to try:  -fopenmp (gcc), -openmp (icc), -mp (SGI & PGI),
-#                -xopenmp (Sun), -omp (Tru64), -qsmp=omp (AIX), none
-ax_openmp_flags="-fopenmp -openmp -mp -xopenmp -omp -qsmp=omp none"
-
-if test "x$OPENMP_CXXFLAGS" != x; then
-  ax_openmp_flags="$OPENMP_CXXFLAGS $ax_openmp_flags"
-fi
-
-for ax_openmp_flag in $ax_openmp_flags; do
-  case $ax_openmp_flag in
-    none) CXXFLAGS=$saveCXX ;;
-    *)    CXXFLAGS="$saveCXXFLAGS $ax_openmp_flag" ;;
-  esac
-
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-    #include <omp.h>
-
-int
-main ()
-{
-
-    const int N = 100000;
-    int i, arr[N];
-
-    omp_set_num_threads(2);
-
-    #pragma omp parallel for
-    for (i = 0; i < N; i++)
-    {
-      arr[i] = i;
-    }
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"; then :
-  ax_cv_cxx_openmp=$ax_openmp_flag; break
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-done
-
-CXXFLAGS=$saveCXXFLAGS
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_cxx_openmp" >&5
-$as_echo "$ax_cv_cxx_openmp" >&6; }
-
-if test "x$ax_cv_cxx_openmp" = "xunknown"; then
-  enableopenmp=no
-else
-  if test "x$ax_cv_cxx_openmp" != "xnone"; then
-    OPENMP_CXXFLAGS=$ax_cv_cxx_openmp
-  fi
-
-$as_echo "#define HAVE_OPENMP 1" >>confdefs.h
-
-fi
-
-   #The above call only sets the flag for C++
-   if (test "x$OPENMP_CXXFLAGS" != x) ; then
-     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with OpenMP support >>>" >&5
-$as_echo "<<< Configuring library with OpenMP support >>>" >&6; }
-     OPENMP_CFLAGS=$OPENMP_CXXFLAGS
-     OPENMP_FFLAGS=$OPENMP_CXXFLAGS
-     CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
-     CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
-     CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
-     CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
-     CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
-     CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
-     CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
-     CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
-     CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
-     CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
-     FFLAGS="$FFLAGS $OPENMP_FFLAGS"
-   fi
-
-
-
-fi
-# -------------------------------------------------------------
-
-
 # See if this compiler has a broken errno_t in a very specific
 # situation (this is not common).
 
@@ -35962,10 +35856,43 @@ fi
 # -------------------------------------------------------------
 
 
+# -------------------------------------------------------------
+# Choose between TBB, OpenMP, and pthreads thread models.
+# The user can control this by configuring with
+#
+# --with-thread-model={tbb,pthread,auto,none}
+#
+# where "auto" will try to automatically detect the best possible
+# version (see threads.m4).
+# -------------------------------------------------------------
 
-# -------------------------------------------------------------
-# Intel's Threading Building Blocks -- enabled by default
-# -------------------------------------------------------------
+
+# Check whether --with-thread-model was given.
+if test "${with_thread_model+set}" = set; then :
+  withval=$with_thread_model; case "${withval}" in
+                tbb)     requested_thread_model=tbb     ;;
+                pthread) requested_thread_model=pthread ;;
+                auto)    requested_thread_model=auto    ;;
+                none)    requested_thread_model=none    ;;
+                *)       as_fn_error $? "bad value ${withval} for --with-thread-model" "$LINENO" 5 ;;
+              esac
+else
+  requested_thread_model=auto
+fi
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: User requested thread model: $requested_thread_model" >&5
+$as_echo "User requested thread model: $requested_thread_model" >&6; }
+
+  # Set this variable when a threading model is found
+  found_thread_model=none
+
+  # Test different threading models, enabling only one.  For auto-detection, the
+  # ordering of the tests is:
+  # .) TBB
+  # .) OpenMP
+  # .) Pthread
+  if (test "x$requested_thread_model" = "xtbb" -o "x$requested_thread_model" = "xauto"); then
 
   # Check whether --enable-tbb was given.
 if test "${enable_tbb+set}" = set; then :
@@ -36027,7 +35954,73 @@ fi
 
                         tbbmajor=`grep "define TBB_VERSION_MAJOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MAJOR[ ]*//g"`
       tbbminor=`grep "define TBB_VERSION_MINOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MINOR[ ]*//g"`
+    else
+      enabletbb=no
+    fi
 
+    # If TBB is still enabled at this point, make sure we can compile
+    # a test code which uses tbb::tbb_thread
+    if test "$enabletbb" != no ; then
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for tbb::tbb_thread support" >&5
+$as_echo_n "checking for tbb::tbb_thread support... " >&6; }
+      ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+      # Add TBB headers to CXXFLAGS, which will be used by AC_COMPILE_IFELSE.
+      saveCXXFLAGS="$CXXFLAGS"
+      CXXFLAGS="$saveCXXFLAGS $TBB_INCLUDE"
+
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+          #include <tbb/tbb_thread.h>
+
+int
+main ()
+{
+
+          tbb::tbb_thread t;
+          t.join();
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+          enabletbb=yes
+
+else
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+          enabletbb=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+      # Restore original flags
+      CXXFLAGS=$saveCXXFLAGS
+
+      ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+    fi
+
+
+    # If TBB is still enabled at this point, set all the necessary defines and print
+    # a success message.
+    if test "$enabletbb" != no ; then
 
 cat >>confdefs.h <<_ACEOF
 #define DETECTED_TBB_VERSION_MAJOR $tbbmajor
@@ -36103,33 +36096,18 @@ _ACEOF
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_tls" >&5
 $as_echo "$ac_cv_tls" >&6; }
 
-    else
-      enabletbb=no
     fi
   fi
 
-if (test $enabletbb = yes); then
-  libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
-  libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
-fi
-# -------------------------------------------------------------
 
-# -------------------------------------------------------------
-# Pthread support -- enabled by default
-# -------------------------------------------------------------
-# Check whether --enable-pthreads was given.
-if test "${enable_pthreads+set}" = set; then :
-  enableval=$enable_pthreads; case "${enableval}" in
-                yes)  enablepthreads=yes ;;
-                no)  enablepthreads=no ;;
-                *)  as_fn_error $? "bad value ${enableval} for --enable-pthreads" "$LINENO" 5 ;;
-              esac
-else
-  enablepthreads=$enableoptional
-fi
+    if (test $enabletbb = yes); then
+      libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
+      libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
+      found_thread_model=tbb
+      break
+    fi
 
-
-if (test "$enablepthreads" != no) ; then
+  elif (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
 
 
 ac_ext=c
@@ -36541,151 +36519,141 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-fi
 
-if (test x$ax_pthread_ok = xyes); then
+    if (test x$ax_pthread_ok = xyes); then
 
 $as_echo "#define USING_THREADS 1" >>confdefs.h
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with pthread support >>>" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with pthread support >>>" >&5
 $as_echo "<<< Configuring library with pthread support >>>" >&6; }
-  libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
-  libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
+      libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
+      libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
+      found_thread_model=pthread
+      break
+    else
+      enablepthreads=no
+    fi
+  fi
+
+  # OpenMP support -- enabled unless the user has requested no
+  # threading, or no valid threading models could be found.
+  #
+  # OpenMP can be enabled independently of whether we are using the
+  # TBB or pthread threading models.  The pthread parallel_for() and
+  # parallel_reduce() implementations use openmp pragmas directly,
+  # while the TBB implementation does not.  We do the test here simply
+  # because it makes sense to keep all the threading stuff together
+  # rather than spreading it out across different m4 files.
+  if (test "$found_thread_model" != none) ; then
+    # Check whether --enable-openmp was given.
+if test "${enable_openmp+set}" = set; then :
+  enableval=$enable_openmp; enableopenmp=$enableval
 else
-  enablepthreads=no
-fi
-# -------------------------------------------------------------
-
-
-# -------------------------------------------------------------
-# C++ Thread Support  -- enabled by default
-# -------------------------------------------------------------
-# Check whether --enable-cppthreads was given.
-if test "${enable_cppthreads+set}" = set; then :
-  enableval=$enable_cppthreads; enablecppthreads=$enableval
-else
-  enablecppthreads=yes
+  enableopenmp=yes
 fi
 
-if (test "$enablecppthreads" != no) ; then
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports std::thread" >&5
-$as_echo_n "checking whether the compiler supports std::thread... " >&6; }
-if ${ac_cv_cxx_thread+:} false; then :
+    if (test "$enableopenmp" != no) ; then
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for OpenMP flag of C++ compiler" >&5
+$as_echo_n "checking for OpenMP flag of C++ compiler... " >&6; }
+if ${ax_cv_cxx_openmp+:} false; then :
   $as_echo_n "(cached) " >&6
 else
+  saveCXXFLAGS=$CXXFLAGS
+ax_cv_cxx_openmp=unknown
+# Flags to try:  -fopenmp (gcc), -openmp (icc), -mp (SGI & PGI),
+#                -xopenmp (Sun), -omp (Tru64), -qsmp=omp (AIX), none
+ax_openmp_flags="-fopenmp -openmp -mp -xopenmp -omp -qsmp=omp none"
 
- ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+if test "x$OPENMP_CXXFLAGS" != x; then
+  ax_openmp_flags="$OPENMP_CXXFLAGS $ax_openmp_flags"
+fi
 
- cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+for ax_openmp_flag in $ax_openmp_flags; do
+  case $ax_openmp_flag in
+    none) CXXFLAGS=$saveCXX ;;
+    *)    CXXFLAGS="$saveCXXFLAGS $ax_openmp_flag" ;;
+  esac
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <thread>
+
+    #include <omp.h>
+
 int
 main ()
 {
 
-  thread_local int i;
-  std::thread t;
-  t.join();
+    const int N = 100000;
+    int i, arr[N];
+
+    omp_set_num_threads(2);
+
+    #pragma omp parallel for
+    for (i = 0; i < N; i++)
+    {
+      arr[i] = i;
+    }
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-  ac_cv_cxx_thread=yes
+if ac_fn_cxx_try_link "$LINENO"; then :
+  ax_cv_cxx_openmp=$ax_openmp_flag; break
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+done
+
+CXXFLAGS=$saveCXXFLAGS
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_cxx_openmp" >&5
+$as_echo "$ax_cv_cxx_openmp" >&6; }
+
+if test "x$ax_cv_cxx_openmp" = "xunknown"; then
+  enableopenmp=no
 else
-  ac_cv_cxx_thread=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
- ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+  if test "x$ax_cv_cxx_openmp" != "xnone"; then
+    OPENMP_CXXFLAGS=$ax_cv_cxx_openmp
+  fi
 
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cxx_thread" >&5
-$as_echo "$ac_cv_cxx_thread" >&6; }
-if test "$ac_cv_cxx_thread" = yes; then
-
-$as_echo "#define HAVE_STD_THREAD 1" >>confdefs.h
-
-  cppthreadflavor="std::thread"
-else
-  false
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether TBB supports tbb::tbb_thread" >&5
-$as_echo_n "checking whether TBB supports tbb::tbb_thread... " >&6; }
-if ${ac_cv_tbb_cxx_thread+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-
- ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
- saveCXXFLAGS="$CXXFLAGS"
- CXXFLAGS="$TBB_INCLUDE"
- cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <tbb/tbb_thread.h>
-int
-main ()
-{
-
-  tbb::tbb_thread t;
-  t.join();
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-  ac_cv_tbb_cxx_thread=yes
-else
-  ac_cv_tbb_cxx_thread=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
- ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-CXXFLAGS="$saveCXXFLAGS"
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_tbb_cxx_thread" >&5
-$as_echo "$ac_cv_tbb_cxx_thread" >&6; }
-
-# if we don't have functioning TBB avoid a false positive
-if test "x$enabletbb" = "xno"; then
-  ac_cv_tbb_cxx_thread=no
-fi
-
-if test "$ac_cv_tbb_cxx_thread" = yes; then
-
-$as_echo "#define HAVE_TBB_CXX_THREAD 1" >>confdefs.h
-
-  cppthreadflavor="tbb::tbb_thread"
-else
-  false
-  enablecppthreads=no
-fi
+$as_echo "#define HAVE_OPENMP 1" >>confdefs.h
 
 fi
 
 
-fi
-# -------------------------------------------------------------
+      # The above call only sets the flag for C++
+      if (test "x$OPENMP_CXXFLAGS" != x) ; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with OpenMP support >>>" >&5
+$as_echo "<<< Configuring library with OpenMP support >>>" >&6; }
+        OPENMP_CFLAGS=$OPENMP_CXXFLAGS
+        OPENMP_FFLAGS=$OPENMP_CXXFLAGS
+        CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
+        CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
+        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
+        CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
+        CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
+        CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
+        CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
+        CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
+        CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
+        CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
+        FFLAGS="$FFLAGS $OPENMP_FFLAGS"
+
+
+
+        break
+      fi
+    fi
+  fi
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Found thread model: $found_thread_model >>>" >&5
+$as_echo "<<< Found thread model: $found_thread_model >>>" >&6; }
+
 
 
 
@@ -44914,24 +44882,18 @@ if (test "x$enableoptional" = "xyes"); then
   echo '     'version....................... : $netcdfversion
   fi
   echo '  'nlopt............................ : $enablenlopt
-  echo '  'openmp........................... : $enableopenmp
   echo '  'parmetis......................... : $enableparmetis
   echo '  'petsc............................ : $enablepetsc
   if (test "x$enablepetsc" = "xyes"); then
   echo '     'version....................... : $petscversion
   fi
-  echo '  'pthreads......................... : $enablepthreads
   echo '  'qhull............................ : $enableqhull
   echo '  'sfcurves......................... : $enablesfc
   echo '  'slepc............................ : $enableslepc
   if (test "x$enableslepc" = "xyes"); then
   echo '     'version....................... : $slepcversion
   fi
-  echo '  'tbb.............................. : $enabletbb
-  echo '  'c++ threads...................... : $enablecppthreads
-  if (test "x$enablecppthreads" = "xyes"); then
-  echo '     'flavor........................ : $cppthreadflavor
-  fi
+  echo '  'thread model..................... : $found_thread_model
   echo '  'c++ rtti ........................ : $ac_cv_cxx_rtti
   echo '  'tecio............................ : $enabletecio
   echo '  'tecplot...\(vendor binaries\)...... : $enabletecplot

--- a/configure
+++ b/configure
@@ -1173,6 +1173,7 @@ with_thread_model
 enable_tbb
 with_tbb
 with_tbb_lib
+enable_pthreads
 enable_openmp
 enable_laspack
 enable_sfc
@@ -1959,6 +1960,7 @@ Optional Features:
   --disable-trilinos      build without Trilinos support
   --disable-tbb           build without threading support via Threading
                           Building Blocks
+  --disable-pthreads      build without POSIX threading (pthreads) support
   --disable-openmp        Build without OpenMP Support
   --disable-laspack       build without LASPACK iterative solver suppport
   --disable-sfc           build without space-filling curves suppport
@@ -35872,6 +35874,7 @@ if test "${with_thread_model+set}" = set; then :
   withval=$with_thread_model; case "${withval}" in
                 tbb)     requested_thread_model=tbb     ;;
                 pthread) requested_thread_model=pthread ;;
+                pthreads) requested_thread_model=pthread ;;
                 auto)    requested_thread_model=auto    ;;
                 none)    requested_thread_model=none    ;;
                 *)       as_fn_error $? "bad value ${withval} for --with-thread-model" "$LINENO" 5 ;;
@@ -35881,8 +35884,8 @@ else
 fi
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: User requested thread model: $requested_thread_model" >&5
-$as_echo "User requested thread model: $requested_thread_model" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< User requested thread model: $requested_thread_model >>>" >&5
+$as_echo "<<< User requested thread model: $requested_thread_model >>>" >&6; }
 
   # Set this variable when a threading model is found
   found_thread_model=none
@@ -36104,10 +36107,27 @@ $as_echo "$ac_cv_tls" >&6; }
       libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
       libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
       found_thread_model=tbb
-      break
     fi
+  fi
 
-  elif (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
+  # If TBB wasn't selected, try pthreads as long as the user requested it (or auto)
+  if (test "$found_thread_model" = none) ; then
+    if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
+
+      # Let the user explicitly specify --{enable,disable}-pthreads.
+      # Check whether --enable-pthreads was given.
+if test "${enable_pthreads+set}" = set; then :
+  enableval=$enable_pthreads; case "${enableval}" in
+                      yes)  enablepthreads=yes ;;
+                      no)  enablepthreads=no ;;
+                      *)  as_fn_error $? "bad value ${enableval} for --enable-pthreads" "$LINENO" 5 ;;
+                    esac
+else
+  enablepthreads=$enableoptional
+fi
+
+
+      if (test "$enablepthreads" = yes) ; then
 
 
 ac_ext=c
@@ -36520,18 +36540,19 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
 
-    if (test x$ax_pthread_ok = xyes); then
+        if (test x$ax_pthread_ok = xyes); then
 
 $as_echo "#define USING_THREADS 1" >>confdefs.h
 
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with pthread support >>>" >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with pthread support >>>" >&5
 $as_echo "<<< Configuring library with pthread support >>>" >&6; }
-      libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
-      libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
-      found_thread_model=pthread
-      break
-    else
-      enablepthreads=no
+          libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
+          libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
+          found_thread_model=pthread
+        else
+          enablepthreads=no
+        fi
+      fi
     fi
   fi
 

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -839,6 +839,9 @@ include_HEADERS = \
         parallel/parallel_sort.h \
         parallel/threads.h \
         parallel/threads_allocators.h \
+        parallel/threads_none.h \
+        parallel/threads_pthread.h \
+        parallel/threads_tbb.h \
         partitioning/centroid_partitioner.h \
         partitioning/hilbert_sfc_partitioner.h \
         partitioning/linear_partitioner.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -271,6 +271,9 @@ include_HEADERS =  \
         parallel/parallel_sort.h \
         parallel/threads.h \
         parallel/threads_allocators.h \
+        parallel/threads_none.h \
+        parallel/threads_pthread.h \
+        parallel/threads_tbb.h \
         partitioning/centroid_partitioner.h \
         partitioning/hilbert_sfc_partitioner.h \
         partitioning/linear_partitioner.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -265,6 +265,9 @@ BUILT_SOURCES = \
         parallel_sort.h \
         threads.h \
         threads_allocators.h \
+        threads_none.h \
+        threads_pthread.h \
+        threads_tbb.h \
         centroid_partitioner.h \
         hilbert_sfc_partitioner.h \
         linear_partitioner.h \
@@ -1297,6 +1300,15 @@ threads.h: $(top_srcdir)/include/parallel/threads.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 threads_allocators.h: $(top_srcdir)/include/parallel/threads_allocators.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+threads_none.h: $(top_srcdir)/include/parallel/threads_none.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+threads_pthread.h: $(top_srcdir)/include/parallel/threads_pthread.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+threads_tbb.h: $(top_srcdir)/include/parallel/threads_tbb.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 centroid_partitioner.h: $(top_srcdir)/include/partitioning/centroid_partitioner.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -566,13 +566,13 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	parallel_conversion_utils.h parallel_elem.h \
 	parallel_ghost_sync.h parallel_hilbert.h parallel_histogram.h \
 	parallel_implementation.h parallel_node.h parallel_object.h \
-	parallel_sort.h threads.h threads_allocators.h \
-	centroid_partitioner.h hilbert_sfc_partitioner.h \
-	linear_partitioner.h metis_csr_graph.h metis_partitioner.h \
-	morton_sfc_partitioner.h parmetis_helper.h \
-	parmetis_partitioner.h partitioner.h sfc_partitioner.h \
-	diff_physics.h diff_qoi.h fem_physics.h quadrature.h \
-	quadrature_clough.h quadrature_composite.h \
+	parallel_sort.h threads.h threads_allocators.h threads_none.h \
+	threads_pthread.h threads_tbb.h centroid_partitioner.h \
+	hilbert_sfc_partitioner.h linear_partitioner.h \
+	metis_csr_graph.h metis_partitioner.h morton_sfc_partitioner.h \
+	parmetis_helper.h parmetis_partitioner.h partitioner.h \
+	sfc_partitioner.h diff_physics.h diff_qoi.h fem_physics.h \
+	quadrature.h quadrature_clough.h quadrature_composite.h \
 	quadrature_conical.h quadrature_gauss.h \
 	quadrature_gauss_lobatto.h quadrature_gm.h quadrature_grid.h \
 	quadrature_jacobi.h quadrature_monomial.h quadrature_simpson.h \
@@ -1645,6 +1645,15 @@ threads.h: $(top_srcdir)/include/parallel/threads.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 threads_allocators.h: $(top_srcdir)/include/parallel/threads_allocators.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+threads_none.h: $(top_srcdir)/include/parallel/threads_none.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+threads_pthread.h: $(top_srcdir)/include/parallel/threads_pthread.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+threads_tbb.h: $(top_srcdir)/include/parallel/threads_tbb.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 centroid_partitioner.h: $(top_srcdir)/include/partitioning/centroid_partitioner.h

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -255,7 +255,7 @@
 /* Flag indicating whether compiler supports std::thread */
 #undef HAVE_CXX11_THREAD
 
-/* Flag indicating whether compiler supports std::thread */
+/* Flag indicating whether compiler supports <type_traits> */
 #undef HAVE_CXX11_TYPE_TRAITS
 
 /* Flag indicating whether compiler supports std::unique_ptr */
@@ -450,9 +450,6 @@
 /* define if the compiler supports std::hash */
 #undef HAVE_STD_HASH
 
-/* define if the compiler supports std::thread */
-#undef HAVE_STD_THREAD
-
 /* define if the compiler supports std::unordered_map */
 #undef HAVE_STD_UNORDERED_MAP
 
@@ -489,9 +486,6 @@
 /* Flag indicating whether the library shall be compiled to use the Threading
    Building Blocks */
 #undef HAVE_TBB_API
-
-/* define if the compiler supports tbb::tbb_thread */
-#undef HAVE_TBB_CXX_THREAD
 
 /* Flag indicating whether the library shall be compiled to use the Tecplot
    interface */

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -176,7 +176,7 @@ typedef tbb::split split;
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided function object in parallel on the specified
+ * Execute the provided function object in parallel on the specified
  * range.
  */
 template <typename Range, typename Body>
@@ -208,7 +208,7 @@ void parallel_for (const Range & range, const Body & body)
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided function object in parallel on the specified
+ * Execute the provided function object in parallel on the specified
  * range with the specified partitioner.
  */
 template <typename Range, typename Body, typename Partitioner>
@@ -240,7 +240,7 @@ void parallel_for (const Range & range, const Body & body, const Partitioner & p
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided reduction operation in parallel on the specified
+ * Execute the provided reduction operation in parallel on the specified
  * range.
  */
 template <typename Range, typename Body>
@@ -272,7 +272,7 @@ void parallel_reduce (const Range & range, Body & body)
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided reduction operation in parallel on the specified
+ * Execute the provided reduction operation in parallel on the specified
  * range with the specified partitioner.
  */
 template <typename Range, typename Body, typename Partitioner>
@@ -326,7 +326,7 @@ typedef tbb::recursive_mutex recursive_mutex;
 template <typename T>
 class atomic : public tbb::atomic<T> {};
 
-#else //LIBMESH_HAVE_TBB_API
+#else // !LIBMESH_HAVE_TBB_API
 #ifdef LIBMESH_HAVE_PTHREAD
 
 //-------------------------------------------------------------------
@@ -391,7 +391,7 @@ public:
 private:
   pthread_spinlock_t slock;
 };
-#endif
+#endif // __APPLE__
 
 //-------------------------------------------------------------------
 /**
@@ -487,7 +487,7 @@ class split {};
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided function object in parallel on the specified
+ * Execute the provided function object in parallel on the specified
  * range.
  */
 template <typename Range, typename Body>
@@ -574,7 +574,7 @@ void parallel_for (const Range & range, const Body & body)
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided function object in parallel on the specified
+ * Execute the provided function object in parallel on the specified
  * range with the specified partitioner.
  */
 template <typename Range, typename Body, typename Partitioner>
@@ -586,7 +586,7 @@ void parallel_for (const Range & range, const Body & body, const Partitioner &)
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided reduction operation in parallel on the specified
+ * Execute the provided reduction operation in parallel on the specified
  * range.
  */
 template <typename Range, typename Body>
@@ -685,7 +685,7 @@ void parallel_reduce (const Range & range, Body & body)
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided reduction operation in parallel on the specified
+ * Execute the provided reduction operation in parallel on the specified
  * range with the specified partitioner.
  */
 template <typename Range, typename Body, typename Partitioner>
@@ -770,7 +770,7 @@ private:
   spin_mutex smutex;
 };
 
-#else //LIBMESH_HAVE_PTHREAD
+#else // !LIBMESH_HAVE_PTHREAD
 
 //-------------------------------------------------------------------
 /**
@@ -794,7 +794,7 @@ class split {};
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided function object in parallel on the specified
+ * Execute the provided function object in parallel on the specified
  * range.
  */
 template <typename Range, typename Body>
@@ -807,7 +807,7 @@ void parallel_for (const Range & range, const Body & body)
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided function object in parallel on the specified
+ * Execute the provided function object in parallel on the specified
  * range with the specified partitioner.
  */
 template <typename Range, typename Body, typename Partitioner>
@@ -820,7 +820,7 @@ void parallel_for (const Range & range, const Body & body, const Partitioner &)
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided reduction operation in parallel on the specified
+ * Execute the provided reduction operation in parallel on the specified
  * range.
  */
 template <typename Range, typename Body>
@@ -833,7 +833,7 @@ void parallel_reduce (const Range & range, Body & body)
 
 //-------------------------------------------------------------------
 /**
- * Exectue the provided reduction operation in parallel on the specified
+ * Execute the provided reduction operation in parallel on the specified
  * range with the specified partitioner.
  */
 template <typename Range, typename Body, typename Partitioner>
@@ -902,7 +902,7 @@ private:
 };
 
 #endif // LIBMESH_HAVE_PTHREAD
-#endif // #ifdef LIBMESH_HAVE_TBB_API
+#endif // LIBMESH_HAVE_TBB_API
 
 
 

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -42,9 +42,9 @@
 #endif
 
 // C++ includes
-#ifdef LIBMESH_HAVE_STD_THREAD
+#ifdef LIBMESH_HAVE_CXX11_THREAD
 #  include <thread>
-#elif LIBMESH_HAVE_TBB_CXX_THREAD
+#elif LIBMESH_HAVE_TBB_API
 #  include "tbb/tbb_thread.h"
 #endif
 
@@ -62,7 +62,7 @@
 
 // Thread-Local-Storage macros
 
-#ifdef LIBMESH_HAVE_STD_THREAD
+#ifdef LIBMESH_HAVE_CXX11_THREAD
 #  define LIBMESH_TLS_TYPE(type)  thread_local type
 #  define LIBMESH_TLS_REF(value)  (value)
 #else
@@ -110,14 +110,14 @@ private:
 };
 
 
-#ifdef LIBMESH_HAVE_STD_THREAD
+#ifdef LIBMESH_HAVE_CXX11_THREAD
 //--------------------------------------------------------------------
 /**
  * Use std::thread when available.
  */
 typedef std::thread Thread;
 
-#elif LIBMESH_HAVE_TBB_CXX_THREAD
+#elif LIBMESH_HAVE_TBB_API
 //--------------------------------------------------------------------
 /**
  * Fall back to tbb::tbb_thread when available.

--- a/include/parallel/threads.h
+++ b/include/parallel/threads.h
@@ -23,64 +23,14 @@
 #include "libmesh/libmesh_config.h"
 #include "libmesh/libmesh_common.h"  // for libmesh_assert
 
-// Threading building blocks includes
-#ifdef LIBMESH_HAVE_TBB_API
-#  include "libmesh/libmesh_logging.h" // only mess with the perflog if we are really multithreaded
-#  include "tbb/tbb_stddef.h"
-#  include "tbb/blocked_range.h"
-#  include "tbb/parallel_for.h"
-#  include "tbb/parallel_reduce.h"
-#  include "tbb/task_scheduler_init.h"
-#  include "tbb/partitioner.h"
-#  include "tbb/spin_mutex.h"
-#  include "tbb/recursive_mutex.h"
-#  include "tbb/atomic.h"
 
-#define TBB_VERSION_LESS_THAN(major,minor)                              \
-  ((LIBMESH_DETECTED_TBB_VERSION_MAJOR < (major) ||                     \
-    (LIBMESH_DETECTED_TBB_VERSION_MAJOR == (major) && (LIBMESH_DETECTED_TBB_VERSION_MINOR < (minor)))) ? 1 : 0)
+// Compile-time check: TBB and pthreads are now mutually exclusive.
+#if defined(LIBMESH_HAVE_TBB_API) && defined(LIBMESH_HAVE_PTHREAD)
+MULTIPLE THREADING MODELS CANNOT BE SIMULTANEOUSLY ACTIVE
 #endif
-
-// C++ includes
-#ifdef LIBMESH_HAVE_CXX11_THREAD
-#  include <thread>
-#elif LIBMESH_HAVE_TBB_API
-#  include "tbb/tbb_thread.h"
-#endif
-
-#ifdef LIBMESH_HAVE_PTHREAD
-#  include "libmesh/libmesh_logging.h" // only mess with the perflog if we are really multithreaded
-#  include <pthread.h>
-#  include <algorithm>
-#  include <vector>
-
-#ifdef __APPLE__
-#include <libkern/OSAtomic.h>
-#endif
-
-#endif
-
-// Thread-Local-Storage macros
-
-#ifdef LIBMESH_HAVE_CXX11_THREAD
-#  define LIBMESH_TLS_TYPE(type)  thread_local type
-#  define LIBMESH_TLS_REF(value)  (value)
-#else
-#  ifdef LIBMESH_HAVE_TBB_API
-#    include "tbb/enumerable_thread_specific.h"
-#    define LIBMESH_TLS_TYPE(type)  tbb::enumerable_thread_specific<type>
-#    define LIBMESH_TLS_REF(value)  (value).local()
-#  else // Maybe support gcc __thread eventually?
-#    define LIBMESH_TLS_TYPE(type)  type
-#    define LIBMESH_TLS_REF(value)  (value)
-#  endif
-#endif
-
-
 
 namespace libMesh
 {
-
 
 /**
  * The Threads namespace is for wrapper functions
@@ -88,6 +38,7 @@ namespace libMesh
  */
 namespace Threads
 {
+
 /**
  * A boolean which is true iff we are in a Threads:: function
  * It may be useful to assert(!Threads::in_threads) in any code
@@ -99,7 +50,8 @@ extern bool in_threads;
  * We use a class to turn Threads::in_threads on and off, to be
  * exception-safe.
  */
-class BoolAcquire {
+class BoolAcquire
+{
 public:
   explicit
   BoolAcquire(bool & b) : _b(b) { libmesh_assert(!_b); _b = true; }
@@ -110,27 +62,11 @@ private:
 };
 
 
-#ifdef LIBMESH_HAVE_CXX11_THREAD
-//--------------------------------------------------------------------
-/**
- * Use std::thread when available.
- */
-typedef std::thread Thread;
-
-#elif LIBMESH_HAVE_TBB_API
-//--------------------------------------------------------------------
-/**
- * Fall back to tbb::tbb_thread when available.
- */
-typedef tbb::tbb_thread Thread;
-
-#else
-//--------------------------------------------------------------------
 /**
  * Simple compatibility class for std::thread 'concurrent' execution.
  * Not at all concurrent, but provides a compatible interface.
  */
-class Thread
+class NonConcurrentThread
 {
 public:
   /**
@@ -139,7 +75,7 @@ public:
    * is complete.
    */
   template <typename Callable>
-  Thread (Callable f) { f(); }
+  NonConcurrentThread (Callable f) { f(); }
 
   /**
    * Join is a no-op, since the constructor blocked until completion.
@@ -152,759 +88,30 @@ public:
   bool joinable() const { return true; }
 };
 
-#endif
+} // namespace Threads
+
+} // namespace libMesh
 
 
 
+// Include thread-model specific algorithms and objects.  These
+// headers include headers of their own and handle their own
+// namespacing.
 #ifdef LIBMESH_HAVE_TBB_API
-//-------------------------------------------------------------------
-/**
- * Scheduler to manage threads.
- */
-typedef tbb::task_scheduler_init task_scheduler_init;
-
-
-
-//-------------------------------------------------------------------
-/**
- * Dummy "splitting object" used to distinguish splitting constructors
- * from copy constructors.
- */
-typedef tbb::split split;
-
-
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided function object in parallel on the specified
- * range.
- */
-template <typename Range, typename Body>
-inline
-void parallel_for (const Range & range, const Body & body)
-{
-  BoolAcquire b(in_threads);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
-  if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
-
-  if (libMesh::n_threads() > 1)
-    tbb::parallel_for (range, body, tbb::auto_partitioner());
-
-  else
-    body(range);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
-}
-
-
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided function object in parallel on the specified
- * range with the specified partitioner.
- */
-template <typename Range, typename Body, typename Partitioner>
-inline
-void parallel_for (const Range & range, const Body & body, const Partitioner & partitioner)
-{
-  BoolAcquire b(in_threads);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
-  if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
-
-  if (libMesh::n_threads() > 1)
-    tbb::parallel_for (range, body, partitioner);
-
-  else
-    body(range);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
-}
-
-
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided reduction operation in parallel on the specified
- * range.
- */
-template <typename Range, typename Body>
-inline
-void parallel_reduce (const Range & range, Body & body)
-{
-  BoolAcquire b(in_threads);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
-  if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
-
-  if (libMesh::n_threads() > 1)
-    tbb::parallel_reduce (range, body, tbb::auto_partitioner());
-
-  else
-    body(range);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
-}
-
-
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided reduction operation in parallel on the specified
- * range with the specified partitioner.
- */
-template <typename Range, typename Body, typename Partitioner>
-inline
-void parallel_reduce (const Range & range, Body & body, const Partitioner & partitioner)
-{
-  BoolAcquire b(in_threads);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
-  if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
-
-  if (libMesh::n_threads() > 1)
-    tbb::parallel_reduce (range, body, partitioner);
-
-  else
-    body(range);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
-}
-
-
-
-//-------------------------------------------------------------------
-/**
- * Spin mutex.  Implements mutual exclusion by busy-waiting in user
- * space for the lock to be acquired.
- */
-typedef tbb::spin_mutex spin_mutex;
-
-//-------------------------------------------------------------------
-/**
- * Recursive mutex.  Implements mutual exclusion by busy-waiting in user
- * space for the lock to be acquired.  The same thread can aquire the
- * same lock multiple times
- */
-typedef tbb::recursive_mutex recursive_mutex;
-
-//-------------------------------------------------------------------
-/**
- * Defines atomic operations which can only be executed on a
- * single thread at a time.  This is used in reference counting,
- * for example, to allow count++/count-- to work.
- */
-template <typename T>
-class atomic : public tbb::atomic<T> {};
-
-#else // !LIBMESH_HAVE_TBB_API
-#ifdef LIBMESH_HAVE_PTHREAD
-
-//-------------------------------------------------------------------
-/**
- * Spin mutex.  Implements mutual exclusion by busy-waiting in user
- * space for the lock to be acquired.
- */
-#ifdef __APPLE__
-class spin_mutex
-{
-public:
-  spin_mutex() : slock(0) {} // The convention is that the lock being zero is _unlocked_
-  ~spin_mutex() {}
-
-  void lock () { OSSpinLockLock(&slock); }
-  void unlock () { OSSpinLockUnlock(&slock); }
-
-  class scoped_lock
-  {
-  public:
-    scoped_lock () : smutex(libmesh_nullptr) {}
-    explicit scoped_lock ( spin_mutex & in_smutex ) : smutex(&in_smutex) { smutex->lock(); }
-
-    ~scoped_lock () { release(); }
-
-    void acquire ( spin_mutex & in_smutex ) { smutex = &in_smutex; smutex->lock(); }
-    void release () { if(smutex) smutex->unlock(); smutex = libmesh_nullptr; }
-
-  private:
-    spin_mutex * smutex;
-  };
-
-private:
-  OSSpinLock slock;
-};
+# include "libmesh/threads_tbb.h"
+#elif LIBMESH_HAVE_PTHREAD
+# include "libmesh/threads_pthread.h"
 #else
-class spin_mutex
-{
-public:
-  // Might want to use PTHREAD_MUTEX_ADAPTIVE_NP on Linux, but it's not available on OSX.
-  spin_mutex() { pthread_spin_init(&slock, PTHREAD_PROCESS_PRIVATE); }
-  ~spin_mutex() { pthread_spin_destroy(&slock); }
-
-  void lock () { pthread_spin_lock(&slock); }
-  void unlock () { pthread_spin_unlock(&slock); }
-
-  class scoped_lock
-  {
-  public:
-    scoped_lock () : smutex(libmesh_nullptr) {}
-    explicit scoped_lock ( spin_mutex & in_smutex ) : smutex(&in_smutex) { smutex->lock(); }
-
-    ~scoped_lock () { release(); }
-
-    void acquire ( spin_mutex & in_smutex ) { smutex = &in_smutex; smutex->lock(); }
-    void release () { if(smutex) smutex->unlock(); smutex = libmesh_nullptr; }
-
-  private:
-    spin_mutex * smutex;
-  };
-
-private:
-  pthread_spinlock_t slock;
-};
-#endif // __APPLE__
-
-//-------------------------------------------------------------------
-/**
- * Recursive mutex.  Implements mutual exclusion by busy-waiting in user
- * space for the lock to be acquired.
- */
-class recursive_mutex
-{
-public:
-  // Might want to use PTHREAD_MUTEX_ADAPTIVE_NP on Linux, but it's not available on OSX.
-  recursive_mutex()
-  {
-    pthread_mutexattr_init(&attr);
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-    pthread_mutex_init(&mutex, &attr);
-  }
-  ~recursive_mutex() { pthread_mutex_destroy(&mutex); }
-
-  void lock () { pthread_mutex_lock(&mutex); }
-  void unlock () { pthread_mutex_unlock(&mutex); }
-
-  class scoped_lock
-  {
-  public:
-    scoped_lock () : rmutex(libmesh_nullptr) {}
-    explicit scoped_lock ( recursive_mutex & in_rmutex ) : rmutex(&in_rmutex) { rmutex->lock(); }
-
-    ~scoped_lock () { release(); }
-
-    void acquire ( recursive_mutex & in_rmutex ) { rmutex = &in_rmutex; rmutex->lock(); }
-    void release () { if(rmutex) rmutex->unlock(); rmutex = libmesh_nullptr; }
-
-  private:
-    recursive_mutex * rmutex;
-  };
-
-private:
-  pthread_mutex_t mutex;
-  pthread_mutexattr_t attr;
-};
-
-template <typename Range>
-unsigned int num_pthreads(Range & range)
-{
-  unsigned int min = std::min((std::size_t)libMesh::n_threads(), range.size());
-  return min > 0 ? min : 1;
-}
-
-template <typename Range, typename Body>
-class RangeBody
-{
-public:
-  Range * range;
-  Body * body;
-};
-
-template <typename Range, typename Body>
-void * run_body(void * args)
-{
-
-  RangeBody<Range, Body> * range_body = (RangeBody<Range, Body> *)args;
-
-  Body & body = *range_body->body;
-  Range & range = *range_body->range;
-
-  body(range);
-
-  return libmesh_nullptr;
-}
-
-//-------------------------------------------------------------------
-/**
- * Scheduler to manage threads.
- */
-class task_scheduler_init
-{
-public:
-  static const int automatic = -1;
-  explicit task_scheduler_init (int = automatic) {}
-  void initialize (int = automatic) {}
-  void terminate () {}
-};
-
-//-------------------------------------------------------------------
-/**
- * Dummy "splitting object" used to distinguish splitting constructors
- * from copy constructors.
- */
-class split {};
-
-
-
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided function object in parallel on the specified
- * range.
- */
-template <typename Range, typename Body>
-inline
-void parallel_for (const Range & range, const Body & body)
-{
-  Threads::BoolAcquire b(Threads::in_threads);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
-  if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
+# include "libmesh/threads_none.h"
 #endif
 
-  unsigned int n_threads = num_pthreads(range);
 
-  std::vector<Range *> ranges(n_threads);
-  std::vector<RangeBody<const Range, const Body> > range_bodies(n_threads);
-  std::vector<pthread_t> threads(n_threads);
 
-  // Create the ranges for each thread
-  unsigned int range_size = range.size() / n_threads;
-
-  typename Range::const_iterator current_beginning = range.begin();
-
-  for(unsigned int i=0; i<n_threads; i++)
-    {
-      unsigned int this_range_size = range_size;
-
-      if(i+1 == n_threads)
-        this_range_size += range.size() % n_threads; // Give the last one the remaining work to do
-
-      ranges[i] = new Range(range, current_beginning, current_beginning + this_range_size);
-
-      current_beginning = current_beginning + this_range_size;
-    }
-
-  // Create the RangeBody arguments
-  for(unsigned int i=0; i<n_threads; i++)
-    {
-      range_bodies[i].range = ranges[i];
-      range_bodies[i].body = &body;
-    }
-
-  // Create the threads.  It may seem redundant to wrap a pragma in
-  // #ifdefs... but GCC warns about an "unknown pragma" if it
-  // encounters this line of code when -fopenmp is not passed to the
-  // compiler.
-#ifdef LIBMESH_HAVE_OPENMP
-#pragma omp parallel for schedule (static)
-#endif
-  for(unsigned int i=0; i<n_threads; i++)
-    {
-#if LIBMESH_HAVE_OPENMP
-      run_body<Range, Body>((void *)&range_bodies[i]);
-#elif LIBMESH_HAVE_PTHREAD
-      pthread_create(&threads[i], libmesh_nullptr, &run_body<Range, Body>, (void *)&range_bodies[i]);
-#endif
-    }
-
-#if !LIBMESH_HAVE_OPENMP
-  // Wait for them to finish
-
-  // The use of 'int' instead of unsigned for the iteration variable
-  // is deliberate here.  This is an OpenMP loop, and some older
-  // compilers warn when you don't use int for the loop index.  The
-  // reason has to do with signed vs. unsigned integer overflow
-  // behavior and optimization.
-  // http://blog.llvm.org/2011/05/what-every-c-programmer-should-know.html
-  for (int i=0; i<static_cast<int>(n_threads); i++)
-      pthread_join(threads[i], libmesh_nullptr);
-#endif
-
-  // Clean up
-  for(unsigned int i=0; i<n_threads; i++)
-    delete ranges[i];
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
-}
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided function object in parallel on the specified
- * range with the specified partitioner.
- */
-template <typename Range, typename Body, typename Partitioner>
-inline
-void parallel_for (const Range & range, const Body & body, const Partitioner &)
+namespace libMesh
 {
-  parallel_for(range, body);
-}
 
-//-------------------------------------------------------------------
-/**
- * Execute the provided reduction operation in parallel on the specified
- * range.
- */
-template <typename Range, typename Body>
-inline
-void parallel_reduce (const Range & range, Body & body)
+namespace Threads
 {
-  Threads::BoolAcquire b(Threads::in_threads);
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
-
-  if (libMesh::n_threads() > 1)
-    libMesh::perflog.disable_logging();
-#endif
-
-  unsigned int n_threads = num_pthreads(range);
-
-  std::vector<Range *> ranges(n_threads);
-  std::vector<Body *> bodies(n_threads);
-  std::vector<RangeBody<Range, Body> > range_bodies(n_threads);
-
-  // Create copies of the body for each thread
-  bodies[0] = &body; // Use the original body for the first one
-  for(unsigned int i=1; i<n_threads; i++)
-    bodies[i] = new Body(body, Threads::split());
-
-  // Create the ranges for each thread
-  unsigned int range_size = range.size() / n_threads;
-
-  typename Range::const_iterator current_beginning = range.begin();
-
-  for(unsigned int i=0; i<n_threads; i++)
-    {
-      unsigned int this_range_size = range_size;
-
-      if(i+1 == n_threads)
-        this_range_size += range.size() % n_threads; // Give the last one the remaining work to do
-
-      ranges[i] = new Range(range, current_beginning, current_beginning + this_range_size);
-
-      current_beginning = current_beginning + this_range_size;
-    }
-
-  // Create the RangeBody arguments
-  for(unsigned int i=0; i<n_threads; i++)
-    {
-      range_bodies[i].range = ranges[i];
-      range_bodies[i].body = bodies[i];
-    }
-
-  // Create the threads
-  std::vector<pthread_t> threads(n_threads);
-
-  // It may seem redundant to wrap a pragma in #ifdefs... but GCC
-  // warns about an "unknown pragma" if it encounters this line of
-  // code when -fopenmp is not passed to the compiler.
-#ifdef LIBMESH_HAVE_OPENMP
-#pragma omp parallel for schedule (static)
-#endif
-  // The use of 'int' instead of unsigned for the iteration variable
-  // is deliberate here.  This is an OpenMP loop, and some older
-  // compilers warn when you don't use int for the loop index.  The
-  // reason has to do with signed vs. unsigned integer overflow
-  // behavior and optimization.
-  // http://blog.llvm.org/2011/05/what-every-c-programmer-should-know.html
-  for (int i=0; i<static_cast<int>(n_threads); i++)
-    {
-#if LIBMESH_HAVE_OPENMP
-      run_body<Range, Body>((void *)&range_bodies[i]);
-#elif LIBMESH_HAVE_PTHREAD
-      pthread_create(&threads[i], libmesh_nullptr, &run_body<Range, Body>, (void *)&range_bodies[i]);
-#endif
-    }
-
-#if !LIBMESH_HAVE_OPENMP
-  // Wait for them to finish
-  for(unsigned int i=0; i<n_threads; i++)
-      pthread_join(threads[i], libmesh_nullptr);
-#endif
-
-  // Join them all down to the original Body
-  for(unsigned int i=n_threads-1; i != 0; i--)
-    bodies[i-1]->join(*bodies[i]);
-
-  // Clean up
-  for(unsigned int i=1; i<n_threads; i++)
-    delete bodies[i];
-  for(unsigned int i=0; i<n_threads; i++)
-    delete ranges[i];
-
-#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
-  if (libMesh::n_threads() > 1 && logging_was_enabled)
-    libMesh::perflog.enable_logging();
-#endif
-}
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided reduction operation in parallel on the specified
- * range with the specified partitioner.
- */
-template <typename Range, typename Body, typename Partitioner>
-inline
-void parallel_reduce (const Range & range, Body & body, const Partitioner &)
-{
-  parallel_reduce(range, body);
-}
-
-
-//-------------------------------------------------------------------
-/**
- * Defines atomic operations which can only be executed on a
- * single thread at a time.
- */
-template <typename T>
-class atomic
-{
-public:
-  atomic () : val(0) {}
-  operator T () { return val; }
-
-  T operator=( T value )
-  {
-    spin_mutex::scoped_lock lock(smutex);
-    val = value;
-    return val;
-  }
-
-  atomic<T> & operator=( const atomic<T> & value )
-  {
-    spin_mutex::scoped_lock lock(smutex);
-    val = value;
-    return *this;
-  }
-
-
-  T operator+=(T value)
-  {
-    spin_mutex::scoped_lock lock(smutex);
-    val += value;
-    return val;
-  }
-
-  T operator-=(T value)
-  {
-    spin_mutex::scoped_lock lock(smutex);
-    val -= value;
-    return val;
-  }
-
-  T operator++()
-  {
-    spin_mutex::scoped_lock lock(smutex);
-    val++;
-    return val;
-  }
-
-  T operator++(int)
-  {
-    spin_mutex::scoped_lock lock(smutex);
-    val++;
-    return val;
-  }
-
-  T operator--()
-  {
-    spin_mutex::scoped_lock lock(smutex);
-    val--;
-    return val;
-  }
-
-  T operator--(int)
-  {
-    spin_mutex::scoped_lock lock(smutex);
-    val--;
-    return val;
-  }
-
-private:
-  T val;
-  spin_mutex smutex;
-};
-
-#else // !LIBMESH_HAVE_PTHREAD
-
-//-------------------------------------------------------------------
-/**
- * Scheduler to manage threads.
- */
-class task_scheduler_init
-{
-public:
-  static const int automatic = -1;
-  explicit task_scheduler_init (int = automatic) {}
-  void initialize (int = automatic) {}
-  void terminate () {}
-};
-
-//-------------------------------------------------------------------
-/**
- * Dummy "splitting object" used to distinguish splitting constructors
- * from copy constructors.
- */
-class split {};
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided function object in parallel on the specified
- * range.
- */
-template <typename Range, typename Body>
-inline
-void parallel_for (const Range & range, const Body & body)
-{
-  BoolAcquire b(in_threads);
-  body(range);
-}
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided function object in parallel on the specified
- * range with the specified partitioner.
- */
-template <typename Range, typename Body, typename Partitioner>
-inline
-void parallel_for (const Range & range, const Body & body, const Partitioner &)
-{
-  BoolAcquire b(in_threads);
-  body(range);
-}
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided reduction operation in parallel on the specified
- * range.
- */
-template <typename Range, typename Body>
-inline
-void parallel_reduce (const Range & range, Body & body)
-{
-  BoolAcquire b(in_threads);
-  body(range);
-}
-
-//-------------------------------------------------------------------
-/**
- * Execute the provided reduction operation in parallel on the specified
- * range with the specified partitioner.
- */
-template <typename Range, typename Body, typename Partitioner>
-inline
-void parallel_reduce (const Range & range, Body & body, const Partitioner &)
-{
-  BoolAcquire b(in_threads);
-  body(range);
-}
-
-//-------------------------------------------------------------------
-/**
- * Spin mutex.  Implements mutual exclusion by busy-waiting in user
- * space for the lock to be acquired.
- */
-class spin_mutex
-{
-public:
-  spin_mutex() {}
-  void lock () {}
-  void unlock () {}
-
-  class scoped_lock
-  {
-  public:
-    scoped_lock () {}
-    explicit scoped_lock ( spin_mutex &  ) {}
-    void acquire ( spin_mutex & ) {}
-    void release () {}
-  };
-};
-
-//-------------------------------------------------------------------
-/**
- * Recursive mutex.  Implements mutual exclusion by busy-waiting in user
- * space for the lock to be acquired.
- */
-class recursive_mutex
-{
-public:
-  recursive_mutex() {}
-
-  class scoped_lock
-  {
-  public:
-    scoped_lock () {}
-    explicit scoped_lock ( recursive_mutex &  ) {}
-    void acquire ( recursive_mutex & ) {}
-    void release () {}
-  };
-};
-
-//-------------------------------------------------------------------
-/**
- * Defines atomic operations which can only be executed on a
- * single thread at a time.
- */
-template <typename T>
-class atomic
-{
-public:
-  atomic () : _val(0) {}
-  operator T & () { return _val; }
-private:
-  T _val;
-};
-
-#endif // LIBMESH_HAVE_PTHREAD
-#endif // LIBMESH_HAVE_TBB_API
-
-
 
 /**
  * Blocked range which can be subdivided and executed in parallel.
@@ -1038,12 +245,12 @@ private:
 
 
 /**
- * A spin mutex object which
+ * A convenient spin mutex object which can be used for obtaining locks.
  */
 extern spin_mutex spin_mtx;
 
 /**
- * A recursive mutex object which
+ * A convenient recursive mutex object which can be used for obtaining locks.
  */
 extern recursive_mutex recursive_mtx;
 

--- a/include/parallel/threads_none.h
+++ b/include/parallel/threads_none.h
@@ -27,31 +27,16 @@
 #define LIBMESH_TLS_TYPE(type)  type
 #define LIBMESH_TLS_REF(value)  (value)
 
-/**
- * Simple compatibility class for std::thread 'concurrent' execution.
- * Not at all concurrent, but provides a compatible interface.
- */
-class Thread
+namespace libMesh
 {
-public:
-  /**
-   * Constructor.  Takes a callable function object and executes it.
-   * Our wrapper class actually blocks execution until the thread
-   * is complete.
-   */
-  template <typename Callable>
-  Thread (Callable f) { f(); }
 
-  /**
-   * Join is a no-op, since the constructor blocked until completion.
-   */
-  void join() {}
+namespace Threads
+{
 
-  /**
-   * Always joinable.
-   */
-  bool joinable() const { return true; }
-};
+/**
+ * Use the non-concurrent placeholder.
+ */
+typedef NonConcurrentThread Thread;
 
 /**
  * Scheduler to manage threads.
@@ -188,6 +173,10 @@ public:
 private:
   T _val;
 };
+
+} // namespace Threads
+
+} // namespace libMesh
 
 #endif // !defined(LIBMESH_HAVE_TBB_API) && !defined(LIBMESH_HAVE_PTHREAD)
 

--- a/include/parallel/threads_none.h
+++ b/include/parallel/threads_none.h
@@ -1,0 +1,194 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2016 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+#ifndef LIBMESH_THREADS_NONE_H
+#define LIBMESH_THREADS_NONE_H
+
+// Do not try to #include this header directly, it is designed to be
+// #included directly by threads.h
+#if !defined(LIBMESH_HAVE_TBB_API) && !defined(LIBMESH_HAVE_PTHREAD)
+
+// Thread-Local-Storage macros
+#define LIBMESH_TLS_TYPE(type)  type
+#define LIBMESH_TLS_REF(value)  (value)
+
+/**
+ * Simple compatibility class for std::thread 'concurrent' execution.
+ * Not at all concurrent, but provides a compatible interface.
+ */
+class Thread
+{
+public:
+  /**
+   * Constructor.  Takes a callable function object and executes it.
+   * Our wrapper class actually blocks execution until the thread
+   * is complete.
+   */
+  template <typename Callable>
+  Thread (Callable f) { f(); }
+
+  /**
+   * Join is a no-op, since the constructor blocked until completion.
+   */
+  void join() {}
+
+  /**
+   * Always joinable.
+   */
+  bool joinable() const { return true; }
+};
+
+/**
+ * Scheduler to manage threads.
+ */
+class task_scheduler_init
+{
+public:
+  static const int automatic = -1;
+  explicit task_scheduler_init (int = automatic) {}
+  void initialize (int = automatic) {}
+  void terminate () {}
+};
+
+
+
+/**
+ * Dummy "splitting object" used to distinguish splitting constructors
+ * from copy constructors.
+ */
+class split {};
+
+
+
+/**
+ * Execute the provided function object in parallel on the specified
+ * range.
+ */
+template <typename Range, typename Body>
+inline
+void parallel_for (const Range & range, const Body & body)
+{
+  BoolAcquire b(in_threads);
+  body(range);
+}
+
+
+
+/**
+ * Execute the provided function object in parallel on the specified
+ * range with the specified partitioner.
+ */
+template <typename Range, typename Body, typename Partitioner>
+inline
+void parallel_for (const Range & range, const Body & body, const Partitioner &)
+{
+  BoolAcquire b(in_threads);
+  body(range);
+}
+
+
+
+/**
+ * Execute the provided reduction operation in parallel on the specified
+ * range.
+ */
+template <typename Range, typename Body>
+inline
+void parallel_reduce (const Range & range, Body & body)
+{
+  BoolAcquire b(in_threads);
+  body(range);
+}
+
+
+
+/**
+ * Execute the provided reduction operation in parallel on the specified
+ * range with the specified partitioner.
+ */
+template <typename Range, typename Body, typename Partitioner>
+inline
+void parallel_reduce (const Range & range, Body & body, const Partitioner &)
+{
+  BoolAcquire b(in_threads);
+  body(range);
+}
+
+
+
+/**
+ * Spin mutex.  Implements mutual exclusion by busy-waiting in user
+ * space for the lock to be acquired.
+ */
+class spin_mutex
+{
+public:
+  spin_mutex() {}
+  void lock () {}
+  void unlock () {}
+
+  class scoped_lock
+  {
+  public:
+    scoped_lock () {}
+    explicit scoped_lock ( spin_mutex &  ) {}
+    void acquire ( spin_mutex & ) {}
+    void release () {}
+  };
+};
+
+
+
+/**
+ * Recursive mutex.  Implements mutual exclusion by busy-waiting in user
+ * space for the lock to be acquired.
+ */
+class recursive_mutex
+{
+public:
+  recursive_mutex() {}
+
+  class scoped_lock
+  {
+  public:
+    scoped_lock () {}
+    explicit scoped_lock ( recursive_mutex &  ) {}
+    void acquire ( recursive_mutex & ) {}
+    void release () {}
+  };
+};
+
+
+
+/**
+ * Defines atomic operations which can only be executed on a
+ * single thread at a time.
+ */
+template <typename T>
+class atomic
+{
+public:
+  atomic () : _val(0) {}
+  operator T & () { return _val; }
+private:
+  T _val;
+};
+
+#endif // !defined(LIBMESH_HAVE_TBB_API) && !defined(LIBMESH_HAVE_PTHREAD)
+
+#endif // LIBMESH_THREADS_NONE_H

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -1,0 +1,538 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2016 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_THREADS_PTHREAD_H
+#define LIBMESH_THREADS_PTHREAD_H
+
+// Do not try to #include this header directly, it is designed to be
+// #included directly by threads.h
+#ifdef LIBMESH_HAVE_PTHREAD
+
+// C++ includes
+#ifdef LIBMESH_HAVE_CXX11_THREAD
+# include <thread>
+#endif
+
+#include "libmesh/libmesh_logging.h"
+#include <pthread.h>
+#include <algorithm>
+#include <vector>
+
+#ifdef __APPLE__
+#include <libkern/OSAtomic.h>
+#endif
+
+// Thread-Local-Storage macros
+#ifdef LIBMESH_HAVE_CXX11_THREAD
+#  define LIBMESH_TLS_TYPE(type)  thread_local type
+#  define LIBMESH_TLS_REF(value)  (value)
+#else // Maybe support gcc __thread eventually?
+#  define LIBMESH_TLS_TYPE(type)  type
+#  define LIBMESH_TLS_REF(value)  (value)
+#endif
+
+
+
+namespace libMesh
+{
+
+
+/**
+ * The Threads namespace is for wrapper functions
+ * for common general multithreading algorithms and tasks.
+ */
+namespace Threads
+{
+
+
+#ifdef LIBMESH_HAVE_CXX11_THREAD
+/**
+ * Use std::thread when available.
+ */
+typedef std::thread Thread;
+
+#else
+/**
+ * Simple compatibility class for std::thread 'concurrent' execution.
+ * Not at all concurrent, but provides a compatible interface.
+ */
+class Thread
+{
+public:
+  /**
+   * Constructor.  Takes a callable function object and executes it.
+   * Our wrapper class actually blocks execution until the thread
+   * is complete.
+   */
+  template <typename Callable>
+  Thread (Callable f) { f(); }
+
+  /**
+   * Join is a no-op, since the constructor blocked until completion.
+   */
+  void join() {}
+
+  /**
+   * Always joinable.
+   */
+  bool joinable() const { return true; }
+};
+#endif // LIBMESH_HAVE_CXX11_THREAD
+
+
+/**
+ * Spin mutex.  Implements mutual exclusion by busy-waiting in user
+ * space for the lock to be acquired.
+ */
+#ifdef __APPLE__
+class spin_mutex
+{
+public:
+  spin_mutex() : slock(0) {} // The convention is that the lock being zero is _unlocked_
+  ~spin_mutex() {}
+
+  void lock () { OSSpinLockLock(&slock); }
+  void unlock () { OSSpinLockUnlock(&slock); }
+
+  class scoped_lock
+  {
+  public:
+    scoped_lock () : smutex(libmesh_nullptr) {}
+    explicit scoped_lock ( spin_mutex & in_smutex ) : smutex(&in_smutex) { smutex->lock(); }
+
+    ~scoped_lock () { release(); }
+
+    void acquire ( spin_mutex & in_smutex ) { smutex = &in_smutex; smutex->lock(); }
+    void release () { if (smutex) smutex->unlock(); smutex = libmesh_nullptr; }
+
+  private:
+    spin_mutex * smutex;
+  };
+
+private:
+  OSSpinLock slock;
+};
+#else
+class spin_mutex
+{
+public:
+  // Might want to use PTHREAD_MUTEX_ADAPTIVE_NP on Linux, but it's not available on OSX.
+  spin_mutex() { pthread_spin_init(&slock, PTHREAD_PROCESS_PRIVATE); }
+  ~spin_mutex() { pthread_spin_destroy(&slock); }
+
+  void lock () { pthread_spin_lock(&slock); }
+  void unlock () { pthread_spin_unlock(&slock); }
+
+  class scoped_lock
+  {
+  public:
+    scoped_lock () : smutex(libmesh_nullptr) {}
+    explicit scoped_lock ( spin_mutex & in_smutex ) : smutex(&in_smutex) { smutex->lock(); }
+
+    ~scoped_lock () { release(); }
+
+    void acquire ( spin_mutex & in_smutex ) { smutex = &in_smutex; smutex->lock(); }
+    void release () { if (smutex) smutex->unlock(); smutex = libmesh_nullptr; }
+
+  private:
+    spin_mutex * smutex;
+  };
+
+private:
+  pthread_spinlock_t slock;
+};
+#endif // __APPLE__
+
+
+
+/**
+ * Recursive mutex.  Implements mutual exclusion by busy-waiting in user
+ * space for the lock to be acquired.
+ */
+class recursive_mutex
+{
+public:
+  // Might want to use PTHREAD_MUTEX_ADAPTIVE_NP on Linux, but it's not available on OSX.
+  recursive_mutex()
+  {
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&mutex, &attr);
+  }
+  ~recursive_mutex() { pthread_mutex_destroy(&mutex); }
+
+  void lock () { pthread_mutex_lock(&mutex); }
+  void unlock () { pthread_mutex_unlock(&mutex); }
+
+  class scoped_lock
+  {
+  public:
+    scoped_lock () : rmutex(libmesh_nullptr) {}
+    explicit scoped_lock ( recursive_mutex & in_rmutex ) : rmutex(&in_rmutex) { rmutex->lock(); }
+
+    ~scoped_lock () { release(); }
+
+    void acquire ( recursive_mutex & in_rmutex ) { rmutex = &in_rmutex; rmutex->lock(); }
+    void release () { if (rmutex) rmutex->unlock(); rmutex = libmesh_nullptr; }
+
+  private:
+    recursive_mutex * rmutex;
+  };
+
+private:
+  pthread_mutex_t mutex;
+  pthread_mutexattr_t attr;
+};
+
+template <typename Range>
+unsigned int num_pthreads(Range & range)
+{
+  unsigned int min = std::min((std::size_t)libMesh::n_threads(), range.size());
+  return min > 0 ? min : 1;
+}
+
+template <typename Range, typename Body>
+class RangeBody
+{
+public:
+  Range * range;
+  Body * body;
+};
+
+template <typename Range, typename Body>
+void * run_body(void * args)
+{
+  RangeBody<Range, Body> * range_body = (RangeBody<Range, Body> *)args;
+
+  Body & body = *range_body->body;
+  Range & range = *range_body->range;
+
+  body(range);
+
+  return libmesh_nullptr;
+}
+
+/**
+ * Scheduler to manage threads.
+ */
+class task_scheduler_init
+{
+public:
+  static const int automatic = -1;
+  explicit task_scheduler_init (int = automatic) {}
+  void initialize (int = automatic) {}
+  void terminate () {}
+};
+
+//-------------------------------------------------------------------
+/**
+ * Dummy "splitting object" used to distinguish splitting constructors
+ * from copy constructors.
+ */
+class split {};
+
+
+
+
+//-------------------------------------------------------------------
+/**
+ * Execute the provided function object in parallel on the specified
+ * range.
+ */
+template <typename Range, typename Body>
+inline
+void parallel_for (const Range & range, const Body & body)
+{
+  Threads::BoolAcquire b(Threads::in_threads);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
+
+  if (libMesh::n_threads() > 1)
+    libMesh::perflog.disable_logging();
+#endif
+
+  unsigned int n_threads = num_pthreads(range);
+
+  std::vector<Range *> ranges(n_threads);
+  std::vector<RangeBody<const Range, const Body> > range_bodies(n_threads);
+  std::vector<pthread_t> threads(n_threads);
+
+  // Create the ranges for each thread
+  unsigned int range_size = range.size() / n_threads;
+
+  typename Range::const_iterator current_beginning = range.begin();
+
+  for (unsigned int i=0; i<n_threads; i++)
+    {
+      unsigned int this_range_size = range_size;
+
+      if (i+1 == n_threads)
+        this_range_size += range.size() % n_threads; // Give the last one the remaining work to do
+
+      ranges[i] = new Range(range, current_beginning, current_beginning + this_range_size);
+
+      current_beginning = current_beginning + this_range_size;
+    }
+
+  // Create the RangeBody arguments
+  for (unsigned int i=0; i<n_threads; i++)
+    {
+      range_bodies[i].range = ranges[i];
+      range_bodies[i].body = &body;
+    }
+
+  // Create the threads.  It may seem redundant to wrap a pragma in
+  // #ifdefs... but GCC warns about an "unknown pragma" if it
+  // encounters this line of code when -fopenmp is not passed to the
+  // compiler.
+#ifdef LIBMESH_HAVE_OPENMP
+#pragma omp parallel for schedule (static)
+#endif
+  for (unsigned int i=0; i<n_threads; i++)
+    {
+#if !LIBMESH_HAVE_OPENMP
+      pthread_create(&threads[i], libmesh_nullptr, &run_body<Range, Body>, (void *)&range_bodies[i]);
+#else
+      run_body<Range, Body>((void *)&range_bodies[i]);
+#endif
+    }
+
+#if !LIBMESH_HAVE_OPENMP
+  // Wait for them to finish
+
+  // The use of 'int' instead of unsigned for the iteration variable
+  // is deliberate here.  This is an OpenMP loop, and some older
+  // compilers warn when you don't use int for the loop index.  The
+  // reason has to do with signed vs. unsigned integer overflow
+  // behavior and optimization.
+  // http://blog.llvm.org/2011/05/what-every-c-programmer-should-know.html
+  for (int i=0; i<static_cast<int>(n_threads); i++)
+      pthread_join(threads[i], libmesh_nullptr);
+#endif
+
+  // Clean up
+  for (unsigned int i=0; i<n_threads; i++)
+    delete ranges[i];
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  if (libMesh::n_threads() > 1 && logging_was_enabled)
+    libMesh::perflog.enable_logging();
+#endif
+}
+
+/**
+ * Execute the provided function object in parallel on the specified
+ * range with the specified partitioner.
+ */
+template <typename Range, typename Body, typename Partitioner>
+inline
+void parallel_for (const Range & range, const Body & body, const Partitioner &)
+{
+  parallel_for (range, body);
+}
+
+/**
+ * Execute the provided reduction operation in parallel on the specified
+ * range.
+ */
+template <typename Range, typename Body>
+inline
+void parallel_reduce (const Range & range, Body & body)
+{
+  Threads::BoolAcquire b(Threads::in_threads);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
+
+  if (libMesh::n_threads() > 1)
+    libMesh::perflog.disable_logging();
+#endif
+
+  unsigned int n_threads = num_pthreads(range);
+
+  std::vector<Range *> ranges(n_threads);
+  std::vector<Body *> bodies(n_threads);
+  std::vector<RangeBody<Range, Body> > range_bodies(n_threads);
+
+  // Create copies of the body for each thread
+  bodies[0] = &body; // Use the original body for the first one
+  for (unsigned int i=1; i<n_threads; i++)
+    bodies[i] = new Body(body, Threads::split());
+
+  // Create the ranges for each thread
+  unsigned int range_size = range.size() / n_threads;
+
+  typename Range::const_iterator current_beginning = range.begin();
+
+  for (unsigned int i=0; i<n_threads; i++)
+    {
+      unsigned int this_range_size = range_size;
+
+      if (i+1 == n_threads)
+        this_range_size += range.size() % n_threads; // Give the last one the remaining work to do
+
+      ranges[i] = new Range(range, current_beginning, current_beginning + this_range_size);
+
+      current_beginning = current_beginning + this_range_size;
+    }
+
+  // Create the RangeBody arguments
+  for (unsigned int i=0; i<n_threads; i++)
+    {
+      range_bodies[i].range = ranges[i];
+      range_bodies[i].body = bodies[i];
+    }
+
+  // Create the threads
+  std::vector<pthread_t> threads(n_threads);
+
+  // It may seem redundant to wrap a pragma in #ifdefs... but GCC
+  // warns about an "unknown pragma" if it encounters this line of
+  // code when -fopenmp is not passed to the compiler.
+#ifdef LIBMESH_HAVE_OPENMP
+#pragma omp parallel for schedule (static)
+#endif
+  // The use of 'int' instead of unsigned for the iteration variable
+  // is deliberate here.  This is an OpenMP loop, and some older
+  // compilers warn when you don't use int for the loop index.  The
+  // reason has to do with signed vs. unsigned integer overflow
+  // behavior and optimization.
+  // http://blog.llvm.org/2011/05/what-every-c-programmer-should-know.html
+  for (int i=0; i<static_cast<int>(n_threads); i++)
+    {
+#if !LIBMESH_HAVE_OPENMP
+      pthread_create(&threads[i], libmesh_nullptr, &run_body<Range, Body>, (void *)&range_bodies[i]);
+#else
+      run_body<Range, Body>((void *)&range_bodies[i]);
+#endif
+    }
+
+#if !LIBMESH_HAVE_OPENMP
+  // Wait for them to finish
+  for (unsigned int i=0; i<n_threads; i++)
+      pthread_join(threads[i], libmesh_nullptr);
+#endif
+
+  // Join them all down to the original Body
+  for (unsigned int i=n_threads-1; i != 0; i--)
+    bodies[i-1]->join(*bodies[i]);
+
+  // Clean up
+  for (unsigned int i=1; i<n_threads; i++)
+    delete bodies[i];
+  for (unsigned int i=0; i<n_threads; i++)
+    delete ranges[i];
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  if (libMesh::n_threads() > 1 && logging_was_enabled)
+    libMesh::perflog.enable_logging();
+#endif
+}
+
+/**
+ * Execute the provided reduction operation in parallel on the specified
+ * range with the specified partitioner.
+ */
+template <typename Range, typename Body, typename Partitioner>
+inline
+void parallel_reduce (const Range & range, Body & body, const Partitioner &)
+{
+  parallel_reduce(range, body);
+}
+
+
+/**
+ * Defines atomic operations which can only be executed on a
+ * single thread at a time.
+ */
+template <typename T>
+class atomic
+{
+public:
+  atomic () : val(0) {}
+  operator T () { return val; }
+
+  T operator=( T value )
+  {
+    spin_mutex::scoped_lock lock(smutex);
+    val = value;
+    return val;
+  }
+
+  atomic<T> & operator=( const atomic<T> & value )
+  {
+    spin_mutex::scoped_lock lock(smutex);
+    val = value;
+    return *this;
+  }
+
+
+  T operator+=(T value)
+  {
+    spin_mutex::scoped_lock lock(smutex);
+    val += value;
+    return val;
+  }
+
+  T operator-=(T value)
+  {
+    spin_mutex::scoped_lock lock(smutex);
+    val -= value;
+    return val;
+  }
+
+  T operator++()
+  {
+    spin_mutex::scoped_lock lock(smutex);
+    val++;
+    return val;
+  }
+
+  T operator++(int)
+  {
+    spin_mutex::scoped_lock lock(smutex);
+    val++;
+    return val;
+  }
+
+  T operator--()
+  {
+    spin_mutex::scoped_lock lock(smutex);
+    val--;
+    return val;
+  }
+
+  T operator--(int)
+  {
+    spin_mutex::scoped_lock lock(smutex);
+    val--;
+    return val;
+  }
+
+private:
+  T val;
+  spin_mutex smutex;
+};
+
+} // namespace Threads
+
+} // namespace libMesh
+
+#endif // #ifdef LIBMESH_HAVE_PTHREAD
+
+#endif // LIBMESH_THREADS_PTHREAD_H

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -45,16 +45,9 @@
 #  define LIBMESH_TLS_REF(value)  (value)
 #endif
 
-
-
 namespace libMesh
 {
 
-
-/**
- * The Threads namespace is for wrapper functions
- * for common general multithreading algorithms and tasks.
- */
 namespace Threads
 {
 
@@ -66,31 +59,12 @@ namespace Threads
 typedef std::thread Thread;
 
 #else
+
 /**
- * Simple compatibility class for std::thread 'concurrent' execution.
- * Not at all concurrent, but provides a compatible interface.
+ * Use the non-concurrent placeholder.
  */
-class Thread
-{
-public:
-  /**
-   * Constructor.  Takes a callable function object and executes it.
-   * Our wrapper class actually blocks execution until the thread
-   * is complete.
-   */
-  template <typename Callable>
-  Thread (Callable f) { f(); }
+typedef NonConcurrentThread Thread;
 
-  /**
-   * Join is a no-op, since the constructor blocked until completion.
-   */
-  void join() {}
-
-  /**
-   * Always joinable.
-   */
-  bool joinable() const { return true; }
-};
 #endif // LIBMESH_HAVE_CXX11_THREAD
 
 

--- a/include/parallel/threads_tbb.h
+++ b/include/parallel/threads_tbb.h
@@ -42,24 +42,21 @@
 #define TBB_VERSION_LESS_THAN(major,minor)                              \
   ((LIBMESH_DETECTED_TBB_VERSION_MAJOR < (major) ||                     \
     (LIBMESH_DETECTED_TBB_VERSION_MAJOR == (major) && (LIBMESH_DETECTED_TBB_VERSION_MINOR < (minor)))) ? 1 : 0)
-#endif
 
 // Thread-Local-Storage macros
 #define LIBMESH_TLS_TYPE(type)  tbb::enumerable_thread_specific<type>
 #define LIBMESH_TLS_REF(value)  (value).local()
 
-
 namespace libMesh
 {
 
-
-/**
- * The Threads namespace is for wrapper functions
- * for common general multithreading algorithms and tasks.
- */
 namespace Threads
 {
 
+/**
+ * Thread object abstraction that provides a basic constructor and
+ * support for join().
+ */
 typedef tbb::tbb_thread Thread;
 
 /**
@@ -217,7 +214,6 @@ typedef tbb::recursive_mutex recursive_mutex;
  */
 template <typename T>
 class atomic : public tbb::atomic<T> {};
-
 
 } // namespace Threads
 

--- a/include/parallel/threads_tbb.h
+++ b/include/parallel/threads_tbb.h
@@ -1,0 +1,228 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2016 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+#ifndef LIBMESH_THREADS_TBB_H
+#define LIBMESH_THREADS_TBB_H
+
+// Do not try to #include this header directly, it is designed to be
+// #included directly by threads.h
+#ifdef LIBMESH_HAVE_TBB_API
+
+// libMesh includes
+#include "libmesh/libmesh_logging.h"
+
+// Threading building blocks includes
+#include "tbb/tbb_stddef.h"
+#include "tbb/blocked_range.h"
+#include "tbb/parallel_for.h"
+#include "tbb/parallel_reduce.h"
+#include "tbb/task_scheduler_init.h"
+#include "tbb/partitioner.h"
+#include "tbb/spin_mutex.h"
+#include "tbb/recursive_mutex.h"
+#include "tbb/atomic.h"
+#include "tbb/tbb_thread.h"
+#include "tbb/enumerable_thread_specific.h"
+
+#define TBB_VERSION_LESS_THAN(major,minor)                              \
+  ((LIBMESH_DETECTED_TBB_VERSION_MAJOR < (major) ||                     \
+    (LIBMESH_DETECTED_TBB_VERSION_MAJOR == (major) && (LIBMESH_DETECTED_TBB_VERSION_MINOR < (minor)))) ? 1 : 0)
+#endif
+
+// Thread-Local-Storage macros
+#define LIBMESH_TLS_TYPE(type)  tbb::enumerable_thread_specific<type>
+#define LIBMESH_TLS_REF(value)  (value).local()
+
+
+namespace libMesh
+{
+
+
+/**
+ * The Threads namespace is for wrapper functions
+ * for common general multithreading algorithms and tasks.
+ */
+namespace Threads
+{
+
+typedef tbb::tbb_thread Thread;
+
+/**
+ * Scheduler to manage threads.
+ */
+typedef tbb::task_scheduler_init task_scheduler_init;
+
+/**
+ * Dummy "splitting object" used to distinguish splitting constructors
+ * from copy constructors.
+ */
+typedef tbb::split split;
+
+/**
+ * Execute the provided function object in parallel on the specified
+ * range.
+ */
+template <typename Range, typename Body>
+inline
+void parallel_for (const Range & range, const Body & body)
+{
+  BoolAcquire b(in_threads);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
+
+  if (libMesh::n_threads() > 1)
+    libMesh::perflog.disable_logging();
+#endif
+
+  if (libMesh::n_threads() > 1)
+    tbb::parallel_for (range, body, tbb::auto_partitioner());
+
+  else
+    body(range);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  if (libMesh::n_threads() > 1 && logging_was_enabled)
+    libMesh::perflog.enable_logging();
+#endif
+}
+
+
+
+/**
+ * Execute the provided function object in parallel on the specified
+ * range with the specified partitioner.
+ */
+template <typename Range, typename Body, typename Partitioner>
+inline
+void parallel_for (const Range & range, const Body & body, const Partitioner & partitioner)
+{
+  BoolAcquire b(in_threads);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
+
+  if (libMesh::n_threads() > 1)
+    libMesh::perflog.disable_logging();
+#endif
+
+  if (libMesh::n_threads() > 1)
+    tbb::parallel_for (range, body, partitioner);
+
+  else
+    body(range);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  if (libMesh::n_threads() > 1 && logging_was_enabled)
+    libMesh::perflog.enable_logging();
+#endif
+}
+
+
+
+/**
+ * Execute the provided reduction operation in parallel on the specified
+ * range.
+ */
+template <typename Range, typename Body>
+inline
+void parallel_reduce (const Range & range, Body & body)
+{
+  BoolAcquire b(in_threads);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
+
+  if (libMesh::n_threads() > 1)
+    libMesh::perflog.disable_logging();
+#endif
+
+  if (libMesh::n_threads() > 1)
+    tbb::parallel_reduce (range, body, tbb::auto_partitioner());
+
+  else
+    body(range);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  if (libMesh::n_threads() > 1 && logging_was_enabled)
+    libMesh::perflog.enable_logging();
+#endif
+}
+
+
+
+/**
+ * Execute the provided reduction operation in parallel on the specified
+ * range with the specified partitioner.
+ */
+template <typename Range, typename Body, typename Partitioner>
+inline
+void parallel_reduce (const Range & range, Body & body, const Partitioner & partitioner)
+{
+  BoolAcquire b(in_threads);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  const bool logging_was_enabled = libMesh::perflog.logging_enabled();
+
+  if (libMesh::n_threads() > 1)
+    libMesh::perflog.disable_logging();
+#endif
+
+  if (libMesh::n_threads() > 1)
+    tbb::parallel_reduce (range, body, partitioner);
+
+  else
+    body(range);
+
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
+  if (libMesh::n_threads() > 1 && logging_was_enabled)
+    libMesh::perflog.enable_logging();
+#endif
+}
+
+
+
+/**
+ * Spin mutex.  Implements mutual exclusion by busy-waiting in user
+ * space for the lock to be acquired.
+ */
+typedef tbb::spin_mutex spin_mutex;
+
+/**
+ * Recursive mutex.  Implements mutual exclusion by busy-waiting in user
+ * space for the lock to be acquired.  The same thread can aquire the
+ * same lock multiple times
+ */
+typedef tbb::recursive_mutex recursive_mutex;
+
+/**
+ * Defines atomic operations which can only be executed on a
+ * single thread at a time.  This is used in reference counting,
+ * for example, to allow count++/count-- to work.
+ */
+template <typename T>
+class atomic : public tbb::atomic<T> {};
+
+
+} // namespace Threads
+
+} // namespace libMesh
+
+#endif // LIBMESH_HAVE_TBB_API
+
+#endif // LIBMESH_THREADS_TBB_H

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -150,24 +150,18 @@ if (test "x$enableoptional" = "xyes"); then
   echo '     'version....................... : $netcdfversion
   fi
   echo '  'nlopt............................ : $enablenlopt
-  echo '  'openmp........................... : $enableopenmp
   echo '  'parmetis......................... : $enableparmetis
   echo '  'petsc............................ : $enablepetsc
   if (test "x$enablepetsc" = "xyes"); then
   echo '     'version....................... : $petscversion
   fi
-  echo '  'pthreads......................... : $enablepthreads
   echo '  'qhull............................ : $enableqhull
   echo '  'sfcurves......................... : $enablesfc
   echo '  'slepc............................ : $enableslepc
   if (test "x$enableslepc" = "xyes"); then
   echo '     'version....................... : $slepcversion
   fi
-  echo '  'tbb.............................. : $enabletbb
-  echo '  'c++ threads...................... : $enablecppthreads
-  if (test "x$enablecppthreads" = "xyes"); then
-  echo '     'flavor........................ : $cppthreadflavor
-  fi
+  echo '  'thread model..................... : $found_thread_model
   echo '  'c++ rtti ........................ : $ac_cv_cxx_rtti
   echo '  'tecio............................ : $enabletecio
   echo '  'tecplot...\(vendor binaries\)...... : $enabletecplot

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -305,7 +305,9 @@ AC_DEFUN([LIBMESH_TEST_CXX11_THREAD],
         @%:@include <thread>
         void my_thread_func() {}
       ]], [[
+        thread_local int i;
         std::thread t(my_thread_func);
+        t.join();
       ]])],[
         AC_MSG_RESULT(yes)
         AC_DEFINE(HAVE_CXX11_THREAD, 1, [Flag indicating whether compiler supports std::thread])
@@ -338,7 +340,7 @@ AC_DEFUN([LIBMESH_TEST_CXX11_TYPE_TRAITS],
         bool c = std::is_floating_point<char>::value;
       ]])],[
         AC_MSG_RESULT(yes)
-        AC_DEFINE(HAVE_CXX11_TYPE_TRAITS, 1, [Flag indicating whether compiler supports std::thread])
+        AC_DEFINE(HAVE_CXX11_TYPE_TRAITS, 1, [Flag indicating whether compiler supports <type_traits>])
         have_cxx11_type_traits=yes
       ],[
         AC_MSG_RESULT(no)

--- a/m4/libmesh_compiler_features.m4
+++ b/m4/libmesh_compiler_features.m4
@@ -193,40 +193,6 @@ AX_CXX_GLIBC_BACKTRACE
 
 
 
-# -------------------------------------------------------------
-# OpenMP Support  -- enabled by default
-# -------------------------------------------------------------
-AC_ARG_ENABLE(openmp,
-             AS_HELP_STRING([--disable-openmp],
-                            [Build without OpenMP Support]),
-             enableopenmp=$enableval,
-             enableopenmp=yes)
-if (test "$enableopenmp" != no) ; then
-   AX_OPENMP([],[enableopenmp=no])
-   #The above call only sets the flag for C++
-   if (test "x$OPENMP_CXXFLAGS" != x) ; then
-     AC_MSG_RESULT(<<< Configuring library with OpenMP support >>>)
-     OPENMP_CFLAGS=$OPENMP_CXXFLAGS
-     OPENMP_FFLAGS=$OPENMP_CXXFLAGS
-     CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
-     CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
-     CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
-     CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
-     CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
-     CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
-     CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
-     CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
-     CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
-     CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
-     FFLAGS="$FFLAGS $OPENMP_FFLAGS"
-   fi
-   AC_SUBST(OPENMP_CXXFLAGS)
-   AC_SUBST(OPENMP_CFLAGS)
-   AC_SUBST(OPENMP_FFLAGS)
-fi
-# -------------------------------------------------------------
-
-
 # See if this compiler has a broken errno_t in a very specific
 # situation (this is not common).
 CHECK_FOR_BROKEN_ERRNO_T

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -189,7 +189,7 @@ fi
 # Choose between TBB, OpenMP, and pthreads thread models.
 # The user can control this by configuring with
 #
-# --with-thread-model={tbb,openmp,pthread,auto}
+# --with-thread-model={tbb,pthread,auto,none}
 #
 # where "auto" will try to automatically detect the best possible
 # version (see threads.m4).

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -185,58 +185,16 @@ fi
 # -------------------------------------------------------------
 
 
-
 # -------------------------------------------------------------
-# Intel's Threading Building Blocks -- enabled by default
+# Choose between TBB, OpenMP, and pthreads thread models.
+# The user can control this by configuring with
+#
+# --with-thread-model={tbb,openmp,pthread,auto}
+#
+# where "auto" will try to automatically detect the best possible
+# version (see threads.m4).
 # -------------------------------------------------------------
-CONFIGURE_TBB
-if (test $enabletbb = yes); then
-  libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
-  libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
-fi
-# -------------------------------------------------------------
-
-# -------------------------------------------------------------
-# Pthread support -- enabled by default
-# -------------------------------------------------------------
-AC_ARG_ENABLE(pthreads,
-              AS_HELP_STRING([--disable-pthreads],
-                             [build without POSIX threading (pthreads) support]),
-              [case "${enableval}" in
-                yes)  enablepthreads=yes ;;
-                no)  enablepthreads=no ;;
-                *)  AC_MSG_ERROR(bad value ${enableval} for --enable-pthreads) ;;
-              esac],
-              [enablepthreads=$enableoptional])
-
-if (test "$enablepthreads" != no) ; then
-  AX_PTHREAD
-fi
-
-if (test x$ax_pthread_ok = xyes); then
-  AC_DEFINE(USING_THREADS, 1,
-            [Flag indicating whether the library shall be compiled to use any particular thread API.])
-  AC_MSG_RESULT(<<< Configuring library with pthread support >>>)
-  libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
-  libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
-else
-  enablepthreads=no
-fi
-# -------------------------------------------------------------
-
-
-# -------------------------------------------------------------
-# C++ Thread Support  -- enabled by default
-# -------------------------------------------------------------
-AC_ARG_ENABLE(cppthreads,
-             AS_HELP_STRING([--disable-cppthreads],
-                            [Build without C++ std::thread support]),
-             enablecppthreads=$enableval,
-             enablecppthreads=yes)
-if (test "$enablecppthreads" != no) ; then
-  ACX_BEST_THREAD
-fi
-# -------------------------------------------------------------
+ACX_BEST_THREAD
 
 
 

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -17,8 +17,7 @@ ac_cv_cxx_thread,
  AC_LANG_RESTORE
 ])
 if test "$ac_cv_cxx_thread" = yes; then
-  AC_DEFINE(HAVE_STD_THREAD,1,
-            [define if the compiler supports std::thread])
+  true
   [$1]
 else
   false
@@ -55,8 +54,7 @@ if test "x$enabletbb" = "xno"; then
 fi
 
 if test "$ac_cv_tbb_cxx_thread" = yes; then
-  AC_DEFINE(HAVE_TBB_CXX_THREAD,1,
-            [define if the compiler supports tbb::tbb_thread])
+  true
   [$1]
 else
   false

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -1,69 +1,4 @@
 # ------------------------------------------------------------------------------
-# Check to see if the compiler can compile a test program using
-# std::thread
-# ------------------------------------------------------------------------------
-AC_DEFUN([ACX_STD_THREAD],
-[AC_CACHE_CHECK(whether the compiler supports std::thread,
-ac_cv_cxx_thread,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([@%:@include <thread>],
-[
-  thread_local int i;
-  std::thread t;
-  t.join();
-],
- ac_cv_cxx_thread=yes, ac_cv_cxx_thread=no)
- AC_LANG_RESTORE
-])
-if test "$ac_cv_cxx_thread" = yes; then
-  true
-  [$1]
-else
-  false
-  [$2]
-fi
-])
-
-
-# ------------------------------------------------------------------------------
-# Check to see if the compiler can invoke the TBB to compile a
-# test program using tbb::tbb_thread
-# ------------------------------------------------------------------------------
-AC_DEFUN([ACX_TBB_STD_THREAD],
-[AC_CACHE_CHECK(whether TBB supports tbb::tbb_thread,
-ac_cv_tbb_cxx_thread,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- saveCXXFLAGS="$CXXFLAGS"
- CXXFLAGS="$TBB_INCLUDE"
- AC_TRY_COMPILE([@%:@include <tbb/tbb_thread.h>],
-[
-  tbb::tbb_thread t;
-  t.join();
-],
- ac_cv_tbb_cxx_thread=yes, ac_cv_tbb_cxx_thread=no)
- AC_LANG_RESTORE
-]
-CXXFLAGS="$saveCXXFLAGS"
-)
-
-# if we don't have functioning TBB avoid a false positive
-if test "x$enabletbb" = "xno"; then
-  ac_cv_tbb_cxx_thread=no
-fi
-
-if test "$ac_cv_tbb_cxx_thread" = yes; then
-  true
-  [$1]
-else
-  false
-  [$2]
-fi
-])
-
-
-# ------------------------------------------------------------------------------
 # Choose the best thread option available, if any
 # ------------------------------------------------------------------------------
 AC_DEFUN([ACX_BEST_THREAD],
@@ -81,6 +16,66 @@ AC_DEFUN([ACX_BEST_THREAD],
 
   AC_MSG_RESULT([User requested thread model: $requested_thread_model])
 
-  ACX_STD_THREAD([cppthreadflavor="std::thread"],
-                  ACX_TBB_STD_THREAD([cppthreadflavor="tbb::tbb_thread"], [enablecppthreads=no]))
+  # Set this variable when a threading model is found
+  found_thread_model=none
+
+  # Test different threading models, enabling only one.  For auto-detection, the
+  # ordering of the tests is:
+  # .) TBB
+  # .) OpenMP
+  # .) Pthread
+  if (test "x$requested_thread_model" = "xtbb" -o "x$requested_thread_model" = "xauto"); then
+    CONFIGURE_TBB
+
+    if (test $enabletbb = yes); then
+      libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
+      libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
+      found_thread_model=tbb
+      break
+    fi
+
+  elif (test "x$requested_thread_model" = "xopenmp" -o "x$requested_thread_model" = "xauto"); then
+    AX_OPENMP([],[enableopenmp=no])
+
+    # The above call only sets the flag for C++
+    if (test "x$OPENMP_CXXFLAGS" != x) ; then
+      AC_MSG_RESULT(<<< Configuring library with OpenMP support >>>)
+      OPENMP_CFLAGS=$OPENMP_CXXFLAGS
+      OPENMP_FFLAGS=$OPENMP_CXXFLAGS
+      CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
+      CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
+      CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
+      CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
+      CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
+      CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
+      CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
+      CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
+      CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
+      CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
+      FFLAGS="$FFLAGS $OPENMP_FFLAGS"
+      AC_SUBST(OPENMP_CXXFLAGS)
+      AC_SUBST(OPENMP_CFLAGS)
+      AC_SUBST(OPENMP_FFLAGS)
+      found_thread_model=openmp
+      break
+    fi
+
+  elif (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
+    AX_PTHREAD
+
+    if (test x$ax_pthread_ok = xyes); then
+      AC_DEFINE(USING_THREADS, 1,
+                [Flag indicating whether the library shall be compiled to use any particular thread API.])
+      AC_MSG_RESULT(<<< Configuring library with pthread support >>>)
+      libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
+      libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
+      found_thread_model=pthread
+      break
+    else
+      enablepthreads=no
+    fi
+
+  fi
+
+  AC_MSG_RESULT([Found thread model: $found_thread_model])
 ])

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -70,7 +70,19 @@ fi
 # ------------------------------------------------------------------------------
 AC_DEFUN([ACX_BEST_THREAD],
 [
-ACX_STD_THREAD([cppthreadflavor="std::thread"],
-ACX_TBB_STD_THREAD([cppthreadflavor="tbb::tbb_thread"],
-[enablecppthreads=no]))
+  AC_ARG_WITH(thread-model,
+              AS_HELP_STRING([--with-thread-model=tbb,openmp,pthread,auto],[Specify the thread model to use]),
+              [case "${withval}" in
+                tbb)     requested_thread_model=tbb     ;;
+                openmp)  requested_thread_model=openmp  ;;
+                pthread) requested_thread_model=pthread ;;
+                auto)    requested_thread_model=auto    ;;
+                *)       AC_MSG_ERROR(bad value ${withval} for --with-thread-model) ;;
+              esac],
+              requested_thread_model=auto)
+
+  AC_MSG_RESULT([User requested thread model: $requested_thread_model])
+
+  ACX_STD_THREAD([cppthreadflavor="std::thread"],
+                  ACX_TBB_STD_THREAD([cppthreadflavor="tbb::tbb_thread"], [enablecppthreads=no]))
 ])

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -26,33 +26,6 @@ else
 fi
 ])
 
-# ------------------------------------------------------------------------------
-# Check to see if the compiler can compile a test program using
-# pthreads
-# ------------------------------------------------------------------------------
-AC_DEFUN([ACX_PTHREAD],
-[AC_CACHE_CHECK(whether the compiler supports pthreads,
-ac_cv_pthread_thread,
-[AC_LANG_SAVE
- AC_LANG_CPLUSPLUS
- AC_TRY_COMPILE([@%:@include <pthread.h>],
-[
-  pthread_t thread;
-  pthread_join(thread, NULL);
-],
- ac_cv_pthread_thread=yes, ac_cv_pthread_thread=no)
- AC_LANG_RESTORE
-])
-if test "$ac_cv_pthread_thread" = yes; then
-  AC_DEFINE(HAVE_PTHREAD_THREAD,1,
-            [define if the compiler supports pthreads])
-  [$1]
-else
-  false
-  [$2]
-fi
-])
-
 
 # ------------------------------------------------------------------------------
 # Check to see if the compiler can invoke the TBB to compile a

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -8,6 +8,7 @@ AC_DEFUN([ACX_BEST_THREAD],
               [case "${withval}" in
                 tbb)     requested_thread_model=tbb     ;;
                 pthread) requested_thread_model=pthread ;;
+                pthreads) requested_thread_model=pthread ;;
                 auto)    requested_thread_model=auto    ;;
                 none)    requested_thread_model=none    ;;
                 *)       AC_MSG_ERROR(bad value ${withval} for --with-thread-model) ;;
@@ -37,17 +38,31 @@ AC_DEFUN([ACX_BEST_THREAD],
   # If TBB wasn't selected, try pthreads as long as the user requested it (or auto)
   if (test "$found_thread_model" = none) ; then
     if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
-      AX_PTHREAD
 
-      if (test x$ax_pthread_ok = xyes); then
-        AC_DEFINE(USING_THREADS, 1,
-                  [Flag indicating whether the library shall be compiled to use any particular thread API.])
-        AC_MSG_RESULT(<<< Configuring library with pthread support >>>)
-        libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
-        libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
-        found_thread_model=pthread
-      else
-        enablepthreads=no
+      # Let the user explicitly specify --{enable,disable}-pthreads.
+      AC_ARG_ENABLE(pthreads,
+                    AS_HELP_STRING([--disable-pthreads],
+                                   [build without POSIX threading (pthreads) support]),
+                    [case "${enableval}" in
+                      yes)  enablepthreads=yes ;;
+                      no)  enablepthreads=no ;;
+                      *)  AC_MSG_ERROR(bad value ${enableval} for --enable-pthreads) ;;
+                    esac],
+                    [enablepthreads=$enableoptional])
+
+      if (test "$enablepthreads" = yes) ; then
+        AX_PTHREAD
+
+        if (test x$ax_pthread_ok = xyes); then
+          AC_DEFINE(USING_THREADS, 1,
+                    [Flag indicating whether the library shall be compiled to use any particular thread API.])
+          AC_MSG_RESULT(<<< Configuring library with pthread support >>>)
+          libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
+          libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
+          found_thread_model=pthread
+        else
+          enablepthreads=no
+        fi
       fi
     fi
   fi

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -14,7 +14,7 @@ AC_DEFUN([ACX_BEST_THREAD],
               esac],
               requested_thread_model=auto)
 
-  AC_MSG_RESULT([User requested thread model: $requested_thread_model])
+  AC_MSG_RESULT([<<< User requested thread model: $requested_thread_model >>>])
 
   # Set this variable when a threading model is found
   found_thread_model=none

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -33,6 +33,13 @@ AC_DEFUN([ACX_BEST_THREAD],
       libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
       found_thread_model=tbb
     fi
+
+    # If TBB was not enabled, but the user requested it, we treat that as an error:
+    # we want to alert the user as soon as possible that their requested thread model
+    # could not be configured correctly.
+    if (test $enabletbb = no -a "x$requested_thread_model" = "xtbb"); then
+      AC_MSG_ERROR([requested threading model, TBB, could not be found.])
+    fi
   fi
 
   # If TBB wasn't selected, try pthreads as long as the user requested it (or auto)
@@ -63,6 +70,13 @@ AC_DEFUN([ACX_BEST_THREAD],
         else
           enablepthreads=no
         fi
+      fi
+
+      # If pthreads were not enabled, but the user requested it, we treat that as an error:
+      # we want to alert the user as soon as possible that their requested thread model
+      # could not be configured correctly.
+      if (test $enablepthreads = no -a "x$requested_thread_model" = "xpthread"); then
+        AC_MSG_ERROR([requested threading model, pthreads, could not be found.])
       fi
     fi
   fi

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -4,12 +4,12 @@
 AC_DEFUN([ACX_BEST_THREAD],
 [
   AC_ARG_WITH(thread-model,
-              AS_HELP_STRING([--with-thread-model=tbb,openmp,pthread,auto],[Specify the thread model to use]),
+              AS_HELP_STRING([--with-thread-model=tbb,pthread,auto,none],[Specify the thread model to use]),
               [case "${withval}" in
                 tbb)     requested_thread_model=tbb     ;;
-                openmp)  requested_thread_model=openmp  ;;
                 pthread) requested_thread_model=pthread ;;
                 auto)    requested_thread_model=auto    ;;
+                none)    requested_thread_model=none    ;;
                 *)       AC_MSG_ERROR(bad value ${withval} for --with-thread-model) ;;
               esac],
               requested_thread_model=auto)
@@ -34,32 +34,6 @@ AC_DEFUN([ACX_BEST_THREAD],
       break
     fi
 
-  elif (test "x$requested_thread_model" = "xopenmp" -o "x$requested_thread_model" = "xauto"); then
-    AX_OPENMP([],[enableopenmp=no])
-
-    # The above call only sets the flag for C++
-    if (test "x$OPENMP_CXXFLAGS" != x) ; then
-      AC_MSG_RESULT(<<< Configuring library with OpenMP support >>>)
-      OPENMP_CFLAGS=$OPENMP_CXXFLAGS
-      OPENMP_FFLAGS=$OPENMP_CXXFLAGS
-      CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
-      CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
-      CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
-      CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
-      CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
-      CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
-      CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
-      CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
-      CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
-      CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
-      FFLAGS="$FFLAGS $OPENMP_FFLAGS"
-      AC_SUBST(OPENMP_CXXFLAGS)
-      AC_SUBST(OPENMP_CFLAGS)
-      AC_SUBST(OPENMP_FFLAGS)
-      found_thread_model=openmp
-      break
-    fi
-
   elif (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
     AX_PTHREAD
 
@@ -74,8 +48,50 @@ AC_DEFUN([ACX_BEST_THREAD],
     else
       enablepthreads=no
     fi
-
   fi
 
-  AC_MSG_RESULT([Found thread model: $found_thread_model])
+  # OpenMP support -- enabled unless the user has requested no
+  # threading, or no valid threading models could be found.
+  #
+  # OpenMP can be enabled independently of whether we are using the
+  # TBB or pthread threading models.  The pthread parallel_for() and
+  # parallel_reduce() implementations use openmp pragmas directly,
+  # while the TBB implementation does not.  We do the test here simply
+  # because it makes sense to keep all the threading stuff together
+  # rather than spreading it out across different m4 files.
+  if (test "$found_thread_model" != none) ; then
+    AC_ARG_ENABLE(openmp,
+                  AS_HELP_STRING([--disable-openmp],
+                                 [Build without OpenMP Support]),
+                  enableopenmp=$enableval,
+                  enableopenmp=yes)
+
+    if (test "$enableopenmp" != no) ; then
+      AX_OPENMP([],[enableopenmp=no])
+
+      # The above call only sets the flag for C++
+      if (test "x$OPENMP_CXXFLAGS" != x) ; then
+        AC_MSG_RESULT(<<< Configuring library with OpenMP support >>>)
+        OPENMP_CFLAGS=$OPENMP_CXXFLAGS
+        OPENMP_FFLAGS=$OPENMP_CXXFLAGS
+        CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
+        CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
+        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
+        CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
+        CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
+        CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
+        CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
+        CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
+        CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
+        CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
+        FFLAGS="$FFLAGS $OPENMP_FFLAGS"
+        AC_SUBST(OPENMP_CXXFLAGS)
+        AC_SUBST(OPENMP_CFLAGS)
+        AC_SUBST(OPENMP_FFLAGS)
+        break
+      fi
+    fi
+  fi
+
+  AC_MSG_RESULT([<<< Found thread model: $found_thread_model >>>])
 ])

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -31,22 +31,24 @@ AC_DEFUN([ACX_BEST_THREAD],
       libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
       libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
       found_thread_model=tbb
-      break
     fi
+  fi
 
-  elif (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
-    AX_PTHREAD
+  # If TBB wasn't selected, try pthreads as long as the user requested it (or auto)
+  if (test "$found_thread_model" = none) ; then
+    if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
+      AX_PTHREAD
 
-    if (test x$ax_pthread_ok = xyes); then
-      AC_DEFINE(USING_THREADS, 1,
-                [Flag indicating whether the library shall be compiled to use any particular thread API.])
-      AC_MSG_RESULT(<<< Configuring library with pthread support >>>)
-      libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
-      libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
-      found_thread_model=pthread
-      break
-    else
-      enablepthreads=no
+      if (test x$ax_pthread_ok = xyes); then
+        AC_DEFINE(USING_THREADS, 1,
+                  [Flag indicating whether the library shall be compiled to use any particular thread API.])
+        AC_MSG_RESULT(<<< Configuring library with pthread support >>>)
+        libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
+        libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
+        found_thread_model=pthread
+      else
+        enablepthreads=no
+      fi
     fi
   fi
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -142,7 +142,11 @@ public:
     _periodic_boundaries(periodic_boundaries),
 #endif
     _mesh(mesh)
-  {}
+  {
+    // Clang detects that _dof_map is not used for anything (other
+    // than being initialized) so let's prevent that warning.
+    libmesh_ignore(_dof_map);
+  }
 
   void operator()(const ConstElemRange & range) const
   {

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -359,6 +359,16 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
     libMesh::libMeshPrivateData::_n_threads =
       libMesh::command_line_value (n_threads, 1);
 
+    // If there's no threading model active, force _n_threads==1
+#if !LIBMESH_USING_THREADS
+    if (libMesh::libMeshPrivateData::_n_threads != 1)
+      {
+        libMesh::libMeshPrivateData::_n_threads = 1;
+        libmesh_warning("Warning: You requested --n-threads>1 but no threading model is active!\n"
+                        << "Forcing --n-threads==1 instead!");
+      }
+#endif
+
     // Set the number of OpenMP threads to the same as the number of threads libMesh is going to use
 #ifdef LIBMESH_HAVE_OPENMP
     omp_set_num_threads(libMesh::libMeshPrivateData::_n_threads);

--- a/src/parallel/threads.C
+++ b/src/parallel/threads.C
@@ -21,10 +21,6 @@
 // Local Includes
 #include "libmesh/threads.h"
 
-#if LIBMESH_HAVE_OPENMP
-#include <omp.h>
-#endif
-
 namespace libMesh
 {
 


### PR DESCRIPTION
This PR is designed to hopefully make it easier to understand threads.h by moving all the interleaved #ifdefs into separate files, and forcing only one threading "model" to be active at a time.  We currently support two real threading models and one fallback model:

* TBB
* pthreads
* none

OpenMP is also still supported, but is not a full model in the same way that the others are.  The current implementation is the same as the old one: OpenMP pragmas are used in the `parallel_for()` and `parallel_reduce()` implementations of pthreads, and are not used in the TBB model at all.  I've tested this locally, and it works with MOOSE in all three modes, but it is a pretty big change so it would be good if others could take a look/comment as well...

Refs #838.