### PR TITLE
RAII for PerfLog

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -443,7 +443,7 @@ void assemble_helmholtz(EquationSystems & es,
       for (unsigned int side=0; side<elem->n_sides(); side++)
         if (elem->neighbor(side) == libmesh_nullptr)
           {
-            START_LOG("damping", "assemble_helmholtz");
+            LOG_SCOPE("damping", "assemble_helmholtz");
 
             // Declare a special finite element object for
             // boundary integration.
@@ -485,8 +485,6 @@ void assemble_helmholtz(EquationSystems & es,
                   for (unsigned int j=0; j<phi_face.size(); j++)
                     Ce(i,j) += rho*an_value*JxW_face[qp]*phi_face[i][qp]*phi_face[j][qp];
               }
-
-            STOP_LOG("damping", "assemble_helmholtz");
           }
 
       // If this assembly program were to be used on an adaptive mesh,
@@ -517,7 +515,7 @@ void assemble_helmholtz(EquationSystems & es,
   // get the normal velocities values on the boundary from the
   // mesh data.
   {
-    START_LOG("rhs", "assemble_helmholtz");
+    LOG_SCOPE("rhs", "assemble_helmholtz");
 
     // get a reference to the mesh data.
     const MeshData & mesh_data = es.get_mesh_data();
@@ -549,9 +547,6 @@ void assemble_helmholtz(EquationSystems & es,
               freq_indep_rhs.set(dn, mesh_data.get_data(node)[0]);
             }
       }
-
-
-    STOP_LOG("rhs", "assemble_helmholtz");
   }
 
   // All done!

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -334,7 +334,7 @@ void scale_mesh_and_plot(EquationSystems & es,
 
 void compute_stresses(EquationSystems & es)
 {
-  START_LOG("compute_stresses()", "main");
+  LOG_SCOPE("compute_stresses()", "main");
 
   const MeshBase & mesh = es.get_mesh();
 
@@ -449,6 +449,4 @@ void compute_stresses(EquationSystems & es)
   // Should call close and update when we set vector entries directly
   stress_system.solution->close();
   stress_system.update();
-
-  STOP_LOG("compute_stresses()", "main");
 }

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -282,13 +282,12 @@ inline void send_receive_vec_of_vec(const unsigned int dest_processor_id,
                                     const libMesh::Parallel::MessageTag & recv_tag,
                                     const libMesh::Parallel::Communicator & comm)
 {
-  START_LOG("send_receive()", "Parallel");
+  LOG_SCOPE("send_receive()", "Parallel");
 
   if (dest_processor_id   == comm.rank() &&
       source_processor_id == comm.rank())
     {
       recv = send;
-      STOP_LOG("send_receive()", "Parallel");
       return;
     }
 
@@ -409,8 +408,6 @@ inline void send_receive_vec_of_vec(const unsigned int dest_processor_id,
     }
 
   request.wait();
-
-  STOP_LOG("send_receive()", "Parallel");
 }
 
 #endif // LIBMESH_HAVE_MPI
@@ -834,7 +831,7 @@ inline Request::~Request () {
 
 inline Status Request::wait ()
 {
-  START_LOG("wait()", "Parallel::Request");
+  LOG_SCOPE("wait()", "Parallel::Request");
 
   if (_prior_request.get())
     _prior_request->wait();
@@ -857,7 +854,6 @@ inline Status Request::wait ()
         *i = libmesh_nullptr;
       }
 
-  STOP_LOG("wait()", "Parallel::Request");
   return stat;
 }
 
@@ -940,12 +936,8 @@ inline void Communicator::barrier () const
 {
   if (this->size() > 1)
     {
-      START_LOG("barrier()", "Parallel");
-
-      libmesh_call_mpi
-        (MPI_Barrier (this->get()));
-
-      STOP_LOG("barrier()", "Parallel");
+      LOG_SCOPE("barrier()", "Parallel");
+      libmesh_call_mpi(MPI_Barrier (this->get()));
     }
 }
 #else
@@ -1519,14 +1511,12 @@ inline void Communicator::min(T & r) const
 {
   if (this->size() > 1)
     {
-      START_LOG("min(scalar)", "Parallel");
+      LOG_SCOPE("min(scalar)", "Parallel");
 
       T temp = r;
       libmesh_call_mpi
         (MPI_Allreduce (&temp, &r, 1, StandardType<T>(&temp), MPI_MIN,
                         this->get()));
-
-      STOP_LOG("min(scalar)", "Parallel");
     }
 }
 
@@ -1535,7 +1525,7 @@ inline void Communicator::min(bool & r) const
 {
   if (this->size() > 1)
     {
-      START_LOG("min(bool)", "Parallel");
+      LOG_SCOPE("min(bool)", "Parallel");
 
       unsigned int tempsend = r;
       unsigned int temp;
@@ -1544,10 +1534,7 @@ inline void Communicator::min(bool & r) const
         (MPI_Allreduce (&tempsend, &temp, 1,
                         StandardType<unsigned int>(), MPI_MIN,
                         this->get()));
-
       r = temp;
-
-      STOP_LOG("min(bool)", "Parallel");
     }
 }
 
@@ -1557,7 +1544,7 @@ inline void Communicator::min(std::vector<T> & r) const
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("min(vector)", "Parallel");
+      LOG_SCOPE("min(vector)", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1566,8 +1553,6 @@ inline void Communicator::min(std::vector<T> & r) const
         (MPI_Allreduce (&temp[0], &r[0], cast_int<int>(r.size()),
                         StandardType<T>(&temp[0]), MPI_MIN,
                         this->get()));
-
-      STOP_LOG("min(vector)", "Parallel");
     }
 }
 
@@ -1576,7 +1561,7 @@ inline void Communicator::min(std::vector<bool> & r) const
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("min(vector<bool>)", "Parallel");
+      LOG_SCOPE("min(vector<bool>)", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1589,8 +1574,6 @@ inline void Communicator::min(std::vector<bool> & r) const
                         StandardType<unsigned int>(), MPI_BAND,
                         this->get()));
       unpack_vector_bool(temp, r);
-
-      STOP_LOG("min(vector<bool>)", "Parallel");
     }
 }
 
@@ -1601,7 +1584,7 @@ inline void Communicator::minloc(T & r,
 {
   if (this->size() > 1)
     {
-      START_LOG("minloc(scalar)", "Parallel");
+      LOG_SCOPE("minloc(scalar)", "Parallel");
 
       DataPlusInt<T> in;
       in.val = r;
@@ -1612,8 +1595,6 @@ inline void Communicator::minloc(T & r,
                         MPI_MINLOC, this->get()));
       r = out.val;
       min_id = out.rank;
-
-      STOP_LOG("minloc(scalar)", "Parallel");
     }
   else
     min_id = this->rank();
@@ -1625,7 +1606,7 @@ inline void Communicator::minloc(bool & r,
 {
   if (this->size() > 1)
     {
-      START_LOG("minloc(bool)", "Parallel");
+      LOG_SCOPE("minloc(bool)", "Parallel");
 
       DataPlusInt<int> in;
       in.val = r;
@@ -1636,8 +1617,6 @@ inline void Communicator::minloc(bool & r,
                         MPI_MINLOC, this->get()));
       r = out.val;
       min_id = out.rank;
-
-      STOP_LOG("minloc(bool)", "Parallel");
     }
   else
     min_id = this->rank();
@@ -1650,7 +1629,7 @@ inline void Communicator::minloc(std::vector<T> & r,
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("minloc(vector)", "Parallel");
+      LOG_SCOPE("minloc(vector)", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1670,8 +1649,6 @@ inline void Communicator::minloc(std::vector<T> & r,
           r[i]      = out[i].val;
           min_id[i] = out[i].rank;
         }
-
-      STOP_LOG("minloc(vector)", "Parallel");
     }
   else if (!r.empty())
     {
@@ -1686,7 +1663,7 @@ inline void Communicator::minloc(std::vector<bool> & r,
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("minloc(vector<bool>)", "Parallel");
+      LOG_SCOPE("minloc(vector<bool>)", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1706,8 +1683,6 @@ inline void Communicator::minloc(std::vector<bool> & r,
           r[i]      = out[i].val;
           min_id[i] = out[i].rank;
         }
-
-      STOP_LOG("minloc(vector<bool>)", "Parallel");
     }
   else if (!r.empty())
     {
@@ -1722,15 +1697,13 @@ inline void Communicator::max(T & r) const
 {
   if (this->size() > 1)
     {
-      START_LOG("max(scalar)", "Parallel");
+      LOG_SCOPE("max(scalar)", "Parallel");
 
       T temp;
       libmesh_call_mpi
         (MPI_Allreduce (&r, &temp, 1, StandardType<T>(&r), MPI_MAX,
                         this->get()));
       r = temp;
-
-      STOP_LOG("max(scalar)", "Parallel");
     }
 }
 
@@ -1739,7 +1712,7 @@ inline void Communicator::max(bool & r) const
 {
   if (this->size() > 1)
     {
-      START_LOG("max(bool)", "Parallel");
+      LOG_SCOPE("max(bool)", "Parallel");
 
       unsigned int tempsend = r;
       unsigned int temp;
@@ -1748,8 +1721,6 @@ inline void Communicator::max(bool & r) const
                         StandardType<unsigned int>(), MPI_MAX,
                         this->get()));
       r = temp;
-
-      STOP_LOG("max(bool)", "Parallel");
     }
 }
 
@@ -1759,7 +1730,7 @@ inline void Communicator::max(std::vector<T> & r) const
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("max(vector)", "Parallel");
+      LOG_SCOPE("max(vector)", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1768,8 +1739,6 @@ inline void Communicator::max(std::vector<T> & r) const
         (MPI_Allreduce (&temp[0], &r[0], cast_int<int>(r.size()),
                         StandardType<T>(&temp[0]), MPI_MAX,
                         this->get()));
-
-      STOP_LOG("max(vector)", "Parallel");
     }
 }
 
@@ -1778,7 +1747,7 @@ inline void Communicator::max(std::vector<bool> & r) const
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("max(vector<bool>)", "Parallel");
+      LOG_SCOPE("max(vector<bool>)", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1791,8 +1760,6 @@ inline void Communicator::max(std::vector<bool> & r) const
                         StandardType<unsigned int>(), MPI_BOR,
                         this->get()));
       unpack_vector_bool(temp, r);
-
-      STOP_LOG("max(vector<bool>)", "Parallel");
     }
 }
 
@@ -1803,7 +1770,7 @@ inline void Communicator::maxloc(T & r,
 {
   if (this->size() > 1)
     {
-      START_LOG("maxloc(scalar)", "Parallel");
+      LOG_SCOPE("maxloc(scalar)", "Parallel");
 
       DataPlusInt<T> in;
       in.val = r;
@@ -1814,8 +1781,6 @@ inline void Communicator::maxloc(T & r,
                         MPI_MAXLOC, this->get()));
       r = out.val;
       max_id = out.rank;
-
-      STOP_LOG("maxloc(scalar)", "Parallel");
     }
   else
     max_id = this->rank();
@@ -1827,7 +1792,7 @@ inline void Communicator::maxloc(bool & r,
 {
   if (this->size() > 1)
     {
-      START_LOG("maxloc(bool)", "Parallel");
+      LOG_SCOPE("maxloc(bool)", "Parallel");
 
       DataPlusInt<int> in;
       in.val = r;
@@ -1838,8 +1803,6 @@ inline void Communicator::maxloc(bool & r,
                         MPI_MAXLOC, this->get()));
       r = out.val;
       max_id = out.rank;
-
-      STOP_LOG("maxloc(bool)", "Parallel");
     }
   else
     max_id = this->rank();
@@ -1852,7 +1815,7 @@ inline void Communicator::maxloc(std::vector<T> & r,
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("maxloc(vector)", "Parallel");
+      LOG_SCOPE("maxloc(vector)", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1872,8 +1835,6 @@ inline void Communicator::maxloc(std::vector<T> & r,
           r[i]      = out[i].val;
           max_id[i] = out[i].rank;
         }
-
-      STOP_LOG("maxloc(vector)", "Parallel");
     }
   else if (!r.empty())
     {
@@ -1888,7 +1849,7 @@ inline void Communicator::maxloc(std::vector<bool> & r,
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("maxloc(vector<bool>)", "Parallel");
+      LOG_SCOPE("maxloc(vector<bool>)", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1908,8 +1869,6 @@ inline void Communicator::maxloc(std::vector<bool> & r,
           r[i]      = out[i].val;
           max_id[i] = out[i].rank;
         }
-
-      STOP_LOG("maxloc(vector<bool>)", "Parallel");
     }
   else if (!r.empty())
     {
@@ -1924,14 +1883,12 @@ inline void Communicator::sum(T & r) const
 {
   if (this->size() > 1)
     {
-      START_LOG("sum()", "Parallel");
+      LOG_SCOPE("sum()", "Parallel");
 
       T temp = r;
       libmesh_call_mpi
         (MPI_Allreduce (&temp, &r, 1, StandardType<T>(&temp), MPI_SUM,
                         this->get()));
-
-      STOP_LOG("sum()", "Parallel");
     }
 }
 
@@ -1941,7 +1898,7 @@ inline void Communicator::sum(std::vector<T> & r) const
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("sum()", "Parallel");
+      LOG_SCOPE("sum()", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1950,8 +1907,6 @@ inline void Communicator::sum(std::vector<T> & r) const
         (MPI_Allreduce (&temp[0], &r[0], cast_int<int>(r.size()),
                         StandardType<T>(&temp[0]), MPI_SUM,
                         this->get()));
-
-      STOP_LOG("sum()", "Parallel");
     }
 }
 
@@ -1963,14 +1918,12 @@ inline void Communicator::sum(std::complex<T> & r) const
 {
   if (this->size() > 1)
     {
-      START_LOG("sum()", "Parallel");
+      LOG_SCOPE("sum()", "Parallel");
 
       std::complex<T> temp(r);
       libmesh_call_mpi
         (MPI_Allreduce (&temp, &r, 2, StandardType<T>(), MPI_SUM,
                         this->get()));
-
-      STOP_LOG("sum()", "Parallel");
     }
 }
 
@@ -1980,7 +1933,7 @@ inline void Communicator::sum(std::vector<std::complex<T> > & r) const
 {
   if (this->size() > 1 && !r.empty())
     {
-      START_LOG("sum()", "Parallel");
+      LOG_SCOPE("sum()", "Parallel");
 
       libmesh_assert(this->verify(r.size()));
 
@@ -1988,8 +1941,6 @@ inline void Communicator::sum(std::vector<std::complex<T> > & r) const
       libmesh_call_mpi
         (MPI_Allreduce (&temp[0], &r[0], cast_int<int>(r.size() * 2),
                         StandardType<T>(libmesh_nullptr), MPI_SUM, this->get()));
-
-      STOP_LOG("sum()", "Parallel");
     }
 }
 
@@ -2041,14 +1992,12 @@ inline void Communicator::set_union(std::map<T1,T2> & data) const
 inline status Communicator::probe (const unsigned int src_processor_id,
                                    const MessageTag & tag) const
 {
-  START_LOG("probe()", "Parallel");
+  LOG_SCOPE("probe()", "Parallel");
 
   status stat;
 
   libmesh_call_mpi
     (MPI_Probe (src_processor_id, tag.value(), this->get(), &stat));
-
-  STOP_LOG("probe()", "Parallel");
 
   return stat;
 }
@@ -2060,7 +2009,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                 std::basic_string<T> & buf,
                                 const MessageTag & tag) const
 {
-  START_LOG("send()", "Parallel");
+  LOG_SCOPE("send()", "Parallel");
 
   T * dataptr = buf.empty() ? libmesh_nullptr : const_cast<T *>(buf.data());
 
@@ -2072,8 +2021,6 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                              dest_processor_id,
                              tag.value(),
                              this->get()));
-
-  STOP_LOG("send()", "Parallel");
 }
 
 
@@ -2084,7 +2031,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                 Request & req,
                                 const MessageTag & tag) const
 {
-  START_LOG("send()", "Parallel");
+  LOG_SCOPE("send()", "Parallel");
 
   T * dataptr = buf.empty() ? libmesh_nullptr : const_cast<T *>(buf.data());
 
@@ -2097,8 +2044,6 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                tag.value(),
                                this->get(),
                                req.get()));
-
-  STOP_LOG("send()", "Parallel");
 }
 
 
@@ -2108,7 +2053,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                 T & buf,
                                 const MessageTag & tag) const
 {
-  START_LOG("send()", "Parallel");
+  LOG_SCOPE("send()", "Parallel");
 
   T * dataptr = &buf;
 
@@ -2120,8 +2065,6 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                              dest_processor_id,
                              tag.value(),
                              this->get()));
-
-  STOP_LOG("send()", "Parallel");
 }
 
 
@@ -2132,7 +2075,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                 Request & req,
                                 const MessageTag & tag) const
 {
-  START_LOG("send()", "Parallel");
+  LOG_SCOPE("send()", "Parallel");
 
   T * dataptr = &buf;
 
@@ -2145,8 +2088,6 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                tag.value(),
                                this->get(),
                                req.get()));
-
-  STOP_LOG("send()", "Parallel");
 }
 
 
@@ -2180,12 +2121,10 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                 const DataType & type,
                                 const MessageTag & tag) const
 {
-  START_LOG("send()", "Parallel");
+  LOG_SCOPE("send()", "Parallel");
 
   std::vector<T> vecbuf(buf.begin(), buf.end());
   this->send(dest_processor_id, vecbuf, type, tag);
-
-  STOP_LOG("send()", "Parallel");
 }
 
 
@@ -2197,7 +2136,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                 Request & req,
                                 const MessageTag & tag) const
 {
-  START_LOG("send()", "Parallel");
+  LOG_SCOPE("send()", "Parallel");
 
   // Allocate temporary buffer on the heap so it lives until after
   // the non-blocking send completes
@@ -2209,8 +2148,6 @@ inline void Communicator::send (const unsigned int dest_processor_id,
     (new Parallel::PostWaitDeleteBuffer<std::vector<T> >(vecbuf));
 
   this->send(dest_processor_id, *vecbuf, type, req, tag);
-
-  STOP_LOG("send()", "Parallel");
 }
 
 
@@ -2244,7 +2181,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                 const DataType & type,
                                 const MessageTag & tag) const
 {
-  START_LOG("send()", "Parallel");
+  LOG_SCOPE("send()", "Parallel");
 
   libmesh_call_mpi
     (((this->send_mode() == SYNCHRONOUS) ?
@@ -2254,8 +2191,6 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                              dest_processor_id,
                              tag.value(),
                              this->get()));
-
-  STOP_LOG("send()", "Parallel");
 }
 
 
@@ -2267,7 +2202,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                 Request & req,
                                 const MessageTag & tag) const
 {
-  START_LOG("send()", "Parallel");
+  LOG_SCOPE("send()", "Parallel");
 
   libmesh_call_mpi
     (((this->send_mode() == SYNCHRONOUS) ?
@@ -2278,8 +2213,6 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                tag.value(),
                                this->get(),
                                req.get()));
-
-  STOP_LOG("send()", "Parallel");
 }
 
 
@@ -2442,7 +2375,7 @@ inline Status Communicator::receive (const unsigned int src_processor_id,
                                      T & buf,
                                      const MessageTag & tag) const
 {
-  START_LOG("receive()", "Parallel");
+  LOG_SCOPE("receive()", "Parallel");
 
   // Get the status of the message, explicitly provide the
   // datatype so we can later query the size
@@ -2451,8 +2384,6 @@ inline Status Communicator::receive (const unsigned int src_processor_id,
   libmesh_call_mpi
     (MPI_Recv (&buf, 1, StandardType<T>(&buf), src_processor_id,
                tag.value(), this->get(), stat.get()));
-
-  STOP_LOG("receive()", "Parallel");
 
   return stat;
 }
@@ -2465,13 +2396,11 @@ inline void Communicator::receive (const unsigned int src_processor_id,
                                    Request & req,
                                    const MessageTag & tag) const
 {
-  START_LOG("receive()", "Parallel");
+  LOG_SCOPE("receive()", "Parallel");
 
   libmesh_call_mpi
     (MPI_Irecv (&buf, 1, StandardType<T>(&buf), src_processor_id,
                 tag.value(), this->get(), req.get()));
-
-  STOP_LOG("receive()", "Parallel");
 }
 
 
@@ -2506,14 +2435,12 @@ inline Status Communicator::receive (const unsigned int src_processor_id,
                                      const DataType & type,
                                      const MessageTag & tag) const
 {
-  START_LOG("receive()", "Parallel");
+  LOG_SCOPE("receive()", "Parallel");
 
   std::vector<T> vecbuf;
   Status stat = this->receive(src_processor_id, vecbuf, type, tag);
   buf.clear();
   buf.insert(vecbuf.begin(), vecbuf.end());
-
-  STOP_LOG("receive()", "Parallel");
 
   return stat;
 }
@@ -2527,7 +2454,7 @@ inline void Communicator::receive (const unsigned int src_processor_id,
                                    Request & req,
                                    const MessageTag & tag) const
 {
-  START_LOG("receive()", "Parallel");
+  LOG_SCOPE("receive()", "Parallel");
 
   // Allocate temporary buffer on the heap so it lives until after
   // the non-blocking send completes
@@ -2547,8 +2474,6 @@ inline void Communicator::receive (const unsigned int src_processor_id,
     (new Parallel::PostWaitDeleteBuffer<std::vector<T> >(vecbuf));
 
   this->receive(src_processor_id, *vecbuf, type, req, tag);
-
-  STOP_LOG("receive()", "Parallel");
 }
 
 
@@ -2583,7 +2508,7 @@ inline Status Communicator::receive (const unsigned int src_processor_id,
                                      const DataType & type,
                                      const MessageTag & tag) const
 {
-  START_LOG("receive()", "Parallel");
+  LOG_SCOPE("receive()", "Parallel");
 
   // Get the status of the message, explicitly provide the
   // datatype so we can later query the size
@@ -2601,8 +2526,6 @@ inline Status Communicator::receive (const unsigned int src_processor_id,
 
   libmesh_assert_equal_to (stat.size(), buf.size());
 
-  STOP_LOG("receive()", "Parallel");
-
   return stat;
 }
 
@@ -2615,14 +2538,12 @@ inline void Communicator::receive (const unsigned int src_processor_id,
                                    Request & req,
                                    const MessageTag & tag) const
 {
-  START_LOG("receive()", "Parallel");
+  LOG_SCOPE("receive()", "Parallel");
 
   libmesh_call_mpi
     (MPI_Irecv (buf.empty() ? libmesh_nullptr : &buf[0],
                 cast_int<int>(buf.size()), type, src_processor_id,
                 tag.value(), this->get(), req.get()));
-
-  STOP_LOG("receive()", "Parallel");
 }
 
 
@@ -2695,13 +2616,12 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
                                        const MessageTag & send_tag,
                                        const MessageTag & recv_tag) const
 {
-  START_LOG("send_receive()", "Parallel");
+  LOG_SCOPE("send_receive()", "Parallel");
 
   if (dest_processor_id   == this->rank() &&
       source_processor_id == this->rank())
     {
       recv = sendvec;
-      STOP_LOG("send_receive()", "Parallel");
       return;
     }
 
@@ -2712,8 +2632,6 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
   this->receive (source_processor_id, recv, type2, recv_tag);
 
   req.wait();
-
-  STOP_LOG("send_receive()", "Parallel");
 }
 
 
@@ -2726,13 +2644,12 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
                                        const MessageTag & send_tag,
                                        const MessageTag & recv_tag) const
 {
-  START_LOG("send_receive()", "Parallel");
+  LOG_SCOPE("send_receive()", "Parallel");
 
   if (dest_processor_id   == this->rank() &&
       source_processor_id == this->rank())
     {
       recv = sendvec;
-      STOP_LOG("send_receive()", "Parallel");
       return;
     }
 
@@ -2753,8 +2670,6 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
                   StandardType<T2>(&recv), source_processor_id,
                   recv_tag.value(), this->get(), &stat));
 #endif
-
-  STOP_LOG("send_receive()", "Parallel");
 }
 
 
@@ -2777,9 +2692,8 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
   if (dest_processor_id   == this->rank() &&
       source_processor_id == this->rank())
     {
-      START_LOG("send_receive()", "Parallel");
+      LOG_SCOPE("send_receive()", "Parallel");
       recv = sendvec;
-      STOP_LOG("send_receive()", "Parallel");
       return;
     }
 
@@ -2867,7 +2781,7 @@ Communicator::send_receive_packed_range (const unsigned int dest_processor_id,
                                          const MessageTag & send_tag,
                                          const MessageTag & recv_tag) const
 {
-  START_LOG("send_receive()", "Parallel");
+  LOG_SCOPE("send_receive()", "Parallel");
 
   Parallel::Request req;
 
@@ -2878,9 +2792,6 @@ Communicator::send_receive_packed_range (const unsigned int dest_processor_id,
                               output_type, recv_tag);
 
   req.wait();
-
-  STOP_LOG("send_receive()", "Parallel");
-
 }
 
 
@@ -2897,7 +2808,7 @@ inline void Communicator::gather(const unsigned int root_id,
 
   if (this->size() > 1)
     {
-      START_LOG("gather()", "Parallel");
+      LOG_SCOPE("gather()", "Parallel");
 
       StandardType<T> send_type(&sendval);
 
@@ -2905,8 +2816,6 @@ inline void Communicator::gather(const unsigned int root_id,
         (MPI_Gather(&sendval, 1, send_type,
                     recv.empty() ? libmesh_nullptr : &recv[0], 1, send_type,
                     root_id, this->get()));
-
-      STOP_LOG("gather()", "Parallel");
     }
   else
     recv[0] = sendval;
@@ -2934,7 +2843,7 @@ inline void Communicator::gather(const unsigned int root_id,
   const int mysize = static_cast<int>(r.size());
   this->allgather(mysize, sendlengths);
 
-  START_LOG("gather()", "Parallel");
+  LOG_SCOPE("gather()", "Parallel");
 
   // Find the total size of the final array and
   // set up the displacement offsets for each processor.
@@ -2947,10 +2856,7 @@ inline void Communicator::gather(const unsigned int root_id,
 
   // Check for quick return
   if (globalsize == 0)
-    {
-      STOP_LOG("gather()", "Parallel");
-      return;
-    }
+    return;
 
   // copy the input buffer
   std::vector<T> r_src(r);
@@ -2966,8 +2872,6 @@ inline void Communicator::gather(const unsigned int root_id,
                   StandardType<T>(), r.empty() ? libmesh_nullptr : &r[0],
                   &sendlengths[0], &displacements[0],
                   StandardType<T>(), root_id, this->get()));
-
-  STOP_LOG("gather()", "Parallel");
 }
 
 
@@ -2975,7 +2879,7 @@ template <typename T>
 inline void Communicator::allgather(T sendval,
                                     std::vector<T> & recv) const
 {
-  START_LOG ("allgather()","Parallel");
+  LOG_SCOPE ("allgather()","Parallel");
 
   libmesh_assert(this->size());
   recv.resize(this->size());
@@ -2991,8 +2895,6 @@ inline void Communicator::allgather(T sendval,
     }
   else if (comm_size > 0)
     recv[0] = sendval;
-
-  STOP_LOG ("allgather()","Parallel");
 }
 
 
@@ -3004,7 +2906,7 @@ inline void Communicator::allgather(std::vector<T> & r,
   if (this->size() < 2)
     return;
 
-  START_LOG("allgather()", "Parallel");
+  LOG_SCOPE("allgather()", "Parallel");
 
   if (identical_buffer_sizes)
     {
@@ -3022,7 +2924,6 @@ inline void Communicator::allgather(std::vector<T> & r,
                         send_type, &r[0], cast_int<int>(r_src.size()),
                         send_type, this->get()));
       // libmesh_assert(this->verify(r));
-      STOP_LOG("allgather()", "Parallel");
       return;
     }
 
@@ -3044,10 +2945,7 @@ inline void Communicator::allgather(std::vector<T> & r,
 
   // Check for quick return
   if (globalsize == 0)
-    {
-      STOP_LOG("allgather()", "Parallel");
-      return;
-    }
+    return;
 
   // copy the input buffer
   std::vector<T> r_src(globalsize);
@@ -3061,8 +2959,6 @@ inline void Communicator::allgather(std::vector<T> & r,
     (MPI_Allgatherv (r_src.empty() ? libmesh_nullptr : &r_src[0], mysize,
                      send_type, &r[0], &sendlengths[0],
                      &displacements[0], send_type, this->get()));
-
-  STOP_LOG("allgather()", "Parallel");
 }
 
 
@@ -3139,7 +3035,7 @@ inline void Communicator::alltoall(std::vector<T> & buf) const
   if (this->size() < 2 || buf.empty())
     return;
 
-  START_LOG("alltoall()", "Parallel");
+  LOG_SCOPE("alltoall()", "Parallel");
 
   // the per-processor size.  this is the same for all
   // processors using MPI_Alltoall, could be variable
@@ -3158,8 +3054,6 @@ inline void Communicator::alltoall(std::vector<T> & buf) const
   libmesh_call_mpi
     (MPI_Alltoall (&tmp[0], size_per_proc, send_type, &buf[0],
                    size_per_proc, send_type, this->get()));
-
-  STOP_LOG("alltoall()", "Parallel");
 }
 
 
@@ -3176,14 +3070,12 @@ inline void Communicator::broadcast (T & data, const unsigned int root_id) const
 
   libmesh_assert_less (root_id, this->size());
 
-  START_LOG("broadcast()", "Parallel");
+  LOG_SCOPE("broadcast()", "Parallel");
 
   // Spread data to remote processors.
   libmesh_call_mpi
     (MPI_Bcast (&data, 1, StandardType<T>(&data), root_id,
                 this->get()));
-
-  STOP_LOG("broadcast()", "Parallel");
 }
 
 
@@ -3199,7 +3091,7 @@ inline void Communicator::broadcast (bool & data, const unsigned int root_id) co
 
   libmesh_assert_less (root_id, this->size());
 
-  START_LOG("broadcast()", "Parallel");
+  LOG_SCOPE("broadcast()", "Parallel");
 
   // We don't want to depend on MPI-2 or C++ MPI, so we don't have
   // MPI::BOOL available
@@ -3211,8 +3103,6 @@ inline void Communicator::broadcast (bool & data, const unsigned int root_id) co
                 root_id, this->get()));
 
   data = char_data;
-
-  STOP_LOG("broadcast()", "Parallel");
 }
 
 
