### PR TITLE
XDA writer should not write trailing whitespace

### DIFF
--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -240,7 +240,7 @@ void XdrIO::write (const std::string & name)
       io.data (write_p_level      ? write_size : zero_size, "# p-level size");
       // Boundary Condition sizes
       io.data (write_bcs          ? write_size : zero_size, "# eid size");   // elem id
-      io.data (write_bcs          ? write_size : zero_size, "# side size "); // side number
+      io.data (write_bcs          ? write_size : zero_size, "# side size");  // side number
       io.data (write_bcs          ? write_size : zero_size, "# bid size");   // boundary id
     }
 
@@ -1264,7 +1264,7 @@ void XdrIO::read (const std::string & name)
           io.data (meta_data[pos++], "# p-level size");
           // Boundary Condition sizes
           io.data (meta_data[pos++], "# eid size");   // elem id
-          io.data (meta_data[pos++], "# side size "); // side number
+          io.data (meta_data[pos++], "# side size");  // side number
           io.data (meta_data[pos++], "# bid size");   // boundary id
         }
     }

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -455,21 +455,35 @@ void XdrIO::write_serialized_connectivity (Xdr & io, const dof_id_type libmesh_d
             for (xdr_id_type elem=0; elem<n_elem_received; elem++, next_global_elem++)
               {
                 output_buffer.clear();
-                const xdr_id_type n_nodes = *recv_conn_iter; ++recv_conn_iter;
-                output_buffer.push_back(*recv_conn_iter);     /* type       */ ++recv_conn_iter;
 
+                // n. nodes
+                const xdr_id_type n_nodes = *recv_conn_iter;
+                ++recv_conn_iter;
+
+                // type
+                output_buffer.push_back(*recv_conn_iter);
+                ++recv_conn_iter;
+
+                // unique_id
                 if (_write_unique_id)
-                  output_buffer.push_back(*recv_conn_iter);   /* unique_id  */ ++recv_conn_iter;
+                  output_buffer.push_back(*recv_conn_iter);
+                ++recv_conn_iter;
 
+                // processor id
                 if (write_partitioning)
-                  output_buffer.push_back(*recv_conn_iter); /* processor id */ ++recv_conn_iter;
+                  output_buffer.push_back(*recv_conn_iter);
+                ++recv_conn_iter;
 
+                // subdomain id
                 if (write_subdomain_id)
-                  output_buffer.push_back(*recv_conn_iter); /* subdomain id */ ++recv_conn_iter;
+                  output_buffer.push_back(*recv_conn_iter);
+                ++recv_conn_iter;
 
 #ifdef LIBMESH_ENABLE_AMR
+                // p level
                 if (write_p_level)
-                  output_buffer.push_back(*recv_conn_iter); /* p level      */ ++recv_conn_iter;
+                  output_buffer.push_back(*recv_conn_iter);
+                ++recv_conn_iter;
 #endif
                 for (dof_id_type node=0; node<n_nodes; node++, ++recv_conn_iter)
                   output_buffer.push_back(*recv_conn_iter);
@@ -566,24 +580,44 @@ void XdrIO::write_serialized_connectivity (Xdr & io, const dof_id_type libmesh_d
                 for (xdr_id_type elem=0; elem<n_elem_received; elem++, next_global_elem++)
                   {
                     output_buffer.clear();
-                    const xdr_id_type n_nodes = *recv_conn_iter; ++recv_conn_iter;
-                    output_buffer.push_back(*recv_conn_iter);                   /* type          */ ++recv_conn_iter;
-                    if (_write_unique_id)
-                      output_buffer.push_back(*recv_conn_iter);                 /* unique_id     */ ++recv_conn_iter;
 
-                    const xdr_id_type parent_local_id = *recv_conn_iter; ++recv_conn_iter;
-                    const xdr_id_type parent_pid      = *recv_conn_iter; ++recv_conn_iter;
+                    // n. nodes
+                    const xdr_id_type n_nodes = *recv_conn_iter;
+                    ++recv_conn_iter;
+
+                    // type
+                    output_buffer.push_back(*recv_conn_iter);
+                    ++recv_conn_iter;
+
+                    // unique_id
+                    if (_write_unique_id)
+                      output_buffer.push_back(*recv_conn_iter);
+                    ++recv_conn_iter;
+
+                    // parent local id
+                    const xdr_id_type parent_local_id = *recv_conn_iter;
+                    ++recv_conn_iter;
+
+                    // parent processor id
+                    const xdr_id_type parent_pid = *recv_conn_iter;
+                    ++recv_conn_iter;
 
                     output_buffer.push_back (parent_local_id+processor_offsets[parent_pid]);
 
+                    // processor id
                     if (write_partitioning)
-                      output_buffer.push_back(*recv_conn_iter); /* processor id */ ++recv_conn_iter;
+                      output_buffer.push_back(*recv_conn_iter);
+                    ++recv_conn_iter;
 
+                    // subdomain id
                     if (write_subdomain_id)
-                      output_buffer.push_back(*recv_conn_iter); /* subdomain id */ ++recv_conn_iter;
+                      output_buffer.push_back(*recv_conn_iter);
+                    ++recv_conn_iter;
 
+                    // p level
                     if (write_p_level)
-                      output_buffer.push_back(*recv_conn_iter); /* p level       */ ++recv_conn_iter;
+                      output_buffer.push_back(*recv_conn_iter);
+                    ++recv_conn_iter;
 
                     for (xdr_id_type node=0; node<n_nodes; node++, ++recv_conn_iter)
                       output_buffer.push_back(*recv_conn_iter);
@@ -658,7 +692,8 @@ void XdrIO::write_serialized_connectivity (Xdr & io, const dof_id_type libmesh_d
           }
         // overwrite the parent_id_map with the child_id_map, but
         // use std::map::swap() for efficiency.
-        parent_id_map.swap(child_id_map); /**/ child_id_map.clear();
+        parent_id_map.swap(child_id_map);
+        child_id_map.clear();
       }
     }
 #endif // LIBMESH_ENABLE_AMR
@@ -1769,7 +1804,8 @@ void XdrIO::read_serialized_bcs (Xdr & io, T)
                         cast_int<unsigned int>(input_buffer.size()));
 
       this->comm().broadcast (input_buffer);
-      dof_bc_data.clear(); /**/ dof_bc_data.reserve (input_buffer.size()/3);
+      dof_bc_data.clear();
+      dof_bc_data.reserve (input_buffer.size()/3);
 
       // convert the input_buffer to DofBCData to facilitate searching
       for (std::size_t idx=0; idx<input_buffer.size(); idx+=3)
@@ -1848,7 +1884,8 @@ void XdrIO::read_serialized_nodesets (Xdr & io, T)
                         cast_int<unsigned int>(input_buffer.size()));
 
       this->comm().broadcast (input_buffer);
