### PR TITLE
OrderWrapper shim class to enable arbitrary FE orders

### DIFF
--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -118,7 +118,7 @@ public:
    * The number of components of this variable.
    */
   unsigned int n_components() const
-  { return type().family == SCALAR ? _type.order : 1; }
+  { return type().family == SCALAR ? _type.order.get_order() : 1; }
 
   /**
    * \p returns \p true if this variable is active on subdomain \p sid,

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -73,15 +73,6 @@ public:
   }
 
   /**
-   * Operator that enables implicit conversion to
-   * an int.
-   */
-  operator int() const
-  {
-    return _order;
-  }
-
-  /**
    * Explicity request the order as an int.
    */
   int get_order() const

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -99,6 +99,48 @@ inline bool operator> (const OrderWrapper& lhs, const OrderWrapper& rhs){ return
 inline bool operator<=(const OrderWrapper& lhs, const OrderWrapper& rhs){ return !(lhs > rhs); }
 inline bool operator>=(const OrderWrapper& lhs, const OrderWrapper& rhs){ return !(lhs < rhs); }
 
+// First disambiguate everything that would be ambiguated by the
+// subsequent disambiguations
+inline bool operator==(int lhs, Order rhs){ return lhs == static_cast<int>(rhs); }
+inline bool operator==(Order lhs, int rhs){ return static_cast<int>(lhs) == rhs; }
+inline bool operator!=(int lhs, Order rhs){ return !(lhs == rhs); }
+inline bool operator!=(Order lhs, int rhs){ return !(lhs == rhs); }
+inline bool operator< (int lhs, Order rhs){ return lhs < static_cast<int>(rhs); }
+inline bool operator< (Order lhs, int rhs){ return static_cast<int>(lhs) < rhs; }
+inline bool operator> (int lhs, Order rhs){ return rhs < lhs; }
+inline bool operator> (Order lhs, int rhs){ return rhs < lhs; }
+inline bool operator<=(int lhs, Order rhs){ return !(lhs > rhs); }
+inline bool operator<=(Order lhs, int rhs){ return !(lhs > rhs); }
+inline bool operator>=(int lhs, Order rhs){ return !(lhs < rhs); }
+inline bool operator>=(Order lhs, int rhs){ return !(lhs < rhs); }
+
+
+// Now disambiguate all the things
+inline bool operator==(int lhs, const OrderWrapper& rhs){ return lhs == rhs.get_order(); }
+inline bool operator==(const OrderWrapper& lhs, int rhs){ return lhs.get_order() == rhs; }
+inline bool operator==(Order lhs, const OrderWrapper& rhs){ return lhs == rhs.get_order(); }
+inline bool operator==(const OrderWrapper& lhs, Order rhs){ return lhs.get_order() == rhs; }
+inline bool operator!=(int lhs, const OrderWrapper& rhs){ return !(lhs == rhs); }
+inline bool operator!=(const OrderWrapper& lhs, int rhs){ return !(lhs == rhs); }
+inline bool operator!=(Order lhs, const OrderWrapper& rhs){ return !(lhs == rhs); }
+inline bool operator!=(const OrderWrapper& lhs, Order rhs){ return !(lhs == rhs); }
+inline bool operator< (int lhs, const OrderWrapper& rhs){ return lhs < rhs.get_order(); }
+inline bool operator< (const OrderWrapper& lhs, int rhs){ return lhs.get_order() < rhs; }
+inline bool operator< (Order lhs, const OrderWrapper& rhs){ return lhs < rhs.get_order(); }
+inline bool operator< (const OrderWrapper& lhs, Order rhs){ return lhs.get_order() < rhs; }
+inline bool operator> (int lhs, const OrderWrapper& rhs){ return rhs < lhs; }
+inline bool operator> (const OrderWrapper& lhs, int rhs){ return rhs < lhs; }
+inline bool operator> (Order lhs, const OrderWrapper& rhs){ return rhs < lhs; }
+inline bool operator> (const OrderWrapper& lhs, Order rhs){ return rhs < lhs; }
+inline bool operator<=(int lhs, const OrderWrapper& rhs){ return !(lhs > rhs); }
+inline bool operator<=(const OrderWrapper& lhs, int rhs){ return !(lhs > rhs); }
+inline bool operator<=(Order lhs, const OrderWrapper& rhs){ return !(lhs > rhs); }
+inline bool operator<=(const OrderWrapper& lhs, Order rhs){ return !(lhs > rhs); }
+inline bool operator>=(int lhs, const OrderWrapper& rhs){ return !(lhs < rhs); }
+inline bool operator>=(const OrderWrapper& lhs, int rhs){ return !(lhs < rhs); }
+inline bool operator>=(Order lhs, const OrderWrapper& rhs){ return !(lhs < rhs); }
+inline bool operator>=(const OrderWrapper& lhs, Order rhs){ return !(lhs < rhs); }
+
 /**
  * Overload stream operators.
  */

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -98,6 +98,24 @@ private:
 
 };
 
