### PR TITLE
If PETSc has its own METIS, libMesh must use it!

### DIFF
--- a/configure
+++ b/configure
@@ -33536,6 +33536,7 @@ $as_echo "<<< PETSc 2.x detected and \"\$PETSC_ARCH\" not set.  PETSc disabled. 
       petsc_use_debug=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_USE_DEBUG`
       petsc_have_superlu_dist=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_SUPERLU_DIST`
       petsc_have_mumps=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_MUMPS`
+      petsc_have_metis=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_METIS`
 
       # We have had a slightly different way of checking for Hypre for
       # quite some time, see below.
@@ -38470,6 +38471,12 @@ else
   build_metis=yes
 fi
 
+
+  # If PETSc has its own METIS, default to using that one regardless
+  # of what the user specified (if anything) in --with-metis.
+  if (test $petsc_have_metis -gt 0) ; then
+    build_metis=no
+  fi
 
       if (test $enablemetis = yes); then
         if (test $build_metis = yes); then

--- a/m4/metis.m4
+++ b/m4/metis.m4
@@ -13,7 +13,7 @@ AC_DEFUN([CONFIGURE_METIS],
                 esac],
                 [enablemetis=$enableoptional])
 
- AC_ARG_WITH(metis,
+  AC_ARG_WITH(metis,
              AS_HELP_STRING([--with-metis=<internal,PETSc>],
                             [metis to use. interal: build from contrib, PETSc: rely on PETSc]),
              [case "${withval}" in
@@ -25,6 +25,12 @@ AC_DEFUN([CONFIGURE_METIS],
                  AC_MSG_ERROR(bad value ${withval} for --with-metis) ;;
               esac],
               [build_metis=yes])
+
+  # If PETSc has its own METIS, default to using that one regardless
+  # of what the user specified (if anything) in --with-metis.
+  if (test $petsc_have_metis -gt 0) ; then
+    build_metis=no
+  fi
 
   dnl The METIS API is distributed with libmesh, so we don't have to guess
   dnl where it might be installed...

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -78,6 +78,7 @@ AC_DEFUN([CONFIGURE_PETSC],
       petsc_use_debug=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_USE_DEBUG`
       petsc_have_superlu_dist=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_SUPERLU_DIST`
       petsc_have_mumps=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_MUMPS`
+      petsc_have_metis=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_METIS`
 
       # We have had a slightly different way of checking for Hypre for
       # quite some time, see below.


### PR DESCRIPTION
This has become a bit more important since PETSc recently [patched](https://bitbucket.org/petsc/pkg-metis/commits/c27a7c30921dc587ae07286774ea2735ad21bb80) thread-local storage out of their METIS fork for all architectures, as it was broken by Xcode 7.3 (not METIS' fault, as far as I can tell).

We haven't done this to our METIS fork yet (I'd prefer to wait and see if Apple fixes their stuff first), so our GKlib/gk_externs.h header is now sufficiently different from the one distributed by PETSc, that we can't get away with mixing them (we had somehow been getting away with this in MOOSE for awhile, not sure exactly how, but it no longer worked for us as of 3.6.4).