-      node_bc_data.clear(); /**/ node_bc_data.reserve (input_buffer.size()/2);
+      node_bc_data.clear();
+      node_bc_data.reserve (input_buffer.size()/2);
 
       // convert the input_buffer to DofBCData to facilitate searching
       for (std::size_t idx=0; idx<input_buffer.size(); idx+=2)

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -1540,7 +1540,7 @@ template void Xdr::data<long double>                      (long double &,       
 template void Xdr::data<std::complex<float> >             (std::complex<float> &,             const char *);
 template void Xdr::data<std::complex<double> >            (std::complex<double> &,            const char *);
 template void Xdr::data<std::complex<long double> >       (std::complex<long double> &,       const char *);
-template void Xdr::data<std::string>                      (std::string &,                      const char *);
+template void Xdr::data<std::string>                      (std::string &,                     const char *);
 template void Xdr::data<std::vector<int> >                (std::vector<int> &,                const char *);
 template void Xdr::data<std::vector<unsigned int> >       (std::vector<unsigned int> &,       const char *);
 template void Xdr::data<std::vector<short int> >          (std::vector<short int> &,          const char *);

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -747,7 +747,14 @@ void Xdr::data (T & a, const char * comment_in)
              << std::setprecision(16);
 
         this->do_write(a);
-        *out << "\t " << comment_in << '\n';
+
+        // If there's a comment provided, write a tab character and
+        // then the comment.
+        if (std::string(comment_in) != "")
+          *out << "\t " << comment_in;
+
+        // Go to the next line.
+        *out << '\n';
 
         return;
       }
