### PR TITLE
Fix configure test for C++11 <regex>

### DIFF
--- a/configure
+++ b/configure
@@ -9170,7 +9170,7 @@ $as_echo "#define HAVE_CXX11_REGEX 1" >>confdefs.h
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, but disabled." >&5
 $as_echo "yes, but disabled." >&6; }
 
-$as_echo "#define HAVE_CXX11_REGEX 1" >>confdefs.h
+$as_echo "#define HAVE_CXX11_REGEX_BUT_DISABLED 1" >>confdefs.h
 
       fi
 

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -318,8 +318,11 @@
 /* Compiler supports range-based for loops, but it is disabled in libmesh */
 #undef HAVE_CXX11_RANGEFOR_BUT_DISABLED
 
-/* Compiler supports std::regex, but it is disabled in libmesh */
+/* Flag indicating whether compiler supports std::regex */
 #undef HAVE_CXX11_REGEX
+
+/* Compiler supports std::regex, but it is disabled in libmesh */
+#undef HAVE_CXX11_REGEX_BUT_DISABLED
 
 /* Flag indicating whether compiler supports rvalue references */
 #undef HAVE_CXX11_RVALUE_REFERENCES

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -508,7 +508,7 @@ AC_DEFUN([LIBMESH_TEST_CXX11_REGEX],
         have_cxx11_regex=yes
       else
         AC_MSG_RESULT([yes, but disabled.])
-        AC_DEFINE(HAVE_CXX11_REGEX, 1, [Compiler supports std::regex, but it is disabled in libmesh])
+        AC_DEFINE(HAVE_CXX11_REGEX_BUT_DISABLED, 1, [Compiler supports std::regex, but it is disabled in libmesh])
       fi
     ],[
       AC_MSG_RESULT(no)


### PR DESCRIPTION
@permcody and @milljm, this should fix the issue where the `<regex>` test always reported no for everyone. 