### PR TITLE
Add support for actual parallel I/O of nodal solutions in Nemesis

### DIFF
--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -106,8 +106,7 @@ public:
    * (u0,v0,w0, u1,v1,w1, u2,v2,w2, u3,v3,w3, ...)
    * and contains n_nodes*n_vars total entries.  Then, it is up to the
    * individual I/O class to extract the required solution values from
-   * this vector, perhaps using NumericVector::create_subvector(), in
-   * order to write chunks of the nodal solution on each processor.
+   * this vector and write them in parallel.
    *
    * If not implemented, localizes the parallel vector into a std::vector
    * and calls the other version of this function.

--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -40,6 +40,7 @@ namespace libMesh
 class EquationSystems;
 template <typename T> class NumericVector;
 
+
 /**
  * This class defines an abstract interface for \p Mesh output.
  * Specific classes derived from this class actually implement
@@ -107,11 +108,13 @@ public:
    * individual I/O class to extract the required solution values from
    * this vector, perhaps using NumericVector::create_subvector(), in
    * order to write chunks of the nodal solution on each processor.
+   *
+   * If not implemented, localizes the parallel vector into a std::vector
+   * and calls the other version of this function.
    */
   virtual void write_nodal_data (const std::string &,
                                  const NumericVector<Number> &,
-                                 const std::vector<std::string> &)
-  { libmesh_not_implemented(); }
+                                 const std::vector<std::string> &);
 
   /**
    * Return/set the precision to use when writing ASCII files.

--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -38,7 +38,7 @@ namespace libMesh
 
 // Forward declares
 class EquationSystems;
-
+template <typename T> class NumericVector;
 
 /**
  * This class defines an abstract interface for \p Mesh output.
@@ -94,6 +94,22 @@ public:
    */
   virtual void write_nodal_data (const std::string &,
                                  const std::vector<Number> &,
+                                 const std::vector<std::string> &)
+  { libmesh_not_implemented(); }
+
+  /**
+   * This method should be overridden by "parallel" output formats for
+   * writing nodal data.  Instead of getting a localized copy of the
+   * nodal solution vector, it is passed a NumericVector of
+   * type=PARALLEL which is in node-major order i.e.
+   * (u0,v0,w0, u1,v1,w1, u2,v2,w2, u3,v3,w3, ...)
+   * and contains n_nodes*n_vars total entries.  Then, it is up to the
+   * individual I/O class to extract the required solution values from
+   * this vector, perhaps using NumericVector::create_subvector(), in
+   * order to write chunks of the nodal solution on each processor.
+   */
+  virtual void write_nodal_data (const std::string &,
+                                 const NumericVector<Number> &,
                                  const std::vector<std::string> &)
   { libmesh_not_implemented(); }
 

--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -136,17 +136,6 @@ private:
    * Precision to use when writing ASCII files.
    */
   unsigned int _ascii_precision;
-
-  /**
-   * A helper function which allows us to fill temporary
-   * name and solution vectors with an EquationSystems object.
-   * Only generate names and solution data corresponding to
-   * systems specified in system_names.
-   */
-  void _build_variable_names_and_solution_vector(const EquationSystems & es,
-                                                 std::vector<Number> & soln,
-                                                 std::vector<std::string> & names,
-                                                 const std::set<std::string> * system_names=libmesh_nullptr);
 };
 
 

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -136,6 +136,14 @@ private:
    * rather than created from scratch when writing.
    */
   bool _append;
