### PR TITLE
Assert valid boundary IDs

### DIFF
--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -404,6 +404,12 @@ void libmesh_assert_valid_amr_interior_parents (const MeshBase & mesh);
 void libmesh_assert_connected_nodes (const MeshBase & mesh);
 
 /**
+ * A function for verifying that boundary condition ids match
+ * across processors.
+ */
+void libmesh_assert_valid_boundary_ids (const MeshBase & mesh);
+
+/**
  * A function for verifying that degree of freedom indexing matches
  * across processors.
  */

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -36,6 +36,7 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_inserter_iterator.h"
+#include "libmesh/mesh_tools.h" // for libmesh_assert_valid_boundary_ids()
 #include "libmesh/numeric_vector.h" // for enforce_constraints_exactly()
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_algebra.h"
@@ -1052,6 +1053,13 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
   LOG_SCOPE("create_dof_constraints()", "DofMap");
 
   libmesh_assert (mesh.is_prepared());
+
+  // The user might have set boundary conditions after the mesh was
+  // prepared; we should double-check that those boundary conditions
+  // are still consistent.
+#ifdef DEBUG
+  MeshTools::libmesh_assert_valid_boundary_ids(mesh);
+#endif
 
   // We might get constraint equations from AMR hanging nodes in 2D/3D
   // or from boundary conditions in any dimension

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -194,6 +194,14 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
   if(!skip_find_neighbors)
     this->find_neighbors();
 
+  // The user may have set boundary conditions.  We require that the
+  // boundary conditions were set consistently.  Because we examine
+  // neighbors when evaluating non-raw boundary condition IDs, this
+  // assert is only valid when our neighbor links are in place.
+#ifdef DEBUG
+  MeshTools::libmesh_assert_valid_boundary_ids(*this);
+#endif
+
   // Search the mesh for all the dimensions of the elements
   // and cache them.
   this->cache_elem_dims();

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1309,7 +1309,12 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
         {
           std::vector<boundary_id_type> bcids;
           if (elem)
-            boundary_info.boundary_ids(elem->node_ptr(n), bcids);
+            {
+              boundary_info.boundary_ids(elem->node_ptr(n), bcids);
+
+              // Ordering of boundary ids shouldn't matter
+              std::sort(bcids.begin(), bcids.end());
+            }
           libmesh_assert(mesh.comm().semiverify
                          (elem ? &bcids : libmesh_nullptr));
         }
@@ -1317,12 +1322,26 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
       for (unsigned short e=0; e != n_edges; ++e)
         {
           std::vector<boundary_id_type> bcids;
+
           if (elem)
-            boundary_info.edge_boundary_ids(elem, e, bcids);
+            {
+              boundary_info.edge_boundary_ids(elem, e, bcids);
+
+              // Ordering of boundary ids shouldn't matter
+              std::sort(bcids.begin(), bcids.end());
+            }
+
           libmesh_assert(mesh.comm().semiverify
                          (elem ? &bcids : libmesh_nullptr));
+
           if (elem)
-            boundary_info.raw_edge_boundary_ids(elem, e, bcids);
+            {
+              boundary_info.raw_edge_boundary_ids(elem, e, bcids);
+
+              // Ordering of boundary ids shouldn't matter
+              std::sort(bcids.begin(), bcids.end());
+            }
+
           libmesh_assert(mesh.comm().semiverify
                          (elem ? &bcids : libmesh_nullptr));
         }
