### PR TITLE
Fixes for --disable-amr builds

### DIFF
--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -78,8 +78,10 @@ using namespace libMesh;
 // In subsequent examples we will employ adaptive mesh refinement,
 // and with a changing mesh it will be necessary to rebuild the
 // system matrix.
+#ifdef LIBMESH_ENABLE_AMR
 void assemble_cd (EquationSystems & es,
                   const std::string & system_name);
+#endif
 
 // Function prototype.  This function will initialize the system.
 // Initialization functions are optional for systems.  They allow
@@ -469,10 +471,10 @@ void init_cd (EquationSystems & es,
 // will be called at each time step.  It is responsible
 // for computing the proper matrix entries for the
 // element stiffness matrices and right-hand sides.
+#ifdef LIBMESH_ENABLE_AMR
 void assemble_cd (EquationSystems & es,
                   const std::string & system_name)
 {
-#ifdef LIBMESH_ENABLE_AMR
   // It is a good idea to make sure we are assembling
   // the proper system.
   libmesh_assert_equal_to (system_name, "Convection-Diffusion");
@@ -704,5 +706,5 @@ void assemble_cd (EquationSystems & es,
 
     }
   // Finished computing the sytem matrix and right-hand side.
-#endif // #ifdef LIBMESH_ENABLE_AMR
 }
+#endif // #ifdef LIBMESH_ENABLE_AMR

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -80,8 +80,10 @@ using namespace libMesh;
 // In subsequent examples we will employ adaptive mesh refinement,
 // and with a changing mesh it will be necessary to rebuild the
 // system matrix.
+#ifdef LIBMESH_ENABLE_AMR
 void assemble_cd (EquationSystems & es,
                   const std::string & system_name);
+#endif
 
 // Function prototype.  This function will initialize the system.
 // Initialization functions are optional for systems.  They allow
@@ -563,10 +565,10 @@ void init_cd (EquationSystems & es,
 // will be called at each time step.  It is responsible
 // for computing the proper matrix entries for the
 // element stiffness matrices and right-hand sides.
+#ifdef LIBMESH_ENABLE_AMR
 void assemble_cd (EquationSystems & es,
                   const std::string & system_name)
 {
-#ifdef LIBMESH_ENABLE_AMR
   // It is a good idea to make sure we are assembling
   // the proper system.
   libmesh_assert_equal_to (system_name, "Convection-Diffusion");
@@ -753,8 +755,8 @@ void assemble_cd (EquationSystems & es,
 
     }
   // Finished computing the sytem matrix and right-hand side.
-#endif // #ifdef LIBMESH_ENABLE_AMR
 }
+#endif // #ifdef LIBMESH_ENABLE_AMR
 
 
 

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic.h
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic.h
@@ -10,10 +10,13 @@
 // Just the bits we're using, since this is a header.
 using libMesh::EquationSystems;
 using libMesh::ExodusII_IO;
-using libMesh::MeshRefinement;
 using libMesh::Point;
 using libMesh::Real;
 using libMesh::UnstructuredMesh;
+
+#ifdef LIBMESH_ENABLE_AMR
+using libMesh::MeshRefinement;
+#endif
 
 /**
  * The Biharmonic class encapsulates most of the data structures
@@ -115,7 +118,9 @@ private:
   friend class JR;
   class JR;       // forward
   UnstructuredMesh * _mesh;
+#ifdef LIBMESH_ENABLE_AMR
   MeshRefinement * _meshRefinement;
+#endif
   JR * _jr;
 };
 

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -171,10 +171,12 @@ public:
    */
   void make_elems_parallel_consistent (MeshBase &);
 
+#ifdef LIBMESH_ENABLE_AMR
   /**
    * Copy p levels of ghost elements from their local processors.
    */
   void make_p_levels_parallel_consistent (MeshBase &);
+#endif // LIBMESH_ENABLE_AMR
 
   /**
    * Assuming all ids on local nodes are globally unique, and

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -615,6 +615,64 @@ const float Tet10::_embedding_matrix[8][10][10] =
 
 
 
+float Tet10::embedding_matrix (const unsigned int i,
+                               const unsigned int j,
+                               const unsigned int k) const
+{
+  // Choose an optimal diagonal, if one has not already been selected
+  this->choose_diagonal();
+
+  // Permuted j and k indices
+  unsigned int
+    jp=j,
+    kp=k;
+
+  if ((i>3) && (this->_diagonal_selection!=DIAG_02_13))
+    {
+      // Just the enum value cast to an unsigned int...
+      const unsigned ds = static_cast<unsigned int>(this->_diagonal_selection); // == 1 or 2
+
+      // Instead of doing a lot of arithmetic, use these
+      // straightforward arrays for the permutations.  Note that 3 ->
+      // 3, and the first array consists of "forward" permutations of
+      // the sets {0,1,2}, {4,5,6}, and {7,8,9} while the second array
+      // consists of "reverse" permutations of the same sets.
+      const unsigned int perms[2][10] =
+        {
+          {1, 2, 0, 3, 5, 6, 4, 8, 9, 7},
+          {2, 0, 1, 3, 6, 4, 5, 9, 7, 8}
+        };
+
+      // Permute j
+      jp = perms[ds-1][j];
+      //      if (jp<3)
+      //        jp = (jp+ds)%3;
+      //      else if (jp>3)
+      //        jp = (jp-1+ds)%3 + 1 + 3*((jp-1)/3);
+
+      // Permute k
+      kp = perms[ds-1][k];
+      //      if (kp<3)
+      //        kp = (kp+ds)%3;
+      //      else if (kp>3)
+      //        kp = (kp-1+ds)%3 + 1 + 3*((kp-1)/3);
+    }
+
+  // Debugging:
+  // libMesh::err << "Selected diagonal " << _diagonal_selection << std::endl;
+  // libMesh::err << "j=" << j << std::endl;
+  // libMesh::err << "k=" << k << std::endl;
+  // libMesh::err << "jp=" << jp << std::endl;
+  // libMesh::err << "kp=" << kp << std::endl;
+
+  // Call embedding matrx with permuted indices
+  return this->_embedding_matrix[i][jp][kp];
+}
+
+#endif // #ifdef LIBMESH_ENABLE_AMR
+
+
+
 Real Tet10::volume () const
 {
   // Make copies of our points.  It makes the subsequent calculations a bit
@@ -723,61 +781,5 @@ Real Tet10::volume () const
 }
 
 
-
-float Tet10::embedding_matrix (const unsigned int i,
-                               const unsigned int j,
-                               const unsigned int k) const
-{
-  // Choose an optimal diagonal, if one has not already been selected
-  this->choose_diagonal();
-
-  // Permuted j and k indices
-  unsigned int
-    jp=j,
-    kp=k;
-
-  if ((i>3) && (this->_diagonal_selection!=DIAG_02_13))
-    {
-      // Just the enum value cast to an unsigned int...
-      const unsigned ds = static_cast<unsigned int>(this->_diagonal_selection); // == 1 or 2
-
-      // Instead of doing a lot of arithmetic, use these
-      // straightforward arrays for the permutations.  Note that 3 ->
-      // 3, and the first array consists of "forward" permutations of
-      // the sets {0,1,2}, {4,5,6}, and {7,8,9} while the second array
-      // consists of "reverse" permutations of the same sets.
-      const unsigned int perms[2][10] =
-        {
-          {1, 2, 0, 3, 5, 6, 4, 8, 9, 7},
-          {2, 0, 1, 3, 6, 4, 5, 9, 7, 8}
-        };
-
-      // Permute j
-      jp = perms[ds-1][j];
-      //      if (jp<3)
-      //        jp = (jp+ds)%3;
-      //      else if (jp>3)
-      //        jp = (jp-1+ds)%3 + 1 + 3*((jp-1)/3);
-
-      // Permute k
-      kp = perms[ds-1][k];
-      //      if (kp<3)
-      //        kp = (kp+ds)%3;
-      //      else if (kp>3)
-      //        kp = (kp-1+ds)%3 + 1 + 3*((kp-1)/3);
-    }
-
-  // Debugging:
-  // libMesh::err << "Selected diagonal " << _diagonal_selection << std::endl;
-  // libMesh::err << "j=" << j << std::endl;
-  // libMesh::err << "k=" << k << std::endl;
-  // libMesh::err << "jp=" << jp << std::endl;
-  // libMesh::err << "kp=" << kp << std::endl;
-
-  // Call embedding matrx with permuted indices
-  return this->_embedding_matrix[i][jp][kp];
-}
-
-#endif // #ifdef LIBMESH_ENABLE_AMR
 
 } // namespace libMesh

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -326,6 +326,16 @@ std::pair<Real, Real> Tet4::min_and_max_angle() const
 
 
 
+dof_id_type Tet4::key () const
+{
+  return this->compute_key(this->node_id(0),
+                           this->node_id(1),
+                           this->node_id(2),
+                           this->node_id(3));
+}
+
+
+
 #ifdef LIBMESH_ENABLE_AMR
 float Tet4::embedding_matrix (const unsigned int i,
                               const unsigned int j,
@@ -365,16 +375,6 @@ float Tet4::embedding_matrix (const unsigned int i,
 
   // Call embedding matrx with permuted indices
   return this->_embedding_matrix[i][jp][kp];
-}
-
-
-
-dof_id_type Tet4::key () const
-{
-  return this->compute_key(this->node_id(0),
-                           this->node_id(1),
-                           this->node_id(2),
-                           this->node_id(3));
 }
 
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -936,6 +936,7 @@ struct SyncIds
 };
 
 
+#ifdef LIBMESH_ENABLE_AMR
 struct SyncPLevels
 {
   typedef unsigned char datum;
@@ -970,6 +971,7 @@ struct SyncPLevels
       }
   }
 };
+#endif // LIBMESH_ENABLE_AMR
 
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
@@ -1080,6 +1082,7 @@ void MeshCommunication::make_elems_parallel_consistent(MeshBase & mesh)
 
 
 // ------------------------------------------------------------
+#ifdef LIBMESH_ENABLE_AMR
 void MeshCommunication::make_p_levels_parallel_consistent(MeshBase & mesh)
 {
   // This function must be run on all processors at once
@@ -1092,6 +1095,7 @@ void MeshCommunication::make_p_levels_parallel_consistent(MeshBase & mesh)
     (mesh.comm(), mesh.elements_begin(), mesh.elements_end(),
      syncplevels);
 }
+#endif // LIBMESH_ENABLE_AMR
 
 
 

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -567,11 +567,13 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
       // doing a projection on this inactive element on this
       // processor, so we won't need correct p settings.  Couldn't
       // hurt to update, though.
+#ifdef LIBMESH_ENABLE_AMR
       if (elem->processor_id() != mesh->processor_id())
         {
           elem->hack_p_level(p_level);
           elem->set_p_refinement_flag(p_refinement_flag);
         }
+#endif // LIBMESH_ENABLE_AMR
 
       // FIXME: We should add some debug mode tests to ensure that the
       // encoded indexing and boundary conditions are consistent.

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1588,6 +1588,7 @@ void FEMContext::pre_fe_reinit(const System & sys, const Elem * e)
         // If !this->has_elem(), then we assume we are dealing with a SCALAR variable
         sys.get_dof_map().dof_indices (libmesh_nullptr, this->get_dof_indices());
     }
+#ifdef LIBMESH_ENABLE_AMR
   else if (algebraic_type() == OLD)
     {
       // Initialize the per-element data for elem.
@@ -1597,6 +1598,7 @@ void FEMContext::pre_fe_reinit(const System & sys, const Elem * e)
         // If !this->has_elem(), then we assume we are dealing with a SCALAR variable
         sys.get_dof_map().old_dof_indices (libmesh_nullptr, this->get_dof_indices());
     }
+#endif // LIBMESH_ENABLE_AMR
 
   const unsigned int n_dofs = cast_int<unsigned int>
     (this->get_dof_indices().size());
@@ -1659,6 +1661,7 @@ void FEMContext::pre_fe_reinit(const System & sys, const Elem * e)
               // If !this->has_elem(), then we assume we are dealing with a SCALAR variable
               sys.get_dof_map().dof_indices (libmesh_nullptr, this->get_dof_indices(i), i);
           }
+#ifdef LIBMESH_ENABLE_AMR
         else if (algebraic_type() == OLD)
           {
             if(this->has_elem())
@@ -1667,6 +1670,7 @@ void FEMContext::pre_fe_reinit(const System & sys, const Elem * e)
               // If !this->has_elem(), then we assume we are dealing with a SCALAR variable
               sys.get_dof_map().old_dof_indices (libmesh_nullptr, this->get_dof_indices(i), i);
           }
+#endif // LIBMESH_ENABLE_AMR
 
         if (this->algebraic_type() != NONE &&
             this->algebraic_type() != DOFS_ONLY)
@@ -1806,6 +1810,7 @@ FEMContext::build_new_fe( const FEGenericBase<OutputShape>* fe,
   // everywhere.
   libmesh_assert(this->has_elem() || fe_type.family == SCALAR);
 
+#ifdef LIBMESH_ENABLE_AMR
   if ((algebraic_type() == OLD) &&
       this->has_elem())
     {
@@ -1814,6 +1819,7 @@ FEMContext::build_new_fe( const FEGenericBase<OutputShape>* fe,
       else if (this->get_elem().p_refinement_flag() == Elem::JUST_COARSENED)
         fe_type.order = static_cast<Order>(fe_type.order + 1);
     }
+#endif // LIBMESH_ENABLE_AMR
 
   unsigned int elem_dim = this->has_elem() ? this->get_elem().dim() : 0;
 

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -214,6 +214,7 @@ void ErrorVector::plot_error(const std::string & filename,
   mesh.allow_renumbering(true);
   mesh.all_first_order();
 
+#ifdef LIBMESH_ENABLE_AMR
   // We don't want p elevation when plotting a single constant value
   // per element
   {
@@ -229,6 +230,7 @@ void ErrorVector::plot_error(const std::string & filename,
         elem->set_p_level(0);
       }
   }
+#endif // LIBMESH_ENABLE_AMR
 
   EquationSystems temp_es (mesh);
   ExplicitSystem & error_system


### PR DESCRIPTION
This was much more straightforward than the MPI-free case.  No conflicts between the patches, even.