+/**
+ * Overload comparison operators for OrderWrapper.
+ */
+inline bool operator==(const OrderWrapper& lhs, const OrderWrapper& rhs){ return lhs.get_order() == rhs.get_order(); }
+inline bool operator!=(const OrderWrapper& lhs, const OrderWrapper& rhs){ return !(lhs == rhs); }
+inline bool operator< (const OrderWrapper& lhs, const OrderWrapper& rhs){ return lhs.get_order() < rhs.get_order(); }
+inline bool operator> (const OrderWrapper& lhs, const OrderWrapper& rhs){ return rhs < lhs; }
+inline bool operator<=(const OrderWrapper& lhs, const OrderWrapper& rhs){ return !(lhs > rhs); }
+inline bool operator>=(const OrderWrapper& lhs, const OrderWrapper& rhs){ return !(lhs < rhs); }
+
+/**
+ * Overload stream operators.
+ */
+inline std::ostream & operator << (std::ostream & os, const OrderWrapper& order)
+{
+  os << order.get_order();
+  return os;
+}
 
 /**
  * class FEType hides (possibly multiple) FEFamily and approximation
@@ -169,12 +187,12 @@ public:
   /**
    * The approximation order in radial direction of the infinite element.
    */
-  Order order;
+  OrderWrapper order;
 
   /**
    * The approximation order in the base of the infinite element.
    */
-  Order radial_order;
+  OrderWrapper radial_order;
 
   /**
    * The type of approximation in radial direction.  Valid types are
@@ -272,7 +290,7 @@ private:
 inline
 Order FEType::default_quadrature_order () const
 {
-  return static_cast<Order>(2*static_cast<unsigned int>(order) + 1);
+  return static_cast<Order>(2*static_cast<unsigned int>(order.get_order()) + 1);
 }
 
 } // namespace libMesh

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -35,6 +35,69 @@ namespace libMesh
 // Forward declarations
 class QBase;
 
+/**
+ * This provides a shim class that wraps the Order enum.
+ * The purpose of this is to store the order as an int
+ * instead of an enum (to enable higher orders) while
+ * retaining backwards compatibility.
+ */
+class OrderWrapper
+{
+public:
+
+  /**
+   * Constructor. Enables implicit conversion from an Order
+   * enum to an OrderWrapper.
+   */
+  OrderWrapper(Order order)
+  :
+    _order(static_cast<int>(order))
+  {}
+
+  /**
+   * Constructor. Enables implicit conversion from an int
+   * to an OrderWrapper.
+   */
+  OrderWrapper(int order)
+  :
+    _order(order)
+  {}
+
+  /**
+   * Operator that enables implicit conversion to
+   * an Order enum.
+   */
+  operator Order() const
+  {
+    return static_cast<Order>(_order);
+  }
+
+  /**
+   * Operator that enables implicit conversion to
+   * an int.
+   */
+  operator int() const
+  {
+    _order;
+  }
+
+  /**
+   * Explicity request the order as an int.
+   */
+  int get_order() const
+  {
+    return _order;
+  }
+
+private:
+
+  /**
+   * The approximation order of the element.
+   */
+  int _order;
+
+};
+
 
 /**
  * class FEType hides (possibly multiple) FEFamily and approximation
@@ -56,13 +119,23 @@ public:
     family(f)
   {}
 
+  /**
+   * Constructor.  Same as above except the order is specified as
+   * an int.
+   */
+  FEType(const int      o = 1,
+         const FEFamily f = LAGRANGE) :
+    order(o),
+    family(f)
+  {}
+
 
   //TODO:[BSK] Could these data types all be const?
   // [RHS] Order can't in the case of p refinement!
   /**
    * The approximation order of the element.
    */