@@ -3229,7 +3119,7 @@ inline void Communicator::broadcast (std::basic_string<T> & data,
 
   libmesh_assert_less (root_id, this->size());
 
-  START_LOG("broadcast()", "Parallel");
+  LOG_SCOPE("broadcast()", "Parallel");
 
   std::size_t data_size = data.size();
   this->broadcast(data_size, root_id);
@@ -3251,8 +3141,6 @@ inline void Communicator::broadcast (std::basic_string<T> & data,
   if (this->rank() == root_id)
     libmesh_assert_equal_to (data, orig);
 #endif
-
-  STOP_LOG("broadcast()", "Parallel");
 }
 
 
@@ -3270,7 +3158,7 @@ inline void Communicator::broadcast (std::vector<T> & data,
 
   libmesh_assert_less (root_id, this->size());
 
-  START_LOG("broadcast()", "Parallel");
+  LOG_SCOPE("broadcast()", "Parallel");
 
   // and get the data from the remote processors.
   // Pass NULL if our vector is empty.
@@ -3279,8 +3167,6 @@ inline void Communicator::broadcast (std::vector<T> & data,
   libmesh_call_mpi
     (MPI_Bcast (data_ptr, cast_int<int>(data.size()),
                 StandardType<T>(data_ptr), root_id, this->get()));
-
-  STOP_LOG("broadcast()", "Parallel");
 }
 
 
@@ -3297,7 +3183,7 @@ inline void Communicator::broadcast (std::vector<std::basic_string<T> > & data,
 
   libmesh_assert_less (root_id, this->size());
 
-  START_LOG("broadcast()", "Parallel");
+  LOG_SCOPE("broadcast()", "Parallel");
 
   std::size_t bufsize=0;
   if (root_id == this->rank())
@@ -3341,8 +3227,6 @@ inline void Communicator::broadcast (std::vector<std::basic_string<T> > & data,
           iter += curr_len;
         }
     }
-
-  STOP_LOG("broadcast()", "Parallel");
 }
 
 
@@ -3361,7 +3245,7 @@ inline void Communicator::broadcast (std::set<T> & data,
 
   libmesh_assert_less (root_id, this->size());
 
-  START_LOG("broadcast()", "Parallel");
+  LOG_SCOPE("broadcast()", "Parallel");
 
   std::vector<T> vecdata;
   if (this->rank() == root_id)
@@ -3378,8 +3262,6 @@ inline void Communicator::broadcast (std::set<T> & data,
       data.clear();
       data.insert(vecdata.begin(), vecdata.end());
     }
-
-  STOP_LOG("broadcast()", "Parallel");
 }
 
 
@@ -3397,7 +3279,7 @@ inline void Communicator::broadcast(std::map<T1, T2> & data,
 
   libmesh_assert_less (root_id, this->size());
 
-  START_LOG("broadcast()", "Parallel");
+  LOG_SCOPE("broadcast()", "Parallel");
 
   std::size_t data_size=data.size();
   this->broadcast(data_size, root_id);
@@ -3431,7 +3313,6 @@ inline void Communicator::broadcast(std::map<T1, T2> & data,
       for (std::size_t i=0; i<pair_first.size(); ++i)
         data[pair_first[i]] = pair_second[i];
     }
-  STOP_LOG("broadcast()", "Parallel");
 }
 
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -56,7 +56,7 @@ DofMap::build_sparsity (const MeshBase & mesh) const
 {
   libmesh_assert (mesh.is_prepared());
 
-  START_LOG("build_sparsity()", "DofMap");
+  LOG_SCOPE("build_sparsity()", "DofMap");
 
   // Compute the sparsity structure of the global matrix.  This can be
   // fed into a PetscMatrix to allocate exacly the number of nonzeros
@@ -97,8 +97,6 @@ DofMap::build_sparsity (const MeshBase & mesh) const
   const dof_id_type n_dofs_on_proc = this->n_dofs_on_processor(proc_id);
 #endif
   libmesh_assert_equal_to (sp->sparsity_pattern.size(), n_dofs_on_proc);
-
-  STOP_LOG("build_sparsity()", "DofMap");
 
   // Check to see if we have any extra stuff to add to the sparsity_pattern
   if (_extra_sparsity_function)
@@ -440,7 +438,7 @@ void DofMap::reinit(MeshBase & mesh)
 {
   libmesh_assert (mesh.is_prepared());
 
-  START_LOG("reinit()", "DofMap");
+  LOG_SCOPE("reinit()", "DofMap");
 
   const unsigned int
     sys_num      = this->sys_number(),
@@ -779,8 +777,6 @@ void DofMap::reinit(MeshBase & mesh)
   // Finally, clear all the current DOF indices
   // (distribute_dofs expects them cleared!)
   this->invalidate_dofs(mesh);
-
-  STOP_LOG("reinit()", "DofMap");
 }
 
 
@@ -848,7 +844,7 @@ void DofMap::distribute_dofs (MeshBase & mesh)
   parallel_object_only();
 
   // Log how long it takes to distribute the degrees of freedom
-  START_LOG("distribute_dofs()", "DofMap");
+  LOG_SCOPE("distribute_dofs()", "DofMap");
 
   libmesh_assert (mesh.is_prepared());
 
@@ -993,8 +989,6 @@ void DofMap::distribute_dofs (MeshBase & mesh)
         _first_scalar_df[v] = current_SCALAR_dof_index;
         current_SCALAR_dof_index += this->variable(v).type().order.get_order();
       }
-
-  STOP_LOG("distribute_dofs()", "DofMap");
 
   // Note that in the add_neighbors_to_send_list nodes on processor
   // boundaries that are shared by multiple elements are added for
@@ -1401,7 +1395,7 @@ void DofMap::distribute_local_dofs_var_major(dof_id_type & next_free_dof,
 
 void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
 {
-  START_LOG("add_neighbors_to_send_list()", "DofMap");
+  LOG_SCOPE("add_neighbors_to_send_list()", "DofMap");
 
   const unsigned int sys_num = this->sys_number();
 
@@ -1550,15 +1544,13 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
               _send_list.push_back(di[j]);
         }
     }
-
-  STOP_LOG("add_neighbors_to_send_list()", "DofMap");
 }
 
 
 
 void DofMap::prepare_send_list ()
 {
-  START_LOG("prepare_send_list()", "DofMap");
+  LOG_SCOPE("prepare_send_list()", "DofMap");
 
   // Check to see if we have any extra stuff to add to the send_list
   if (_extra_send_list_function)
@@ -1589,8 +1581,6 @@ void DofMap::prepare_send_list ()
   // Remove the end of the send_list.  Use the "swap trick"
   // from Effective STL
   std::vector<dof_id_type> (_send_list.begin(), new_end).swap (_send_list);
-
-  STOP_LOG("prepare_send_list()", "DofMap");
 }
 
 
@@ -1813,7 +1803,7 @@ void DofMap::dof_indices (const Elem * const elem,
   // active)
   libmesh_assert(!elem || elem->active());
 
-  START_LOG("dof_indices()", "DofMap");
+  LOG_SCOPE("dof_indices()", "DofMap");
 
   // Clear the DOF indices vector
   di.clear();
@@ -1860,7 +1850,6 @@ void DofMap::dof_indices (const Elem * const elem,
             }
         }
 
-      STOP_LOG("dof_indices()", "DofMap");
       return;
     }
 
@@ -1891,8 +1880,6 @@ void DofMap::dof_indices (const Elem * const elem,
 #ifdef DEBUG
   libmesh_assert_equal_to (tot_size, di.size());
 #endif
-
-  STOP_LOG("dof_indices()", "DofMap");
 }
 
 
@@ -1904,7 +1891,7 @@ void DofMap::dof_indices (const Elem * const elem,
   // We now allow elem==NULL to request just SCALAR dofs
   // libmesh_assert(elem);
 
-  START_LOG("dof_indices()", "DofMap");
+  LOG_SCOPE("dof_indices()", "DofMap");
 
   // Clear the DOF indices vector
   di.clear();
@@ -1938,7 +1925,6 @@ void DofMap::dof_indices (const Elem * const elem,
                        );
         }
 
-      STOP_LOG("dof_indices()", "DofMap");
       return;
     }
 
@@ -1967,8 +1953,6 @@ void DofMap::dof_indices (const Elem * const elem,
 #ifdef DEBUG
   libmesh_assert_equal_to (tot_size, di.size());
 #endif
-
-  STOP_LOG("dof_indices()", "DofMap");
 }
 
 
@@ -2100,7 +2084,7 @@ void DofMap::SCALAR_dof_indices (std::vector<dof_id_type> & di,
 #endif
                                  ) const
 {
-  START_LOG("SCALAR_dof_indices()", "DofMap");
+  LOG_SCOPE("SCALAR_dof_indices()", "DofMap");
 
   libmesh_assert(this->variable(vn).type().family == SCALAR);
 
@@ -2123,8 +2107,6 @@ void DofMap::SCALAR_dof_indices (std::vector<dof_id_type> & di,
   di.resize(n_dofs_vn);
   for(int i = 0; i != n_dofs_vn; ++i)
     di[i] = my_idx++;
-
-  STOP_LOG("SCALAR_dof_indices()", "DofMap");
 }
 
 
@@ -2156,7 +2138,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                               std::vector<dof_id_type> & di,
                               const unsigned int vn) const
 {
-  START_LOG("old_dof_indices()", "DofMap");
+  LOG_SCOPE("old_dof_indices()", "DofMap");
 
   libmesh_assert(elem);
 
@@ -2316,8 +2298,6 @@ void DofMap::old_dof_indices (const Elem * const elem,
                 }
             }
       } // end loop over variables
-
-  STOP_LOG("old_dof_indices()", "DofMap");
 }
 
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1049,7 +1049,7 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
 {
   parallel_object_only();
 
-  START_LOG("create_dof_constraints()", "DofMap");
+  LOG_SCOPE("create_dof_constraints()", "DofMap");
 
   libmesh_assert (mesh.is_prepared());
 
@@ -1090,8 +1090,6 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
       _node_constraints.clear();
 #endif
 
-      // make sure we stop logging though
-      STOP_LOG("create_dof_constraints()", "DofMap");
       return;
     }
 
@@ -1185,8 +1183,6 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
     }
 
 #endif // LIBMESH_ENABLE_DIRICHLET
-
-  STOP_LOG("create_dof_constraints()", "DofMap");
 }
 
 
@@ -1407,7 +1403,7 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
 
   this->build_constraint_matrix (C, elem_dofs);
 
-  START_LOG("constrain_elem_matrix()", "DofMap");
+  LOG_SCOPE("constrain_elem_matrix()", "DofMap");
 
   // It is possible that the matrix is not constrained at all.
   if ((C.m() == matrix.m()) &&
@@ -1456,8 +1452,6 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
               }
           }
     } // end if is constrained...
-
-  STOP_LOG("constrain_elem_matrix()", "DofMap");
 }
 
 
@@ -1481,7 +1475,7 @@ void DofMap::constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
 
   this->build_constraint_matrix (C, elem_dofs);
 
-  START_LOG("cnstrn_elem_mat_vec()", "DofMap");
+  LOG_SCOPE("cnstrn_elem_mat_vec()", "DofMap");
 
   // It is possible that the matrix is not constrained at all.
   if ((C.m() == matrix.m()) &&
@@ -1537,8 +1531,6 @@ void DofMap::constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
       // compute matrix/vector product
       C.vector_mult_transpose(rhs, old_rhs);
     } // end if is constrained...
-
-  STOP_LOG("cnstrn_elem_mat_vec()", "DofMap");
 }
 
 
@@ -1564,7 +1556,7 @@ void DofMap::heterogenously_constrain_element_matrix_and_vector (DenseMatrix<Num
 
   this->build_constraint_matrix_and_vector (C, H, elem_dofs, qoi_index);
 
-  START_LOG("hetero_cnstrn_elem_mat_vec()", "DofMap");
+  LOG_SCOPE("hetero_cnstrn_elem_mat_vec()", "DofMap");
 
   // It is possible that the matrix is not constrained at all.
   if ((C.m() == matrix.m()) &&
@@ -1645,8 +1637,6 @@ void DofMap::heterogenously_constrain_element_matrix_and_vector (DenseMatrix<Num
         }
 
     } // end if is constrained...
-
-  STOP_LOG("hetero_cnstrn_elem_mat_vec()", "DofMap");
 }
 
 
@@ -1672,7 +1662,7 @@ void DofMap::heterogenously_constrain_element_vector (const DenseMatrix<Number> 
 
   this->build_constraint_matrix_and_vector (C, H, elem_dofs, qoi_index);
 
-  START_LOG("hetero_cnstrn_elem_vec()", "DofMap");
+  LOG_SCOPE("hetero_cnstrn_elem_vec()", "DofMap");
 
   // It is possible that the matrix is not constrained at all.
   if ((C.m() == matrix.m()) &&
@@ -1722,8 +1712,6 @@ void DofMap::heterogenously_constrain_element_vector (const DenseMatrix<Number> 
         }
 
     } // end if is constrained...
-
-  STOP_LOG("hetero_cnstrn_elem_vec()", "DofMap");
 }
 
 
@@ -1754,7 +1742,7 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
   this->build_constraint_matrix (R, orig_row_dofs);
   this->build_constraint_matrix (C, orig_col_dofs);
 
-  START_LOG("constrain_elem_matrix()", "DofMap");
+  LOG_SCOPE("constrain_elem_matrix()", "DofMap");
 
   row_dofs = orig_row_dofs;
   col_dofs = orig_col_dofs;
@@ -1815,8 +1803,6 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
               }
           }
     } // end if is constrained...
-
-  STOP_LOG("constrain_elem_matrix()", "DofMap");
 }
 
 
@@ -1836,7 +1822,7 @@ void DofMap::constrain_element_vector (DenseVector<Number> & rhs,
 
   this->build_constraint_matrix (R, row_dofs);
 
-  START_LOG("constrain_elem_vector()", "DofMap");
+  LOG_SCOPE("constrain_elem_vector()", "DofMap");
 
   // It is possible that the vector is not constrained at all.
   if ((R.m() == rhs.size()) &&
@@ -1857,8 +1843,6 @@ void DofMap::constrain_element_vector (DenseVector<Number> & rhs,
             rhs(i) = 0;
           }
     } // end if the RHS is constrained.
-
-  STOP_LOG("constrain_elem_vector()", "DofMap");
 }
 
 
@@ -1880,7 +1864,7 @@ void DofMap::constrain_element_dyad_matrix (DenseVector<Number> & v,
 
   this->build_constraint_matrix (R, row_dofs);
 
-  START_LOG("cnstrn_elem_dyad_mat()", "DofMap");
+  LOG_SCOPE("cnstrn_elem_dyad_mat()", "DofMap");
 
   // It is possible that the vector is not constrained at all.
   if ((R.m() == v.size()) &&
@@ -1908,8 +1892,6 @@ void DofMap::constrain_element_dyad_matrix (DenseVector<Number> & v,
             v(i) = 0;
           }
     } // end if the RHS is constrained.
-
-  STOP_LOG("cnstrn_elem_dyad_mat()", "DofMap");
 }
 
 
@@ -1937,7 +1919,7 @@ void DofMap::enforce_constraints_exactly (const System & system,
   if (!this->n_constrained_dofs())
     return;
 
-  START_LOG("enforce_constraints_exactly()","DofMap");
+  LOG_SCOPE("enforce_constraints_exactly()","DofMap");
 
   if (!v)
     v = system.solution.get();
@@ -2023,8 +2005,6 @@ void DofMap::enforce_constraints_exactly (const System & system,
       v_global->localize (*v);
     }
   v->close();
-
-  STOP_LOG("enforce_constraints_exactly()","DofMap");
 }
 
 
@@ -2037,7 +2017,7 @@ void DofMap::enforce_adjoint_constraints_exactly (NumericVector<Number> & v,
   if (!this->n_constrained_dofs())
     return;
 
-  START_LOG("enforce_adjoint_constraints_exactly()","DofMap");
+  LOG_SCOPE("enforce_adjoint_constraints_exactly()", "DofMap");
 
   NumericVector<Number> * v_local  = libmesh_nullptr; // will be initialized below
   NumericVector<Number> * v_global = libmesh_nullptr; // will be initialized below
@@ -2128,8 +2108,6 @@ void DofMap::enforce_adjoint_constraints_exactly (NumericVector<Number> & v,
       v_global->localize (v);
     }
   v.close();
-
-  STOP_LOG("enforce_adjoint_constraints_exactly()","DofMap");
 }
 
 
@@ -2222,7 +2200,7 @@ void DofMap::build_constraint_matrix (DenseMatrix<Number> & C,
                                       std::vector<dof_id_type> & elem_dofs,
                                       const bool called_recursively) const
 {
-  if (!called_recursively) START_LOG("build_constraint_matrix()", "DofMap");
+  LOG_SCOPE_IF("build_constraint_matrix()", "DofMap", !called_recursively);
 
   // Create a set containing the DOFs we already depend on
   typedef std::set<dof_id_type> RCSet;
@@ -2260,10 +2238,7 @@ void DofMap::build_constraint_matrix (DenseMatrix<Number> & C,
   // May be safe to return at this point
   // (but remember to stop the perflog)
   if (!we_have_constraints)
-    {
-      STOP_LOG("build_constraint_matrix()", "DofMap");
-      return;
-    }
+    return;
 
   for (unsigned int i=0; i != elem_dofs.size(); ++i)
     dof_set.erase (elem_dofs[i]);
@@ -2329,8 +2304,6 @@ void DofMap::build_constraint_matrix (DenseMatrix<Number> & C,
 
       libmesh_assert_equal_to (C.n(), elem_dofs.size());
     }
-
-  if (!called_recursively) STOP_LOG("build_constraint_matrix()", "DofMap");
 }
 
 
@@ -2341,8 +2314,7 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
                                                  int qoi_index,
                                                  const bool called_recursively) const
 {
-  if (!called_recursively)
-    START_LOG("build_constraint_matrix_and_vector()", "DofMap");
+  LOG_SCOPE_IF("build_constraint_matrix_and_vector()", "DofMap", !called_recursively);
 
   // Create a set containing the DOFs we already depend on
   typedef std::set<dof_id_type> RCSet;
@@ -2380,10 +2352,7 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
   // May be safe to return at this point
   // (but remember to stop the perflog)
   if (!we_have_constraints)
-    {
-      STOP_LOG("build_constraint_matrix_and_vector()", "DofMap");
-      return;
-    }
+    return;
 
   for (unsigned int i=0; i != elem_dofs.size(); ++i)
     dof_set.erase (elem_dofs[i]);
@@ -2477,9 +2446,6 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
 
       libmesh_assert_equal_to (C.n(), elem_dofs.size());
     }
-
-  if (!called_recursively)
-    STOP_LOG("build_constraint_matrix_and_vector()", "DofMap");
 }
 
 

--- a/src/error_estimation/adjoint_residual_error_estimator.C
+++ b/src/error_estimation/adjoint_residual_error_estimator.C
@@ -53,7 +53,7 @@ void AdjointResidualErrorEstimator::estimate_error (const System & _system,
                                                     const NumericVector<Number> * solution_vector,
                                                     bool estimate_parent_error)
 {
-  START_LOG("estimate_error()", "AdjointResidualErrorEstimator");
+  LOG_SCOPE("estimate_error()", "AdjointResidualErrorEstimator");
 
   // The current mesh
   const MeshBase & mesh = _system.get_mesh();
@@ -274,8 +274,6 @@ void AdjointResidualErrorEstimator::estimate_error (const System & _system,
         delete dual_errors_per_cell[std::make_pair(&_system, v)];
         delete total_dual_errors_per_cell[std::make_pair(&_system, v)];
       }
-
-  STOP_LOG("estimate_error()", "AdjointResidualErrorEstimator");
 }
 
 } // namespace libMesh

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -394,19 +394,15 @@ void ExactErrorEstimator::estimate_error (const System & system,
   this->reduce_error(error_per_cell, system.comm());
 
   // Compute the square-root of each component.
-  START_LOG("std::sqrt()", "ExactErrorEstimator");
-  for (dof_id_type i=0; i<error_per_cell.size(); i++)
-    {
-
+  {
+    LOG_SCOPE("std::sqrt()", "ExactErrorEstimator");
+    for (dof_id_type i=0; i<error_per_cell.size(); i++)
       if (error_per_cell[i] != 0.)
         {
           libmesh_assert_greater (error_per_cell[i], 0.);
           error_per_cell[i] = std::sqrt(error_per_cell[i]);
         }
-
-
-    }
-  STOP_LOG("std::sqrt()", "ExactErrorEstimator");
+  }
 
   // If we used a non-standard solution before, now is the time to fix
   // the current_local_solution

--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -144,7 +144,7 @@ void HPCoarsenTest::add_projection(const System & system,
 
 void HPCoarsenTest::select_refinement (System & system)
 {
-  START_LOG("select_refinement()", "HPCoarsenTest");
+  LOG_SCOPE("select_refinement()", "HPCoarsenTest");
 
   // The current mesh
   MeshBase & mesh = system.get_mesh();
@@ -580,8 +580,6 @@ void HPCoarsenTest::select_refinement (System & system)
           elem->set_refinement_flag(Elem::DO_NOTHING);
         }
     }
-
-  STOP_LOG("select_refinement()", "HPCoarsenTest");
 }
 
 } // namespace libMesh

--- a/src/error_estimation/hp_singular.C
+++ b/src/error_estimation/hp_singular.C
@@ -35,7 +35,7 @@ namespace libMesh
 
 void HPSingularity::select_refinement (System & system)
 {
-  START_LOG("select_refinement()", "HPSingularity");
+  LOG_SCOPE("select_refinement()", "HPSingularity");
 
   // The current mesh
   MeshBase & mesh = system.get_mesh();
@@ -69,8 +69,6 @@ void HPSingularity::select_refinement (System & system)
             }
         }
     }
-
-  STOP_LOG("select_refinement()", "HPSingularity");
 }
 
 } // namespace libMesh

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -55,43 +55,43 @@ void JumpErrorEstimator::estimate_error (const System & system,
                                          const NumericVector<Number> * solution_vector,
                                          bool estimate_parent_error)
 {
-  START_LOG("estimate_error()", "JumpErrorEstimator");
-  /*
+  LOG_SCOPE("estimate_error()", "JumpErrorEstimator");
 
-    Conventions for assigning the direction of the normal:
-
-    - e & f are global element ids
-
-    Case (1.) Elements are at the same level, e<f
-    Compute the flux jump on the face and
-    add it as a contribution to error_per_cell[e]
-    and error_per_cell[f]
-
-    ----------------------
-    |           |          |
-    |           |    f     |
-    |           |          |
-    |    e      |---> n    |
-    |           |          |
-    |           |          |
-    ----------------------
-
-
-    Case (2.) The neighbor is at a higher level.
-    Compute the flux jump on e's face and
-    add it as a contribution to error_per_cell[e]
-    and error_per_cell[f]
-
-    ----------------------
-    |     |     |          |
-    |     |  e  |---> n    |
-    |     |     |          |
-    |-----------|    f     |
-    |     |     |          |
-    |     |     |          |
-    |     |     |          |
-    ----------------------
-  */
+  /**
+   * Conventions for assigning the direction of the normal:
+   *
+   * - e & f are global element ids
+   *
+   * Case (1.) Elements are at the same level, e<f
+   * Compute the flux jump on the face and
+   * add it as a contribution to error_per_cell[e]
+   * and error_per_cell[f]
+   *
+   *  ----------------------
+   * |           |          |
+   * |           |    f     |
+   * |           |          |
+   * |    e      |---> n    |
+   * |           |          |
+   * |           |          |
+   *  ----------------------
+   *
+   *
+   * Case (2.) The neighbor is at a higher level.
+   * Compute the flux jump on e's face and
+   * add it as a contribution to error_per_cell[e]
+   * and error_per_cell[f]
+   *
+   *  ----------------------
+   * |     |     |          |
+   * |     |  e  |---> n    |
+   * |     |     |          |
+   * |-----------|    f     |
+   * |     |     |          |
+   * |     |     |          |
+   * |     |     |          |
+   *  ----------------------
+   */
 
   // The current mesh
   const MeshBase & mesh = system.get_mesh();
@@ -414,8 +414,6 @@ void JumpErrorEstimator::estimate_error (const System & system,
       newsol->swap(*sys.solution);
       sys.update();
     }
-
-  STOP_LOG("estimate_error()", "JumpErrorEstimator");
 }
 
 

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -133,7 +133,7 @@ void PatchRecoveryErrorEstimator::estimate_error (const System & system,
                                                   const NumericVector<Number> * solution_vector,
                                                   bool)
 {
-  START_LOG("estimate_error()", "PatchRecoveryErrorEstimator");
+  LOG_SCOPE("estimate_error()", "PatchRecoveryErrorEstimator");
 
   // The current mesh
   const MeshBase & mesh = system.get_mesh();
@@ -181,8 +181,6 @@ void PatchRecoveryErrorEstimator::estimate_error (const System & system,
       newsol->swap(*sys.solution);
       sys.update();
     }
-
-  STOP_LOG("estimate_error()", "PatchRecoveryErrorEstimator");
 }
 
 

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -51,7 +51,7 @@ void UniformRefinementEstimator::estimate_error (const System & _system,
                                                  const NumericVector<Number> * solution_vector,
                                                  bool estimate_parent_error)
 {
-  START_LOG("estimate_error()", "UniformRefinementEstimator");
+  LOG_SCOPE("estimate_error()", "UniformRefinementEstimator");
   std::map<const System *, const NumericVector<Number> *> solution_vectors;
   solution_vectors[&_system] = solution_vector;
   this->_estimate_error (libmesh_nullptr,
@@ -61,7 +61,6 @@ void UniformRefinementEstimator::estimate_error (const System & _system,
                          libmesh_nullptr,
                          &solution_vectors,
                          estimate_parent_error);
-  STOP_LOG("estimate_error()", "UniformRefinementEstimator");
 }
 
 void UniformRefinementEstimator::estimate_errors (const EquationSystems & _es,
@@ -70,7 +69,7 @@ void UniformRefinementEstimator::estimate_errors (const EquationSystems & _es,
                                                   const std::map<const System *, const NumericVector<Number> *> * solution_vectors,
                                                   bool estimate_parent_error)
 {
-  START_LOG("estimate_errors()", "UniformRefinementEstimator");
+  LOG_SCOPE("estimate_errors()", "UniformRefinementEstimator");
   this->_estimate_error (&_es,
                          libmesh_nullptr,
                          &error_per_cell,
@@ -78,7 +77,6 @@ void UniformRefinementEstimator::estimate_errors (const EquationSystems & _es,
                          &error_norms,
                          solution_vectors,
                          estimate_parent_error);
-  STOP_LOG("estimate_errors()", "UniformRefinementEstimator");
 }
 
 void UniformRefinementEstimator::estimate_errors (const EquationSystems & _es,
@@ -86,7 +84,7 @@ void UniformRefinementEstimator::estimate_errors (const EquationSystems & _es,
                                                   const std::map<const System *, const NumericVector<Number> *> * solution_vectors,
                                                   bool estimate_parent_error)
 {
-  START_LOG("estimate_errors()", "UniformRefinementEstimator");
+  LOG_SCOPE("estimate_errors()", "UniformRefinementEstimator");
   this->_estimate_error (&_es,
                          libmesh_nullptr,
                          libmesh_nullptr,
@@ -94,7 +92,6 @@ void UniformRefinementEstimator::estimate_errors (const EquationSystems & _es,
                          libmesh_nullptr,
                          solution_vectors,
                          estimate_parent_error);
-  STOP_LOG("estimate_errors()", "UniformRefinementEstimator");
 }
 
 void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
@@ -683,11 +680,10 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
       this->reduce_error(*error_per_cell, es.comm());
 
       // Compute the square-root of each component.
-      START_LOG("std::sqrt()", "UniformRefinementEstimator");
+      LOG_SCOPE("std::sqrt()", "UniformRefinementEstimator");
       for (unsigned int i=0; i<error_per_cell->size(); i++)
         if ((*error_per_cell)[i] != 0.)
           (*error_per_cell)[i] = std::sqrt((*error_per_cell)[i]);
-      STOP_LOG("std::sqrt()", "UniformRefinementEstimator");
     }
   else
     {
@@ -699,11 +695,10 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
           this->reduce_error(*e, es.comm());
 
           // Compute the square-root of each component.
-          START_LOG("std::sqrt()", "UniformRefinementEstimator");
+          LOG_SCOPE("std::sqrt()", "UniformRefinementEstimator");
           for (unsigned int i=0; i<e->size(); i++)
             if ((*e)[i] != 0.)
               (*e)[i] = std::sqrt((*e)[i]);
-          STOP_LOG("std::sqrt()", "UniformRefinementEstimator");
         }
     }
 

--- a/src/error_estimation/weighted_patch_recovery_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_estimator.C
@@ -46,7 +46,7 @@ void WeightedPatchRecoveryErrorEstimator::estimate_error (const System & system,
                                                           const NumericVector<Number> * solution_vector,
                                                           bool)
 {
-  START_LOG("estimate_error()", "WeightedPatchRecoveryErrorEstimator");
+  LOG_SCOPE("estimate_error()", "WeightedPatchRecoveryErrorEstimator");
 
   // The current mesh
   const MeshBase & mesh = system.get_mesh();
@@ -94,8 +94,6 @@ void WeightedPatchRecoveryErrorEstimator::estimate_error (const System & system,
       newsol->swap(*sys.solution);
       sys.update();
     }
-
-  STOP_LOG("estimate_error()", "WeightedPatchRecoveryErrorEstimator");
 }
 
 

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -280,13 +280,8 @@ template <unsigned int Dim, FEFamily T>
 void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
                                      const Elem * elem)
 {
-  // We can be called with no element.  If we're evaluating SCALAR
-  // dofs we'll still have work to do.
-  // libmesh_assert(elem);
-
   // Start logging the shape function initialization
-  START_LOG("init_shape_functions()", "FE");
-
+  LOG_SCOPE("init_shape_functions()", "FE");
 
   // The number of quadrature points.
   const unsigned int n_qp = cast_int<unsigned int>(qp.size());
@@ -531,9 +526,6 @@ void FE<Dim,T>::init_shape_functions(const std::vector<Point> & qp,
     default:
       libmesh_error_msg("Invalid dimension Dim = " << Dim);
     }
-
-  // Stop logging the shape function initialization
-  STOP_LOG("init_shape_functions()", "FE");
 }
 
 

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -679,8 +679,8 @@ FEGenericBase<RealGradient>::build_InfFE (const unsigned int,
 
 
 template <typename OutputType>
-void FEGenericBase<OutputType> ::compute_shape_functions (const Elem * elem,
-                                                          const std::vector<Point> & qp)
+void FEGenericBase<OutputType>::compute_shape_functions (const Elem * elem,
+                                                         const std::vector<Point> & qp)
 {
   //-------------------------------------------------------------------------
   // Compute the shape function values (and derivatives)
@@ -688,7 +688,7 @@ void FEGenericBase<OutputType> ::compute_shape_functions (const Elem * elem,
   // have already been computed via init_shape_functions
 
   // Start logging the shape function computation
-  START_LOG("compute_shape_functions()", "FE");
+  LOG_SCOPE("compute_shape_functions()", "FE");
 
   this->determine_calculations();
 
@@ -713,9 +713,6 @@ void FEGenericBase<OutputType> ::compute_shape_functions (const Elem * elem,
   // Only compute div for vector-valued elements
   if( calculate_div_phi && TypesEqual<OutputType,RealGradient>::value )
     this->_fe_trans->map_div( this->dim, elem, qp, (*this), this->div_phi );
-
-  // Stop logging the shape function computation
-  STOP_LOG("compute_shape_functions()", "FE");
 }
 
 

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -400,10 +400,8 @@ template<unsigned int Dim>
 void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
                                       const Elem * side)
 {
-  /**
-   * Start logging the shape function initialization
-   */
-  START_LOG("init_face_shape_functions()", "FEMap");
+  // Start logging the shape function initialization
+  LOG_SCOPE("init_face_shape_functions()", "FEMap");
 
   libmesh_assert(side);
 
@@ -501,22 +499,14 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
             }
         }
     }
-
-
-  /**
-   * Stop logging the shape function initialization
-   */
-  STOP_LOG("init_face_shape_functions()", "FEMap");
 }
 
 template<unsigned int Dim>
 void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
                                       const Elem * edge)
 {
-  /**
-   * Start logging the shape function initialization
-   */
-  START_LOG("init_edge_shape_functions()", "FEMap");
+  // Start logging the shape function initialization
+  LOG_SCOPE("init_edge_shape_functions()", "FEMap");
 
   libmesh_assert(edge);
 
@@ -568,11 +558,6 @@ void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
             this->d2psidxi2_map[i][p]  = FE<1,LAGRANGE>::shape_second_deriv(mapping_elem_type, mapping_order, i, 0, qp[p]);
         }
     }
-
-  /**
-   * Stop logging the shape function initialization
-   */
-  STOP_LOG("init_edge_shape_functions()", "FEMap");
 }
 
 
@@ -585,7 +570,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
   // We're calculating now!
   this->determine_calculations();
 
-  START_LOG("compute_face_map()", "FEMap");
+  LOG_SCOPE("compute_face_map()", "FEMap");
 
   // The number of quadrature points.
   const unsigned int n_qp = cast_int<unsigned int>(qw.size());
@@ -919,7 +904,6 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
     default:
       libmesh_error_msg("Invalid dimension dim = " << dim);
     }
-  STOP_LOG("compute_face_map()", "FEMap");
 }
 
 
