### PR TITLE
Work around PetscOptions API changes in PETSc 3.7

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -64,6 +64,7 @@
 // Necessary for programmatically setting petsc options
 #ifdef LIBMESH_HAVE_PETSC
 #include <petsc.h>
+#include "libmesh/petsc_macro.h"
 #endif
 
 // Bring in everything from the libMesh namespace
@@ -198,7 +199,11 @@ int main (int argc, char ** argv)
     {
 #ifdef LIBMESH_HAVE_PETSC
       //Use the jacobian for preconditioning.
+#  if PETSC_VERSION_LESS_THAN(3,7,0)
       PetscOptionsSetValue("-snes_mf_operator", PETSC_NULL);
+#  else
+      PetscOptionsSetValue(PETSC_NULL, "-snes_mf_operator", PETSC_NULL);
+#  endif
 #else
       libMesh::err << "Must be using PETSc to use jacobian based preconditioning" << std::endl;
 


### PR DESCRIPTION
We don't seem to have any affected library code, but one example used the old API.