### PR TITLE
RB Change: Updated relative error in greedy algorithm.

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/eim.in
+++ b/examples/reduced_basis/reduced_basis_ex4/eim.in
@@ -1,7 +1,7 @@
 # ========= EIM system parameters =========
 
 Nmax = 20
-training_tolerance = 0.001
+rel_training_tolerance = 0.001
 
 parameter_names = 'center_x center_y'
 

--- a/examples/reduced_basis/reduced_basis_ex4/rb.in
+++ b/examples/reduced_basis/reduced_basis_ex4/rb.in
@@ -1,7 +1,7 @@
 # ========= RB system parameters =========
 
 Nmax = 15
-training_tolerance = 0.001
+rel_training_tolerance = 0.001
 
 parameter_names = 'center_x center_y'
 

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.in
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.in
@@ -21,7 +21,7 @@ store_basis_functions = true                # Do we store the basis functions in
 # ========= RB system parameters =========
 
 Nmax = 15                                   # The maximum number of basis functions we can generate in the Offline stage
-training_tolerance = 1.e-3                  # The error bound tolerance used to terminate the Greedy algorithm
+rel_training_tolerance = 1.e-3              # The error bound tolerance used to terminate the Greedy algorithm
 
 parameter_names = 'x_scaling load_Fx load_Fy load_Fz point_load_Fx point_load_Fy point_load_Fz'
 

--- a/examples/reduced_basis/reduced_basis_ex6/eim.in
+++ b/examples/reduced_basis/reduced_basis_ex6/eim.in
@@ -1,7 +1,7 @@
 # ========= EIM system parameters =========
 
 Nmax = 20
-training_tolerance = 0.001
+rel_training_tolerance = 0.001
 
 parameter_names = 'curvature'
 

--- a/examples/reduced_basis/reduced_basis_ex6/rb.in
+++ b/examples/reduced_basis/reduced_basis_ex6/rb.in
@@ -1,7 +1,7 @@
 # ========= RB system parameters =========
 
 Nmax = 15
-training_tolerance = 0.001
+rel_training_tolerance = 0.001
 
 parameter_names = 'curvature Bi kappa'
 

--- a/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.in
+++ b/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.in
@@ -7,8 +7,8 @@ n_frequencies = 100            # The number of frequencies in the Online loop ov
 
 # ========= RB system parameters =========
 
-training_tolerance = 5.e-3    # Terminate the Greedy algorithm if this tolerance is satisfied
-Nmax = 20                     # The maximum number of basis functions we can generate in the Offline stage
+rel_training_tolerance = 5.e-3 # Terminate the Greedy algorithm if this tolerance is satisfied
+Nmax = 20                      # The maximum number of basis functions we can generate in the Offline stage
 
 parameter_names = 'frequency' # The names of the parameters
 

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -172,11 +172,18 @@ public:
   const RBParameters & get_greedy_parameter(unsigned int i);
 
   /**
-   * Get/set the tolerance for the basis training.
+   * Get/set the relative tolerance for the basis training.
    */
-  void set_training_tolerance(Real new_training_tolerance)
-  {this->training_tolerance = new_training_tolerance; }
-  Real get_training_tolerance() { return training_tolerance; }
+  void set_rel_training_tolerance(Real new_training_tolerance)
+  {this->rel_training_tolerance = new_training_tolerance; }
+  Real get_rel_training_tolerance() { return rel_training_tolerance; }
+
+  /**
+   * Get/set the absolute tolerance for the basis training.
+   */
+  void set_abs_training_tolerance(Real new_training_tolerance)
+  {this->abs_training_tolerance = new_training_tolerance; }
+  Real get_abs_training_tolerance() { return abs_training_tolerance; }
 
   /**
    * Get/set Nmax, the maximum number of RB
@@ -346,11 +353,11 @@ public:
    */
   void set_rb_construction_parameters(unsigned int n_training_samples_in,
                                       bool deterministic_training_in,
-                                      bool use_relative_bound_in_greedy_in,
                                       unsigned int training_parameters_random_seed_in,
                                       bool quiet_mode_in,
                                       unsigned int Nmax_in,
-                                      Real training_tolerance_in,
+                                      Real rel_training_tolerance_in,
+                                      Real abs_training_tolerance_in,
                                       RBParameters mu_min_in,
                                       RBParameters mu_max_in,
                                       std::map< std::string, std::vector<Real> > discrete_parameter_values_in,
@@ -466,13 +473,6 @@ public:
   std::vector<Number> Fq_representor_innerprods;
 
   /**
-   * Boolean flag to indicate whether we use an absolute or
-   * relative error bound in the Greedy algorithm for training
-   * a Reduced Basis.
-   */
-  bool use_relative_bound_in_greedy;
-
-  /**
    * Boolean flag to indicate whether we exit the greedy if
    * we select the same parameters twice in a row. In some
    * problems this indicates that the greedy has "saturated"
@@ -548,7 +548,8 @@ protected:
    * Function that indicates when to terminate the Greedy
    * basis training. Overload in subclasses to specialize.
    */
-  virtual bool greedy_termination_test(Real training_greedy_error, int count);
+  virtual bool greedy_termination_test(
+    Real abs_greedy_error, Real initial_greedy_error, int count);
 
   /**
    * Update the list of Greedily chosen parameters with
@@ -754,9 +755,11 @@ private:
   std::vector< std::vector< NumericVector<Number> * > > non_dirichlet_outputs_vector;
 
   /**
-   * Tolerance for training reduced basis using the Greedy scheme.
+   * Relative and absolute tolerances for training reduced basis
+   * using the Greedy scheme.
    */
-  Real training_tolerance;
+  Real rel_training_tolerance;
+  Real abs_training_tolerance;
 
 };
 

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -265,7 +265,8 @@ protected:
    * Function that indicates when to terminate the Greedy
    * basis training. Overload in subclasses to specialize.
    */
