### PR TITLE
Reindent source

### DIFF
--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -517,10 +517,10 @@ protected:
     calculations_started = true;
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-  // Second derivative calculations currently have first derivative
-  // calculations as a prerequisite
-  if (calculate_d2xyz)
-    calculate_dxyz = true;
+    // Second derivative calculations currently have first derivative
+    // calculations as a prerequisite
+    if (calculate_d2xyz)
+      calculate_dxyz = true;
 #endif
   }
 

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -50,8 +50,7 @@ public:
    * Constructor. Enables implicit conversion from an Order
    * enum to an OrderWrapper.
    */
-  OrderWrapper(Order order)
-  :
+  OrderWrapper(Order order) :
     _order(static_cast<int>(order))
   {}
 
@@ -59,8 +58,7 @@ public:
    * Constructor. Enables implicit conversion from an int
    * to an OrderWrapper.
    */
-  OrderWrapper(int order)
-  :
+  OrderWrapper(int order) :
     _order(order)
   {}
 

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -183,7 +183,7 @@ public:
    */
   void make_node_ids_parallel_consistent (MeshBase &);
 
- /**
+  /**
    * Assuming all unique_ids on local nodes are globally unique, and
    * assuming all processor ids are parallel consistent, this function makes
    * all ghost unique_ids parallel consistent.

--- a/include/numerics/const_function.h
+++ b/include/numerics/const_function.h
@@ -34,8 +34,11 @@ class ConstFunction : public FunctionBase<Output>
 {
 public:
   explicit
-  ConstFunction (const Output & c) : _c(c) { this->_initialized = true;
-                                             this->_is_time_dependent = false;}
+  ConstFunction (const Output & c) : _c(c)
+  {
+    this->_initialized = true;
+    this->_is_time_dependent = false;
+  }
 
   virtual Output operator() (const Point &,
                              const Real = 0) libmesh_override

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -64,11 +64,9 @@ public:
 #endif // LIBMESH_HAVE_MPI
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-  typedef
-  std::pair<Hilbert::HilbertIndices, unique_id_type> DofObjectKey;
+typedef std::pair<Hilbert::HilbertIndices, unique_id_type> DofObjectKey;
 #else
-  typedef
-  Hilbert::HilbertIndices DofObjectKey;
+typedef Hilbert::HilbertIndices DofObjectKey;
 #endif
 
 
@@ -85,10 +83,8 @@ namespace Hilbert {
 // XCode didn't find it in the libMesh namespace.
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
 inline
-std::ostream&
-operator <<
-  (std::ostream& os,
-   const libMesh::Parallel::DofObjectKey & hilbert_pair)
+std::ostream & operator << (std::ostream& os,
+                            const libMesh::Parallel::DofObjectKey & hilbert_pair)
 {
   os << '(' << hilbert_pair.first << ',' << hilbert_pair.second << ')' << std::endl;
   return os;

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -40,18 +40,18 @@ namespace Parallel {
   {                                                                     \
   public:                                                               \
     explicit                                                            \
-      StandardType(const cxxtype * = libmesh_nullptr) : DataType(mpitype) {}       \
+      StandardType(const cxxtype * = libmesh_nullptr) : DataType(mpitype) {} \
   }
 
 #else
 
-#define STANDARD_TYPE(cxxtype,mpitype)                          \
-  template<>                                                    \
-  class StandardType<cxxtype> : public DataType                 \
-  {                                                             \
-  public:                                                       \
-    explicit                                                    \
-      StandardType(const cxxtype * = libmesh_nullptr) : DataType() {}      \
+#define STANDARD_TYPE(cxxtype,mpitype)                                  \
+  template<>                                                            \
+  class StandardType<cxxtype> : public DataType                         \
+  {                                                                     \
+  public:                                                               \
+    explicit                                                            \
+      StandardType(const cxxtype * = libmesh_nullptr) : DataType() {}   \
   }
 
 #endif
@@ -2698,7 +2698,7 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
     }
 
   const T* example = sendvec.empty() ?
-                     (recv.empty() ? libmesh_nullptr : &recv[0]) : &sendvec[0];
+    (recv.empty() ? libmesh_nullptr : &recv[0]) : &sendvec[0];
 
   // Call the user-defined type version with automatic
   // type conversion based on template argument:

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -300,7 +300,7 @@ void parallel_for (const Range & range, const Body & body)
   // behavior and optimization.
   // http://blog.llvm.org/2011/05/what-every-c-programmer-should-know.html
   for (int i=0; i<static_cast<int>(n_threads); i++)
-      pthread_join(threads[i], libmesh_nullptr);
+    pthread_join(threads[i], libmesh_nullptr);
 #endif
 
   // Clean up
@@ -403,7 +403,7 @@ void parallel_reduce (const Range & range, Body & body)
 #if !LIBMESH_HAVE_OPENMP
   // Wait for them to finish
   for (unsigned int i=0; i<n_threads; i++)
-      pthread_join(threads[i], libmesh_nullptr);
+    pthread_join(threads[i], libmesh_nullptr);
 #endif
 
   // Join them all down to the original Body

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -556,8 +556,9 @@ protected:
    * Function that indicates when to terminate the Greedy
    * basis training. Overload in subclasses to specialize.
    */
-  virtual bool greedy_termination_test(
-    Real abs_greedy_error, Real initial_greedy_error, int count);
+  virtual bool greedy_termination_test(Real abs_greedy_error,
+                                       Real initial_greedy_error,
+                                       int count);
 
   /**
    * Update the list of Greedily chosen parameters with

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -194,15 +194,17 @@ public:
    * Load \p source into the subvector of \p dest corresponding
    * to var \p var.
    */
-  void set_explicit_sys_subvector(
-    NumericVector<Number>& dest, unsigned int var, NumericVector<Number>& source);
+  void set_explicit_sys_subvector(NumericVector<Number>& dest,
+                                  unsigned int var,
+                                  NumericVector<Number>& source);
 
   /**
    * Load the subvector of \p localized_source corresponding to variable \p var into
    * \p dest. We require localized_source to be localized before we call this method.
    */
