### PR TITLE
Reduced basis compilation with big IDs

### DIFF
--- a/include/reduced_basis/rb_construction_base.h
+++ b/include/reduced_basis/rb_construction_base.h
@@ -189,7 +189,7 @@ protected:
    * processors.
    */
   static void get_global_max_error_pair(const Parallel::Communicator & communicator,
-                                        std::pair<unsigned int, Real> & error_pair);
+                                        std::pair<numeric_index_type, Real> & error_pair);
 
   /**
    * Static helper function for generating a randomized set of parameters.

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -1325,7 +1325,7 @@ Real RBConstruction::compute_max_error_bound()
   unsigned int max_err_index = 0;
   Real max_err = 0.;
 
-  unsigned int first_index = get_first_local_training_index();
+  numeric_index_type first_index = get_first_local_training_index();
   for(unsigned int i=0; i<get_local_n_training_samples(); i++)
     {
       // Load training parameter i, this is only loaded
@@ -1341,7 +1341,7 @@ Real RBConstruction::compute_max_error_bound()
         }
     }
 
-  std::pair<unsigned int,Real> error_pair(first_index+max_err_index, max_err);
+  std::pair<numeric_index_type, Real> error_pair(first_index+max_err_index, max_err);
   get_global_max_error_pair(this->comm(),error_pair);
 
   // If we have a serial training set (i.e. a training set that is the same on all processors)

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -168,7 +168,7 @@ void RBConstructionBase<Base>::set_params_from_training_set_and_broadcast(unsign
 {
   libmesh_assert(training_parameters_initialized);
 
-  unsigned int root_id = 0;
+  processor_id_type root_id = 0;
   if( (this->get_first_local_training_index() <= index) &&
       (index < this->get_last_local_training_index()) )
     {

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -92,7 +92,7 @@ void RBConstructionBase<Base>::init_data ()
 
 template <class Base>
 void RBConstructionBase<Base>::get_global_max_error_pair(const Parallel::Communicator & communicator,
-                                                         std::pair<unsigned int, Real> & error_pair)
+                                                         std::pair<numeric_index_type, Real> & error_pair)
 {
   // Set error_pair.second to the maximum global value and also
   // find which processor contains the maximum value

--- a/src/reduced_basis/rb_scm_construction.C
+++ b/src/reduced_basis/rb_scm_construction.C
@@ -433,7 +433,7 @@ std::pair<unsigned int,Real> RBSCMConstruction::compute_SCM_bounds_on_training_s
   unsigned int new_C_J_index = 0;
   Real max_SCM_error = 0.;
 
-  unsigned int first_index = get_first_local_training_index();
+  numeric_index_type first_index = get_first_local_training_index();
   for(unsigned int i=0; i<get_local_n_training_samples(); i++)
     {
       set_params_from_training_set(first_index+i);
@@ -450,8 +450,8 @@ std::pair<unsigned int,Real> RBSCMConstruction::compute_SCM_bounds_on_training_s
         }
     }
 
-  unsigned int global_index = first_index + new_C_J_index;
-  std::pair<unsigned int,Real> error_pair(global_index, max_SCM_error);
+  numeric_index_type global_index = first_index + new_C_J_index;
+  std::pair<numeric_index_type,Real> error_pair(global_index, max_SCM_error);
   get_global_max_error_pair(this->comm(),error_pair);
 
   return error_pair;

--- a/src/reduced_basis/rb_scm_construction.C
+++ b/src/reduced_basis/rb_scm_construction.C
@@ -240,11 +240,11 @@ void RBSCMConstruction::perform_SCM_greedy()
   rb_scm_eval->initialize_parameters(*this);
 
   // Get a list of constrained dofs from rb_system
-  std::set<unsigned int> constrained_dofs_set;
+  std::set<dof_id_type> constrained_dofs_set;
   EquationSystems & es = this->get_equation_systems();
   RBConstruction & rb_system = es.get_system<RBConstruction>(RB_system_name);
 
-  for(unsigned int i=0; i<rb_system.n_dofs(); i++)
+  for(dof_id_type i=0; i<rb_system.n_dofs(); i++)
     {
       if( rb_system.get_dof_map().is_constrained_dof(i) )
         {


### PR DESCRIPTION
This fixes compilation with 64-bit dof_id_type, and replaces a few other inappropriately "unsigned int" types I noticed along the way.