### PR TITLE
Handle case where PETSc has no METIS, yet user requests to use it

### DIFF
--- a/configure
+++ b/configure
@@ -38478,6 +38478,19 @@ fi
     build_metis=no
   fi
 
+  # Conversely, if:
+  # .) METIS is enabled in libmesh,
+  # .) PETSc does not have a METIS, and
+  # .) build_metis=no because user said --with-metis=PETSc,
+  # then we need to make sure that libmesh builds its own METIS!
+  if (test $enablemetis = yes) ; then
+    if (test $petsc_have_metis -eq 0) ; then
+      if (test $build_metis = no) ; then
+        build_metis=yes
+      fi
+    fi
+  fi
+
       if (test $enablemetis = yes); then
         if (test $build_metis = yes); then
       METIS_INCLUDE="-I\$(top_srcdir)/contrib/metis/include"

--- a/m4/metis.m4
+++ b/m4/metis.m4
@@ -32,6 +32,19 @@ AC_DEFUN([CONFIGURE_METIS],
     build_metis=no
   fi
 
+  # Conversely, if:
+  # .) METIS is enabled in libmesh,
+  # .) PETSc does not have a METIS, and
+  # .) build_metis=no because user said --with-metis=PETSc,
+  # then we need to make sure that libmesh builds its own METIS!
+  if (test $enablemetis = yes) ; then
+    if (test $petsc_have_metis -eq 0) ; then
+      if (test $build_metis = no) ; then
+        build_metis=yes
+      fi
+    fi
+  fi
+
   dnl The METIS API is distributed with libmesh, so we don't have to guess
   dnl where it might be installed...
   if (test $enablemetis = yes); then


### PR DESCRIPTION
This is a follow-up to #908 that handles the converse case.