### PR TITLE
Add --enable-cxx11-required configure option.

### DIFF
--- a/configure
+++ b/configure
@@ -1116,6 +1116,7 @@ enable_fortran
 with_fc
 with_f77
 enable_cxx11
+enable_cxx11_required
 enable_sanitize
 enable_glibcxx_debugging
 enable_glibcxx_debugging_cppunit
@@ -1901,6 +1902,7 @@ Optional Features:
                           speeds up one-time build
   --disable-fortran       build without Fortran language support
   --disable-cxx11         build without C++11 support
+  --enable-cxx11-required Error if compiler does not support C++11
   --enable-sanitize="opt dbg devel prof oprof"
                           turn on sanitizer flags for the given methods
   --disable-glibcxx-debugging
@@ -6959,13 +6961,35 @@ else
 fi
 
 
+
+# --------------------------------------------------------------
+# Setting --enable-cxx11-required causes an error to be emitted during
+# configure if the compiler does not support a specific subset of
+# C++11 features.  This is useful for app codes which require C++11,
+# since it prevents situations where libmesh is built without C++11
+# support (which may take a very long time), and then the app fails to
+# compile, requiring you to redo everything.
+# --------------------------------------------------------------
+# Check whether --enable-cxx11-required was given.
+if test "${enable_cxx11_required+set}" = set; then :
+  enableval=$enable_cxx11_required; case "${enableval}" in
+                   yes) cxx11required=yes ;;
+                   no)  cxx11required=no ;;
+                   *)   as_fn_error $? "bad value ${enableval} for --enable-cxx11-required" "$LINENO" 5 ;;
+                   esac
+else
+  cxx11required=no
+fi
+
+
 # --------------------------------------------------------------
 # Standard autoconf macro for determining the proper -std=c++11
 # flag for the current compiler.  Adds the result to CXXFLAGS if
 # one is found.  See ax_cxx_compile_stdcxx_11.m4 for details.
 # --------------------------------------------------------------
+if (test $cxx11required = yes); then
 
-    ax_cxx_compile_cxx11_required=false
+    ax_cxx_compile_cxx11_required=true
   ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -7159,7 +7183,12 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
   if test x$ax_cxx_compile_cxx11_required = xtrue; then
     if test x$ac_success = xno; then
-      as_fn_error $? "*** A compiler with support for C++11 language features is required." "$LINENO" 5
+                              as_fn_error 2 "*** A compiler with support for C++11 language features is required." "$LINENO" 5
+    else
+      HAVE_CXX11=1
+
+$as_echo "#define HAVE_CXX11 1" >>confdefs.h
+
     fi
   else
     if test x$ac_success = xno; then
@@ -7179,6 +7208,227 @@ $as_echo "#define HAVE_CXX11 1" >>confdefs.h
 
   fi
 
