### PR TITLE
Add -rpath flags to $LIBS for VTK autoconf tests.

### DIFF
--- a/configure
+++ b/configure
@@ -38349,8 +38349,6 @@ _ACEOF
        fi
 
        if (test x$enablevtk = xyes); then
-
-
                   old_LIBS="$LIBS"
          old_CPPFLAGS="$CPPFLAGS"
 
@@ -38394,7 +38392,7 @@ _ACEOF
                                    -lvtkIOImage -lvtkImagingMath -lvtkIOParallelXML"
          fi
 
-                                             if (test $vtkmajor -gt 5); then
+                           if (test $vtkmajor -gt 5); then
            CPPFLAGS="$CPPFLAGS -I$VTK_INC"
 
                       LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY_NO_VERSION"
@@ -38483,7 +38481,7 @@ $as_echo "<<< Linking a test program against the VTK libraries failed >>>" >&6; 
            LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY"
            CPPFLAGS="$CPPFLAGS -I$VTK_INC"
 
-           { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkIO" >&5
+                      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkIO" >&5
 $as_echo_n "checking for main in -lvtkIO... " >&6; }
 if ${ac_cv_lib_vtkIO_main+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -38518,7 +38516,6 @@ if test "x$ac_cv_lib_vtkIO_main" = xyes; then :
 else
   enablevtk=no
 fi
-ac_cv_lib_vtkIO=ac_cv_lib_vtkIO_main
 
 
            if (test $enablevtk = yes); then
@@ -38557,7 +38554,6 @@ if test "x$ac_cv_lib_vtkCommon_main" = xyes; then :
 else
   enablevtk=no
 fi
-ac_cv_lib_vtkCommon=ac_cv_lib_vtkCommon_main
 
            fi
 
@@ -38597,7 +38593,6 @@ if test "x$ac_cv_lib_vtkFiltering_main" = xyes; then :
 else
   enablevtk=no
 fi
-ac_cv_lib_vtkFiltering=ac_cv_lib_vtkFiltering_main
 
            fi
 

--- a/configure
+++ b/configure
@@ -38354,6 +38354,18 @@ _ACEOF
                   old_LIBS="$LIBS"
          old_CPPFLAGS="$CPPFLAGS"
 
+         # If this compiler supports -rpath commands, create a
+         # variable for them now that can be used in $LIBS below.  We
+         # ran across an issue where GCC's linker actually needed
+         # -rpath flags in order to *link* a test program.  From the
+         # man page for GNU ld:
+         #   The -rpath option is also used when locating shared objects
+         #   which are needed by shared objects explicitly included in
+         #   the link; see the description of the -rpath-link option.
+         if (test "x$RPATHFLAG" != "x" -a -d $VTK_LIB); then
+           VTK_RPATH_FLAGS="${RPATHFLAG}${VTK_LIB}"
+         fi
+
                   if (test $vtkmajor -eq 5); then
            VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
 
@@ -38385,7 +38397,7 @@ _ACEOF
                                              if (test $vtkmajor -gt 5); then
            CPPFLAGS="$CPPFLAGS -I$VTK_INC"
 
-                      LIBS="$old_LIBS $VTK_LIBRARY_NO_VERSION"
+                      LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY_NO_VERSION"
            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -38422,7 +38434,7 @@ rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
                       if (test x$enablevtk = xno); then
-             LIBS="$old_LIBS $VTK_LIBRARY_WITH_VERSION"
+             LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY_WITH_VERSION"
              cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -38468,7 +38480,7 @@ $as_echo "<<< Linking a test program against the VTK libraries failed >>>" >&6; 
            CPPFLAGS="$old_CPPFLAGS"
 
                   else
-           LIBS="$old_LIBS $VTK_LIBRARY"
+           LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY"
            CPPFLAGS="$CPPFLAGS -I$VTK_INC"
 
            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkIO" >&5

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -143,11 +143,6 @@ AC_DEFUN([CONFIGURE_VTK],
        fi
 
        if (test x$enablevtk = xyes); then
-         dnl Also Check for existence of required libraries.
-
-         dnl AC_HAVE_LIBRARY (library, [action-if-found], [action-if-not-found], [other-libraries])
-         dnl Note: Basically tries to compile a function which calls main().
-
          dnl Save original value of LIBS, then append $VTK_LIB
          old_LIBS="$LIBS"
          old_CPPFLAGS="$CPPFLAGS"
@@ -196,9 +191,7 @@ AC_DEFUN([CONFIGURE_VTK],
          fi
 
          dnl Try to compile test prog to check for existence of VTK libraries.
-         dnl AC_LINK_IFELSE uses the LIBS variable.  Note that we cannot use
-         dnl AC_HAVE_LIBRARY here because its first argument must be a literal
-         dnl string.
+         dnl AC_LINK_IFELSE uses the LIBS variable.
          if (test $vtkmajor -gt 5); then
            CPPFLAGS="$CPPFLAGS -I$VTK_INC"
 
@@ -232,15 +225,16 @@ AC_DEFUN([CONFIGURE_VTK],
            LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY"
            CPPFLAGS="$CPPFLAGS -I$VTK_INC"
 
-           AC_HAVE_LIBRARY([vtkIO], [enablevtk=yes], [enablevtk=no], [-lvtkCommon -lvtkFiltering -lvtkImaging])
+           dnl AC_CHECK_LIB (library, function, [action-if-found], [action-if-not-found], [other-libraries])
+           AC_CHECK_LIB([vtkIO], main, [enablevtk=yes], [enablevtk=no], [-lvtkCommon -lvtkFiltering -lvtkImaging])
 
            if (test $enablevtk = yes); then
-             AC_HAVE_LIBRARY([vtkCommon], [enablevtk=yes], [enablevtk=no])
+             AC_CHECK_LIB([vtkCommon], main, [enablevtk=yes], [enablevtk=no])
            fi
 
            dnl As of VTK 5.4 it seems we also need vtkFiltering
            if (test $enablevtk = yes); then
-             AC_HAVE_LIBRARY([vtkFiltering], [enablevtk=yes], [enablevtk=no])
+             AC_CHECK_LIB([vtkFiltering], main, [enablevtk=yes], [enablevtk=no])
            fi
 
            dnl Reset $LIBS, $CPPFLAGS

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -152,6 +152,18 @@ AC_DEFUN([CONFIGURE_VTK],
          old_LIBS="$LIBS"
          old_CPPFLAGS="$CPPFLAGS"
 
+         # If this compiler supports -rpath commands, create a
+         # variable for them now that can be used in $LIBS below.  We
+         # ran across an issue where GCC's linker actually needed
+         # -rpath flags in order to *link* a test program.  From the
+         # man page for GNU ld:
+         #   The -rpath option is also used when locating shared objects
+         #   which are needed by shared objects explicitly included in
+         #   the link; see the description of the -rpath-link option.
+         if (test "x$RPATHFLAG" != "x" -a -d $VTK_LIB); then
+           VTK_RPATH_FLAGS="${RPATHFLAG}${VTK_LIB}"
+         fi
+
          dnl VTK 5.x
          if (test $vtkmajor -eq 5); then
            VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
@@ -191,7 +203,7 @@ AC_DEFUN([CONFIGURE_VTK],
            CPPFLAGS="$CPPFLAGS -I$VTK_INC"
 
            dnl 1. First try linking the NO_VERSION library names
-           LIBS="$old_LIBS $VTK_LIBRARY_NO_VERSION"
+           LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY_NO_VERSION"
            AC_LINK_IFELSE([AC_LANG_PROGRAM([_AX_CXX_COMPILE_VTK_preamble],[_AX_CXX_COMPILE_VTK_body])],
                           [enablevtk=yes
                            VTK_LIBRARY=$VTK_LIBRARY_NO_VERSION],
@@ -199,7 +211,7 @@ AC_DEFUN([CONFIGURE_VTK],
 
            dnl 2. If that didn't work, try linking the library names with version numbers.
            if (test x$enablevtk = xno); then
-             LIBS="$old_LIBS $VTK_LIBRARY_WITH_VERSION"
+             LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY_WITH_VERSION"
              AC_LINK_IFELSE([AC_LANG_PROGRAM([_AX_CXX_COMPILE_VTK_preamble],[_AX_CXX_COMPILE_VTK_body])],
                             [enablevtk=yes
                              VTK_LIBRARY=$VTK_LIBRARY_WITH_VERSION],
@@ -217,7 +229,7 @@ AC_DEFUN([CONFIGURE_VTK],
 
          dnl Check for VTK 5.x libraries
          else
-           LIBS="$old_LIBS $VTK_LIBRARY"
+           LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY"
            CPPFLAGS="$CPPFLAGS -I$VTK_INC"
 
            AC_HAVE_LIBRARY([vtkIO], [enablevtk=yes], [enablevtk=no], [-lvtkCommon -lvtkFiltering -lvtkImaging])


### PR DESCRIPTION
This should fix the issue raised by Harshad (and apparently also Vasileios Vavourakis) where some VTK builds would fail to link the autoconf test program.

It could be related to the cmake flag `-DCMAKE_BUILD_TYPE=Release` which we seem to have always used in our VTK builds, but Harshad did not have in his.

Refs libmesh-users [thread](https://sourceforge.net/p/libmesh/mailman/libmesh-users/thread/CAC0ZLSo4R94ZUoFUfbjymqKvq6z8v%2BV_oqX8fZ3Mzpkzwikz5g%40mail.gmail.com/#msg34915953).
