### PR TITLE
Fix compile error on systems where size_t and int have the same size.

### DIFF
--- a/configure
+++ b/configure
@@ -28975,6 +28975,39 @@ _ACEOF
 # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
 # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
 # This bug is HP SR number 8606223364.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of size_t" >&5
+$as_echo_n "checking size of size_t... " >&6; }
+if ${ac_cv_sizeof_size_t+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if ac_fn_cxx_compute_int "$LINENO" "(long int) (sizeof (size_t))" "ac_cv_sizeof_size_t"        "$ac_includes_default"; then :
+
+else
+  if test "$ac_cv_type_size_t" = yes; then
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error 77 "cannot compute sizeof (size_t)
+See \`config.log' for more details" "$LINENO" 5; }
+   else
+     ac_cv_sizeof_size_t=0
+   fi
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_size_t" >&5
+$as_echo "$ac_cv_sizeof_size_t" >&6; }
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_SIZE_T $ac_cv_sizeof_size_t
+_ACEOF
+
+
+# The cast to long int works around a bug in the HP C Compiler
+# version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+# declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+# This bug is HP SR number 8606223364.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking size of long int" >&5
 $as_echo_n "checking size of long int... " >&6; }
 if ${ac_cv_sizeof_long_int+:} false; then :

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -128,8 +128,9 @@ inline bool operator>=(const OrderWrapper& lhs, const OrderWrapper& rhs){ return
 
 OrderWrapperOperators(int)
 OrderWrapperOperators(unsigned int)
-OrderWrapperOperators(std::size_t)
-
+#if LIBMESH_SIZEOF_SIZE_T != LIBMESH_SIZEOF_UNSIGNED_INT
+  OrderWrapperOperators(std::size_t)
+#endif
 
 // Now disambiguate all the things
 inline bool operator==(int lhs, const OrderWrapper& rhs){ return lhs == rhs.get_order(); }

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -745,6 +745,9 @@
 /* The size of `short int', as computed by sizeof. */
 #undef SIZEOF_SHORT_INT
 
+/* The size of `size_t', as computed by sizeof. */
+#undef SIZEOF_SIZE_T
+
 /* The size of `unsigned int', as computed by sizeof. */
 #undef SIZEOF_UNSIGNED_INT
 

--- a/m4/libmesh_compiler_features.m4
+++ b/m4/libmesh_compiler_features.m4
@@ -123,6 +123,7 @@ fi
 AC_CHECK_SIZEOF(short int)
 AC_CHECK_SIZEOF(int)
 AC_CHECK_SIZEOF(unsigned int)
+AC_CHECK_SIZEOF(size_t)
 AC_CHECK_SIZEOF(long int)
 AC_CHECK_SIZEOF(float)
 AC_CHECK_SIZEOF(double)


### PR DESCRIPTION
The Raspberry Pi (Arm) is such a system.

Closes #962 