### PR TITLE
Make default unique_id size in help string match actual default.

### DIFF
--- a/configure
+++ b/configure
@@ -2043,7 +2043,7 @@ Optional Packages:
                           bytes of storage per element used to store the
                           subdomain_id [2]
   --with-unique-id-bytes=<1|2|4|8>
-                          bytes used per unique id [4]
+                          bytes used per unique id [8]
   --with-boost[=ARG]      use Boost library from a standard location
                           (ARG=yes), from the specified location (ARG=<path>),
                           or disable it (ARG=no) [ARG=yes]

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -301,7 +301,7 @@ fi
 # -------------------------------------------------------------
 AC_ARG_WITH([unique_id_bytes],
             AS_HELP_STRING([--with-unique-id-bytes=<1|2|4|8>],
-                           [bytes used per unique id [4]]),
+                           [bytes used per unique id [8]]),
             [unique_bytes="$withval"],
             [unique_bytes=8])
 


### PR DESCRIPTION
The default is 8 bytes, but the help message said 4.