+else
+      ax_cxx_compile_cxx11_required=false
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+  ac_success=no
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CXX supports C++11 features by default" >&5
+$as_echo_n "checking whether $CXX supports C++11 features by default... " >&6; }
+if ${ax_cv_cxx_compile_cxx11+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+  template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+    typedef check<check<bool>> right_angle_brackets;
+
+    int a;
+    decltype(a) b;
+
+    typedef check<int> check_type;
+    check_type c;
+    check_type&& cr = static_cast<check_type&&>(c);
+
+    auto d = a;
+    auto l = [](){};
+
+    // The compiler may evaluate something like:
+    // const int val = multiply(10, 10);
+    // at compile time.
+    constexpr int multiply (int x, int y) { return x * y; }
+
+    // A minimally-conforming C++11 compiler must support alias declarations
+    template <typename T>
+    using MyCheck = check<T>;
+
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ax_cv_cxx_compile_cxx11=yes
+else
+  ax_cv_cxx_compile_cxx11=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_cxx_compile_cxx11" >&5
+$as_echo "$ax_cv_cxx_compile_cxx11" >&6; }
+  if test x$ax_cv_cxx_compile_cxx11 = xyes; then
+    ac_success=yes
+  fi
+
+    if test x$ac_success = xno; then
+    for switch in -std=gnu++11 -std=gnu++0x; do
+      cachevar=`$as_echo "ax_cv_cxx_compile_cxx11_$switch" | $as_tr_sh`
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CXX supports C++11 features with $switch" >&5
+$as_echo_n "checking whether $CXX supports C++11 features with $switch... " >&6; }
+if eval \${$cachevar+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
+         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+  template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+    typedef check<check<bool>> right_angle_brackets;
+
+    int a;
+    decltype(a) b;
+
+    typedef check<int> check_type;
+    check_type c;
+    check_type&& cr = static_cast<check_type&&>(c);
+
+    auto d = a;
+    auto l = [](){};
+
+    // The compiler may evaluate something like:
+    // const int val = multiply(10, 10);
+    // at compile time.
+    constexpr int multiply (int x, int y) { return x * y; }
+
+    // A minimally-conforming C++11 compiler must support alias declarations
+    template <typename T>
+    using MyCheck = check<T>;
+
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  eval $cachevar=yes
+else
+  eval $cachevar=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+         CXXFLAGS="$ac_save_CXXFLAGS"
+fi
+eval ac_res=\$$cachevar
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+      if eval test x\$$cachevar = xyes; then
+                                                if (test "x$enablecxx11" = "xyes"); then
+          CXXFLAGS="$CXXFLAGS $switch"
+          CXXFLAGS_OPT="$CXXFLAGS_OPT $switch"
+          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $switch"
+          CXXFLAGS_DBG="$CXXFLAGS_DBG $switch"
+        fi
+        ac_success=yes
+        break
+      fi
+    done
+  fi
+
+              if test x$ac_success = xno; then
+    for switch in -std=c++11 -std=c++0x; do
+      cachevar=`$as_echo "ax_cv_cxx_compile_cxx11_$switch" | $as_tr_sh`
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CXX supports C++11 features with $switch" >&5
+$as_echo_n "checking whether $CXX supports C++11 features with $switch... " >&6; }
+if eval \${$cachevar+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
+         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+  template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+    typedef check<check<bool>> right_angle_brackets;
+
+    int a;
+    decltype(a) b;
+
+    typedef check<int> check_type;
+    check_type c;
+    check_type&& cr = static_cast<check_type&&>(c);
+
+    auto d = a;
+    auto l = [](){};
+
+    // The compiler may evaluate something like:
+    // const int val = multiply(10, 10);
+    // at compile time.
+    constexpr int multiply (int x, int y) { return x * y; }
+
+    // A minimally-conforming C++11 compiler must support alias declarations
+    template <typename T>
+    using MyCheck = check<T>;
+
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  eval $cachevar=yes
+else
+  eval $cachevar=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+         CXXFLAGS="$ac_save_CXXFLAGS"
+fi
+eval ac_res=\$$cachevar
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+      if eval test x\$$cachevar = xyes; then
+                                                if (test "x$enablecxx11" = "xyes"); then
+          CXXFLAGS="$CXXFLAGS $switch"
+          CXXFLAGS_OPT="$CXXFLAGS_OPT $switch"
+          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $switch"
+          CXXFLAGS_DBG="$CXXFLAGS_DBG $switch"
+        fi
+        ac_success=yes
+        break
+      fi
+    done
+  fi
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+  if test x$ax_cxx_compile_cxx11_required = xtrue; then
+    if test x$ac_success = xno; then
+                              as_fn_error 2 "*** A compiler with support for C++11 language features is required." "$LINENO" 5
+    else
+      HAVE_CXX11=1
+
+$as_echo "#define HAVE_CXX11 1" >>confdefs.h
+
+    fi
+  else
+    if test x$ac_success = xno; then
+      HAVE_CXX11=0
+      { $as_echo "$as_me:${as_lineno-$LINENO}: No compiler with C++11 support was found" >&5
+$as_echo "$as_me: No compiler with C++11 support was found" >&6;}
+                              enablecxx11=no
+    else
+            if (test "x$enablecxx11" = "xyes"); then
+        HAVE_CXX11=1
+
+$as_echo "#define HAVE_CXX11 1" >>confdefs.h
+
+      fi
+    fi
+
+
+  fi
+
+fi
 
 # --------------------------------------------------------------
 # See compiler.m4 for the definition of this function.  It uses the

--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,11 @@ AC_ARG_ENABLE(cxx11-required,
 # flag for the current compiler.  Adds the result to CXXFLAGS if
 # one is found.  See ax_cxx_compile_stdcxx_11.m4 for details.
 # --------------------------------------------------------------
-AX_CXX_COMPILE_STDCXX_11([],[optional])
+if (test $cxx11required = yes); then
+  AX_CXX_COMPILE_STDCXX_11([],[mandatory])
+else
+  AX_CXX_COMPILE_STDCXX_11([],[optional])
+fi
 
 # --------------------------------------------------------------
 # See compiler.m4 for the definition of this function.  It uses the

--- a/configure.ac
+++ b/configure.ac
@@ -143,6 +143,25 @@ AC_ARG_ENABLE(cxx11,
                    esac],
                    [enablecxx11=yes])
 
+
+# --------------------------------------------------------------
+# Setting --enable-cxx11-required causes an error to be emitted during
+# configure if the compiler does not support a specific subset of
+# C++11 features.  This is useful for app codes which require C++11,
+# since it prevents situations where libmesh is built without C++11
+# support (which may take a very long time), and then the app fails to
+# compile, requiring you to redo everything.
+# --------------------------------------------------------------
+AC_ARG_ENABLE(cxx11-required,
+              AC_HELP_STRING([--enable-cxx11-required],
+                             [Error if compiler does not support C++11]),
+                             [case "${enableval}" in
+                   yes) cxx11required=yes ;;
+                   no)  cxx11required=no ;;
+                   *)   AC_MSG_ERROR(bad value ${enableval} for --enable-cxx11-required) ;;
+                   esac],
+                   [cxx11required=no])
+
 # --------------------------------------------------------------
 # Standard autoconf macro for determining the proper -std=c++11
 # flag for the current compiler.  Adds the result to CXXFLAGS if

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -154,6 +154,9 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl
   if test x$ax_cxx_compile_cxx11_required = xtrue; then
     if test x$ac_success = xno; then
       AC_MSG_ERROR([*** A compiler with support for C++11 language features is required.])