@@ -942,7 +926,7 @@ void FEMap::compute_edge_map(int dim,
 
   libmesh_assert_equal_to (dim, 3);  // 1D is unnecessary and currently unsupported
 
-  START_LOG("compute_edge_map()", "FEMap");
+  LOG_SCOPE("compute_edge_map()", "FEMap");
 
   // We're calculating now!
   this->determine_calculations();
@@ -1021,8 +1005,6 @@ void FEMap::compute_edge_map(int dim,
 
         this->JxW[p] = the_jac*qw[p];
       }
-
-  STOP_LOG("compute_edge_map()", "FEMap");
 }
 
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -65,11 +65,11 @@ UniquePtr<FEMap> FEMap::build( FEType fe_type )
 
 
 template<unsigned int Dim>
-void FEMap::init_reference_to_physical_map( const std::vector<Point> & qp,
-                                            const Elem * elem)
+void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
+                                           const Elem * elem)
 {
   // Start logging the reference->physical map initialization
-  START_LOG("init_reference_to_physical_map()", "FEMap");
+  LOG_SCOPE("init_reference_to_physical_map()", "FEMap");
 
   // We're calculating now!
   this->determine_calculations();
@@ -388,10 +388,6 @@ void FEMap::init_reference_to_physical_map( const std::vector<Point> & qp,
     default:
       libmesh_error_msg("Invalid Dim = " << Dim);
     }
-
-  // Stop logging the reference->physical map initialization
-  STOP_LOG("init_reference_to_physical_map()", "FEMap");
-  return;
 }
 
 
@@ -1167,12 +1163,12 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
 
 
 
-void FEMap::compute_affine_map( const unsigned int dim,
-                                const std::vector<Real> & qw,
-                                const Elem * elem )
+void FEMap::compute_affine_map(const unsigned int dim,
+                               const std::vector<Real> & qw,
+                               const Elem * elem)
 {
   // Start logging the map computation.
-  START_LOG("compute_affine_map()", "FEMap");
+  LOG_SCOPE("compute_affine_map()", "FEMap");
 
   libmesh_assert(elem);
 
@@ -1243,17 +1239,15 @@ void FEMap::compute_affine_map( const unsigned int dim,
         jac[p] = jac[0];
         JxW[p] = JxW[0] / qw[0] * qw[p];
       }
-
-  STOP_LOG("compute_affine_map()", "FEMap");
 }
 
 
 
-void FEMap::compute_null_map( const unsigned int dim,
-                              const std::vector<Real> & qw)
+void FEMap::compute_null_map(const unsigned int dim,
+                             const std::vector<Real> & qw)
 {
   // Start logging the map computation.
-  START_LOG("compute_null_map()", "FEMap");
+  LOG_SCOPE("compute_null_map()", "FEMap");
 
   const unsigned int n_qp = cast_int<unsigned int>(qw.size());
 
@@ -1320,8 +1314,6 @@ void FEMap::compute_null_map( const unsigned int dim,
           JxW[p] = qw[p];
         }
     }
-
-  STOP_LOG("compute_null_map()", "FEMap");
 }
 
 
@@ -1344,7 +1336,7 @@ void FEMap::compute_map(const unsigned int dim,
     }
 
   // Start logging the map computation.
-  START_LOG("compute_map()", "FEMap");
+  LOG_SCOPE("compute_map()", "FEMap");
 
   libmesh_assert(elem);
 
@@ -1373,9 +1365,6 @@ void FEMap::compute_map(const unsigned int dim,
   // Compute map at all quadrature points
   for (unsigned int p=0; p!=n_qp; p++)
     this->compute_single_point_map(dim, qw, elem, p, elem_nodes, calculate_d2phi);
-
-  // Stop logging the map computation.
-  STOP_LOG("compute_map()", "FEMap");
 }
 
 
@@ -1526,7 +1515,7 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
 
 
   // Start logging the map inversion.
-  START_LOG("inverse_map()", "FE");
+  LOG_SCOPE("inverse_map()", "FE");
 
   // How much did the point on the reference
   // element change by in this Newton step?
@@ -1813,7 +1802,6 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
               for (unsigned int i=0; i != Dim; ++i)
                 p(i) = 1e6;
 
-              STOP_LOG("inverse_map()", "FE");
               return p;
             }
         }
@@ -1861,11 +1849,6 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
     }
 
 #endif
-
-
-
-  //  Stop logging the map inversion.
-  STOP_LOG("inverse_map()", "FE");
 
   return p;
 }

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -417,7 +417,7 @@ void FESubdivision::init_shape_functions(const std::vector<Point> & qp,
   libmesh_assert_equal_to(elem->type(), TRI3SUBDIVISION);
   const Tri3Subdivision * sd_elem = static_cast<const Tri3Subdivision *>(elem);
 
-  START_LOG("init_shape_functions()", "FESubdivision");
+  LOG_SCOPE("init_shape_functions()", "FESubdivision");
 
   calculations_started = true;
 
@@ -650,8 +650,6 @@ void FESubdivision::init_shape_functions(const std::vector<Point> & qp,
   this->_fe_map->get_d2phideta2_map()   = d2phideta2;
   this->_fe_map->get_d2phidxideta_map() = d2phidxideta;
 #endif
-
-  STOP_LOG("init_shape_functions()", "FESubdivision");
 }
 
 
@@ -678,7 +676,7 @@ void FESubdivision::reinit(const Elem * elem,
   const Tri3Subdivision * sd_elem = static_cast<const Tri3Subdivision *>(elem);
 #endif
 
-  START_LOG("reinit()", "FESubdivision");
+  LOG_SCOPE("reinit()", "FESubdivision");
 
   libmesh_assert(!sd_elem->is_ghost());
   libmesh_assert(sd_elem->is_subdivision_updated());
@@ -703,8 +701,6 @@ void FESubdivision::reinit(const Elem * elem,
 
   // Compute the map for this element.
   this->_fe_map->compute_map (this->dim, this->qrule->get_weights(), elem, this->calculate_d2phi);
-
-  STOP_LOG("reinit()", "FESubdivision");
 }
 
 

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -584,8 +584,7 @@ void FEXYZ<Dim>::init_shape_functions(const std::vector<Point> & qp,
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   // Start logging the shape function initialization
-  START_LOG("init_shape_functions()", "FE");
-
+  LOG_SCOPE("init_shape_functions()", "FE");
 
   // The number of quadrature points.
   const std::size_t n_qp = qp.size();
@@ -673,9 +672,6 @@ void FEXYZ<Dim>::init_shape_functions(const std::vector<Point> & qp,
 
   }
 #endif // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-
-  // Stop logging the shape function initialization
-  STOP_LOG("init_shape_functions()", "FE");
 }
 
 
@@ -693,7 +689,7 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
   // have already been computed via init_shape_functions
 
   // Start logging the shape function computation
-  START_LOG("compute_shape_functions()", "FE");
+  LOG_SCOPE("compute_shape_functions()", "FE");
 
   const std::vector<Point> & xyz_qp = this->get_xyz();
 
@@ -838,9 +834,6 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Invalid dimension " << this->dim);
     }
-
-  // Stop logging the shape function computation
-  STOP_LOG("compute_shape_functions()", "FE");
 }
 
 

--- a/src/fe/fe_xyz_boundary.C
+++ b/src/fe/fe_xyz_boundary.C
@@ -132,7 +132,7 @@ void FEXYZ<Dim>::compute_face_values(const Elem * elem,
   libmesh_assert(elem);
   libmesh_assert(side);
 
-  START_LOG("compute_face_values()", "FEXYZ");
+  LOG_SCOPE("compute_face_values()", "FEXYZ");
 
   // The number of quadrature points.
   const std::size_t n_qp = qw.size();
@@ -218,8 +218,6 @@ void FEXYZ<Dim>::compute_face_values(const Elem * elem,
     default:
       libmesh_error_msg("Invalid dim " << this->dim);
     }
-
-  STOP_LOG("compute_face_values()", "FEXYZ");
 }
 
 

--- a/src/fe/fe_xyz_map.C
+++ b/src/fe/fe_xyz_map.C
@@ -25,7 +25,7 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
 {
   libmesh_assert(side);
 
-  START_LOG("compute_face_map()", "FEXYZMap");
+  LOG_SCOPE("compute_face_map()", "FEXYZMap");
 
   // The number of quadrature points.
   const unsigned int n_qp = cast_int<unsigned int>(qw.size());
@@ -213,10 +213,6 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
       libmesh_error_msg("Invalid dim = " << dim);
 
     } // switch(dim)
-
-  STOP_LOG("compute_face_map()", "FEXYZMap");
-
-  return;
 }
 
 } // namespace libMesh

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -291,12 +291,8 @@ void InfFE<Dim,T_radial,T_map>::init_radial_shape_functions(const Elem * libmesh
   libmesh_assert(radial_qrule);
   libmesh_assert(inf_elem);
 
-
-  /**
-   * Start logging the radial shape function initialization
-   */
-  START_LOG("init_radial_shape_functions()", "InfFE");
-
+  // Start logging the radial shape function initialization
+  LOG_SCOPE("init_radial_shape_functions()", "InfFE");
 
   // -----------------------------------------------------------------
   // initialize most of the things related to mapping
@@ -369,12 +365,6 @@ void InfFE<Dim,T_radial,T_map>::init_radial_shape_functions(const Elem * libmesh
         radial_map[i][p]    = InfFE<Dim,INFINITE_MAP,T_map>::eval       (radial_qp[p](0), radial_mapping_order, i);
         dradialdv_map[i][p] = InfFE<Dim,INFINITE_MAP,T_map>::eval_deriv (radial_qp[p](0), radial_mapping_order, i);
       }
-
-  /**
-   * Stop logging the radial shape function initialization
-   */
-  STOP_LOG("init_radial_shape_functions()", "InfFE");
-
 }
 
 
@@ -386,10 +376,8 @@ void InfFE<Dim,T_radial,T_map>::init_shape_functions(const Elem * inf_elem)
 {
   libmesh_assert(inf_elem);
 
-
   // Start logging the radial shape function initialization
-  START_LOG("init_shape_functions()", "InfFE");
-
+  LOG_SCOPE("init_shape_functions()", "InfFE");
 
   // -----------------------------------------------------------------
   // fast access to some const int's for the radial data
@@ -720,13 +708,6 @@ void InfFE<Dim,T_radial,T_map>::init_shape_functions(const Elem * inf_elem)
           _total_qrule_weights[  bp+rp*n_base_qp ] = radial_qw[rp] * base_qw[bp];
         }
   }
-
-
-  /**
-   * Stop logging the radial shape function initialization
-   */
-  STOP_LOG("init_shape_functions()", "InfFE");
-
 }
 
 
@@ -741,12 +722,8 @@ void InfFE<Dim,T_radial,T_map>::combine_base_radial(const Elem * inf_elem)
   // otherwise this version of computing dist would give problems
   libmesh_assert_equal_to (base_elem->type(), Base::get_elem_type(inf_elem->type()));
 
-
-  /**
-   * Start logging the combination of radial and base parts
-   */
-  START_LOG("combine_base_radial()", "InfFE");
-
+  // Start logging the combination of radial and base parts
+  LOG_SCOPE("combine_base_radial()", "InfFE");
 
   // zero  the phase, since it is to be summed up
   std::fill (dphasedxi.begin(),   dphasedxi.end(),   0.);
@@ -882,12 +859,6 @@ void InfFE<Dim,T_radial,T_map>::combine_base_radial(const Elem * inf_elem)
     default:
       libmesh_error_msg("Unsupported Dim = " << Dim);
     }
-
-
-  /**
-   * Start logging the combination of radial and base parts
-   */
-  STOP_LOG("combine_base_radial()", "InfFE");
 }
 
 
@@ -902,11 +873,9 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_functions(const Elem *,
   libmesh_assert(radial_qrule);
 
   // Start logging the overall computation of shape functions
-  START_LOG("compute_shape_functions()", "InfFE");
-
+  LOG_SCOPE("compute_shape_functions()", "InfFE");
 
   const unsigned int n_total_qp  = _n_total_qp;
-
 
   //-------------------------------------------------------------------------
   // Compute the shape function values (and derivatives)
@@ -999,9 +968,6 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_functions(const Elem *,
     default:
       libmesh_error_msg("Unsupported dim = " << dim);
     }
-
-  // Stop logging the overall computation of shape functions
-  STOP_LOG("compute_shape_functions()", "InfFE");
 }
 
 

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -95,10 +95,8 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
   libmesh_assert(inf_elem);
   libmesh_assert_greater_equal (tolerance, 0.);
 
-
   // Start logging the map inversion.
-  START_LOG("inverse_map()", "InfFE");
-
+  LOG_SCOPE("inverse_map()", "InfFE");
 
   // 1.)
   // build a base element to do the map inversion in the base face
@@ -607,12 +605,6 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
     }
   */
 #endif
-
-
-
-
-  // Stop logging the map inversion.
-  STOP_LOG("inverse_map()", "InfFE");
 
   return p;
 }

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -147,7 +147,7 @@ void BoundaryInfo::sync (const std::set<boundary_id_type> & requested_boundary_i
                          MeshData *     boundary_mesh_data,
                          MeshData *     this_mesh_data)
 {
-  START_LOG("sync()", "BoundaryInfo");
+  LOG_SCOPE("sync()", "BoundaryInfo");
 
   boundary_mesh.clear();
 
@@ -252,8 +252,6 @@ void BoundaryInfo::sync (const std::set<boundary_id_type> & requested_boundary_i
 
   // and finally distribute element partitioning to the nodes
   Partitioner::set_node_processor_ids(boundary_mesh);
-
-  STOP_LOG("sync()", "BoundaryInfo");
 }
 
 
@@ -262,7 +260,7 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
                                            std::map<dof_id_type, unsigned char> & side_id_map,
                                            Real tolerance)
 {
-  START_LOG("get_side_and_node_maps()", "BoundaryInfo");
+  LOG_SCOPE("get_side_and_node_maps()", "BoundaryInfo");
 
   node_id_map.clear();
   side_id_map.clear();
@@ -311,15 +309,13 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
         }
 
     }
-
-  STOP_LOG("get_side_and_node_maps()", "BoundaryInfo");
 }
 
 
 void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_boundary_ids,
                                 UnstructuredMesh & boundary_mesh)
 {
-  START_LOG("add_elements()", "BoundaryInfo");
+  LOG_SCOPE("add_elements()", "BoundaryInfo");
 
   // We're not prepared to mix serial and distributed meshes in this
   // method, so make sure they match from the start.
@@ -542,8 +538,6 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
     parmesh->libmesh_assert_valid_parallel_ids();
 # endif
 #endif
-
-  STOP_LOG("add_elements()", "BoundaryInfo");
 }
 
 

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -76,7 +76,7 @@ CheckpointIO::~CheckpointIO ()
 
 void CheckpointIO::write (const std::string & name)
 {
-  START_LOG("write()","CheckpointIO");
+  LOG_SCOPE("write()", "CheckpointIO");
 
   // convenient reference to our mesh
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
@@ -138,8 +138,6 @@ void CheckpointIO::write (const std::string & name)
     }
 
   this->comm().barrier();
-
-  STOP_LOG("write()","CheckpointIO");
 }
 
 
@@ -401,7 +399,7 @@ void CheckpointIO::write_bc_names (Xdr & io, const BoundaryInfo & info, bool is_
 
 void CheckpointIO::read (const std::string & name)
 {
-  START_LOG("read()","CheckpointIO");
+  LOG_SCOPE("read()","CheckpointIO");
 
   MeshBase & mesh = MeshInput<MeshBase>::mesh();
 
@@ -472,8 +470,6 @@ void CheckpointIO::read (const std::string & name)
   // If the mesh is serial then we only read it on processor 0 so we need to broadcast it
   if(!parallel_mesh)
     MeshCommunication().broadcast(mesh);
-
-  STOP_LOG("read()","CheckpointIO");
 }
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -608,7 +608,7 @@ void ExodusII_IO::write_nodal_data (const std::string & fname,
                                     const std::vector<Number> & soln,
                                     const std::vector<std::string> & names)
 {
-  START_LOG("write_nodal_data()", "ExodusII_IO");
+  LOG_SCOPE("write_nodal_data()", "ExodusII_IO");
 
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
@@ -635,11 +635,8 @@ void ExodusII_IO::write_nodal_data (const std::string & fname,
   this->write_nodal_data_common(fname, output_names, /*continuous=*/true);
 #endif
 
-  if(mesh.processor_id())
-    {
-      STOP_LOG("write_nodal_data()", "ExodusII_IO");
-      return;
-    }
+  if (mesh.processor_id())
+    return;
 
   // This will count the number of variables actually output
   for (int c=0; c<num_vars; c++)
@@ -678,8 +675,6 @@ void ExodusII_IO::write_nodal_data (const std::string & fname,
 #endif
 
     }
-
-  STOP_LOG("write_nodal_data()", "ExodusII_IO");
 }
 
 
@@ -811,8 +806,7 @@ void ExodusII_IO::write_nodal_data_discontinuous (const std::string & fname,
                                                   const std::vector<Number> & soln,
                                                   const std::vector<std::string> & names)
 {
-
-  START_LOG("write_nodal_data_discontinuous()", "ExodusII_IO");
+  LOG_SCOPE("write_nodal_data_discontinuous()", "ExodusII_IO");
 
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
@@ -836,10 +830,7 @@ void ExodusII_IO::write_nodal_data_discontinuous (const std::string & fname,
 #endif
 
   if (mesh.processor_id())
-    {
-      STOP_LOG("write_nodal_data_discontinuous()", "ExodusII_IO");
-      return;
-    }
+    return;
 
   for (int c=0; c<num_vars; c++)
     {
@@ -867,8 +858,6 @@ void ExodusII_IO::write_nodal_data_discontinuous (const std::string & fname,
       exio_helper->write_nodal_values(c+1,cur_soln,_timestep);
 #endif
     }
-
-  STOP_LOG("write_nodal_data_discontinuous()", "ExodusII_IO");
 }
 
 

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -653,13 +653,10 @@ void GmshIO::write_nodal_data (const std::string & fname,
                                const std::vector<Number> & soln,
                                const std::vector<std::string> & names)
 {
-  START_LOG("write_nodal_data()", "GmshIO");
+  LOG_SCOPE("write_nodal_data()", "GmshIO");
 
-  //this->_binary = true;
   if (MeshOutput<MeshBase>::mesh().processor_id() == 0)
     this->write_post  (fname, &soln, &names);
-
-  STOP_LOG("write_nodal_data()", "GmshIO");
 }
 
 

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -219,14 +219,12 @@ void GMVIO::write_nodal_data (const std::string & fname,
                               const std::vector<Number> & soln,
                               const std::vector<std::string> & names)
 {
-  START_LOG("write_nodal_data()", "GMVIO");
+  LOG_SCOPE("write_nodal_data()", "GMVIO");
 
   if (this->binary())
     this->write_binary (fname, &soln, &names);
   else
     this->write_ascii_old_impl  (fname, &soln, &names);
-
-  STOP_LOG("write_nodal_data()", "GMVIO");
 }
 
 

--- a/src/mesh/gnuplot_io.C
+++ b/src/mesh/gnuplot_io.C
@@ -49,11 +49,8 @@ void GnuPlotIO::write_nodal_data (const std::string & fname,
                                   const std::vector<Number> & soln,
                                   const std::vector<std::string> & names)
 {
-  START_LOG("write_nodal_data()", "GnuPlotIO");
-
+  LOG_SCOPE("write_nodal_data()", "GnuPlotIO");
   this->write_solution(fname, &soln, &names);
-
-  STOP_LOG("write_nodal_data()", "GnuPlotIO");
 }
 
 

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -300,7 +300,7 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
   // update element neighbors
   this->_mesh.find_neighbors();
 
-  START_LOG("build_inf_elem()", "InfElemBuilder");
+  LOG_SCOPE("build_inf_elem()", "InfElemBuilder");
 
   // A set for storing element number, side number pairs.
   // pair.first == element number, pair.second == side number
@@ -650,8 +650,6 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
                  << std::endl
                  << std::endl;
 #endif
-
-  STOP_LOG("build_inf_elem()", "InfElemBuilder");
 }
 
 } // namespace libMesh

--- a/src/mesh/medit_io.C
+++ b/src/mesh/medit_io.C
@@ -47,13 +47,11 @@ void MEDITIO::write_nodal_data (const std::string & fname,
                                 const std::vector<Number> & soln,
                                 const std::vector<std::string> & names)
 {
-  START_LOG("write_nodal_data()", "MEDITIO");
+  LOG_SCOPE("write_nodal_data()", "MEDITIO");
 
   if (this->mesh().processor_id() == 0)
     if (!this->binary())
       this->write_ascii  (fname, &soln, &names);
-
-  STOP_LOG("write_nodal_data()", "MEDITIO");
 }
 
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -191,7 +191,7 @@ void MeshCommunication::redistribute (ParallelMesh & mesh) const
   libmesh_assert (MeshTools::n_elem(mesh.unpartitioned_elements_begin(),
                                     mesh.unpartitioned_elements_end()) == 0);
 
-  START_LOG("redistribute()","MeshCommunication");
+  LOG_SCOPE("redistribute()", "MeshCommunication");
 
   // Get a few unique message tags to use in communications; we'll
   // default to some numbers around pi*1000
@@ -382,8 +382,6 @@ void MeshCommunication::redistribute (ParallelMesh & mesh) const
 
   MeshTools::libmesh_assert_valid_refinement_tree(mesh);
 #endif
-
-  STOP_LOG("redistribute()","MeshCommunication");
 }
 #endif // LIBMESH_HAVE_MPI
 
@@ -408,7 +406,7 @@ void MeshCommunication::gather_neighboring_elements (ParallelMesh & mesh) const
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
 
-  START_LOG("gather_neighboring_elements()","MeshCommunication");
+  LOG_SCOPE("gather_neighboring_elements()", "MeshCommunication");
 
   //------------------------------------------------------------------
   // The purpose of this function is to provide neighbor data structure
@@ -757,8 +755,6 @@ void MeshCommunication::gather_neighboring_elements (ParallelMesh & mesh) const
 
   Parallel::sync_dofobject_data_by_id
     (mesh.comm(), mesh.elements_begin(), mesh.elements_end(), nsync);
-
-  STOP_LOG("gather_neighboring_elements()","MeshCommunication");
 }
 #endif // LIBMESH_HAVE_MPI
 
@@ -782,7 +778,7 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
 
-  START_LOG("broadcast()","MeshCommunication");
+  LOG_SCOPE("broadcast()", "MeshCommunication");
 
   // Explicitly clear the mesh on all but processor 0.
   if (mesh.processor_id() != 0)
@@ -822,8 +818,6 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
   MeshTools::libmesh_assert_valid_procids<Elem>(mesh);
   MeshTools::libmesh_assert_valid_procids<Node>(mesh);
 #endif
-
-  STOP_LOG("broadcast()","MeshCommunication");
 }
 #endif // LIBMESH_HAVE_MPI
 
@@ -850,7 +844,7 @@ void MeshCommunication::gather (const processor_id_type root_id, ParallelMesh & 
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
 
-  START_LOG("(all)gather()","MeshCommunication");
+  LOG_SCOPE("(all)gather()", "MeshCommunication");
 
   (root_id == DofObject::invalid_processor_id) ?
 
@@ -902,7 +896,6 @@ void MeshCommunication::gather (const processor_id_type root_id, ParallelMesh & 
     mesh.find_neighbors(true);
 
   // All done!
-  STOP_LOG("(all)gather()","MeshCommunication");
 }
 #endif // LIBMESH_HAVE_MPI
 
@@ -1032,32 +1025,31 @@ void MeshCommunication::make_node_ids_parallel_consistent (MeshBase & mesh)
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
 
-  START_LOG ("make_node_ids_parallel_consistent()", "MeshCommunication");
+  LOG_SCOPE ("make_node_ids_parallel_consistent()", "MeshCommunication");
 
   SyncIds syncids(mesh, &MeshBase::renumber_node);
-  Parallel::sync_node_data_by_element_id
-    (mesh, mesh.elements_begin(), mesh.elements_end(), syncids);
-
-  STOP_LOG ("make_node_ids_parallel_consistent()", "MeshCommunication");
+  Parallel::sync_node_data_by_element_id(mesh,
+                                         mesh.elements_begin(),
+                                         mesh.elements_end(),
+                                         syncids);
 }
 
 
 
-void MeshCommunication::make_node_unique_ids_parallel_consistent
-(MeshBase &mesh)
+void MeshCommunication::make_node_unique_ids_parallel_consistent (MeshBase &mesh)
 {
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-  START_LOG ("make_node_unique_ids_parallel_consistent()", "MeshCommunication");
+  LOG_SCOPE ("make_node_unique_ids_parallel_consistent()", "MeshCommunication");
 
   SyncUniqueIds<Node> syncuniqueids(mesh, &MeshBase::query_node_ptr);
-  Parallel::sync_dofobject_data_by_id
-    (mesh.comm(), mesh.nodes_begin(), mesh.nodes_end(),
-     syncuniqueids);
+  Parallel::sync_dofobject_data_by_id(mesh.comm(),
+                                      mesh.nodes_begin(),
+                                      mesh.nodes_end(),
+                                      syncuniqueids);
 
-  STOP_LOG ("make_node_unique_ids_parallel_consistent()", "MeshCommunication");
 #endif
 }
 
@@ -1070,7 +1062,7 @@ void MeshCommunication::make_elems_parallel_consistent(MeshBase & mesh)
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
 
-  START_LOG ("make_elems_parallel_consistent()", "MeshCommunication");
+  LOG_SCOPE ("make_elems_parallel_consistent()", "MeshCommunication");
 
   SyncIds syncids(mesh, &MeshBase::renumber_elem);
   Parallel::sync_element_data_by_parent_id
@@ -1083,8 +1075,6 @@ void MeshCommunication::make_elems_parallel_consistent(MeshBase & mesh)
     (mesh.comm(), mesh.active_elements_begin(),
      mesh.active_elements_end(), syncuniqueids);
 #endif
-
-  STOP_LOG ("make_elems_parallel_consistent()", "MeshCommunication");
 }
 
 
@@ -1095,14 +1085,12 @@ void MeshCommunication::make_p_levels_parallel_consistent(MeshBase & mesh)
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
 
-  START_LOG ("make_p_levels_parallel_consistent()", "MeshCommunication");
+  LOG_SCOPE ("make_p_levels_parallel_consistent()", "MeshCommunication");
 
   SyncPLevels syncplevels(mesh);
   Parallel::sync_dofobject_data_by_id
     (mesh.comm(), mesh.elements_begin(), mesh.elements_end(),
      syncplevels);
-
-  STOP_LOG ("make_p_levels_parallel_consistent()", "MeshCommunication");
 }
 
 
@@ -1155,7 +1143,7 @@ struct SyncProcIds
 // ------------------------------------------------------------
 void MeshCommunication::make_node_proc_ids_parallel_consistent(MeshBase & mesh)
 {
-  START_LOG ("make_node_proc_ids_parallel_consistent()", "MeshCommunication");
+  LOG_SCOPE ("make_node_proc_ids_parallel_consistent()", "MeshCommunication");
 
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
@@ -1173,12 +1161,9 @@ void MeshCommunication::make_node_proc_ids_parallel_consistent(MeshBase & mesh)
   // Ghost nodes touching local elements should have processor ids
   // consistent with all processors which own an element touching
   // them.
-
   SyncProcIds sync(mesh);
   Parallel::sync_node_data_by_element_id
     (mesh, mesh.elements_begin(), mesh.elements_end(), sync);
-
-  STOP_LOG ("make_node_proc_ids_parallel_consistent()", "MeshCommunication");
 }
 
 
@@ -1230,7 +1215,7 @@ void MeshCommunication::delete_remote_elements(ParallelMesh & mesh, const std::s
   // The mesh should know it's about to be parallelized
   libmesh_assert (!mesh.is_serial());
 
-  START_LOG("delete_remote_elements()", "MeshCommunication");
+  LOG_SCOPE("delete_remote_elements()", "MeshCommunication");
 
 #ifdef DEBUG
   // We expect maximum ids to be in sync so we can use them to size
@@ -1408,8 +1393,6 @@ void MeshCommunication::delete_remote_elements(ParallelMesh & mesh, const std::s
 #ifdef DEBUG
   MeshTools::libmesh_assert_valid_refinement_tree(mesh);
 #endif
-
-  STOP_LOG("delete_remote_elements()", "MeshCommunication");
 }
 
 } // namespace libMesh

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -170,7 +170,7 @@ namespace libMesh
 #if defined(LIBMESH_HAVE_LIBHILBERT) && defined(LIBMESH_HAVE_MPI)
 void MeshCommunication::assign_global_indices (MeshBase & mesh) const
 {
-  START_LOG ("assign_global_indices()", "MeshCommunication");
+  LOG_SCOPE ("assign_global_indices()", "MeshCommunication");
 
   // This method determines partition-agnostic global indices
   // for nodes and elements.
@@ -566,8 +566,6 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
       }
     }
   }
-
-  STOP_LOG ("assign_global_indices()", "MeshCommunication");
 }
 #else // LIBMESH_HAVE_LIBHILBERT, LIBMESH_HAVE_MPI
 void MeshCommunication::assign_global_indices (MeshBase &) const
@@ -579,7 +577,7 @@ void MeshCommunication::assign_global_indices (MeshBase &) const
 #if defined(LIBMESH_HAVE_LIBHILBERT) && defined(LIBMESH_HAVE_MPI)
 void MeshCommunication::check_for_duplicate_global_indices (MeshBase & mesh) const
 {
-  START_LOG ("check_for_duplicate_global_indices()", "MeshCommunication");
+  LOG_SCOPE ("check_for_duplicate_global_indices()", "MeshCommunication");
 
   // Global bounding box
   MeshTools::BoundingBox bbox =
@@ -662,8 +660,6 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase & mesh) con
         }
     }
   } // done checking Hilbert keys
-
-  STOP_LOG ("check_for_duplicate_global_indices()", "MeshCommunication");
 }
 #else // LIBMESH_HAVE_LIBHILBERT, LIBMESH_HAVE_MPI
 void MeshCommunication::check_for_duplicate_global_indices (MeshBase &) const
@@ -679,7 +675,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
                                              const ForwardIterator & end,
                                              std::vector<dof_id_type> & index_map) const
 {
-  START_LOG ("find_global_indices()", "MeshCommunication");
+  LOG_SCOPE ("find_global_indices()", "MeshCommunication");
 
   // This method determines partition-agnostic global indices
   // for nodes and elements.
@@ -705,7 +701,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
   sorted_hilbert_keys.reserve(n_objects);
   hilbert_keys.reserve(n_objects);
   {
-    START_LOG("compute_hilbert_indices()", "MeshCommunication");
+    LOG_SCOPE("compute_hilbert_indices()", "MeshCommunication");
     for (ForwardIterator it=begin; it!=end; ++it)
       {
         const Parallel::DofObjectKey hi(get_hilbert_index (*it, bbox));
@@ -719,14 +715,13 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
             ((*it)->processor_id() == DofObject::invalid_processor_id))
           sorted_hilbert_keys.push_back(hi);
       }
-    STOP_LOG("compute_hilbert_indices()", "MeshCommunication");
   }
 
   //-------------------------------------------------------------
   // (2) parallel sort the Hilbert keys
   START_LOG ("parallel_sort()", "MeshCommunication");
   Parallel::Sort<Parallel::DofObjectKey> sorter (communicator,
-                                                  sorted_hilbert_keys);
+                                                 sorted_hilbert_keys);
   sorter.sort();
   STOP_LOG ("parallel_sort()", "MeshCommunication");
   const std::vector<Parallel::DofObjectKey> & my_bin = sorter.bin();
@@ -915,8 +910,6 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
   }
 
   libmesh_assert_equal_to(index_map.size(), n_objects);
-
-  STOP_LOG ("find_global_indices()", "MeshCommunication");
 }
 #else // LIBMESH_HAVE_LIBHILBERT, LIBMESH_HAVE_MPI
 template <typename ForwardIterator>

