### PR TITLE
Rename SerialMesh->ReplicatedMesh, ParallelMesh->DistributedMesh

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -742,7 +742,7 @@ public:
    * Prints (from processor 0) all DoF and Node constraints.  If \p
    * print_nonlocal is true, then each constraint is printed once for
    * each processor that knows about it, which may be useful for \p
-   * ParallelMesh debugging.
+   * DistributedMesh debugging.
    */
   void print_dof_constraints(std::ostream & os=libMesh::out,
                              bool print_nonlocal=false) const;

--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -40,9 +40,13 @@ namespace libMesh
 
 // Forward declarations
 class Elem;
-class SerialMesh;
+class ReplicatedMesh;
 class TriangleInterface;
 class TetGenMeshInterface;
+
+// This is for backwards compatibility, but if your code relies on
+// forward declarations in our headers then fix it.
+class SerialMesh;
 
 /**
  * This class implements cutting a single element into a collection

--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -59,7 +59,7 @@ public:
 
   /**
    * Constructor.  Initializes pointer data
-   * without requiring a full \p SerialMesh in this header file.
+   * without requiring a full \p ReplicatedMesh in this header file.
    */
   ElemCutter();
 

--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -154,10 +154,10 @@ protected:
   std::vector<Elem const *> _inside_elem;
   std::vector<Elem const *> _outside_elem;
 
-  UniquePtr<SerialMesh> _inside_mesh_2D;
-  UniquePtr<SerialMesh> _outside_mesh_2D;
-  UniquePtr<SerialMesh> _inside_mesh_3D;
-  UniquePtr<SerialMesh> _outside_mesh_3D;
+  UniquePtr<ReplicatedMesh> _inside_mesh_2D;
+  UniquePtr<ReplicatedMesh> _outside_mesh_2D;
+  UniquePtr<ReplicatedMesh> _inside_mesh_3D;
+  UniquePtr<ReplicatedMesh> _outside_mesh_3D;
 
   Parallel::Communicator _comm_self; // defaults to MPI_COMM_SELF
 

--- a/include/mesh/mesh.h
+++ b/include/mesh/mesh.h
@@ -24,12 +24,12 @@
 #ifdef LIBMESH_ENABLE_PARMESH
 #include "libmesh/parallel_mesh.h"
 namespace libMesh {
-typedef ParallelMesh DefaultMesh;
+typedef DistributedMesh DefaultMesh;
 }
 #else
 #include "libmesh/serial_mesh.h"
 namespace libMesh {
-typedef SerialMesh DefaultMesh;
+typedef ReplicatedMesh DefaultMesh;
 }
 #endif
 

--- a/include/mesh/mesh.h
+++ b/include/mesh/mesh.h
@@ -37,11 +37,11 @@ namespace libMesh
 {
 
 // Forward declarations don't like typedefs...
-// typedef SerialMesh Mesh;
+// typedef ReplicatedMesh Mesh;
 
 /**
- * The \p Mesh class is a thin wrapper, around the \p SerialMesh class
- * by default.
+ * The \p Mesh class is a thin wrapper, around the \p ReplicatedMesh
+ * class by default.
  */
 class Mesh : public DefaultMesh
 {

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -659,7 +659,7 @@ public:
   /**
    * Redistribute elements between processors.  This gets called
    * automatically by the Partitioner, and is a no-op in the case of a
-   * SerialMesh or serialized ParallelMesh
+   * ReplicatedMesh or serialized DistributedMesh
    */
   virtual void redistribute () {}
 
@@ -829,7 +829,7 @@ public:
    * Verify id and processor_id consistency of our elements and
    * nodes containers.
    * Calls libmesh_assert() on each possible failure.
-   * Currently only implemented on ParallelMesh; a serial data
+   * Currently only implemented on DistributedMesh; a serial data
    * structure is much harder to get out of sync.
    */
   virtual void libmesh_assert_valid_parallel_ids() const {}

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -33,6 +33,10 @@ namespace libMesh
 
 // Forward declarations
 class MeshBase;
+class DistributedMesh;
+
+// This is for backwards compatibility, but if your code relies on
+// forward declarations in our headers then fix it.
 class ParallelMesh;
 
 /**

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -99,10 +99,10 @@ public:
   void gather_neighboring_elements (ParallelMesh &) const;
 
   /**
-   * This method takes an input \p ParallelMesh which may be
+   * This method takes an input \p DistributedMesh which may be
    * distributed among all the processors.  Each processor then
    * sends its local nodes and elements to processor \p root_id.
-   * The end result is that a previously distributed \p ParallelMesh
+   * The end result is that a previously distributed \p DistributedMesh
    * will be serialized on processor \p root_id.  Since this method is
    * collective it must be called by all processors. For the special
    * case of \p root_id equal to \p DofObject::invalid_processor_id
@@ -111,10 +111,10 @@ public:
   void gather (const processor_id_type root_id, ParallelMesh &) const;
 
   /**
-   * This method takes an input \p ParallelMesh which may be
+   * This method takes an input \p DistributedMesh which may be
    * distributed among all the processors.  Each processor then
    * sends its local nodes and elements to the other processors.
-   * The end result is that a previously distributed \p ParallelMesh
+   * The end result is that a previously distributed \p DistributedMesh
    * will be serialized on each processor.  Since this method is
    * collective it must be called by all processors.
    */
@@ -122,12 +122,12 @@ public:
   { MeshCommunication::gather(DofObject::invalid_processor_id, mesh); }
 
   /**
-   * This method takes an input \p ParallelMesh which may be
+   * This method takes an input \p DistributedMesh which may be
    * distributed among all the processors.  Each processor
    * deletes all elements which are neither local elements nor "ghost"
    * elements which touch local elements, and deletes all nodes which
    * are not contained in local or ghost elements.
-   * The end result is that a previously serial \p ParallelMesh
+   * The end result is that a previously serial \p DistributedMesh
    * will be distributed between processors.  Since this method is
    * collective it must be called by all processors.
    *

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -95,12 +95,12 @@ public:
    * to satisfy data dependencies. This method can be invoked after a
    * partitioning step to affect the new partitioning.
    */
-  void redistribute (ParallelMesh &) const;
+  void redistribute (DistributedMesh &) const;
 
   /**
    *
    */
-  void gather_neighboring_elements (ParallelMesh &) const;
+  void gather_neighboring_elements (DistributedMesh &) const;
 
   /**
    * This method takes an input \p DistributedMesh which may be
@@ -112,7 +112,7 @@ public:
    * case of \p root_id equal to \p DofObject::invalid_processor_id
    * this function performs an allgather.
    */
-  void gather (const processor_id_type root_id, ParallelMesh &) const;
+  void gather (const processor_id_type root_id, DistributedMesh &) const;
 
   /**
    * This method takes an input \p DistributedMesh which may be
@@ -122,7 +122,7 @@ public:
    * will be serialized on each processor.  Since this method is
    * collective it must be called by all processors.
    */
-  void allgather (ParallelMesh & mesh) const
+  void allgather (DistributedMesh & mesh) const
   { MeshCommunication::gather(DofObject::invalid_processor_id, mesh); }
 
   /**
@@ -139,7 +139,7 @@ public:
    * to delete.  These will be left on the current processor along with
    * local elements and ghosted neighbors.
    */
-  void delete_remote_elements (ParallelMesh &, const std::set<Elem *> &) const;
+  void delete_remote_elements (DistributedMesh &, const std::set<Elem *> &) const;
 
   /**
    * This method assigns globally unique, partition-agnostic

--- a/include/mesh/mesh_serializer.h
+++ b/include/mesh/mesh_serializer.h
@@ -30,7 +30,7 @@ namespace libMesh
 class MeshBase;
 
 /**
- * Temporarily serialize a ParallelMesh for output; a distributed
+ * Temporarily serialize a DistributedMesh for output; a distributed
  * mesh is allgathered by the MeshSerializer constructor if
  * need_serial is true, then remote elements are deleted again by the
  * destructor.

--- a/include/mesh/mesh_tetgen_interface.h
+++ b/include/mesh/mesh_tetgen_interface.h
@@ -101,7 +101,7 @@ protected:
   /**
    * This function copies nodes from the _mesh into TetGen's
    * pointlist.  Takes some pains to ensure that non-sequential
-   * node numberings (which can happen with e.g. ParallelMesh)
+   * node numberings (which can happen with e.g. DistributedMesh)
    * are handled.
    */
   void fill_pointlist(TetGenWrapper & wrapper);
@@ -147,7 +147,7 @@ protected:
 
   /**
    * We should not assume libmesh nodes are numbered sequentially...
-   * This is not the default behavior of ParallelMesh, for example,
+   * This is not the default behavior of DistributedMesh, for example,
    * unless you specify node IDs explicitly.  So this array allows us
    * to keep a mapping between the sequential numbering in
    * tetgen_data.pointlist.

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -395,7 +395,7 @@ void libmesh_assert_valid_amr_interior_parents (const MeshBase & mesh);
  * A function for verifying that all nodes are connected to at least
  * one element.
  *
- * This will fail in the most general case.  When ParallelMesh and
+ * This will fail in the most general case.  When DistributedMesh and
  * NodeConstraints are enabled, we expect the possibility that a
  * processor will be given remote nodes to satisfy node constraints
  * without also being given the remote elements connected to those

--- a/include/mesh/xdr_io.h
+++ b/include/mesh/xdr_io.h
@@ -118,7 +118,7 @@ public:
 
   /**
    * Insist that we should write parallel files if and only if the
-   * mesh is an already distributed ParallelMesh.
+   * mesh is an already distributed DistributedMesh.
    */
   void set_auto_parallel ();
 

--- a/include/reduced_basis/rb_data_deserialization.h
+++ b/include/reduced_basis/rb_data_deserialization.h
@@ -238,7 +238,7 @@ void load_point(RBData::Point3D::Reader point_reader, Point & point);
  */
 void load_elem_into_mesh(RBData::MeshElem::Reader mesh_elem_reader,
                          libMesh::Elem * elem,
-                         libMesh::SerialMesh & mesh);
+                         libMesh::ReplicatedMesh & mesh);
 
 } // namespace RBDataDeserialization
 

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -96,7 +96,7 @@ public:
   /**
    * Get a writable reference to the interpolation points mesh.
    */
