### PR TITLE
Build MeshFunction from ReplicatedMesh

### DIFF
--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -134,7 +134,9 @@ public:
 
   void testProjectCubeWithMeshFunction(const ElemType elem_type)
   {
-    Mesh mesh(*TestCommWorld);
+    // The source mesh needs to exist everywhere it's queried, so we
+    // use a ReplicatedMesh
+    ReplicatedMesh mesh(*TestCommWorld);
 
     EquationSystems es(mesh);
     System &sys = es.add_system<System> ("SimpleSystem");


### PR DESCRIPTION
Otherwise when the two meshes partition differently we'll have one trying to evaluate from remote elements of the other.

This should hopefully fix a tests failure I see with --enable-parmesh.

This use case might be another good argument for the abstract interface @friedmud is suggesting in #977.