### PR TITLE
Enhance configure test of C++11 threads.

### DIFF
--- a/configure
+++ b/configure
@@ -8789,6 +8789,8 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 /* end confdefs.h.  */
 
         #include <thread>
+        #include <atomic>
+        #include <mutex>
         void my_thread_func() {}
 
 int
@@ -8798,6 +8800,17 @@ main ()
         thread_local int i;
         std::thread t(my_thread_func);
         t.join();
+
+        std::atomic<bool> ab1, ab2;
+        ab1.store(true, std::memory_order_relaxed);
+        ab2.store(false, std::memory_order_relaxed);
+        ab1.exchange(ab2);
+
+        std::mutex m;
+        std::lock_guard<std::mutex> lock(m);
+
+        std::atomic_thread_fence(std::memory_order_acquire);
+        std::atomic_thread_fence(std::memory_order_release);
 
   ;
   return 0;

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -303,11 +303,24 @@ AC_DEFUN([LIBMESH_TEST_CXX11_THREAD],
 
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
         @%:@include <thread>
+        @%:@include <atomic>
+        @%:@include <mutex>
         void my_thread_func() {}
       ]], [[
         thread_local int i;
         std::thread t(my_thread_func);
         t.join();
+
+        std::atomic<bool> ab1, ab2;
+        ab1.store(true, std::memory_order_relaxed);
+        ab2.store(false, std::memory_order_relaxed);
+        ab1.exchange(ab2);
+
+        std::mutex m;
+        std::lock_guard<std::mutex> lock(m);
+
+        std::atomic_thread_fence(std::memory_order_acquire);
+        std::atomic_thread_fence(std::memory_order_release);
       ]])],[
         AC_MSG_RESULT(yes)
         AC_DEFINE(HAVE_CXX11_THREAD, 1, [Flag indicating whether compiler supports std::thread])


### PR DESCRIPTION
With the new code introduced by 01072ba, we need to be sure the
compiler supports several things, including:

* std::atomic
* std::mutex
* std::atomic::store()
* std::atomic::exchange()
* std::atomic_thread_fence
* std::memory_order_acquire
* std::memory_order_release
* std::memory_order_relaxed
* std::lock_guard<T>

Refs #856.