### PR TITLE
Fixes for assorted odd build configurations

### DIFF
--- a/examples/adjoints/adjoints_ex1/femparameters.C
+++ b/examples/adjoints/adjoints_ex1/femparameters.C
@@ -58,7 +58,9 @@ FEMParameters::FEMParameters(const Parallel::Communicator & comm_in) :
 
   system_types(0),
 
+#ifdef LIBMESH_ENABLE_PERIODIC
   periodic_boundaries(0),
+#endif
 
   run_simulation(true), run_postprocess(false),
 
@@ -268,6 +270,7 @@ void FEMParameters::read(GetPot & input,
     }
 
 
+#ifdef LIBMESH_ENABLE_PERIODIC
   GETPOT_REGISTER(periodic_boundaries);
   const unsigned int n_periodic_bcs =
     input.vector_variable_size("periodic_boundaries");
@@ -329,6 +332,7 @@ void FEMParameters::read(GetPot & input,
           periodic_boundaries[i].pairedboundary = pairedboundary;
         }
     }
+#endif // LIBMESH_ENABLE_PERIODIC
 
   // Use std::string inputs so GetPot doesn't have to make a bunch
   // of internal C string copies

--- a/examples/adjoints/adjoints_ex1/femparameters.h
+++ b/examples/adjoints/adjoints_ex1/femparameters.h
@@ -77,7 +77,9 @@ public:
 
   //   Boundary and initial conditions
 
+#ifdef LIBMESH_ENABLE_PERIODIC
   std::vector<libMesh::PeriodicBoundary> periodic_boundaries;
+#endif
 
   std::map<libMesh::subdomain_id_type, libMesh::FunctionBase<libMesh::Number> *>
   initial_conditions;

--- a/examples/adjoints/adjoints_ex2/femparameters.h
+++ b/examples/adjoints/adjoints_ex2/femparameters.h
@@ -77,7 +77,9 @@ public:
 
   //   Boundary and initial conditions
 
+#ifdef LIBMESH_ENABLE_PERIODIC
   std::vector<libMesh::PeriodicBoundary> periodic_boundaries;
+#endif
 
   std::map<libMesh::subdomain_id_type, libMesh::FunctionBase<libMesh::Number> *>
   initial_conditions;

--- a/examples/adjoints/adjoints_ex3/femparameters.h
+++ b/examples/adjoints/adjoints_ex3/femparameters.h
@@ -77,7 +77,9 @@ public:
 
   //   Boundary and initial conditions
 
+#ifdef LIBMESH_ENABLE_PERIODIC
   std::vector<libMesh::PeriodicBoundary> periodic_boundaries;
+#endif
 
   std::map<libMesh::subdomain_id_type, libMesh::FunctionBase<libMesh::Number> *>
   initial_conditions;

--- a/examples/adjoints/adjoints_ex4/femparameters.h
+++ b/examples/adjoints/adjoints_ex4/femparameters.h
@@ -77,7 +77,9 @@ public:
 
   //   Boundary and initial conditions
 
+#ifdef LIBMESH_ENABLE_PERIODIC
   std::vector<libMesh::PeriodicBoundary> periodic_boundaries;
+#endif
 
   std::map<libMesh::subdomain_id_type, libMesh::FunctionBase<libMesh::Number> *>
   initial_conditions;

--- a/examples/adjoints/adjoints_ex5/femparameters.h
+++ b/examples/adjoints/adjoints_ex5/femparameters.h
@@ -77,7 +77,9 @@ public:
 
   //   Boundary and initial conditions
 
+#ifdef LIBMESH_ENABLE_PERIODIC
   std::vector<libMesh::PeriodicBoundary> periodic_boundaries;
+#endif
 
   std::map<libMesh::subdomain_id_type, libMesh::FunctionBase<libMesh::Number> *>
   initial_conditions;

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -78,6 +78,11 @@ int main (int argc, char ** argv)
   // Skip this 3D example if libMesh was compiled as 1D/2D-only.
   libmesh_example_requires (3 == LIBMESH_DIM, "3D support");
 
+  // Our input mesh here is in ExodusII format
+#ifndef LIBMESH_HAVE_EXODUS_API
+  libmesh_example_requires (false, "ExodusII support");
+#endif
+
   // This example does a bunch of linear algebra during assembly, and
   // therefore requires Eigen.
 #ifndef LIBMESH_HAVE_EIGEN

--- a/examples/optimization/optimization_ex1/optimization_ex1.C
+++ b/examples/optimization/optimization_ex1/optimization_ex1.C
@@ -247,6 +247,10 @@ int main (int argc, char ** argv)
 
   libmesh_example_requires(false, "PETSc >= 3.5.0 with built-in TAO support");
 
+#elif !defined(LIBMESH_ENABLE_GHOSTED)
+
+  libmesh_example_requires(false, "--enable-ghosted");
+
 #elif LIBMESH_USE_COMPLEX_NUMBERS
 
   // According to

--- a/examples/optimization/optimization_ex1/optimization_ex1.C
+++ b/examples/optimization/optimization_ex1/optimization_ex1.C
@@ -349,9 +349,11 @@ int main (int argc, char ** argv)
   // Print convergence information
   system.optimization_solver->print_converged_reason();
 
+#ifdef LIBMESH_HAVE_EXODUS_API
   std::stringstream filename;
   ExodusII_IO (mesh).write_equation_systems("optimization_soln.exo",
                                             equation_systems);
+#endif
 
   return 0;
 }

--- a/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
+++ b/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
@@ -661,9 +661,11 @@ int main (int argc, char ** argv)
 
       lde.compute_stresses();
 