--- a/src/mesh/mesh_data.C
+++ b/src/mesh/mesh_data.C
@@ -163,7 +163,7 @@ void MeshData::translate (const MeshBase & out_mesh,
 {
   libmesh_assert (_active || _compatibility_mode);
 
-  START_LOG("translate()", "MeshData");
+  LOG_SCOPE("translate()", "MeshData");
 
   const unsigned int n_comp = this->n_val_per_node();
 
@@ -209,8 +209,6 @@ void MeshData::translate (const MeshBase & out_mesh,
         names.push_back(name_buf.str());
       }
   }
-
-  STOP_LOG("translate()", "MeshData");
 }
 
 
@@ -236,7 +234,7 @@ void MeshData::close_foreign_id_maps ()
 
 void MeshData::read (const std::string & name)
 {
-  START_LOG("read()", "MeshData");
+  LOG_SCOPE("read()", "MeshData");
 
   libmesh_assert (_active || _compatibility_mode);
 
@@ -274,8 +272,6 @@ void MeshData::read (const std::string & name)
                       << "     *.xta  -- Internal ASCII data format\n"  \
                       << "     *.xtr  -- Internal binary data format\n" \
                       << "     *.unv  -- I-deas format");
-
-  STOP_LOG("read()", "MeshData");
 }
 
 
@@ -285,7 +281,7 @@ void MeshData::read (const std::string & name)
 
 void MeshData::write (const std::string & name)
 {
-  START_LOG("write()", "MeshData");
+  LOG_SCOPE("write()", "MeshData");
 
   libmesh_assert (_active || _compatibility_mode);
 
@@ -318,7 +314,6 @@ void MeshData::write (const std::string & name)
                         << "     *.xtr  -- Internal binary data format\n" \
                         << "     *.unv  -- I-deas format");
   }
-  STOP_LOG("write()", "MeshData");
 }
 
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -70,9 +70,7 @@ void MeshTools::Modification::distort (MeshBase & mesh,
   libmesh_assert (mesh.n_elem());
   libmesh_assert ((factor >= 0.) && (factor <= 1.));
 
-  START_LOG("distort()", "MeshTools::Modification");
-
-
+  LOG_SCOPE("distort()", "MeshTools::Modification");
 
   // First find nodes on the boundary and flag them
   // so that we don't move them
@@ -144,10 +142,6 @@ void MeshTools::Modification::distort (MeshBase & mesh,
             (*node)(2) += dir(2)*factor*hmin[n];
         }
   }
-
-
-  // All done
-  STOP_LOG("distort()", "MeshTools::Modification");
 }
 
 
@@ -158,7 +152,7 @@ void MeshTools::Modification::redistribute (MeshBase & mesh,
   libmesh_assert (mesh.n_nodes());
   libmesh_assert (mesh.n_elem());
 
-  START_LOG("redistribute()", "MeshTools::Modification");
+  LOG_SCOPE("redistribute()", "MeshTools::Modification");
 
   DenseVector<Real> output_vec(LIBMESH_DIM);
 
@@ -182,9 +176,6 @@ void MeshTools::Modification::redistribute (MeshBase & mesh,
       (*node)(2) = output_vec(2);
 #endif
     }
-
-  // All done
-  STOP_LOG("redistribute()", "MeshTools::Modification");
 }
 
 

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -31,7 +31,7 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
                                              const EquationSystems & es,
                                              const std::set<std::string> * system_names)
 {
-  START_LOG("write_equation_systems()", "MeshOutput");
+  LOG_SCOPE("write_equation_systems()", "MeshOutput");
 
   // We may need to gather and/or renumber a ParallelMesh to output
   // it, making that const qualifier in our constructor a dirty lie
@@ -75,8 +75,6 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
   //es.build_solution_vector (soln);
 
   this->write_nodal_data (fname, soln, names);
-
-  STOP_LOG("write_equation_systems()", "MeshOutput");
 }
 
 

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -107,15 +107,12 @@ Node * MeshRefinement::add_node(const Elem & parent,
                                 unsigned int node,
                                 processor_id_type proc_id)
 {
-  START_LOG("add_node()", "MeshRefinement");
+  LOG_SCOPE("add_node()", "MeshRefinement");
 
   unsigned int parent_n = parent.as_parent_node(child, node);
 
   if (parent_n != libMesh::invalid_uint)
-    {
-      STOP_LOG("add_node()", "MeshRefinement");
-      return parent.get_node(parent_n);
-    }
+    return parent.get_node(parent_n);
 
   const std::vector<std::pair<dof_id_type, dof_id_type> >
     bracketing_nodes = parent.bracketing_nodes(child, node);
@@ -129,10 +126,7 @@ Node * MeshRefinement::add_node(const Elem & parent,
 
   // Return the node if it already exists
   if (new_node_id != DofObject::invalid_id)
-    {
-      STOP_LOG("add_node()", "MeshRefinement");
-      return _mesh.node_ptr(new_node_id);
-    }
+    return _mesh.node_ptr(new_node_id);
 
   // Otherwise we need to add a new node, with a default id and the
   // requested processor_id.  Figure out where to add the point:
@@ -159,8 +153,6 @@ Node * MeshRefinement::add_node(const Elem & parent,
 
   // Add the node to the map.
   _new_nodes_map.add_node(*new_node, bracketing_nodes);
-
-  STOP_LOG("add_node()", "MeshRefinement");
 
   // Return the address of the new node
   return new_node;
@@ -835,7 +827,7 @@ bool MeshRefinement::make_flags_parallel_consistent()
   // This function must be run on all processors at once
   parallel_object_only();
 
-  START_LOG ("make_flags_parallel_consistent()", "MeshRefinement");
+  LOG_SCOPE ("make_flags_parallel_consistent()", "MeshRefinement");
 
   SyncRefinementFlags hsync(_mesh, &Elem::refinement_flag,
                             &Elem::set_refinement_flag);
@@ -852,8 +844,6 @@ bool MeshRefinement::make_flags_parallel_consistent()
   bool parallel_consistent = hsync.parallel_consistent &&
     psync.parallel_consistent;
   this->comm().min(parallel_consistent);
-
-  STOP_LOG ("make_flags_parallel_consistent()", "MeshRefinement");
 
   return parallel_consistent;
 }
@@ -879,7 +869,7 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
     point_locator = _mesh.sub_point_locator();
 #endif
 
-  START_LOG ("make_coarsening_compatible()", "MeshRefinement");
+  LOG_SCOPE ("make_coarsening_compatible()", "MeshRefinement");
 
   bool _maintain_level_one = maintain_level_one;
 
@@ -936,8 +926,6 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
   // there is no work for us to do
   if (max_level == 0 && max_p_level == 0)
     {
-      STOP_LOG ("make_coarsening_compatible()", "MeshRefinement");
-
       // But we still have to check with other processors
       this->comm().min(compatible_with_refinement);
 
@@ -1193,8 +1181,6 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
         }
     }
 
-  STOP_LOG ("make_coarsening_compatible()", "MeshRefinement");
-
   // If one processor finds an incompatibility, we're globally
   // incompatible
   this->comm().min(compatible_with_refinement);
@@ -1228,7 +1214,7 @@ bool MeshRefinement::make_refinement_compatible(const bool maintain_level_one)
     point_locator = _mesh.sub_point_locator();
 #endif
 
-  START_LOG ("make_refinement_compatible()", "MeshRefinement");
+  LOG_SCOPE ("make_refinement_compatible()", "MeshRefinement");
 
   bool _maintain_level_one = maintain_level_one;
 
@@ -1396,8 +1382,6 @@ bool MeshRefinement::make_refinement_compatible(const bool maintain_level_one)
   // compatible
   this->comm().min(compatible_with_coarsening);
 
-  STOP_LOG ("make_refinement_compatible()", "MeshRefinement");
-
   return compatible_with_coarsening;
 }
 
@@ -1409,7 +1393,7 @@ bool MeshRefinement::_coarsen_elements ()
   // This function must be run on all processors at once
   parallel_object_only();
 
-  START_LOG ("_coarsen_elements()", "MeshRefinement");
+  LOG_SCOPE ("_coarsen_elements()", "MeshRefinement");
 
   // Flags indicating if this call actually changes the mesh
   bool mesh_changed = false;
@@ -1519,8 +1503,6 @@ bool MeshRefinement::_coarsen_elements ()
       MeshCommunication().make_p_levels_parallel_consistent (_mesh);
     }
 
-  STOP_LOG ("_coarsen_elements()", "MeshRefinement");
-
   return (mesh_changed || mesh_p_changed);
 }
 
@@ -1535,7 +1517,7 @@ bool MeshRefinement::_refine_elements ()
   // find nodes to connect to.
   this->update_nodes_map ();
 
-  START_LOG ("_refine_elements()", "MeshRefinement");
+  LOG_SCOPE ("_refine_elements()", "MeshRefinement");
 
   // Iterate over the elements, counting the elements
   // flagged for h refinement.
@@ -1611,8 +1593,6 @@ bool MeshRefinement::_refine_elements ()
 
   // Clear the _new_nodes_map and _unused_elements data structures.
   this->clear();
-
-  STOP_LOG ("_refine_elements()", "MeshRefinement");
 
   return (mesh_changed || mesh_p_changed);
 }

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -164,13 +164,13 @@ void NameBasedIO::read (const std::string & name)
   // Serial mesh formats
   else
     {
-      START_LOG("read()", "NameBasedIO");
-
       // Read the file based on extension.  Only processor 0
       // needs to read the mesh.  It will then broadcast it and
       // the other processors will pick it up
       if (mymesh.processor_id() == 0)
         {
+          LOG_SCOPE("read()", "NameBasedIO");
+
           std::ostringstream pid_suffix;
           pid_suffix << '_' << getpid();
           // Nasty hack for reading/writing zipped files
@@ -182,10 +182,9 @@ void NameBasedIO::read (const std::string & name)
               new_name += pid_suffix.str();
               std::string system_string = "bunzip2 -f -k -c ";
               system_string += name + " > " + new_name;
-              START_LOG("system(bunzip2)", "NameBasedIO");
+              LOG_SCOPE("system(bunzip2)", "NameBasedIO");
               if (std::system(system_string.c_str()))
                 libmesh_file_error(system_string);
-              STOP_LOG("system(bunzip2)", "NameBasedIO");
 #else
               libmesh_error_msg("ERROR: need bzip2/bunzip2 to open .bz2 file " << name);
 #endif
@@ -197,10 +196,9 @@ void NameBasedIO::read (const std::string & name)
               new_name += pid_suffix.str();
               std::string system_string = "xz -f -d -k -c ";
               system_string += name + " > " + new_name;
-              START_LOG("system(xz -d)", "XdrIO");
+              LOG_SCOPE("system(xz -d)", "XdrIO");
               if (std::system(system_string.c_str()))
                 libmesh_file_error(system_string);
-              STOP_LOG("system(xz -d)", "XdrIO");
 #else
               libmesh_error_msg("ERROR: need xz to open .xz file " << name);
 #endif
@@ -275,9 +273,6 @@ void NameBasedIO::read (const std::string & name)
           if (name.size() - name.rfind(".xz") == 3)
             std::remove(new_name.c_str());
         }
-
-
-      STOP_LOG("read()", "NameBasedIO");
 
       // Send the mesh & bcs (which are now only on processor 0) to the other
       // processors
@@ -407,7 +402,7 @@ void NameBasedIO::write (const std::string & name)
       // Nasty hack for reading/writing zipped files
       if (name.size() - name.rfind(".bz2") == 4)
         {
-          START_LOG("system(bzip2)", "NameBasedIO");
+          LOG_SCOPE("system(bzip2)", "NameBasedIO");
           if (mymesh.processor_id() == 0)
             {
               std::string system_string = "bzip2 -f -c ";
@@ -417,11 +412,10 @@ void NameBasedIO::write (const std::string & name)
               std::remove(new_name.c_str());
             }
           mymesh.comm().barrier();
-          STOP_LOG("system(bzip2)", "NameBasedIO");
         }
       if (name.size() - name.rfind(".xz") == 3)
         {
-          START_LOG("system(xz)", "NameBasedIO");
+          LOG_SCOPE("system(xz)", "NameBasedIO");
           if (mymesh.processor_id() == 0)
             {
               std::string system_string = "xz -f -c ";
@@ -431,7 +425,6 @@ void NameBasedIO::write (const std::string & name)
               std::remove(new_name.c_str());
             }
           mymesh.comm().barrier();
-          STOP_LOG("system(xz)", "NameBasedIO");
         }
     }
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -148,7 +148,7 @@ void Nemesis_IO::read (const std::string & base_filename)
       return;
     }
 
-  START_LOG ("read()","Nemesis_IO");
+  LOG_SCOPE ("read()","Nemesis_IO");
 
   // This function must be run on all processors at once
   parallel_object_only();
@@ -1133,8 +1133,6 @@ void Nemesis_IO::read (const std::string & base_filename)
       libMesh::out << "mesh.parallel_n_elem()=" << mesh.parallel_n_elem() << std::endl;
     }
 
-  STOP_LOG ("read()","Nemesis_IO");
-
   // For ParallelMesh, it seems that _is_serial is true by default.  A hack to
   // make the Mesh think it's parallel might be to call:
   mesh.update_post_partitioning();
@@ -1257,7 +1255,7 @@ void Nemesis_IO::write_nodal_data (const std::string & base_filename,
                                    const std::vector<Number> & soln,
                                    const std::vector<std::string> & names)
 {
-  START_LOG("write_nodal_data()", "Nemesis_IO");
+  LOG_SCOPE("write_nodal_data()", "Nemesis_IO");
 
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
@@ -1309,8 +1307,6 @@ void Nemesis_IO::write_nodal_data (const std::string & base_filename,
     }
 
   nemhelper->write_nodal_solution(soln, names, _timestep);
-
-  STOP_LOG("write_nodal_data()", "Nemesis_IO");
 }
 
 #else

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -1235,7 +1235,7 @@ void ParallelMesh::renumber_nodes_and_elements ()
   this->libmesh_assert_valid_parallel_p_levels();
 #endif
 
-  START_LOG("renumber_nodes_and_elements()", "ParallelMesh");
+  LOG_SCOPE("renumber_nodes_and_elements()", "ParallelMesh");
 
   std::set<dof_id_type> used_nodes;
 
@@ -1283,7 +1283,6 @@ void ParallelMesh::renumber_nodes_and_elements ()
   if (_skip_renumber_nodes_and_elements)
     {
       this->update_parallel_id_counts();
-      STOP_LOG("renumber_nodes_and_elements()", "ParallelMesh");
       return;
     }
 
@@ -1316,8 +1315,6 @@ void ParallelMesh::renumber_nodes_and_elements ()
   // And make sure we've made our numbering monotonic
   MeshTools::libmesh_assert_valid_elem_ids(*this);
 #endif
-
-  STOP_LOG("renumber_nodes_and_elements()", "ParallelMesh");
 }
 
 

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -663,8 +663,7 @@ unique_id_type SerialMesh::parallel_max_unique_id() const
 
 void SerialMesh::renumber_nodes_and_elements ()
 {
-
-  START_LOG("renumber_nodes_and_elem()", "Mesh");
+  LOG_SCOPE("renumber_nodes_and_elem()", "Mesh");
 
   // node and element id counters
   dof_id_type next_free_elem = 0;
@@ -816,8 +815,6 @@ void SerialMesh::renumber_nodes_and_elements ()
   libmesh_assert_equal_to (next_free_node, _nodes.size());
 
   this->update_parallel_id_counts();
-
-  STOP_LOG("renumber_nodes_and_elem()", "Mesh");
 }
 
 
@@ -845,7 +842,7 @@ void SerialMesh::stitch_meshes (SerialMesh & other_mesh,
                                 bool use_binary_search,
                                 bool enforce_all_nodes_match_on_boundaries)
 {
-  START_LOG("stitch_meshes()", "SerialMesh");
+  LOG_SCOPE("stitch_meshes()", "SerialMesh");
   stitching_helper(&other_mesh,
                    this_mesh_boundary_id,
                    other_mesh_boundary_id,
@@ -855,7 +852,6 @@ void SerialMesh::stitch_meshes (SerialMesh & other_mesh,
                    use_binary_search,
                    enforce_all_nodes_match_on_boundaries,
                    true);
-  STOP_LOG("stitch_meshes()", "SerialMesh");
 }
 
 void SerialMesh::stitch_surfaces (boundary_id_type boundary_id_1,

--- a/src/mesh/tecplot_io.C
+++ b/src/mesh/tecplot_io.C
@@ -187,7 +187,7 @@ void TecplotIO::write_nodal_data (const std::string & fname,
                                   const std::vector<Number> & soln,
                                   const std::vector<std::string> & names)
 {
-  START_LOG("write_nodal_data()", "TecplotIO");
+  LOG_SCOPE("write_nodal_data()", "TecplotIO");
 
   if (this->mesh().processor_id() == 0)
     {
@@ -196,8 +196,6 @@ void TecplotIO::write_nodal_data (const std::string & fname,
       else
         this->write_ascii  (fname, &soln, &names);
     }
-
-  STOP_LOG("write_nodal_data()", "TecplotIO");
 }
 
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -242,7 +242,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
   // This function must be run on all processors at once
   parallel_object_only();
 
-  START_LOG("find_neighbors()", "Mesh");
+  LOG_SCOPE("find_neighbors()", "Mesh");
 
   const element_iterator el_end = this->elements_end();
 
@@ -569,8 +569,6 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                                             !reset_remote_elements);
   MeshTools::libmesh_assert_valid_amr_interior_parents(*this);
 #endif
-
-  STOP_LOG("find_neighbors()", "Mesh");
 }
 
 
@@ -618,7 +616,7 @@ void UnstructuredMesh::read (const std::string & name,
 void UnstructuredMesh::write (const std::string & name,
                               MeshData * mesh_data)
 {
-  START_LOG("write()", "Mesh");
+  LOG_SCOPE("write()", "Mesh");
 
   if (mesh_data)
     {
@@ -630,8 +628,6 @@ void UnstructuredMesh::write (const std::string & name,
     }
 
   NameBasedIO(*this).write(name);
-
-  STOP_LOG("write()", "Mesh");
 }
 
 
@@ -640,11 +636,9 @@ void UnstructuredMesh::write (const std::string & name,
                               const std::vector<Number> & v,
                               const std::vector<std::string> & vn)
 {
-  START_LOG("write()", "Mesh");
+  LOG_SCOPE("write()", "Mesh");
 
   NameBasedIO(*this).write_nodal_data(name, v, vn);
-
-  STOP_LOG("write()", "Mesh");
 }
 
 
@@ -774,7 +768,7 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh & new_mesh,
 #ifdef LIBMESH_ENABLE_AMR
 bool UnstructuredMesh::contract ()
 {
-  START_LOG ("contract()", "Mesh");
+  LOG_SCOPE ("contract()", "Mesh");
 
   // Flag indicating if this call actually changes the mesh
   bool mesh_changed = false;
@@ -831,8 +825,6 @@ bool UnstructuredMesh::contract ()
   // FIXME: Need to understand why deleting subactive children
   // invalidates the point locator.  For now we will clear it explicitly
   this->clear_point_locator();
-
-  STOP_LOG ("contract()", "Mesh");
 
   return mesh_changed;
 }

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -327,7 +327,7 @@ void UNVIO::write_implementation (std::ostream & out_file)
 
 void UNVIO::nodes_in (std::istream & in_file)
 {
-  START_LOG("nodes_in()","UNVIO");
+  LOG_SCOPE("nodes_in()","UNVIO");
 
   if (this->verbose())
     libMesh::out << "  Reading nodes" << std::endl;
@@ -397,8 +397,6 @@ void UNVIO::nodes_in (std::istream & in_file)
       if (_mesh_data)
         _mesh_data->add_foreign_node_id (added_node, node_label);
     }
-
-  STOP_LOG("nodes_in()","UNVIO");
 }
 
 
@@ -609,7 +607,7 @@ void UNVIO::groups_in (std::istream & in_file)
 
 void UNVIO::elements_in (std::istream & in_file)
 {
-  START_LOG("elements_in()","UNVIO");
+  LOG_SCOPE("elements_in()","UNVIO");
 
   if (this->verbose())
     libMesh::out << "  Reading elements" << std::endl;
@@ -897,8 +895,6 @@ void UNVIO::elements_in (std::istream & in_file)
       // Increment the counter for the next iteration
       ctr++;
     } // end while(true)
-
-  STOP_LOG("elements_in()","UNVIO");
 }
 
 

--- a/src/partitioning/linear_partitioner.C
+++ b/src/partitioning/linear_partitioner.C
@@ -45,7 +45,7 @@ void LinearPartitioner::_do_partition (MeshBase & mesh,
 
   // Create a simple linear partitioning
   {
-    START_LOG ("partition()", "LinearPartitioner");
+    LOG_SCOPE ("partition()", "LinearPartitioner");
 
     const dof_id_type n_active_elem = mesh.n_active_elem();
     const dof_id_type blksize       = n_active_elem/n;
@@ -72,8 +72,6 @@ void LinearPartitioner::_do_partition (MeshBase & mesh,
 
         e++;
       }
-
-    STOP_LOG ("partition()", "LinearPartitioner");
   }
 }
 

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -87,7 +87,7 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
   // What to do if the Metis library IS present
 #else
 
-  START_LOG("partition()", "MetisPartitioner");
+  LOG_SCOPE("partition()", "MetisPartitioner");
 
   const dof_id_type n_active_elem = mesh.n_active_elem();
 
@@ -471,8 +471,6 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
         elem->processor_id() = elem_procid;
       }
   }
-
-  STOP_LOG("partition()", "MetisPartitioner");
 #endif
 }
 

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -126,7 +126,7 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
       return;
     }
 
-  START_LOG("repartition()", "ParmetisPartitioner");
+  LOG_SCOPE("repartition()", "ParmetisPartitioner");
 
   // Initialize the data structures required by ParMETIS
   this->initialize (mesh, n_sbdmns);
@@ -147,12 +147,8 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
       {
         // FIXME: revert to METIS, although this requires a serial mesh
         MeshSerializer serialize(mesh);
-
-        STOP_LOG ("repartition()", "ParmetisPartitioner");
-
         MetisPartitioner mp;
         mp.partition (mesh, n_sbdmns);
-
         return;
       }
   }
@@ -189,9 +185,6 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
 
   // Assign the returned processor ids
   this->assign_partitioning (mesh);
-
-
-  STOP_LOG ("repartition()", "ParmetisPartitioner");
 
 #endif // #ifndef LIBMESH_HAVE_PARMETIS ... else ...
 

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -156,7 +156,7 @@ void Partitioner::repartition (MeshBase & mesh,
 
 void Partitioner::single_partition (MeshBase & mesh)
 {
-  START_LOG("single_partition()","Partitioner");
+  LOG_SCOPE("single_partition()","Partitioner");
 
   // Loop over all the elements and assign them to processor 0.
   MeshBase::element_iterator       elem_it  = mesh.elements_begin();
@@ -171,8 +171,6 @@ void Partitioner::single_partition (MeshBase & mesh)
 
   for ( ; node_it != node_end; ++node_it)
     (*node_it)->processor_id() = 0;
-
-  STOP_LOG("single_partition()","Partitioner");
 }
 
 
@@ -259,11 +257,11 @@ void Partitioner::partition_unpartitioned_elements (MeshBase & mesh,
 
 
 void Partitioner::set_parent_processor_ids(MeshBase & mesh)
- {
+{
   // Ignore the parameter when !LIBMESH_ENABLE_AMR
   libmesh_ignore(mesh);
 
-  START_LOG("set_parent_processor_ids()","Partitioner");
+  LOG_SCOPE("set_parent_processor_ids()", "Partitioner");
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -429,15 +427,13 @@ void Partitioner::set_parent_processor_ids(MeshBase & mesh)
     }
 
 #endif // LIBMESH_ENABLE_AMR
-
-  STOP_LOG("set_parent_processor_ids()","Partitioner");
 }
 
 
 
 void Partitioner::set_node_processor_ids(MeshBase & mesh)
 {
-  START_LOG("set_node_processor_ids()","Partitioner");
+  LOG_SCOPE("set_node_processor_ids()","Partitioner");
 
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
@@ -632,8 +628,6 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
 #ifdef DEBUG
   MeshTools::libmesh_assert_valid_procids<Node>(mesh);
 #endif
-
-  STOP_LOG("set_node_processor_ids()","Partitioner");
 }
 
 } // namespace libMesh

--- a/src/partitioning/sfc_partitioner.C
+++ b/src/partitioning/sfc_partitioner.C
@@ -70,7 +70,7 @@ void SFCPartitioner::_do_partition (MeshBase & mesh,
   // What to do if the sfcurves library IS present
 #else
 
-  START_LOG("sfc_partition()", "SFCPartitioner");
+  LOG_SCOPE("sfc_partition()", "SFCPartitioner");
 
   const dof_id_type n_active_elem = mesh.n_active_elem();
   const dof_id_type n_elem        = mesh.n_elem();
@@ -180,8 +180,6 @@ void SFCPartitioner::_do_partition (MeshBase & mesh,
           (i/blksize);
       }
   }
-
-  STOP_LOG("sfc_partition()", "SFCPartitioner");
 
 #endif
 

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -94,7 +94,7 @@ RBConstruction::~RBConstruction ()
 
 void RBConstruction::clear()
 {
-  START_LOG("clear()", "RBConstruction");
+  LOG_SCOPE("clear()", "RBConstruction");
 
   Parent::clear();
 
@@ -148,8 +148,6 @@ void RBConstruction::clear()
   // Set Fq_representor_innerprods_computed flag to false now
   // that we've cleared the Fq representors
   Fq_representor_innerprods_computed = false;
-
-  STOP_LOG("clear()", "RBConstruction");
 }
 
 std::string RBConstruction::system_type () const
@@ -608,7 +606,7 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
                                                   bool symmetrize,
                                                   bool apply_dof_constraints)
 {
-  START_LOG("add_scaled_matrix_and_vector()", "RBConstruction");
+  LOG_SCOPE("add_scaled_matrix_and_vector()", "RBConstruction");
 
   bool assemble_matrix = (input_matrix != libmesh_nullptr);
   bool assemble_vector = (input_vector != libmesh_nullptr);
@@ -796,8 +794,6 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
     input_matrix->close();
   if(assemble_vector)
     input_vector->close();
-
-  STOP_LOG("add_scaled_matrix_and_vector()", "RBConstruction");
 }
 
 void RBConstruction::set_context_solution_vec(NumericVector<Number> & vec)
@@ -810,7 +806,7 @@ void RBConstruction::set_context_solution_vec(NumericVector<Number> & vec)
 
 void RBConstruction::truth_assembly()
 {
-  START_LOG("truth_assembly()", "RBConstruction");
+  LOG_SCOPE("truth_assembly()", "RBConstruction");
 
   const RBParameters & mu = get_parameters();
 
@@ -842,8 +838,6 @@ void RBConstruction::truth_assembly()
 
   this->matrix->close();
   this->rhs->close();
-
-  STOP_LOG("truth_assembly()", "RBConstruction");
 }
 
 void RBConstruction::assemble_inner_product_matrix(SparseMatrix<Number> * input_matrix,
@@ -880,7 +874,7 @@ void RBConstruction::add_scaled_Aq(Number scalar,
                                    SparseMatrix<Number> * input_matrix,
                                    bool symmetrize)
 {
-  START_LOG("add_scaled_Aq()", "RBConstruction");
+  LOG_SCOPE("add_scaled_Aq()", "RBConstruction");
 
   if(q_a >= get_rb_theta_expansion().get_n_A_terms())
     libmesh_error_msg("Error: We must have q < Q_a in add_scaled_Aq.");
@@ -898,8 +892,6 @@ void RBConstruction::add_scaled_Aq(Number scalar,
                                    libmesh_nullptr,
                                    symmetrize);
     }
-
-  STOP_LOG("add_scaled_Aq()", "RBConstruction");
 }
 
 void RBConstruction::assemble_misc_matrices()
@@ -1004,7 +996,7 @@ void RBConstruction::assemble_all_output_vectors()
 
 Real RBConstruction::train_reduced_basis(const bool resize_rb_eval_data)
 {
-  START_LOG("train_reduced_basis()", "RBConstruction");
+  LOG_SCOPE("train_reduced_basis()", "RBConstruction");
 
   int count = 0;
 
@@ -1093,7 +1085,6 @@ Real RBConstruction::train_reduced_basis(const bool resize_rb_eval_data)
       count++;
     }
   this->update_greedy_param_list();
-  STOP_LOG("train_reduced_basis()", "RBConstruction");
 
   return training_greedy_error;
 }
@@ -1153,7 +1144,7 @@ const RBParameters & RBConstruction::get_greedy_parameter(unsigned int i)
 
 Real RBConstruction::truth_solve(int plot_solution)
 {
-  START_LOG("truth_solve()", "RBConstruction");
+  LOG_SCOPE("truth_solve()", "RBConstruction");
 
   truth_assembly();
 
@@ -1205,8 +1196,6 @@ Real RBConstruction::truth_solve(int plot_solution)
   inner_product_matrix->vector_mult(*inner_product_storage_vector, *solution);
   Number truth_X_norm = std::sqrt(inner_product_storage_vector->dot(*solution));
 
-  STOP_LOG("truth_solve()", "RBConstruction");
-
   return libmesh_real(truth_X_norm);
 }
 
@@ -1217,20 +1206,18 @@ void RBConstruction::set_Nmax(unsigned int Nmax_in)
 
 void RBConstruction::load_basis_function(unsigned int i)
 {
-  START_LOG("load_basis_function()", "RBConstruction");
+  LOG_SCOPE("load_basis_function()", "RBConstruction");
 
   libmesh_assert_less (i, get_rb_evaluation().get_n_basis_functions());
 
   *solution = get_rb_evaluation().get_basis_function(i);
 
   this->update();
-
-  STOP_LOG("load_basis_function()", "RBConstruction");
 }
 
 void RBConstruction::enrich_RB_space()
 {
-  START_LOG("enrich_RB_space()", "RBConstruction");
+  LOG_SCOPE("enrich_RB_space()", "RBConstruction");
 
   NumericVector<Number> * new_bf = NumericVector<Number>::build(this->comm()).release();
   new_bf->init (this->n_dofs(), this->n_local_dofs(), false, PARALLEL);
@@ -1260,8 +1247,6 @@ void RBConstruction::enrich_RB_space()
 
   // load the new basis function into the basis_functions vector.
   get_rb_evaluation().basis_functions.push_back( new_bf );
-
-  STOP_LOG("enrich_RB_space()", "RBConstruction");
 }
 
 void RBConstruction::update_system()
@@ -1317,7 +1302,7 @@ void RBConstruction::recompute_all_residual_terms(bool compute_inner_products)
 
 Real RBConstruction::compute_max_error_bound()
 {
-  START_LOG("compute_max_error_bound()", "RBConstruction");
+  LOG_SCOPE("compute_max_error_bound()", "RBConstruction");
 
   // Treat the case with no parameters in a special way
   if(get_n_params() == 0)
@@ -1331,8 +1316,6 @@ Real RBConstruction::compute_max_error_bound()
         {
           max_val = std::numeric_limits<Real>::max();
         }
-
-      STOP_LOG("compute_max_error_bound()", "RBConstruction");
 
       // Make sure we do at least one solve, but otherwise return a zero error bound
       // when we have no parameters
@@ -1385,14 +1368,12 @@ Real RBConstruction::compute_max_error_bound()
       broadcast_parameters(root_id);
     }
 
-  STOP_LOG("compute_max_error_bound()", "RBConstruction");
-
   return error_pair.second;
 }
 
 void RBConstruction::update_RB_system_matrices()
 {
-  START_LOG("update_RB_system_matrices()", "RBConstruction");
+  LOG_SCOPE("update_RB_system_matrices()", "RBConstruction");
 
   unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
 
@@ -1456,14 +1437,12 @@ void RBConstruction::update_RB_system_matrices()
             }
         }
     }