-  void get_explicit_sys_subvector(
-    NumericVector<Number>& dest, unsigned int var, NumericVector<Number>& localized_source);
+  void get_explicit_sys_subvector(NumericVector<Number>& dest,
+                                  unsigned int var,
+                                  NumericVector<Number>& localized_source);
 
   /**
    * Set up the index map between the implicit and explicit systems.
@@ -265,8 +267,9 @@ protected:
    * Function that indicates when to terminate the Greedy
    * basis training. Overload in subclasses to specialize.
    */
-  virtual bool greedy_termination_test(
-    Real abs_greedy_error, Real initial_greedy_error, int count) libmesh_override;
+  virtual bool greedy_termination_test(Real abs_greedy_error,
+                                       Real initial_greedy_error,
+                                       int count) libmesh_override;
 
   /**
    * Loop over the training set and compute the parametrized function for each

--- a/include/reduced_basis/transient_rb_construction.h
+++ b/include/reduced_basis/transient_rb_construction.h
@@ -118,8 +118,9 @@ public:
    * Function that indicates when to terminate the Greedy
    * basis training.
    */
-  virtual bool greedy_termination_test(
-    Real abs_greedy_error, Real initial_greedy_error, int count) libmesh_override;
+  virtual bool greedy_termination_test(Real abs_greedy_error,
+                                       Real initial_greedy_error,
+                                       int count) libmesh_override;
 
   /**
    * Assemble and store all the affine operators.

--- a/src/apps/grid2grid.C
+++ b/src/apps/grid2grid.C
@@ -100,8 +100,7 @@ int main (int argc, char ** argv)
     for (unsigned int e=0; e<mesh_coarse.n_elem(); e++)
     {
     libMesh::out << "looking for centroid of element " << e << std::endl;
-    const Elem * elem =
-      octree_coarse.find_element(mesh_coarse.elem_ref(e).centroid(mesh_coarse));
+    const Elem * elem = octree_coarse.find_element(mesh_coarse.elem_ref(e).centroid(mesh_coarse));
 
     libmesh_assert(elem);
     }

--- a/src/error_estimation/weighted_patch_recovery_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_estimator.C
@@ -197,7 +197,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                  (error_estimator.error_norm.type(var-1) == L_INF ||
                   error_estimator.error_norm.type(var-1) == W1_INF_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == W2_INF_SEMINORM));
-                libmesh_assert (is_valid_norm_type);
+              libmesh_assert (is_valid_norm_type);
             }
 #endif // DEBUG
 

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -679,7 +679,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
 
         const unsigned int n_mapping_shape_functions =
           FE<2,LAGRANGE>::n_shape_functions (side->type(),
-                                               side->default_order());
+                                             side->default_order());
 
         // compute x, dxdxi at the quadrature points
         for (unsigned int i=0; i<n_mapping_shape_functions; i++) // sum over the nodes
@@ -813,7 +813,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
 
         const unsigned int n_mapping_shape_functions =
           FE<3,LAGRANGE>::n_shape_functions (side->type(),
-                                               side->default_order());
+                                             side->default_order());
 
         // compute x, dxdxi at the quadrature points
         for (unsigned int i=0; i<n_mapping_shape_functions; i++) // sum over the nodes

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -192,19 +192,27 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
               {
                 if (calculate_xyz)
                   this->phi_map[i][0] =
-                    FE<Dim,LAGRANGE>::shape
-                      (mapping_elem_type, mapping_order, i, qp[0]);
+                    FE<Dim,LAGRANGE>::shape(mapping_elem_type,
+                                            mapping_order,
+                                            i,
+                                            qp[0]);
 
                 if (calculate_dxyz)
                   this->dphidxi_map[i][0] =
-                    FE<Dim,LAGRANGE>::shape_deriv
-                      (mapping_elem_type, mapping_order, i, 0, qp[0]);
+                    FE<Dim,LAGRANGE>::shape_deriv(mapping_elem_type,
+                                                  mapping_order,
+                                                  i,
+                                                  0,
+                                                  qp[0]);
 
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                 if (calculate_d2xyz)
                   this->d2phidxi2_map[i][0] =
-                    FE<Dim,LAGRANGE>::shape_second_deriv
-                      (mapping_elem_type, mapping_order, i, 0, qp[0]);
+                    FE<Dim,LAGRANGE>::shape_second_deriv(mapping_elem_type,
+                                                         mapping_order,
+                                                         i,
+                                                         0,
+                                                         qp[0]);
 #endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                 for (std::size_t p=1; p<n_qp; p++)
                   {

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -609,7 +609,7 @@ void CheckpointIO::read_connectivity (Xdr & io)
 
           Elem * parent =
             (parent_id == DofObject::invalid_processor_id) ?
-             libmesh_nullptr : mesh.elem_ptr(parent_id);
+            libmesh_nullptr : mesh.elem_ptr(parent_id);
 
           // Create the element
           Elem * elem = Elem::build(elem_type, parent).release();

--- a/src/mesh/diva_io.C
+++ b/src/mesh/diva_io.C
@@ -155,38 +155,38 @@ void DivaIO::write_stream (std::ostream & out_file)
      */
     for(unsigned int e=0; e<the_mesh.n_elem(); e++)
       {
-      const Elem & elem = the_mesh.elem_ref(e);
-      if (elem.active())
-        for (unsigned int s=0; s<elem.n_sides(); s++)
-          if (elem.neighbor(s) == libmesh_nullptr)
-            {
-              const UniquePtr<Elem> side(elem.build_side(s));
+        const Elem & elem = the_mesh.elem_ref(e);
+        if (elem.active())
+          for (unsigned int s=0; s<elem.n_sides(); s++)
+            if (elem.neighbor(s) == libmesh_nullptr)
+              {
+                const UniquePtr<Elem> side(elem.build_side(s));
 
-              if (side->type() == TRI3)
-                {
-                  out_file << side->node_id(0)+1 << " "
-                           << side->node_id(1)+1 << " "
-                           << side->node_id(2)+1 << '\n';
-                }
-              else if (side->type() == TRI6)
-                {
-                  out_file << side->node_id(0)+1 << " "
-                           << side->node_id(3)+1 << " "
-                           << side->node_id(5)+1 << '\n'
+                if (side->type() == TRI3)
+                  {
+                    out_file << side->node_id(0)+1 << " "
+                             << side->node_id(1)+1 << " "
+                             << side->node_id(2)+1 << '\n';
+                  }
+                else if (side->type() == TRI6)
+                  {
+                    out_file << side->node_id(0)+1 << " "
+                             << side->node_id(3)+1 << " "
+                             << side->node_id(5)+1 << '\n'
 
-                           << side->node_id(3)+1 << " "
-                           << side->node_id(1)+1 << " "
-                           << side->node_id(4)+1 << '\n'
+                             << side->node_id(3)+1 << " "
+                             << side->node_id(1)+1 << " "
+                             << side->node_id(4)+1 << '\n'
 
-                           << side->node_id(5)+1 << " "
-                           << side->node_id(4)+1 << " "
-                           << side->node_id(2)+1 << '\n'
+                             << side->node_id(5)+1 << " "
+                             << side->node_id(4)+1 << " "
+                             << side->node_id(2)+1 << '\n'
 
-                           << side->node_id(3)+1 << " "
-                           << side->node_id(4)+1 << " "
-                           << side->node_id(5)+1 << '\n';
-                }
-            }
+                             << side->node_id(3)+1 << " "
+                             << side->node_id(4)+1 << " "
+                             << side->node_id(5)+1 << '\n';
+                  }
+              }
       }
 
 
