### PR TITLE
Update to MeshFunction::clone()

### DIFF
--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -166,9 +166,13 @@ MeshFunction::clear ()
 
 UniquePtr<FunctionBase<Number> > MeshFunction::clone () const
 {
-  return UniquePtr<FunctionBase<Number> >
-    (new MeshFunction
-     (_eqn_systems, _vector, _dof_map, _system_vars, this));
+  FunctionBase<Number> * mf_clone =
+    new MeshFunction(_eqn_systems, _vector, _dof_map, _system_vars, this);
+
+  if(this->initialized())
+    mf_clone->init();
+
+  return UniquePtr< FunctionBase<Number> >(mf_clone);
 }
 
 


### PR DESCRIPTION
Call clone->init() inside the clone method if the original object was initialized. This is important when you want to use a MeshFunction with System::project(), because project makes a clone of the MeshFunction and we need to make sure that the clone is initialized.