-
-  STOP_LOG("update_RB_system_matrices()", "RBConstruction");
 }
 
 
 void RBConstruction::update_residual_terms(bool compute_inner_products)
 {
-  START_LOG("update_residual_terms()", "RBConstruction");
+  LOG_SCOPE("update_residual_terms()", "RBConstruction");
 
   unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
 
@@ -1552,8 +1531,6 @@ void RBConstruction::update_residual_terms(bool compute_inner_products)
             }
         }
     } // end if (compute_inner_products)
-
-  STOP_LOG("update_residual_terms()", "RBConstruction");
 }
 
 SparseMatrix<Number> & RBConstruction::get_matrix_for_output_dual_solves()
@@ -1574,7 +1551,7 @@ void RBConstruction::compute_output_dual_innerprods()
         }
 
       // Only log if we get to here
-      START_LOG("compute_output_dual_innerprods()", "RBConstruction");
+      LOG_SCOPE("compute_output_dual_innerprods()", "RBConstruction");
 
       libMesh::out << "Compute output dual inner products" << std::endl;
 
@@ -1661,9 +1638,6 @@ void RBConstruction::compute_output_dual_innerprods()
       linear_solver->reuse_preconditioner(false);
 
       output_dual_innerprods_computed = true;
-
-      STOP_LOG("compute_output_dual_innerprods()", "RBConstruction");
-
     }
 
   get_rb_evaluation().output_dual_innerprods = output_dual_innerprods;
@@ -1676,7 +1650,7 @@ void RBConstruction::compute_Fq_representor_innerprods(bool compute_inner_produc
   if(!Fq_representor_innerprods_computed)
     {
       // Only log if we get to here
-      START_LOG("compute_Fq_representor_innerprods()", "RBConstruction");
+      LOG_SCOPE("compute_Fq_representor_innerprods()", "RBConstruction");
 
       for(unsigned int q_f=0; q_f<get_rb_theta_expansion().get_n_F_terms(); q_f++)
         {
@@ -1734,8 +1708,6 @@ void RBConstruction::compute_Fq_representor_innerprods(bool compute_inner_produc
         } // end if (compute_inner_products)
 
       Fq_representor_innerprods_computed = true;
-
-      STOP_LOG("compute_Fq_representor_innerprods()", "RBConstruction");
     }
 
   get_rb_evaluation().Fq_representor_innerprods = Fq_representor_innerprods;
@@ -1743,7 +1715,7 @@ void RBConstruction::compute_Fq_representor_innerprods(bool compute_inner_produc
 
 void RBConstruction::load_rb_solution()
 {
-  START_LOG("load_rb_solution()", "RBConstruction");
+  LOG_SCOPE("load_rb_solution()", "RBConstruction");
 
   solution->zero();
 
@@ -1758,15 +1730,13 @@ void RBConstruction::load_rb_solution()
     }
 
   update();
-
-  STOP_LOG("load_rb_solution()", "RBConstruction");
 }
 
 // The slow (but simple, non-error prone) way to compute the residual dual norm
 // Useful for error checking
 //Real RBConstruction::compute_residual_dual_norm(const unsigned int N)
 //{
-//  START_LOG("compute_residual_dual_norm()", "RBConstruction");
+//   LOG_SCOPE("compute_residual_dual_norm()", "RBConstruction");
 //
 //   // Put the residual in rhs in order to compute the norm of the Riesz representor
 //   // Note that this only works in serial since otherwise each processor will
@@ -1810,9 +1780,7 @@ void RBConstruction::load_rb_solution()
 //
 //   Real slow_residual_norm_sq = solution->dot(*inner_product_storage_vector);
 //
-//  STOP_LOG("compute_residual_dual_norm()", "RBConstruction");
-//
-//  return std::sqrt( libmesh_real(slow_residual_norm_sq) );
+//   return std::sqrt( libmesh_real(slow_residual_norm_sq) );
 //}
 
 SparseMatrix<Number> * RBConstruction::get_inner_product_matrix()
@@ -1949,7 +1917,7 @@ UniquePtr<DirichletBoundary> RBConstruction::build_zero_dirichlet_boundary_objec
 void RBConstruction::write_riesz_representors_to_files(const std::string & riesz_representors_dir,
                                                        const bool write_binary_residual_representors)
 {
-  START_LOG("write_riesz_representors_to_files()", "RBConstruction");
+  LOG_SCOPE("write_riesz_representors_to_files()", "RBConstruction");
 
   // Write out Riesz representors. These are useful to have when restarting,
   // so you don't have to recompute them all over again.
@@ -2049,8 +2017,6 @@ void RBConstruction::write_riesz_representors_to_files(const std::string & riesz
           // for the system call, be sure to do it only on one processor, etc.
         }
       }
-
-  STOP_LOG("write_riesz_representors_to_files()", "RBConstruction");
 }
 
 
@@ -2058,7 +2024,7 @@ void RBConstruction::write_riesz_representors_to_files(const std::string & riesz
 void RBConstruction::read_riesz_representors_from_files(const std::string & riesz_representors_dir,
                                                         const bool read_binary_residual_representors)
 {
-  START_LOG("read_riesz_representors_from_files()", "RBConstruction");
+  LOG_SCOPE("read_riesz_representors_from_files()", "RBConstruction");
 
   libMesh::out << "Reading in the Fq_representors..." << std::endl;
 
@@ -2148,8 +2114,6 @@ void RBConstruction::read_riesz_representors_from_files(const std::string & ries
         //*Aq_representor[i][j] = *solution;
         get_rb_evaluation().Aq_representor[i][j]->swap(*solution);
       }
-
-  STOP_LOG("read_riesz_representors_from_files()", "RBConstruction");
 }
 
 void RBConstruction::check_convergence(LinearSolver<Number> & input_solver)

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -78,7 +78,7 @@ RBEvaluationDeserialization::~RBEvaluationDeserialization()
 void RBEvaluationDeserialization::read_from_file(const std::string & path,
                                                  bool read_error_bound_data)
 {
-  START_LOG("read_from_file()", "RBEvaluationDeserialization");
+  LOG_SCOPE("read_from_file()", "RBEvaluationDeserialization");
 
   int fd = open(path.c_str(), O_RDONLY);
   if (!fd)
@@ -99,8 +99,6 @@ void RBEvaluationDeserialization::read_from_file(const std::string & path,
 #endif
 
   load_rb_evaluation_data(_rb_eval, rb_eval_reader, read_error_bound_data);
-
-  STOP_LOG("read_from_file()", "RBEvaluationDeserialization");
 }
 
 // ---- RBEvaluationDeserialization (END) ----
@@ -119,7 +117,7 @@ TransientRBEvaluationDeserialization::~TransientRBEvaluationDeserialization()
 void TransientRBEvaluationDeserialization::read_from_file(const std::string & path,
                                                           bool read_error_bound_data)
 {
-  START_LOG("read_from_file()", "TransientRBEvaluationDeserialization");
+  LOG_SCOPE("read_from_file()", "TransientRBEvaluationDeserialization");
 
   int fd = open(path.c_str(), O_RDONLY);
   if (!fd)
@@ -147,8 +145,6 @@ void TransientRBEvaluationDeserialization::read_from_file(const std::string & pa
                                     rb_eval_reader,
                                     trans_rb_eval_reader,
                                     read_error_bound_data);
-
-  STOP_LOG("read_from_file()", "TransientRBEvaluationDeserialization");
 }
 
 // ---- TransientRBEvaluationDeserialization (END) ----
@@ -166,7 +162,7 @@ RBEIMEvaluationDeserialization::~RBEIMEvaluationDeserialization()
 
 void RBEIMEvaluationDeserialization::read_from_file(const std::string & path)
 {
-  START_LOG("read_from_file()", "RBEIMEvaluationDeserialization");
+  LOG_SCOPE("read_from_file()", "RBEIMEvaluationDeserialization");
 
   int fd = open(path.c_str(), O_RDONLY);
   if (!fd)
@@ -193,8 +189,6 @@ void RBEIMEvaluationDeserialization::read_from_file(const std::string & path)
   load_rb_eim_evaluation_data(_rb_eim_eval,
                               rb_eval_reader,
                               rb_eim_eval_reader);
-
-  STOP_LOG("read_from_file()", "RBEIMEvaluationDeserialization");
 }
 
 // ---- RBEIMEvaluationDeserialization (END) ----
@@ -216,7 +210,7 @@ RBSCMEvaluationDeserialization::~RBSCMEvaluationDeserialization()
 
 void RBSCMEvaluationDeserialization::read_from_file(const std::string & path)
 {
-  START_LOG("read_from_file()", "RBSCMEvaluationDeserialization");
+  LOG_SCOPE("read_from_file()", "RBSCMEvaluationDeserialization");
 
   int fd = open(path.c_str(), O_RDONLY);
   if (!fd)
@@ -233,8 +227,6 @@ void RBSCMEvaluationDeserialization::read_from_file(const std::string & path)
 
   load_rb_scm_evaluation_data(_rb_scm_eval,
                               rb_scm_eval_reader);
-
-  STOP_LOG("read_from_file()", "RBSCMEvaluationDeserialization");
 }
 
 #endif // LIBMESH_HAVE_SLEPC && LIBMESH_HAVE_GLPK

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -80,7 +80,7 @@ RBEvaluationSerialization::~RBEvaluationSerialization()
 
 void RBEvaluationSerialization::write_to_file(const std::string & path)
 {
-  START_LOG("write_to_file()", "RBEvaluationSerialization");
+  LOG_SCOPE("write_to_file()", "RBEvaluationSerialization");
 
   if(_rb_eval.comm().rank() == 0)
     {
@@ -106,8 +106,6 @@ void RBEvaluationSerialization::write_to_file(const std::string & path)
       if (error)
         libmesh_error_msg("Error closing a write-only file descriptor to " + path);
     }
-
-  STOP_LOG("write_to_file()", "RBEvaluationSerialization");
 }
 
 // ---- RBEvaluationSerialization (END) ----
@@ -127,7 +125,7 @@ TransientRBEvaluationSerialization::~TransientRBEvaluationSerialization()
 
 void TransientRBEvaluationSerialization::write_to_file(const std::string & path)
 {
-  START_LOG("write_to_file()", "TransientRBEvaluationSerialization");
+  LOG_SCOPE("write_to_file()", "TransientRBEvaluationSerialization");
 
   if(_trans_rb_eval.comm().rank() == 0)
     {
@@ -159,8 +157,6 @@ void TransientRBEvaluationSerialization::write_to_file(const std::string & path)
       if (error)
         libmesh_error_msg("Error closing a write-only file descriptor to " + path);
     }
-
-  STOP_LOG("write_to_file()", "TransientRBEvaluationSerialization");
 }
 
 // ---- TransientRBEvaluationSerialization (END) ----
@@ -180,7 +176,7 @@ RBEIMEvaluationSerialization::~RBEIMEvaluationSerialization()
 
 void RBEIMEvaluationSerialization::write_to_file(const std::string & path)
 {
-  START_LOG("write_to_file()", "RBEIMEvaluationSerialization");
+  LOG_SCOPE("write_to_file()", "RBEIMEvaluationSerialization");
 
   if(_rb_eim_eval.comm().rank() == 0)
     {
@@ -212,8 +208,6 @@ void RBEIMEvaluationSerialization::write_to_file(const std::string & path)
       if (error)
         libmesh_error_msg("Error closing a write-only file descriptor to " + path);
     }
-
-  STOP_LOG("write_to_file()", "RBEIMEvaluationSerialization");
 }
 
 // ---- RBEIMEvaluationSerialization (END) ----
@@ -235,7 +229,7 @@ RBSCMEvaluationSerialization::~RBSCMEvaluationSerialization()
 
 void RBSCMEvaluationSerialization::write_to_file(const std::string & path)
 {
-  START_LOG("write_to_file()", "RBSCMEvaluationSerialization");
+  LOG_SCOPE("write_to_file()", "RBSCMEvaluationSerialization");
 
   if(_rb_scm_eval.comm().rank() == 0)
     {
@@ -256,8 +250,6 @@ void RBSCMEvaluationSerialization::write_to_file(const std::string & path)
       if (error)
         libmesh_error_msg("Error closing a write-only file descriptor to " + path);
     }
-
-  STOP_LOG("write_to_file()", "RBSCMEvaluationSerialization");
 }
 
 #endif // LIBMESH_HAVE_SLEPC && LIBMESH_HAVE_GLPK

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -74,7 +74,7 @@ void RBEIMAssembly::evaluate_basis_function(unsigned int var,
                                             const QBase & element_qrule,
                                             std::vector<Number> & values)
 {
-  START_LOG("evaluate_basis_function", "RBEIMAssembly");
+  LOG_SCOPE("evaluate_basis_function", "RBEIMAssembly");
 
   bool repeated_qrule = false;
   if (_qrule != libmesh_nullptr)
@@ -121,8 +121,6 @@ void RBEIMAssembly::evaluate_basis_function(unsigned int var,
       for (unsigned int i=0; i<dof_indices_var.size(); i++)
         values[qp] += (*_ghosted_basis_function)(dof_indices_var[i]) * phi[i][qp];
     }
-
-  STOP_LOG("evaluate_basis_function", "RBEIMAssembly");
 }
 
 RBEIMConstruction & RBEIMAssembly::get_rb_eim_construction()

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -263,20 +263,18 @@ ExplicitSystem& RBEIMConstruction::get_explicit_system()
 
 void RBEIMConstruction::load_basis_function(unsigned int i)
 {
-  START_LOG("load_basis_function()", "RBEIMConstruction");
+  LOG_SCOPE("load_basis_function()", "RBEIMConstruction");
 
   libmesh_assert_less (i, get_rb_evaluation().get_n_basis_functions());
 
   *get_explicit_system().solution = get_rb_evaluation().get_basis_function(i);
 
   get_explicit_system().update();
-
-  STOP_LOG("load_basis_function()", "RBEIMConstruction");
 }
 
 void RBEIMConstruction::load_rb_solution()
 {
-  START_LOG("load_rb_solution()", "RBEIMConstruction");
+  LOG_SCOPE("load_rb_solution()", "RBEIMConstruction");
 
   solution->zero();
 
@@ -292,8 +290,6 @@ void RBEIMConstruction::load_rb_solution()
     }
 
   get_explicit_system().update();
-
-  STOP_LOG("load_rb_solution()", "RBEIMConstruction");
 }
 
 std::vector<ElemAssembly *> RBEIMConstruction::get_eim_assembly_objects()
@@ -303,7 +299,7 @@ std::vector<ElemAssembly *> RBEIMConstruction::get_eim_assembly_objects()
 
 void RBEIMConstruction::enrich_RB_space()
 {
-  START_LOG("enrich_RB_space()", "RBEIMConstruction");
+  LOG_SCOPE("enrich_RB_space()", "RBEIMConstruction");
 
   // put solution in _ghosted_meshfunction_vector so we can access it from the mesh function
   // this allows us to compute EIM_rhs appropriately
@@ -459,8 +455,6 @@ void RBEIMConstruction::enrich_RB_space()
       eim_eval.extra_interpolation_point_var = optimal_var;
       eim_eval.extra_interpolation_point_elem = mesh.elem(optimal_elem_id);
     }
-
-  STOP_LOG("enrich_RB_space()", "RBEIMConstruction");
 }
 
 void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
@@ -515,7 +509,7 @@ void RBEIMConstruction::plot_parametrized_functions_in_training_set(const std::s
 
 Real RBEIMConstruction::compute_best_fit_error()
 {
-  START_LOG("compute_best_fit_error()", "RBEIMConstruction");
+  LOG_SCOPE("compute_best_fit_error()", "RBEIMConstruction");
 
   const unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
 
@@ -567,14 +561,12 @@ Real RBEIMConstruction::compute_best_fit_error()
 
   Real best_fit_error = get_explicit_system().solution->linfty_norm();
 
-  STOP_LOG("compute_best_fit_error()", "RBEIMConstruction");
-
   return best_fit_error;
 }
 
 Real RBEIMConstruction::truth_solve(int plot_solution)
 {
-  START_LOG("truth_solve()", "RBEIMConstruction");
+  LOG_SCOPE("truth_solve()", "RBEIMConstruction");
 
   int training_parameters_found_index = -1;
   if( _parametrized_functions_in_training_set_initialized )
@@ -720,7 +712,6 @@ Real RBEIMConstruction::truth_solve(int plot_solution)
                                                       this->get_equation_systems());
 #endif
     }
-  STOP_LOG("truth_solve()", "RBEIMConstruction");
 
   return 0.;
 }
@@ -741,7 +732,7 @@ void RBEIMConstruction::init_context_with_sys(FEMContext & c, System & sys)
 
 void RBEIMConstruction::update_RB_system_matrices()
 {
-  START_LOG("update_RB_system_matrices()", "RBEIMConstruction");
+  LOG_SCOPE("update_RB_system_matrices()", "RBEIMConstruction");
 
   // First, update the inner product matrix
   {
@@ -810,8 +801,6 @@ void RBEIMConstruction::update_RB_system_matrices()
                                     eim_eval.extra_interpolation_point );
         }
     }
-
-  STOP_LOG("update_RB_system_matrices()", "RBEIMConstruction");
 }
 
 Real RBEIMConstruction::get_RB_error_bound()
@@ -870,7 +859,7 @@ bool RBEIMConstruction::greedy_termination_test(
 void RBEIMConstruction::set_explicit_sys_subvector(
   NumericVector<Number> & dest, unsigned int var, NumericVector<Number> & source)
 {
-  START_LOG("set_explicit_sys_subvector()", "RBEIMConstruction");
+  LOG_SCOPE("set_explicit_sys_subvector()", "RBEIMConstruction");
 
   // For convenience we localize the source vector first to make it easier to
   // copy over (no need to do distinct send/receives).
@@ -893,14 +882,12 @@ void RBEIMConstruction::set_explicit_sys_subvector(
     }
 
   dest.close();
-
-  STOP_LOG("set_explicit_sys_subvector()", "RBEIMConstruction");
 }
 
 void RBEIMConstruction::get_explicit_sys_subvector(
   NumericVector<Number>& dest, unsigned int var, NumericVector<Number>& localized_source)
 {
-  START_LOG("get_explicit_sys_subvector()", "RBEIMConstruction");
+  LOG_SCOPE("get_explicit_sys_subvector()", "RBEIMConstruction");
 
   for(unsigned int i=0; i<_dof_map_between_systems[var].size(); i++)
     {
@@ -916,13 +903,11 @@ void RBEIMConstruction::get_explicit_sys_subvector(
     }
 
   dest.close();
-
-  STOP_LOG("get_explicit_sys_subvector()", "RBEIMConstruction");
 }
 
 void RBEIMConstruction::init_dof_map_between_systems()
 {
-  START_LOG("init_dof_map_between_systems()", "RBEIMConstruction");
+  LOG_SCOPE("init_dof_map_between_systems()", "RBEIMConstruction");
 
   unsigned int n_vars = get_explicit_system().n_vars();
   unsigned int n_sys_dofs = this->n_dofs();
@@ -963,8 +948,6 @@ void RBEIMConstruction::init_dof_map_between_systems()
             }
         }
     }
-
-  STOP_LOG("init_dof_map_between_systems()", "RBEIMConstruction");
 }
 
 } // namespace libMesh

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -130,7 +130,7 @@ Real RBEIMEvaluation::rb_solve(unsigned int N)
   _previous_parameters = get_parameters();
   _previous_N = N;
 
-  START_LOG("rb_solve()", "RBEIMEvaluation");
+  LOG_SCOPE("rb_solve()", "RBEIMEvaluation");
 
   if(N > get_n_basis_functions())
     libmesh_error_msg("ERROR: N cannot be larger than the number of basis functions in rb_solve");
@@ -186,14 +186,11 @@ Real RBEIMEvaluation::rb_solve(unsigned int N)
 
       Real error_estimate = std::abs(g_at_next_x - EIM_approx_at_next_x);
 
-      STOP_LOG("rb_solve()", "RBEIMEvaluation");
-
       _previous_error_bound = error_estimate;
       return error_estimate;
     }
   else // Don't evaluate an error bound
     {
-      STOP_LOG("rb_solve()", "RBEIMEvaluation");
       _previous_error_bound = -1.;
       return -1.;
     }
@@ -202,7 +199,7 @@ Real RBEIMEvaluation::rb_solve(unsigned int N)
 
 void RBEIMEvaluation::rb_solve(DenseVector<Number> & EIM_rhs)
 {
-  START_LOG("rb_solve()", "RBEIMEvaluation");
+  LOG_SCOPE("rb_solve()", "RBEIMEvaluation");
 
   if(EIM_rhs.size() > get_n_basis_functions())
     libmesh_error_msg("ERROR: N cannot be larger than the number of basis functions in rb_solve");
@@ -215,8 +212,6 @@ void RBEIMEvaluation::rb_solve(DenseVector<Number> & EIM_rhs)
   interpolation_matrix.get_principal_submatrix(N, interpolation_matrix_N);
 
   interpolation_matrix_N.lu_solve(EIM_rhs, RB_solution);
-
-  STOP_LOG("rb_solve()", "RBEIMEvaluation");
 }
 
 Real RBEIMEvaluation::get_error_bound_normalization()
@@ -251,7 +246,7 @@ UniquePtr<RBTheta> RBEIMEvaluation::build_eim_theta(unsigned int index)
 void RBEIMEvaluation::legacy_write_offline_data_to_files(const std::string & directory_name,
                                                          const bool read_binary_data)
 {
-  START_LOG("legacy_write_offline_data_to_files()", "RBEIMEvaluation");
+  LOG_SCOPE("legacy_write_offline_data_to_files()", "RBEIMEvaluation");
 
   Parent::legacy_write_offline_data_to_files(directory_name);
 
@@ -347,8 +342,6 @@ void RBEIMEvaluation::legacy_write_offline_data_to_files(const std::string & dir
   // Write out the elements associated with the interpolation points.
   // This uses mesh I/O, hence we have to do it on all processors.
   legacy_write_out_interpolation_points_elem(directory_name);
-
-  STOP_LOG("legacy_write_offline_data_to_files()", "RBEIMEvaluation");
 }
 
 void RBEIMEvaluation::legacy_write_out_interpolation_points_elem(const std::string & directory_name)
@@ -470,7 +463,7 @@ void RBEIMEvaluation::legacy_read_offline_data_from_files(const std::string & di
                                                           bool read_error_bound_data,
                                                           const bool read_binary_data)
 {
-  START_LOG("legacy_read_offline_data_from_files()", "RBEIMEvaluation");
+  LOG_SCOPE("legacy_read_offline_data_from_files()", "RBEIMEvaluation");
 
   Parent::legacy_read_offline_data_from_files(directory_name, read_error_bound_data);
 
@@ -597,8 +590,6 @@ void RBEIMEvaluation::legacy_read_offline_data_from_files(const std::string & di
 
   // Read in the elements corresponding to the interpolation points
   legacy_read_in_interpolation_points_elem(directory_name);
-
-  STOP_LOG("legacy_read_offline_data_from_files()", "RBEIMEvaluation");
 }
 
 void RBEIMEvaluation::legacy_read_in_interpolation_points_elem(const std::string & directory_name)

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -57,7 +57,7 @@ RBEvaluation::~RBEvaluation()
 
 void RBEvaluation::clear()
 {
-  START_LOG("clear()", "RBEvaluation");
+  LOG_SCOPE("clear()", "RBEvaluation");
 
   // Clear the basis functions
   for(unsigned int i=0; i<basis_functions.size(); i++)
@@ -77,8 +77,6 @@ void RBEvaluation::clear()
   for(unsigned int i=0; i<greedy_param_list.size(); i++)
     greedy_param_list[i].clear();
   greedy_param_list.clear();
-
-  STOP_LOG("clear()", "RBEvaluation");
 }
 
 void RBEvaluation::set_rb_theta_expansion(RBThetaExpansion & rb_theta_expansion_in)
@@ -109,7 +107,7 @@ bool RBEvaluation::is_rb_theta_expansion_initialized() const
 void RBEvaluation::resize_data_structures(const unsigned int Nmax,
                                           bool resize_error_bound_data)
 {
-  START_LOG("resize_data_structures()", "RBEvaluation");
+  LOG_SCOPE("resize_data_structures()", "RBEvaluation");
 
   if(Nmax < this->get_n_basis_functions())
     libmesh_error_msg("Error: Cannot set Nmax to be less than the current number of basis functions.");
@@ -198,9 +196,6 @@ void RBEvaluation::resize_data_structures(const unsigned int Nmax,
           Aq_representor[q_a].resize(Nmax);
         }
     }
-
-
-  STOP_LOG("resize_data_structures()", "RBEvaluation");
 }
 
 NumericVector<Number> & RBEvaluation::get_basis_function(unsigned int i)
@@ -212,7 +207,7 @@ NumericVector<Number> & RBEvaluation::get_basis_function(unsigned int i)
 
 Real RBEvaluation::rb_solve(unsigned int N)
 {
-  START_LOG("rb_solve()", "RBEvaluation");
+  LOG_SCOPE("rb_solve()", "RBEvaluation");
 
   if(N > get_n_basis_functions())
     libmesh_error_msg("ERROR: N cannot be larger than the number of basis functions in rb_solve");
@@ -283,13 +278,10 @@ Real RBEvaluation::rb_solve(unsigned int N)
           RB_output_error_bounds[n] = abs_error_bound * eval_output_dual_norm(n, mu);
         }
 
-      STOP_LOG("rb_solve()", "RBEvaluation");
-
       return abs_error_bound;
     }
   else // Don't calculate the error bounds
     {
-      STOP_LOG("rb_solve()", "RBEvaluation");
       // Just return -1. if we did not compute the error bound
       return -1.;
     }
@@ -308,7 +300,7 @@ Real RBEvaluation::get_error_bound_normalization()
 
 Real RBEvaluation::compute_residual_dual_norm(const unsigned int N)
 {
-  START_LOG("compute_residual_dual_norm()", "RBEvaluation");
+  LOG_SCOPE("compute_residual_dual_norm()", "RBEvaluation");
 
   const RBParameters & mu = get_parameters();
 
@@ -378,8 +370,6 @@ Real RBEvaluation::compute_residual_dual_norm(const unsigned int N)
       residual_norm_sq = std::abs(residual_norm_sq);
     }
 
-  STOP_LOG("compute_residual_dual_norm()", "RBEvaluation");
-
   return std::sqrt( libmesh_real(residual_norm_sq) );
 }
 
@@ -435,7 +425,7 @@ void RBEvaluation::clear_riesz_representors()
 void RBEvaluation::legacy_write_offline_data_to_files(const std::string & directory_name,
                                                       const bool write_binary_data)
 {
-  START_LOG("legacy_write_offline_data_to_files()", "RBEvaluation");
+  LOG_SCOPE("legacy_write_offline_data_to_files()", "RBEvaluation");
 
   // Get the number of basis functions
   unsigned int n_bfs = get_n_basis_functions();
@@ -659,15 +649,13 @@ void RBEvaluation::legacy_write_offline_data_to_files(const std::string & direct
       }
 
     }
-
-  STOP_LOG("legacy_write_offline_data_to_files()", "RBEvaluation");
 }
 
 void RBEvaluation::legacy_read_offline_data_from_files(const std::string & directory_name,
                                                        bool read_error_bound_data,
                                                        const bool read_binary_data)
 {
-  START_LOG("legacy_read_offline_data_from_files()", "RBEvaluation");
+  LOG_SCOPE("legacy_read_offline_data_from_files()", "RBEvaluation");
 
   // The reading mode: DECODE for binary, READ for ASCII
   XdrMODE mode = read_binary_data ? DECODE : READ;
@@ -902,8 +890,6 @@ void RBEvaluation::legacy_read_offline_data_from_files(const std::string & direc
         }
       basis_functions[i] = libmesh_nullptr;
     }
-
-  STOP_LOG("legacy_read_offline_data_from_files()", "RBEvaluation");
 }
 
 void RBEvaluation::assert_file_exists(const std::string & file_name)
