### PR TITLE
Speed up make check

### DIFF
--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.in
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.in
@@ -60,4 +60,4 @@ singularity = true
 output_intermediate = false
 
 # Use how many linear iterations max before giving up?
-max_linear_iterations = 50000
+max_linear_iterations = 1000

--- a/examples/adaptivity/adaptivity_ex3/run.sh
+++ b/examples/adaptivity/adaptivity_ex3/run.sh
@@ -9,7 +9,7 @@ example_dir=examples/adaptivity/$example_name
 
 run_example "$example_name" refinement_type=h
 run_example "$example_name" refinement_type=p
-run_example "$example_name" refinement_type=hp
 
-# Solvers still give us trouble with too much matchedhp?
-run_example "$example_name" refinement_type=matchedhp max_r_steps=5
+# Some solvers still give us trouble with too much hp
+run_example "$example_name" refinement_type=hp max_r_steps=8
+run_example "$example_name" refinement_type=matchedhp max_r_steps=4

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -77,9 +77,9 @@ int main (int argc, char ** argv)
   // Create a 3D mesh distributed across the default MPI communicator.
   Mesh mesh(init.comm(), dim);
   MeshTools::Generation::build_cube (mesh,
-                                     40,
-                                     10,
-                                     5,
+                                     32,
+                                     8,
+                                     4,
                                      0., 1.*x_scaling,
                                      0., 0.3,
                                      0., 0.1,

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -95,6 +95,10 @@ int main(int argc, char ** argv)
   libmesh_example_requires(false, "double precision");
 #endif
 
+  // Eigen can take forever to solve the offline mode portion of this
+  // example
+  libmesh_example_requires(libMesh::default_solver_package() != EIGEN_SOLVERS, "--enable-petsc or --enable-laspack");
+
   // This example only works if libMesh was compiled for 3D
   const unsigned int dim = 3;
   libmesh_example_requires(dim == LIBMESH_DIM, "3D support");

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.in
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.in
@@ -12,9 +12,9 @@ x_size  = 1.
 y_size = 0.3
 z_size = 0.1
 
-n_elem_x = 40
-n_elem_y = 8
-n_elem_z = 4
+n_elem_x = 32
+n_elem_y = 6
+n_elem_z = 3
 
 store_basis_functions = true                # Do we store the basis functions in the offline_data directory once Offline finishes?
 

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.in
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.in
@@ -1,7 +1,7 @@
 # ========= Main function parameters =========
 
-n_elem_xy = 10
-n_elem_z  = 50
+n_elem_xy = 8
+n_elem_z  = 40
 
 store_basis_functions = true
 online_N = 20

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -414,9 +414,9 @@ int main (int argc, char ** argv)
   // Create a 3D mesh distributed across the default MPI communicator.
   Mesh mesh(init.comm(), dim);
   MeshTools::Generation::build_cube (mesh,
-                                     40,
-                                     10,
-                                     5,
+                                     32,
+                                     8,
+                                     4,
                                      0., 1.*x_scaling,
                                      0., 0.3,
                                      0., 0.1,


### PR DESCRIPTION
Alhough "make check" runs at a decent clip with PETSc on 4 cores, it can be interminable when BuildBot forces it to use weaker solvers and run in serial.  Tweaking example parameters (and disabling one when we're using Eigen's sparse solver) should fix that.