### PR TITLE
Replace find command in install-data-hook with shell wildcards.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,7 +89,7 @@ install-data-hook:
 	@if (test "x$(prefix)" != "x@prefix@") ; then \
           oldprefix="@prefix@" ; \
           newprefix="$(prefix)" ; \
-          for genfile in `find $(DESTDIR)$(prefix) -name "*.pc" -o -name Make.common -o -name libmesh-config -type f` ; do \
+          for genfile in `echo $(DESTDIR)$(prefix)/lib/pkgconfig/*.pc $(DESTDIR)$(prefix)/etc/libmesh/*.pc $(DESTDIR)$(prefix)/etc/libmesh/Make.common $(DESTDIR)$(prefix)/lib/pkgconfig/Make.common $(DESTDIR)$(prefix)/bin/libmesh-config` ; do \
             echo " " ; \
             echo " *** replacing $$oldprefix" ; \
             echo " ***      with $$newprefix" ; \

--- a/Makefile.in
+++ b/Makefile.in
@@ -29266,7 +29266,7 @@ install-data-hook:
 	@if (test "x$(prefix)" != "x@prefix@") ; then \
           oldprefix="@prefix@" ; \
           newprefix="$(prefix)" ; \
-          for genfile in `find $(DESTDIR)$(prefix) -name "*.pc" -o -name Make.common -o -name libmesh-config -type f` ; do \
+          for genfile in `echo $(DESTDIR)$(prefix)/lib/pkgconfig/*.pc $(DESTDIR)$(prefix)/etc/libmesh/*.pc $(DESTDIR)$(prefix)/etc/libmesh/Make.common $(DESTDIR)$(prefix)/lib/pkgconfig/Make.common $(DESTDIR)$(prefix)/bin/libmesh-config` ; do \
             echo " " ; \
             echo " *** replacing $$oldprefix" ; \
             echo " ***      with $$newprefix" ; \


### PR DESCRIPTION
This partially addresses concerns raised in #903, and should allow us
to 'make install prefix=/somewhere/else' on systems where find is not
installed.  We could still check for find in configure, but it should
not be a fatal error if it's not found.