### PR TITLE
Add a bit of delay to PetscVector::_get_array

### DIFF
--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1368,7 +1368,11 @@ void PetscVector<T>::_get_array() const
             _last = static_cast<numeric_index_type>(petsc_last);
           }
 
-          _array_is_present = true;
+	  // Ok, I know this is funky.  What we're trying to do is delay
+	  // setting _array_is_present until the values of _first and _last
+	  // have been proagated to the other processors when doing threading.
+	  // See the discussion here: https://github.com/idaholab/moose/issues/6436
+          _array_is_present = std::cos(_first) + std::sin(_last) + 10;
         }
     }
 }


### PR DESCRIPTION
Ok - look... I'm not crazy... and this DOES work.  I ran hundreds of thousands of tests to prove it.

The deal is that we need to delay setting `_array_is_present = true` until the values of `_first` and `_last` have had time to propagate to the other processors.  I brainstormed some ideas with people around here and this is the best we could come up with... making `_array_is_present` depend on the values of complex functions called with `_first` and `_last` as arguments will ensure that `_array_is_present` could never get set to `true` before there has been plenty of time for the memory subsystem to propagate those values.

This looks like it would slow things down... but actually, this only happens on the first access out of thousands/millions... so it's a fairly rare event and we're only adding a few flops to that one line.  It should definitely be faster than doing any locking or most likely even memory fences.

Let's have a healthy discussion about this.  I know it looks like a hack... but it works.

Later, when we switch to C++11 we can investigate adding memory fences here as a permanent/true fix.  Without C++11 the only alternatives would be INCREDIBLY slow.

refs idaholab/moose#6436