+#ifdef LIBMESH_HAVE_EXODUS_API
       std::stringstream filename;
       filename << "solution_" << count << ".exo";
       ExodusII_IO (mesh).write_equation_systems(filename.str(), equation_systems);
+#endif
     }
 
   return 0;

--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
@@ -61,6 +61,11 @@ int main (int argc, char ** argv)
 {
   LibMeshInit init (argc, argv);
 
+  // This example uses an ExodusII input file
+#ifndef LIBMESH_HAVE_EXODUS_API
+  libmesh_example_requires(false, "--enable-exodus");
+#endif
+
   // This example requires the PETSc nonlinear solvers
   libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
 

--- a/include/solvers/trilinos_aztec_linear_solver.h
+++ b/include/solvers/trilinos_aztec_linear_solver.h
@@ -138,6 +138,12 @@ public:
   Real get_initial_residual();
 
   /**
+   * Prints a useful message about why the latest linear solve
+   * con(di)verged.
+   */
+  virtual void print_converged_reason() const libmesh_override;
+
+  /**
    * Returns the solver's convergence flag
    */
   virtual LinearConvergenceReason get_converged_reason() const libmesh_override;

--- a/include/utils/hashword.h
+++ b/include/utils/hashword.h
@@ -274,6 +274,16 @@ uint16_t hashword(const uint16_t * k, size_t length)
   return static_cast<uint16_t>(c);
 }
 
+
+// Calls function above with slightly more convenient std::vector interface.
+inline
+uint16_t hashword(const std::vector<uint16_t> & keys)
+{
+  return hashword(&keys[0], keys.size());
+}
+
+
+
 } // end Utility namespace
 } // end libMesh namespace
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -921,8 +921,9 @@ void FEMap::compute_single_point_map(const unsigned int dim,
               }
 
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
-          }
+
 #endif // LIBMESH_DIM == 3
+          }
         // done computing the map
         break;
       }

--- a/src/solvers/laspack_linear_solver.C
+++ b/src/solvers/laspack_linear_solver.C
@@ -514,7 +514,15 @@ void LaspackLinearSolver<T>::set_laspack_preconditioner_type ()
 template <typename T>
 void LaspackLinearSolver<T>::print_converged_reason() const
 {
-  libMesh::out << "print_converged_reason() is currently only supported"
+  switch (LASResult())
+    {
+    case LASOK :
+      libMesh::out << "Laspack converged.\n";
+      break;
+    default    :
+      libMesh::out << "Laspack diverged.\n";
+    }
+  libMesh::out << "Detailed reporting is currently only supported"
                << "with Petsc 2.3.1 and later." << std::endl;
 }
 
@@ -523,7 +531,11 @@ void LaspackLinearSolver<T>::print_converged_reason() const
 template <typename T>
 LinearConvergenceReason LaspackLinearSolver<T>::get_converged_reason() const
 {
-  libmesh_not_implemented();
+  switch (LASResult())
+    {
+    case LASOK : return CONVERGED_RTOL_NORMAL;
+    default    : return DIVERGED_NULL;
+    }
 }
 
 

--- a/src/solvers/trilinos_aztec_linear_solver.C
+++ b/src/solvers/trilinos_aztec_linear_solver.C
@@ -183,11 +183,51 @@ Real AztecLinearSolver<T>::get_initial_residual()
 
 
 template <typename T>
+void AztecLinearSolver<T>::print_converged_reason() const
+{
+  const double *status = _linear_solver->GetAztecStatus();
+
+  switch (static_cast<int>(status[AZ_why]))
+    {
+    case AZ_normal :
+      libMesh::out << "AztecOO converged.\n";
+      break;
+    case AZ_maxits :
+      libMesh::out << "AztecOO failed to converge within maximum iterations.\n";
+      break;
+    case AZ_param :
+      libMesh::out << "AztecOO failed to support a user-requested parameter.\n";
+      break;
+    case AZ_breakdown :
+      libMesh::out << "AztecOO encountered numerical breakdown.\n";
+      break;
+    case AZ_loss :
+      libMesh::out << "AztecOO encountered numerical loss of precision.\n";
+      break;
+    case AZ_ill_cond :
+      libMesh::out << "AztecOO encountered an ill-conditioned GMRES Hessian.\n";
+      break;
+    default:
+      libMesh::out << "AztecOO reported an unrecognized condition.\n";
+      break;
+    }
+}
+
+
+
+template <typename T>
 LinearConvergenceReason AztecLinearSolver<T>::get_converged_reason() const
 {
-  libmesh_not_implemented();
+  const double *status = _linear_solver->GetAztecStatus();
 
-  return UNKNOWN_FLAG;
+  switch (static_cast<int>(status[AZ_why]))
+    {
+    case AZ_normal :
+      return CONVERGED_RTOL_NORMAL;
+    case AZ_maxits :
+      return DIVERGED_ITS;
+    }
+  return DIVERGED_NULL;
 }
 
 


### PR DESCRIPTION
PECOS finally has BuildBot up and running again!

This means that we can finally resume automatic testing of all the little fiddly configuration options that the main developers don't commonly use.  In particular I'm looking forward to explaining that the answer to "does --enable-complex work" is "yes, at least as of last night", rather than "yes, at least if you use a git hash from shortly after the last time someone complained about --enable-complex not working".

This PR is still a work in progress; I'll take off the "do not merge" tag once everything in our current set of test configurations builds cleanly again.

There are a lot of warnings to be fixed as well; I'll leave those in a separate PR.  My hope is that the fixes for even corner-case errors can get merged down to 1.0, but IMHO that's not worth it for fixes for warnings.