### PR TITLE
Various fixes for HDF5 configure test

### DIFF
--- a/configure
+++ b/configure
@@ -40495,17 +40495,23 @@ HAVE_HDF5=0
 
 # Check whether --with-hdf5 was given.
 if test "${with_hdf5+set}" = set; then :
-  withval=$with_hdf5; with_hdf5=$withval
-if test "${with_hdf5}" != yes; then
-    HDF5_PREFIX=$withval
-fi
+  withval=$with_hdf5;
+    with_hdf5=$withval
+    if test "${with_hdf5}" != yes; then
+      HDF5_PREFIX=$withval
+    fi
 
 else
 
-with_hdf5=$withval
-if test "x${HDF5_DIR}" != "x"; then
-   HDF5_PREFIX=${HDF5_DIR}
-fi
+    # This is "no" if the user did not specify --with-hdf5=foo
+    with_hdf5=$withval
+
+    # If $HDF5_DIR is set in the user's environment, then treat that
+    # as though they had said --with-hdf5=$HDF5_DIR.
+    if test "x${HDF5_DIR}" != "x"; then
+      HDF5_PREFIX=${HDF5_DIR}
+      with_hdf5=yes
+    fi
 
 fi
 
@@ -40513,14 +40519,28 @@ fi
 # package requirement; if not specified, the default is to assume that
 # the package is optional
 
+# GNU-m4 ifelse documentation:
+# ifelse (string-1, string-2, equal, [not-equal])
+# If string-1 and string-2 are equal (character for character),
+# expands to the string in 'equal', otherwise to the string in
+# 'not-equal'.
 is_package_required=no
 
 if test "${with_hdf5}" != no ; then
 
     if test -d "${HDF5_PREFIX}/lib" ; then
-       HDF5_LIBS="-L${HDF5_PREFIX}/lib -lhdf5 -Wl,-rpath,${HDF5_PREFIX}/lib"
-       HDF5_FLIBS="-L${HDF5_PREFIX}/lib -lhdf5_fortran -Wl,-rpath,${HDF5_PREFIX}/lib"
-       HDF5_CXXLIBS="-L${HDF5_PREFIX}/lib -lhdf5_cpp -Wl,-rpath,${HDF5_PREFIX}/lib"
+       HDF5_LIBS="-L${HDF5_PREFIX}/lib -lhdf5"
+       HDF5_FLIBS="-L${HDF5_PREFIX}/lib -lhdf5_fortran"
+       HDF5_CXXLIBS="-L${HDF5_PREFIX}/lib -lhdf5_cpp"
+    fi
+
+    # If there is an "rpath" flag detected, append it to the various
+    # LIBS vars.  This avoids hard-coding -Wl,-rpath, in case that is
+    # not the right approach for some compilers.
+    if (test "x$RPATHFLAG" != "x" -a -d "${HDF5_PREFIX}/lib"); then
+      HDF5_LIBS="${HDF5_LIBS} ${RPATHFLAG}${HDF5_PREFIX}/lib"
+      HDF5_FLIBS="${HDF5_FLIBS} ${RPATHFLAG}${HDF5_PREFIX}/lib"
+      HDF5_CXXLIBS="${HDF5_CXXLIBS} ${RPATHFLAG}${HDF5_PREFIX}/lib"
     fi
 
     if test -d "${HDF5_PREFIX}/include" ; then
@@ -40550,17 +40570,16 @@ fi
 
 
 
-    #-----------------------
+    #----------------------
     # Minimum version check
     #----------------------
 
     min_hdf5_version=1.8.0
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for hdf5 - version >= $min_hdf5_version" >&5
-$as_echo_n "checking for hdf5 - version >= $min_hdf5_version... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for HDF5 version >= $min_hdf5_version" >&5
+$as_echo_n "checking for HDF5 version >= $min_hdf5_version... " >&6; }
 
-    # looking for major.minor.micro style versioning
-
+    # Strip the major.minor.micro version numbers out of the min version string
     MAJOR_VER=`echo $min_hdf5_version | sed 's/^\([0-9]*\).*/\1/'`
     if test "x${MAJOR_VER}" = "x" ; then
        MAJOR_VER=0
