### PR TITLE
Bounding box fixes for ParallelMesh

### DIFF
--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -464,6 +464,10 @@ MeshTools::processor_bounding_box (const MeshBase & mesh,
                                             mesh.pid_elements_end(pid)),
                             find_bbox);
 
+  // Compare the bounding boxes across processors
+  mesh.comm().min(find_bbox.min());
+  mesh.comm().max(find_bbox.max());
+
   return find_bbox.bbox();
 }
 


### PR DESCRIPTION
This should give us correct results rather than incorrect results and segfaults when using subdomain_bounding_box() or processor_bounding_box() with ParallelMesh.