### PR TITLE
fix libmesh_nullptr usage

### DIFF
--- a/src/apps/meshid.C
+++ b/src/apps/meshid.C
@@ -26,13 +26,13 @@
 #include <stdlib.h> // rand, srand
 
 #include "libmesh/libmesh_config.h"
+#include "libmesh/libmesh_nullptr.h"
 
 #ifdef LIBMESH_HAVE_EXODUS_API
 
 #include "exodusII.h"
 #include "exodusII_int.h"
 #include "libmesh/getpot.h"
-#include "libmesh/libmesh_nullptr.h"
 
 #define EXODUS_DIM 0x8
 #define BLOCKS     0x4


### PR DESCRIPTION
libmesh_nullptr is used outside LIBMESH_HAVE_EXODUS_API but included inside.