@@ -40577,7 +40596,6 @@ $as_echo_n "checking for hdf5 - version >= $min_hdf5_version... " >&6; }
     fi
 
     # begin additional test(s) if header if available
-
     succeeded=no
     ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -40587,8 +40605,10 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
     if test "x${found_header}" = "xyes" ; then
-      version_succeeded=no
+      min_version_succeeded=no
+      hdf5_has_cxx=no
 
+      # Test that HDF5 version is greater than or equal to the required min version.
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -40612,14 +40632,11 @@ main ()
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
 
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-            version_succeeded=yes
+            min_version_succeeded=yes
 
 else
 
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
+            min_version_succeeded=no
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
@@ -40631,15 +40648,20 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-      if test "$version_succeeded" != "yes";then
+      if (test "$min_version_succeeded" = "no"); then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
         if test "$is_package_required" = yes; then
-          as_fn_error $? "Your HDF5 library version does not meet the minimum versioning
-                        requirements ($min_hdf5_version).  Please use --with-hdf5 to specify the location
-                        of an updated installation or consider upgrading the system version." "$LINENO" 5
+          as_fn_error $? "Your HDF5 library version does not meet the minimum version
+                        requirement (HDF5 >= $min_hdf5_version).
+                        Please use --with-hdf5 to specify the location of a valid installation." "$LINENO" 5
         fi
+      else
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
       fi
 
-      # Library availability
+      # Check for -lhdf5
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for H5Fopen in -lhdf5" >&5
 $as_echo_n "checking for H5Fopen in -lhdf5... " >&6; }
 if ${ac_cv_lib_hdf5_H5Fopen+:} false; then :
@@ -40682,6 +40704,8 @@ else
   found_library=no
 fi
 
+
+      # Test for the HDF5 C++ interface by trying to link a test code.
       ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -40689,15 +40713,75 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking If HDF5 C++ interface is present" >&5
+$as_echo_n "checking If HDF5 C++ interface is present... " >&6; }
+
+      # Using the C++ interface requires linking against both the C
+      # and C++ libs.
+      LIBS="${HDF5_LIBS} ${HDF5_CXXLIBS}"
+
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+        #include <H5Cpp.h>
+        #ifndef H5_NO_NAMESPACE
+        using namespace H5;
+        #endif
+
+int
+main ()
+{
+
+        H5std_string  fname("test.h5");
+        H5File file (fname, H5F_ACC_TRUNC);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+
+            hdf5_has_cxx=yes
+
+else
+
+            hdf5_has_cxx=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+      ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+      # Not having the C++ interface doesn't disqualify us from using
+      # the C interface.  We'll set a define if C++ is available, so
+      # code can conditionally make use of it.
+      if test "$hdf5_has_cxx" = yes; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_HDF5_CXX 1" >>confdefs.h
+
+      else
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+      fi
+
       succeeded=no
       if test "$found_header" = yes; then
-        if test "$version_succeeded" = yes; then
+        if test "$min_version_succeeded" = yes; then
           if test "$found_library" = yes; then
             succeeded=yes
           fi
         fi
       fi
     fi
+    # Reset variables used by configure tests.
     CFLAGS="$ac_HDF5_save_CFLAGS"
     CPPFLAGS="$ac_HDF5_save_CPPFLAGS"
     LDFLAGS="$ac_HDF5_save_LDFLAGS"
@@ -40737,14 +40821,23 @@ fi
 
     if (test "x$HAVE_HDF5" = "x0"); then
       enablehdf5=no
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< HDF5 support not found or disabled >>>" >&5
+$as_echo "<<< HDF5 support not found or disabled >>>" >&6; }
     else
-       { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with HDF5 support >>>" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with HDF5 support >>>" >&5
 $as_echo "<<< Configuring library with HDF5 support >>>" >&6; }
     fi
   fi
 
 if (test $enablehdf5 = yes); then
   libmesh_optional_INCLUDES="$HDF5_CPPFLAGS $libmesh_optional_INCLUDES"