@@ -916,15 +902,13 @@ void RBEvaluation::write_out_basis_functions(System & sys,
                                              const std::string & directory_name,
                                              const bool write_binary_basis_functions)
 {
-  START_LOG("write_out_basis_functions()", "RBEvaluation");
+  LOG_SCOPE("write_out_basis_functions()", "RBEvaluation");
 
   write_out_vectors(sys,
                     basis_functions,
                     directory_name,
                     "bf",
                     write_binary_basis_functions);
-
-  STOP_LOG("write_out_basis_functions()", "RBEvaluation");
 }
 
 void RBEvaluation::write_out_vectors(System & sys,
@@ -933,8 +917,7 @@ void RBEvaluation::write_out_vectors(System & sys,
                                      const std::string & data_name,
                                      const bool write_binary_vectors)
 {
-  START_LOG("write_out_vectors()", "RBEvaluation");
-  //libMesh::out << "Writing out the basis functions..." << std::endl;
+  LOG_SCOPE("write_out_vectors()", "RBEvaluation");
 
   if(this->processor_id() == 0)
     {
@@ -1006,23 +989,19 @@ void RBEvaluation::write_out_vectors(System & sys,
 
   // Undo the temporary renumbering
   sys.get_mesh().fix_broken_node_and_element_numbering();
-
-  STOP_LOG("write_out_vectors()", "RBEvaluation");
 }
 
 void RBEvaluation::read_in_basis_functions(System & sys,
                                            const std::string & directory_name,
                                            const bool read_binary_basis_functions)
 {
-  START_LOG("read_in_basis_functions()", "RBEvaluation");
+  LOG_SCOPE("read_in_basis_functions()", "RBEvaluation");
 
   read_in_vectors(sys,
                   basis_functions,
                   directory_name,
                   "bf",
                   read_binary_basis_functions);
-
-  STOP_LOG("read_in_basis_functions()", "RBEvaluation");
 }
 
 void RBEvaluation::read_in_vectors(System & sys,
@@ -1053,7 +1032,7 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
                                                        const std::vector<std::string> & multiple_data_names,
                                                        const bool read_binary_vectors)
 {
-  START_LOG("read_in_vectors_from_multiple_files()", "RBEvaluation");
+  LOG_SCOPE("read_in_vectors_from_multiple_files()", "RBEvaluation");
 
   unsigned int n_files = multiple_vectors.size();
   unsigned int n_directories = multiple_directory_names.size();
@@ -1142,8 +1121,6 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
 
   // Undo the temporary renumbering
   sys.get_mesh().fix_broken_node_and_element_numbering();
-
-  STOP_LOG("read_in_vectors_from_multiple_files()", "RBEvaluation");
 }
 
 std::string RBEvaluation::get_io_version_string()

--- a/src/reduced_basis/rb_scm_construction.C
+++ b/src/reduced_basis/rb_scm_construction.C
@@ -214,12 +214,11 @@ void RBSCMConstruction::resize_SCM_vectors()
 
 void RBSCMConstruction::add_scaled_symm_Aq(unsigned int q_a, Number scalar)
 {
-  START_LOG("add_scaled_symm_Aq()", "RBSCMConstruction");
+  LOG_SCOPE("add_scaled_symm_Aq()", "RBSCMConstruction");
   // Load the operators from the RBConstruction
   EquationSystems & es = this->get_equation_systems();
   RBConstruction & rb_system = es.get_system<RBConstruction>(RB_system_name);
   rb_system.add_scaled_Aq(scalar, q_a, matrix_A, true);
-  STOP_LOG("add_scaled_symm_Aq()", "RBSCMConstruction");
 }
 
 void RBSCMConstruction::load_matrix_B()
@@ -235,7 +234,7 @@ void RBSCMConstruction::load_matrix_B()
 
 void RBSCMConstruction::perform_SCM_greedy()
 {
-  START_LOG("perform_SCM_greedy()", "RBSCMConstruction");
+  LOG_SCOPE("perform_SCM_greedy()", "RBSCMConstruction");
 
   // initialize rb_scm_eval's parameters
   rb_scm_eval->initialize_parameters(*this);
@@ -292,13 +291,11 @@ void RBSCMConstruction::perform_SCM_greedy()
 
       SCM_iter++;
     }
-
-  STOP_LOG("perform_SCM_greedy()", "RBSCMConstruction");
 }
 
 void RBSCMConstruction::compute_SCM_bounding_box()
 {
-  START_LOG("compute_SCM_bounding_box()", "RBSCMConstruction");
+  LOG_SCOPE("compute_SCM_bounding_box()", "RBSCMConstruction");
 
   // Resize the bounding box vectors
   rb_scm_eval->B_min.resize(get_rb_theta_expansion().get_n_A_terms());
@@ -351,13 +348,11 @@ void RBSCMConstruction::compute_SCM_bounding_box()
       else
         libmesh_error_msg("Eigen solver for computing B_max did not converge");
     }
-
-  STOP_LOG("compute_SCM_bounding_box()", "RBSCMConstruction");
 }
 
 void RBSCMConstruction::evaluate_stability_constant()
 {
-  START_LOG("evaluate_stability_constant()", "RBSCMConstruction");
+  LOG_SCOPE("evaluate_stability_constant()", "RBSCMConstruction");
 
   // Get current index of C_J
   const unsigned int j = rb_scm_eval->C_J.size()-1;
@@ -406,8 +401,6 @@ void RBSCMConstruction::evaluate_stability_constant()
     }
   else
     libmesh_error_msg("Error: Eigensolver did not converge in evaluate_stability_constant");
-
-  STOP_LOG("evaluate_stability_constant()", "RBSCMConstruction");
 }
 
 Number RBSCMConstruction::B_inner_product(const NumericVector<Number> & v,
@@ -434,7 +427,7 @@ Number RBSCMConstruction::Aq_inner_product(unsigned int q,
 
 std::pair<unsigned int,Real> RBSCMConstruction::compute_SCM_bounds_on_training_set()
 {
-  START_LOG("compute_SCM_bounds_on_training_set()", "RBSCMConstruction");
+  LOG_SCOPE("compute_SCM_bounds_on_training_set()", "RBSCMConstruction");
 
   // Now compute the maximum bound error over training_parameters
   unsigned int new_C_J_index = 0;
@@ -461,14 +454,12 @@ std::pair<unsigned int,Real> RBSCMConstruction::compute_SCM_bounds_on_training_s
   std::pair<unsigned int,Real> error_pair(global_index, max_SCM_error);
   get_global_max_error_pair(this->comm(),error_pair);
 
-  STOP_LOG("compute_SCM_bounds_on_training_set()", "RBSCMConstruction");
-
   return error_pair;
 }
 
 void RBSCMConstruction::enrich_C_J(unsigned int new_C_J_index)
 {
-  START_LOG("enrich_C_J()", "RBSCMConstruction");
+  LOG_SCOPE("enrich_C_J()", "RBSCMConstruction");
 
   set_params_from_training_set_and_broadcast(new_C_J_index);
 
@@ -492,8 +483,6 @@ void RBSCMConstruction::enrich_C_J(unsigned int new_C_J_index)
 
   std::vector<Real> zero_vector(get_rb_theta_expansion().get_n_A_terms());
   rb_scm_eval->SCM_UB_vectors.push_back(zero_vector);
-
-  STOP_LOG("enrich_C_J()", "RBSCMConstruction");
 }
 
 

--- a/src/reduced_basis/rb_scm_evaluation.C
+++ b/src/reduced_basis/rb_scm_evaluation.C
@@ -165,7 +165,7 @@ void RBSCMEvaluation::set_B_max(unsigned int q, Real B_max_val)
 
 Real RBSCMEvaluation::get_SCM_LB()
 {
-  START_LOG("get_SCM_LB()", "RBSCMEvaluation");
+  LOG_SCOPE("get_SCM_LB()", "RBSCMEvaluation");
 
   // Initialize the LP
   glp_prob * lp;
@@ -276,14 +276,12 @@ Real RBSCMEvaluation::get_SCM_LB()
   // Destroy the LP
   glp_delete_prob(lp);
 
-  STOP_LOG("get_SCM_LB()", "RBSCMEvaluation");
-
   return min_J_obj;
 }
 
 Real RBSCMEvaluation::get_SCM_UB()
 {
-  START_LOG("get_SCM_UB()", "RBSCMEvaluation");
+  LOG_SCOPE("get_SCM_UB()", "RBSCMEvaluation");
 
   // Add rows to the LP: corresponds to the auxiliary
   // variables that define the constraints at each
@@ -311,8 +309,6 @@ Real RBSCMEvaluation::get_SCM_UB()
         }
     }
 
-  STOP_LOG("get_SCM_UB()", "RBSCMEvaluation");
-
   return min_J_obj;
 }
 
@@ -334,7 +330,7 @@ void RBSCMEvaluation::reload_current_parameters()
 void RBSCMEvaluation::legacy_write_offline_data_to_files(const std::string & directory_name,
                                                          const bool write_binary_data)
 {
-  START_LOG("legacy_write_offline_data_to_files()", "RBSCMEvaluation");
+  LOG_SCOPE("legacy_write_offline_data_to_files()", "RBSCMEvaluation");
 
   if(this->processor_id() == 0)
     {
@@ -448,15 +444,13 @@ void RBSCMEvaluation::legacy_write_offline_data_to_files(const std::string & dir
         }
       SCM_UB_vectors_out.close();
     }
-
-  STOP_LOG("legacy_write_offline_data_to_files()", "RBSCMEvaluation");
 }
 
 
 void RBSCMEvaluation::legacy_read_offline_data_from_files(const std::string & directory_name,
                                                           const bool read_binary_data)
 {
-  START_LOG("legacy_read_offline_data_from_files()", "RBSCMEvaluation");
+  LOG_SCOPE("legacy_read_offline_data_from_files()", "RBSCMEvaluation");
 
   // The reading mode: DECODE for binary, READ for ASCII
   XdrMODE mode = read_binary_data ? DECODE : READ;
@@ -571,8 +565,6 @@ void RBSCMEvaluation::legacy_read_offline_data_from_files(const std::string & di
         }
     }
   SCM_UB_vectors_in.close();
-
-  STOP_LOG("legacy_read_offline_data_from_files()", "RBSCMEvaluation");
 }
 
 } // namespace libMesh

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -396,7 +396,7 @@ void TransientRBConstruction::mass_matrix_scaled_matvec(Number scalar,
                                                         NumericVector<Number> & dest,
                                                         NumericVector<Number> & arg)
 {
-  START_LOG("mass_matrix_scaled_matvec()", "TransientRBConstruction");
+  LOG_SCOPE("mass_matrix_scaled_matvec()", "TransientRBConstruction");
 
   dest.zero();
 
@@ -415,13 +415,11 @@ void TransientRBConstruction::mass_matrix_scaled_matvec(Number scalar,
       get_M_q(q)->vector_mult(*temp_vec, arg);
       dest.add(scalar * trans_theta_expansion.eval_M_theta(q,mu), *temp_vec);
     }
-
-  STOP_LOG("mass_matrix_scaled_matvec()", "TransientRBConstruction");
 }
 
 void TransientRBConstruction::truth_assembly()
 {
-  START_LOG("truth_assembly()", "TransientRBConstruction");
+  LOG_SCOPE("truth_assembly()", "TransientRBConstruction");
 
   this->matrix->close();
 
@@ -470,8 +468,6 @@ void TransientRBConstruction::truth_assembly()
 
   this->matrix->close();
   this->rhs->close();
-
-  STOP_LOG("truth_assembly()", "TransientRBConstruction");
 }
 
 void TransientRBConstruction::set_L2_assembly(ElemAssembly & L2_assembly_in)
@@ -540,7 +536,7 @@ void TransientRBConstruction::assemble_misc_matrices()
 
 Real TransientRBConstruction::truth_solve(int write_interval)
 {
-  START_LOG("truth_solve()", "TransientRBConstruction");
+  LOG_SCOPE("truth_solve()", "TransientRBConstruction");
 
   const RBParameters & mu = get_parameters();
   const unsigned int n_time_steps = get_n_time_steps();
@@ -633,8 +629,6 @@ Real TransientRBConstruction::truth_solve(int write_interval)
   Real final_truth_L2_norm = libmesh_real(std::sqrt(inner_product_storage_vector->dot(*solution)));
 
 
-  STOP_LOG("truth_solve()", "TransientRBConstruction");
-
   return final_truth_L2_norm;
 }
 
@@ -653,7 +647,7 @@ bool TransientRBConstruction::greedy_termination_test(
 
 Number TransientRBConstruction::set_error_temporal_data()
 {
-  START_LOG("set_error_temporal_data()", "TransientRBConstruction");
+  LOG_SCOPE("set_error_temporal_data()", "TransientRBConstruction");
 
   // first compute the projection of solution onto the current
   // RB space
@@ -714,8 +708,6 @@ Number TransientRBConstruction::set_error_temporal_data()
       *(temporal_data[time_step]) = *temp;
     }
 
-  STOP_LOG("set_error_temporal_data()", "TransientRBConstruction");
-
   // return the square of the X norm of the truth solution
   inner_product_matrix->vector_mult(*inner_product_storage_vector,*solution);
 
@@ -724,13 +716,11 @@ Number TransientRBConstruction::set_error_temporal_data()
 
 const NumericVector<Number> & TransientRBConstruction::get_error_temporal_data()
 {
-  START_LOG("get_error_temporal_data()", "TransientRBConstruction");
+  LOG_SCOPE("get_error_temporal_data()", "TransientRBConstruction");
 
   const unsigned int time_step = get_time_step();
 
   return *temporal_data[time_step];
-
-  STOP_LOG("get_error_temporal_data()", "TransientRBConstruction");
 }
 
 void TransientRBConstruction::initialize_truth ()
@@ -753,7 +743,7 @@ void TransientRBConstruction::initialize_truth ()
 
 void TransientRBConstruction::add_IC_to_RB_space()
 {
-  START_LOG("add_IC_to_RB_space()", "TransientRBConstruction");
+  LOG_SCOPE("add_IC_to_RB_space()", "TransientRBConstruction");
 
   if (get_rb_evaluation().get_n_basis_functions() > 0)
     libmesh_error_msg("Error: Should not call TransientRBConstruction::add_IC_to_RB_space() " \
@@ -781,15 +771,13 @@ void TransientRBConstruction::add_IC_to_RB_space()
   set_delta_N(1);
   update_system();
   set_delta_N(saved_delta_N);
-
-  STOP_LOG("add_IC_to_RB_space()", "TransientRBConstruction");
 }
 
 void TransientRBConstruction::enrich_RB_space()
 {
   // Need SLEPc to get the POD eigenvalues
 #if defined(LIBMESH_HAVE_SLEPC)
-  START_LOG("enrich_RB_space()", "TransientRBConstruction");
+  LOG_SCOPE("enrich_RB_space()", "TransientRBConstruction");
 
   // With the "method of snapshots", the size of
   // the eigenproblem is determined by the number
@@ -945,7 +933,6 @@ void TransientRBConstruction::enrich_RB_space()
         }
     }
 
-  STOP_LOG("enrich_RB_space()", "TransientRBConstruction");
 #else
   libmesh_not_implemented();
 #endif
@@ -971,7 +958,7 @@ SparseMatrix<Number> & TransientRBConstruction::get_matrix_for_output_dual_solve
 
 void TransientRBConstruction::load_rb_solution()
 {
-  START_LOG("load_rb_solution()", "TransientRBConstruction");
+  LOG_SCOPE("load_rb_solution()", "TransientRBConstruction");
 
   solution->zero();
 
@@ -993,13 +980,11 @@ void TransientRBConstruction::load_rb_solution()
     }
 
   update();
-
-  STOP_LOG("load_rb_solution()", "TransientRBConstruction");
 }
 
 void TransientRBConstruction::update_RB_system_matrices()
 {
-  START_LOG("update_RB_system_matrices()", "TransientRBConstruction");
+  LOG_SCOPE("update_RB_system_matrices()", "TransientRBConstruction");
 
   Parent::update_RB_system_matrices();
 
@@ -1050,8 +1035,6 @@ void TransientRBConstruction::update_RB_system_matrices()
 
         }
     }
-
-  STOP_LOG("update_RB_system_matrices()", "TransientRBConstruction");
 }
 
 
@@ -1059,7 +1042,7 @@ void TransientRBConstruction::update_RB_system_matrices()
 
 void TransientRBConstruction::update_residual_terms(bool compute_inner_products)
 {
-  START_LOG("update_residual_terms()", "TransientRBConstruction");
+  LOG_SCOPE("update_residual_terms()", "TransientRBConstruction");
 
   Parent::update_residual_terms(compute_inner_products);
 
@@ -1189,14 +1172,12 @@ void TransientRBConstruction::update_residual_terms(bool compute_inner_products)
             } // end for j
         } // end for i
     } // end if (compute_inner_products)
-
-  STOP_LOG("update_residual_terms()", "TransientRBConstruction");
 }
 
 
 void TransientRBConstruction::update_RB_initial_condition_all_N()
 {
-  START_LOG("update_RB_initial_condition_all_N()", "TransientRBConstruction");
+  LOG_SCOPE("update_RB_initial_condition_all_N()", "TransientRBConstruction");
 
   TransientRBEvaluation & trans_rb_eval = cast_ref<TransientRBEvaluation &>(get_rb_evaluation());
 
@@ -1258,13 +1239,11 @@ void TransientRBConstruction::update_RB_initial_condition_all_N()
 
       trans_rb_eval.initial_L2_error_all_N[N] = libmesh_real(std::sqrt(temp2->dot(*temp1)));
     }
-
-  STOP_LOG("update_RB_initial_condition_all_N()", "TransientRBConstruction");
 }
 
 //Real TransientRBConstruction::uncached_compute_residual_dual_norm(const unsigned int N)
 //{
-//  START_LOG("uncached_compute_residual_dual_norm()", "TransientRBConstruction");
+//   LOG_SCOPE("uncached_compute_residual_dual_norm()", "TransientRBConstruction");
 //
 //   // This is the "slow" way of computing the residual, but it is useful
 //   // for validating the "fast" way.
@@ -1336,16 +1315,13 @@ void TransientRBConstruction::update_RB_initial_condition_all_N()
 //
 //  Real slow_residual_norm_sq = solution->dot(*inner_product_storage_vector);
 //
-//
-//  STOP_LOG("uncached_compute_residual_dual_norm()", "TransientRBConstruction");
-//
 //  return libmesh_real(std::sqrt( slow_residual_norm_sq ));
 //}
 
 void TransientRBConstruction::write_riesz_representors_to_files(const std::string & riesz_representors_dir,
                                                                 const bool write_binary_residual_representors)
 {
-  START_LOG("write_riesz_representors_to_files()", "TransientRBConstruction");
+  LOG_SCOPE("write_riesz_representors_to_files()", "TransientRBConstruction");
 
   // Write out the M_q_representors.  These are useful to have when restarting,
   // so you don't have to recompute them all over again.  There should be
@@ -1389,14 +1365,12 @@ void TransientRBConstruction::write_riesz_representors_to_files(const std::strin
           // for the system call, be sure to do it only on one processor, etc.
         }
       }
-
-  STOP_LOG("write_riesz_representors_to_files()", "TransientRBConstruction");
 }
 
 void TransientRBConstruction::read_riesz_representors_from_files(const std::string & riesz_representors_dir,
                                                                  const bool read_binary_residual_representors)
 {
-  START_LOG("read_riesz_representors_from_files()", "TransientRBConstruction");
+  LOG_SCOPE("read_riesz_representors_from_files()", "TransientRBConstruction");
 
   const std::string riesz_representor_suffix =
     (read_binary_residual_representors ? ".xdr" : ".dat");
@@ -1448,8 +1422,6 @@ void TransientRBConstruction::read_riesz_representors_from_files(const std::stri
         //*M_q_representor[i][j] = *solution;
         trans_rb_eval.M_q_representor[i][j]->swap(*solution);
       }
-
-  STOP_LOG("read_riesz_representors_from_files()", "TransientRBConstruction");
 }
 
 } // namespace libMesh

--- a/src/reduced_basis/transient_rb_evaluation.C
+++ b/src/reduced_basis/transient_rb_evaluation.C
@@ -79,7 +79,7 @@ void TransientRBEvaluation::clear_riesz_representors()
 void TransientRBEvaluation::resize_data_structures(const unsigned int Nmax,
                                                    bool resize_error_bound_data)
 {
-  START_LOG("resize_data_structures()", "TransientRBEvaluation");
+  LOG_SCOPE("resize_data_structures()", "TransientRBEvaluation");
 
   Parent::resize_data_structures(Nmax, resize_error_bound_data);
 
@@ -160,13 +160,11 @@ void TransientRBEvaluation::resize_data_structures(const unsigned int Nmax,
           M_q_representor[q_m].resize(Nmax);
         }
     }
-
-  STOP_LOG("resize_data_structures()", "TransientRBEvaluation");
 }
 
 Real TransientRBEvaluation::rb_solve(unsigned int N)
 {
-  START_LOG("rb_solve()", "TransientRBEvaluation");
+  LOG_SCOPE("rb_solve()", "TransientRBEvaluation");
 
   if(N > get_n_basis_functions())
     libmesh_error_msg("ERROR: N cannot be larger than the number of basis functions in rb_solve");
@@ -359,8 +357,6 @@ Real TransientRBEvaluation::rb_solve(unsigned int N)
         }
     }
 
-  STOP_LOG("rb_solve()", "TransientRBEvaluation");
-
   _rb_solve_data_cached = true ;
 
   if(evaluate_RB_error_bound) // Calculate the error bounds
@@ -434,7 +430,7 @@ Real TransientRBEvaluation::residual_scaling_numer(Real)
 
 void TransientRBEvaluation::cache_online_residual_terms(const unsigned int N)
 {
-  START_LOG("cache_online_residual_terms()", "TransientRBEvaluation");
+  LOG_SCOPE("cache_online_residual_terms()", "TransientRBEvaluation");
 
   const RBParameters mu = get_parameters();
 
@@ -552,13 +548,11 @@ void TransientRBEvaluation::cache_online_residual_terms(const unsigned int N)
           q++;
         }
     }
-
-  STOP_LOG("cache_online_residual_terms()", "TransientRBEvaluation");
 }
 
 Real TransientRBEvaluation::compute_residual_dual_norm(const unsigned int N)
 {
-  START_LOG("compute_residual_dual_norm()", "TransientRBEvaluation");
+  LOG_SCOPE("compute_residual_dual_norm()", "TransientRBEvaluation");
 
   // This assembly assumes we have already called cache_online_residual_terms
   // and that the rb_solve parameter is constant in time
@@ -601,14 +595,12 @@ Real TransientRBEvaluation::compute_residual_dual_norm(const unsigned int N)
       residual_norm_sq = std::abs(residual_norm_sq);
     }
 
-  STOP_LOG("compute_residual_dual_norm()", "TransientRBEvaluation");
-
   return libmesh_real(std::sqrt( residual_norm_sq ));
 }
 
 Real TransientRBEvaluation::uncached_compute_residual_dual_norm(const unsigned int N)
 {
-  START_LOG("uncached_compute_residual_dual_norm()", "TransientRBEvaluation");
+  LOG_SCOPE("uncached_compute_residual_dual_norm()", "TransientRBEvaluation");
 
   // Use the stored representor inner product values
   // to evaluate the residual norm
@@ -754,15 +746,13 @@ Real TransientRBEvaluation::uncached_compute_residual_dual_norm(const unsigned i
   //   libMesh::out << "slow residual_sq = " << slow_residual_norm_sq
   //                << ", fast residual_sq = " << residual_norm_sq << std::endl;
 
-  STOP_LOG("uncached_compute_residual_dual_norm()", "TransientRBEvaluation");
-
   return libmesh_real(std::sqrt( residual_norm_sq ));
 }
 
 void TransientRBEvaluation::legacy_write_offline_data_to_files(const std::string & directory_name,
                                                                const bool write_binary_data)
 {
-  START_LOG("legacy_write_offline_data_to_files()", "TransientRBEvaluation");
+  LOG_SCOPE("legacy_write_offline_data_to_files()", "TransientRBEvaluation");
 
   Parent::legacy_write_offline_data_to_files(directory_name);
 
@@ -909,15 +899,13 @@ void TransientRBEvaluation::legacy_write_offline_data_to_files(const std::string
         }
       RB_Aq_Mq_terms_out.close();
     }
-
-  STOP_LOG("legacy_write_offline_data_to_files()", "TransientRBEvaluation");
 }
 
 void TransientRBEvaluation::legacy_read_offline_data_from_files(const std::string & directory_name,
                                                                 bool read_error_bound_data,
                                                                 const bool read_binary_data)
 {
-  START_LOG("legacy_read_offline_data_from_files()", "TransientRBEvaluation");
+  LOG_SCOPE("legacy_read_offline_data_from_files()", "TransientRBEvaluation");
 
   Parent::legacy_read_offline_data_from_files(directory_name);
 
@@ -1089,9 +1077,6 @@ void TransientRBEvaluation::legacy_read_offline_data_from_files(const std::strin
         }
       RB_Aq_Mq_terms_in.close();
     }
-
-  STOP_LOG("legacy_read_offline_data_from_files()", "TransientRBEvaluation");
-
 }
 
 }

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -138,12 +138,10 @@ void MeshfreeInterpolation::gather_remote_data ()
   // This function must be run on all processors at once
   parallel_object_only();
 
-  START_LOG ("gather_remote_data()", "MeshfreeInterpolation");
+  LOG_SCOPE ("gather_remote_data()", "MeshfreeInterpolation");
 
   this->comm().allgather(_src_pts);
   this->comm().allgather(_src_vals);
-
-  STOP_LOG  ("gather_remote_data()", "MeshfreeInterpolation");
 
 #endif // LIBMESH_HAVE_MPI
 }
@@ -157,7 +155,7 @@ void InverseDistanceInterpolation<KDDim>::construct_kd_tree ()
 {
 #ifdef LIBMESH_HAVE_NANOFLANN
 
-  START_LOG ("construct_kd_tree()", "InverseDistanceInterpolation<>");
+  LOG_SCOPE ("construct_kd_tree()", "InverseDistanceInterpolation<>");
 
   // Initialize underlying KD tree
   if (_kd_tree.get() == libmesh_nullptr)
@@ -168,8 +166,6 @@ void InverseDistanceInterpolation<KDDim>::construct_kd_tree ()
   libmesh_assert (_kd_tree.get() != libmesh_nullptr);
 
   _kd_tree->buildIndex();
-
-  STOP_LOG ("construct_kd_tree()", "InverseDistanceInterpolation<>");
 #endif
 }
 
@@ -203,7 +199,7 @@ void InverseDistanceInterpolation<KDDim>::interpolate_field_data (const std::vec
     const_cast<InverseDistanceInterpolation<KDDim> *>(this)->construct_kd_tree();
 #endif
 
-  START_LOG ("interpolate_field_data()", "InverseDistanceInterpolation<>");
+  LOG_SCOPE ("interpolate_field_data()", "InverseDistanceInterpolation<>");
 
   libmesh_assert_equal_to (field_names.size(), this->n_field_variables());
 
@@ -255,8 +251,6 @@ void InverseDistanceInterpolation<KDDim>::interpolate_field_data (const std::vec
                     << "with nanoflann KD-Tree approximate nearest neighbor support!");
 
 #endif
-
-  STOP_LOG ("interpolate_field_data()", "InverseDistanceInterpolation<>");
 }
 
 template <unsigned int KDDim>

--- a/src/solution_transfer/radial_basis_interpolation.C
+++ b/src/solution_transfer/radial_basis_interpolation.C
@@ -54,7 +54,7 @@ void RadialBasisInterpolation<KDDim,RBF>::prepare_for_use()
   libmesh_error_msg("ERROR: this functionality presently requires Eigen!");
 
 #else
-  START_LOG ("prepare_for_use()", "RadialBasisInterpolation<>");
+  LOG_SCOPE ("prepare_for_use()", "RadialBasisInterpolation<>");
 
   // Construct a bounding box for our source points
   _src_bbox.invalidate();
@@ -139,8 +139,6 @@ void RadialBasisInterpolation<KDDim,RBF>::prepare_for_use()
     for (unsigned int var=0; var<n_vars; var++)
       _weights[i*n_vars + var] = x(i,var);
 
-
-  STOP_LOG  ("prepare_for_use()", "RadialBasisInterpolation<>");
 #endif
 
 }
@@ -152,7 +150,7 @@ void RadialBasisInterpolation<KDDim,RBF>::interpolate_field_data (const std::vec
                                                                   const std::vector<Point> & tgt_pts,
                                                                   std::vector<Number> & tgt_vals) const
 {
-  START_LOG ("interpolate_field_data()", "RadialBasisInterpolation<>");
+  LOG_SCOPE ("interpolate_field_data()", "RadialBasisInterpolation<>");
 
   libmesh_experimental();
 
@@ -195,8 +193,6 @@ void RadialBasisInterpolation<KDDim,RBF>::interpolate_field_data (const std::vec
             tgt_vals[tgt*n_vars + var] += _weights[i*n_vars + var]*phi_i;
         }
     }
-
-  STOP_LOG ("interpolate_field_data()", "RadialBasisInterpolation<>");
 }
 
 

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -84,7 +84,7 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
                                    const double tol,
                                    const unsigned int m_its)
 {
-  START_LOG("solve()", "EigenSparseLinearSolver");
+  LOG_SCOPE("solve()", "EigenSparseLinearSolver");
   this->init ();
 
   // Make sure the data passed in are really Eigen types
@@ -214,8 +214,6 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
 
         this->_solver_type = BICGSTAB;
 
-        STOP_LOG("solve()", "EigenSparseLinearSolver");
-
         return this->solve (matrix,
                             solution,
                             rhs,
@@ -224,7 +222,6 @@ EigenSparseLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
       }
     }
 
-  STOP_LOG("solve()", "EigenSparseLinearSolver");
   return retval;
 }
 
@@ -238,8 +235,7 @@ EigenSparseLinearSolver<T>::adjoint_solve (SparseMatrix<T> & matrix_in,
                                            const double tol,
                                            const unsigned int m_its)
 {
-
-  START_LOG("adjoint_solve()", "EigenSparseLinearSolver");
+  LOG_SCOPE("adjoint_solve()", "EigenSparseLinearSolver");
 
   libmesh_experimental();
   EigenSparseMatrix<T> mat_trans(this->comm());
@@ -250,8 +246,6 @@ EigenSparseLinearSolver<T>::adjoint_solve (SparseMatrix<T> & matrix_in,
                                                       rhs_in,
                                                       tol,
                                                       m_its);
-
-  STOP_LOG("adjoint_solve()", "EigenSparseLinearSolver");
 
   return retval;
 }

--- a/src/solvers/laspack_linear_solver.C
+++ b/src/solvers/laspack_linear_solver.C
@@ -112,7 +112,7 @@ LaspackLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
                                const double tol,
                                const unsigned int m_its)
 {
-  START_LOG("solve()", "LaspackLinearSolver");
+  LOG_SCOPE("solve()", "LaspackLinearSolver");
   this->init ();
 
   // Make sure the data passed in are really in Laspack types
@@ -272,7 +272,6 @@ LaspackLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
       libmesh_error_msg("Exiting after LASPACK Error!");
     }
 
-  STOP_LOG("solve()", "LaspackLinearSolver");
   // Get the convergence step # and residual
   return std::make_pair(GetLastNoIter(), GetLastAccuracy());
 }
@@ -287,7 +286,7 @@ LaspackLinearSolver<T>::adjoint_solve (SparseMatrix<T> & matrix_in,
                                        const double tol,
                                        const unsigned int m_its)
 {
-  START_LOG("adjoint_solve()", "LaspackLinearSolver");
+  LOG_SCOPE("adjoint_solve()", "LaspackLinearSolver");
   this->init ();
 
   // Make sure the data passed in are really in Laspack types
@@ -447,7 +446,6 @@ LaspackLinearSolver<T>::adjoint_solve (SparseMatrix<T> & matrix_in,
       libmesh_error_msg("Exiting after LASPACK Error!");
     }
 
-  STOP_LOG("adjoint_solve()", "LaspackLinearSolver");
   // Get the convergence step # and residual
   return std::make_pair(GetLastNoIter(), GetLastAccuracy());
 }

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -133,7 +133,7 @@ std::pair<unsigned int, Real> LinearSolver<T>::adjoint_solve (SparseMatrix<T> & 
                                                               const unsigned int n_iter)
 {
   // Log how long the linear solve takes.
-  START_LOG("adjoint_solve()", "LinearSolver");
+  LOG_SCOPE("adjoint_solve()", "LinearSolver");
 
   // Take the discrete adjoint
   mat.close();
@@ -147,11 +147,7 @@ std::pair<unsigned int, Real> LinearSolver<T>::adjoint_solve (SparseMatrix<T> & 
   // by taking the discrete adjoint
   mat.get_transpose(mat);
 
-  // Stop logging the nonlinear solve
-  STOP_LOG("adjoint_solve()", "LinearSolver");
-
   return totalrval;
-
 }
 
 template <typename T>

--- a/src/solvers/newton_solver.C
+++ b/src/solvers/newton_solver.C
@@ -276,7 +276,7 @@ void NewtonSolver::reinit()
 
 unsigned int NewtonSolver::solve()
 {
-  START_LOG("solve()", "NewtonSolver");
+  LOG_SCOPE("solve()", "NewtonSolver");
 
   // Reset any prior solve result
   _solve_result = INVALID_SOLVE_RESULT;
@@ -547,8 +547,6 @@ unsigned int NewtonSolver::solve()
 
   // We may need to localize a parallel solution
   _system.update ();
-
-  STOP_LOG("solve()", "NewtonSolver");
 
   // Make sure we are returning something sensible as the
   // _solve_result, except in the edge case where we weren't really asked to

--- a/src/solvers/nlopt_optimization_solver.C
+++ b/src/solvers/nlopt_optimization_solver.C
@@ -38,7 +38,7 @@ double __libmesh_nlopt_objective(unsigned n,
                                  double * gradient,
                                  void * data)
 {
-  START_LOG("objective()", "NloptOptimizationSolver");
+  LOG_SCOPE("objective()", "NloptOptimizationSolver");
 
   // ctx should be a pointer to the solver (it was passed in as void *)
   NloptOptimizationSolver<Number> * solver =
@@ -94,8 +94,6 @@ double __libmesh_nlopt_objective(unsigned n,
         libmesh_error_msg("Gradient function not defined in __libmesh_nlopt_objective");
     }
 
-  STOP_LOG("objective()", "NloptOptimizationSolver");
-
   // Increment the iteration count.
   solver->get_iteration_count()++;
 
@@ -115,7 +113,7 @@ void __libmesh_nlopt_equality_constraints(unsigned m,
                                           double * gradient,
                                           void * data)
 {
-  START_LOG("equality_constraints()", "NloptOptimizationSolver");
+  LOG_SCOPE("equality_constraints()", "NloptOptimizationSolver");
 
   libmesh_assert(data);
 
@@ -192,10 +190,6 @@ void __libmesh_nlopt_equality_constraints(unsigned m,
     }
   else
     libmesh_error_msg("Constraints function not defined in __libmesh_nlopt_equality_constraints");
-
-
-
-  STOP_LOG("equality_constraints()", "NloptOptimizationSolver");
 }
 
 
@@ -206,7 +200,7 @@ void __libmesh_nlopt_inequality_constraints(unsigned m,
                                             double * gradient,
                                             void * data)
 {
-  START_LOG("inequality_constraints()", "NloptOptimizationSolver");
+  LOG_SCOPE("inequality_constraints()", "NloptOptimizationSolver");
 
   libmesh_assert(data);
 
@@ -283,8 +277,6 @@ void __libmesh_nlopt_inequality_constraints(unsigned m,
     }
   else
     libmesh_error_msg("Constraints function not defined in __libmesh_nlopt_inequality_constraints");
-
-  STOP_LOG("inequality_constraints()", "NloptOptimizationSolver");
 }
 
 //---------------------------------------------------------------------
@@ -359,7 +351,7 @@ void NloptOptimizationSolver<T>::init ()
 template <typename T>
 void NloptOptimizationSolver<T>::solve ()
 {
-  START_LOG("solve()", "NloptOptimizationSolver");
+  LOG_SCOPE("solve()", "NloptOptimizationSolver");
 
   this->init ();
 
@@ -455,8 +447,6 @@ void NloptOptimizationSolver<T>::solve ()
                  << this->get_iteration_count()
                  << " iterations."
                  << std::endl;
-
-  STOP_LOG("solve()", "NloptOptimizationSolver");
 }
 
 

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -208,7 +208,7 @@ PetscDiffSolver::PetscDiffSolver (sys_type & s)
 
 void PetscDiffSolver::init ()
 {
-  START_LOG("init()", "PetscDiffSolver");
+  LOG_SCOPE("init()", "PetscDiffSolver");
 
   Parent::init();
 
@@ -239,8 +239,6 @@ void PetscDiffSolver::init ()
   LIBMESH_CHKERR(ierr);
 
   petsc_auto_fieldsplit(my_pc, _system);
-
-  STOP_LOG("init()", "PetscDiffSolver");
 }
 
 
@@ -253,12 +251,10 @@ PetscDiffSolver::~PetscDiffSolver ()
 
 void PetscDiffSolver::clear()
 {
-  START_LOG("clear()", "PetscDiffSolver");
+  LOG_SCOPE("clear()", "PetscDiffSolver");
 
   int ierr = LibMeshSNESDestroy(&_snes);
   LIBMESH_CHKERR(ierr);
-
-  STOP_LOG("clear()", "PetscDiffSolver");
 }
 
 
@@ -333,7 +329,7 @@ unsigned int PetscDiffSolver::solve()
 {
   this->init();
 
-  START_LOG("solve()", "PetscDiffSolver");
+  LOG_SCOPE("solve()", "PetscDiffSolver");
 
   PetscVector<Number> & x =
     *(cast_ptr<PetscVector<Number> *>(_system.solution.get()));
@@ -358,8 +354,6 @@ unsigned int PetscDiffSolver::solve()
 
   ierr = SNESSolve (_snes, PETSC_NULL, x.vec());
   LIBMESH_CHKERR(ierr);
-
-  STOP_LOG("solve()", "PetscDiffSolver");
 
   SNESConvergedReason reason;
   SNESGetConvergedReason(_snes, &reason);

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -389,7 +389,7 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
                              const double tol,
                              const unsigned int m_its)
 {
-  START_LOG("solve()", "PetscLinearSolver");
+  LOG_SCOPE("solve()", "PetscLinearSolver");
 
   // Make sure the data passed in are really of Petsc types
   PetscMatrix<T> * matrix   = cast_ptr<PetscMatrix<T> *>(&matrix_in);
@@ -656,7 +656,6 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
       LIBMESH_CHKERR(ierr);
     }
 
-  STOP_LOG("solve()", "PetscLinearSolver");
   // return the # of its. and the final residual norm.
   return std::make_pair(its, final_resid);
 }
@@ -669,7 +668,7 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
                                      const double tol,
                                      const unsigned int m_its)
 {
-  START_LOG("solve()", "PetscLinearSolver");
+  LOG_SCOPE("solve()", "PetscLinearSolver");
 
   // Make sure the data passed in are really of Petsc types
   PetscMatrix<T> * matrix   = cast_ptr<PetscMatrix<T> *>(&matrix_in);
@@ -922,7 +921,6 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
       LIBMESH_CHKERR(ierr);
     }
 
-  STOP_LOG("solve()", "PetscLinearSolver");
   // return the # of its. and the final residual norm.
   return std::make_pair(its, final_resid);
 }