+    else
+      HAVE_CXX11=1
+      AC_DEFINE(HAVE_CXX11, 1, [define if the compiler supports basic C++11 syntax])
     fi
   else
     if test x$ac_success = xno; then

--- a/m4/ax_cxx_compile_stdcxx_11.m4
+++ b/m4/ax_cxx_compile_stdcxx_11.m4
@@ -153,7 +153,11 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX_11], [dnl
 
   if test x$ax_cxx_compile_cxx11_required = xtrue; then
     if test x$ac_success = xno; then
-      AC_MSG_ERROR([*** A compiler with support for C++11 language features is required.])
+      dnl We return error code 2 here, since 0 means success and 1 is
+      dnl indistinguishable from other errors.  Ideally, all of the
+      dnl AC_MSG_ERROR calls in our m4 files would return a different
+      dnl error code, but currently this is not implemented.
+      AC_MSG_ERROR([*** A compiler with support for C++11 language features is required.], 2)
     else
       HAVE_CXX11=1
       AC_DEFINE(HAVE_CXX11, 1, [define if the compiler supports basic C++11 syntax])


### PR DESCRIPTION
If enabled, this option throws an error at configure time if the compiler does not support a particular subset of C++11. In an ideal world I would have named this option differently, but autoconf only supports user-defined command line options that start with `--{enable,disable}` and `--{with,without}`.

I tested this on compilers which both support and don't support C++11 and it seems to work fine.  Our goal is to start using this in the libmesh build script for MOOSE, so that users are notified ASAP if their compiler does not support C++11.