+
+  /**
+   * Helper function containing code shared between the two different
+   * versions of write_nodal_data which take std::vector and
+   * NumericVector, respectively.
+   */
+  void prepare_to_write_nodal_data (const std::string & fname,
+                                    const std::vector<std::string> & names);
 };
 
 

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -94,6 +94,13 @@ public:
                                  const std::vector<std::string> & names) libmesh_override;
 
   /**
+   * Output a nodal solution in parallel, without localizing the soln vector.
+   */
+  virtual void write_nodal_data (const std::string & fname,
+                                 const NumericVector<Number> & parallel_soln,
+                                 const std::vector<std::string> & names) libmesh_override;
+
+  /**
    * Set the flag indicationg if we should be verbose.
    */
   void verbose (bool set_verbosity);

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -32,6 +32,9 @@
 namespace libMesh
 {
 
+// Forward declaration
+template <typename T> class NumericVector;
+
 // The Nemesis API header file.  Should already be
 // correctly extern C'd but it doesn't hurt :)
 namespace Nemesis {
@@ -299,6 +302,14 @@ public:
    * Takes a solution vector containing the solution for all variables and outputs it to the files
    */
   void write_nodal_solution(const std::vector<Number> & values,
+                            const std::vector<std::string> & names,
+                            int timestep);
+
+  /**
+   * Takes a parallel solution vector containing the node-major
+   * solution vector for all variables and outputs it to the files.
+   */
+  void write_nodal_solution(const NumericVector<Number> & parallel_soln,
                             const std::vector<std::string> & names,
                             int timestep);
 

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -299,17 +299,24 @@ public:
   virtual void initialize(std::string title, const MeshBase & mesh, bool use_discontinuous=false);
 
   /**
-   * Takes a solution vector containing the solution for all variables and outputs it to the files
+   * Takes a parallel solution vector containing the node-major
+   * solution vector for all variables and outputs it to the files.
+   *
+   * Note: This version of write_nodal_solution() is called by the
+   * parallel version of Nemesis_IO::write_nodal_data(), which is
+   * called by MeshOutput::write_equation_systems() for parallel I/O
+   * formats like Nemesis.  The other version is still available to
+   * continue supporting things like NamebasedIO::write_nodal_data(),
+   * but this version should be preferred when running in parallel.
    */
-  void write_nodal_solution(const std::vector<Number> & values,
+  void write_nodal_solution(const NumericVector<Number> & parallel_soln,
                             const std::vector<std::string> & names,
                             int timestep);
 
   /**
-   * Takes a parallel solution vector containing the node-major
-   * solution vector for all variables and outputs it to the files.
+   * Takes a solution vector containing the solution for all variables and outputs it to the files
    */
-  void write_nodal_solution(const NumericVector<Number> & parallel_soln,
+  void write_nodal_solution(const std::vector<Number> & values,
                             const std::vector<std::string> & names,
                             int timestep);
 

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -375,6 +375,13 @@ public:
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
   /**
+   * Fill in the local std::vector "v_local" with the global indices
+   * given in "indices".  See numeric_vector.h for more details.
+   */
+  virtual void localize (std::vector<T> & v_local,
+                         const std::vector<numeric_index_type> & indices) const libmesh_override;
+
+  /**
    * Updates a local vector with selected values from neighboring
    * processors, as defined by \p send_list.
    */

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -374,6 +374,13 @@ public:
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
   /**
+   * Fill in the local std::vector "v_local" with the global indices
+   * given in "indices".  See numeric_vector.h for more details.
+   */
+  virtual void localize (std::vector<T> & v_local,
+                         const std::vector<numeric_index_type> & indices) const libmesh_override;
+
+  /**
    * Updates a local vector with selected values from neighboring
    * processors, as defined by \p send_list.
    */

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -374,6 +374,13 @@ public:
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
   /**
+   * Fill in the local std::vector "v_local" with the global indices
+   * given in "indices".  See numeric_vector.h for more details.
+   */
+  virtual void localize (std::vector<T> & v_local,
+                         const std::vector<numeric_index_type> & indices) const libmesh_override;
+
+  /**
    * Updates a local vector with selected values from neighboring
    * processors, as defined by \p send_list.
    */

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -586,13 +586,9 @@ public:
    * This function is useful in parallel I/O routines, when you have a
    * parallel vector of solution values which you want to write a
    * subset of.
-   *
-   * TODO: make this pure virtual with libmesh_not_implemented() in
-   * derived classes where it is not yet implemented.
    */
   virtual void localize (std::vector<T> & /*v_local*/,
-                         const std::vector<numeric_index_type> & /*indices*/) const
-  { libmesh_not_implemented(); }
+                         const std::vector<numeric_index_type> & /*indices*/) const = 0;
 
   /**
    * Updates a local vector with selected values from neighboring

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -562,6 +562,39 @@ public:
                          const std::vector<numeric_index_type> & send_list) const = 0;
 
   /**
+   * Fill in the local std::vector "v_local" with the global indices
+   * given in "indices".  Note that indices can be different on every
+   * processor, and the same index can be localized to more than one
+   * processor.  The resulting v_local can be shorter than the
+   * original, and the entries will be in the order specified by
+   * indices.
+   *
+   * Example:
+   *   On 4 procs *this = {a, b, c, d, e, f, g, h, i} is a parallel vector.
+   *   On each proc, the indices arrays are set up as:
+   *   proc0, indices = {1,2,4,5}
+   *   proc1, indices = {2,5,6,8}
+   *   proc2, indices = {2,3,6,7}
+   *   proc3, indices = {0,1,2,3}
+   *
+   *   After calling this version of localize, the v_local vectors are:
+   *   proc0, v_local = {b,c,e,f}
+   *   proc1, v_local = {c,f,g,i}
+   *   proc2, v_local = {c,d,g,h}
+   *   proc3, v_local = {a,b,c,d}
+   *
+   * This function is useful in parallel I/O routines, when you have a
+   * parallel vector of solution values which you want to write a
+   * subset of.
+   *
+   * TODO: make this pure virtual with libmesh_not_implemented() in
+   * derived classes where it is not yet implemented.
+   */
+  virtual void localize (std::vector<T> & v_local,
+                         const std::vector<numeric_index_type> & indices) const
+  { libmesh_not_implemented(); }
+
+  /**
    * Updates a local vector with selected values from neighboring
    * processors, as defined by \p send_list.
    */

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -590,8 +590,8 @@ public:
    * TODO: make this pure virtual with libmesh_not_implemented() in
    * derived classes where it is not yet implemented.
    */
-  virtual void localize (std::vector<T> & v_local,
-                         const std::vector<numeric_index_type> & indices) const
+  virtual void localize (std::vector<T> & /*v_local*/,
+                         const std::vector<numeric_index_type> & /*indices*/) const
   { libmesh_not_implemented(); }
 
   /**

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -448,6 +448,13 @@ public:
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
   /**
+   * Fill in the local std::vector "v_local" with the global indices
+   * given in "indices".  See numeric_vector.h for more details.
+   */
+  virtual void localize (std::vector<T> & v_local,
+                         const std::vector<numeric_index_type> & indices) const libmesh_override;
+
+  /**
    * Updates a local vector with selected values from neighboring
    * processors, as defined by \p send_list.
    */

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -412,6 +412,14 @@ public:
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
   /**
+   * Fill in the local std::vector "v_local" with the global indices
+   * given in "indices".  See numeric_vector.h for more details.
+   */
+  virtual void localize (std::vector<T> & v_local,
+                         const std::vector<numeric_index_type> & indices) const libmesh_override;
+
+
+  /**
    * Updates a local vector with selected values from neighboring
    * processors, as defined by \p send_list.
    */
@@ -691,7 +699,7 @@ EpetraVector<T>::EpetraVector(Epetra_Vector & v,
 
   _map = new Epetra_Map(_vec->GlobalLength(),
                         _vec->MyLength(),
-                        0,
+                        0, // IndexBase = 0 for C/C++, 1 for Fortran.
                         Epetra_MpiComm (this->comm().get()));
 
   //Currently we impose the restriction that NumVectors==1, so we won't

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -285,6 +285,16 @@ public:
                               const std::set<std::string> * system_names=libmesh_nullptr) const;
 
   /**
+   * A version of build_solution_vector which is appropriate for
+   * "parallel" output formats like Nemesis.  Returns a UniquePtr to a
+   * node-major NumericVector of total length n_nodes*n_vars that is
+   * hopefully partitioned correctly for writing out all the values of
+   * a given variable for a given processor.
+   */
+  UniquePtr<NumericVector<Number> >
+  build_parallel_solution_vector(const std::set<std::string> * system_names=libmesh_nullptr) const;
+
+  /**
    * Retrieve the solution data for CONSTANT MONOMIALs.  If \p names
    * is populated, only the variables corresponding to those names will
    * be retrieved.  This can be used to filter which variables are retrieved.

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -287,9 +287,9 @@ public:
   /**
    * A version of build_solution_vector which is appropriate for
    * "parallel" output formats like Nemesis.  Returns a UniquePtr to a
-   * node-major NumericVector of total length n_nodes*n_vars that is
-   * hopefully partitioned correctly for writing out all the values of
-   * a given variable for a given processor.
+   * node-major NumericVector of total length n_nodes*n_vars that
+   * various I/O classes can then use to get the local values they
+   * need to write on each processor.
    */
   UniquePtr<NumericVector<Number> >
   build_parallel_solution_vector(const std::set<std::string> * system_names=libmesh_nullptr) const;

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -22,6 +22,7 @@
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_mesh.h"
 #include "libmesh/unstructured_mesh.h"
+#include "libmesh/numeric_vector.h"
 
 namespace libMesh
 {
@@ -65,49 +66,55 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
 
   MeshSerializer serialize(const_cast<MT &>(*_obj), !_is_parallel_format);
 
-  // Build the nodal solution values & get the variable
-  // names from the EquationSystems object
-  std::vector<Number>      soln;
-  std::vector<std::string> names;
-
-  this->_build_variable_names_and_solution_vector(es, soln, names, system_names);
-  //es.build_variable_names  (names);
-  //es.build_solution_vector (soln);
-
-  this->write_nodal_data (fname, soln, names);
-}
-
-
-
-template <class MT>
-void MeshOutput<MT>::
-_build_variable_names_and_solution_vector (const EquationSystems & es,
-                                           std::vector<Number> & soln,
-                                           std::vector<std::string> & names,
-                                           const std::set<std::string> * system_names)
-{
-  if(!_is_parallel_format)
+  if (!_is_parallel_format)
     {
       // We need a serial mesh for MeshOutput for now
       const_cast<EquationSystems &>(es).allgather();
+
+      // Build the nodal solution values & get the variable
+      // names from the EquationSystems object
+      std::vector<Number>      soln;
+      std::vector<std::string> names;
+
+      es.build_variable_names  (names, libmesh_nullptr, system_names);
+      es.build_solution_vector (soln, system_names);
+
+      this->write_nodal_data (fname, soln, names);
     }
-
-  es.build_variable_names  (names, libmesh_nullptr, system_names);
-  es.build_solution_vector (soln, system_names);
-
-  // For now, if we're doing a parallel format we're going to broadcast the vector from processor 0
-  // to all of the processors to mimic what build_solution_vector used to do.
-  // this is TERRIBLE and WASTEFUL but it's only temporary until we redesign the output of build_solution_vector
-  // and the inputs to the I/O... both of which should actually be NumericVectors....
-  if(_is_parallel_format)
+  else // _is_parallel_format
     {
-      size_t size = soln.size();
-      _obj->comm().broadcast(size);
+      std::vector<Number>      soln;
+      std::vector<std::string> names;
 
-      if(_obj->comm().rank())
-        soln.resize(size);
+      es.build_variable_names  (names, libmesh_nullptr, system_names);
 
-      _obj->comm().broadcast(soln);
+      UniquePtr<NumericVector<Number> > parallel_soln =
+        es.build_parallel_solution_vector(system_names);
+
+      // Localize parallel_soln into soln.  This is a place-holder.
+      // It is exactly what's already done in
+      // es.build_solution_vector();
+      parallel_soln->localize_to_one(soln);
+
+      // For now, if we're doing a parallel format we're going to
+      // broadcast the vector from processor 0 to all of the
+      // processors to mimic what build_solution_vector used to do.
+      // this is TERRIBLE and WASTEFUL but it's only temporary until
+      // we redesign the output of build_solution_vector and the
+      // inputs to the I/O... both of which should actually be
+      // NumericVectors....
+      if (_is_parallel_format)
+        {
+          size_t size = soln.size();
+          _obj->comm().broadcast(size);
+
+          if(_obj->comm().rank())
+            soln.resize(size);
+
+          _obj->comm().broadcast(soln);
+        }
+
+      this->write_nodal_data (fname, soln, names);
     }
 }
 

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -66,6 +66,10 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
 
   MeshSerializer serialize(const_cast<MT &>(*_obj), !_is_parallel_format);
 
+  // Build the list of variable names that will be written.
+  std::vector<std::string> names;
+  es.build_variable_names  (names, libmesh_nullptr, system_names);
+
   if (!_is_parallel_format)
     {
       // We need a serial mesh for MeshOutput for now
@@ -73,49 +77,33 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
 
       // Build the nodal solution values & get the variable
       // names from the EquationSystems object
-      std::vector<Number>      soln;
-      std::vector<std::string> names;
-
-      es.build_variable_names  (names, libmesh_nullptr, system_names);
+      std::vector<Number> soln;
       es.build_solution_vector (soln, system_names);
 
       this->write_nodal_data (fname, soln, names);
     }
   else // _is_parallel_format
     {
-      std::vector<Number>      soln;
-      std::vector<std::string> names;
-
-      es.build_variable_names  (names, libmesh_nullptr, system_names);
-
       UniquePtr<NumericVector<Number> > parallel_soln =
         es.build_parallel_solution_vector(system_names);
 
-      // Localize parallel_soln into soln.  This is a place-holder.
-      // It is exactly what's already done in
-      // es.build_solution_vector();
-      parallel_soln->localize_to_one(soln);
-
-      // For now, if we're doing a parallel format we're going to
-      // broadcast the vector from processor 0 to all of the
-      // processors to mimic what build_solution_vector used to do.
-      // this is TERRIBLE and WASTEFUL but it's only temporary until
-      // we redesign the output of build_solution_vector and the
-      // inputs to the I/O... both of which should actually be
-      // NumericVectors....
-      if (_is_parallel_format)
-        {
-          size_t size = soln.size();
-          _obj->comm().broadcast(size);
-
-          if(_obj->comm().rank())
-            soln.resize(size);
-
-          _obj->comm().broadcast(soln);
-        }
-
-      this->write_nodal_data (fname, soln, names);
+      this->write_nodal_data (fname, *parallel_soln, names);
     }
+}
+
+
+
+template <class MT>
+void MeshOutput<MT>::write_nodal_data (const std::string & fname,
+                                       const NumericVector<Number> & parallel_soln,
+                                       const std::vector<std::string> & names)
+{
+  // This is the fallback implementation for parallel I/O formats that
+  // do not yet implement proper writing in parallel, and instead rely
+  // on the full solution vector being available on all processors.
+  std::vector<Number> soln;
+  parallel_soln.localize(soln);
+  this->write_nodal_data(fname, soln, names);
 }
 
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -31,7 +31,6 @@
 #include "libmesh/utility.h" // is_sorted, deallocate
 #include "libmesh/boundary_info.h"
 #include "libmesh/mesh_communication.h"
-#include "libmesh/numeric_vector.h"
 
 namespace libMesh
 {
@@ -1244,17 +1243,16 @@ void Nemesis_IO::write_timestep (const std::string &,
 
 #endif // #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
 
+
+
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
 
-void Nemesis_IO::write_nodal_data (const std::string & base_filename,
-                                   const std::vector<Number> & soln,
-                                   const std::vector<std::string> & names)
+void Nemesis_IO::prepare_to_write_nodal_data (const std::string & fname,
+                                              const std::vector<std::string> & names)
 {
-  LOG_SCOPE("write_nodal_data()", "Nemesis_IO");
-
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
-  std::string nemesis_filename = nemhelper->construct_nemesis_filename(base_filename);
+  std::string nemesis_filename = nemhelper->construct_nemesis_filename(fname);
 
   if (!nemhelper->opened_for_writing)
     {
@@ -1300,82 +1298,29 @@ void Nemesis_IO::write_nodal_data (const std::string & base_filename,
 #endif
         }
     }
-
-  nemhelper->write_nodal_solution(soln, names, _timestep);
 }
 
 #else
 
-void Nemesis_IO::write_nodal_data (const std::string & ,
-                                   const std::vector<Number> & ,
-                                   const std::vector<std::string> & )
+void Nemesis_IO::prepare_to_write_nodal_data (const std::string & fname,
+                                              const std::vector<std::string> & names)
 {
   libmesh_error_msg("ERROR, Nemesis API is not defined.");
 }
 
-
-#endif // #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
+#endif
 
 
 
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
 
-// TODO: this will eventually replace the other version of
-// write_nodal_data() that takes a std::vector.
 void Nemesis_IO::write_nodal_data (const std::string & base_filename,
                                    const NumericVector<Number> & parallel_soln,
                                    const std::vector<std::string> & names)
 {
-  LOG_SCOPE("write_nodal_data()", "Nemesis_IO");
+  LOG_SCOPE("write_nodal_data(parallel)", "Nemesis_IO");
 
-  const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
-
-  std::string nemesis_filename = nemhelper->construct_nemesis_filename(base_filename);
-
-  if (!nemhelper->opened_for_writing)
-    {
-      // If we're appending, open() the file with read_only=false,
-      // otherwise create() it and write the contents of the mesh to
-      // it.
-      if (_append)
-        {
-          nemhelper->open(nemesis_filename.c_str(), /*read_only=*/false);
-          // After opening the file, read the header so that certain
-          // fields, such as the number of nodes and the number of
-          // elements, are correctly initialized for the subsequent
-          // call to write the nodal solution.
-          nemhelper->read_header();
-        }
-      else
-        {
-          nemhelper->create(nemesis_filename);
-          nemhelper->initialize(nemesis_filename,mesh);
-          nemhelper->write_nodal_coordinates(mesh);
-          nemhelper->write_elements(mesh);
-          nemhelper->write_nodesets(mesh);
-          nemhelper->write_sidesets(mesh);
-
-          if( (mesh.get_boundary_info().n_edge_conds() > 0) &&
-              _verbose )
-            {
-              libMesh::out << "Warning: Mesh contains edge boundary IDs, but these "
-                           << "are not supported by the ExodusII format."
-                           << std::endl;
-            }
-
-          // If we don't have any nodes written out on this processor,
-          // Exodus seems to like us better if we don't try to write out any
-          // variable names too...
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-
-          std::vector<std::string> complex_names = nemhelper->get_complex_names(names);
-
-          nemhelper->initialize_nodal_variables(complex_names);
-#else
-          nemhelper->initialize_nodal_variables(names);
-#endif
-        }
-    }
+  this->prepare_to_write_nodal_data(base_filename, names);
 
   // Call the new version of write_nodal_solution() that takes a
   // NumericVector directly without localizing.
@@ -1386,6 +1331,32 @@ void Nemesis_IO::write_nodal_data (const std::string & base_filename,
 
 void Nemesis_IO::write_nodal_data (const std::string &,
                                    const NumericVector<Number> &,
+                                   const std::vector<std::string> &)
+{
+  libmesh_error_msg("ERROR, Nemesis API is not defined.");
+}
+
+#endif
+
+
+
+#if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
+
+void Nemesis_IO::write_nodal_data (const std::string & base_filename,
+                                   const std::vector<Number> & soln,
+                                   const std::vector<std::string> & names)
+{
+  LOG_SCOPE("write_nodal_data(serialized)", "Nemesis_IO");
+
+  this->prepare_to_write_nodal_data(base_filename, names);
+
+  nemhelper->write_nodal_solution(soln, names, _timestep);
+}
+
+#else
+
+void Nemesis_IO::write_nodal_data (const std::string &,
+                                   const std::vector<Number> &,
                                    const std::vector<std::string> &)
 {
   libmesh_error_msg("ERROR, Nemesis API is not defined.");

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1377,11 +1377,9 @@ void Nemesis_IO::write_nodal_data (const std::string & base_filename,
         }
     }
 
-  // Localize the parallel solution on all procs, and call the
-  // function in the helper.
-  std::vector<Number> soln;
-  parallel_soln.localize(soln);
-  nemhelper->write_nodal_solution(soln, names, _timestep);
+  // Call the new version of write_nodal_solution() that takes a
+  // NumericVector directly without localizing.
+  nemhelper->write_nodal_solution(parallel_soln, names, _timestep);
 }
 
 #else

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2484,7 +2484,6 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
 {
   int num_vars = cast_int<int>(names.size());
 
-  // Debugging: Print out the nodes we are responsible for
   for (int c=0; c<num_vars; c++)
     {
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
@@ -2496,10 +2495,7 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
       std::vector<numeric_index_type> required_indices(num_nodes);
 
       for (int i=0; i<num_nodes; i++)
-        {
-          dof_id_type dof_needed = this->exodus_node_num_to_libmesh[i]*num_vars + c;
-          required_indices[i] = dof_needed;
-        }
+        required_indices[i] = this->exodus_node_num_to_libmesh[i]*num_vars + c;
 
       // Hard-code the scatter operation for PETSc vectors for now...
 

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -30,9 +30,6 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/numeric_vector.h"
 
-// Temporarily, to get PetscVec stuff working
-#include "libmesh/petsc_vector.h"
-
 #if defined(LIBMESH_HAVE_NEMESIS_API) && defined(LIBMESH_HAVE_EXODUS_API)
 
 namespace libMesh
@@ -2497,94 +2494,13 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
       for (int i=0; i<num_nodes; i++)
         required_indices[i] = this->exodus_node_num_to_libmesh[i]*num_vars + c;
 
-      // Hard-code the scatter operation for PETSc vectors for now...
+      // Get the dof values required to write just our local part of
+      // the solution vector.
+      std::vector<Number> local_soln;
+      parallel_soln.localize(local_soln, required_indices);
 
-      // Create a sequential destination Vec with the right number of entries on each proc.
-      Vec dest;
-      PetscErrorCode ierr = 0;
-      ierr = VecCreateSeq(PETSC_COMM_SELF, required_indices.size(), &dest);
-      LIBMESH_CHKERR(ierr);
-
-      // Create an IS using the libmesh routine.  PETSc does not own the
-      // IS memory in this case, it is automatically cleaned up by the
-      // std::vector destructor.
-      IS is;
-      ierr = ISCreateLibMesh(parallel_soln.comm().get(),
-                             required_indices.size(),
-                             numeric_petsc_cast(&required_indices[0]),
-                             PETSC_USE_POINTER,
-                             &is);
-      LIBMESH_CHKERR(ierr);
-
-      // Cast the incoming NumericVector to a PetscVector.
-      const PetscVector<Number> * parallel_soln_as_petscvector =
-        dynamic_cast<const PetscVector<Number> *>(&parallel_soln);
-
-      if (!parallel_soln_as_petscvector)
-        libmesh_error_msg("Cast failed.");
-
-      // Get the underlying Vec. We have to cast away constness
-      // because VecScatterCreate requires a non-const Vec and the
-      // PetscVector::vec() function is non-const.
-      Vec parallel_vec = const_cast<PetscVector<Number>* >(parallel_soln_as_petscvector)->vec();
-
-      // Create VecScatter.  "NULL" means "use the identity IS".
-      VecScatter scatter;
-      ierr = VecScatterCreate(/*src vec=*/parallel_vec,
-                              /*src is=*/is,
-                              /*dest vec=*/dest,
-                              /*dest is=*/NULL,
-                              &scatter);
-      LIBMESH_CHKERR(ierr);
-
-      // Do the scatter
-      ierr = VecScatterBegin(scatter, parallel_vec, dest, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-      ierr = VecScatterEnd(scatter, parallel_vec, dest, INSERT_VALUES, SCATTER_FORWARD);
-      LIBMESH_CHKERR(ierr);
-
-      // Print the values of dest.  Hopefully they are different on each
-      // proc...  This is a sequential vector but we are passing
-      // init.comm(), which doesn't seem consistent.  Since this object
-      // is only for printing, though, who cares.
-//      {
-//        PetscVector<Number> wrapper(dest, parallel_soln.comm());
-//        for (numeric_index_type i=0; i<required_indices.size(); ++i)
-//          libMesh::out << wrapper(i) << " ";
-//        libMesh::out << std::endl;
-//      }
-
-      // Now, we want to call:
-      // write_nodal_values(c+1,cur_soln,timestep);
-      // passing a std::vector as the second argument, so make that
-      // std::vector now.
-      PetscScalar * values;
-      ierr = VecGetArray (dest, &values);
-      LIBMESH_CHKERR(ierr);
-      std::vector<Number> cur_soln(values, values+required_indices.size());
-
-//      // Debugging: make sure that worked
-//      for (numeric_index_type i=0; i<required_indices.size(); ++i)
-//        libMesh::out << cur_soln[i] << " ";
-//      libMesh::out << std::endl;
-
-      // We are supposed to restore the array when we're done, so do that.
-      ierr = VecRestoreArray (dest, &values);
-      LIBMESH_CHKERR(ierr);
-
-      // Finally, we can call the funcion that actually writes the
-      // values to the Exodus file.
-      write_nodal_values(c+1, cur_soln, timestep);
-
-      // Clean up
-      ierr = LibMeshISDestroy (&is);
-      LIBMESH_CHKERR(ierr);
-
-      ierr = LibMeshVecScatterDestroy(&scatter);
-      LIBMESH_CHKERR(ierr);
-
-      ierr = LibMeshVecDestroy(&dest);
-      LIBMESH_CHKERR(ierr);
+      // Call the ExodusII_IO_Helper function to write the data.
+      write_nodal_values(c+1, local_soln, timestep);
     }
 }
 

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2481,13 +2481,10 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
 {
   int num_vars = cast_int<int>(names.size());
 
+#ifndef LIBMESH_USE_COMPLEX_NUMBERS
+
   for (int c=0; c<num_vars; c++)
     {
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-      // TODO: once we get the real-valued version working...
-      libmesh_not_implemented();
-#endif
-
       // Fill up a std::vector with the dofs for the current variable
       std::vector<numeric_index_type> required_indices(num_nodes);
 
@@ -2502,6 +2499,44 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
       // Call the ExodusII_IO_Helper function to write the data.
       write_nodal_values(c+1, local_soln, timestep);
     }
+
+#else // LIBMESH_USE_COMPLEX_NUMBERS
+
+  for (int c=0; c<num_vars; c++)
+    {
+      // Fill up a std::vector with the dofs for the current variable
+      std::vector<numeric_index_type> required_indices(num_nodes);
+
+      for (int i=0; i<num_nodes; i++)
+        required_indices[i] = this->exodus_node_num_to_libmesh[i]*num_vars + c;
+
+      // Get the dof values required to write just our local part of
+      // the solution vector.
+      std::vector<Number> local_soln;
+      parallel_soln.localize(local_soln, required_indices);
+
+      // We have the local (complex) values. Now extract the real,
+      // imaginary, and magnitude values from them.
+      std::vector<Real> real_parts(num_nodes);
+      std::vector<Real> imag_parts(num_nodes);
+      std::vector<Real> magnitudes(num_nodes);
+
+      for (int i=0; i<num_nodes; ++i)
+        {
+          real_parts[i] = local_soln[i].real();
+          imag_parts[i] = local_soln[i].imag();
+          magnitudes[i] = std::abs(local_soln[i]);
+        }
+
+      // Write the real, imaginary, and magnitude values to file.
+      write_nodal_values(3*c+1, real_parts, timestep);
+      write_nodal_values(3*c+2, imag_parts, timestep);
+      write_nodal_values(3*c+3, magnitudes, timestep);
+    }
+
+#endif
+
+
 }
 
 

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2474,7 +2474,6 @@ void Nemesis_IO_Helper::write_nodal_solution(const std::vector<Number> & values,
 
 
 
-// TODO: this should eventually completely replace the other version of write_nodal_solution.
 void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & parallel_soln,
                                              const std::vector<std::string> & names,
                                              int timestep)

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -83,6 +83,8 @@ VTKIO::VTKIO (MeshBase & mesh, MeshData * mesh_data) :
   ,_compress(false)
 #endif
 {
+  // Ignore unused parameters when !LIBMESH_HAVE_VTK
+  libmesh_ignore(mesh_data);
   libmesh_experimental();
 }
 
@@ -97,6 +99,8 @@ VTKIO::VTKIO (const MeshBase & mesh, MeshData * mesh_data) :
   ,_compress(false)
 #endif
 {
+  // Ignore unused parameters when !LIBMESH_HAVE_VTK
+  libmesh_ignore(mesh_data);
   libmesh_experimental();
 }
 

--- a/src/numerics/eigen_sparse_vector.C
+++ b/src/numerics/eigen_sparse_vector.C
@@ -352,6 +352,19 @@ void EigenSparseVector<T>::localize (NumericVector<T> & v_local_in,
 
 
 template <typename T>
+void EigenSparseVector<T>::localize (std::vector<T> & v_local,
+                                     const std::vector<numeric_index_type> & indices) const
+{
+  // EigenSparseVectors are serial, so we can just copy values
+  v_local.resize(indices.size());
+
+  for (numeric_index_type i=0; i<v_local.size(); i++)
+    v_local[i] = (*this)(indices[i]);
+}
+
+
+
+template <typename T>
 void EigenSparseVector<T>::localize (const numeric_index_type libmesh_dbg_var(first_local_idx),
                                      const numeric_index_type libmesh_dbg_var(last_local_idx),
                                      const std::vector<numeric_index_type> & libmesh_dbg_var(send_list))

--- a/src/numerics/laspack_vector.C
+++ b/src/numerics/laspack_vector.C
@@ -362,6 +362,19 @@ void LaspackVector<T>::localize (NumericVector<T> & v_local_in,
 
 
 template <typename T>
+void LaspackVector<T>::localize (std::vector<T> & v_local,
+                                 const std::vector<numeric_index_type> & indices) const
+{
+  // LaspackVectors are serial, so we can just copy values
+  v_local.resize(indices.size());
+
+  for (numeric_index_type i=0; i<v_local.size(); i++)
+    v_local[i] = (*this)(indices[i]);
+}
+
+
+
+template <typename T>
 void LaspackVector<T>::localize (const numeric_index_type libmesh_dbg_var(first_local_idx),
                                  const numeric_index_type libmesh_dbg_var(last_local_idx),
                                  const std::vector<numeric_index_type> & libmesh_dbg_var(send_list))


### PR DESCRIPTION
Previously, we were broadcasting the serialized node-major solution vector to all processors in order to support parallel I/O.  This is obviously a big waste of memory for large problems, and has been replaced by an algorithm that does additional parallel communication to get just the values needed.  VTKIO, another parallel I/O class, currently falls back on the existing broadcast implementation, but could also be updated in the future.

A new kind of `NumericVector::localize()` interface (with implementations for PETSc, Trilinos, and the serial NumericVector types) was added to support this capability.  The basic idea is described in the numeric_vector.h documentation:

```
  /**
   * Fill in the local std::vector "v_local" with the global indices
   * given in "indices".  Note that indices can be different on every
   * processor, and the same index can be localized to more than one
   * processor.  The resulting v_local can be shorter than the
   * original, and the entries will be in the order specified by
   * indices.
   *
   * Example:
   *   On 4 procs *this = {a, b, c, d, e, f, g, h, i} is a parallel vector.
   *   On each proc, the indices arrays are set up as:
   *   proc0, indices = {1,2,4,5}
   *   proc1, indices = {2,5,6,8}
   *   proc2, indices = {2,3,6,7}
   *   proc3, indices = {0,1,2,3}
   *
   *   After calling this version of localize, the v_local vectors are:
   *   proc0, v_local = {b,c,e,f}
   *   proc1, v_local = {c,f,g,i}
   *   proc2, v_local = {c,d,g,h}
   *   proc3, v_local = {a,b,c,d}
   *
   * This function is useful in parallel I/O routines, when you have a
   * parallel vector of solution values which you want to write a
   * subset of.
   */
```