@@ -945,7 +943,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
                       << "submatrix generation of shell matrices.");
 #endif
 
-  START_LOG("solve()", "PetscLinearSolver");
+  LOG_SCOPE("solve()", "PetscLinearSolver");
 
   // Make sure the data passed in are really of Petsc types
   PetscVector<T> * solution = cast_ptr<PetscVector<T> *>(&solution_in);
@@ -1191,7 +1189,6 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
   ierr = LibMeshMatDestroy(&mat);
   LIBMESH_CHKERR(ierr);
 
-  STOP_LOG("solve()", "PetscLinearSolver");
   // return the # of its. and the final residual norm.
   return std::make_pair(its, final_resid);
 }
@@ -1216,7 +1213,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
                       << "submatrix generation of shell matrices.");
 #endif
 
-  START_LOG("solve()", "PetscLinearSolver");
+  LOG_SCOPE("solve()", "PetscLinearSolver");
 
   // Make sure the data passed in are really of Petsc types
   const PetscMatrix<T> * precond  = cast_ptr<const PetscMatrix<T> *>(&precond_matrix);
@@ -1496,7 +1493,6 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
   ierr = LibMeshMatDestroy(&mat);
   LIBMESH_CHKERR(ierr);
 
-  STOP_LOG("solve()", "PetscLinearSolver");
   // return the # of its. and the final residual norm.
   return std::make_pair(its, final_resid);
 }

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -73,7 +73,7 @@ extern "C"
   PetscErrorCode
   __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
-    START_LOG("residual()", "PetscNonlinearSolver");
+    LOG_SCOPE("residual()", "PetscNonlinearSolver");
 
     PetscErrorCode ierr=0;
 
@@ -143,8 +143,6 @@ extern "C"
 
     R.close();
 
-    STOP_LOG("residual()", "PetscNonlinearSolver");
-
     return ierr;
   }
 
@@ -161,7 +159,7 @@ extern "C"
 #endif
                                 )
   {
-    START_LOG("jacobian()", "PetscNonlinearSolver");
+    LOG_SCOPE("jacobian()", "PetscNonlinearSolver");
 
     PetscErrorCode ierr=0;
 
@@ -239,7 +237,6 @@ extern "C"
 #if PETSC_RELEASE_LESS_THAN(3,5,0)
     *msflag = SAME_NONZERO_PATTERN;
 #endif
-    STOP_LOG("jacobian()", "PetscNonlinearSolver");
 
     return ierr;
   }
@@ -262,7 +259,7 @@ extern "C"
 #endif
                                                 )
   {
-    START_LOG("postcheck()", "PetscNonlinearSolver");
+    LOG_SCOPE("postcheck()", "PetscNonlinearSolver");
 
     PetscErrorCode ierr = 0;
 
@@ -346,8 +343,6 @@ extern "C"
         // Swap back
         petsc_w.swap(system_soln);
       }
-
-    STOP_LOG("postcheck()", "PetscNonlinearSolver");
 
     return ierr;
   }
@@ -591,7 +586,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  jac_in,  // System Jacobian M
                                 const double,              // Stopping tolerance
                                 const unsigned int)
 {
-  START_LOG("solve()", "PetscNonlinearSolver");
+  LOG_SCOPE("solve()", "PetscNonlinearSolver");
   this->init ();
 
   // Make sure the data passed in are really of Petsc types
@@ -714,8 +709,6 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  jac_in,  // System Jacobian M
   this->converged = (_reason >= 0);
 
   this->clear();
-
-  STOP_LOG("solve()", "PetscNonlinearSolver");
 
   // return the # of its. and the final residual norm.
   return std::make_pair(n_iterations, final_residual_norm);

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -85,7 +85,7 @@ SlepcEigenSolver<T>::solve_standard (SparseMatrix<T> & matrix_A_in,
                                      const double tol,         // solver tolerance
                                      const unsigned int m_its) // maximum number of iterations
 {
-  //   START_LOG("solve_standard()", "SlepcEigenSolver");
+  LOG_SCOPE("solve_standard()", "SlepcEigenSolver");
 
   this->init ();
 
@@ -94,14 +94,6 @@ SlepcEigenSolver<T>::solve_standard (SparseMatrix<T> & matrix_A_in,
 
   // Close the matrix and vectors in case this wasn't already done.
   matrix_A->close ();
-
-  // just for debugging, remove this
-  //   char mat_file[] = "matA.petsc";
-  //   PetscViewer petsc_viewer;
-  //   ierr = PetscViewerBinaryOpen(this->comm().get(), mat_file, PETSC_FILE_CREATE, &petsc_viewer);
-  //          LIBMESH_CHKERR(ierr);
-  //   ierr = MatView(matrix_A->mat(),petsc_viewer);
-  //          LIBMESH_CHKERR(ierr);
 
   return _solve_standard_helper(matrix_A->mat(), nev, ncv, tol, m_its);
 }
@@ -152,7 +144,7 @@ SlepcEigenSolver<T>::_solve_standard_helper(Mat mat,
                                             const double tol,         // solver tolerance
                                             const unsigned int m_its) // maximum number of iterations
 {
-  START_LOG("solve_standard()", "SlepcEigenSolver");
+  LOG_SCOPE("solve_standard()", "SlepcEigenSolver");
 
   PetscErrorCode ierr=0;
 
@@ -262,13 +254,9 @@ SlepcEigenSolver<T>::_solve_standard_helper(Mat mat,
   LIBMESH_CHKERR(ierr);
 #endif // DEBUG
 
-
-  STOP_LOG("solve_standard()", "SlepcEigenSolver");
-
   // return the number of converged eigenpairs
   // and the number of iterations
   return std::make_pair(nconv, its);
-
 }
 
 
@@ -445,7 +433,7 @@ SlepcEigenSolver<T>::_solve_generalized_helper (Mat mat_A,
                                                 const double tol,         // solver tolerance
                                                 const unsigned int m_its) // maximum number of iterations
 {
-  START_LOG("solve_generalized()", "SlepcEigenSolver");
+  LOG_SCOPE("solve_generalized()", "SlepcEigenSolver");
 
   PetscErrorCode ierr=0;
 
@@ -557,12 +545,9 @@ SlepcEigenSolver<T>::_solve_generalized_helper (Mat mat_A,
   LIBMESH_CHKERR(ierr);
 #endif // DEBUG
 
-  STOP_LOG("solve_generalized()", "SlepcEigenSolver");
-
   // return the number of converged eigenpairs
   // and the number of iterations
   return std::make_pair(nconv, its);
-
 }
 
 

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -48,7 +48,7 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_objective (Tao /*tao*/, Vec x, PetscReal * objective, void * ctx)
   {
-    START_LOG("objective()", "TaoOptimizationSolver");
+    LOG_SCOPE("objective()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = 0;
 
@@ -81,8 +81,6 @@ extern "C"
     else
       libmesh_error_msg("Objective function not defined in __libmesh_tao_objective");
 
-    STOP_LOG("objective()", "TaoOptimizationSolver");
-
     return ierr;
   }
 
@@ -93,7 +91,7 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_gradient(Tao /*tao*/, Vec x, Vec g, void * ctx)
   {
-    START_LOG("gradient()", "TaoOptimizationSolver");
+    LOG_SCOPE("gradient()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = 0;
 
@@ -135,8 +133,6 @@ extern "C"
 
     gradient.close();
 
-    STOP_LOG("gradient()", "TaoOptimizationSolver");
-
     return ierr;
   }
 
@@ -145,7 +141,7 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_hessian(Tao /*tao*/, Vec x, Mat h, Mat pc, void * ctx)
   {
-    START_LOG("hessian()", "TaoOptimizationSolver");
+    LOG_SCOPE("hessian()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = 0;
 
@@ -192,8 +188,6 @@ extern "C"
     PC.close();
     hessian.close();
 
-    STOP_LOG("hessian()", "TaoOptimizationSolver");
-
     return ierr;
   }
 
@@ -203,7 +197,7 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_equality_constraints(Tao /*tao*/, Vec x, Vec ce, void * ctx)
   {
-    START_LOG("equality_constraints()", "TaoOptimizationSolver");
+    LOG_SCOPE("equality_constraints()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = 0;
 
@@ -245,8 +239,6 @@ extern "C"
 
     eq_constraints.close();
 
-    STOP_LOG("equality_constraints()", "TaoOptimizationSolver");
-
     return ierr;
   }
 
@@ -256,7 +248,7 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_equality_constraints_jacobian(Tao /*tao*/, Vec x, Mat J, Mat Jpre, void * ctx)
   {
-    START_LOG("equality_constraints_jacobian()", "TaoOptimizationSolver");
+    LOG_SCOPE("equality_constraints_jacobian()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = 0;
 
@@ -296,8 +288,6 @@ extern "C"
     J_petsc.close();
     Jpre_petsc.close();
 
-    STOP_LOG("equality_constraints_jacobian()", "TaoOptimizationSolver");
-
     return ierr;
   }
 
@@ -306,7 +296,7 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_inequality_constraints(Tao /*tao*/, Vec x, Vec cineq, void * ctx)
   {
-    START_LOG("inequality_constraints()", "TaoOptimizationSolver");
+    LOG_SCOPE("inequality_constraints()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = 0;
 
@@ -348,8 +338,6 @@ extern "C"
 
     ineq_constraints.close();
 
-    STOP_LOG("inequality_constraints()", "TaoOptimizationSolver");
-
     return ierr;
   }
 
@@ -359,7 +347,7 @@ extern "C"
   PetscErrorCode
   __libmesh_tao_inequality_constraints_jacobian(Tao /*tao*/, Vec x, Mat J, Mat Jpre, void * ctx)
   {
-    START_LOG("inequality_constraints_jacobian()", "TaoOptimizationSolver");
+    LOG_SCOPE("inequality_constraints_jacobian()", "TaoOptimizationSolver");
 
     PetscErrorCode ierr = 0;
 
@@ -399,8 +387,6 @@ extern "C"
     J_petsc.close();
     Jpre_petsc.close();
 
-    STOP_LOG("inequality_constraints_jacobian()", "TaoOptimizationSolver");
-
     return ierr;
   }
 
@@ -412,8 +398,7 @@ extern "C"
 //---------------------------------------------------------------------
 // TaoOptimizationSolver<> methods
 template <typename T>
-TaoOptimizationSolver<T>::TaoOptimizationSolver (OptimizationSystem & system_in)
-  :
+TaoOptimizationSolver<T>::TaoOptimizationSolver (OptimizationSystem & system_in) :
   OptimizationSolver<T>(system_in),
   _reason(TAO_CONVERGED_USER) // Arbitrary initial value...
 {
@@ -463,7 +448,7 @@ void TaoOptimizationSolver<T>::init ()
 template <typename T>
 void TaoOptimizationSolver<T>::solve ()
 {
-  START_LOG("solve()", "TaoOptimizationSolver");
+  LOG_SCOPE("solve()", "TaoOptimizationSolver");
 
   this->init ();
 
@@ -601,15 +586,13 @@ void TaoOptimizationSolver<T>::solve ()
   // Store the convergence/divergence reason
   ierr = TaoGetConvergedReason(_tao, &_reason);
   LIBMESH_CHKERR(ierr);
-
-  STOP_LOG("solve()", "TaoOptimizationSolver");
 }
 
 
 template <typename T>
 void TaoOptimizationSolver<T>::get_dual_variables()
 {
-  START_LOG("get_dual_variables()", "TaoOptimizationSolver");
+  LOG_SCOPE("get_dual_variables()", "TaoOptimizationSolver");
 
   PetscVector<T> * lambda_eq_petsc =
     cast_ptr<PetscVector<T> *>(this->system().lambda_eq.get());
@@ -624,8 +607,6 @@ void TaoOptimizationSolver<T>::get_dual_variables()
                              &lambda_eq_petsc_vec,
                              &lambda_ineq_petsc_vec);
   LIBMESH_CHKERR(ierr);
-
-  STOP_LOG("get_dual_variables()", "TaoOptimizationSolver");
 }
 
 

--- a/src/solvers/trilinos_aztec_linear_solver.C
+++ b/src/solvers/trilinos_aztec_linear_solver.C
@@ -107,7 +107,7 @@ AztecLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
                              const double tol,
                              const unsigned int m_its)
 {
-  START_LOG("solve()", "AztecLinearSolver");
+  LOG_SCOPE("solve()", "AztecLinearSolver");
 
   // Make sure the data passed in are really of Epetra types
   EpetraMatrix<T> * matrix   = cast_ptr<EpetraMatrix<T> *>(&matrix_in);
@@ -132,8 +132,6 @@ AztecLinearSolver<T>::solve (SparseMatrix<T> & matrix_in,
 
   _linear_solver->Iterate(emat, esol, erhs, m_its, tol);
 
-  STOP_LOG("solve()", "AztecLinearSolver");
-
   // return the # of its. and the final residual norm.
   return std::make_pair(_linear_solver->NumIters(), _linear_solver->TrueResidual());
 }
@@ -147,11 +145,6 @@ AztecLinearSolver<T>::solve (const ShellMatrix<T> &,
                              NumericVector<T> &,
                              const double,
                              const unsigned int)
-//AztecLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
-//     NumericVector<T> & solution_in,
-//     NumericVector<T> & rhs_in,
-//     const double tol,
-//     const unsigned int m_its)
 {
   libmesh_not_implemented();
 }
@@ -166,12 +159,6 @@ AztecLinearSolver<T>::solve (const ShellMatrix<T> &,
                              NumericVector<T> &,
                              const double,
                              const unsigned int)
-//AztecLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
-//     const SparseMatrix<T> & precond_matrix,
-//     NumericVector<T> & solution_in,
-//     NumericVector<T> & rhs_in,
-//     const double tol,
-//     const unsigned int m_its)
 {
   libmesh_not_implemented();
 }

--- a/src/solvers/trilinos_nox_nonlinear_solver.C
+++ b/src/solvers/trilinos_nox_nonlinear_solver.C
@@ -99,7 +99,7 @@ bool Problem_Interface::computeF(const Epetra_Vector & x,
                                  Epetra_Vector & r,
                                  NOX::Epetra::Interface::Required::FillType /*fillType*/)
 {
-  START_LOG("residual()", "TrilinosNoxNonlinearSolver");
+  LOG_SCOPE("residual()", "TrilinosNoxNonlinearSolver");
 
   NonlinearImplicitSystem & sys = _solver->system();
 
@@ -148,8 +148,6 @@ bool Problem_Interface::computeF(const Epetra_Vector & x,
   R.close();
   X_global.close();
 
-  STOP_LOG("residual()", "TrilinosNoxNonlinearSolver");
-
   return true;
 }
 
@@ -158,7 +156,7 @@ bool Problem_Interface::computeF(const Epetra_Vector & x,
 bool Problem_Interface::computeJacobian(const Epetra_Vector & x,
                                         Epetra_Operator & jac)
 {
-  START_LOG("jacobian()", "TrilinosNoxNonlinearSolver");
+  LOG_SCOPE("jacobian()", "TrilinosNoxNonlinearSolver");
 
   NonlinearImplicitSystem & sys = _solver->system();
 
@@ -204,8 +202,6 @@ bool Problem_Interface::computeJacobian(const Epetra_Vector & x,
   Jac.close();
   X_global.close();
 
-  STOP_LOG("jacobian()", "TrilinosNoxNonlinearSolver");
-
   return true;
 }
 
@@ -223,7 +219,7 @@ bool Problem_Interface::computePreconditioner(const Epetra_Vector & x,
                                               Epetra_Operator & prec,
                                               Teuchos::ParameterList * /*p*/)
 {
-  START_LOG("preconditioner()", "TrilinosNoxNonlinearSolver");
+  LOG_SCOPE("preconditioner()", "TrilinosNoxNonlinearSolver");
 
   NonlinearImplicitSystem & sys = _solver->system();
   TrilinosPreconditioner<Number> & tpc = dynamic_cast<TrilinosPreconditioner<Number> &>(prec);
@@ -271,8 +267,6 @@ bool Problem_Interface::computePreconditioner(const Epetra_Vector & x,
   X_global.close();
 
   tpc.compute();
-
-  STOP_LOG("preconditioner()", "TrilinosNoxNonlinearSolver");
 
   return true;
 }

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -101,13 +101,12 @@ dof_id_type CondensedEigenSystem::n_global_non_condensed_dofs() const
 
 void CondensedEigenSystem::solve()
 {
-  START_LOG("solve()", "CondensedEigenSystem");
+  LOG_SCOPE("solve()", "CondensedEigenSystem");
 
   // If we haven't initialized any condensed dofs,
   // just use the default eigen_system
   if(!condensed_dofs_initialized)
     {
-      STOP_LOG("solve()", "CondensedEigenSystem");
       Parent::solve();
       return;
     }
@@ -174,23 +173,18 @@ void CondensedEigenSystem::solve()
 
   set_n_converged(solve_data.first);
   set_n_iterations(solve_data.second);
-
-  STOP_LOG("solve()", "CondensedEigenSystem");
 }
 
 
 
 std::pair<Real, Real> CondensedEigenSystem::get_eigenpair(unsigned int i)
 {
-  START_LOG("get_eigenpair()", "CondensedEigenSystem");
+  LOG_SCOPE("get_eigenpair()", "CondensedEigenSystem");
 
   // If we haven't initialized any condensed dofs,
   // just use the default eigen_system
-  if(!condensed_dofs_initialized)
-    {
-      STOP_LOG("get_eigenpair()", "CondensedEigenSystem");
-      return Parent::get_eigenpair(i);
-    }
+  if (!condensed_dofs_initialized)
+    return Parent::get_eigenpair(i);
 
   // If we reach here, then there should be some non-condensed dofs
   libmesh_assert(!local_non_condensed_dofs_vector.empty());
@@ -216,8 +210,6 @@ std::pair<Real, Real> CondensedEigenSystem::get_eigenpair(unsigned int i)
 
   solution->close();
   this->update();
-
-  STOP_LOG("get_eigenpair()", "CondensedEigenSystem");
 
   return eval;
 }

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -337,13 +337,11 @@ void EquationSystems::allgather ()
 
 void EquationSystems::update ()
 {
-  START_LOG("update()","EquationSystems");
+  LOG_SCOPE("update()", "EquationSystems");
 
   // Localize each system's vectors
   for (unsigned int i=0; i != this->n_systems(); ++i)
     this->get_system(i).update();
-
-  STOP_LOG("update()","EquationSystems");
 }
 
 
@@ -668,7 +666,7 @@ void EquationSystems::build_solution_vector (std::vector<Number> &,
 void EquationSystems::build_solution_vector (std::vector<Number> & soln,
                                              const std::set<std::string> * system_names) const
 {
-  START_LOG("build_solution_vector()", "EquationSystems");
+  LOG_SCOPE("build_solution_vector()", "EquationSystems");
 
   // This function must be run on all processors at once
   parallel_object_only();
@@ -871,8 +869,6 @@ void EquationSystems::build_solution_vector (std::vector<Number> & soln,
   parallel_soln /= repeat_count;
 
   parallel_soln.localize_to_one(soln);
-
-  STOP_LOG("build_solution_vector()", "EquationSystems");
 }
 
 
@@ -1010,7 +1006,7 @@ void EquationSystems::get_solution (std::vector<Number> & soln,
 void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> & soln,
                                                            const std::set<std::string> * system_names) const
 {
-  START_LOG("build_discontinuous_solution_vector()", "EquationSystems");
+  LOG_SCOPE("build_discontinuous_solution_vector()", "EquationSystems");
 
   libmesh_assert (this->n_systems());
 
@@ -1134,8 +1130,6 @@ void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> &
         var_num += nv_sys;
       }
   }
-
-  STOP_LOG("build_discontinuous_solution_vector()", "EquationSystems");
 }
 
 

--- a/src/systems/equation_systems_io.C
+++ b/src/systems/equation_systems_io.C
@@ -481,7 +481,7 @@ void EquationSystems::write(const std::string & name,
     Xdr io((this->processor_id()==0) ? name : "", mode);
     libmesh_assert (io.writing());
 
-    START_LOG("write()","EquationSystems");
+    LOG_SCOPE("write()", "EquationSystems");
 
     const unsigned int proc_id = this->processor_id();
 
@@ -576,8 +576,6 @@ void EquationSystems::write(const std::string & name,
               pos->second->write_serialized_data (io,write_additional_data);
           }
       }
-
-    STOP_LOG("write()","EquationSystems");
   }
 
   // the EquationSystems::write() method should look constant,

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -860,7 +860,7 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
   else
     log_name = "assembly(get_jacobian)";
 
-  START_LOG(log_name, "FEMSystem");
+  LOG_SCOPE(log_name.c_str(), "FEMSystem");
 
   const MeshBase & mesh = this->get_mesh();
 
@@ -1042,7 +1042,6 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
       libMesh::out << "J = [" << *(this->matrix) << "];" << std::endl;
       libMesh::out.precision(old_precision);
     }
-  STOP_LOG(log_name, "FEMSystem");
 }
 
 
@@ -1105,7 +1104,7 @@ void FEMSystem::mesh_position_set()
 
 void FEMSystem::postprocess ()
 {
-  START_LOG("postprocess()", "FEMSystem");
+  LOG_SCOPE("postprocess()", "FEMSystem");
 
   const MeshBase & mesh = this->get_mesh();
 
@@ -1119,15 +1118,13 @@ void FEMSystem::postprocess ()
   Threads::parallel_for(elem_range.reset(mesh.active_local_elements_begin(),
                                          mesh.active_local_elements_end()),
                         PostprocessContributions(*this));
-
-  STOP_LOG("postprocess()", "FEMSystem");
 }
 
 
 
 void FEMSystem::assemble_qoi (const QoISet & qoi_indices)
 {
-  START_LOG("assemble_qoi()", "FEMSystem");
+  LOG_SCOPE("assemble_qoi()", "FEMSystem");
 
   const MeshBase & mesh = this->get_mesh();
 
@@ -1151,8 +1148,6 @@ void FEMSystem::assemble_qoi (const QoISet & qoi_indices)
                            qoi_contributions);
 
   this->diff_qoi->parallel_op( this->comm(), this->qoi, qoi_contributions.qoi, qoi_indices );
-
-  STOP_LOG("assemble_qoi()", "FEMSystem");
 }
 
 
@@ -1161,7 +1156,7 @@ void FEMSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
                                          bool include_liftfunc,
                                          bool apply_constraints)
 {
-  START_LOG("assemble_qoi_derivative()", "FEMSystem");
+  LOG_SCOPE("assemble_qoi_derivative()", "FEMSystem");
 
   const MeshBase & mesh = this->get_mesh();
 
@@ -1180,8 +1175,6 @@ void FEMSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
                                                    *(this->diff_qoi),
                                                    include_liftfunc,
                                                    apply_constraints));
-
-  STOP_LOG("assemble_qoi_derivative()", "FEMSystem");
 }
 
 
@@ -1298,27 +1291,24 @@ void FEMSystem::numerical_jacobian (TimeSolverResPtr res,
 
 void FEMSystem::numerical_elem_jacobian (FEMContext & context) const
 {
-  START_LOG("numerical_elem_jacobian()", "FEMSystem");
+  LOG_SCOPE("numerical_elem_jacobian()", "FEMSystem");
   this->numerical_jacobian(&TimeSolver::element_residual, context);
-  STOP_LOG("numerical_elem_jacobian()", "FEMSystem");
 }
 
 
 
 void FEMSystem::numerical_side_jacobian (FEMContext & context) const
 {
-  START_LOG("numerical_side_jacobian()", "FEMSystem");
+  LOG_SCOPE("numerical_side_jacobian()", "FEMSystem");
   this->numerical_jacobian(&TimeSolver::side_residual, context);
-  STOP_LOG("numerical_side_jacobian()", "FEMSystem");
 }
 
 
 
 void FEMSystem::numerical_nonlocal_jacobian (FEMContext & context) const
 {
-  START_LOG("numerical_nonlocal_jacobian()", "FEMSystem");
+  LOG_SCOPE("numerical_nonlocal_jacobian()", "FEMSystem");
   this->numerical_jacobian(&TimeSolver::nonlocal_residual, context);
-  STOP_LOG("numerical_nonlocal_jacobian()", "FEMSystem");
 }
 
 

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -120,7 +120,7 @@ void FrequencySystem::init_data ()
   LinearImplicitSystem::init_data();
 
   // Log how long initializing the system takes
-  START_LOG("init()", "FrequencySystem");
+  LOG_SCOPE("init()", "FrequencySystem");
 
   EquationSystems & es =
     this->get_equation_systems();
@@ -149,9 +149,6 @@ void FrequencySystem::init_data ()
     }
 
   _finished_init = true;
-
-  // Stop logging init()
-  STOP_LOG("init()", "FrequencySystem");
 }
 
 
@@ -164,7 +161,7 @@ void FrequencySystem::assemble ()
     libmesh_error_msg("ERROR: Matrices already assembled.");
 
   // Log how long assemble() takes
-  START_LOG("assemble()", "FrequencySystem");
+  LOG_SCOPE("assemble()", "FrequencySystem");
 
   // prepare matrix with the help of the _dof_map,
   // fill with sparsity pattern, initialize the
@@ -175,9 +172,6 @@ void FrequencySystem::assemble ()
   //rhs.print    ();
 
   _finished_assemble = true;
-
-  // Log how long assemble() takes
-  STOP_LOG("assemble()", "FrequencySystem");
 }
 
 

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -304,7 +304,7 @@ std::pair<unsigned int, Real>
 ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
 {
   // Log how long the linear solve takes.
-  START_LOG("sensitivity_solve()", "ImplicitSystem");
+  LOG_SCOPE("sensitivity_solve()", "ImplicitSystem");
 
   // The forward system should now already be solved.
   // Now assemble the corresponding sensitivity system.
@@ -353,9 +353,6 @@ ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
 
   this->release_linear_solver(linear_solver);
 
-  // Stop logging the nonlinear solve
-  STOP_LOG("sensitivity_solve()", "ImplicitSystem");
-
   return totalrval;
 }
 
@@ -365,7 +362,7 @@ std::pair<unsigned int, Real>
 ImplicitSystem::adjoint_solve (const QoISet & qoi_indices)
 {
   // Log how long the linear solve takes.
-  START_LOG("adjoint_solve()", "ImplicitSystem");
+  LOG_SCOPE("adjoint_solve()", "ImplicitSystem");
 
   if (this->assemble_before_solve)
     // Assemble the linear system
@@ -409,9 +406,6 @@ ImplicitSystem::adjoint_solve (const QoISet & qoi_indices)
         (this->get_adjoint_solution(i), i);
 #endif
 
-  // Stop logging the nonlinear solve
-  STOP_LOG("adjoint_solve()", "ImplicitSystem");
-
   return totalrval;
 }
 
@@ -423,7 +417,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
                                                     const QoISet & qoi_indices)
 {
   // Log how long the linear solve takes.
-  START_LOG("weighted_sensitivity_adjoint_solve()", "ImplicitSystem");
+  LOG_SCOPE("weighted_sensitivity_adjoint_solve()", "ImplicitSystem");
 
   // We currently get partial derivatives via central differencing
   const Real delta_p = TOLERANCE;
@@ -562,9 +556,6 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
          /* homogeneous = */ true);
 #endif
 
-  // Stop logging the nonlinear solve
-  STOP_LOG("weighted_sensitivity_adjoint_solve()", "ImplicitSystem");
-
   return totalrval;
 }
 
@@ -575,7 +566,7 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector & parameters_i
                                             const ParameterVector & weights)
 {
   // Log how long the linear solve takes.
-  START_LOG("weighted_sensitivity_solve()", "ImplicitSystem");
+  LOG_SCOPE("weighted_sensitivity_solve()", "ImplicitSystem");
 
   // We currently get partial derivatives via central differencing
   const Real delta_p = TOLERANCE;
@@ -648,9 +639,6 @@ ImplicitSystem::weighted_sensitivity_solve (const ParameterVector & parameters_i
     (*this, &this->get_weighted_sensitivity_solution(),
      /* homogeneous = */ true);
 #endif
-
-  // Stop logging the nonlinear solve
-  STOP_LOG("weighted_sensitivity_solve()", "ImplicitSystem");
 
   return rval;
 }

--- a/src/systems/newmark_system.C
+++ b/src/systems/newmark_system.C
@@ -156,7 +156,7 @@ void NewmarkSystem::initial_conditions ()
   // libmesh_assert(init_cond_fptr);
 
   // Log how long the user's matrix assembly code takes
-  START_LOG("initial_conditions ()", "NewmarkSystem");
+  LOG_SCOPE("initial_conditions ()", "NewmarkSystem");
 
   // Set all values to 0, then
   // call the user-specified function for initial conditions.
@@ -164,9 +164,6 @@ void NewmarkSystem::initial_conditions ()
   this->get_vector("velocity").zero();
   this->get_vector("acceleration").zero();
   this->user_initialization();
-
-  // Stop logging the user code
-  STOP_LOG("initial_conditions ()", "NewmarkSystem");
 }
 
 
@@ -192,7 +189,7 @@ void NewmarkSystem::compute_matrix ()
 
 void NewmarkSystem::update_rhs ()
 {
-  START_LOG("update_rhs ()", "NewmarkSystem");
+  LOG_SCOPE("update_rhs ()", "NewmarkSystem");
 
   // zero the rhs-vector
   NumericVector<Number> & the_rhs = *this->rhs;
@@ -201,7 +198,6 @@ void NewmarkSystem::update_rhs ()
   // get writable references to some vectors
   NumericVector<Number> & rhs_m = this->get_vector("rhs_m");
   NumericVector<Number> & rhs_c = this->get_vector("rhs_c");
-
 
   // zero the vectors for matrix-vector product
   rhs_m.zero();
@@ -220,15 +216,13 @@ void NewmarkSystem::update_rhs ()
   the_rhs.add(this->get_vector("force"));
   the_rhs.add_vector(rhs_m, this->get_matrix("mass"));
   the_rhs.add_vector(rhs_c, this->get_matrix("damping"));
-
-  STOP_LOG("update_rhs ()", "NewmarkSystem");
 }
 
 
 
 void NewmarkSystem::update_u_v_a ()
 {
-  START_LOG("update_u_v_a ()", "NewmarkSystem");
+  LOG_SCOPE("update_u_v_a ()", "NewmarkSystem");
 
   // get some references for convenience
   const NumericVector<Number> &  solu = *this->solution;
@@ -253,8 +247,6 @@ void NewmarkSystem::update_u_v_a ()
   // compute the new velocity vector
   vel_vec.add(_a_6,old_acc);
   vel_vec.add(_a_7,acc_vec);
-
-  STOP_LOG("update_u_v_a ()", "NewmarkSystem");
 }
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -474,13 +474,10 @@ void System::restrict_solve_to (const SystemSubset * subset,
 void System::assemble ()
 {
   // Log how long the user's assembly code takes
-  START_LOG("assemble()", "System");
+  LOG_SCOPE("assemble()", "System");
 
   // Call the user-specified assembly function
   this->user_assembly();
-
-  // Stop logging the user code
-  STOP_LOG("assemble()", "System");
 }
 
 
@@ -488,13 +485,10 @@ void System::assemble ()
 void System::assemble_qoi (const QoISet & qoi_indices)
 {
   // Log how long the user's assembly code takes
-  START_LOG("assemble_qoi()", "System");
+  LOG_SCOPE("assemble_qoi()", "System");
 
   // Call the user-specified quantity of interest function
   this->user_QOI(qoi_indices);
-
-  // Stop logging the user code
-  STOP_LOG("assemble_qoi()", "System");
 }
 
 
@@ -504,14 +498,11 @@ void System::assemble_qoi_derivative(const QoISet & qoi_indices,
                                      bool apply_constraints)
 {
   // Log how long the user's assembly code takes
-  START_LOG("assemble_qoi_derivative()", "System");
+  LOG_SCOPE("assemble_qoi_derivative()", "System");
 
   // Call the user-specified quantity of interest function
   this->user_QOI_derivative(qoi_indices, include_liftfunc,
                             apply_constraints);
-
-  // Stop logging the user code
-  STOP_LOG("assemble_qoi_derivative()", "System");
 }
 
 
@@ -1428,14 +1419,13 @@ Real System::calculate_norm(const NumericVector<Number> & v,
   // This function must be run on all processors at once
   parallel_object_only();
 
-  START_LOG ("calculate_norm()", "System");
+  LOG_SCOPE ("calculate_norm()", "System");
 
   // Zero the norm before summation
   Real v_norm = 0.;
 
   if (norm.is_discrete())
     {
-      STOP_LOG ("calculate_norm()", "System");
       //Check to see if all weights are 1.0 and all types are equal
       FEMNormType norm_type0 = norm.type(0);
       unsigned int check_var = 0;
@@ -1701,8 +1691,6 @@ Real System::calculate_norm(const NumericVector<Number> & v,
     {
       this->comm().max(v_norm);
     }
-
-  STOP_LOG ("calculate_norm()", "System");
 
   return v_norm;
 }

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -241,16 +241,13 @@ public:
                        const Point & p,
                        Real /* time */ =0.)
   {
-    START_LOG ("eval_at_point()", "OldSolutionValue");
+    LOG_SCOPE ("eval_at_point()", "OldSolutionValue");
+
     if (!this->check_old_context(c, p))
-      {
-        STOP_LOG ("eval_at_point()", "OldSolutionValue");
-        return 0;
-      }
+      return 0;
 
     Output n;
     (old_context.*point_output)(i, p, n, out_of_elem_tol);
-    STOP_LOG ("eval_at_point()", "OldSolutionValue");
     return n;
   }
 
@@ -260,7 +257,7 @@ public:
                       unsigned int var,
                       std::vector<Output> & values)
   {
-    START_LOG ("eval_old_dofs()", "OldSolutionValue");
+    LOG_SCOPE ("eval_old_dofs()", "OldSolutionValue");
 
     this->check_old_context(c);
 
@@ -270,14 +267,12 @@ public:
     libmesh_assert_equal_to (old_dof_indices.size(), values.size());
 
     old_solution.get(old_dof_indices, values);
-
-    STOP_LOG ("eval_old_dofs()", "OldSolutionValue");
   }
 
 protected:
   void check_old_context (const FEMContext & c)
   {
-    START_LOG ("check_old_context(c)", "OldSolutionValue");
+    LOG_SCOPE ("check_old_context(c)", "OldSolutionValue");
     const Elem & elem = c.get_elem();
     if (last_elem != &elem)
       {
@@ -305,14 +300,12 @@ protected:
       {
         libmesh_assert(old_context.has_elem());
       }
-
-    STOP_LOG ("check_old_context(c)", "OldSolutionValue");
   }
 
 
   bool check_old_context (const FEMContext & c, const Point & p)
   {
-    START_LOG ("check_old_context(c,p)", "OldSolutionValue");
+    LOG_SCOPE ("check_old_context(c,p)", "OldSolutionValue");
     const Elem & elem = c.get_elem();
     if (last_elem != &elem)
       {
@@ -344,10 +337,7 @@ protected:
         else
           {
             if (!elem.old_dof_object)
-              {
-                STOP_LOG ("check_old_context(c,p)", "OldSolutionValue");
-                return false;
-              }
+              return false;
 
             old_context.pre_fe_reinit(sys, &elem);
           }
@@ -377,7 +367,6 @@ protected:
           }
       }
 
-    STOP_LOG ("check_old_context(c,p)", "OldSolutionValue");
     return true;
   }
 
@@ -415,7 +404,7 @@ OldSolutionValue<Number, &FEMContext::point_value>::eval_at_node (const FEMConte
                                                                   const Node & n,
                                                                   Real)
 {
-  START_LOG ("Number eval_at_node()", "OldSolutionValue");
+  LOG_SCOPE ("Number eval_at_node()", "OldSolutionValue");
 
   // Optimize for the common case, where this node was part of the
   // old solution.
@@ -430,11 +419,8 @@ OldSolutionValue<Number, &FEMContext::point_value>::eval_at_node (const FEMConte
     {
       const dof_id_type old_id =
         n.old_dof_object->dof_number(sys.number(), i, 0);
-      STOP_LOG ("Number eval_at_node()", "OldSolutionValue");
       return old_solution(old_id);
     }
-
-  STOP_LOG ("Number eval_at_node()", "OldSolutionValue");
 
   return this->eval_at_point(c, i, n, 0);
 }
@@ -449,7 +435,7 @@ OldSolutionValue<Gradient, &FEMContext::point_gradient>::eval_at_node (const FEM
                                                                        const Node & n,
                                                                        Real)
 {
-  START_LOG ("Gradient eval_at_node()", "OldSolutionValue");
+  LOG_SCOPE ("Gradient eval_at_node()", "OldSolutionValue");
 
   // Optimize for the common case, where this node was part of the
   // old solution.
@@ -469,11 +455,8 @@ OldSolutionValue<Gradient, &FEMContext::point_gradient>::eval_at_node (const FEM
             n.old_dof_object->dof_number(sys.number(), i, d+1);
           g(d) = old_solution(old_id);
         }
-      STOP_LOG ("Gradient eval_at_node()", "OldSolutionValue");
       return g;
     }
-
-  STOP_LOG ("Gradient eval_at_node()", "OldSolutionValue");
 
   return this->eval_at_point(c, i, n, 0);
 }
@@ -604,7 +587,7 @@ void System::project_vector (const NumericVector<Number> & old_v,
                              NumericVector<Number> & new_v,
                              int is_adjoint) const
 {
-  START_LOG ("project_vector(old,new)", "System");
+  LOG_SCOPE ("project_vector(old,new)", "System");
 
   /**
    * This method projects a solution from an old mesh to a current, refined
@@ -785,8 +768,6 @@ void System::project_vector (const NumericVector<Number> & old_v,
   new_v = old_v;
 
 #endif // #ifdef LIBMESH_ENABLE_AMR
-
-  STOP_LOG("project_vector(old,new)", "System");
 }
 
 
@@ -867,7 +848,7 @@ void System::project_vector (NumericVector<Number> & new_vector,
                              FunctionBase<Gradient> * g,
                              int is_adjoint) const
 {
-  START_LOG ("project_vector(FunctionBase)", "System");
+  LOG_SCOPE ("project_vector(FunctionBase)", "System");
 
   libmesh_assert(f);
 
@@ -881,8 +862,6 @@ void System::project_vector (NumericVector<Number> & new_vector,
     }
   else
     this->project_vector(new_vector, &f_fem, libmesh_nullptr, is_adjoint);
-
-  STOP_LOG ("project_vector(FunctionBase)", "System");
 }
 
 
@@ -895,7 +874,7 @@ void System::project_vector (NumericVector<Number> & new_vector,
                              FEMFunctionBase<Gradient> * g,
                              int is_adjoint) const
 {
-  START_LOG ("project_fem_vector()", "System");
+  LOG_SCOPE ("project_fem_vector()", "System");
 
   libmesh_assert (f);
 
@@ -974,8 +953,6 @@ void System::project_vector (NumericVector<Number> & new_vector,
     this->get_dof_map().enforce_adjoint_constraints_exactly(new_vector,
                                                             is_adjoint);
 #endif
-
-  STOP_LOG("project_fem_vector()", "System");
 }
 
 
@@ -1056,7 +1033,7 @@ void System::boundary_project_vector (const std::set<boundary_id_type> & b,
                                       FunctionBase<Gradient> * g,
                                       int is_adjoint) const
 {
-  START_LOG ("boundary_project_vector()", "System");
+  LOG_SCOPE ("boundary_project_vector()", "System");
 
   Threads::parallel_for
     (ConstElemRange (this->get_mesh().active_local_elements_begin(),
@@ -1078,8 +1055,6 @@ void System::boundary_project_vector (const std::set<boundary_id_type> & b,
     this->get_dof_map().enforce_adjoint_constraints_exactly(new_vector,
                                                             is_adjoint);
 #endif
-
-  STOP_LOG("boundary_project_vector()", "System");
 }
 
 
@@ -1089,7 +1064,7 @@ template <typename FFunctor, typename GFunctor,
 void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
   (const ConstElemRange & range) const
 {
-  START_LOG ("operator()","GenericProjector");
+  LOG_SCOPE ("operator()", "GenericProjector");
 
   ProjectionAction action(master_action);
   FFunctor f(master_f);
@@ -1244,13 +1219,11 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
           // then we can simply copy its old dof
           // values to new indices.
             {
-              START_LOG ("copy_dofs","GenericProjector");
+              LOG_SCOPE ("copy_dofs", "GenericProjector");
 
               f.eval_old_dofs(context, var_component, Ue.get_values());
 
               action.insert(context, var, Ue);
-
-              STOP_LOG ("copy_dofs","GenericProjector");
 
               continue;
             }
@@ -1934,8 +1907,6 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
           action.insert(context, var, Ue);
         } // end variables loop
     } // end elements loop
-
-  STOP_LOG ("operator()","GenericProjector");
 }
 
 

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -42,7 +42,7 @@ namespace libMesh
 // ErrorVector class member functions
 ErrorVectorReal ErrorVector::minimum() const
 {
-  START_LOG ("minimum()", "ErrorVector");
+  LOG_SCOPE ("minimum()", "ErrorVector");
 
   const dof_id_type n = cast_int<dof_id_type>(this->size());
   ErrorVectorReal min = std::numeric_limits<ErrorVectorReal>::max();
@@ -54,7 +54,6 @@ ErrorVectorReal ErrorVector::minimum() const
       if (this->is_active_elem(i))
         min = std::min (min, (*this)[i]);
     }
-  STOP_LOG ("minimum()", "ErrorVector");
 
   // ErrorVectors are for positive values
   libmesh_assert_greater_equal (min, 0.);
@@ -66,7 +65,7 @@ ErrorVectorReal ErrorVector::minimum() const
 
 Real ErrorVector::mean() const
 {
-  START_LOG ("mean()", "ErrorVector");
+  LOG_SCOPE ("mean()", "ErrorVector");
 
   const dof_id_type n = cast_int<dof_id_type>(this->size());
 
@@ -80,8 +79,6 @@ Real ErrorVector::mean() const
 
         nnz++;
       }
-
-  STOP_LOG ("mean()", "ErrorVector");
 
   return the_mean;
 }
@@ -127,7 +124,7 @@ Real ErrorVector::variance(const Real mean_in) const
 {
   const dof_id_type n = cast_int<dof_id_type>(this->size());
 
-  START_LOG ("variance()", "ErrorVector");
+  LOG_SCOPE ("variance()", "ErrorVector");
 
   Real the_variance = 0;
   dof_id_type nnz = 0;
@@ -141,8 +138,6 @@ Real ErrorVector::variance(const Real mean_in) const
         nnz++;
       }
 
-  STOP_LOG ("variance()", "ErrorVector");
-
   return the_variance;
 }
 
@@ -151,7 +146,7 @@ Real ErrorVector::variance(const Real mean_in) const
 
 std::vector<dof_id_type> ErrorVector::cut_below(Real cut) const
 {
-  START_LOG ("cut_below()", "ErrorVector");
+  LOG_SCOPE ("cut_below()", "ErrorVector");
 
   const dof_id_type n = cast_int<dof_id_type>(this->size());
 
@@ -167,8 +162,6 @@ std::vector<dof_id_type> ErrorVector::cut_below(Real cut) const
           }
       }
 
-  STOP_LOG ("cut_below()", "ErrorVector");
-
   return cut_indices;
 }
 
@@ -177,7 +170,7 @@ std::vector<dof_id_type> ErrorVector::cut_below(Real cut) const
 
 std::vector<dof_id_type> ErrorVector::cut_above(Real cut) const
 {
-  START_LOG ("cut_above()", "ErrorVector");
+  LOG_SCOPE ("cut_above()", "ErrorVector");
 
   const dof_id_type n = cast_int<dof_id_type>(this->size());
 
@@ -192,8 +185,6 @@ std::vector<dof_id_type> ErrorVector::cut_above(Real cut) const
             cut_indices.push_back(i);
           }
       }
-
-  STOP_LOG ("cut_above()", "ErrorVector");
 
   return cut_indices;
 }

--- a/src/utils/location_maps.C
+++ b/src/utils/location_maps.C
@@ -54,7 +54,7 @@ void LocationMap<T>::init(MeshBase & mesh)
   if (!mesh.is_serial())
     libmesh_parallel_only(mesh.comm());
 
-  START_LOG("init()", "LocationMap");
+  LOG_SCOPE("init()", "LocationMap");
 
   // Clear the old map
   _map.clear();
@@ -90,8 +90,6 @@ void LocationMap<T>::init(MeshBase & mesh)
     }
 
   this->fill(mesh);
-
-  STOP_LOG("init()", "LocationMap");
 }
 
 
@@ -124,7 +122,7 @@ template <typename T>
 T * LocationMap<T>::find(const Point & p,
                          const Real tol)
 {
-  START_LOG("find()","LocationMap");
+  LOG_SCOPE("find()", "LocationMap");
 
   // Look for a likely key in the multimap
   unsigned int pointkey = this->key(p);
@@ -135,12 +133,8 @@ T * LocationMap<T>::find(const Point & p,
     pos = _map.equal_range(pointkey);
 
   while (pos.first != pos.second)
-    if (p.absolute_fuzzy_equals
-        (this->point_of(*(pos.first->second)), tol))
-      {
-        STOP_LOG("find()","LocationMap");
-        return pos.first->second;
-      }
+    if (p.absolute_fuzzy_equals(this->point_of(*(pos.first->second)), tol))
+      return pos.first->second;
     else
       ++pos.first;
 
@@ -158,19 +152,14 @@ T * LocationMap<T>::find(const Point & p,
                                            yoffset*chunkmax +
                                            zoffset);
               while (key_pos.first != key_pos.second)
-                if (p.absolute_fuzzy_equals
-                    (this->point_of(*(key_pos.first->second)), tol))
-                  {
-                    STOP_LOG("find()","LocationMap");
-                    return key_pos.first->second;
-                  }
+                if (p.absolute_fuzzy_equals(this->point_of(*(key_pos.first->second)), tol))
+                  return key_pos.first->second;
                 else
                   ++key_pos.first;
             }
         }
     }
 
-  STOP_LOG("find()","LocationMap");
   return libmesh_nullptr;
 }
 

--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -88,7 +88,7 @@ void PointLocatorList::init ()
     {
       if (this->_master == libmesh_nullptr)
         {
-          START_LOG("init(no master)", "PointLocatorList");
+          LOG_SCOPE("init(no master)", "PointLocatorList");
 
           // We are the master, so we have to build the list.
           // First create it, then get a handy reference, and
@@ -107,8 +107,6 @@ void PointLocatorList::init ()
 
           for (; el!=end; ++el)
             my_list.push_back(std::make_pair((*el)->centroid(), *el));
-
-          STOP_LOG("init(no master)", "PointLocatorList");
         }
 
       else
@@ -139,7 +137,7 @@ const Elem * PointLocatorList::operator() (const Point & p,
 {
   libmesh_assert (this->_initialized);
 
-  START_LOG("operator()", "PointLocatorList");
+  LOG_SCOPE("operator()", "PointLocatorList");
 
   // Ask the list.  This is quite expensive, since
   // we loop through the whole list to try to find
@@ -187,8 +185,6 @@ const Elem * PointLocatorList::operator() (const Point & p,
 
     // If we found an element and have a restriction list, they better match
     libmesh_assert (!last_elem || !allowed_subdomains || allowed_subdomains->count(last_elem->subdomain_id()));
-
-    STOP_LOG("operator()", "PointLocatorList");
 
     // return the element
     return last_elem;

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -119,7 +119,7 @@ void PointLocatorTree::init (Trees::BuildType build_type)
 
       if (this->_master == libmesh_nullptr)
         {
-          START_LOG("init(no master)", "PointLocatorTree");
+          LOG_SCOPE("init(no master)", "PointLocatorTree");
 
           if (this->_mesh.mesh_dimension() == 3)
             _tree = new Trees::OctTree (this->_mesh, get_target_bin_size(), _build_type);
@@ -155,8 +155,6 @@ void PointLocatorTree::init (Trees::BuildType build_type)
               _tree = new Trees::BinaryTree (this->_mesh, get_target_bin_size(), _build_type);
 #endif
             }
-
-          STOP_LOG("init(no master)", "PointLocatorTree");
         }
 
       else
@@ -194,7 +192,7 @@ const Elem * PointLocatorTree::operator() (const Point & p,
 {
   libmesh_assert (this->_initialized);
 
-  START_LOG("operator()", "PointLocatorTree");
+  LOG_SCOPE("operator()", "PointLocatorTree");
 
   // If we're provided with an allowed_subdomains list and have a cached element, make sure it complies
   if (allowed_subdomains && this->_element && !allowed_subdomains->count(this->_element->subdomain_id())) this->_element = libmesh_nullptr;
@@ -219,8 +217,6 @@ const Elem * PointLocatorTree::operator() (const Point & p,
           if (_out_of_mesh_mode == false)
             {
               this->_element = this->perform_linear_search(p, allowed_subdomains, /*use_close_to_point*/ false);
-
-              STOP_LOG("operator()", "PointLocatorTree");
               return this->_element;
             }
 
@@ -243,7 +239,6 @@ const Elem * PointLocatorTree::operator() (const Point & p,
                                             /*use_close_to_point*/ true,
                                             _close_to_point_tol);
 
-              STOP_LOG("operator()", "PointLocatorTree");
               return this->_element;
             }
         }