-  virtual bool greedy_termination_test(Real training_greedy_error, int count) libmesh_override;
+  virtual bool greedy_termination_test(
+    Real abs_greedy_error, Real initial_greedy_error, int count) libmesh_override;
 
   /**
    * Loop over the training set and compute the parametrized function for each

--- a/include/reduced_basis/transient_rb_construction.h
+++ b/include/reduced_basis/transient_rb_construction.h
@@ -118,7 +118,8 @@ public:
    * Function that indicates when to terminate the Greedy
    * basis training.
    */
-  virtual bool greedy_termination_test(Real training_greedy_error, int count) libmesh_override;
+  virtual bool greedy_termination_test(
+    Real abs_greedy_error, Real initial_greedy_error, int count) libmesh_override;
 
   /**
    * Assemble and store all the affine operators.

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -817,12 +817,6 @@ void RBEIMConstruction::update_RB_system_matrices()
 Real RBEIMConstruction::get_RB_error_bound()
 {
   Real best_fit_error = compute_best_fit_error();
-
-  if(use_relative_bound_in_greedy)
-    {
-      best_fit_error /= get_rb_evaluation().get_rb_solution_norm();
-    }
-
   return best_fit_error;
 }
 
@@ -832,7 +826,8 @@ void RBEIMConstruction::update_system()
   update_RB_system_matrices();
 }
 
-bool RBEIMConstruction::greedy_termination_test(Real training_greedy_error, int)
+bool RBEIMConstruction::greedy_termination_test(
+  Real abs_greedy_error, Real initial_error, int)
 {
   if(_performing_extra_greedy_step)
     {
@@ -843,9 +838,18 @@ bool RBEIMConstruction::greedy_termination_test(Real training_greedy_error, int)
 
   _performing_extra_greedy_step = false;
 
-  if(training_greedy_error < get_training_tolerance())
+  if(abs_greedy_error < get_abs_training_tolerance())
     {
-      libMesh::out << "Specified error tolerance reached." << std::endl
+      libMesh::out << "Absolute error tolerance reached." << std::endl
+                   << "Perform one more Greedy iteration for error bounds." << std::endl;
+      _performing_extra_greedy_step = true;
+      return false;
+    }
+
+  Real rel_greedy_error = abs_greedy_error/initial_error;
+  if(rel_greedy_error < get_rel_training_tolerance())
+    {
+      libMesh::out << "Relative error tolerance reached." << std::endl
                    << "Perform one more Greedy iteration for error bounds." << std::endl;
       _performing_extra_greedy_step = true;
       return false;

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -638,7 +638,8 @@ Real TransientRBConstruction::truth_solve(int write_interval)
   return final_truth_L2_norm;
 }
 
-bool TransientRBConstruction::greedy_termination_test(Real training_greedy_error, int count)
+bool TransientRBConstruction::greedy_termination_test(
+  Real abs_greedy_error, Real initial_greedy_error, int count)
 {
   if ( (get_max_truth_solves()>0) && (count >= get_max_truth_solves()) )
     {
@@ -647,7 +648,7 @@ bool TransientRBConstruction::greedy_termination_test(Real training_greedy_error
       return true;
     }
 
-  return Parent::greedy_termination_test(training_greedy_error, count);
+  return Parent::greedy_termination_test(abs_greedy_error, initial_greedy_error, count);
 }
 
 Number TransientRBConstruction::set_error_temporal_data()


### PR DESCRIPTION
Previously we divided by the norm of the solution in order to provide a relative error measurement.
A better way to get relative error is to compare the error at each iteration to the initial error,
and hence ensure that the error has decreased a certain amount. This is the way that relative tolerances
are generally implemented in iterative solvers, for example.