+
+  # If the HDF5 C++ interface was found, add the C++ library to the link line.
+  if test "$hdf5_has_cxx" = yes; then
+    libmesh_optional_LIBS="$HDF5_CXXLIBS $libmesh_optional_LIBS"
+  fi
+
+  # And add the HDF5 C library to the link line.
   libmesh_optional_LIBS="$HDF5_LIBS $libmesh_optional_LIBS"
 fi
  if test x$enablehdf5 = xyes; then
@@ -41355,7 +41448,7 @@ for ac_lib in '' dl dld; do
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_cxx_try_link "$LINENO"; then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_dlopen=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
@@ -41459,11 +41552,11 @@ fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+    ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
   fi
 
@@ -41842,7 +41935,7 @@ fi
        for ac_header in $CURL_INC/curl.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
-ac_fn_cxx_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
 #define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
@@ -41899,7 +41992,7 @@ return main ();
   return 0;
 }
 _ACEOF
-if ac_fn_cxx_try_link "$LINENO"; then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_lib_curl_main=yes
 else
   ac_cv_lib_curl_main=no

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -455,6 +455,9 @@
 /* Define if HDF5 is available */
 #undef HAVE_HDF5
 
+/* Define if the HDF5 C++ interface is available */
+#undef HAVE_HDF5_CXX
+
 /* Flag indicating whether the library will be compiled with Howard Hinnant's
    C++03 unique_ptr implementation */
 #undef HAVE_HINNANT_UNIQUE_PTR

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -14,7 +14,7 @@ AC_DEFUN([CONFIGURE_HDF5],
                 [enablehdf5=$enableoptional])
 
   if (test $enablehdf5 = yes); then
-    AX_PATH_HDF5(1.8.0,,no)
+    AX_PATH_HDF5(1.8.0,no)
     if (test "x$HAVE_HDF5" = "x0"); then
       enablehdf5=no
       AC_MSG_RESULT(<<< HDF5 support not found or disabled >>>)
