### PR TITLE
fixed syntax-error with 'disable-second'

### DIFF
--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -42,9 +42,10 @@ template< typename OutputShape >
 void H1FETransformation<OutputShape>::init_map_d2phi(const FEGenericBase<OutputShape> & fe) const
 {
   fe.get_fe_map().get_dxidx();
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   fe.get_fe_map().get_d2xidxyz2();
+#endif
 }
-
 
 template< typename OutputShape >
 void H1FETransformation<OutputShape>::map_phi( const unsigned int dim,

--- a/src/fe/hcurl_fe_transformation.C
+++ b/src/fe/hcurl_fe_transformation.C
@@ -41,7 +41,9 @@ template< typename OutputShape >
 void HCurlFETransformation<OutputShape>::init_map_d2phi(const FEGenericBase<OutputShape> & fe) const
 {
   fe.get_fe_map().get_dxidx();
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   fe.get_fe_map().get_d2xidxyz2();
+#endif
 }
 
 


### PR DESCRIPTION
when configured with the option '  --disable-second ',  I get an error message with the newest version saying that 'get_d2xidxyz2' does not exist. 
With the changes here, it works for me. 
Maybe it is better to remove the whole function init_map_d2phi() in that case but I am not able to foresee the consequences of it completely.
I hope, this helps,
Best