-  SerialMesh & get_interpolation_points_mesh();
+  ReplicatedMesh & get_interpolation_points_mesh();
 
   /**
    * @return the value of the parametrized function that is being
@@ -260,7 +260,7 @@ private:
    * Mesh object that we use to store copies of the elements associated with
    * interpolation points.
    */
-  SerialMesh _interpolation_points_mesh;
+  ReplicatedMesh _interpolation_points_mesh;
 
 };
 

--- a/include/utils/mapvector.h
+++ b/include/utils/mapvector.h
@@ -29,7 +29,8 @@ namespace libMesh
 /**
  * This \p mapvector templated class is intended to provide the
  * performance characteristics of a std::map with an interface more
- * closely resembling that of a std::vector, for use with ParallelMesh.
+ * closely resembling that of a std::vector, for use with
+ * DistributedMesh.
  *
  * \author  Roy H. Stogner
  */

--- a/src/apps/projection.C
+++ b/src/apps/projection.C
@@ -119,7 +119,7 @@ int main(int argc, char ** argv)
   // Load the old mesh from --inmesh filename.
   // Keep it serialized; we don't want elements on the new mesh to be
   // looking for data on old mesh elements that live off-processor.
-  SerialMesh old_mesh(init.comm(), requested_dim);
+  ReplicatedMesh old_mesh(init.comm(), requested_dim);
 
   const std::string meshname =
     assert_argument(cl, "--inmesh", argv[0], std::string("mesh.xda"));

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -909,7 +909,7 @@ void DofMap::distribute_dofs (MeshBase & mesh)
 
   //------------------------------------------------------------
   // At this point, all n_comp and dof_number values on local
-  // DofObjects should be correct, but a ParallelMesh might have
+  // DofObjects should be correct, but a DistributedMesh might have
   // incorrect values on non-local DofObjects.  Let's request the
   // correct values from each other processor.
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1103,7 +1103,7 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
                         mesh.local_elements_end());
 
   // Global computation fails if we're using a FEMFunctionBase BC on a
