### PR TITLE
Add sanity check for DirichletBoundaries

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1409,6 +1409,12 @@ private:
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
   /**
+   * Check that all the ids in dirichlet_bcids are actually present in the mesh.
+   * If not, this will throw an error.
+   */
+  void check_dirichlet_bcid_consistency (const MeshBase & mesh,
+                                         const DirichletBoundary & boundary) const;
+  /**
    * Data structure containing Dirichlet functions.  The ith
    * entry is the constraint matrix row for boundaryid i.
    */


### PR DESCRIPTION
Check that the boundary ids provided to the DirichletBoundary are actually present in the mesh. If not, throw an error. Prior to these checks, the Dirichlet constraints were silently ignored.

I haven't run this through the libMesh examples (I'm abusing Civet), but did test on application code that error is thrown (or not) when expected. I dropped this in `create_dof_constraints` since that is called everytime `reinit_constraints` is called. That seemed appropriate to me since it's conceivable (although I'd guess unlikely) the mesh boundary ids changed between the calls to `reinit_constraints`.