@@ -195,44 +195,44 @@ void DivaIO::write_stream (std::ostream & out_file)
      */
     for(unsigned int e=0; e<the_mesh.n_elem(); e++)
       {
-      const Elem & elem = the_mesh.elem_ref(e);
-      if (elem.active())
-        for (unsigned int s=0; s<elem.n_sides(); s++)
-          if (elem.neighbor(s) == libmesh_nullptr)
-            {
-              const UniquePtr<Elem> side(elem.build_side(s));
+        const Elem & elem = the_mesh.elem_ref(e);
+        if (elem.active())
+          for (unsigned int s=0; s<elem.n_sides(); s++)
+            if (elem.neighbor(s) == libmesh_nullptr)
+              {
+                const UniquePtr<Elem> side(elem.build_side(s));
 
-              if ((side->type() == QUAD4) ||
-                  (side->type() == QUAD8)  )
-                {
-                  out_file << side->node_id(0)+1 << " "
-                           << side->node_id(1)+1 << " "
-                           << side->node_id(2)+1 << " "
-                           << side->node_id(3)+1 << '\n';
-                }
-              else if (side->type() == QUAD9)
-                {
-                  out_file << side->node_id(0)+1 << " "
-                           << side->node_id(4)+1 << " "
-                           << side->node_id(8)+1 << " "
-                           << side->node_id(7)+1 << '\n'
+                if ((side->type() == QUAD4) ||
+                    (side->type() == QUAD8)  )
+                  {
+                    out_file << side->node_id(0)+1 << " "
+                             << side->node_id(1)+1 << " "
+                             << side->node_id(2)+1 << " "
+                             << side->node_id(3)+1 << '\n';
+                  }
+                else if (side->type() == QUAD9)
+                  {
+                    out_file << side->node_id(0)+1 << " "
+                             << side->node_id(4)+1 << " "
+                             << side->node_id(8)+1 << " "
+                             << side->node_id(7)+1 << '\n'
 
-                           << side->node_id(4)+1 << " "
-                           << side->node_id(1)+1 << " "
-                           << side->node_id(5)+1 << " "
-                           << side->node_id(8)+1 << '\n'
+                             << side->node_id(4)+1 << " "
+                             << side->node_id(1)+1 << " "
+                             << side->node_id(5)+1 << " "
+                             << side->node_id(8)+1 << '\n'
 
-                           << side->node_id(7)+1 << " "
-                           << side->node_id(8)+1 << " "
-                           << side->node_id(6)+1 << " "
-                           << side->node_id(3)+1 << '\n'
+                             << side->node_id(7)+1 << " "
+                             << side->node_id(8)+1 << " "
+                             << side->node_id(6)+1 << " "
+                             << side->node_id(3)+1 << '\n'
 
-                           << side->node_id(8)+1 << " "
-                           << side->node_id(5)+1 << " "
-                           << side->node_id(2)+1 << " "
-                           << side->node_id(6)+1 << '\n';
-                }
-            }
+                             << side->node_id(8)+1 << " "
+                             << side->node_id(5)+1 << " "
+                             << side->node_id(2)+1 << " "
+                             << side->node_id(6)+1 << '\n';
+                  }
+              }
       }
   }
 
@@ -247,19 +247,19 @@ void DivaIO::write_stream (std::ostream & out_file)
      */
     for(unsigned int e=0; e<the_mesh.n_elem(); e++)
       {
-      const Elem & elem = the_mesh.elem_ref(e);
-      if (elem.active())
-        for (unsigned short s=0; s<elem.n_sides(); s++)
-          if (elem.neighbor(s) == libmesh_nullptr)
-            {
-              const UniquePtr<Elem> side(elem.build_side(s));
+        const Elem & elem = the_mesh.elem_ref(e);
+        if (elem.active())
+          for (unsigned short s=0; s<elem.n_sides(); s++)
+            if (elem.neighbor(s) == libmesh_nullptr)
+              {
+                const UniquePtr<Elem> side(elem.build_side(s));
 
-              if ((side->type() == TRI3) ||
-                  (side->type() == TRI6)  )
+                if ((side->type() == TRI3) ||
+                    (side->type() == TRI6)  )
 
-                out_file << the_mesh.get_boundary_info().boundary_id(&elem, s)
-                         << '\n';
-            }
+                  out_file << the_mesh.get_boundary_info().boundary_id(&elem, s)
+                           << '\n';
+              }
       }
 
 
