### PR TITLE
Enable Trilinos with double precision only

### DIFF
--- a/configure
+++ b/configure
@@ -36249,9 +36249,34 @@ else
 fi
 
 
-  # Trump --enable-trilinos with --disable-mpi
-  if (test "x$enablempi" = xno); then
-    enabletrilinos=no
+  if (test "x$enabletrilinos" = xyes); then
+    # Trump --enable-trilinos with --disable-mpi
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking Whether MPI is available for Trilinos" >&5
+$as_echo_n "checking Whether MPI is available for Trilinos... " >&6; }
+    if (test "x$enablempi" = xno); then
+      enabletrilinos=no
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+    fi
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking Whether Real precision is compatible with Trilinos" >&5
+$as_echo_n "checking Whether Real precision is compatible with Trilinos... " >&6; }
+    # Trump --enable-trilinos with --enable anything except double
+    # precision - the modules we use are hardcoded to double
+
+    if (test "x$enablesingleprecision" != xno -o \
+             "x$enabletripleprecision" != xno -o \
+             "x$enablequadrupleprecision" != xno); then
+      enabletrilinos=no
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+    fi
   fi
 
 

--- a/m4/trilinos.m4
+++ b/m4/trilinos.m4
@@ -518,9 +518,28 @@ AC_DEFUN([CONFIGURE_TRILINOS],
                                esac],
                                [enabletrilinos=$enableoptional])
 
-  # Trump --enable-trilinos with --disable-mpi
-  if (test "x$enablempi" = xno); then
-    enabletrilinos=no
+  if (test "x$enabletrilinos" = xyes); then
+    # Trump --enable-trilinos with --disable-mpi
+    AC_MSG_CHECKING([Whether MPI is available for Trilinos])
+    if (test "x$enablempi" = xno); then
+      enabletrilinos=no
+      AC_MSG_RESULT(no)
+    else
+      AC_MSG_RESULT(yes)
+    fi
+
+    AC_MSG_CHECKING([Whether Real precision is compatible with Trilinos])
+    # Trump --enable-trilinos with --enable anything except double
+    # precision - the modules we use are hardcoded to double
+ 
+    if (test "x$enablesingleprecision" != xno -o \
+             "x$enabletripleprecision" != xno -o \
+             "x$enablequadrupleprecision" != xno); then
+      enabletrilinos=no
+      AC_MSG_RESULT(no)
+    else
+      AC_MSG_RESULT(yes)
+    fi
   fi
 
   AC_ARG_VAR([TRILINOS_DIR],  [path to Trilinos installation])


### PR DESCRIPTION
And give better configure messages when non-standard precision or disabled MPI forces us to disable Trilinos too.

This isn't worth backporting, since "--disable-trilinos" was an easy workaround.