### PR TITLE
TAO API change isn't in PETSc 3.6.4.

### DIFF
--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -500,8 +500,9 @@ void TaoOptimizationSolver<T>::solve ()
   // ||g(X)|| / ||g(X0)||                <= gttol
   // Command line equivalents: -tao_fatol, -tao_frtol, -tao_gatol, -tao_grtol, -tao_gttol
   ierr = TaoSetTolerances(_tao,
-#if PETSC_RELEASE_LESS_THAN(3,6,4)
-                          // Releases up to 3.6.3 had fatol and frtol, after that they were removed.
+#if PETSC_RELEASE_LESS_THAN(3,7,0)
+                          // Releases up to 3.X.Y had fatol and frtol, after that they were removed.
+                          // Hopefully we'll be able to know X and Y soon. Guessing at 3.7.0.
                           /*fatol=*/PETSC_DEFAULT,
                           /*frtol=*/PETSC_DEFAULT,
 #endif


### PR DESCRIPTION
So let's guess 3.7.0 now.

Should've updated after @jwpeterson suggested it in #749. This gets us building with PETSc 3.6.4.