@@ -268,19 +268,19 @@ void DivaIO::write_stream (std::ostream & out_file)
      */
     for(unsigned int e=0; e<the_mesh.n_elem(); e++)
       {
-      const Elem & elem = the_mesh.elem_ref(e);
-      if (elem.active())
-        for (unsigned short s=0; s<elem.n_sides(); s++)
-          if (elem.neighbor(s) == libmesh_nullptr)
-            {
-              const UniquePtr<Elem> side(elem.build_side(s));
+        const Elem & elem = the_mesh.elem_ref(e);
+        if (elem.active())
+          for (unsigned short s=0; s<elem.n_sides(); s++)
+            if (elem.neighbor(s) == libmesh_nullptr)
+              {
+                const UniquePtr<Elem> side(elem.build_side(s));
 
-              if ((side->type() == QUAD4) ||
-                  (side->type() == QUAD8) ||
-                  (side->type() == QUAD9))
+                if ((side->type() == QUAD4) ||
+                    (side->type() == QUAD8) ||
+                    (side->type() == QUAD9))
 
-                out_file << the_mesh.get_boundary_info().boundary_id(&elem, s);
-            }
+                  out_file << the_mesh.get_boundary_info().boundary_id(&elem, s);
+              }
       }
   }
 
@@ -291,59 +291,59 @@ void DivaIO::write_stream (std::ostream & out_file)
    */
   for (unsigned int e=0; e<the_mesh.n_elem(); e++)
     {
-    const Elem & elem = the_mesh.elem_ref(e);
-    if (elem.active())
-      {
-        if (elem.type() == TET4)
-          {
-            out_file << elem.node_id(0)+1 << " "
-                     << elem.node_id(1)+1 << " "
-                     << elem.node_id(2)+1 << " "
-                     << elem.node_id(3)+1 << '\n';
-          }
-        else if (elem.type() == TET10)
-          {
-            out_file << elem.node_id(0)+1 << " "
-                     << elem.node_id(4)+1 << " "
-                     << elem.node_id(6)+1 << " "
-                     << elem.node_id(7)+1 << '\n';
+      const Elem & elem = the_mesh.elem_ref(e);
+      if (elem.active())
+        {
+          if (elem.type() == TET4)
+            {
+              out_file << elem.node_id(0)+1 << " "
+                       << elem.node_id(1)+1 << " "
+                       << elem.node_id(2)+1 << " "
+                       << elem.node_id(3)+1 << '\n';
+            }
+          else if (elem.type() == TET10)
+            {
+              out_file << elem.node_id(0)+1 << " "
+                       << elem.node_id(4)+1 << " "
+                       << elem.node_id(6)+1 << " "
+                       << elem.node_id(7)+1 << '\n';
 
-            out_file << elem.node_id(4)+1 << " "
-                     << elem.node_id(1)+1 << " "
-                     << elem.node_id(5)+1 << " "
-                     << elem.node_id(8)+1 << '\n';
+              out_file << elem.node_id(4)+1 << " "
+                       << elem.node_id(1)+1 << " "
+                       << elem.node_id(5)+1 << " "
+                       << elem.node_id(8)+1 << '\n';
 
-            out_file << elem.node_id(6)+1 << " "
-                     << elem.node_id(5)+1 << " "
-                     << elem.node_id(2)+1 << " "
-                     << elem.node_id(9)+1 << '\n';
+              out_file << elem.node_id(6)+1 << " "
+                       << elem.node_id(5)+1 << " "
+                       << elem.node_id(2)+1 << " "
+                       << elem.node_id(9)+1 << '\n';
 
-            out_file << elem.node_id(7)+1 << " "
-                     << elem.node_id(8)+1 << " "
-                     << elem.node_id(9)+1 << " "
-                     << elem.node_id(3)+1 << '\n';
+              out_file << elem.node_id(7)+1 << " "
+                       << elem.node_id(8)+1 << " "
+                       << elem.node_id(9)+1 << " "
+                       << elem.node_id(3)+1 << '\n';
 
-            out_file << elem.node_id(4)+1 << " "
-                     << elem.node_id(8)+1 << " "
-                     << elem.node_id(6)+1 << " "
-                     << elem.node_id(7)+1 << '\n';
+              out_file << elem.node_id(4)+1 << " "
+                       << elem.node_id(8)+1 << " "
+                       << elem.node_id(6)+1 << " "
+                       << elem.node_id(7)+1 << '\n';
 
-            out_file << elem.node_id(4)+1 << " "
-                     << elem.node_id(5)+1 << " "
-                     << elem.node_id(6)+1 << " "
-                     << elem.node_id(8)+1 << '\n';
+              out_file << elem.node_id(4)+1 << " "
+                       << elem.node_id(5)+1 << " "
+                       << elem.node_id(6)+1 << " "
+                       << elem.node_id(8)+1 << '\n';
 
-            out_file << elem.node_id(6)+1 << " "
-                     << elem.node_id(5)+1 << " "
-                     << elem.node_id(9)+1 << " "
-                     << elem.node_id(8)+1 << '\n';
+              out_file << elem.node_id(6)+1 << " "
+                       << elem.node_id(5)+1 << " "
+                       << elem.node_id(9)+1 << " "
+                       << elem.node_id(8)+1 << '\n';
 
-            out_file << elem.node_id(6)+1 << " "
-                     << elem.node_id(8)+1 << " "
-                     << elem.node_id(9)+1 << " "
-                     << elem.node_id(7)+1 << '\n';
-          }
-      }
+              out_file << elem.node_id(6)+1 << " "
+                       << elem.node_id(8)+1 << " "
+                       << elem.node_id(9)+1 << " "
+                       << elem.node_id(7)+1 << '\n';
+            }
+        }
     }
 
 