@@ -31,7 +31,7 @@ AC_DEFUN([CONFIGURE_HDF5],
 #
 #   Test for HDF5
 #
-#   AX_PATH_HDF5( <Minimum Required Version>, <Maximum Allowed Version>, <package-required=yes/no> )
+#   AX_PATH_HDF5( <Minimum Required Version>, <package-required=yes/no> )
 #
 # DESCRIPTION
 #
@@ -40,7 +40,7 @@ AC_DEFUN([CONFIGURE_HDF5],
 #   usual places for HDF5 headers and libraries.
 #
 #   On success, sets HDF5_CFLAGS, HDF5_LIBS, and #defines HAVE_HDF5.
-#   Assumes package is optional unless overridden with $3=yes.
+#   Assumes package is optional unless overridden with $2=yes.
 #
 # LAST MODIFICATION
 #
@@ -97,7 +97,7 @@ AC_ARG_WITH(hdf5,
 # If string-1 and string-2 are equal (character for character),
 # expands to the string in 'equal', otherwise to the string in
 # 'not-equal'.
-is_package_required=ifelse([$3], ,no, $3)
+is_package_required=ifelse([$2], ,no, $2)
 
 if test "${with_hdf5}" != no ; then
 
@@ -131,20 +131,13 @@ if test "${with_hdf5}" != no ; then
     AC_LANG_PUSH([C])
     AC_CHECK_HEADER([hdf5.h],[found_header=yes],[found_header=no])
 
-    #------------------------------
-    # Minimum/Maximum version check
-    #------------------------------
+    #----------------------
+    # Minimum version check
+    #----------------------
 
     min_hdf5_version=ifelse([$1], ,1.8.0, $1)
 
-    # If a max version is not provided, set it to 0.0.0.
-    max_hdf5_version=ifelse([$2], ,0.0.0, $2)
-
-    if (test "$max_hdf5_version" != "0.0.0"); then
-      AC_MSG_CHECKING([for $min_hdf5_version <= HDF5 <= $max_hdf5_version])
-    else
-      AC_MSG_CHECKING([for HDF5 version >= $min_hdf5_version])
-    fi
+    AC_MSG_CHECKING([for HDF5 version >= $min_hdf5_version])
 
     # Strip the major.minor.micro version numbers out of the min version string
     MAJOR_VER=`echo $min_hdf5_version | sed 's/^\([[0-9]]*\).*/\1/'`
@@ -162,30 +155,12 @@ if test "${with_hdf5}" != no ; then
        MICRO_VER=0
     fi
 
-    # Strip the major.minor.micro version numbers out of the max version string
-    MAJOR_VER_MAX=`echo $max_hdf5_version | sed 's/^\([[0-9]]*\).*/\1/'`
-    if test "x${MAJOR_VER_MAX}" = "x" ; then
-       MAJOR_VER_MAX=0
-    fi
-
-    MINOR_VER_MAX=`echo $max_hdf5_version | sed 's/^\([[0-9]]*\)\.\{0,1\}\([[0-9]]*\).*/\2/'`
-    if test "x${MINOR_VER_MAX}" = "x" ; then
-       MINOR_VER_MAX=0
-    fi
-
-    MICRO_VER_MAX=`echo $max_hdf5_version | sed 's/^\([[0-9]]*\)\.\{0,1\}\([[0-9]]*\)\.\{0,1\}\([[0-9]]*\).*/\3/'`
-    if test "x${MICRO_VER_MAX}" = "x" ; then
-       MICRO_VER_MAX=0
-    fi
-
     # begin additional test(s) if header if available
-
     succeeded=no
     AC_LANG_PUSH([C])
 
     if test "x${found_header}" = "xyes" ; then
       min_version_succeeded=no
-      max_version_succeeded=no
       hdf5_has_cxx=no
 
       # Test that HDF5 version is greater than or equal to the required min version.
@@ -205,37 +180,13 @@ if test "${with_hdf5}" != no ; then
             min_version_succeeded=no
         ])
 
-      # If the max version is 0.0.0, accept any version for the max and automatically pass the test.
-      if (test "$MAJOR_VER_MAX" = "0" -a "$MINOR_VER_MAX" = "0" -a "$MICRO_VER_MAX" = "0"); then
-        max_version_succeeded=yes
-      else
-        # Test that HDF5 version is less than or equal to the required max version.
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-          @%:@include <hdf5.h>
-              ]], [[
-              @%:@if H5_VERS_MAJOR > $MAJOR_VER_MAX
-              @%:@  error HDF5 version is too new
-              @%:@elif (H5_VERS_MAJOR == $MAJOR_VER_MAX) && (H5_VERS_MINOR > $MINOR_VER_MAX)
-              @%:@  error HDF5 version is too new
-              @%:@elif (H5_VERS_MAJOR == $MAJOR_VER_MAX) && (H5_VERS_MINOR == $MINOR_VER_MAX) && (H5_VERS_RELEASE > $MICRO_VER_MAX)
-              @%:@  error HDF5 version is too new
-              @%:@else
-              /* It should work */
-              @%:@endif
-          ]])],[
-              max_version_succeeded=yes
-          ],[
-              min_version_succeeded=no
-          ])
-      fi
-
       AC_LANG_POP([C])
 
-      if (test "$min_version_succeeded" = "no" -o "$max_version_succeeded" = "no"); then
+      if (test "$min_version_succeeded" = "no"); then
         AC_MSG_RESULT(no)
         if test "$is_package_required" = yes; then