@@ -1330,12 +1349,26 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
       for (unsigned short s=0; s != n_sides; ++s)
         {
           std::vector<boundary_id_type> bcids;
+
           if (elem)
-            boundary_info.boundary_ids(elem, s, bcids);
+            {
+              boundary_info.boundary_ids(elem, s, bcids);
+
+              // Ordering of boundary ids shouldn't matter
+              std::sort(bcids.begin(), bcids.end());
+            }
+
           libmesh_assert(mesh.comm().semiverify
                          (elem ? &bcids : libmesh_nullptr));
+
           if (elem)
-            boundary_info.raw_boundary_ids(elem, s, bcids);
+            {
+              boundary_info.raw_boundary_ids(elem, s, bcids);
+
+              // Ordering of boundary ids shouldn't matter
+              std::sort(bcids.begin(), bcids.end());
+            }
+
           libmesh_assert(mesh.comm().semiverify
                          (elem ? &bcids : libmesh_nullptr));
         }

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1278,6 +1278,70 @@ void MeshTools::libmesh_assert_connected_nodes (const MeshBase & mesh)
 
 namespace MeshTools {
 
+void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
+{
+  if (mesh.n_processors() == 1)
+    return;
+
+  libmesh_parallel_only(mesh.comm());
+
+  const BoundaryInfo & boundary_info = mesh.get_boundary_info();
+
+  dof_id_type pmax_elem_id = mesh.max_elem_id();
+  mesh.comm().max(pmax_elem_id);
+
+  for (dof_id_type i=0; i != pmax_elem_id; ++i)
+    {
+      const Elem *elem = mesh.query_elem_ptr(i);
+      unsigned int n_nodes = elem ? elem->n_nodes() : 0;
+      unsigned int n_edges = elem ? elem->n_edges() : 0;
+      unsigned int n_sides = elem ? elem->n_sides() : 0;
+      libmesh_assert(mesh.comm().semiverify
+                     (elem ? &n_nodes : libmesh_nullptr));
+      libmesh_assert(mesh.comm().semiverify
+                     (elem ? &n_edges : libmesh_nullptr));
+      libmesh_assert(mesh.comm().semiverify
+                     (elem ? &n_sides : libmesh_nullptr));
+      mesh.comm().max(n_nodes);
+      mesh.comm().max(n_edges);
+      mesh.comm().max(n_sides);
+      for (unsigned int n=0; n != n_nodes; ++n)
+        {
+          std::vector<boundary_id_type> bcids;
+          if (elem)
+            boundary_info.boundary_ids(elem->node_ptr(n), bcids);
+          libmesh_assert(mesh.comm().semiverify
+                         (elem ? &bcids : libmesh_nullptr));
+        }
+
+      for (unsigned short e=0; e != n_edges; ++e)
+        {
+          std::vector<boundary_id_type> bcids;
+          if (elem)
+            boundary_info.edge_boundary_ids(elem, e, bcids);
+          libmesh_assert(mesh.comm().semiverify
+                         (elem ? &bcids : libmesh_nullptr));
+          if (elem)
+            boundary_info.raw_edge_boundary_ids(elem, e, bcids);
+          libmesh_assert(mesh.comm().semiverify
+                         (elem ? &bcids : libmesh_nullptr));
+        }
+
+      for (unsigned short s=0; s != n_sides; ++s)
+        {
+          std::vector<boundary_id_type> bcids;
+          if (elem)
+            boundary_info.boundary_ids(elem, s, bcids);
+          libmesh_assert(mesh.comm().semiverify
+                         (elem ? &bcids : libmesh_nullptr));
+          if (elem)
+            boundary_info.raw_boundary_ids(elem, s, bcids);
+          libmesh_assert(mesh.comm().semiverify
+                         (elem ? &bcids : libmesh_nullptr));
+        }
+    }
+}
+
 void libmesh_assert_valid_dof_ids(const MeshBase & mesh)
 {
   if (mesh.n_processors() == 1)

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1372,6 +1372,33 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
           libmesh_assert(mesh.comm().semiverify
                          (elem ? &bcids : libmesh_nullptr));
         }
+
+      for (unsigned short sf=0; sf != 2; ++sf)
+        {
+          std::vector<boundary_id_type> bcids;
+
+          if (elem)
+            {
+              boundary_info.shellface_boundary_ids(elem, sf, bcids);
+
+              // Ordering of boundary ids shouldn't matter
+              std::sort(bcids.begin(), bcids.end());
+            }
+
+          libmesh_assert(mesh.comm().semiverify
+                         (elem ? &bcids : libmesh_nullptr));
+
+          if (elem)
+            {
+              boundary_info.raw_shellface_boundary_ids(elem, sf, bcids);
+
+              // Ordering of boundary ids shouldn't matter
+              std::sort(bcids.begin(), bcids.end());
+            }
+
+          libmesh_assert(mesh.comm().semiverify
+                         (elem ? &bcids : libmesh_nullptr));
+        }
     }
 }
 


### PR DESCRIPTION
This should be a more reliable way to catch some of the inconsistency bugs that I fixed in the examples in #943