@@ -871,14 +878,19 @@ void Xdr::data_stream (T * val, const unsigned int len, const unsigned int line_
             }
         else
           {
+            const unsigned imax = std::min(line_break, len);
             unsigned int cnt=0;
             while (cnt < len)
               {
-                for (unsigned int i=0; i<std::min(line_break,len); i++)
+                for (unsigned int i=0; i<imax; i++)
                   {
                     libmesh_assert(out.get());
                     libmesh_assert (out->good());
-                    *out << val[cnt++] << " ";
+                    *out << val[cnt++];
+
+                    // Write a space unless this is the last character on the current line.
+                    if (i+1 != imax)
+                      *out << " ";
                   }
                 libmesh_assert(out.get());
                 libmesh_assert (out->good());
@@ -963,14 +975,19 @@ void Xdr::data_stream (double * val, const unsigned int len, const unsigned int 
             }
         else
           {
+            const unsigned imax = std::min(line_break, len);
             unsigned int cnt=0;
             while (cnt < len)
               {
-                for (unsigned int i=0; i<std::min(line_break,len); i++)
+                for (unsigned int i=0; i<imax; i++)
                   {
                     libmesh_assert(out.get());
                     libmesh_assert (out->good());
-                    *out << val[cnt++] << ' ';
+                    *out << val[cnt++];
+
+                    // Write a space unless this is the last character on the current line.
+                    if (i+1 != imax)
+                      *out << " ";
                   }
                 libmesh_assert(out.get());
                 libmesh_assert (out->good());
@@ -1057,14 +1074,19 @@ void Xdr::data_stream (float * val, const unsigned int len, const unsigned int l
             }
         else
           {
+            const unsigned imax = std::min(line_break, len);
             unsigned int cnt=0;
             while (cnt < len)
               {
-                for (unsigned int i=0; i<std::min(line_break,len); i++)
+                for (unsigned int i=0; i<imax; i++)
                   {
                     libmesh_assert(out.get());
                     libmesh_assert (out->good());
-                    *out << val[cnt++] << ' ';
+                    *out << val[cnt++];
+
+                    // Write a space unless this is the last character on the current line.
+                    if (i+1 != imax)
+                      *out << " ";
                   }
                 libmesh_assert(out.get());
                 libmesh_assert (out->good());
@@ -1177,14 +1199,19 @@ void Xdr::data_stream (long double * val, const unsigned int len, const unsigned
             }
         else
           {
+            const unsigned imax = std::min(line_break, len);
             unsigned int cnt=0;
             while (cnt < len)
               {
-                for (unsigned int i=0; i<std::min(line_break,len); i++)
+                for (unsigned int i=0; i<imax; i++)
                   {
                     libmesh_assert(out.get());
                     libmesh_assert (out->good());
-                    *out << val[cnt++] << ' ';
+                    *out << val[cnt++];
+
+                    // Write a space unless this is the last character on the current line.
+                    if (i+1 != imax)
+                      *out << " ";
                   }
                 libmesh_assert(out.get());
                 libmesh_assert (out->good());
@@ -1296,16 +1323,21 @@ void Xdr::data_stream (std::complex<double> * val, const unsigned int len, const
             }
         else
           {
+            const unsigned imax = std::min(line_break, len);
             unsigned int cnt=0;
             while (cnt < len)
               {
-                for (unsigned int i=0; i<std::min(line_break,len); i++)
+                for (unsigned int i=0; i<imax; i++)
                   {
                     libmesh_assert(out.get());
                     libmesh_assert (out->good());
                     *out << val[cnt].real() << ' ';
-                    *out << val[cnt].imag() << ' ';
+                    *out << val[cnt].imag();
                     cnt++;
+
+                    // Write a space unless this is the last character on the current line.
+                    if (i+1 != imax)
+                      *out << " ";
                   }
                 libmesh_assert(out.get());
                 libmesh_assert (out->good());
@@ -1423,15 +1455,20 @@ void Xdr::data_stream (std::complex<long double> * val, const unsigned int len, 
             }
         else
           {
+            const unsigned imax = std::min(line_break, len);
             unsigned int cnt=0;
             while (cnt < len)
               {
-                for (unsigned int i=0; i<std::min(line_break,len); i++)
+                for (unsigned int i=0; i<imax; i++)
                   {
                     libmesh_assert(out.get());
                     libmesh_assert (out->good());
-                    *out << val[cnt].real() << ' ' << val[cnt].imag() << ' ';
+                    *out << val[cnt].real() << ' ' << val[cnt].imag();
                     cnt++;
+
+                    // Write a space unless this is the last character on the current line.
+                    if (i+1 != imax)
+                      *out << " ";
                   }
                 libmesh_assert(out.get());
                 libmesh_assert (out->good());


### PR DESCRIPTION
Also fixed some confusingly formatted code in XdrIO.