### PR TITLE
get_eigen*() should be indexed by dof_id_type

### DIFF
--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -199,14 +199,14 @@ public:
    * Returns the \p ith eigenvalue (real and imaginary part),
    * and copies the \ ith eigen vector to the solution vector.
    */
-  virtual std::pair<Real, Real> get_eigenpair (unsigned int i,
+  virtual std::pair<Real, Real> get_eigenpair (dof_id_type i,
                                                NumericVector<T> & solution) = 0;
 
   /**
    * Returns the \p ith eigenvalue (real and imaginary part).
    * Same as above function, except it does copy the eigenvector.
    */
-  virtual std::pair<Real, Real> get_eigenvalue (unsigned int i) = 0;
+  virtual std::pair<Real, Real> get_eigenvalue (dof_id_type i) = 0;
 
   /**
    * Attach a deflation space defined by a single vector.

--- a/include/solvers/slepc_eigen_solver.h
+++ b/include/solvers/slepc_eigen_solver.h
@@ -184,14 +184,14 @@ public:
    * entries the eigenpair may be complex values.
    */
   virtual std::pair<Real, Real>
-  get_eigenpair (unsigned int i,
+  get_eigenpair (dof_id_type i,
                  NumericVector<T> & solution_in) libmesh_override;
 
   /**
    * Same as above, but does not copy the eigenvector.
    */
   virtual std::pair<Real, Real>
-  get_eigenvalue (unsigned int i) libmesh_override;
+  get_eigenvalue (dof_id_type i) libmesh_override;
 
   /**
    * @returns the relative error ||A*x-lambda*x||/|lambda*x|

--- a/include/systems/eigen_system.h
+++ b/include/systems/eigen_system.h
@@ -103,7 +103,7 @@ public:
    * Returns real and imaginary part of the ith eigenvalue and copies
    * the respective eigen vector to the solution vector.
    */
-  virtual std::pair<Real, Real> get_eigenpair (unsigned int i);
+  virtual std::pair<Real, Real> get_eigenpair (dof_id_type i);
 
   /**
    * @returns \p "Eigen".  Helps in identifying

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -654,7 +654,7 @@ void SlepcEigenSolver<T>:: set_slepc_position_of_spectrum()
 
 
 template <typename T>
-std::pair<Real, Real> SlepcEigenSolver<T>::get_eigenpair(unsigned int i,
+std::pair<Real, Real> SlepcEigenSolver<T>::get_eigenpair(dof_id_type i,
                                                          NumericVector<T> & solution_in)
 {
   PetscErrorCode ierr=0;
@@ -685,7 +685,7 @@ std::pair<Real, Real> SlepcEigenSolver<T>::get_eigenpair(unsigned int i,
 
 
 template <typename T>
-std::pair<Real, Real> SlepcEigenSolver<T>::get_eigenvalue(unsigned int i)
+std::pair<Real, Real> SlepcEigenSolver<T>::get_eigenvalue(dof_id_type i)
 {
   PetscErrorCode ierr=0;
 

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -176,7 +176,7 @@ void CondensedEigenSystem::solve()
 
 
 
-std::pair<Real, Real> CondensedEigenSystem::get_eigenpair(unsigned int i)
+std::pair<Real, Real> CondensedEigenSystem::get_eigenpair(dof_id_type i)
 {
   LOG_SCOPE("get_eigenpair()", "CondensedEigenSystem");
 

--- a/src/systems/eigen_system.C
+++ b/src/systems/eigen_system.C
@@ -266,7 +266,7 @@ void EigenSystem::assemble ()
 }
 
 
-std::pair<Real, Real> EigenSystem::get_eigenpair (unsigned int i)
+std::pair<Real, Real> EigenSystem::get_eigenpair (dof_id_type i)
 {
   // call the eigen_solver get_eigenpair method
   return eigen_solver->get_eigenpair (i, *solution);


### PR DESCRIPTION
Not by unsigned int.

I don't actually know whether SLEPc supports this or will truncate
anything above 2^32.

I also don't know whether there are any algorithms which would make
querying the five billionth eigenvalue a computationally sane thing to
do.

I also don't know whether there are any use cases which would make
querying the five billionth eigenvalue a reasonable scientific or
engineering question.

But I do know that there was a libmesh_override error when we built
with a 64-bit-enabled SLEPc, and this should fix it in the most
aspirationally appropriate way.