### PR TITLE
Print error messages to libMesh::err in fe_map.C

### DIFF
--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -497,7 +497,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                 if (!failing)
                   {
                     failing = true;
-                    elem->print_info();
+                    elem->print_info(libMesh::err);
                     libmesh_error_msg("ERROR: negative Jacobian " \
                                       << jac[p] \
                                       << " at point " \
@@ -559,7 +559,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                 if (!failing)
                   {
                     failing = true;
-                    elem->print_info();
+                    elem->print_info(libMesh::err);
                     libmesh_error_msg("Encountered invalid 1D element!");
                   }
                 else
@@ -605,7 +605,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                 if (!failing)
                   {
                     failing = true;
-                    elem->print_info();
+                    elem->print_info(libMesh::err);
                     libmesh_error_msg("Encountered invalid 1D element!");
                   }
                 else
@@ -728,7 +728,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                 if (!failing)
                   {
                     failing = true;
-                    elem->print_info();
+                    elem->print_info(libMesh::err);
                     libmesh_error_msg("ERROR: negative Jacobian " \
                                       << jac[p] \
                                       << " at point " \
@@ -813,7 +813,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                 if (!failing)
                   {
                     failing = true;
-                    elem->print_info();
+                    elem->print_info(libMesh::err);
                     libmesh_error_msg("ERROR: negative Jacobian " \
                                       << det \
                                       << " at point " \
@@ -1033,7 +1033,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                 if (!failing)
                   {
                     failing = true;
-                    elem->print_info();
+                    elem->print_info(libMesh::err);
                     if (calculate_xyz)
                       libmesh_error_msg("ERROR: negative Jacobian " \
                                         << jac[p]

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -498,12 +498,26 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
-                    libmesh_error_msg("ERROR: negative Jacobian " \
-                                      << jac[p] \
-                                      << " at point " \
-                                      << xyz[p] \
-                                      << " in element " \
-                                      << elem->id());
+                    if(calculate_xyz)
+                      {
+                        libmesh_error_msg("ERROR: negative Jacobian " \
+                                          << jac[p] \
+                                          << " at point " \
+                                          << xyz[p] \
+                                          << " in element " \
+                                          << elem->id());
+                      }
+                    else
+                      {
+                        // In this case xyz[p] is not defined, so don't
+                        // try to print it out.
+                        libmesh_error_msg("ERROR: negative Jacobian " \
+                                          << jac[p] \
+                                          << " at point index " \
+                                          << p \
+                                          << " in element " \
+                                          << elem->id());
+                      }
                   }
                 else
                   {
@@ -729,12 +743,26 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
-                    libmesh_error_msg("ERROR: negative Jacobian " \
-                                      << jac[p] \
-                                      << " at point " \
-                                      << xyz[p] \
-                                      << " in element " \
-                                      << elem->id());
+                    if(calculate_xyz)
+                      {
+                        libmesh_error_msg("ERROR: negative Jacobian " \
+                                          << jac[p] \
+                                          << " at point " \
+                                          << xyz[p] \
+                                          << " in element " \
+                                          << elem->id());
+                      }
+                    else
+                      {
+                        // In this case xyz[p] is not defined, so don't
+                        // try to print it out.
+                        libmesh_error_msg("ERROR: negative Jacobian " \
+                                          << jac[p] \
+                                          << " at point index " \
+                                          << p \
+                                          << " in element " \
+                                          << elem->id());
+                      }
                   }
                 else
                   {
@@ -814,12 +842,26 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
-                    libmesh_error_msg("ERROR: negative Jacobian " \
-                                      << det \
-                                      << " at point " \
-                                      << xyz[p] \
-                                      << " in element " \
-                                      << elem->id());
+                    if(calculate_xyz)
+                      {
+                        libmesh_error_msg("ERROR: negative Jacobian " \
+                                          << det \
+                                          << " at point " \
+                                          << xyz[p] \
+                                          << " in element " \
+                                          << elem->id());
+                      }
+                    else
+                      {
+                        // In this case xyz[p] is not defined, so don't
+                        // try to print it out.
+                        libmesh_error_msg("ERROR: negative Jacobian " \
+                                          << det \
+                                          << " at point index " \
+                                          << p \
+                                          << " in element " \
+                                          << elem->id());
+                      }
                   }
                 else
                   {
@@ -1034,20 +1076,26 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
-                    if (calculate_xyz)
-                      libmesh_error_msg("ERROR: negative Jacobian " \
-                                        << jac[p]
-                                        << " at point " \
-                                        << xyz[p] \
-                                        << " in element " \
-                                        << elem->id());
+                    if(calculate_xyz)
+                      {
+                        libmesh_error_msg("ERROR: negative Jacobian " \
+                                          << jac[p] \
+                                          << " at point " \
+                                          << xyz[p] \
+                                          << " in element " \
+                                          << elem->id());
+                      }
                     else
-                      libmesh_error_msg("ERROR: negative Jacobian " \
-                                        << jac[p]
-                                        << " at point index " \
-                                        << p \
-                                        << " in element " \
-                                        << elem->id());
+                      {
+                        // In this case xyz[p] is not defined, so don't
+                        // try to print it out.
+                        libmesh_error_msg("ERROR: negative Jacobian " \
+                                          << jac[p] \
+                                          << " at point index " \
+                                          << p \
+                                          << " in element " \
+                                          << elem->id());
+                      }
                   }
                 else
                   {


### PR DESCRIPTION
In fe_map.C we call elem->print_info() as part of error reporting. This should be elem->print_info(libMesh::err) so that this info gets printed to libMesh::err.

Also, some libmesh_error_msg calls in fe_map.C caused segfaults because they attempted to print uninitialized data.