-  // SerialMesh in parallel
+  // ReplicatedMesh in parallel
   // ConstElemRange range (mesh.elements_begin(),
   //                       mesh.elements_end());
 

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1442,7 +1442,7 @@ bool Elem::ancestor() const
 {
 #ifdef LIBMESH_ENABLE_AMR
 
-  // Use a fast, ParallelMesh-safe definition
+  // Use a fast, DistributedMesh-safe definition
   const bool is_ancestor =
     !this->active() && !this->subactive();
 

--- a/src/geom/elem_cutter.C
+++ b/src/geom/elem_cutter.C
@@ -40,11 +40,11 @@ namespace libMesh
 // ElemCutter implementation
 ElemCutter::ElemCutter()
 {
-  _inside_mesh_2D.reset  (new SerialMesh(_comm_self,2)); /**/ _triangle_inside.reset  (new TriangleInterface (*_inside_mesh_2D));
-  _outside_mesh_2D.reset (new SerialMesh(_comm_self,2)); /**/ _triangle_outside.reset (new TriangleInterface (*_outside_mesh_2D));
+  _inside_mesh_2D.reset  (new ReplicatedMesh(_comm_self,2)); /**/ _triangle_inside.reset  (new TriangleInterface (*_inside_mesh_2D));
+  _outside_mesh_2D.reset (new ReplicatedMesh(_comm_self,2)); /**/ _triangle_outside.reset (new TriangleInterface (*_outside_mesh_2D));
 
-  _inside_mesh_3D.reset  (new SerialMesh(_comm_self,3)); /**/ _tetgen_inside.reset  (new TetGenMeshInterface (*_inside_mesh_3D));
-  _outside_mesh_3D.reset (new SerialMesh(_comm_self,3)); /**/ _tetgen_outside.reset (new TetGenMeshInterface (*_outside_mesh_3D));
+  _inside_mesh_3D.reset  (new ReplicatedMesh(_comm_self,3)); /**/ _tetgen_inside.reset  (new TetGenMeshInterface (*_inside_mesh_3D));
+  _outside_mesh_3D.reset (new ReplicatedMesh(_comm_self,3)); /**/ _tetgen_outside.reset (new TetGenMeshInterface (*_outside_mesh_3D));
 
   cut_cntr = 0;
 }

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -533,7 +533,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
   // Make sure we didn't add ids inconsistently
 #ifdef DEBUG
 # ifdef LIBMESH_HAVE_RTTI
-  ParallelMesh * parmesh = dynamic_cast<ParallelMesh *>(&boundary_mesh);
+  DistributedMesh * parmesh = dynamic_cast<DistributedMesh *>(&boundary_mesh);
   if (parmesh)
     parmesh->libmesh_assert_valid_parallel_ids();
 # endif

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -459,7 +459,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
 
       new_elem->set_interior_parent (const_cast<Elem *>(elem));
 
-      // On non-local elements on ParallelMesh we might have
+      // On non-local elements on DistributedMesh we might have
       // RemoteElem neighbor links to construct
       if (!_mesh.is_serial() &&
           (elem->processor_id() != this->processor_id()))
@@ -1834,7 +1834,7 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> & requested_bo
                                  dof_id_type first_free_elem_id,
                                  std::map<std::pair<dof_id_type, unsigned char>, dof_id_type> * side_id_map)
 {
-  // We'll do the same modulus trick that ParallelMesh uses to avoid
+  // We'll do the same modulus trick that DistributedMesh uses to avoid
   // id conflicts between different processors
   dof_id_type
     next_node_id = first_free_node_id + this->processor_id(),

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -81,10 +81,10 @@ void CheckpointIO::write (const std::string & name)
   // convenient reference to our mesh
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
-  // Try to dynamic cast the mesh to see if it's a ParallelMesh object
+  // Try to dynamic cast the mesh to see if it's a DistributedMesh object
   // Note: Just using is_serial() is not good enough because the Mesh won't
   // have been prepared yet when is when that flag gets set to false... sigh.
-  bool parallel_mesh = dynamic_cast<const ParallelMesh *>(&mesh);
+  bool parallel_mesh = dynamic_cast<const DistributedMesh *>(&mesh);
 
   // If this is a serial mesh then we're only going to write it on processor 0
   if(parallel_mesh || this->processor_id() == 0)
@@ -403,10 +403,10 @@ void CheckpointIO::read (const std::string & name)
 
   MeshBase & mesh = MeshInput<MeshBase>::mesh();
 
-  // Try to dynamic cast the mesh to see if it's a ParallelMesh object
+  // Try to dynamic cast the mesh to see if it's a DistributedMesh object
   // Note: Just using is_serial() is not good enough because the Mesh won't
   // have been prepared yet when is when that flag gets set to false... sigh.
-  bool parallel_mesh = dynamic_cast<ParallelMesh *>(&mesh);
+  bool parallel_mesh = dynamic_cast<DistributedMesh *>(&mesh);
 
   // If this is a serial mesh then we're going to only read it on processor 0 and broadcast it
   if(parallel_mesh || this->processor_id() == 0)

--- a/src/mesh/diva_io.C
+++ b/src/mesh/diva_io.C
@@ -41,7 +41,7 @@ DivaIO::DivaIO (const MeshBase & mesh_in) :
 
 void DivaIO::write (const std::string & fname)
 {
-  // We may need to gather a ParallelMesh to output it, making that
+  // We may need to gather a DistributedMesh to output it, making that
   // const qualifier in our constructor a dirty lie
   MeshSerializer serialize(const_cast<MeshBase &>(this->mesh()), !_is_parallel_format);
 

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -134,7 +134,7 @@ void EnsightIO::add_scalar(const std::string & system_name,
 // the MeshOutput base class.
 void EnsightIO::write (const std::string & name)
 {
-  // We may need to gather a ParallelMesh to output it, making that
+  // We may need to gather a DistributedMesh to output it, making that
   // const qualifier in our constructor a dirty lie
   MeshSerializer serialize(const_cast<MeshBase &>(this->mesh()), !_is_parallel_format);
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -512,13 +512,13 @@ void ExodusII_IO::write_element_data (const EquationSystems & es)
   if (MeshOutput<MeshBase>::mesh().processor_id() == 0 && !exio_helper->opened_for_writing)
     libmesh_error_msg("ERROR, ExodusII file must be initialized before outputting element variables.");
 
-  // This function currently only works on SerialMeshes. We rely on
-  // having a reference to a non-const MeshBase object from our
+  // This function currently only works on serialized meshes. We rely
+  // on having a reference to a non-const MeshBase object from our
   // MeshInput parent class to construct a MeshSerializer object,
   // similar to what is done in ExodusII_IO::write().  Note that
   // calling ExodusII_IO::write_timestep() followed by
   // ExodusII_IO::write_element_data() when the underlying Mesh is a
-  // ParallelMesh will result in an unnecessary additional
+  // DistributedMesh will result in an unnecessary additional
   // serialization/re-parallelization step.
   MeshSerializer serialize(MeshInput<MeshBase>::mesh(), !MeshOutput<MeshBase>::_is_parallel_format);
 
@@ -763,7 +763,7 @@ void ExodusII_IO::write (const std::string & fname)
 {
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
-  // We may need to gather a ParallelMesh to output it, making that
+  // We may need to gather a DistributedMesh to output it, making that
   // const qualifier in our constructor a dirty lie
   MeshSerializer serialize(const_cast<MeshBase &>(mesh), !MeshOutput<MeshBase>::_is_parallel_format);
 

--- a/src/mesh/fro_io.C
+++ b/src/mesh/fro_io.C
@@ -40,7 +40,7 @@ namespace libMesh
 // FroIO  members
 void FroIO::write (const std::string & fname)
 {
-  // We may need to gather a ParallelMesh to output it, making that
+  // We may need to gather a DistributedMesh to output it, making that
   // const qualifier in our constructor a dirty lie
   MeshSerializer serialize(const_cast<MeshBase &>(this->mesh()), !_is_parallel_format);
 

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -563,7 +563,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
   // if (!mesh.is_serial())
   //   {
   //     if (MeshOutput<MeshBase>::mesh().processor_id() == 0)
-  //       libMesh::err << "Error: GMVIO cannot yet write a ParallelMesh solution"
+  //       libMesh::err << "Error: GMVIO cannot yet write a DistributedMesh solution"
   //                     << std::endl;
   //     return;
   //   }

--- a/src/mesh/gnuplot_io.C
+++ b/src/mesh/gnuplot_io.C
@@ -60,7 +60,7 @@ void GnuPlotIO::write_solution(const std::string & fname,
                                const std::vector<Number> * soln,
                                const std::vector<std::string> * names)
 {
-  // Even when writing on a serialized ParallelMesh, we expect
+  // Even when writing on a serialized DistributedMesh, we expect
   // non-proc-0 help with calls like n_active_elem
   // libmesh_assert_equal_to (this->mesh().processor_id(), 0);
 

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -215,7 +215,7 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
   // Partition the mesh.
   this->partition();
 
-  // If we're using ParallelMesh, we'll want it parallelized.
+  // If we're using DistributedMesh, we'll want it parallelized.
   this->delete_remote_elements();
 
   if(!_skip_renumber_nodes_and_elements)

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -161,14 +161,14 @@ void MeshCommunication::clear ()
 
 #ifndef LIBMESH_HAVE_MPI // avoid spurious gcc warnings
 // ------------------------------------------------------------
-void MeshCommunication::redistribute (ParallelMesh &) const
+void MeshCommunication::redistribute (DistributedMesh &) const
 {
   // no MPI == one processor, no redistribution
   return;
 }
 #else
 // ------------------------------------------------------------
-void MeshCommunication::redistribute (ParallelMesh & mesh) const
+void MeshCommunication::redistribute (DistributedMesh & mesh) const
 {
   // This method will be called after a new partitioning has been
   // assigned to the elements.  This partitioning was defined in
@@ -389,14 +389,14 @@ void MeshCommunication::redistribute (ParallelMesh & mesh) const
 
 #ifndef LIBMESH_HAVE_MPI // avoid spurious gcc warnings
 // ------------------------------------------------------------
-void MeshCommunication::gather_neighboring_elements (ParallelMesh &) const
+void MeshCommunication::gather_neighboring_elements (DistributedMesh &) const
 {
   // no MPI == one processor, no need for this method...
   return;
 }
 #else
 // ------------------------------------------------------------
-void MeshCommunication::gather_neighboring_elements (ParallelMesh & mesh) const
+void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) const
 {
   // Don't need to do anything if there is
   // only one processor.
@@ -825,14 +825,14 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
 
 #ifndef LIBMESH_HAVE_MPI // avoid spurious gcc warnings
 // ------------------------------------------------------------
-void MeshCommunication::gather (const processor_id_type, ParallelMesh &) const
+void MeshCommunication::gather (const processor_id_type, DistributedMesh &) const
 {
   // no MPI == one processor, no need for this method...
   return;
 }
 #else
 // ------------------------------------------------------------
-void MeshCommunication::gather (const processor_id_type root_id, ParallelMesh & mesh) const
+void MeshCommunication::gather (const processor_id_type root_id, DistributedMesh & mesh) const
 {
   // The mesh should know it's about to be serialized
   libmesh_assert (mesh.is_serial());
@@ -1214,7 +1214,9 @@ void MeshCommunication::make_nodes_parallel_consistent (MeshBase & mesh)
 
 
 // ------------------------------------------------------------
-void MeshCommunication::delete_remote_elements(ParallelMesh & mesh, const std::set<Elem *> & extra_ghost_elem_ids) const
+void MeshCommunication::delete_remote_elements
+  (DistributedMesh & mesh,
+   const std::set<Elem *> & extra_ghost_elem_ids) const
 {
   // The mesh should know it's about to be parallelized
   libmesh_assert (!mesh.is_serial());

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1564,7 +1564,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
       // Build a circle or hollow sphere in two dimensions
     case 2:
       {
-        // For ParallelMesh, if we don't specify node IDs the Mesh
+        // For DistributedMesh, if we don't specify node IDs the Mesh
         // will try to pick an appropriate (unique) one for us.  But
         // since we are adding these nodes on all processors, we want
         // to be sure they have consistent IDs across all processors.
@@ -1734,7 +1734,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
         // (Temporary) convenient storage for node pointers
         std::vector<Node *> nodes(16);
 
-        // For ParallelMesh, if we don't specify node IDs the Mesh
+        // For DistributedMesh, if we don't specify node IDs the Mesh
         // will try to pick an appropriate (unique) one for us.  But
         // since we are adding these nodes on all processors, we want
         // to be sure they have consistent IDs across all processors.

--- a/src/mesh/mesh_iterators.C
+++ b/src/mesh/mesh_iterators.C
@@ -31,47 +31,47 @@ namespace libMesh
 // functions for the mesh class.
 
 // This macro generates four iterator accessor function definitions
-// (const/non-const and begin/end) for both Serial and ParallelMesh
+// (const/non-const and begin/end) for both Replicated and DistributedMesh
 // given the Predicate PRED, which may be passed an arbitrary number
 // of arguments.
 #define INSTANTIATE_ELEM_ACCESSORS(FUNC_PREFIX, PRED, FUNC_ARG, ...)    \
-  SerialMesh::element_iterator                                          \
-  SerialMesh::FUNC_PREFIX##_begin (FUNC_ARG)                            \
+  ReplicatedMesh::element_iterator                                          \
+  ReplicatedMesh::FUNC_PREFIX##_begin (FUNC_ARG)                            \
   {                                                                     \
     return element_iterator(_elements.begin(), _elements.end(), Predicates::PRED<elem_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  SerialMesh::const_element_iterator                                    \
-  SerialMesh::FUNC_PREFIX##_begin (FUNC_ARG) const                      \
+  ReplicatedMesh::const_element_iterator                                    \
+  ReplicatedMesh::FUNC_PREFIX##_begin (FUNC_ARG) const                      \
   {                                                                     \
     return const_element_iterator(_elements.begin(), _elements.end(), Predicates::PRED<const_elem_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  SerialMesh::element_iterator                                          \
-  SerialMesh::FUNC_PREFIX##_end (FUNC_ARG)                              \
+  ReplicatedMesh::element_iterator                                          \
+  ReplicatedMesh::FUNC_PREFIX##_end (FUNC_ARG)                              \
   {                                                                     \
     return element_iterator(_elements.end(), _elements.end(), Predicates::PRED<elem_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  SerialMesh::const_element_iterator                                    \
-  SerialMesh::FUNC_PREFIX##_end (FUNC_ARG) const                        \
+  ReplicatedMesh::const_element_iterator                                    \
+  ReplicatedMesh::FUNC_PREFIX##_end (FUNC_ARG) const                        \
   {                                                                     \
     return const_element_iterator(_elements.end(), _elements.end(), Predicates::PRED<const_elem_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  ParallelMesh::element_iterator                                        \
-  ParallelMesh::FUNC_PREFIX##_begin (FUNC_ARG)                          \
+  DistributedMesh::element_iterator                                        \
+  DistributedMesh::FUNC_PREFIX##_begin (FUNC_ARG)                          \
   {                                                                     \
     return element_iterator(_elements.begin(), _elements.end(), Predicates::PRED<elem_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  ParallelMesh::const_element_iterator                                  \
-  ParallelMesh::FUNC_PREFIX##_begin (FUNC_ARG) const                    \
+  DistributedMesh::const_element_iterator                                  \
+  DistributedMesh::FUNC_PREFIX##_begin (FUNC_ARG) const                    \
   {                                                                     \
     return const_element_iterator(_elements.begin(), _elements.end(), Predicates::PRED<const_elem_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  ParallelMesh::element_iterator                                        \
-  ParallelMesh::FUNC_PREFIX##_end (FUNC_ARG)                            \
+  DistributedMesh::element_iterator                                        \
+  DistributedMesh::FUNC_PREFIX##_end (FUNC_ARG)                            \
   {                                                                     \
     return element_iterator(_elements.end(), _elements.end(), Predicates::PRED<elem_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  ParallelMesh::const_element_iterator                                  \
-  ParallelMesh::FUNC_PREFIX##_end (FUNC_ARG) const                      \
+  DistributedMesh::const_element_iterator                                  \
+  DistributedMesh::FUNC_PREFIX##_end (FUNC_ARG) const                      \
   {                                                                     \
     return const_element_iterator(_elements.end(), _elements.end(), Predicates::PRED<const_elem_iterator_imp>(__VA_ARGS__)); \
   }
@@ -81,43 +81,43 @@ namespace libMesh
 // This macro is similar to the one above except that it generates
 // node iterator accessor functions.
 #define INSTANTIATE_NODE_ACCESSORS(FUNC_PREFIX, PRED, FUNC_ARG, ...)    \
-  SerialMesh::node_iterator                                             \
-  SerialMesh::FUNC_PREFIX##_begin (FUNC_ARG)                            \
+  ReplicatedMesh::node_iterator                                             \
+  ReplicatedMesh::FUNC_PREFIX##_begin (FUNC_ARG)                            \
   {                                                                     \
     return node_iterator(_nodes.begin(), _nodes.end(), Predicates::PRED<node_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  SerialMesh::const_node_iterator                                       \
-  SerialMesh::FUNC_PREFIX##_begin (FUNC_ARG) const                      \
+  ReplicatedMesh::const_node_iterator                                       \
+  ReplicatedMesh::FUNC_PREFIX##_begin (FUNC_ARG) const                      \
   {                                                                     \
     return const_node_iterator(_nodes.begin(), _nodes.end(), Predicates::PRED<const_node_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  SerialMesh::node_iterator                                             \
-  SerialMesh::FUNC_PREFIX##_end (FUNC_ARG)                              \
+  ReplicatedMesh::node_iterator                                             \
+  ReplicatedMesh::FUNC_PREFIX##_end (FUNC_ARG)                              \
   {                                                                     \
     return node_iterator(_nodes.end(), _nodes.end(), Predicates::PRED<node_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  SerialMesh::const_node_iterator                                       \
-  SerialMesh::FUNC_PREFIX##_end (FUNC_ARG) const                        \
+  ReplicatedMesh::const_node_iterator                                       \
+  ReplicatedMesh::FUNC_PREFIX##_end (FUNC_ARG) const                        \
   {                                                                     \
     return const_node_iterator(_nodes.end(), _nodes.end(), Predicates::PRED<const_node_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  ParallelMesh::node_iterator                                           \
-  ParallelMesh::FUNC_PREFIX##_begin (FUNC_ARG)                          \
+  DistributedMesh::node_iterator                                           \
+  DistributedMesh::FUNC_PREFIX##_begin (FUNC_ARG)                          \
   {                                                                     \
     return node_iterator(_nodes.begin(), _nodes.end(), Predicates::PRED<node_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  ParallelMesh::const_node_iterator                                     \
-  ParallelMesh::FUNC_PREFIX##_begin (FUNC_ARG) const                    \
+  DistributedMesh::const_node_iterator                                     \
+  DistributedMesh::FUNC_PREFIX##_begin (FUNC_ARG) const                    \
   {                                                                     \
     return const_node_iterator(_nodes.begin(), _nodes.end(), Predicates::PRED<const_node_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  ParallelMesh::node_iterator                                           \
-  ParallelMesh::FUNC_PREFIX##_end (FUNC_ARG)                            \
+  DistributedMesh::node_iterator                                           \
+  DistributedMesh::FUNC_PREFIX##_end (FUNC_ARG)                            \
   {                                                                     \
     return node_iterator(_nodes.end(), _nodes.end(), Predicates::PRED<node_iterator_imp>(__VA_ARGS__)); \
   }                                                                     \
-  ParallelMesh::const_node_iterator                                     \
-  ParallelMesh::FUNC_PREFIX##_end (FUNC_ARG) const                      \
+  DistributedMesh::const_node_iterator                                     \
+  DistributedMesh::FUNC_PREFIX##_end (FUNC_ARG) const                      \
   {                                                                     \
     return const_node_iterator(_nodes.end(), _nodes.end(), Predicates::PRED<const_node_iterator_imp>(__VA_ARGS__)); \
   }

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -712,7 +712,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
 
   STOP_LOG("all_second_order()", "Mesh");
 
-  // In a ParallelMesh our ghost node processor ids may be bad,
+  // In a DistributedMesh our ghost node processor ids may be bad,
   // the ids of nodes touching remote elements may be inconsistent,
   // and unique_ids of newly added non-local nodes remain unset.
   // make_nodes_parallel_consistent() will fix all this.
@@ -762,7 +762,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
   std::vector<boundary_id_type> new_bndry_ids;
 
   // We may need to add new points if we run into a 1.5th order
-  // element; if we do that on a ParallelMesh in a ghost element then
+  // element; if we do that on a DistributedMesh in a ghost element then
   // we will need to fix their ids / unique_ids
   bool added_new_ghost_point = false;
 
@@ -1541,7 +1541,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                                           new_bndry_ids[s]);
     }
 
-  // In a ParallelMesh any newly added ghost node ids may be
+  // In a DistributedMesh any newly added ghost node ids may be
   // inconsistent, and unique_ids of newly added ghost nodes remain
   // unset.
   // make_nodes_parallel_consistent() will fix all this.
@@ -1797,7 +1797,7 @@ void MeshTools::Modification::flatten(MeshBase & mesh)
         copy->set_unique_id() = elem->unique_id();
 #endif
 
-        // This element could have boundary info or ParallelMesh
+        // This element could have boundary info or DistributedMesh
         // remote_elem links as well.  We need to save the (elem,
         // side, bc_id) triples and those links
         for (unsigned short s=0; s<elem->n_sides(); s++)

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -112,6 +112,6 @@ void MeshOutput<MT>::write_nodal_data (const std::string & fname,
 // move any functions in this file to the header file instead.
 template class MeshOutput<MeshBase>;
 template class MeshOutput<UnstructuredMesh>;
-template class MeshOutput<ParallelMesh>;
+template class MeshOutput<DistributedMesh>;
 
 } // namespace libMesh

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -34,7 +34,7 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
 {
   LOG_SCOPE("write_equation_systems()", "MeshOutput");
 
-  // We may need to gather and/or renumber a ParallelMesh to output
+  // We may need to gather and/or renumber a DistributedMesh to output
   // it, making that const qualifier in our constructor a dirty lie
   MT & my_mesh = const_cast<MT &>(*_obj);
 

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -38,7 +38,7 @@
 #include "libmesh/remote_elem.h"
 
 #ifdef DEBUG
-// Some extra validation for ParallelMesh
+// Some extra validation for DistributedMesh
 #include "libmesh/mesh_tools.h"
 #include "libmesh/parallel_mesh.h"
 #endif // DEBUG
@@ -1474,7 +1474,7 @@ bool MeshRefinement::_coarsen_elements ()
   this->comm().max(mesh_changed);
   this->comm().max(mesh_p_changed);
 
-  // And we may need to update ParallelMesh values reflecting the changes
+  // And we may need to update DistributedMesh values reflecting the changes
   if (mesh_changed)
     _mesh.update_parallel_id_counts();
 
@@ -1573,7 +1573,7 @@ bool MeshRefinement::_refine_elements ()
   this->comm().max(mesh_changed);
   this->comm().max(mesh_p_changed);
 
-  // And we may need to update ParallelMesh values reflecting the changes
+  // And we may need to update DistributedMesh values reflecting the changes
   if (mesh_changed)
     _mesh.update_parallel_id_counts();
 

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -285,7 +285,7 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector & error_pe
 
   sorted_error.reserve (n_active_elem);
 
-  // On a ParallelMesh, we need to communicate to know which remote ids
+  // On a DistributedMesh, we need to communicate to know which remote ids
   // correspond to active elements.
   {
     std::vector<bool> is_active(max_elem_id, false);
@@ -368,7 +368,7 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector & error_pe
       refine_count++;
     }
 
-  // On a ParallelMesh, we need to communicate to know which remote ids
+  // On a DistributedMesh, we need to communicate to know which remote ids
   // correspond to refinable elements
   dof_id_type successful_refine_count = 0;
   {
@@ -422,7 +422,7 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector & error_pe
           dof_id_type parent_id = sorted_parent_error[i].second;
           Elem * parent = _mesh.query_elem_ptr(parent_id);
 
-          // On a ParallelMesh we skip remote elements
+          // On a DistributedMesh we skip remote elements
           if (!parent)
             continue;
 

--- a/src/mesh/mesh_smoother_laplace.C
+++ b/src/mesh/mesh_smoother_laplace.C
@@ -87,7 +87,7 @@ void LaplaceMeshSmoother::smooth(unsigned int n_iterations)
                     // Will these nodal positions always be available
                     // or will they refer to remote nodes?  This will
                     // fail an assertion in the latter case, which
-                    // shouldn't occur if ParallelMesh is working
+                    // shouldn't occur if DistributedMesh is working
                     // correctly.
                     const Point & connected_node = _mesh.point(_graph[node->id()][j]);
 

--- a/src/mesh/mesh_triangle_wrapper.C
+++ b/src/mesh/mesh_triangle_wrapper.C
@@ -112,7 +112,7 @@ void TriangleWrapper::copy_tri_to_mesh(const triangulateio & triangle_data_input
   // Node information
   for (int i=0, c=0; c<triangle_data_input.numberofpoints; i+=2, ++c)
     {
-      // Specify ID when adding point, otherwise, if this is ParallelMesh,
+      // Specify ID when adding point, otherwise, if this is DistributedMesh,
       // it might add points with a non-sequential numbering...
       mesh_output.add_point( Point(triangle_data_input.pointlist[i],
                                    triangle_data_input.pointlist[i+1]),

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -428,7 +428,7 @@ void Nemesis_IO::read (const std::string & base_filename)
                  << my_node_offset
                  << std::endl;
 
-  // Add internal nodes to the ParallelMesh, using the node ID offset we
+  // Add internal nodes to the DistributedMesh, using the node ID offset we
   // computed and the current processor's ID.
   for (unsigned int i=0; i<to_uint(nemhelper->num_internal_nodes); ++i)
     {
@@ -1127,14 +1127,14 @@ void Nemesis_IO::read (const std::string & base_filename)
       libMesh::out << "mesh.parallel_n_elem()=" << mesh.parallel_n_elem() << std::endl;
     }
 
-  // For ParallelMesh, it seems that _is_serial is true by default.  A hack to
+  // For DistributedMesh, it seems that _is_serial is true by default.  A hack to
   // make the Mesh think it's parallel might be to call:
   mesh.update_post_partitioning();
   MeshCommunication().make_node_unique_ids_parallel_consistent(mesh);
   mesh.delete_remote_elements();
 
   // And if that didn't work, then we're actually reading into a
-  // SerialMesh, so forget about gathering neighboring elements
+  // ReplicatedMesh, so forget about gathering neighboring elements
   if (mesh.is_serial())
     return;
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1139,7 +1139,7 @@ void Nemesis_IO::read (const std::string & base_filename)
     return;
 
   // Gather neighboring elements so that the mesh has the proper "ghost" neighbor information.
-  MeshCommunication().gather_neighboring_elements(cast_ref<ParallelMesh &>(mesh));
+  MeshCommunication().gather_neighboring_elements(cast_ref<DistributedMesh &>(mesh));
 }
 
 #else

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -746,8 +746,8 @@ void Nemesis_IO_Helper::create(std::string filename)
 
 void Nemesis_IO_Helper::initialize(std::string title_in, const MeshBase & mesh, bool /*use_discontinuous*/)
 {
-  // Make sure that the reference passed in is really a ParallelMesh
-  // const ParallelMesh & pmesh = cast_ref<const ParallelMesh &>(mesh);
+  // Make sure that the reference passed in is really a DistributedMesh
+  // const DistributedMesh & pmesh = cast_ref<const DistributedMesh &>(mesh);
   const MeshBase & pmesh = mesh;
 
   // According to Nemesis documentation, first call when writing should be to
@@ -2312,8 +2312,8 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
 
 void Nemesis_IO_Helper::write_nodal_coordinates(const MeshBase & mesh, bool /*use_discontinuous*/)
 {
-  // Make sure that the reference passed in is really a ParallelMesh
-  // const ParallelMesh & pmesh = cast_ref<const ParallelMesh &>(mesh);
+  // Make sure that the reference passed in is really a DistributedMesh
+  // const DistributedMesh & pmesh = cast_ref<const DistributedMesh &>(mesh);
 
   unsigned local_num_nodes =
     cast_int<unsigned int>(this->exodus_node_num_to_libmesh.size());

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -30,9 +30,9 @@ namespace libMesh
 {
 
 // ------------------------------------------------------------
-// ParallelMesh class member functions
-ParallelMesh::ParallelMesh (const Parallel::Communicator & comm_in,
-                            unsigned char d) :
+// DistributedMesh class member functions
+DistributedMesh::DistributedMesh (const Parallel::Communicator & comm_in,
+                                  unsigned char d) :
   UnstructuredMesh (comm_in,d), _is_serial(true),
   _n_nodes(0), _n_elem(0), _max_node_id(0), _max_elem_id(0),
   _next_free_local_node_id(this->processor_id()),
@@ -54,8 +54,8 @@ ParallelMesh::ParallelMesh (const Parallel::Communicator & comm_in,
 
 #ifndef LIBMESH_DISABLE_COMMWORLD
 // ------------------------------------------------------------
-// ParallelMesh class member functions
-ParallelMesh::ParallelMesh (unsigned char d) :
+// DistributedMesh class member functions
+DistributedMesh::DistributedMesh (unsigned char d) :
   UnstructuredMesh (d), _is_serial(true),
   _n_nodes(0), _n_elem(0), _max_node_id(0), _max_elem_id(0),
   _next_free_local_node_id(this->processor_id()),
@@ -76,7 +76,7 @@ ParallelMesh::ParallelMesh (unsigned char d) :
 #endif
 
 
-ParallelMesh::~ParallelMesh ()
+DistributedMesh::~DistributedMesh ()
 {
   this->clear();  // Free nodes and elements
 }
@@ -85,7 +85,7 @@ ParallelMesh::~ParallelMesh ()
 // This might be specialized later, but right now it's just here to
 // make sure the compiler doesn't give us a default (non-deep) copy
 // constructor instead.
-ParallelMesh::ParallelMesh (const ParallelMesh & other_mesh) :
+DistributedMesh::DistributedMesh (const DistributedMesh & other_mesh) :
   UnstructuredMesh (other_mesh), _is_serial(other_mesh._is_serial),
   _n_nodes(0), _n_elem(0), _max_node_id(0), _max_elem_id(0),
   _next_free_local_node_id(this->processor_id()),
@@ -123,7 +123,7 @@ ParallelMesh::ParallelMesh (const ParallelMesh & other_mesh) :
 
 
 
-ParallelMesh::ParallelMesh (const UnstructuredMesh & other_mesh) :
+DistributedMesh::DistributedMesh (const UnstructuredMesh & other_mesh) :
   UnstructuredMesh (other_mesh), _is_serial(other_mesh.is_serial()),
   _n_nodes(0), _n_elem(0), _max_node_id(0), _max_elem_id(0),
   _next_free_local_node_id(this->processor_id()),
@@ -145,7 +145,7 @@ ParallelMesh::ParallelMesh (const UnstructuredMesh & other_mesh) :
 // from one processor without bothering the rest, but
 // we may need to update those caches before doing a full
 // renumbering
-void ParallelMesh::update_parallel_id_counts()
+void DistributedMesh::update_parallel_id_counts()
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -187,7 +187,7 @@ void ParallelMesh::update_parallel_id_counts()
 
 // Or in debug mode we may want to test the uncached values without
 // changing the cache
-dof_id_type ParallelMesh::parallel_n_elem() const
+dof_id_type DistributedMesh::parallel_n_elem() const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -200,7 +200,7 @@ dof_id_type ParallelMesh::parallel_n_elem() const
 
 
 
-dof_id_type ParallelMesh::parallel_max_elem_id() const
+dof_id_type DistributedMesh::parallel_max_elem_id() const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -231,7 +231,7 @@ dof_id_type ParallelMesh::parallel_max_elem_id() const
 
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-unique_id_type ParallelMesh::parallel_max_unique_id() const
+unique_id_type DistributedMesh::parallel_max_unique_id() const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -245,7 +245,7 @@ unique_id_type ParallelMesh::parallel_max_unique_id() const
 
 
 
-dof_id_type ParallelMesh::parallel_n_nodes() const
+dof_id_type DistributedMesh::parallel_n_nodes() const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -258,7 +258,7 @@ dof_id_type ParallelMesh::parallel_n_nodes() const
 
 
 
-dof_id_type ParallelMesh::parallel_max_node_id() const
+dof_id_type DistributedMesh::parallel_max_node_id() const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -288,14 +288,14 @@ dof_id_type ParallelMesh::parallel_max_node_id() const
 
 
 
-const Point & ParallelMesh::point (const dof_id_type i) const
+const Point & DistributedMesh::point (const dof_id_type i) const
 {
   return this->node_ref(i);
 }
 
 
 
-const Node * ParallelMesh::node_ptr (const dof_id_type i) const
+const Node * DistributedMesh::node_ptr (const dof_id_type i) const
 {
   libmesh_assert(_nodes[i]);
   libmesh_assert_equal_to (_nodes[i]->id(), i);
@@ -306,7 +306,7 @@ const Node * ParallelMesh::node_ptr (const dof_id_type i) const
 
 
 
-Node * ParallelMesh::node_ptr (const dof_id_type i)
+Node * DistributedMesh::node_ptr (const dof_id_type i)
 {
   libmesh_assert(_nodes[i]);
   libmesh_assert_equal_to (_nodes[i]->id(), i);
@@ -317,7 +317,7 @@ Node * ParallelMesh::node_ptr (const dof_id_type i)
 
 
 
-const Node * ParallelMesh::query_node_ptr (const dof_id_type i) const
+const Node * DistributedMesh::query_node_ptr (const dof_id_type i) const
 {
   std::map<dof_id_type, Node *>::const_iterator it = _nodes.find(i);
   if (it != _nodes.end().it)
@@ -333,7 +333,7 @@ const Node * ParallelMesh::query_node_ptr (const dof_id_type i) const
 
 
 
-Node * ParallelMesh::query_node_ptr (const dof_id_type i)
+Node * DistributedMesh::query_node_ptr (const dof_id_type i)
 {
   std::map<dof_id_type, Node *>::const_iterator it = _nodes.find(i);
   if (it != _nodes.end().it)
@@ -349,7 +349,7 @@ Node * ParallelMesh::query_node_ptr (const dof_id_type i)
 
 
 
-const Elem * ParallelMesh::elem_ptr (const dof_id_type i) const
+const Elem * DistributedMesh::elem_ptr (const dof_id_type i) const
 {
   libmesh_assert(_elements[i]);
   libmesh_assert_equal_to (_elements[i]->id(), i);
@@ -360,7 +360,7 @@ const Elem * ParallelMesh::elem_ptr (const dof_id_type i) const
 
 
 
-Elem * ParallelMesh::elem_ptr (const dof_id_type i)
+Elem * DistributedMesh::elem_ptr (const dof_id_type i)
 {
   libmesh_assert(_elements[i]);
   libmesh_assert_equal_to (_elements[i]->id(), i);
@@ -371,7 +371,7 @@ Elem * ParallelMesh::elem_ptr (const dof_id_type i)
 
 
 
-const Elem * ParallelMesh::query_elem_ptr (const dof_id_type i) const
+const Elem * DistributedMesh::query_elem_ptr (const dof_id_type i) const
 {
   std::map<dof_id_type, Elem *>::const_iterator it = _elements.find(i);
   if (it != _elements.end().it)
@@ -387,7 +387,7 @@ const Elem * ParallelMesh::query_elem_ptr (const dof_id_type i) const
 
 
 
-Elem * ParallelMesh::query_elem_ptr (const dof_id_type i)
+Elem * DistributedMesh::query_elem_ptr (const dof_id_type i)
 {
   std::map<dof_id_type, Elem *>::const_iterator it = _elements.find(i);
   if (it != _elements.end().it)
@@ -403,7 +403,7 @@ Elem * ParallelMesh::query_elem_ptr (const dof_id_type i)
 
 
 
-Elem * ParallelMesh::add_elem (Elem * e)
+Elem * DistributedMesh::add_elem (Elem * e)
 {
   // Don't try to add NULLs!
   libmesh_assert(e);
@@ -500,7 +500,7 @@ Elem * ParallelMesh::add_elem (Elem * e)
 
 
 
-Elem * ParallelMesh::insert_elem (Elem * e)
+Elem * DistributedMesh::insert_elem (Elem * e)
 {
   if (_elements[e->id()])
     this->delete_elem(_elements[e->id()]);
@@ -534,7 +534,7 @@ Elem * ParallelMesh::insert_elem (Elem * e)
 
 
 
-void ParallelMesh::delete_elem(Elem * e)
+void DistributedMesh::delete_elem(Elem * e)
 {
   libmesh_assert (e);
 
@@ -562,8 +562,8 @@ void ParallelMesh::delete_elem(Elem * e)
 
 
 
-void ParallelMesh::renumber_elem(const dof_id_type old_id,
-                                 const dof_id_type new_id)
+void DistributedMesh::renumber_elem(const dof_id_type old_id,
+                                    const dof_id_type new_id)
 {
   Elem * el = _elements[old_id];
   libmesh_assert (el);
@@ -577,9 +577,9 @@ void ParallelMesh::renumber_elem(const dof_id_type old_id,
 
 
 
-Node * ParallelMesh::add_point (const Point & p,
-                                const dof_id_type id,
-                                const processor_id_type proc_id)
+Node * DistributedMesh::add_point (const Point & p,
+                                   const dof_id_type id,
+                                   const processor_id_type proc_id)
 {
   if (_nodes.count(id))
     {
@@ -596,12 +596,12 @@ Node * ParallelMesh::add_point (const Point & p,
   Node * n = Node::build(p, id).release();
   n->processor_id() = proc_id;
 
-  return ParallelMesh::add_node(n);
+  return DistributedMesh::add_node(n);
 }
 
 
 
-Node * ParallelMesh::add_node (Node * n)
+Node * DistributedMesh::add_node (Node * n)
 {
   // Don't try to add NULLs!
   libmesh_assert(n);
@@ -699,14 +699,14 @@ Node * ParallelMesh::add_node (Node * n)
 
 
 
-Node * ParallelMesh::insert_node(Node * n)
+Node * DistributedMesh::insert_node(Node * n)
 {
-  return ParallelMesh::add_node(n);
+  return DistributedMesh::add_node(n);
 }
 
 
 
-void ParallelMesh::delete_node(Node * n)
+void DistributedMesh::delete_node(Node * n)
 {
   libmesh_assert(n);
   libmesh_assert(_nodes[n->id()]);
@@ -735,8 +735,8 @@ void ParallelMesh::delete_node(Node * n)
 
 
 
-void ParallelMesh::renumber_node(const dof_id_type old_id,
-                                 const dof_id_type new_id)
+void DistributedMesh::renumber_node(const dof_id_type old_id,
+                                    const dof_id_type new_id)
 {
   Node * nd = _nodes[old_id];
   libmesh_assert (nd);
@@ -770,7 +770,7 @@ void ParallelMesh::renumber_node(const dof_id_type old_id,
 
 
 
-void ParallelMesh::clear ()
+void DistributedMesh::clear ()
 {
   // Call parent clear function
   MeshBase::clear();
@@ -820,7 +820,7 @@ void ParallelMesh::clear ()
 
 
 
-void ParallelMesh::redistribute ()
+void DistributedMesh::redistribute ()
 {
   // If this is a truly parallel mesh, go through the redistribution/gather/delete remote steps
   if (!this->is_serial())
@@ -850,7 +850,7 @@ void ParallelMesh::redistribute ()
 
 
 
-void ParallelMesh::update_post_partitioning ()
+void DistributedMesh::update_post_partitioning ()
 {
   // this->recalculate_n_partitions();
 
@@ -861,7 +861,7 @@ void ParallelMesh::update_post_partitioning ()
 
 
 template <typename T>
-void ParallelMesh::libmesh_assert_valid_parallel_object_ids(const mapvector<T *, dof_id_type> & objects) const
+void DistributedMesh::libmesh_assert_valid_parallel_object_ids(const mapvector<T *, dof_id_type> & objects) const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -915,7 +915,7 @@ void ParallelMesh::libmesh_assert_valid_parallel_object_ids(const mapvector<T *,
 
 
 
-void ParallelMesh::libmesh_assert_valid_parallel_ids () const
+void DistributedMesh::libmesh_assert_valid_parallel_ids () const
 {
   this->libmesh_assert_valid_parallel_object_ids (this->_elements);
   this->libmesh_assert_valid_parallel_object_ids (this->_nodes);
@@ -923,7 +923,7 @@ void ParallelMesh::libmesh_assert_valid_parallel_ids () const
 
 
 
-void ParallelMesh::libmesh_assert_valid_parallel_p_levels () const
+void DistributedMesh::libmesh_assert_valid_parallel_p_levels () const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -944,7 +944,7 @@ void ParallelMesh::libmesh_assert_valid_parallel_p_levels () const
 
 
 
-void ParallelMesh::libmesh_assert_valid_parallel_flags () const
+void DistributedMesh::libmesh_assert_valid_parallel_flags () const
 {
 #ifdef LIBMESH_ENABLE_AMR
   // This function must be run on all processors at once
@@ -974,7 +974,7 @@ void ParallelMesh::libmesh_assert_valid_parallel_flags () const
 
 template <typename T>
 dof_id_type
-ParallelMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
+DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -1197,7 +1197,7 @@ ParallelMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
 }
 
 
-void ParallelMesh::renumber_nodes_and_elements ()
+void DistributedMesh::renumber_nodes_and_elements ()
 {
   parallel_object_only();
 
@@ -1208,7 +1208,7 @@ void ParallelMesh::renumber_nodes_and_elements ()
   this->libmesh_assert_valid_parallel_p_levels();
 #endif
 
-  LOG_SCOPE("renumber_nodes_and_elements()", "ParallelMesh");
+  LOG_SCOPE("renumber_nodes_and_elements()", "DistributedMesh");
 
   std::set<dof_id_type> used_nodes;
 
@@ -1292,7 +1292,7 @@ void ParallelMesh::renumber_nodes_and_elements ()
 
 
 
-void ParallelMesh::fix_broken_node_and_element_numbering ()
+void DistributedMesh::fix_broken_node_and_element_numbering ()
 {
   // We need access to iterators for the underlying containers,
   // not the mapvector<> reimplementations.
@@ -1324,7 +1324,7 @@ void ParallelMesh::fix_broken_node_and_element_numbering ()
 
 
 
-dof_id_type ParallelMesh::n_active_elem () const
+dof_id_type DistributedMesh::n_active_elem () const
 {
   parallel_object_only();
 
@@ -1345,7 +1345,7 @@ dof_id_type ParallelMesh::n_active_elem () const
 
 
 
-void ParallelMesh::delete_remote_elements()
+void DistributedMesh::delete_remote_elements()
 {
 #ifdef DEBUG
   // Make sure our neighbor links are all fine
@@ -1412,7 +1412,7 @@ void ParallelMesh::delete_remote_elements()
 }
 
 
-void ParallelMesh::add_extra_ghost_elem(Elem * e)
+void DistributedMesh::add_extra_ghost_elem(Elem * e)
 {
   // First add the elem like normal
   add_elem(e);
@@ -1423,7 +1423,7 @@ void ParallelMesh::add_extra_ghost_elem(Elem * e)
 }
 
 
-void ParallelMesh::allgather()
+void DistributedMesh::allgather()
 {
   if (_is_serial)
     return;

--- a/src/mesh/postscript_io.C
+++ b/src/mesh/postscript_io.C
@@ -70,7 +70,7 @@ PostscriptIO::~PostscriptIO ()
 
 void PostscriptIO::write (const std::string & fname)
 {
-  // We may need to gather a ParallelMesh to output it, making that
+  // We may need to gather a DistributedMesh to output it, making that
   // const qualifier in our constructor a dirty lie
   MeshSerializer serialize(const_cast<MeshBase &>(this->mesh()), !_is_parallel_format);
 

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -117,9 +117,9 @@ namespace libMesh
 {
 
 // ------------------------------------------------------------
-// SerialMesh class member functions
-SerialMesh::SerialMesh (const Parallel::Communicator & comm_in,
-                        unsigned char d) :
+// ReplicatedMesh class member functions
+ReplicatedMesh::ReplicatedMesh (const Parallel::Communicator & comm_in,
+                                unsigned char d) :
   UnstructuredMesh (comm_in,d)
 {
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
@@ -133,7 +133,7 @@ SerialMesh::SerialMesh (const Parallel::Communicator & comm_in,
 
 
 #ifndef LIBMESH_DISABLE_COMMWORLD
-SerialMesh::SerialMesh (unsigned char d) :
+ReplicatedMesh::ReplicatedMesh (unsigned char d) :
   UnstructuredMesh (d)
 {
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
@@ -146,7 +146,7 @@ SerialMesh::SerialMesh (unsigned char d) :
 #endif
 
 
-SerialMesh::~SerialMesh ()
+ReplicatedMesh::~ReplicatedMesh ()
 {
   this->clear();  // Free nodes and elements
 }
@@ -155,7 +155,7 @@ SerialMesh::~SerialMesh ()
 // This might be specialized later, but right now it's just here to
 // make sure the compiler doesn't give us a default (non-deep) copy
 // constructor instead.
-SerialMesh::SerialMesh (const SerialMesh & other_mesh) :
+ReplicatedMesh::ReplicatedMesh (const ReplicatedMesh & other_mesh) :
   UnstructuredMesh (other_mesh)
 {
   this->copy_nodes_and_elements(other_mesh);
@@ -166,7 +166,7 @@ SerialMesh::SerialMesh (const SerialMesh & other_mesh) :
 }
 
 
-SerialMesh::SerialMesh (const UnstructuredMesh & other_mesh) :
+ReplicatedMesh::ReplicatedMesh (const UnstructuredMesh & other_mesh) :
   UnstructuredMesh (other_mesh)
 {
   this->copy_nodes_and_elements(other_mesh);
@@ -174,7 +174,7 @@ SerialMesh::SerialMesh (const UnstructuredMesh & other_mesh) :
 }
 
 
-const Point & SerialMesh::point (const dof_id_type i) const
+const Point & ReplicatedMesh::point (const dof_id_type i) const
 {
   return this->node_ref(i);
 }
@@ -182,7 +182,7 @@ const Point & SerialMesh::point (const dof_id_type i) const
 
 
 
-const Node * SerialMesh::node_ptr (const dof_id_type i) const
+const Node * ReplicatedMesh::node_ptr (const dof_id_type i) const
 {
   libmesh_assert_less (i, this->n_nodes());
   libmesh_assert(_nodes[i]);
@@ -194,7 +194,7 @@ const Node * SerialMesh::node_ptr (const dof_id_type i) const
 
 
 
-Node * SerialMesh::node_ptr (const dof_id_type i)
+Node * ReplicatedMesh::node_ptr (const dof_id_type i)
 {
   libmesh_assert_less (i, this->n_nodes());
   libmesh_assert(_nodes[i]);
@@ -206,7 +206,7 @@ Node * SerialMesh::node_ptr (const dof_id_type i)
 
 
 
-const Node * SerialMesh::query_node_ptr (const dof_id_type i) const
+const Node * ReplicatedMesh::query_node_ptr (const dof_id_type i) const
 {
   if (i >= this->n_nodes())
     return libmesh_nullptr;
@@ -219,7 +219,7 @@ const Node * SerialMesh::query_node_ptr (const dof_id_type i) const
 
 
 
-Node * SerialMesh::query_node_ptr (const dof_id_type i)
+Node * ReplicatedMesh::query_node_ptr (const dof_id_type i)
 {
   if (i >= this->n_nodes())
     return libmesh_nullptr;
@@ -232,7 +232,7 @@ Node * SerialMesh::query_node_ptr (const dof_id_type i)
 
 
 
-const Elem * SerialMesh::elem_ptr (const dof_id_type i) const
+const Elem * ReplicatedMesh::elem_ptr (const dof_id_type i) const
 {
   libmesh_assert_less (i, this->n_elem());
   libmesh_assert(_elements[i]);
@@ -244,7 +244,7 @@ const Elem * SerialMesh::elem_ptr (const dof_id_type i) const
 
 
 
-Elem * SerialMesh::elem_ptr (const dof_id_type i)
+Elem * ReplicatedMesh::elem_ptr (const dof_id_type i)
 {
   libmesh_assert_less (i, this->n_elem());
   libmesh_assert(_elements[i]);
@@ -256,7 +256,7 @@ Elem * SerialMesh::elem_ptr (const dof_id_type i)
 
 
 
-const Elem * SerialMesh::query_elem_ptr (const dof_id_type i) const
+const Elem * ReplicatedMesh::query_elem_ptr (const dof_id_type i) const
 {
   if (i >= this->n_elem())
     return libmesh_nullptr;
@@ -269,7 +269,7 @@ const Elem * SerialMesh::query_elem_ptr (const dof_id_type i) const
 
 
 
-Elem * SerialMesh::query_elem_ptr (const dof_id_type i)
+Elem * ReplicatedMesh::query_elem_ptr (const dof_id_type i)
 {
   if (i >= this->n_elem())
     return libmesh_nullptr;
@@ -282,11 +282,11 @@ Elem * SerialMesh::query_elem_ptr (const dof_id_type i)
 
 
 
-Elem * SerialMesh::add_elem (Elem * e)
+Elem * ReplicatedMesh::add_elem (Elem * e)
 {
   libmesh_assert(e);
 
-  // We no longer merely append elements with SerialMesh
+  // We no longer merely append elements with ReplicatedMesh
 
   // If the user requests a valid id that doesn't correspond to an
   // existing element, let's give them that id, resizing the elements
@@ -318,7 +318,7 @@ Elem * SerialMesh::add_elem (Elem * e)
 
 
 
-Elem * SerialMesh::insert_elem (Elem * e)
+Elem * ReplicatedMesh::insert_elem (Elem * e)
 {
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   if (!e->valid_unique_id())
@@ -342,7 +342,7 @@ Elem * SerialMesh::insert_elem (Elem * e)
 
 
 
-void SerialMesh::delete_elem(Elem * e)
+void ReplicatedMesh::delete_elem(Elem * e)
 {
   libmesh_assert(e);
 
@@ -384,7 +384,7 @@ void SerialMesh::delete_elem(Elem * e)
 
 
 
-void SerialMesh::renumber_elem(const dof_id_type old_id,
+void ReplicatedMesh::renumber_elem(const dof_id_type old_id,
                                const dof_id_type new_id)
 {
   // This doesn't get used in serial yet
@@ -399,11 +399,11 @@ void SerialMesh::renumber_elem(const dof_id_type old_id,
 
 
 
-Node * SerialMesh::add_point (const Point & p,
-                              const dof_id_type id,
-                              const processor_id_type proc_id)
+Node * ReplicatedMesh::add_point (const Point & p,
+                                  const dof_id_type id,
+                                  const processor_id_type proc_id)
 {
-  //   // We only append points with SerialMesh
+  //   // We only append points with ReplicatedMesh
   //   libmesh_assert(id == DofObject::invalid_id || id == _nodes.size());
   //   Node *n = Node::build(p, _nodes.size()).release();
   //   n->processor_id() = proc_id;
@@ -452,10 +452,10 @@ Node * SerialMesh::add_point (const Point & p,
 
 
 
-Node * SerialMesh::add_node (Node * n)
+Node * ReplicatedMesh::add_node (Node * n)
 {
   libmesh_assert(n);
-  // We only append points with SerialMesh
+  // We only append points with ReplicatedMesh
   libmesh_assert(!n->valid_id() || n->id() == _nodes.size());
 
   n->set_id (cast_int<dof_id_type>(_nodes.size()));
@@ -472,7 +472,7 @@ Node * SerialMesh::add_node (Node * n)
 
 
 
-Node * SerialMesh::insert_node(Node * n)
+Node * ReplicatedMesh::insert_node(Node * n)
 {
   if (!n)
     libmesh_error_msg("Error, attempting to insert NULL node.");
@@ -515,7 +515,7 @@ Node * SerialMesh::insert_node(Node * n)
 
 
 
-void SerialMesh::delete_node(Node * n)
+void ReplicatedMesh::delete_node(Node * n)
 {
   libmesh_assert(n);
   libmesh_assert_less (n->id(), _nodes.size());
@@ -554,8 +554,8 @@ void SerialMesh::delete_node(Node * n)
 
 
 
-void SerialMesh::renumber_node(const dof_id_type old_id,
-                               const dof_id_type new_id)
+void ReplicatedMesh::renumber_node(const dof_id_type old_id,
+                                   const dof_id_type new_id)
 {
   // This doesn't get used in serial yet
   Node * nd = _nodes[old_id];
@@ -569,7 +569,7 @@ void SerialMesh::renumber_node(const dof_id_type old_id,
 
 
 
-void SerialMesh::clear ()
+void ReplicatedMesh::clear ()
 {
   // Call parent clear function
   MeshBase::clear();
@@ -606,7 +606,7 @@ void SerialMesh::clear ()
 
 
 
-void SerialMesh::update_parallel_id_counts()
+void ReplicatedMesh::update_parallel_id_counts()
 {
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   _next_unique_id = this->parallel_max_unique_id();
@@ -616,7 +616,7 @@ void SerialMesh::update_parallel_id_counts()
 
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-unique_id_type SerialMesh::parallel_max_unique_id() const
+unique_id_type ReplicatedMesh::parallel_max_unique_id() const
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -629,7 +629,7 @@ unique_id_type SerialMesh::parallel_max_unique_id() const
 
 
 
-void SerialMesh::renumber_nodes_and_elements ()
+void ReplicatedMesh::renumber_nodes_and_elements ()
 {
   LOG_SCOPE("renumber_nodes_and_elem()", "Mesh");
 
@@ -787,7 +787,7 @@ void SerialMesh::renumber_nodes_and_elements ()
 
 
 
-void SerialMesh::fix_broken_node_and_element_numbering ()
+void ReplicatedMesh::fix_broken_node_and_element_numbering ()
 {
   // Nodes first
   for (dof_id_type n=0; n<this->_nodes.size(); n++)
@@ -801,16 +801,16 @@ void SerialMesh::fix_broken_node_and_element_numbering ()
 }
 
 
-void SerialMesh::stitch_meshes (SerialMesh & other_mesh,
-                                boundary_id_type this_mesh_boundary_id,
-                                boundary_id_type other_mesh_boundary_id,
-                                Real tol,
-                                bool clear_stitched_boundary_ids,
-                                bool verbose,
-                                bool use_binary_search,
-                                bool enforce_all_nodes_match_on_boundaries)
+void ReplicatedMesh::stitch_meshes (ReplicatedMesh & other_mesh,
+                                    boundary_id_type this_mesh_boundary_id,
+                                    boundary_id_type other_mesh_boundary_id,
+                                    Real tol,
+                                    bool clear_stitched_boundary_ids,
+                                    bool verbose,
+                                    bool use_binary_search,
+                                    bool enforce_all_nodes_match_on_boundaries)
 {
-  LOG_SCOPE("stitch_meshes()", "SerialMesh");
+  LOG_SCOPE("stitch_meshes()", "ReplicatedMesh");
   stitching_helper(&other_mesh,
                    this_mesh_boundary_id,
                    other_mesh_boundary_id,
@@ -822,13 +822,13 @@ void SerialMesh::stitch_meshes (SerialMesh & other_mesh,
                    true);
 }
 
-void SerialMesh::stitch_surfaces (boundary_id_type boundary_id_1,
-                                  boundary_id_type boundary_id_2,
-                                  Real tol,
-                                  bool clear_stitched_boundary_ids,
-                                  bool verbose,
-                                  bool use_binary_search,
-                                  bool enforce_all_nodes_match_on_boundaries)
+void ReplicatedMesh::stitch_surfaces (boundary_id_type boundary_id_1,
+                                      boundary_id_type boundary_id_2,
+                                      Real tol,
+                                      bool clear_stitched_boundary_ids,
+                                      bool verbose,
+                                      bool use_binary_search,
+                                      bool enforce_all_nodes_match_on_boundaries)
 {
   stitching_helper(libmesh_nullptr,
                    boundary_id_1,
@@ -841,15 +841,15 @@ void SerialMesh::stitch_surfaces (boundary_id_type boundary_id_1,
                    true);
 }
 
-void SerialMesh::stitching_helper (SerialMesh * other_mesh,
-                                   boundary_id_type this_mesh_boundary_id,
-                                   boundary_id_type other_mesh_boundary_id,
-                                   Real tol,
-                                   bool clear_stitched_boundary_ids,
-                                   bool verbose,
-                                   bool use_binary_search,
-                                   bool enforce_all_nodes_match_on_boundaries,
-                                   bool skip_find_neighbors)
+void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
+                                       boundary_id_type this_mesh_boundary_id,
+                                       boundary_id_type other_mesh_boundary_id,
+                                       Real tol,
+                                       bool clear_stitched_boundary_ids,
+                                       bool verbose,
+                                       bool use_binary_search,
+                                       bool enforce_all_nodes_match_on_boundaries,
+                                       bool skip_find_neighbors)
 {
   std::map<dof_id_type, dof_id_type> node_to_node_map, other_to_this_node_map; // The second is the inverse map of the first
   std::map<dof_id_type, std::vector<dof_id_type> > node_to_elems_map;
@@ -882,7 +882,7 @@ void SerialMesh::stitching_helper (SerialMesh * other_mesh,
         // Make temporary fixed-size arrays for loop
         boundary_id_type id_array[2]        = {this_mesh_boundary_id, other_mesh_boundary_id};
         std::set<dof_id_type> * set_array[2] = {&this_boundary_node_ids, &other_boundary_node_ids};
-        SerialMesh * mesh_array[2]           = {this, other_mesh};
+        ReplicatedMesh * mesh_array[2]           = {this, other_mesh};
 
         for (unsigned i=0; i<2; ++i)
           {
@@ -993,7 +993,7 @@ void SerialMesh::stitching_helper (SerialMesh * other_mesh,
 
       if (verbose)
         {
-          libMesh::out << "In SerialMesh::stitch_meshes:\n"
+          libMesh::out << "In ReplicatedMesh::stitch_meshes:\n"
                        << "This mesh has "  << this_boundary_node_ids.size()
                        << " nodes on boundary " << this_mesh_boundary_id  << ".\n"
                        << "Other mesh has " << other_boundary_node_ids.size()
@@ -1026,7 +1026,7 @@ void SerialMesh::stitching_helper (SerialMesh * other_mesh,
           // Create and sort the vectors we will use to do the geometric searching
           {
             std::set<dof_id_type> * set_array[2] = {&this_boundary_node_ids, &other_boundary_node_ids};
-            SerialMesh * mesh_array[2]           = {this, other_mesh};
+            ReplicatedMesh * mesh_array[2]           = {this, other_mesh};
             PointVector * vec_array[2]           = {&this_sorted_bndry_nodes, &other_sorted_bndry_nodes};
 
             for (unsigned i=0; i<2; ++i)
@@ -1154,7 +1154,7 @@ void SerialMesh::stitching_helper (SerialMesh * other_mesh,
 
       if(verbose)
         {
-          libMesh::out << "In SerialMesh::stitch_meshes:\n"
+          libMesh::out << "In ReplicatedMesh::stitch_meshes:\n"
                        << "Found " << node_to_node_map.size()
                        << " matching nodes.\n"
                        << std::endl;
@@ -1174,7 +1174,7 @@ void SerialMesh::stitching_helper (SerialMesh * other_mesh,
     {
       if(verbose)
         {
-          libMesh::out << "Skip node merging in SerialMesh::stitch_meshes:" << std::endl;
+          libMesh::out << "Skip node merging in ReplicatedMesh::stitch_meshes:" << std::endl;
         }
     }
 
@@ -1456,7 +1456,7 @@ void SerialMesh::stitching_helper (SerialMesh * other_mesh,
 }
 
 
-dof_id_type SerialMesh::n_active_elem () const
+dof_id_type ReplicatedMesh::n_active_elem () const
 {
   return static_cast<dof_id_type>(std::distance (this->active_elements_begin(),
                                                  this->active_elements_end()));

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -161,6 +161,17 @@ template <>
 template <>
 unsigned int
 Packing<const Elem *>::packable_size (const Elem * const & elem,
+                                      const DistributedMesh * mesh)
+{
+  return packable_size(elem, static_cast<const MeshBase *>(mesh));
+}
+
+
+
+template <>
+template <>
+unsigned int
+Packing<const Elem *>::packable_size (const Elem * const & elem,
                                       const ParallelMesh * mesh)
 {
   return packable_size(elem, static_cast<const MeshBase *>(mesh));
@@ -281,6 +292,18 @@ Packing<const Elem *>::pack (const Elem * const & elem,
             *data_out++ =(*bc_it);
         }
     }
+}
+
+
+
+template <>
+template <>
+void
+Packing<const Elem *>::pack (const Elem * const & elem,
+                             std::back_insert_iterator<std::vector<largest_id_type> > data_out,
+                             const DistributedMesh * mesh)
+{
+  pack(elem, data_out, static_cast<const MeshBase*>(mesh));
 }
 
 
@@ -735,6 +758,17 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
 
   // Return the new element
   return elem;
+}
+
+
+
+template <>
+template <>
+Elem *
+Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
+                         DistributedMesh * mesh)
+{
+  return unpack(in, static_cast<MeshBase*>(mesh));
 }
 
 

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -106,6 +106,17 @@ template <>
 template <>
 unsigned int
 Packing<const Node *>::packable_size (const Node * const & node,
+                                      const DistributedMesh * mesh)
+{
+  return packable_size(node, static_cast<const MeshBase *>(mesh));
+}
+
+
+
+template <>
+template <>
+unsigned int
+Packing<const Node *>::packable_size (const Node * const & node,
                                       const ParallelMesh * mesh)
 {
   return packable_size(node, static_cast<const MeshBase *>(mesh));
@@ -165,6 +176,18 @@ Packing<const Node *>::pack (const Node * const & node,
   for (std::vector<boundary_id_type>::iterator bc_it=bcs.begin();
        bc_it != bcs.end(); ++bc_it)
     *data_out++ =(*bc_it);
+}
+
+
+
+template <>
+template <>
+void
+Packing<const Node *>::pack (const Node* const & node,
+                             std::back_insert_iterator<std::vector<largest_id_type> > data_out,
+                             const DistributedMesh * mesh)
+{
+  pack(node, data_out, static_cast<const MeshBase*>(mesh));
 }
 
 
@@ -284,6 +307,17 @@ Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,
 #endif
 
   return node;
+}
+
+
+
+template <>
+template <>
+Node *
+Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,
+                         DistributedMesh * mesh)
+{
+  return unpack(in, static_cast<MeshBase*>(mesh));
 }
 
 

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -565,7 +565,7 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
     }
 
   // We can't assert that all nodes are connected to elements, because
-  // a ParallelMesh with NodeConstraints might have pulled in some
+  // a DistributedMesh with NodeConstraints might have pulled in some
   // remote nodes solely for evaluating those constraints.
   // MeshTools::libmesh_assert_connected_nodes(mesh);
 

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -705,7 +705,7 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
   // Interpolation elements (including the "extra one")
   {
     libMesh::dof_id_type elem_id = 0;
-    libMesh::SerialMesh & interpolation_points_mesh =
+    libMesh::ReplicatedMesh & interpolation_points_mesh =
       rb_eim_evaluation.get_interpolation_points_mesh();
     interpolation_points_mesh.clear();
 
@@ -855,7 +855,7 @@ void load_point(RBData::Point3D::Reader point_reader, Point & point)
 
 void load_elem_into_mesh(RBData::MeshElem::Reader mesh_elem_reader,
                          libMesh::Elem * elem,
-                         libMesh::SerialMesh & mesh)
+                         libMesh::ReplicatedMesh & mesh)
 {
   auto mesh_elem_point_list = mesh_elem_reader.getPoints();
   unsigned int n_points = mesh_elem_point_list.size();

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -102,7 +102,7 @@ unsigned int RBEIMEvaluation::get_n_parametrized_functions() const
     (_parametrized_functions.size());
 }
 
-SerialMesh & RBEIMEvaluation::get_interpolation_points_mesh()
+ReplicatedMesh & RBEIMEvaluation::get_interpolation_points_mesh()
 {
   return _interpolation_points_mesh;
 }


### PR DESCRIPTION
So, @jwpeterson, when I told you "I don't have any upcoming PRs that need to get into 1.0", it turns out that what I actually meant was "I need to rejigger one of our most fundamental classes before 1.0 comes out".  My bad.

This implements the changes settled on a few months ago:
https://sourceforge.net/p/libmesh/mailman/libmesh-devel/thread/CAFfxPjp%2B0%3Dx_w-7eACBh9nTn5WR%2BrPjJVvytvb9iX_%2BnzaNDCw%40mail.gmail.com/
in order to make our mesh class names less confusing.

Shim subclasses should keep us backwards-compatible with older application code from before the change.  I don't intend to remove the old names for years; just want to make sure that the new names are available to everyone from 1.0.0 onward.

GRINS, my private apps, and MOOSE still compile and pass test suites for me.