-  Order order;
+  OrderWrapper order;
 
   /**
    * The type of finite element.  Valid types are \p LAGRANGE,

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -22,6 +22,7 @@
 
 // Local includes
 #include "libmesh/auto_ptr.h"
+#include "libmesh/compare_types.h"
 #include "libmesh/libmesh_config.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_fe_family.h"
@@ -101,18 +102,35 @@ inline bool operator>=(const OrderWrapper& lhs, const OrderWrapper& rhs){ return
 
 // First disambiguate everything that would be ambiguated by the
 // subsequent disambiguations
-inline bool operator==(int lhs, Order rhs){ return lhs == static_cast<int>(rhs); }
-inline bool operator==(Order lhs, int rhs){ return static_cast<int>(lhs) == rhs; }
-inline bool operator!=(int lhs, Order rhs){ return !(lhs == rhs); }
-inline bool operator!=(Order lhs, int rhs){ return !(lhs == rhs); }
-inline bool operator< (int lhs, Order rhs){ return lhs < static_cast<int>(rhs); }
-inline bool operator< (Order lhs, int rhs){ return static_cast<int>(lhs) < rhs; }
-inline bool operator> (int lhs, Order rhs){ return rhs < lhs; }
-inline bool operator> (Order lhs, int rhs){ return rhs < lhs; }
-inline bool operator<=(int lhs, Order rhs){ return !(lhs > rhs); }
-inline bool operator<=(Order lhs, int rhs){ return !(lhs > rhs); }
-inline bool operator>=(int lhs, Order rhs){ return !(lhs < rhs); }
-inline bool operator>=(Order lhs, int rhs){ return !(lhs < rhs); }
+#define OrderWrapperOperators(comparisontype) \
+inline bool operator==(comparisontype lhs, Order rhs) \
+{ return lhs == static_cast<comparisontype>(rhs); } \
+inline bool operator==(Order lhs, comparisontype rhs) \
+{ return static_cast<comparisontype>(lhs) == rhs; } \
+inline bool operator!=(comparisontype lhs, Order rhs) \
+{ return !(lhs == rhs); } \
+inline bool operator!=(Order lhs, comparisontype rhs) \
+{ return !(lhs == rhs); } \
+inline bool operator< (comparisontype lhs, Order rhs) \
+{ return lhs < static_cast<comparisontype>(rhs); } \
+inline bool operator< (Order lhs, comparisontype rhs) \
+{ return static_cast<comparisontype>(lhs) < rhs; } \
+inline bool operator> (comparisontype lhs, Order rhs) \
+{ return rhs < lhs; } \
+inline bool operator> (Order lhs, comparisontype rhs) \
+{ return rhs < lhs; } \
+inline bool operator<=(comparisontype lhs, Order rhs) \
+{ return !(lhs > rhs); } \
+inline bool operator<=(Order lhs, comparisontype rhs) \
+{ return !(lhs > rhs); } \
+inline bool operator>=(comparisontype lhs, Order rhs) \
+{ return !(lhs < rhs); } \
+inline bool operator>=(Order lhs, comparisontype rhs) \
+{ return !(lhs < rhs); }
+
+OrderWrapperOperators(int)
+OrderWrapperOperators(unsigned int)
+OrderWrapperOperators(std::size_t)
 
 
 // Now disambiguate all the things

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -163,7 +163,7 @@ public:
    */
   FEType(const int        o  = 1,
          const FEFamily   f  = LAGRANGE,
-         const Order      ro = THIRD,
+         const int        ro = THIRD,
          const FEFamily   rf = JACOBI_20_00,
          const InfMapType im = CARTESIAN) :
     order(o),

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -78,7 +78,7 @@ public:
    */
   operator int() const
   {
-    _order;
+    return _order;
   }
 
   /**

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -131,16 +131,6 @@ public:
    * Constructor.  Optionally takes the approximation \p Order
    * and the finite element family \p FEFamily
    */
