### PR TITLE
More GenericProjector reoptimization

### DIFF
--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1194,14 +1194,21 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
           // Zero the interpolated values
           Ue.resize (n_dofs); Ue.zero();
 
-          // If this element hasn't been changed, and we're projecting
-          // from its old self, then we can simply move its old dof
-          // values to new indices.
+          // If we're projecting from an old grid
           if (f.is_grid_projection() &&
-              elem->refinement_flag() != Elem::JUST_REFINED &&
-              elem->refinement_flag() != Elem::JUST_COARSENED &&
-              elem->p_refinement_flag() != Elem::JUST_REFINED &&
-              elem->p_refinement_flag() != Elem::JUST_COARSENED)
+          // And either this is an unchanged element
+              ((elem->refinement_flag() != Elem::JUST_REFINED &&
+                elem->refinement_flag() != Elem::JUST_COARSENED &&
+                elem->p_refinement_flag() != Elem::JUST_REFINED &&
+                elem->p_refinement_flag() != Elem::JUST_COARSENED) ||
+          // Or this is a low order monomial element
+               (fe_type.family == MONOMIAL &&
+                fe_type.order == CONSTANT &&
+                elem->p_level() == 0 &&
+                elem->p_refinement_flag() != Elem::JUST_COARSENED))
+             )
+          // then we can simply copy its old dof
+          // values to new indices.
             {
               for (unsigned int d=0; d != n_dofs; ++d)
                 {

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1212,12 +1212,16 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
           // then we can simply copy its old dof
           // values to new indices.
             {
+              START_LOG ("copy_dofs","GenericProjector");
+
               for (unsigned int d=0; d != n_dofs; ++d)
                 {
                   Ue(d) = f.eval_old_dof(context, var_component, d);
                 }
 
               action.insert(context, var, Ue);
+
+              STOP_LOG ("copy_dofs","GenericProjector");
 
               continue;
             }

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1201,10 +1201,12 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
                 elem->refinement_flag() != Elem::JUST_COARSENED &&
                 elem->p_refinement_flag() != Elem::JUST_REFINED &&
                 elem->p_refinement_flag() != Elem::JUST_COARSENED) ||
-          // Or this is a low order monomial element
+	  // Or this is a low order monomial element which has merely
+	  // been h refined
                (fe_type.family == MONOMIAL &&
                 fe_type.order == CONSTANT &&
                 elem->p_level() == 0 &&
+                elem->refinement_flag() != Elem::JUST_COARSENED &&
                 elem->p_refinement_flag() != Elem::JUST_COARSENED))
              )
           // then we can simply copy its old dof

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -165,9 +165,9 @@ public:
 
   bool is_grid_projection() { return false; }
 
-  Output eval_old_dof (const FEMContext & /* c */,
-                       unsigned int /* var_component */,
-                       unsigned int /* dof_index */)
+  void eval_old_dofs (const FEMContext & /* c */,
+                      unsigned int /* var_component */,
+                      std::vector<Output> /* values */)
   { libmesh_error(); }
 
 private:
@@ -256,24 +256,20 @@ public:
 
   bool is_grid_projection() { return true; }
 
-  Output eval_old_dof (const FEMContext & c,
-                       unsigned int var,
-                       unsigned int dof_index)
+  void eval_old_dofs (const FEMContext & c,
+                      unsigned int var,
+                      std::vector<Output> & values)
   {
-    START_LOG ("eval_old_dof()", "OldSolutionValue");
+    START_LOG ("eval_old_dofs()", "OldSolutionValue");
 
     this->check_old_context(c);
 
     const std::vector<dof_id_type> & old_dof_indices =
       old_context.get_dof_indices(var);
 
-    libmesh_assert_greater(old_dof_indices.size(), dof_index);
+    old_solution.get(old_dof_indices, values);
 
-    const dof_id_type old_id = old_dof_indices[dof_index];
-
-    STOP_LOG ("eval_old_dof()", "OldSolutionValue");
-
-    return old_solution(old_id);
+    STOP_LOG ("eval_old_dofs()", "OldSolutionValue");
   }
 
 protected:
@@ -1248,10 +1244,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
             {
               START_LOG ("copy_dofs","GenericProjector");
 
-              for (unsigned int d=0; d != n_dofs; ++d)
-                {
-                  Ue(d) = f.eval_old_dof(context, var_component, d);
-                }
+              f.eval_old_dofs(context, var_component, Ue.get_values());
 
               action.insert(context, var, Ue);
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -267,6 +267,8 @@ public:
     const std::vector<dof_id_type> & old_dof_indices =
       old_context.get_dof_indices(var);
 
+    libmesh_assert_equal_to (old_dof_indices.size(), values.size());
+
     old_solution.get(old_dof_indices, values);
 
     STOP_LOG ("eval_old_dofs()", "OldSolutionValue");


### PR DESCRIPTION
This still isn't back to where we should be but it gives a big speedup on constant monomial variables and a decent speedup on lagrange variables, which are the two biggest MOOSE use cases.