### PR TITLE
Allow LIBMESH_RUN in optimization_ex2

### DIFF
--- a/examples/optimization/optimization_ex2/optimization_ex2.C
+++ b/examples/optimization/optimization_ex2/optimization_ex2.C
@@ -428,6 +428,13 @@ int main (int argc, char ** argv)
   // We use a 2D domain.
   libmesh_example_requires(LIBMESH_DIM > 1, "--disable-1D-only");
 
+  // TAO is giving us problems in parallel?
+  if (init.comm().size() != 1)
+    {
+      libMesh::out << "This example can currently only be run in serial." << std::endl;
+      return 77;
+    }
+
   GetPot infile("optimization_ex2.in");
   const std::string approx_order = infile("approx_order", "FIRST");
   const std::string fe_family = infile("fe_family", "LAGRANGE");

--- a/examples/optimization/optimization_ex2/run.sh
+++ b/examples/optimization/optimization_ex2/run.sh
@@ -10,8 +10,5 @@ example_dir=examples/optimization/$example_name
 
 options="-tao_monitor -tao_view -tao_type ipm -pc_type jacobi -ksp_max_it 100"
 
-# Prevent the environment from running this example in parallel or
-# changing the command line arguments.
-LIBMESH_OPTIONS=
-LIBMESH_RUN=
-run_example "$example_name" "$options"
+# This example is very sensitive to solver options
+run_example_no_extra_options "$example_name" "$options"


### PR DESCRIPTION
This reduces test coverage in some cases but fixes breakage in others.