### PR TITLE
Fix p_level calculation when elem==NULL

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1911,7 +1911,7 @@ void DofMap::dof_indices (const Elem * const elem,
 
   // Use the default p refinement level?
   if (p_level == -12345)
-    p_level = elem->p_level();
+    p_level = elem ? elem->p_level() : 0;
 
 #ifdef DEBUG
   // Check that sizes match in DEBUG mode


### PR DESCRIPTION
We clearly need better test coverage if this doesn't make libMesh or
MOOSE scream.

We should also get GRINS tests running with CI as soon as @pbauman has his new build hardware.