-          AC_MSG_ERROR([Your HDF5 library version does not meet the minimum and maximum versioning
-                        requirements ($min_hdf5_version <= HDF5 <= $max_hdf5_version).
+          AC_MSG_ERROR([Your HDF5 library version does not meet the minimum version
+                        requirement (HDF5 >= $min_hdf5_version).
                         Please use --with-hdf5 to specify the location of a valid installation.])
         fi
       else
@@ -283,10 +234,8 @@ if test "${with_hdf5}" != no ; then
       succeeded=no
       if test "$found_header" = yes; then
         if test "$min_version_succeeded" = yes; then
-          if test "$max_version_succeeded" = yes; then
-            if test "$found_library" = yes; then
-              succeeded=yes
-            fi
+          if test "$found_library" = yes; then
+            succeeded=yes
           fi
         fi
       fi

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -92,6 +92,11 @@ AC_ARG_WITH(hdf5,
 # package requirement; if not specified, the default is to assume that
 # the package is optional
 
+# GNU-m4 ifelse documentation:
+# ifelse (string-1, string-2, equal, [not-equal])
+# If string-1 and string-2 are equal (character for character),
+# expands to the string in 'equal', otherwise to the string in
+# 'not-equal'.
 is_package_required=ifelse([$2], ,no, $2 )
 
 AC_MSG_RESULT([Debugging: with_hdf5 = $with_hdf5])

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -104,9 +104,18 @@ AC_MSG_RESULT([Debugging: with_hdf5 = $with_hdf5])
 if test "${with_hdf5}" != no ; then
 
     if test -d "${HDF5_PREFIX}/lib" ; then
-       HDF5_LIBS="-L${HDF5_PREFIX}/lib -lhdf5 -Wl,-rpath,${HDF5_PREFIX}/lib"
-       HDF5_FLIBS="-L${HDF5_PREFIX}/lib -lhdf5_fortran -Wl,-rpath,${HDF5_PREFIX}/lib"
-       HDF5_CXXLIBS="-L${HDF5_PREFIX}/lib -lhdf5_cpp -Wl,-rpath,${HDF5_PREFIX}/lib"
+       HDF5_LIBS="-L${HDF5_PREFIX}/lib -lhdf5"
+       HDF5_FLIBS="-L${HDF5_PREFIX}/lib -lhdf5_fortran"
+       HDF5_CXXLIBS="-L${HDF5_PREFIX}/lib -lhdf5_cpp"
+    fi
+
+    # If there is an "rpath" flag detected, append it to the various
+    # LIBS vars.  This avoids hard-coding -Wl,-rpath, in case that is
+    # not the right approach for some compilers.
+    if (test "x$RPATHFLAG" != "x" -a -d "${HDF5_PREFIX}/lib"); then
+      HDF5_LIBS="${HDF5_LIBS} ${RPATHFLAG}${HDF5_PREFIX}/lib"
+      HDF5_FLIBS="${HDF5_FLIBS} ${RPATHFLAG}${HDF5_PREFIX}/lib"
+      HDF5_CXXLIBS="${HDF5_CXXLIBS} ${RPATHFLAG}${HDF5_PREFIX}/lib"
     fi
 
     if test -d "${HDF5_PREFIX}/include" ; then
@@ -267,6 +276,7 @@ if test "${with_hdf5}" != no ; then
       fi
     fi dnl end test if header if available
 
+    # Reset variables used by configure tests.
     CFLAGS="$ac_HDF5_save_CFLAGS"
     CPPFLAGS="$ac_HDF5_save_CPPFLAGS"
     LDFLAGS="$ac_HDF5_save_LDFLAGS"

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -178,13 +178,13 @@ if test "${with_hdf5}" != no ; then
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
         @%:@include <hdf5.h>
             ]], [[
-            #if H5_VERS_MAJOR > $MAJOR_VER
+            @%:@if H5_VERS_MAJOR > $MAJOR_VER
             /* Sweet nibblets */
-            #elif (H5_VERS_MAJOR >= $MAJOR_VER) && (H5_VERS_MINOR >= $MINOR_VER) && (H5_VERS_RELEASE >= $MICRO_VER)
+            @%:@elif (H5_VERS_MAJOR >= $MAJOR_VER) && (H5_VERS_MINOR >= $MINOR_VER) && (H5_VERS_RELEASE >= $MICRO_VER)
             /* Winner winner, chicken dinner */
-            #else
-            #  error HDF5 version is too old
-            #endif
+            @%:@else
+            @%:@  error HDF5 version is too old
+            @%:@endif
         ]])],[
             min_version_succeeded=yes
         ],[
@@ -195,15 +195,15 @@ if test "${with_hdf5}" != no ; then
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
         @%:@include <hdf5.h>
             ]], [[
-            #if H5_VERS_MAJOR > $MAJOR_VER_MAX
-            #  error HDF5 version is too new
-            #elif (H5_VERS_MAJOR == $MAJOR_VER_MAX) && (H5_VERS_MINOR > $MINOR_VER_MAX)
-            #  error HDF5 version is too new
-            #elif (H5_VERS_MAJOR == $MAJOR_VER_MAX) && (H5_VERS_MINOR == $MINOR_VER_MAX) && (H5_VERS_RELEASE > $MICRO_VER_MAX)
-            #  error HDF5 version is too new
-            #else
+            @%:@if H5_VERS_MAJOR > $MAJOR_VER_MAX
+            @%:@  error HDF5 version is too new
+            @%:@elif (H5_VERS_MAJOR == $MAJOR_VER_MAX) && (H5_VERS_MINOR > $MINOR_VER_MAX)
+            @%:@  error HDF5 version is too new
+            @%:@elif (H5_VERS_MAJOR == $MAJOR_VER_MAX) && (H5_VERS_MINOR == $MINOR_VER_MAX) && (H5_VERS_RELEASE > $MICRO_VER_MAX)
+            @%:@  error HDF5 version is too new
+            @%:@else
             /* It should work */
-            #endif
+            @%:@endif
         ]])],[
             max_version_succeeded=yes
         ],[

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -17,8 +17,9 @@ AC_DEFUN([CONFIGURE_HDF5],
     AX_PATH_HDF5(1.8.0,no)
     if (test "x$HAVE_HDF5" = "x0"); then
       enablehdf5=no
+      AC_MSG_RESULT(<<< HDF5 support not found or disabled >>>)
     else
-       AC_MSG_RESULT(<<< Configuring library with HDF5 support >>>)
+      AC_MSG_RESULT(<<< Configuring library with HDF5 support >>>)
     fi
   fi
 ])
