### PR TITLE
reduced_basis_ex7 fixes

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
+++ b/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
@@ -159,7 +159,7 @@ int main (int argc, char** argv)
                        << "Try running with -ksp_type preonly -pc_type lu instead.\n"
                        << "********************************************************************************"
                        << std::endl;
-          return 1;
+          return 77;
         }
 #endif
 

--- a/examples/reduced_basis/reduced_basis_ex7/run.sh
+++ b/examples/reduced_basis/reduced_basis_ex7/run.sh
@@ -15,8 +15,8 @@ example_dir=examples/reduced_basis/$example_name
 # or, using an external direct solver like mumps:
 #
 # -ksp_type preonly -pc_type lu -pc_factor_mat_solver_package mumps
-options="-online_mode 0"
-run_example "$example_name" "$options"
+options="-online_mode 0 -ksp_type preonly -pc_type lu -pc_factor_mat_solver_package mumps"
+run_example_no_extra_options "$example_name" "$options"
 
 options="-online_mode 1"
 run_example "$example_name" "$options"


### PR DESCRIPTION
Before, complex-valued PETSc-enabled libMesh builds would die on reduced_basis_ex7 unless you manually set LIBMESH_OPTIONS to a direct solver.

Now, complex-valued PETSc-enabled libMesh builds will die on reduced_basis_ex7 unless you configured PETSc with MUMPS.

This should be enough to get my BuildBot libMesh --enable-complex stage working, which is what I care about, but suggestions for further improvement would be welcome.