@@ -254,8 +249,6 @@ const Elem * PointLocatorTree::operator() (const Point & p,
 
   // If we found an element and have a restriction list, they better match
   libmesh_assert (!this->_element || !allowed_subdomains || allowed_subdomains->count(this->_element->subdomain_id()));
-
-  STOP_LOG("operator()", "PointLocatorTree");
 
   // return the element
   return this->_element;
@@ -268,7 +261,7 @@ const Elem * PointLocatorTree::perform_linear_search(const Point & p,
                                                      bool use_close_to_point,
                                                      Real close_to_point_tolerance) const
 {
-  START_LOG("perform_linear_search", "PointLocatorTree");
+  LOG_SCOPE("perform_linear_search", "PointLocatorTree");
 
   // The type of iterator depends on the Trees::BuildType
   // used for this PointLocator.  If it's
@@ -290,23 +283,16 @@ const Elem * PointLocatorTree::perform_linear_search(const Point & p,
           if(!use_close_to_point)
             {
               if ((*pos)->contains_point(p))
-                {
-                  STOP_LOG("perform_linear_search", "PointLocatorTree");
-                  return (*pos);
-                }
+                return (*pos);
             }
           else
             {
               if ((*pos)->close_to_point(p, close_to_point_tolerance))
-                {
-                  STOP_LOG("perform_linear_search", "PointLocatorTree");
-                  return (*pos);
-                }
+                return (*pos);
             }
         }
     }
 
-  STOP_LOG("perform_linear_search", "PointLocatorTree");
   return libmesh_nullptr;
 }
 

--- a/src/utils/statistics.C
+++ b/src/utils/statistics.C
@@ -47,11 +47,9 @@ Real StatisticsVector<T>::l2_norm() const
 template <typename T>
 T StatisticsVector<T>::minimum() const
 {
-  START_LOG ("minimum()", "StatisticsVector");
+  LOG_SCOPE ("minimum()", "StatisticsVector");
 
   const T min = *(std::min_element(this->begin(), this->end()));
-
-  STOP_LOG ("minimum()", "StatisticsVector");
 
   return min;
 }
@@ -62,11 +60,9 @@ T StatisticsVector<T>::minimum() const
 template <typename T>
 T StatisticsVector<T>::maximum() const
 {
-  START_LOG ("maximum()", "StatisticsVector");
+  LOG_SCOPE ("maximum()", "StatisticsVector");
 
   const T max = *(std::max_element(this->begin(), this->end()));
-
-  STOP_LOG ("maximum()", "StatisticsVector");
 
   return max;
 }
@@ -77,7 +73,7 @@ T StatisticsVector<T>::maximum() const
 template <typename T>
 Real StatisticsVector<T>::mean() const
 {
-  START_LOG ("mean()", "StatisticsVector");
+  LOG_SCOPE ("mean()", "StatisticsVector");
 
   const dof_id_type n = cast_int<dof_id_type>(this->size());
 
@@ -88,8 +84,6 @@ Real StatisticsVector<T>::mean() const
       the_mean += ( static_cast<Real>((*this)[i]) - the_mean ) /
         static_cast<Real>(i + 1);
     }
-
-  STOP_LOG ("mean()", "StatisticsVector");
 
   return the_mean;
 }
@@ -105,7 +99,7 @@ Real StatisticsVector<T>::median()
   if (n == 0)
     return 0.;
 
-  START_LOG ("median()", "StatisticsVector");
+  LOG_SCOPE ("median()", "StatisticsVector");
 
   std::sort(this->begin(), this->end());
 
@@ -125,8 +119,6 @@ Real StatisticsVector<T>::median()
       the_median = ( static_cast<Real>((*this)[lhs]) +
                      static_cast<Real>((*this)[rhs]) ) / 2.0;
     }
-
-  STOP_LOG ("median()", "StatisticsVector");
 
   return the_median;
 }
@@ -150,7 +142,7 @@ Real StatisticsVector<T>::variance(const Real mean_in) const
 {
   const dof_id_type n = cast_int<dof_id_type>(this->size());
 
-  START_LOG ("variance()", "StatisticsVector");
+  LOG_SCOPE ("variance()", "StatisticsVector");
 
   Real the_variance = 0;
 
@@ -164,8 +156,6 @@ Real StatisticsVector<T>::variance(const Real mean_in) const
   if (n > 1)
     the_variance *= static_cast<Real>(n) / static_cast<Real>(n - 1);
 
-  STOP_LOG ("variance()", "StatisticsVector");
-
   return the_variance;
 }
 
@@ -177,9 +167,7 @@ void StatisticsVector<T>::normalize()
   const Real max = this->maximum();
 
   for (dof_id_type i=0; i<n; i++)
-    {
-      (*this)[i] = static_cast<T>((*this)[i] / max);
-    }
+    (*this)[i] = static_cast<T>((*this)[i] / max);
 }
 
 
@@ -203,7 +191,7 @@ void StatisticsVector<T>::histogram(std::vector<dof_id_type> & bin_members,
   Real max      = static_cast<Real>(this->maximum());
   Real bin_size = (max - min) / static_cast<Real>(n_bins);
 
-  START_LOG ("histogram()", "StatisticsVector");
+  LOG_SCOPE ("histogram()", "StatisticsVector");
 
   std::vector<Real> bin_bounds(n_bins+1);
   for (unsigned int i=0; i<bin_bounds.size(); i++)
@@ -272,9 +260,6 @@ void StatisticsVector<T>::histogram(std::vector<dof_id_type> & bin_members,
                    << n << "." << std::endl;
     }
 #endif
-
-
-  STOP_LOG ("histogram()", "StatisticsVector");
 }
 
 
@@ -339,7 +324,7 @@ void StatisticsVector<T>::histogram(std::vector<dof_id_type> & bin_members,
 template <typename T>
 std::vector<dof_id_type> StatisticsVector<T>::cut_below(Real cut) const
 {
-  START_LOG ("cut_below()", "StatisticsVector");
+  LOG_SCOPE ("cut_below()", "StatisticsVector");
 
   const dof_id_type n = cast_int<dof_id_type>(this->size());
 
@@ -354,8 +339,6 @@ std::vector<dof_id_type> StatisticsVector<T>::cut_below(Real cut) const
         }
     }
 
-  STOP_LOG ("cut_below()", "StatisticsVector");
-
   return cut_indices;
 }
 
@@ -365,7 +348,7 @@ std::vector<dof_id_type> StatisticsVector<T>::cut_below(Real cut) const
 template <typename T>
 std::vector<dof_id_type> StatisticsVector<T>::cut_above(Real cut) const
 {
-  START_LOG ("cut_above()", "StatisticsVector");
+  LOG_SCOPE ("cut_above()", "StatisticsVector");
 
   const dof_id_type n = cast_int<dof_id_type>(this->size());
 
@@ -373,14 +356,8 @@ std::vector<dof_id_type> StatisticsVector<T>::cut_above(Real cut) const
   cut_indices.reserve(n/2);  // Arbitrary
 
   for (dof_id_type i=0; i<n; i++)
-    {
-      if ((*this)[i] > cut)
-        {
-          cut_indices.push_back(i);
-        }
-    }
-
-  STOP_LOG ("cut_above()", "StatisticsVector");
+    if ((*this)[i] > cut)
+      cut_indices.push_back(i);
 
   return cut_indices;
 }

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -41,14 +41,12 @@ void TopologyMap::init(MeshBase & mesh)
   if (!mesh.is_serial())
     libmesh_parallel_only(mesh.comm());
 
-  START_LOG("init()", "TopologyMap");
+  LOG_SCOPE("init()", "TopologyMap");
 
   // Clear the old map
   _map.clear();
 
   this->fill(mesh);
-
-  STOP_LOG("init()", "TopologyMap");
 }
 
 

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -40,14 +40,12 @@ namespace {
 void bzip_file (const std::string & unzipped_name)
 {
 #ifdef LIBMESH_HAVE_BZIP
-  START_LOG("system(bzip2)", "XdrIO");
+  LOG_SCOPE("system(bzip2)", "XdrIO");
 
   std::string system_string = "bzip2 -f ";
   system_string += unzipped_name;
   if (std::system(system_string.c_str()))
     libmesh_file_error(system_string);
-
-  STOP_LOG("system(bzip2)", "XdrIO");
 #else
   libmesh_error_msg("ERROR: need bzip2/bunzip2 to create " << unzipped_name << ".bz2");
 #endif
@@ -64,12 +62,11 @@ std::string unzip_file (const std::string & name)
 #ifdef LIBMESH_HAVE_BZIP
       new_name.erase(new_name.end() - 4, new_name.end());
       new_name += pid_suffix.str();
-      START_LOG("system(bunzip2)", "XdrIO");
+      LOG_SCOPE("system(bunzip2)", "XdrIO");
       std::string system_string = "bunzip2 -f -k -c ";
       system_string += name + " > " + new_name;
       if (std::system(system_string.c_str()))
         libmesh_file_error(system_string);
-      STOP_LOG("system(bunzip2)", "XdrIO");
 #else
       libmesh_error_msg("ERROR: need bzip2/bunzip2 to open .bz2 file " << name);
 #endif
@@ -79,12 +76,11 @@ std::string unzip_file (const std::string & name)
 #ifdef LIBMESH_HAVE_XZ
       new_name.erase(new_name.end() - 3, new_name.end());
       new_name += pid_suffix.str();
-      START_LOG("system(xz -d)", "XdrIO");
+      LOG_SCOPE("system(xz -d)", "XdrIO");
       std::string system_string = "xz -f -d -k -c ";
       system_string += name + " > " + new_name;
       if (std::system(system_string.c_str()))
         libmesh_file_error(system_string);
-      STOP_LOG("system(xz -d)", "XdrIO");
 #else
       libmesh_error_msg("ERROR: need xz to open .xz file " << name);
 #endif
@@ -95,14 +91,12 @@ std::string unzip_file (const std::string & name)
 void xzip_file (const std::string & unzipped_name)
 {
 #ifdef LIBMESH_HAVE_XZ
-  START_LOG("system(xz)", "XdrIO");
+  LOG_SCOPE("system(xz)", "XdrIO");
 
   std::string system_string = "xz -f ";
   system_string += unzipped_name;
   if (std::system(system_string.c_str()))
     libmesh_file_error(system_string);
-
-  STOP_LOG("system(xz)", "XdrIO");
 #else
   libmesh_error_msg("ERROR: need xz to create " << unzipped_name << ".xz");
 #endif


### PR DESCRIPTION
This gets us about 95% of the way to the RAII PerfLog feature discussed in #199.  It uses the macro trick to generate a unique variable name based on `__LINE__`, but instead of outright replacing the existing `START_LOG`/`STOP_LOG` macros, I've introduced a new one called `LOG_SCOPE` that creates a simple logging object that does the `push()`/`pop()` stuff in the constructor/destructor.

There are situations where a scope-based logging macro just doesn't make sense, but they are pretty rare. Almost all `START_LOG`/`STOP_LOG` pairs in the library can be replaced with the new `LOG_SCOPE` macro, and the ones that can't easily be replaced can just remain unchanged.

Another nice aspect of this approach not mentioned in #199 is when logged code throws an exception.  Previously, if the exception was caught and dealt with, the PerfLog would likely have been in a bad state (`push()` with no corresponding `pop()`).  Now the destructor for the new class is guaranteed to be called, hopefully leaving the PerfLog in a valid state for continuing after dealing with the exception.