### PR TITLE
Switch while loop to for loop in example outer iteration

### DIFF
--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
@@ -190,9 +190,16 @@ int main (int argc, char ** argv)
 
   Real current_max_gap_function = std::numeric_limits<Real>::max();
 
-  unsigned int outer_iteration = 0;
-  while (current_max_gap_function > gap_function_tol)
+  const unsigned int max_outer_iterations = 10;
+  for (unsigned int outer_iteration = 0;
+       outer_iteration != max_outer_iterations; ++outer_iteration)
     {
+      if (current_max_gap_function <= gap_function_tol)
+        {
+          libMesh::out << "Outer iterative loop converged!" << std::endl;
+          break;
+        }
+
       libMesh::out << "Starting outer iteration " << outer_iteration << std::endl;
 
       // Perform inner iteration (i.e. Newton's method loop)


### PR DESCRIPTION
If we're diverging (e.g. with single precision) then that means we should be sad, not keep trying to converge forever.

In other news, the "timeout" option on my BuildBot configuration doesn't seem to be working properly.  It's supposed to quit and die after an hour, not three days.