@@ -352,16 +352,16 @@ void DivaIO::write_stream (std::ostream & out_file)
    */
   for (unsigned int e=0; e<the_mesh.n_elem(); e++)
     {
-    const Elem & elem = the_mesh.elem_ref(e);
-    if (elem.active())
-      if (elem.type() == PYRAMID5)
-        {
-          out_file << elem.node_id(0)+1 << " "
-                   << elem.node_id(1)+1 << " "
-                   << elem.node_id(2)+1 << " "
-                   << elem.node_id(3)+1 << " "
-                   << elem.node_id(4)+1 << '\n';
-        }
+      const Elem & elem = the_mesh.elem_ref(e);
+      if (elem.active())
+        if (elem.type() == PYRAMID5)
+          {
+            out_file << elem.node_id(0)+1 << " "
+                     << elem.node_id(1)+1 << " "
+                     << elem.node_id(2)+1 << " "
+                     << elem.node_id(3)+1 << " "
+                     << elem.node_id(4)+1 << '\n';
+          }
     }
 
 
@@ -371,21 +371,21 @@ void DivaIO::write_stream (std::ostream & out_file)
    */
   for (unsigned int e=0; e<the_mesh.n_elem(); e++)
     {
-    const Elem & elem = the_mesh.elem_ref(e);
-    if (elem.active())
-      {
-        if (elem.type() == PRISM6)
-          {
-            out_file << elem.node_id(0)+1 << " "
-                     << elem.node_id(1)+1 << " "
-                     << elem.node_id(2)+1 << " "
-                     << elem.node_id(3)+1 << " "
-                     << elem.node_id(4)+1 << " "
-                     << elem.node_id(5)+1 << '\n';
-          }
-        else if (elem.type() == PRISM18)
-          libmesh_error_msg("PRISM18 element type not supported.");
-      }
+      const Elem & elem = the_mesh.elem_ref(e);
+      if (elem.active())
+        {
+          if (elem.type() == PRISM6)
+            {
+              out_file << elem.node_id(0)+1 << " "
+                       << elem.node_id(1)+1 << " "
+                       << elem.node_id(2)+1 << " "
+                       << elem.node_id(3)+1 << " "
+                       << elem.node_id(4)+1 << " "
+                       << elem.node_id(5)+1 << '\n';
+            }
+          else if (elem.type() == PRISM18)
+            libmesh_error_msg("PRISM18 element type not supported.");
+        }
     }
 
 
@@ -394,27 +394,27 @@ void DivaIO::write_stream (std::ostream & out_file)
    */
   for (unsigned int e=0; e<the_mesh.n_elem(); e++)
     {
-    const Elem & elem = the_mesh.elem_ref(e);
-    if (elem.active())
-      if ((elem.type() == HEX8)   ||
-          (elem.type() == HEX20) ||
-          (elem.type() == HEX27)   )
-        {
-          std::vector<dof_id_type> conn;
-          for (unsigned int se=0; se<elem.n_sub_elem(); se++)
-            {
-              elem.connectivity(se, TECPLOT, conn);
+      const Elem & elem = the_mesh.elem_ref(e);
+      if (elem.active())
+        if ((elem.type() == HEX8)   ||
+            (elem.type() == HEX20) ||
+            (elem.type() == HEX27)   )
+          {
+            std::vector<dof_id_type> conn;
+            for (unsigned int se=0; se<elem.n_sub_elem(); se++)
+              {
+                elem.connectivity(se, TECPLOT, conn);
 
-              out_file << conn[0] << ' '
-                       << conn[1] << ' '
-                       << conn[2] << ' '
-                       << conn[3] << ' '
-                       << conn[4] << ' '
-                       << conn[5] << ' '
-                       << conn[6] << ' '
-                       << conn[7] << '\n';
-            }
-        }
+                out_file << conn[0] << ' '
+                         << conn[1] << ' '
+                         << conn[2] << ' '
+                         << conn[3] << ' '
+                         << conn[4] << ' '
+                         << conn[5] << ' '
+                         << conn[6] << ' '
+                         << conn[7] << '\n';
+              }
+          }
     }
 }
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -204,7 +204,7 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
 
   // Fix up node unique ids in case mesh generation code didn't take
   // exceptional care to do so.
-//  MeshCommunication().make_node_unique_ids_parallel_consistent(*this);
+  //  MeshCommunication().make_node_unique_ids_parallel_consistent(*this);
 
   // We're going to still require that mesh generation code gets
   // element unique ids consistent.

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -42,17 +42,17 @@
 
 namespace
 {
-  bool split_first_diagonal(const libMesh::Elem * elem,
-                            unsigned int diag_1_node_1,
-                            unsigned int diag_1_node_2,
-                            unsigned int diag_2_node_1,
-                            unsigned int diag_2_node_2)
-    {
-      return ((elem->node_id(diag_1_node_1) > elem->node_id(diag_2_node_1) &&
-               elem->node_id(diag_1_node_1) > elem->node_id(diag_2_node_2)) ||
-              (elem->node_id(diag_1_node_2) > elem->node_id(diag_2_node_1) &&
-               elem->node_id(diag_1_node_2) > elem->node_id(diag_2_node_2)));
-    }
+bool split_first_diagonal(const libMesh::Elem * elem,
+                          unsigned int diag_1_node_1,
+                          unsigned int diag_1_node_2,
+                          unsigned int diag_2_node_1,
+                          unsigned int diag_2_node_2)
+{
+  return ((elem->node_id(diag_1_node_1) > elem->node_id(diag_2_node_1) &&
+           elem->node_id(diag_1_node_1) > elem->node_id(diag_2_node_2)) ||
+          (elem->node_id(diag_1_node_2) > elem->node_id(diag_2_node_1) &&
+           elem->node_id(diag_1_node_2) > elem->node_id(diag_2_node_2)));
+}
 
 }
 
@@ -1373,8 +1373,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
           case TET4:
           case TET10:
           case INFEDGE2:
