### PR TITLE
Free communicators created by split()

### DIFF
--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -581,6 +581,7 @@ inline void Communicator::split(int color, int key, Communicator & target) const
     (MPI_Comm_split(this->get(), color, key, &newcomm));
 
   target.assign(newcomm);
+  target._I_duped_it = true;
   target.send_mode(this->send_mode());
 }
 #else

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -25,6 +25,7 @@ public:
   CPPUNIT_TEST( testIsendRecv );
   CPPUNIT_TEST( testIrecvSend );
   CPPUNIT_TEST( testSemiVerify );
+  CPPUNIT_TEST( testSplit );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -278,6 +279,15 @@ public:
     inf = -std::numeric_limits<double>::infinity();
 
     CPPUNIT_ASSERT (TestCommWorld->semiverify(infptr));
+  }
+
+
+  void testSplit ()
+  {
+    Parallel::Communicator subcomm;
+    unsigned int rank = TestCommWorld->rank();
+    unsigned int color = rank % 2;
+    TestCommWorld->split(color, rank, subcomm);
   }
 
 


### PR DESCRIPTION
Fix for a bug discovered by @manavbhatia, plus a new unit test which will slightly exercise that code.