-  FEType(const Order    o = FIRST,
-         const FEFamily f = LAGRANGE) :
-    order(o),
-    family(f)
-  {}
-
-  /**
-   * Constructor.  Same as above except the order is specified as
-   * an int.
-   */
   FEType(const int      o = 1,
          const FEFamily f = LAGRANGE) :
     order(o),
@@ -171,7 +161,7 @@ public:
    * so, otherwise what we switch on would change when infinite
    * elements are not compiled in.
    */
-  FEType(const Order      o  = FIRST,
+  FEType(const int        o  = 1,
          const FEFamily   f  = LAGRANGE,
          const Order      ro = THIRD,
          const FEFamily   rf = JACOBI_20_00,
@@ -182,7 +172,6 @@ public:
     radial_family(rf),
     inf_map(im)
   {}
-
 
   /**
    * The approximation order in radial direction of the infinite element.

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -550,7 +550,7 @@ void DofMap::reinit(MeshBase & mesh)
       // Just increment _n_SCALAR_dofs
       if(base_fe_type.family == SCALAR)
         {
-          this->_n_SCALAR_dofs += base_fe_type.order*n_var_in_group;
+          this->_n_SCALAR_dofs += base_fe_type.order.get_order()*n_var_in_group;
           continue;
         }
 
@@ -585,7 +585,7 @@ void DofMap::reinit(MeshBase & mesh)
               FEInterface::max_order(base_fe_type, type))
             {
 #  ifdef DEBUG
-              if (FEInterface::max_order(base_fe_type,type) < static_cast<unsigned int>(base_fe_type.order))
+              if (FEInterface::max_order(base_fe_type,type) < static_cast<unsigned int>(base_fe_type.order.get_order()))
                 libmesh_error_msg("ERROR: Finite element "              \
                                   << Utility::enum_to_string(base_fe_type.family) \
                                   << " on geometric element "           \
@@ -991,7 +991,7 @@ void DofMap::distribute_dofs (MeshBase & mesh)
     if(this->variable(v).type().family == SCALAR)
       {
         _first_scalar_df[v] = current_SCALAR_dof_index;
-        current_SCALAR_dof_index += this->variable(v).type().order;
+        current_SCALAR_dof_index += this->variable(v).type().order.get_order();
       }
 
   STOP_LOG("distribute_dofs()", "DofMap");
@@ -1212,7 +1212,7 @@ void DofMap::distribute_local_dofs_node_major(dof_id_type & next_free_dof,
       if( vg_description.type().family == SCALAR )
         {
           this->_n_SCALAR_dofs += (vg_description.n_variables()*
-                                   vg_description.type().order);
+                                   vg_description.type().order.get_order());
           continue;
         }
     }
@@ -1362,7 +1362,7 @@ void DofMap::distribute_local_dofs_var_major(dof_id_type & next_free_dof,
       if( vg_description.type().family == SCALAR )
         {
           this->_n_SCALAR_dofs += (vg_description.n_variables()*
-                                   vg_description.type().order);
+                                   vg_description.type().order.get_order());
           continue;
         }
     }
@@ -2109,7 +2109,7 @@ void DofMap::SCALAR_dof_indices (std::vector<dof_id_type> & di,
   libmesh_assert_not_equal_to(my_idx, DofObject::invalid_id);
 
   // The number of SCALAR dofs comes from the variable order
-  const int n_dofs_vn = this->variable(vn).type().order;
+  const int n_dofs_vn = this->variable(vn).type().order.get_order();
 
   di.resize(n_dofs_vn);
   for(int i = 0; i != n_dofs_vn; ++i)

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -106,7 +106,7 @@ void InfFE<Dim,T_radial,T_map>:: attach_quadrature_rule (QBase * q)
   libmesh_assert(base_fe);
 
   const Order base_int_order   = q->get_order();
-  const Order radial_int_order = static_cast<Order>(2 * (static_cast<unsigned int>(fe_type.radial_order) + 1) +2);
+  const Order radial_int_order = static_cast<Order>(2 * (static_cast<unsigned int>(fe_type.radial_order.get_order()) + 1) +2);
   const unsigned int qrule_dim = q->get_dim();
 
   if (Dim != 1)

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -730,7 +730,7 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_indices (const FEType & fet,
    * 8. element-associated dof further out
    */
 
-  const unsigned int radial_order       = static_cast<unsigned int>(fet.radial_order);             // 4
+  const unsigned int radial_order       = static_cast<unsigned int>(fet.radial_order.get_order()); // 4
   const unsigned int radial_order_p_one = radial_order+1;                                          // 5
 
   const ElemType base_elem_type           (Base::get_elem_type(inf_elem_type));                    // QUAD9

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -2390,7 +2390,7 @@ void GMVIO::copy_nodal_solution(EquationSystems & es)
               // The only type of nodal data we can read in from GMV is for
               // linear LAGRANGE type elements.
               const FEType & fe_type = system.variable_type(var_num);
-              if ((fe_type.order != FIRST) || (fe_type.family != LAGRANGE))
+              if ((fe_type.order.get_order() != FIRST) || (fe_type.family != LAGRANGE))
                 {
                   libMesh::err << "Only FIRST-order LAGRANGE variables can be read from GMV files. "
                                << "Skipping variable " << var_name << std::endl;

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1460,17 +1460,17 @@ void FEMContext::elem_position_get()
   libmesh_assert(this->get_mesh_x_var() == libMesh::invalid_uint ||
                  (this->get_element_fe(this->get_mesh_x_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
-                  this->get_element_fe(this->get_mesh_x_var(), dim)->get_fe_type().order
+                  this->get_element_fe(this->get_mesh_x_var(), dim)->get_fe_type().order.get_order()
                   == this->get_elem().default_order()));
   libmesh_assert(this->get_mesh_y_var() == libMesh::invalid_uint ||
                  (this->get_element_fe(this->get_mesh_y_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
-                  this->get_element_fe(this->get_mesh_y_var(), dim)->get_fe_type().order
+                  this->get_element_fe(this->get_mesh_y_var(), dim)->get_fe_type().order.get_order()
                   == this->get_elem().default_order()));
   libmesh_assert(this->get_mesh_z_var() == libMesh::invalid_uint ||
                  (this->get_element_fe(this->get_mesh_z_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
-                  this->get_element_fe(this->get_mesh_z_var(), dim)->get_fe_type().order
+                  this->get_element_fe(this->get_mesh_z_var(), dim)->get_fe_type().order.get_order()
                   == this->get_elem().default_order()));
 
   // Get degree of freedom coefficients from point coordinates

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -227,8 +227,8 @@ void System::read_header (Xdr & io,
         // to be an unlikely occurance, but catch it anyway.
         if (read_legacy_format)
           if ((type.family == MONOMIAL || type.family == XYZ) &&
-              ((type.order > 2 && this->get_mesh().mesh_dimension() == 2) ||
-               (type.order > 1 && this->get_mesh().mesh_dimension() == 3)))
+              ((type.order.get_order() > 2 && this->get_mesh().mesh_dimension() == 2) ||
+               (type.order.get_order() > 1 && this->get_mesh().mesh_dimension() == 3)))
             {
               libmesh_here();
               libMesh::out << "*****************************************************************\n"
@@ -1103,7 +1103,7 @@ unsigned int System::read_SCALAR_dofs (const unsigned int var,
   unsigned int n_assigned_vals = 0; // the number of values assigned, this will be returned.
 
   // Processor 0 will read the block from the buffer stream and send it to the last processor
-  const unsigned int n_SCALAR_dofs = this->variable(var).type().order;
+  const unsigned int n_SCALAR_dofs = this->variable(var).type().order.get_order();
   std::vector<Number> input_buffer(n_SCALAR_dofs);
   if (this->processor_id() == 0)
     {


### PR DESCRIPTION
Based 99% on the work @dknez did.

Obsoletes #824

This seems to get everything compiling and running sanely for me.

I'd like to get this merged soon if everyone is happy; I just discovered that we might have a use for specifying *negative* FE order as well; I need to be able to specify temporary p-coarsening via some less hackish code in order to fix a race condition in threaded constraint evaluation on hp-refined meshes.