### PR TITLE
Copy edge boundary conditions in all_first_order()

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -504,6 +504,15 @@ public:
                          const unsigned short int side,
                          std::vector<boundary_id_type> & vec_to_fill) const;
 
+  /*
+   * Copy boundary ids associated with old_elem (but not its nodes)
+   * from old_boundary_info (which may be this) into this boundary
+   * info, associating them with new_elem.
+   */
+  void copy_boundary_ids (const Elem * const new_elem,
+                          const Elem * const old_elem,
+                          const BoundaryInfo &old_boundary_info);
+
   /**
    * Returns a side of element \p elem whose associated boundary id is
    * \p boundary_id if such a side exists.

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -509,9 +509,9 @@ public:
    * from old_boundary_info (which may be this) into this boundary
    * info, associating them with new_elem.
    */
-  void copy_boundary_ids (const Elem * const new_elem,
+  void copy_boundary_ids (const BoundaryInfo &old_boundary_info,
                           const Elem * const old_elem,
-                          const BoundaryInfo &old_boundary_info);
+                          const Elem * const new_elem);
 
   /**
    * Returns a side of element \p elem whose associated boundary id is

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -509,7 +509,7 @@ public:
    * from old_boundary_info (which may be this) into this boundary
    * info, associating them with new_elem.
    */
-  void copy_boundary_ids (const BoundaryInfo &old_boundary_info,
+  void copy_boundary_ids (const BoundaryInfo & old_boundary_info,
                           const Elem * const old_elem,
                           const Elem * const new_elem);
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1286,9 +1286,9 @@ void BoundaryInfo::raw_boundary_ids (const Elem * const elem,
 
 
 void BoundaryInfo::copy_boundary_ids
-  (const Elem * const new_elem,
+  (const BoundaryInfo &old_boundary_info,
    const Elem * const old_elem,
-   const BoundaryInfo &old_boundary_info)
+   const Elem * const new_elem)
 {
   libmesh_assert_equal_to (old_elem->n_sides(), new_elem->n_sides());
   libmesh_assert_equal_to (old_elem->n_edges(), new_elem->n_edges());

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1285,10 +1285,9 @@ void BoundaryInfo::raw_boundary_ids (const Elem * const elem,
 
 
 
-void BoundaryInfo::copy_boundary_ids
-  (const BoundaryInfo &old_boundary_info,
-   const Elem * const old_elem,
-   const Elem * const new_elem)
+void BoundaryInfo::copy_boundary_ids (const BoundaryInfo & old_boundary_info,
+                                      const Elem * const old_elem,
+                                      const Elem * const new_elem)
 {
   libmesh_assert_equal_to (old_elem->n_sides(), new_elem->n_sides());
   libmesh_assert_equal_to (old_elem->n_edges(), new_elem->n_edges());

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1285,6 +1285,31 @@ void BoundaryInfo::raw_boundary_ids (const Elem * const elem,
 
 
 
+void BoundaryInfo::copy_boundary_ids
+  (const Elem * const new_elem,
+   const Elem * const old_elem,
+   const BoundaryInfo &old_boundary_info)
+{
+  libmesh_assert_equal_to (old_elem->n_sides(), new_elem->n_sides());
+  libmesh_assert_equal_to (old_elem->n_edges(), new_elem->n_edges());
+
+  std::vector<boundary_id_type> bndry_ids;
+
+  for (unsigned short s=0; s<old_elem->n_sides(); s++)
+    {
+      old_boundary_info.raw_boundary_ids (old_elem, s, bndry_ids);
+      this->add_side (new_elem, s, bndry_ids);
+    }
+
+  for (unsigned short e=0; e<old_elem->n_edges(); e++)
+    {
+      old_boundary_info.raw_edge_boundary_ids (old_elem, e, bndry_ids);
+      this->add_edge (new_elem, e, bndry_ids);
+    }
+}
+
+
+
 void BoundaryInfo::remove (const Node * node)
 {
   libmesh_assert(node);

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1306,6 +1306,12 @@ void BoundaryInfo::copy_boundary_ids
       old_boundary_info.raw_edge_boundary_ids (old_elem, e, bndry_ids);
       this->add_edge (new_elem, e, bndry_ids);
     }
+
+  for (unsigned short sf=0; sf != 2; sf++)
+    {
+      old_boundary_info.raw_shellface_boundary_ids (old_elem, sf, bndry_ids);
+      this->add_shellface (new_elem, sf, bndry_ids);
+    }
 }
 
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -401,7 +401,7 @@ void UnstructuredMesh::all_first_order ()
        * data structure by insert_elem.
        */
       this->get_boundary_info().copy_boundary_ids
-        (lo_elem, so_elem, this->get_boundary_info());
+        (this->get_boundary_info(), so_elem, lo_elem);
 
       /*
        * The new first-order element is ready.
@@ -694,7 +694,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
        * here.
        */
       this->get_boundary_info().copy_boundary_ids
-        (so_elem, lo_elem, this->get_boundary_info());
+        (this->get_boundary_info(), lo_elem, so_elem);
 
       /*
        * The new second-order element is ready.

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -399,6 +399,12 @@ void UnstructuredMesh::all_first_order ()
           this->get_boundary_info().add_side (lo_elem, s, bndry_ids);
         }
 
+      for (unsigned short e=0; e<so_elem->n_edges(); e++)
+        {
+          this->get_boundary_info().raw_edge_boundary_ids (so_elem, e, bndry_ids);
+          this->get_boundary_info().add_edge (lo_elem, e, bndry_ids);
+        }
+
       /*
        * The new first-order element is ready.
        * Inserting it into the mesh will replace and delete


### PR DESCRIPTION
Previously we were only preserving node and side conditions.

This actually turned out to be a red herring w.r.t. the bug I was
hunting, but it's nice to fix it too.