-          // No way to split infinite quad/prism elements, so
-          // hopefully no need to
+            // No way to split infinite quad/prism elements, so
+            // hopefully no need to
           case INFQUAD4:
           case INFQUAD6:
           case INFPRISM6:

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2405,8 +2405,7 @@ void Nemesis_IO_Helper::write_elements(const MeshBase & mesh, bool /*use_discont
           //Note that Exodus assumes all elements in a block are of the same type!
           //We are using that same assumption here!
           const ExodusII_IO_Helper::Conversion conv =
-            em.assign_conversion
-              (mesh.elem_ref(elements_in_this_block[0]).type());
+            em.assign_conversion(mesh.elem_ref(elements_in_this_block[0]).type());
 
           this->num_nodes_per_elem =
             mesh.elem_ref(elements_in_this_block[0]).n_nodes();

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -508,7 +508,7 @@ void DistributedVector<T>::localize (std::vector<T> & v_local,
           // Actually set the value in v_local
           v_local[local_requested_index] = values_to_receive[i];
         }
-   }
+    }
 }
 
 

--- a/src/parallel/parallel_bin_sorter.C
+++ b/src/parallel/parallel_bin_sorter.C
@@ -126,8 +126,7 @@ void BinSorter<KeyType,IdxType>::binsort (const IdxType nbins,
           bin_bounds[b+1] = phist.upper_bound (current_histogram_bin);
           bin_iters[b+1] =
             std::lower_bound(bin_iters[b], data.end(),
-                             Parallel::Utils::Convert<KeyType>::to_key_type
-                               (bin_bounds[b+1]));
+                             Parallel::Utils::Convert<KeyType>::to_key_type(bin_bounds[b+1]));
         }
 
       // Just be sure the last boundary points to the right place

--- a/src/parallel/parallel_histogram.C
+++ b/src/parallel/parallel_histogram.C
@@ -78,8 +78,7 @@ void Histogram<KeyType,IdxType>::make_histogram (const IdxType nbins,
 
       bin_iters[b] =
         std::lower_bound (bin_iters[b-1], data.end(),
-                          Parallel::Utils::Convert<KeyType>::to_key_type
-                            (bin_bounds[b]));
+                          Parallel::Utils::Convert<KeyType>::to_key_type(bin_bounds[b]));
     }
 
   bin_iters[nbins]  = data.end();

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -110,7 +110,7 @@ template <>
 template <>
 unsigned int
 Packing<const Node *>::packable_size (const Node * const & node,
-                                     const ParallelMesh * mesh)
+                                      const ParallelMesh * mesh)
 {
   return packable_size(node, static_cast<const MeshBase *>(mesh));
 }

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -226,15 +226,15 @@ void RBConstruction::process_parameters_file (const std::string & parameters_fil
   unsigned int training_parameters_random_seed_in =
     static_cast<unsigned int>(-1);
   training_parameters_random_seed_in = infile("training_parameters_random_seed",
-                                               training_parameters_random_seed_in);
+                                              training_parameters_random_seed_in);
   const bool quiet_mode_in = infile("quiet_mode", quiet_mode);
   const unsigned int Nmax_in = infile("Nmax", Nmax);
   const Real rel_training_tolerance_in = infile("rel_training_tolerance",
-                                                 rel_training_tolerance);
+                                                rel_training_tolerance);
   const Real abs_training_tolerance_in = infile("abs_training_tolerance",
-                                                 abs_training_tolerance);
+                                                abs_training_tolerance);
   const bool normalize_rb_bound_in_greedy_in = infile("normalize_rb_bound_in_greedy",
-                                                       normalize_rb_bound_in_greedy_in);
+                                                      normalize_rb_bound_in_greedy_in);
 
   // Read in the parameters from the input file too
   unsigned int n_continuous_parameters = infile.vector_variable_size("parameter_names");
@@ -1052,18 +1052,16 @@ Real RBConstruction::train_reduced_basis(const bool resize_rb_eval_data)
           libMesh::out << "Maximum error bound is " << training_greedy_error << std::endl << std::endl;
 
           // record the initial error
-          if(!initial_greedy_error_initialized)
-          {
-            initial_greedy_error = training_greedy_error;
-            initial_greedy_error_initialized = true;
-          }
+          if (!initial_greedy_error_initialized)
+            {
+              initial_greedy_error = training_greedy_error;
+              initial_greedy_error_initialized = true;
+            }
 
           // Break out of training phase if we have reached Nmax
           // or if the training_tolerance is satisfied.
-          if( greedy_termination_test(training_greedy_error, initial_greedy_error, count) )
-            {
-              break;
-            }
+          if (greedy_termination_test(training_greedy_error, initial_greedy_error, count))
+            break;
         }
 
       libMesh::out << "Performing truth solve at parameter:" << std::endl;
@@ -1089,8 +1087,9 @@ Real RBConstruction::train_reduced_basis(const bool resize_rb_eval_data)
   return training_greedy_error;
 }
 
-bool RBConstruction::greedy_termination_test(
-  Real abs_greedy_error, Real initial_error, int)
+bool RBConstruction::greedy_termination_test(Real abs_greedy_error,
+                                             Real initial_error,
+                                             int)
 {
   if(abs_greedy_error < this->abs_training_tolerance)
     {
@@ -1265,22 +1264,20 @@ Real RBConstruction::get_RB_error_bound()
 
   Real error_bound = get_rb_evaluation().rb_solve(get_rb_evaluation().get_n_basis_functions());
 
-  if(normalize_rb_bound_in_greedy)
-  {
-    Real error_bound_normalization = get_rb_evaluation().get_error_bound_normalization();
+  if (normalize_rb_bound_in_greedy)
+    {
+      Real error_bound_normalization = get_rb_evaluation().get_error_bound_normalization();
 
-    if( (error_bound < abs_training_tolerance) ||
-        (error_bound_normalization < abs_training_tolerance) )
-    {
-      // We don't want to normalize this error bound if the bound or the
-      // normalization value are below the absolute tolerance. Hence do nothing
-      // in this case.
+      if ((error_bound < abs_training_tolerance) ||
+          (error_bound_normalization < abs_training_tolerance))
+        {
+          // We don't want to normalize this error bound if the bound or the
+          // normalization value are below the absolute tolerance. Hence do nothing
+          // in this case.
+        }
+      else
+        error_bound /= error_bound_normalization;
     }
-    else
-    {
-      error_bound /= error_bound_normalization;
-    }
-  }
 
   return error_bound;
 }

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -35,8 +35,7 @@ RBEIMAssembly::RBEIMAssembly(RBEIMConstruction & rb_eim_con_in,
                              unsigned int basis_function_index_in)
   : _rb_eim_con(rb_eim_con_in),
     _basis_function_index(basis_function_index_in),
-    _ghosted_basis_function(NumericVector<Number>::build(
-      rb_eim_con_in.get_explicit_system().comm())),
+    _ghosted_basis_function(NumericVector<Number>::build(rb_eim_con_in.get_explicit_system().comm())),
     _fe(NULL),
     _qrule(NULL)
 {
@@ -50,7 +49,7 @@ RBEIMAssembly::RBEIMAssembly(RBEIMConstruction & rb_eim_con_in,
                                  GHOSTED);
   _rb_eim_con.get_rb_evaluation().get_basis_function(_basis_function_index).
     localize(*_ghosted_basis_function,
-              _rb_eim_con.get_explicit_system().get_dof_map().get_send_list());
+             _rb_eim_con.get_explicit_system().get_dof_map().get_send_list());
 #else
   _ghosted_basis_function->init (_rb_eim_con.get_explicit_system().n_dofs(), false, SERIAL);
   _rb_eim_con.get_rb_evaluation().get_basis_function(_basis_function_index).

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -283,11 +283,9 @@ void RBEIMConstruction::load_rb_solution()
                       << " RB_solution vector constains " << get_rb_evaluation().RB_solution.size() << " entries." \
                       << " RB_solution in RBConstruction::load_rb_solution is too long!");
 
-  for(unsigned int i=0; i<get_rb_evaluation().RB_solution.size(); i++)
-    {
-      get_explicit_system().solution->add(
-        get_rb_evaluation().RB_solution(i), get_rb_evaluation().get_basis_function(i));
-    }
+  for (unsigned int i=0; i<get_rb_evaluation().RB_solution.size(); i++)
+    get_explicit_system().solution->add(get_rb_evaluation().RB_solution(i),
+                                        get_rb_evaluation().get_basis_function(i));
 
   get_explicit_system().update();
 }
@@ -303,8 +301,8 @@ void RBEIMConstruction::enrich_RB_space()
 
   // put solution in _ghosted_meshfunction_vector so we can access it from the mesh function
   // this allows us to compute EIM_rhs appropriately
-  get_explicit_system().solution->localize(
-    *_ghosted_meshfunction_vector, get_explicit_system().get_dof_map().get_send_list());
+  get_explicit_system().solution->localize(*_ghosted_meshfunction_vector,
+                                           get_explicit_system().get_dof_map().get_send_list());
 
   RBEIMEvaluation & eim_eval = cast_ref<RBEIMEvaluation &>(get_rb_evaluation());
 
@@ -437,13 +435,15 @@ void RBEIMConstruction::enrich_RB_space()
 
           for (unsigned int var=0; var<get_explicit_system().n_vars(); var++)
             {
-              get_explicit_sys_subvector(
-                *implicit_sys_temp1, var, *localized_new_bf);
+              get_explicit_sys_subvector(*implicit_sys_temp1,
+                                         var,
+                                         *localized_new_bf);
 
               inner_product_matrix->vector_mult(*implicit_sys_temp2, *implicit_sys_temp1);
 
-              set_explicit_sys_subvector(
-                *matrix_times_new_bf, var, *implicit_sys_temp2);
+              set_explicit_sys_subvector(*matrix_times_new_bf,
+                                         var,
+                                         *implicit_sys_temp2);
             }
 
           _matrix_times_bfs.push_back(matrix_times_new_bf);
@@ -553,11 +553,9 @@ Real RBEIMConstruction::compute_best_fit_error()
     }
 
   // load the error into solution
-  for(unsigned int i=0; i<get_rb_evaluation().get_n_basis_functions(); i++)
-    {
-      get_explicit_system().solution->add(
-        -get_rb_evaluation().RB_solution(i), get_rb_evaluation().get_basis_function(i));
-    }
+  for (unsigned int i=0; i<get_rb_evaluation().get_n_basis_functions(); i++)
+    get_explicit_system().solution->add(-get_rb_evaluation().RB_solution(i),
+                                        get_rb_evaluation().get_basis_function(i));
 
   Real best_fit_error = get_explicit_system().solution->linfty_norm();
 
@@ -759,8 +757,7 @@ void RBEIMConstruction::update_RB_system_matrices()
             for(unsigned int var=0; var<get_explicit_system().n_vars(); var++)
               {
                 get_explicit_sys_subvector(*temp1, var, *localized_basis_function);
-                inner_product_matrix->vector_mult(
-                  *temp2, *temp1);
+                inner_product_matrix->vector_mult(*temp2, *temp1);
                 set_explicit_sys_subvector(*explicit_sys_temp, var, *temp2);
               }
 
@@ -785,8 +782,8 @@ void RBEIMConstruction::update_RB_system_matrices()
     {
       // Sample the basis functions at the
       // new interpolation point
-      get_rb_evaluation().get_basis_function(j).localize(
-        *_ghosted_meshfunction_vector, get_explicit_system().get_dof_map().get_send_list());
+      get_rb_evaluation().get_basis_function(j).localize(*_ghosted_meshfunction_vector,
+                                                         get_explicit_system().get_dof_map().get_send_list());
 
       if(!_performing_extra_greedy_step)
         {
@@ -815,8 +812,9 @@ void RBEIMConstruction::update_system()
   update_RB_system_matrices();
 }
 
-bool RBEIMConstruction::greedy_termination_test(
-  Real abs_greedy_error, Real initial_error, int)
+bool RBEIMConstruction::greedy_termination_test(Real abs_greedy_error,
+                                                Real initial_error,
+                                                int)
 {
   if(_performing_extra_greedy_step)
     {
@@ -856,8 +854,9 @@ bool RBEIMConstruction::greedy_termination_test(
   return false;
 }
 
-void RBEIMConstruction::set_explicit_sys_subvector(
-  NumericVector<Number> & dest, unsigned int var, NumericVector<Number> & source)
+void RBEIMConstruction::set_explicit_sys_subvector(NumericVector<Number> & dest,
+                                                   unsigned int var,
+                                                   NumericVector<Number> & source)
 {
   LOG_SCOPE("set_explicit_sys_subvector()", "RBEIMConstruction");
 
@@ -873,19 +872,18 @@ void RBEIMConstruction::set_explicit_sys_subvector(
       dof_id_type implicit_sys_dof_index = i;
       dof_id_type explicit_sys_dof_index = _dof_map_between_systems[var][i];
 
-      if( (dest.first_local_index() <= explicit_sys_dof_index) &&
-          (explicit_sys_dof_index < dest.last_local_index()) )
-      {
-        dest.set(
-          explicit_sys_dof_index, (*localized_source)(implicit_sys_dof_index));
-      }
+      if ((dest.first_local_index() <= explicit_sys_dof_index) &&
+          (explicit_sys_dof_index < dest.last_local_index()))
+        dest.set(explicit_sys_dof_index,
+                 (*localized_source)(implicit_sys_dof_index));
     }
 
   dest.close();
 }
 
-void RBEIMConstruction::get_explicit_sys_subvector(
-  NumericVector<Number>& dest, unsigned int var, NumericVector<Number>& localized_source)
+void RBEIMConstruction::get_explicit_sys_subvector(NumericVector<Number> & dest,
+                                                   unsigned int var,
+                                                   NumericVector<Number> & localized_source)
 {
   LOG_SCOPE("get_explicit_sys_subvector()", "RBEIMConstruction");
 
@@ -894,12 +892,10 @@ void RBEIMConstruction::get_explicit_sys_subvector(
       dof_id_type implicit_sys_dof_index = i;
       dof_id_type explicit_sys_dof_index = _dof_map_between_systems[var][i];
 
-      if( (dest.first_local_index() <= implicit_sys_dof_index) &&
-          (implicit_sys_dof_index < dest.last_local_index()) )
-      {
-        dest.set(
-          implicit_sys_dof_index, localized_source(explicit_sys_dof_index));
-      }
+      if ((dest.first_local_index() <= implicit_sys_dof_index) &&
+          (implicit_sys_dof_index < dest.last_local_index()))
+        dest.set(implicit_sys_dof_index,
+                 localized_source(explicit_sys_dof_index));
     }
 
   dest.close();

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -632,8 +632,10 @@ Real TransientRBConstruction::truth_solve(int write_interval)
   return final_truth_L2_norm;
 }
 
-bool TransientRBConstruction::greedy_termination_test(
-  Real abs_greedy_error, Real initial_greedy_error, int count)
+bool
+TransientRBConstruction::greedy_termination_test(Real abs_greedy_error,
+                                                 Real initial_greedy_error,
+                                                 int count)
 {
   if ( (get_max_truth_solves()>0) && (count >= get_max_truth_solves()) )
     {

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -42,8 +42,7 @@ CondensedEigenSystem::CondensedEigenSystem (EquationSystems & es,
 }
 
 void
-CondensedEigenSystem::initialize_condensed_dofs
-  (const std::set<dof_id_type> & global_dirichlet_dofs_set)
+CondensedEigenSystem::initialize_condensed_dofs(const std::set<dof_id_type> & global_dirichlet_dofs_set)
 {
   const DofMap & dof_map = this->get_dof_map();
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1512,19 +1512,13 @@ Real System::calculate_norm(const NumericVector<Number> & v,
       const std::set<unsigned char> & elem_dims = _mesh.elem_dimensions();
 
       // Prepare finite elements for each dimension present in the mesh
-      for( std::set<unsigned char>::const_iterator d_it = elem_dims.begin();
-           d_it != elem_dims.end(); ++d_it )
+      for (std::set<unsigned char>::const_iterator d_it = elem_dims.begin();
+           d_it != elem_dims.end(); ++d_it)
         {
-          if(skip_dimensions)
-          {
-            if(skip_dimensions->find(*d_it) != skip_dimensions->end())
-            {
-              continue;
-            }
-          }
+          if (skip_dimensions && skip_dimensions->find(*d_it) != skip_dimensions->end())
+            continue;
 
           q_rules[*d_it] =
-
             fe_type.default_quadrature_rule (*d_it).release();
 
           // Construct finite element object
@@ -1548,13 +1542,8 @@ Real System::calculate_norm(const NumericVector<Number> & v,
           const Elem * elem = *el;
           const unsigned int dim = elem->dim();
 
-          if(skip_dimensions)
-          {
-            if(skip_dimensions->find(dim) != skip_dimensions->end())
-            {
-              continue;
-            }
-          }
+          if (skip_dimensions && skip_dimensions->find(dim) != skip_dimensions->end())
+            continue;
 
           FEBase * fe = fe_ptrs[dim];
           QBase * qrule = q_rules[dim];

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1203,7 +1203,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
 
           // If we're projecting from an old grid
           if (f.is_grid_projection() &&
-          // And either this is an unchanged element
+              // And either this is an unchanged element
               ((elem->refinement_flag() != Elem::JUST_REFINED &&
                 elem->refinement_flag() != Elem::JUST_COARSENED &&
                 elem->p_refinement_flag() != Elem::JUST_REFINED &&
@@ -1215,9 +1215,9 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
                 elem->p_level() == 0 &&
                 elem->refinement_flag() != Elem::JUST_COARSENED &&
                 elem->p_refinement_flag() != Elem::JUST_COARSENED))
-             )
-          // then we can simply copy its old dof
-          // values to new indices.
+              )
+            // then we can simply copy its old dof
+            // values to new indices.
             {
               LOG_SCOPE ("copy_dofs", "GenericProjector");
 


### PR DESCRIPTION
Just ran contrib/bin/reindent.sh and fixed some stuff manually, so nothing should have changed.  It's nice to be sure, though.

Note to self: the class "final" (or in our case libmesh_final) keyword in class declarations, e.g.

```
class Hex20 libmesh_final : public Hex
```

confuses the emacs-based indentation script, at least it is broken in emacs 24.5-1, and I haven't tried any later versions.
