### PR TITLE
Global dirichlet id check

### DIFF
--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -160,8 +160,10 @@ int main (int argc, char ** argv)
 
   {
     // Add boundary IDs to this mesh so that we can use DirichletBoundary
-    MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
+  // Each processor should know about each boundary condition it can
+  // see, so we loop over all elements, not just local elements.
+    MeshBase::const_element_iterator       el     = mesh.elements_begin();
+    const MeshBase::const_element_iterator end_el = mesh.elements_end();
     for ( ; el != end_el; ++el)
       {
         const Elem * elem = *el;

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -89,9 +89,11 @@ int main (int argc, char ** argv)
   // Print information about the mesh to the screen.
   mesh.print_info();
 
-  // Let's add some node and edge boundary conditions
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
+  // Let's add some node and edge boundary conditions.
+  // Each processor should know about each boundary condition it can
+  // see, so we loop over all elements, not just local elements.
+  MeshBase::const_element_iterator       el     = mesh.elements_begin();
+  const MeshBase::const_element_iterator end_el = mesh.elements_end();
   for ( ; el != end_el; ++el)
     {
       const Elem * elem = *el;

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -128,9 +128,12 @@ int main(int argc, char ** argv)
                                      0., z_size,
                                      HEX8);
 
-  // Let's add a some node boundary condition so that we can impose a point load
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
+  // Let's add a node boundary condition so that we can impose a point
+  // load.
+  // Each processor should know about each boundary condition it can
+  // see, so we loop over all elements, not just local elements.
+  MeshBase::const_element_iterator       el     = mesh.elements_begin();
+  const MeshBase::const_element_iterator end_el = mesh.elements_end();
   for ( ; el != end_el; ++el)
     {
       const Elem * elem = *el;

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -427,8 +427,10 @@ int main (int argc, char ** argv)
   mesh.print_info();
 
   // Let's add some node and edge boundary conditions
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
+  // Each processor should know about each boundary condition it can
+  // see, so we loop over all elements, not just local elements.
+  MeshBase::const_element_iterator       el     = mesh.elements_begin();
+  const MeshBase::const_element_iterator end_el = mesh.elements_end();
   for ( ; el != end_el; ++el)
     {
       const Elem * elem = *el;

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -512,29 +512,34 @@ public:
                         std::vector<boundary_id_type> &   bc_id_list) const;
 
   /**
-   * @returns the user-specified boundary ids.
+   * @returns a set of the boundary ids which exist on semilocal parts
+   * of the mesh.
+   *
+   * DistributedMesh-compatible code may need a set_union or other
+   * manipulations to work with sets of boundary ids which include ids
+   * on remote parts of the mesh.
    */
   const std::set<boundary_id_type> & get_boundary_ids () const
   { return _boundary_ids; }
 
   /**
-   * Returns a reference to the set of all boundary IDs
-   * specified on sides.
+   * Returns a reference to the set of the boundary IDs specified on
+   * sides of semilocal mesh elements.
    */
   const std::set<boundary_id_type> & get_side_boundary_ids () const
   { return _side_boundary_ids; }
 
   /**
-   * Returns a reference to the set of all boundary IDs
-   * specified on edges.
+   * Returns a reference to the set of all boundary IDs specified on
+   * edges of semilocal mesh elements.
    * Edge-based boundary IDs should only be used in 3D.
    */
   const std::set<boundary_id_type> & get_edge_boundary_ids () const
   { return _edge_boundary_ids; }
 
   /**
-   * Returns a reference to the set of all boundary IDs
-   * specified on nodes.
+   * Returns a reference to the set of all boundary IDs specified on
+   * semilocal mesh nodes.
    */
   const std::set<boundary_id_type> & get_node_boundary_ids () const
   { return _node_boundary_ids; }

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3889,8 +3889,12 @@ void DofMap::check_dirichlet_bcid_consistency (const MeshBase & mesh,
 
   for (std::set<boundary_id_type>::const_iterator bid = dbc_bcids.begin();
        bid != dbc_bcids.end(); ++bid)
-    if (mesh_bcids.find(*bid) == mesh_bcids.end())
-      libmesh_error_msg("Could not find Dirichlet boundary id " << *bid << " in mesh!");
+    {
+      bool found_bcid = (mesh_bcids.find(*bid) != mesh_bcids.end());
+      mesh.comm().max(found_bcid);
+      if (!found_bcid)
+        libmesh_error_msg("Could not find Dirichlet boundary id " << *bid << " in mesh!");
+    }
 }
 
 #endif // LIBMESH_ENABLE_DIRICHLET

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3887,11 +3887,22 @@ void DofMap::check_dirichlet_bcid_consistency (const MeshBase & mesh,
   const std::set<boundary_id_type>& mesh_bcids = mesh.get_boundary_info().get_boundary_ids();
   const std::set<boundary_id_type>& dbc_bcids = boundary.b;
 
+  // DirichletBoundary id sets should be consistent across all ranks
+  mesh.comm().verify(dbc_bcids.size());
+
   for (std::set<boundary_id_type>::const_iterator bid = dbc_bcids.begin();
        bid != dbc_bcids.end(); ++bid)
     {
+      // DirichletBoundary id sets should be consistent across all ranks
+      mesh.comm().verify(*bid);
+
       bool found_bcid = (mesh_bcids.find(*bid) != mesh_bcids.end());
+
+      // On a distributed mesh, boundary id sets may *not* be
+      // consistent across all ranks, since not all ranks see all
+      // boundaries
       mesh.comm().max(found_bcid);
+
       if (!found_bcid)
         libmesh_error_msg("Could not find Dirichlet boundary id " << *bid << " in mesh!");
     }


### PR DESCRIPTION
The second commit here fixes a regression in DistributedMesh introduced by #936 and triggered by fem_system_ex3.  I'm confident this is the right fix.

The first commit here tries to fix the misleading documentation which led to the regression.  I'm less confident this is the right phrasing.

The third commit tries to make sure that, even if users are still thoroughly confused at this point about the supposed-to-be-local BCID sets our APIs hand them, we sanely catch any inconsistencies in the supposed-to-be-global BCID sets that they hand us.