@@ -67,22 +68,33 @@ HAVE_HDF5=0
 AC_ARG_VAR(HDF5_DIR,[root directory of HDF5 installation])
 
 AC_ARG_WITH(hdf5,
-  [AS_HELP_STRING([--with-hdf5[=DIR]],[root directory of HDF5 installation (default = HDF5_DIR)])],
-  [with_hdf5=$withval
-if test "${with_hdf5}" != yes; then
-    HDF5_PREFIX=$withval
-fi
-],[
-with_hdf5=$withval
-if test "x${HDF5_DIR}" != "x"; then
-   HDF5_PREFIX=${HDF5_DIR}
-fi
-])
+  [AS_HELP_STRING([--with-hdf5=DIR],[root directory of HDF5 installation (default = HDF5_DIR)])],
+  dnl action-if-given
+  [
+    with_hdf5=$withval
+    if test "${with_hdf5}" != yes; then
+      HDF5_PREFIX=$withval
+    fi
+  ],
+  dnl action-if-not-given
+  [
+    # This is "no" if the user did not specify --with-hdf5=foo
+    with_hdf5=$withval
+
+    # If $HDF5_DIR is set in the user's environment, then treat that
+    # as though they had said --with-hdf5=$HDF5_DIR.
+    if test "x${HDF5_DIR}" != "x"; then
+      HDF5_PREFIX=${HDF5_DIR}
+      with_hdf5=yes
+    fi
+  ])
 
 # package requirement; if not specified, the default is to assume that
 # the package is optional
 
 is_package_required=ifelse([$2], ,no, $2 )
+
+AC_MSG_RESULT([Debugging: with_hdf5 = $with_hdf5])
 
 if test "${with_hdf5}" != no ; then
 

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -522,6 +522,13 @@ AC_CONFIG_FILES([contrib/capnproto/Makefile])
 CONFIGURE_HDF5
 if (test $enablehdf5 = yes); then
   libmesh_optional_INCLUDES="$HDF5_CPPFLAGS $libmesh_optional_INCLUDES"
+
+  # If the HDF5 C++ interface was found, add the C++ library to the link line.
+  if test "$hdf5_has_cxx" = yes; then
+    libmesh_optional_LIBS="$HDF5_CXXLIBS $libmesh_optional_LIBS"
+  fi
+
+  # And add the HDF5 C library to the link line.
   libmesh_optional_LIBS="$HDF5_LIBS $libmesh_optional_LIBS"
 fi
 AM_CONDITIONAL(LIBMESH_ENABLE_HDF5, test x$enablehdf5 = xyes)


### PR DESCRIPTION
Misc. fixes and libMesh will now link against the HDF5 C++ library if it is found, as well as setting the `LIBMESH_HAVE_HDF5_CXX` preprocessor macro so you can guard code that uses the HDF5 C++ interfaces appropriately.

Refs #910.