### PR TITLE
Make various Elem interfaces const-correct

### DIFF
--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -302,7 +302,7 @@ void assemble_1D(EquationSystems & es,
           // If this element has a NULL neighbor, then it is on the edge of the
           // mesh and we need to enforce a boundary condition using the penalty
           // method.
-          if (elem->neighbor(s) == libmesh_nullptr)
+          if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               Ke(s,s) += penalty;
               Fe(s)   += 0*penalty;

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -664,7 +664,7 @@ void assemble_cd (EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int s=0; s<elem->n_sides(); s++)
-          if (elem->neighbor(s) == libmesh_nullptr)
+          if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               fe_face->reinit(elem, s);
 

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -780,7 +780,7 @@ void assemble_laplace(EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int s=0; s<elem->n_sides(); s++)
-          if (elem->neighbor(s) == libmesh_nullptr)
+          if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               fe_face->reinit(elem, s);
 

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -751,7 +751,7 @@ void assemble_biharmonic(EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int s=0; s<elem->n_sides(); s++)
-          if (elem->neighbor(s) == libmesh_nullptr)
+          if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               // The value of the shape functions at the quadrature
               // points.

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -169,12 +169,8 @@ int main (int argc, char ** argv)
         const Elem * elem = *el;
 
         for (unsigned int side=0; side<elem->n_sides(); side++)
-          {
-            if(elem->neighbor(side) == NULL)
-              {
-                mesh.get_boundary_info().add_side(elem, side, BOUNDARY_ID);
-              }
-          }
+          if (elem->neighbor_ptr (side) == NULL)
+            mesh.get_boundary_info().add_side(elem, side, BOUNDARY_ID);
       }
   }
 

--- a/examples/introduction/introduction_ex3/introduction_ex3.C
+++ b/examples/introduction/introduction_ex3/introduction_ex3.C
@@ -393,7 +393,7 @@ void assemble_poisson(EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int side=0; side<elem->n_sides(); side++)
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               // The value of the shape functions at the quadrature
               // points.

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -589,7 +589,7 @@ void assemble_shell (EquationSystems & es,
       // that is, the boundary of the original mesh without ghosts.
       for (unsigned int s=0; s<elem->n_sides(); ++s)
         {
-          const Tri3Subdivision * nb_elem = static_cast<const Tri3Subdivision *> (elem->neighbor(s));
+          const Tri3Subdivision * nb_elem = static_cast<const Tri3Subdivision *> (elem->neighbor_ptr(s));
           if (nb_elem == libmesh_nullptr || nb_elem->is_ghost())
             continue;
 
@@ -608,7 +608,7 @@ void assemble_shell (EquationSystems & es,
            *     \  /
            *      n1
            */
-          Node * nodes [4]; // n1, n2, n3, n4
+          const Node * nodes [4]; // n1, n2, n3, n4
           nodes[1] = gh_elem->node_ptr(s); // n2
           nodes[2] = gh_elem->node_ptr(MeshTools::Subdivision::next[s]); // n3
           nodes[3] = gh_elem->node_ptr(MeshTools::Subdivision::prev[s]); // n4

--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -432,7 +432,7 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
       // If the element has no neighbor on a side then that
       // side MUST live on a boundary of the domain.
       for (unsigned int side=0; side<elem->n_sides(); side++)
-        if (elem->neighbor(side) == libmesh_nullptr)
+        if (elem->neighbor_ptr(side) == libmesh_nullptr)
           {
             // The value of the shape functions at the quadrature
             // points.

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -401,7 +401,7 @@ void assemble (EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int s=0; s<elem->n_sides(); s++)
-          if (elem->neighbor(s) == libmesh_nullptr)
+          if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               fe_face->reinit(elem, s);
 

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -279,12 +279,12 @@ void assemble_ellipticdg(EquationSystems & es,
       // side MUST live on a boundary of the domain.
       for (unsigned int side=0; side<elem->n_sides(); side++)
         {
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               // Pointer to the element face
               fe_elem_face->reinit(elem, side);
 
-              UniquePtr<Elem> elem_side (elem->build_side(side));
+              UniquePtr<const Elem> elem_side (elem->build_side_ptr(side));
               // h elemet dimension to compute the interior penalty penalty parameter
               const unsigned int elem_b_order = static_cast<unsigned int> (fe_elem_face->get_order());
               const double h_elem = elem->volume()/elem_side->volume() * 1./pow(elem_b_order, 2.);
@@ -325,7 +325,7 @@ void assemble_ellipticdg(EquationSystems & es,
             {
               // Store a pointer to the neighbor we are currently
               // working on.
-              const Elem * neighbor = elem->neighbor(side);
+              const Elem * neighbor = elem->neighbor_ptr(side);
 
               // Get the global id of the element and the neighbor
               const unsigned int elem_id = elem->id();
@@ -342,7 +342,7 @@ void assemble_ellipticdg(EquationSystems & es,
                   (neighbor->level() < elem->level()))
                 {
                   // Pointer to the element side
-                  UniquePtr<Elem> elem_side (elem->build_side(side));
+                  UniquePtr<const Elem> elem_side (elem->build_side_ptr(side));
 
                   // h dimension to compute the interior penalty penalty parameter
                   const unsigned int elem_b_order = static_cast<unsigned int>(fe_elem_face->get_order());

--- a/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
+++ b/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
@@ -44,11 +44,11 @@ void AugmentSparsityOnInterface::augment_sparsity_pattern (SparsityPattern::Grap
 
       {
         for (unsigned char side=0; side<elem->n_sides(); side++)
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               if (mesh.get_boundary_info().has_boundary_id(elem, side, _crack_boundary_lower))
                 {
-                  UniquePtr<Elem> side_elem = elem->build_side(side);
+                  UniquePtr<const Elem> side_elem = elem->build_side_ptr(side);
 
                   lower_centroids[std::make_pair(elem->id(), side)] = side_elem->centroid();
                 }
@@ -57,11 +57,11 @@ void AugmentSparsityOnInterface::augment_sparsity_pattern (SparsityPattern::Grap
 
       {
         for (unsigned char side=0; side<elem->n_sides(); side++)
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               if (mesh.get_boundary_info().has_boundary_id(elem, side, _crack_boundary_upper))
                 {
-                  UniquePtr<Elem> side_elem = elem->build_side(side);
+                  UniquePtr<const Elem> side_elem = elem->build_side_ptr(side);
 
                   upper_centroids[std::make_pair(elem->id(), side)] = side_elem->centroid();
                 }

--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -241,7 +241,7 @@ void assemble_poisson(EquationSystems & es,
       // Boundary flux provides forcing in this example
       {
         for (unsigned int side=0; side<elem->n_sides(); side++)
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               if (mesh.get_boundary_info().has_boundary_id (elem, side, MIN_Z_BOUNDARY))
                 {
@@ -258,7 +258,7 @@ void assemble_poisson(EquationSystems & es,
       // Add boundary terms on the crack
       {
         for (unsigned int side=0; side<elem->n_sides(); side++)
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               // Found the lower side of the crack. Assemble terms due to lower and upper in here.
               if (mesh.get_boundary_info().has_boundary_id (elem, side, CRACK_BOUNDARY_LOWER))

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -594,8 +594,8 @@ void assemble_poisson(EquationSystems & es,
             // is different from 1, the side is also located on the
             // boundary.
             for (unsigned int side=0; side<elem->n_sides(); side++)
-              if ((elem->neighbor(side) == libmesh_nullptr) ||
-                  (elem->neighbor(side)->subdomain_id()!=1))
+              if ((elem->neighbor_ptr(side) == libmesh_nullptr) ||
+                  (elem->neighbor_ptr(side)->subdomain_id()!=1))
                 {
 
                   // The penalty value.  \frac{1}{\epsilon}

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -538,8 +538,8 @@ void assemble_poisson(EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int side=0; side<elem->n_sides(); side++)
-          if ((elem->neighbor(side) == libmesh_nullptr) ||
-              (elem->neighbor(side)->subdomain_id() != elem->subdomain_id()))
+          if ((elem->neighbor_ptr(side) == libmesh_nullptr) ||
+              (elem->neighbor_ptr(side)->subdomain_id() != elem->subdomain_id()))
             {
 
               // The penalty value.  \frac{1}{\epsilon}

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -358,9 +358,9 @@ void assemble_stokes (EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int s=0; s<elem->n_sides(); s++)
-          if (elem->neighbor(s) == libmesh_nullptr)
+          if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
-              UniquePtr<Elem> side (elem->build_side(s));
+              UniquePtr<const Elem> side (elem->build_side_ptr(s));
 
               // Loop over the nodes on the side.
               for (unsigned int ns=0; ns<side->n_nodes(); ns++)

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -594,9 +594,9 @@ void assemble_stokes (EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int s=0; s<elem->n_sides(); s++)
-          if (elem->neighbor(s) == libmesh_nullptr)
+          if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
-              UniquePtr<Elem> side (elem->build_side(s));
+              UniquePtr<const Elem> side (elem->build_side_ptr(s));
 
               // Loop over the nodes on the side.
               for (unsigned int ns=0; ns<side->n_nodes(); ns++)
@@ -631,7 +631,7 @@ void assemble_stokes (EquationSystems & es,
                         Fv(n) += penalty*v_value;
                       }
                 } // end face node loop
-            } // end if (elem->neighbor(side) == libmesh_nullptr)
+            } // end if (elem->neighbor_ptr(side) == libmesh_nullptr)
 
         // Pin the pressure to zero at global node number "pressure_node".
         // This effectively removes the non-trivial null space of constant

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -602,9 +602,9 @@ void assemble_stokes (EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int s=0; s<elem->n_sides(); s++)
-          if (elem->neighbor(s) == libmesh_nullptr)
+          if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
-              UniquePtr<Elem> side (elem->build_side(s));
+              UniquePtr<const Elem> side (elem->build_side_ptr(s));
 
               // Loop over the nodes on the side.
               for (unsigned int ns=0; ns<side->n_nodes(); ns++)

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -305,7 +305,7 @@ void assemble_elasticity(EquationSystems & es,
 
       {
         for (unsigned int side=0; side<elem->n_sides(); side++)
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               const std::vector<std::vector<Real> > & phi_face = fe_face->get_phi();
               const std::vector<Real> & JxW_face = fe_face->get_JxW();

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -325,7 +325,7 @@ void assemble_elasticity(EquationSystems & es,
       {
         std::vector<boundary_id_type> bc_ids;
         for (unsigned int side=0; side<elem->n_sides(); side++)
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               mesh.get_boundary_info().boundary_ids (elem, side, bc_ids);
 

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -249,7 +249,7 @@ public:
         g_vec(2) = -1.;
         {
           for (unsigned int side=0; side<elem->n_sides(); side++)
-            if (elem->neighbor(side) == libmesh_nullptr)
+            if (elem->neighbor_ptr(side) == libmesh_nullptr)
               {
                 const std::vector<std::vector<Real> > & phi_face = fe_face->get_phi();
                 const std::vector<Real> & JxW_face = fe_face->get_JxW();

--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
@@ -165,7 +165,7 @@ void LinearElasticityWithContact::initialize_contact_load_paths()
 
       for (unsigned int side=0; side<elem->n_sides(); side++)
         {
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               bool on_lower_contact_surface =
                 mesh.get_boundary_info().has_boundary_id (elem, side, CONTACT_BOUNDARY_LOWER);

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -477,7 +477,7 @@ void assemble_cd (EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int s=0; s<elem->n_sides(); s++)
-          if (elem->neighbor(s) == libmesh_nullptr)
+          if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               fe_face->reinit(elem, s);
 

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -477,7 +477,7 @@ void assemble_wave(EquationSystems & es,
         // don't do this for any side
         for (unsigned int side=0; side<elem->n_sides(); side++)
           if (!true)
-            // if (elem->neighbor(side) == libmesh_nullptr)
+            // if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               // Declare a special finite element object for
               // boundary integration.
@@ -519,7 +519,7 @@ void assemble_wave(EquationSystems & es,
                         *phi_face[i][qp]*JxW_face[qp];
                     }
                 } // end face quadrature point loop
-            } // end if (elem->neighbor(side) == libmesh_nullptr)
+            } // end if (elem->neighbor_ptr(side) == libmesh_nullptr)
 
         // In this example the Dirichlet boundary conditions will be
         // imposed via panalty method after the

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -391,7 +391,7 @@ void assemble_poisson(EquationSystems & es,
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
         for (unsigned int side=0; side<elem->n_sides(); side++)
-          if (elem->neighbor(side) == libmesh_nullptr)
+          if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               // The value of the shape functions at the quadrature
               // points.

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -256,8 +256,8 @@ struct facelocal_pid : predicate<T>
     if ((*it)->processor_id() == _pid)
       return true;
     for (unsigned int n = 0; n != (*it)->n_neighbors(); ++n)
-      if ((*it)->neighbor(n) &&
-          (*it)->neighbor(n)->processor_id() == _pid)
+      if ((*it)->neighbor_ptr(n) &&
+          (*it)->neighbor_ptr(n)->processor_id() == _pid)
         return true;
     return false;
   }

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -58,7 +58,7 @@ public:
                                 const std::vector<Real> & qw,
                                 const Elem * elem,
                                 unsigned int p,
-                                const std::vector<Node *> & elem_nodes,
+                                const std::vector<const Node *> & elem_nodes,
                                 bool compute_second_derivatives);
 
   /**

--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -129,7 +129,7 @@ public:
    * @returns a primitive (4-noded) quad for
    * face i.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
   /**
    * Based on the quality metric q specified by the user,

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -165,12 +165,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -136,14 +136,14 @@ public:
    * Builds a \p QUAD8 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -152,14 +152,14 @@ public:
    * Builds a \p QUAD9 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -181,12 +181,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -122,14 +122,14 @@ public:
    * Builds a QUAD4 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a EDGE2 built coincident with edge i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -125,7 +125,7 @@ public:
    * @returns a primitive (4-noded) quad or infquad for
    * face i.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
   /**
    * Based on the quality metric q specified by the user,

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -168,12 +168,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -135,15 +135,15 @@ public:
    * built coincident with faces 1 to 4. Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Returns a \p EDGE3 built coincident with edges 0 to 3, or \p INFEDGE2
    * built coincident with edges 4 to 11. Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -135,15 +135,15 @@ public:
    * built coincident with faces 1 to 4. Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Returns a \p EDGE3 built coincident with edges 0-3, an \p INFEDGE2
    * built coincident with edges 4 to 11. Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   /**
    * Don't hide Elem::key() defined in the base class.

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -183,12 +183,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -121,15 +121,15 @@ public:
    * built coincident with faces 1 to 4. Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Returns an \p EDGE2 built coincident with edges 0 to 3, an \p INFEDGE2
    * built coincident with edges 4 to 7. Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -124,7 +124,7 @@ public:
    * @returns a primitive (3-noded) tri or (4-noded) infquad for
    * face i.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
 
 protected:

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -156,12 +156,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -126,15 +126,15 @@ public:
    * built coincident with faces 1 to 3.  Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Returns a \p EDGE3 built coincident with edges 0 to 2, an \p INFEDGE2
    * built coincident with edges 3 to 5.  Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -119,15 +119,15 @@ public:
    * built coincident with faces 1 to 3.  Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Returns a \p EDGE2 built coincident with edges 0 to 2, an \p INFEDGE2
    * built coincident with edges 3 to 5.  Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -120,7 +120,7 @@ public:
    * @returns a primitive triangle or quad for
    * face i.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
 
 protected:

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -170,12 +170,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -142,14 +142,14 @@ public:
    * Builds a \p QUAD8 or \p TRI6 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE3 or \p INFEDGE2 coincident with edge i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -158,14 +158,14 @@ public:
    * Builds a \p QUAD9 or \p TRI6 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE3 or \p INFEDGE2 built coincident with edge i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -186,12 +186,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -115,14 +115,14 @@ public:
    * Builds a \p QUAD4 or \p TRI3 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE2 or \p INFEDGE2 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -121,7 +121,7 @@ public:
    * @returns a primitive triangle or quad for
    * face i.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
 
 protected:

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -141,14 +141,14 @@ public:
    * Builds a \p QUAD8 or \p TRI6 coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE3 coincident with edge i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -160,14 +160,14 @@ public:
    * Builds a \p QUAD9 or \p TRI6 coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE3 coincident with edge i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -116,14 +116,14 @@ public:
    * Builds a \p QUAD4 or \p TRI3 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE2 built coincident with edge i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -108,7 +108,7 @@ public:
    * @returns a primitive (3-noded) triangle for
    * face i.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
   /**
    * Based on the quality metric q specified by the user,

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -135,14 +135,14 @@ public:
    * Builds a \p TRI6 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -164,12 +164,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -134,14 +134,14 @@ public:
    * Builds a \p TRI3 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
    * Builds a \p EDGE2 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -143,13 +143,13 @@ public:
    * The \p Elem::side() member returns
    * an auto pointer to a NodeElem for the specified node.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   /**
-   * The \p Elem::build_edge() member makes no sense for edges.
+   * The \p Elem::build_edge_ptr() member makes no sense for edges.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int) const libmesh_override
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int) libmesh_override
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
 

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -137,7 +137,7 @@ public:
    * The \p Elem::side() member returns
    * an auto pointer to a NodeElem for the specified node.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
   /**
    * The \p Elem::side() member returns

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -140,12 +140,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -658,8 +658,18 @@ public:
    * If you really need a full-ordered, non-proxy side object, call
    * this function with proxy=false.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy=true) const = 0;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i, bool proxy=true) = 0;
+  UniquePtr<const Elem> build_side_ptr (const unsigned int i, bool proxy=true) const;
+
+  /**
+   * @returns a proxy element coincident with side \p i.
+   *
+   * This method will eventually be deprecated/removed, since it
+   * returns a non-const pointer to a side that could be used to
+   * indirectly modify this.  Please use the the const-correct
+   * build_side_ptr() function instead.
+   */
+  UniquePtr<Elem> build_side (const unsigned int i, bool proxy=true) const;
 
   /**
    * Creates an element coincident with edge \p i. The element returned is
@@ -669,7 +679,18 @@ public:
    * A \p UniquePtr<Elem> is returned to prevent a memory leak.
    * This way the user need not remember to delete the object.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const = 0;
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) = 0;
+  UniquePtr<const Elem> build_edge_ptr (const unsigned int i) const;
+
+  /**
+   * Creates an element coincident with edge \p i.
+   *
+   * This method will eventually be deprecated/removed, since it
+   * returns a non-const pointer to an edge that could be used to
+   * indirectly modify this.  Please use the the const-correct
+   * build_edge_ptr() function instead.
+   */
+  UniquePtr<Elem> build_edge (const unsigned int i) const;
 
   /**
    * @returns the default approximation order for this element type.
@@ -1743,6 +1764,54 @@ UniquePtr<Elem> Elem::side (const unsigned int i) const
   // Call the const version of side_ptr(), and const_cast the result.
   Elem * s = const_cast<Elem *>(this->side_ptr(i).release());
   return UniquePtr<Elem>(s);
+}
+
+
+
+inline
+UniquePtr<const Elem>
+Elem::build_side_ptr (const unsigned int i, bool proxy) const
+{
+  // Call the non-const version of this function, return the result as
+  // a UniquePtr<const Elem>.
+  Elem * me = const_cast<Elem *>(this);
+  const Elem * s = const_cast<const Elem *>(me->build_side_ptr(i, proxy).release());
+  return UniquePtr<const Elem>(s);
+}
+
+
+
+inline
+UniquePtr<Elem>
+Elem::build_side (const unsigned int i, bool proxy) const
+{
+  // Call the const version of build_side_ptr(), and const_cast the result.
+  Elem * s = const_cast<Elem *>(this->build_side_ptr(i, proxy).release());
+  return UniquePtr<Elem>(s);
+}
+
+
+
+inline
+UniquePtr<const Elem>
+Elem::build_edge_ptr (const unsigned int i) const
+{
+  // Call the non-const version of this function, return the result as
+  // a UniquePtr<const Elem>.
+  Elem * me = const_cast<Elem *>(this);
+  const Elem * e = const_cast<const Elem *>(me->build_edge_ptr(i).release());
+  return UniquePtr<const Elem>(e);
+}
+
+
+
+inline
+UniquePtr<Elem>
+Elem::build_edge (const unsigned int i) const
+{
+  // Call the const version of build_edge_ptr(), and const_cast the result.
+  Elem * e = const_cast<Elem *>(this->build_edge_ptr(i).release());
+  return UniquePtr<Elem>(e);
 }
 
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -629,7 +629,18 @@ public:
    * you want the full-ordered face (i.e. a 9-noded quad face for a 27-noded
    * hexahedral) use the build_side method.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const = 0;
+  virtual UniquePtr<Elem> side_ptr (unsigned int i) = 0;
+  UniquePtr<const Elem> side_ptr (unsigned int i) const;
+
+  /**
+   * @returns a proxy element coincident with side \p i.
+   *
+   * This method will eventually be deprecated/removed, since it
+   * returns a non-const pointer to a side that could be used to
+   * indirectly modify this.  Please use the the const-correct
+   * side_ptr() function instead.
+   */
+  UniquePtr<Elem> side (const unsigned int i) const;
 
   /**
    * Creates an element coincident with side \p i. The element returned is
@@ -1710,6 +1721,28 @@ const Elem * Elem::child_neighbor (const Elem * elem) const
       return elem->neighbor(n);
 
   return libmesh_nullptr;
+}
+
+
+
+inline
+UniquePtr<const Elem> Elem::side_ptr (unsigned int i) const
+{
+  // Call the non-const version of this function, return the result as
+  // a UniquePtr<const Elem>.
+  Elem * me = const_cast<Elem *>(this);
+  const Elem * s = const_cast<const Elem *>(me->side_ptr(i).release());
+  return UniquePtr<const Elem>(s);
+}
+
+
+
+inline
+UniquePtr<Elem> Elem::side (const unsigned int i) const
+{
+  // Call the const version of side_ptr(), and const_cast the result.
+  Elem * s = const_cast<Elem *>(this->side_ptr(i).release());
+  return UniquePtr<Elem>(s);
 }
 
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -253,13 +253,25 @@ public:
   bool operator == (const Elem & rhs) const;
 
   /**
-   * @returns a pointer to the \f$ i^{th} \f$ neighbor of this element.
+   * @returns a const pointer to the \f$ i^{th} \f$ neighbor of this element.
    * If \p MeshBase::find_neighbors() has not been called this
    * simply returns \p NULL.  If \p MeshBase::find_neighbors()
    * has been called and this returns \p NULL then the side is on
    * a boundary of the domain.
    */
+  const Elem * neighbor_ptr (unsigned int i) const;
+
+  /**
+   * @returns a non-const pointer to the \f$ i^{th} \f$ neighbor of this element.
+   */
+  Elem * neighbor_ptr (unsigned int i);
+
+  /**
+   * This function is deprecated.  Use the more specifically named and
+   * const-correct neighbor_ptr() functions instead.
+   */
   Elem * neighbor (const unsigned int i) const;
+
 
 #ifdef LIBMESH_ENABLE_PERIODIC
   /**
@@ -1702,11 +1714,31 @@ subdomain_id_type & Elem::subdomain_id ()
 
 
 inline
-Elem * Elem::neighbor (const unsigned int i) const
+const Elem * Elem::neighbor_ptr (unsigned int i) const
 {
   libmesh_assert_less (i, this->n_neighbors());
 
   return _elemlinks[i+1];
+}
+
+
+
+inline
+Elem * Elem::neighbor_ptr (unsigned int i)
+{
+  libmesh_assert_less (i, this->n_neighbors());
+
+  return _elemlinks[i+1];
+}
+
+
+
+inline
+Elem * Elem::neighbor (const unsigned int i) const
+{
+  // Support the deprecated interface by calling the new,
+  // const-correct interface and casting the result to an Elem *.
+  return const_cast<Elem *>(this->neighbor_ptr(i));
 }
 
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -160,14 +160,24 @@ public:
   const Node * const * get_nodes () const;
 
   /**
-   * @returns the pointer to local \p Node \p i.
+   * @returns a const pointer to local \p Node \p i.
    */
-  Node * node_ptr (const unsigned int i) const;
+  const Node * node_ptr (const unsigned int i) const;
 
   /**
-   * @returns a reference to local \p Node \p i.
+   * @returns a non-const pointer to local \p Node \p i.
    */
-  Node & node_ref (const unsigned int i) const;
+  Node * node_ptr (const unsigned int i);
+
+  /**
+   * @returns a const reference to local \p Node \p i.
+   */
+  const Node & node_ref (const unsigned int i) const;
+
+  /**
+   * @returns a writable reference to local \p Node \p i.
+   */
+  Node & node_ref (const unsigned int i);
 
   /**
    * @returns the pointer to local \p Node \p i.
@@ -1557,7 +1567,7 @@ const Node * const * Elem::get_nodes () const
 
 
 inline
-Node * Elem::node_ptr (const unsigned int i) const
+const Node * Elem::node_ptr (const unsigned int i) const
 {
   libmesh_assert_less (i, this->n_nodes());
   libmesh_assert(_nodes[i]);
@@ -1568,7 +1578,26 @@ Node * Elem::node_ptr (const unsigned int i) const
 
 
 inline
-Node & Elem::node_ref (const unsigned int i) const
+Node * Elem::node_ptr (const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_nodes());
+  libmesh_assert(_nodes[i]);
+
+  return _nodes[i];
+}
+
+
+
+inline
+const Node & Elem::node_ref (const unsigned int i) const
+{
+  return *this->node_ptr(i);
+}
+
+
+
+inline
+Node & Elem::node_ref (const unsigned int i)
 {
   return *this->node_ptr(i);
 }
@@ -1578,7 +1607,13 @@ Node & Elem::node_ref (const unsigned int i) const
 inline
 Node * Elem::get_node (const unsigned int i) const
 {
-  return this->node_ptr(i);
+  // This const function has incorrectly returned a non-const pointer
+  // for years.  Now that it is reimplemented in terms of the new
+  // interface which does return a const pointer, we need to use a
+  // const_cast to mimic the old (incorrect) behavior.  This function
+  // will be officially deprecated (hopefully soon) and eventually
+  // removed entirely, obviating the need for this ugly cast.
+  return const_cast<Node *>(this->node_ptr(i));
 }
 
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -982,10 +982,23 @@ public:
                          INVALID_REFINEMENTSTATE };
 
   /**
-   * @returns a pointer to the \f$ i^{th} \f$ child for this element.
+   * @returns a constant pointer to the \f$ i^{th} \f$ child for this element.
    * Do not call if this element has no children, i.e. is active.
    */
+  const Elem * child_ptr (unsigned int i) const;
+
+  /**
+   * @returns a non-constant pointer to the \f$ i^{th} \f$ child for this element.
+   * Do not call if this element has no children, i.e. is active.
+   */
+  Elem * child_ptr (unsigned int i);
+
+  /**
+   * This function is now deprecated, use the more accurately-named and
+   * const correct child_ptr() function instead.
+   */
   Elem * child (const unsigned int i) const;
+
 
 private:
   /**
@@ -2079,12 +2092,30 @@ unsigned int Elem::p_level() const
 #ifdef LIBMESH_ENABLE_AMR
 
 inline
-Elem * Elem::child (const unsigned int i) const
+const Elem * Elem::child_ptr (unsigned int i) const
 {
   libmesh_assert(_children);
   libmesh_assert(_children[i]);
 
   return _children[i];
+}
+
+inline
+Elem * Elem::child_ptr (unsigned int i)
+{
+  libmesh_assert(_children);
+  libmesh_assert(_children[i]);
+
+  return _children[i];
+}
+
+
+inline
+Elem * Elem::child (const unsigned int i) const
+{
+  // Support the deprecated interface by calling the new,
+  // const-correct interface and casting the result to an Elem *.
+  return const_cast<Elem *>(this->child_ptr(i));
 }
 
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -322,7 +322,7 @@ public:
    * of a child of this element, this returns a pointer
    * to that child.  Otherwise it returns NULL.
    */
-  Elem * child_neighbor (Elem * elem) const;
+  Elem * child_neighbor (Elem * elem);
 
   /**
    * If the element \p elem in question is a neighbor
@@ -1766,7 +1766,7 @@ bool Elem::has_neighbor (const Elem * elem) const
 
 
 inline
-Elem * Elem::child_neighbor (Elem * elem) const
+Elem * Elem::child_neighbor (Elem * elem)
 {
   for (unsigned int n=0; n<elem->n_neighbors(); n++)
     if (elem->neighbor(n) &&

--- a/include/geom/face.h
+++ b/include/geom/face.h
@@ -66,8 +66,8 @@ public:
   /**
    * build_side and build_edge are identical for faces
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override
-  { return build_side(i); }
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override
+  { return build_side_ptr(i); }
 
   /*
    * is_edge_on_side is trivial in 2D

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -147,7 +147,7 @@ public:
   virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
   /**
-   * build_edge() and build_side() are identical in 2D
+   * build_edge_ptr() and build_side_ptr() are identical in 2D
    */
   virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override
   { return build_side_ptr(i); }

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -147,10 +147,10 @@ public:
   virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
   /**
-   * build_edge and build_side are identical in 2D
+   * build_edge() and build_side() are identical in 2D
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int i) const libmesh_override
-  { return build_side(i); }
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int i) libmesh_override
+  { return build_side_ptr(i); }
 
   /*
    * is_edge_on_side is trivial in 2D

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -144,7 +144,7 @@ public:
    * @returns a primitive (2-noded) edge or infedge for
    * edge \p i.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
   /**
    * build_edge and build_side are identical in 2D

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -113,8 +113,8 @@ public:
    * Creates and returns an \p Edge2 for the base side, and an \p InfEdge2 for
    * the sides 1, 2.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -153,13 +153,9 @@ public:
                                                            const unsigned int v) const libmesh_override;
 
   /**
-   * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * @returns the child number \p c and element-local index \p v of
+   * the \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -131,8 +131,8 @@ public:
    * Creates and returns an \p Edge3 for the base (0) side, and an \p InfEdge2 for
    * the sides 1, 2.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -147,7 +147,7 @@ public:
    * @returns a primitive (2-noded) edge for
    * edge i.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
   /**
    * Based on the quality metric q specified by the user,

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -108,8 +108,8 @@ public:
    */
   virtual Order default_order() const libmesh_override { return FIRST; }
 
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -136,8 +136,8 @@ public:
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -159,12 +159,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -143,8 +143,8 @@ public:
    */
   virtual dof_id_type key () const libmesh_override;
 
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -165,12 +165,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element. See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -138,7 +138,7 @@ public:
    * @returns a primitive (2-noded) edge for
    * edge i.
    */
-  virtual UniquePtr<Elem> side (const unsigned int i) const libmesh_override;
+  virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
   /**
    * Based on the quality metric q specified by the user,

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -118,8 +118,8 @@ public:
    */
   virtual Order default_order() const libmesh_override { return FIRST; }
 
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -136,8 +136,8 @@ public:
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
-  virtual UniquePtr<Elem> build_side (const unsigned int i,
-                                      bool proxy) const libmesh_override;
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
+                                          bool proxy) libmesh_override;
 
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -159,12 +159,8 @@ public:
 
   /**
    * @returns the child number \p c and element-local index \p v of the
-   * \f$ n^{th} \f$ second-order node on the parent element.  Note that
-   * the return values are always less \p this->n_children() and
-   * \p this->child(c)->n_vertices(), while \p n has to be greater or equal
-   * to \p * this->n_vertices().  For linear elements this returns 0,0.
-   * On refined second order elements, the return value will satisfy
-   * \p this->node_ptr(n)==this->child(c)->node_ptr(v)
+   * \f$ n^{th} \f$ second-order node on the parent element.  See
+   * elem.h for further details.
    */
   virtual std::pair<unsigned short int, unsigned short int>
   second_order_child_vertex (const unsigned int n) const libmesh_override;

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -118,15 +118,15 @@ public:
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
   /**
-   * The \p Elem::build_side() member makes no sense for nodes.
+   * The \p Elem::build_side_ptr() member makes no sense for nodes.
    */
-  virtual UniquePtr<Elem> build_side (const unsigned int, bool) const libmesh_override
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int, bool) libmesh_override
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
   /**
    * The \p Elem::build_edge() member makes no sense for nodes.
    */
-  virtual UniquePtr<Elem> build_edge (const unsigned int) const libmesh_override
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int) libmesh_override
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
   /**

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -124,7 +124,7 @@ public:
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
   /**
-   * The \p Elem::build_edge() member makes no sense for nodes.
+   * The \p Elem::build_edge_ptr() member makes no sense for nodes.
    */
   virtual UniquePtr<Elem> build_edge_ptr (const unsigned int) libmesh_override
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -114,7 +114,7 @@ public:
   /**
    * The \p Elem::side() member makes no sense for nodes.
    */
-  virtual UniquePtr<Elem> side (const unsigned int) const libmesh_override
+  virtual UniquePtr<Elem> side_ptr (const unsigned int) libmesh_override
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
   /**

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -148,7 +148,7 @@ public:
   virtual unsigned int n_sub_elem () const libmesh_override
   { libmesh_not_implemented(); return 0; }
 
-  virtual UniquePtr<Elem> side (const unsigned int) const libmesh_override
+  virtual UniquePtr<Elem> side_ptr (const unsigned int) libmesh_override
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
   virtual UniquePtr<Elem> build_side (const unsigned int,

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -151,11 +151,11 @@ public:
   virtual UniquePtr<Elem> side_ptr (const unsigned int) libmesh_override
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
-  virtual UniquePtr<Elem> build_side (const unsigned int,
-                                      bool) const libmesh_override
+  virtual UniquePtr<Elem> build_side_ptr (const unsigned int,
+                                          bool) libmesh_override
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
-  virtual UniquePtr<Elem> build_edge (const unsigned int) const libmesh_override
+  virtual UniquePtr<Elem> build_edge_ptr (const unsigned int) libmesh_override
   { libmesh_not_implemented(); return UniquePtr<Elem>(); }
 
   virtual Order default_order () const libmesh_override

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -62,7 +62,7 @@ protected:
    * by the Mesh class.  A user should never instantiate
    * this class.  Therefore the constructor is protected.
    */
-  BoundaryInfo (const MeshBase & m);
+  BoundaryInfo (MeshBase & m);
 
 public:
   /**
@@ -724,7 +724,7 @@ private:
   /**
    * The Mesh this boundary info pertains to.
    */
-  const MeshBase & _mesh;
+  MeshBase & _mesh;
 
   /**
    * Data structure that maps nodes in the mesh

--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -299,7 +299,7 @@ public:
    * if necessary.
    * The processor_id is assigned to any newly created node.
    */
-  Node * add_node (const Elem & parent,
+  Node * add_node (Elem & parent,
                    unsigned int child,
                    unsigned int node,
                    processor_id_type proc_id);

--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -706,9 +706,9 @@ private:
    * Local dispatch function for checking the correct has_neighbor
    * function from the Elem class
    */
-  bool has_topological_neighbor (Elem * elem,
+  bool has_topological_neighbor (const Elem * elem,
                                  const PointLocatorBase * point_locator,
-                                 Elem * neighbor);
+                                 const Elem * neighbor);
 
   /**
    * Data structure that holds the new nodes information.

--- a/include/mesh/mesh_subdivision_support.h
+++ b/include/mesh/mesh_subdivision_support.h
@@ -63,7 +63,8 @@ namespace Subdivision
  *        5--4--3
  * \endverbatim
  */
-void find_one_ring(const Tri3Subdivision * elem, std::vector<Node *> & nodes);
+void find_one_ring(const Tri3Subdivision * elem,
+                   std::vector<const Node *> & nodes);
 
 /**
  * Turns a triangulated \p mesh into a subdivision mesh. This

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -421,7 +421,7 @@ void sync_element_data_by_parent_id(MeshBase &       mesh,
         {
           Elem & parent = mesh.elem_ref(request_to_fill_parent_id[i]);
           libmesh_assert(parent.has_children());
-          Elem * child = parent.child(request_to_fill_child_num[i]);
+          Elem * child = parent.child_ptr(request_to_fill_child_num[i]);
           libmesh_assert(child);
           libmesh_assert(child->active());
           request_to_fill_id[i] = child->id();
@@ -585,7 +585,7 @@ void sync_node_data_by_element_id(MeshBase &       mesh,
           const unsigned int n = request_to_fill_node_num[i];
           libmesh_assert_less (n, elem.n_nodes());
 
-          Node & node = elem.node_ref(n);
+          const Node & node = elem.node_ref(n);
 
           // This isn't a safe assertion in the case where we're
           // synching processor ids

--- a/src/apps/amr.C
+++ b/src/apps/amr.C
@@ -236,7 +236,7 @@ void assemble(EquationSystems & es,
       if (dim == 3)
         {
           for (unsigned int side=0; side<elem->n_sides(); side++)
-            if (elem->neighbor(side) == libmesh_nullptr)
+            if (elem->neighbor_ptr(side) == libmesh_nullptr)
               {
                 fe_face->reinit (elem, side);
 

--- a/src/apps/meshbcid.C
+++ b/src/apps/meshbcid.C
@@ -148,7 +148,7 @@ int main(int argc, char ** argv)
       unsigned int n_sides = elem->n_sides();
       for (unsigned short s=0; s != n_sides; ++s)
         {
-          if (elem->neighbor(s))
+          if (elem->neighbor_ptr(s))
             continue;
 
           fe->reinit(elem,s);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1472,17 +1472,17 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
 
       // Loop over the neighbors of those elements
       for (unsigned int s=0; s<elem->n_neighbors(); s++)
-        if (elem->neighbor(s) != libmesh_nullptr)
+        if (elem->neighbor_ptr(s) != libmesh_nullptr)
           {
             family.clear();
 
             // Find all the active elements that neighbor elem
 #ifdef LIBMESH_ENABLE_AMR
-            if (!elem->neighbor(s)->active())
-              elem->neighbor(s)->active_family_tree_by_neighbor(family, elem);
+            if (!elem->neighbor_ptr(s)->active())
+              elem->neighbor_ptr(s)->active_family_tree_by_neighbor(family, elem);
             else
 #endif
-              family.push_back(elem->neighbor(s));
+              family.push_back(elem->neighbor_ptr(s));
 
             for (dof_id_type i=0; i!=family.size(); ++i)
               // If the neighbor lives on a different processor
@@ -1820,7 +1820,7 @@ void DofMap::dof_indices (const Elem * const elem,
       if (!sd_elem->is_ghost())
         {
           // Determine the nodes contributing to element elem
-          std::vector<Node *> elem_nodes;
+          std::vector<const Node *> elem_nodes;
           MeshTools::Subdivision::find_one_ring(sd_elem, elem_nodes);
 
           // Get the dof numbers
@@ -1910,7 +1910,7 @@ void DofMap::dof_indices (const Elem * const elem,
       if (!sd_elem->is_ghost())
         {
           // Determine the nodes contributing to element elem
-          std::vector<Node *> elem_nodes;
+          std::vector<const Node *> elem_nodes;
           MeshTools::Subdivision::find_one_ring(sd_elem, elem_nodes);
 
           _dof_indices(elem, p_level, di, vn, &elem_nodes[0],
@@ -2154,7 +2154,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
   di.clear();
 
   // Determine the nodes contributing to element elem
-  std::vector<Node *> elem_nodes;
+  std::vector<const Node *> elem_nodes;
   if (elem->type() == TRI3SUBDIVISION)
     {
       // Subdivision surface FE require the 1-ring around elem
@@ -2560,9 +2560,9 @@ void SparsityPattern::Build::operator()(const ConstElemRange & range)
               // TODO:[BSK] optimize this like above!
               if (implicit_neighbor_dofs)
                 for (unsigned int s=0; s<elem->n_sides(); s++)
-                  if (elem->neighbor(s) != libmesh_nullptr)
+                  if (elem->neighbor_ptr(s) != libmesh_nullptr)
                     {
-                      const Elem * const neighbor_0 = elem->neighbor(s);
+                      const Elem * const neighbor_0 = elem->neighbor_ptr(s);
 #ifdef LIBMESH_ENABLE_AMR
                       neighbor_0->active_family_tree_by_neighbor(active_neighbors,elem);
 #else
@@ -2748,9 +2748,9 @@ void SparsityPattern::Build::operator()(const ConstElemRange & range)
                         // TODO:[BSK] optimize this like above!
                         if (implicit_neighbor_dofs)
                           for (unsigned int s=0; s<elem->n_sides(); s++)
-                            if (elem->neighbor(s) != libmesh_nullptr)
+                            if (elem->neighbor_ptr(s) != libmesh_nullptr)
                               {
-                                const Elem * const neighbor_0 = elem->neighbor(s);
+                                const Elem * const neighbor_0 = elem->neighbor_ptr(s);
 #ifdef LIBMESH_ENABLE_AMR
                                 neighbor_0->active_family_tree_by_neighbor(active_neighbors,elem);
 #else

--- a/src/base/periodic_boundaries.C
+++ b/src/base/periodic_boundaries.C
@@ -67,7 +67,7 @@ const Elem * PeriodicBoundaries::neighbor(boundary_id_type boundary_id,
 {
   // Find a point on that side (and only that side)
 
-  Point p = e->build_side(side)->centroid();
+  Point p = e->build_side_ptr(side)->centroid();
 
   const PeriodicBoundaryBase * b = this->boundary(boundary_id);
   libmesh_assert (b);

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -276,7 +276,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
         for(unsigned int n=0; n != elem->n_nodes(); ++n)
           {
             // Get a reference to the current node
-            Node & node = elem->node_ref(n);
+            const Node & node = elem->node_ref(n);
 
             // Get the id of this node
             dof_id_type node_id = node.id();

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -339,7 +339,7 @@ void ExactErrorEstimator::estimate_error (const System & system,
             compute_on_parent = false;
           else
             for (unsigned int c=0; c != parent->n_children(); ++c)
-              if (!parent->child(c)->active())
+              if (!parent->child_ptr(c)->active())
                 compute_on_parent = false;
 
           if (compute_on_parent &&

--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -52,7 +52,7 @@ void HPCoarsenTest::add_projection(const System & system,
     {
       libmesh_assert(!elem->subactive());
       for (unsigned int c = 0; c != elem->n_children(); ++c)
-        this->add_projection(system, elem->child(c), var);
+        this->add_projection(system, elem->child_ptr(c), var);
       return;
     }
 

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -189,7 +189,7 @@ void JumpErrorEstimator::estimate_error (const System & system,
         compute_on_parent = false;
       else
         for (unsigned int c=0; c != parent->n_children(); ++c)
-          if (!parent->child(c)->active())
+          if (!parent->child_ptr(c)->active())
             compute_on_parent = false;
 
       if (compute_on_parent &&
@@ -203,11 +203,11 @@ void JumpErrorEstimator::estimate_error (const System & system,
           // Loop over the neighbors of the parent
           for (unsigned int n_p=0; n_p<parent->n_neighbors(); n_p++)
             {
-              if (parent->neighbor(n_p) != libmesh_nullptr) // parent has a neighbor here
+              if (parent->neighbor_ptr(n_p) != libmesh_nullptr) // parent has a neighbor here
                 {
                   // Find the active neighbors in this direction
                   std::vector<const Elem *> active_neighbors;
-                  parent->neighbor(n_p)->
+                  parent->neighbor_ptr(n_p)->
                     active_family_tree_by_neighbor(active_neighbors,
                                                    parent);
                   // Compute the flux to each active neighbor
@@ -292,16 +292,16 @@ void JumpErrorEstimator::estimate_error (const System & system,
       // Loop over the neighbors of element e
       for (unsigned int n_e=0; n_e<e->n_neighbors(); n_e++)
         {
-          if ((e->neighbor(n_e) != libmesh_nullptr) ||
+          if ((e->neighbor_ptr(n_e) != libmesh_nullptr) ||
               integrate_boundary_sides)
             {
               fine_context->side = n_e;
               fine_context->side_fe_reinit();
             }
 
-          if (e->neighbor(n_e) != libmesh_nullptr) // e is not on the boundary
+          if (e->neighbor_ptr(n_e) != libmesh_nullptr) // e is not on the boundary
             {
-              const Elem * f           = e->neighbor(n_e);
+              const Elem * f           = e->neighbor_ptr(n_e);
               const dof_id_type f_id = f->id();
 
               // Compute flux jumps if we are in case 1 or case 2.
@@ -359,7 +359,7 @@ void JumpErrorEstimator::estimate_error (const System & system,
 
               if (scale_by_n_flux_faces && found_boundary_flux)
                 n_flux_faces[fine_context->get_elem().id()]++;
-            } // end if (e->neighbor(n_e) == libmesh_nullptr)
+            } // end if (e->neighbor_ptr(n_e) == libmesh_nullptr)
         } // end loop over neighbors
     } // End loop over active local elements
 

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -811,10 +811,10 @@ void FEAbstract::compute_node_constraints (NodeConstraints & constraints,
   // Look at the element faces.  Check to see if we need to
   // build constraints.
   for (unsigned int s=0; s<elem->n_sides(); s++)
-    if (elem->neighbor(s) != libmesh_nullptr &&
-        elem->neighbor(s) != remote_elem)
-      if (elem->neighbor(s)->level() < elem->level()) // constrain dofs shared between
-        {                                                     // this element and ones coarser
+    if (elem->neighbor_ptr(s) != libmesh_nullptr &&
+        elem->neighbor_ptr(s) != remote_elem)
+      if (elem->neighbor_ptr(s)->level() < elem->level()) // constrain dofs shared between
+        {                                                 // this element and ones coarser
           // than this element.
           // Get pointers to the elements of interest and its parent.
           const Elem * parent = elem->parent();
@@ -824,8 +824,8 @@ void FEAbstract::compute_node_constraints (NodeConstraints & constraints,
           // level than their neighbors!
           libmesh_assert(parent);
 
-          const UniquePtr<Elem> my_side     (elem->build_side(s));
-          const UniquePtr<Elem> parent_side (parent->build_side(s));
+          const UniquePtr<const Elem> my_side     (elem->build_side_ptr(s));
+          const UniquePtr<const Elem> parent_side (parent->build_side_ptr(s));
 
           const unsigned int n_side_nodes = my_side->n_nodes();
 
@@ -959,7 +959,7 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
   std::vector<boundary_id_type> bc_ids;
   for (unsigned short int s=0; s<elem->n_sides(); s++)
     {
-      if (elem->neighbor(s))
+      if (elem->neighbor_ptr(s))
         continue;
 
       mesh.get_boundary_info().boundary_ids (elem, s, bc_ids);
@@ -988,8 +988,8 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
                   libmesh_assert(neigh->active());
 #endif // #ifdef LIBMESH_ENABLE_AMR
 
-                  const UniquePtr<Elem> my_side    (elem->build_side(s));
-                  const UniquePtr<Elem> neigh_side (neigh->build_side(s_neigh));
+                  const UniquePtr<const Elem> my_side    (elem->build_side_ptr(s));
+                  const UniquePtr<const Elem> neigh_side (neigh->build_side_ptr(s_neigh));
 
                   const unsigned int n_side_nodes = my_side->n_nodes();
 

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -92,7 +92,7 @@ const Elem * primary_boundary_point_neighbor(const Elem * elem,
           if (!on_relevant_boundary)
             continue;
 
-          if (!pt_neighbor->build_side(ns)->contains_point(p))
+          if (!pt_neighbor->build_side_ptr(ns)->contains_point(p))
             continue;
 
           vertex_on_periodic_side = true;
@@ -156,7 +156,7 @@ const Elem * primary_boundary_edge_neighbor(const Elem * elem,
           if (!on_relevant_boundary)
             continue;
 
-          UniquePtr<Elem> periodic_side = e_neighbor->build_side(ns);
+          UniquePtr<const Elem> periodic_side = e_neighbor->build_side_ptr(ns);
           if (!(periodic_side->contains_point(p1) &&
                 periodic_side->contains_point(p2)))
             continue;
@@ -921,11 +921,11 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
         // where p refinement creates more vertex dofs; we have
         // no such elements yet.
         /*
-          if (elem->child(n)->p_level() < elem->p_level())
+          if (elem->child_ptr(n)->p_level() < elem->p_level())
           {
           temp_fe_type.order =
           static_cast<Order>(temp_fe_type.order +
-          elem->child(n)->p_level());
+          elem->child_ptr(n)->p_level());
           }
         */
         const unsigned int nc =
@@ -967,7 +967,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
           {
             if (!elem->is_child_on_edge(c,e))
               continue;
-            Elem * child = elem->child(c);
+            const Elem * child = elem->child_ptr(c);
 
             std::vector<dof_id_type> child_dof_indices;
             if (use_old_dof_indices)
@@ -1110,7 +1110,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
           {
             if (!elem->is_child_on_side(c,s))
               continue;
-            Elem * child = elem->child(c);
+            const Elem * child = elem->child_ptr(c);
 
             std::vector<dof_id_type> child_dof_indices;
             if (use_old_dof_indices)
@@ -1242,7 +1242,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
   // Add projection terms from each child
   for (unsigned int c=0; c != elem->n_children(); ++c)
     {
-      Elem * child = elem->child(c);
+      const Elem * child = elem->child_ptr(c);
 
       std::vector<dof_id_type> child_dof_indices;
       if (use_old_dof_indices)
@@ -1449,10 +1449,10 @@ FEGenericBase<OutputType>::compute_proj_constraints (DofConstraints & constraint
   // Look at the element faces.  Check to see if we need to
   // build constraints.
   for (unsigned int s=0; s<elem->n_sides(); s++)
-    if (elem->neighbor(s) != libmesh_nullptr)
+    if (elem->neighbor_ptr(s) != libmesh_nullptr)
       {
         // Get pointers to the element's neighbor.
-        const Elem * neigh = elem->neighbor(s);
+        const Elem * neigh = elem->neighbor_ptr(s);
 
         // h refinement constraints:
         // constrain dofs shared between
@@ -1746,7 +1746,7 @@ compute_periodic_constraints (DofConstraints & constraints,
   // build constraints.
   for (unsigned short int s=0; s<elem->n_sides(); s++)
     {
-      if (elem->neighbor(s))
+      if (elem->neighbor_ptr(s))
         continue;
 
       mesh.get_boundary_info().boundary_ids (elem, s, bc_ids);
@@ -2076,7 +2076,7 @@ compute_periodic_constraints (DofConstraints & constraints,
                           libmesh_assert_less (e, elem->n_edges());
 
                           // Find the edge end nodes
-                          Node
+                          const Node
                             * e1 = libmesh_nullptr,
                             * e2 = libmesh_nullptr;
                           for (unsigned int nn = 0; nn != elem->n_nodes(); ++nn)

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -159,13 +159,13 @@ void FE<Dim,T>::reinit(const Elem * elem,
   this->determine_calculations();
 
   // Build the side of interest
-  const UniquePtr<Elem> side(elem->build_side(s));
+  const UniquePtr<const Elem> side(elem->build_side_ptr(s));
 
   // Find the max p_level to select
   // the right quadrature rule for side integration
   unsigned int side_p_level = elem->p_level();
-  if (elem->neighbor(s) != libmesh_nullptr)
-    side_p_level = std::max(side_p_level, elem->neighbor(s)->p_level());
+  if (elem->neighbor_ptr(s) != libmesh_nullptr)
+    side_p_level = std::max(side_p_level, elem->neighbor_ptr(s)->p_level());
 
   // Initialize the shape functions at the user-specified
   // points
@@ -277,7 +277,7 @@ void FE<Dim,T>::edge_reinit(const Elem * elem,
   this->determine_calculations();
 
   // Build the side of interest
-  const UniquePtr<Elem> edge(elem->build_edge(e));
+  const UniquePtr<const Elem> edge(elem->build_edge_ptr(e));
 
   // Initialize the shape functions at the user-specified
   // points
@@ -361,8 +361,8 @@ void FE<Dim,T>::side_map (const Elem * elem,
   this->determine_calculations();
 
   unsigned int side_p_level = elem->p_level();
-  if (elem->neighbor(s) != libmesh_nullptr)
-    side_p_level = std::max(side_p_level, elem->neighbor(s)->p_level());
+  if (elem->neighbor_ptr(s) != libmesh_nullptr)
+    side_p_level = std::max(side_p_level, elem->neighbor_ptr(s)->p_level());
 
   if (side->type() != last_side ||
       side_p_level != this->_p_level ||

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -694,9 +694,9 @@ void lagrange_compute_constraints (DofConstraints & constraints,
   // Look at the element faces.  Check to see if we need to
   // build constraints.
   for (unsigned int s=0; s<elem->n_sides(); s++)
-    if (elem->neighbor(s) != libmesh_nullptr)
-      if (elem->neighbor(s)->level() < elem->level()) // constrain dofs shared between
-        {                                                     // this element and ones coarser
+    if (elem->neighbor_ptr(s) != libmesh_nullptr)
+      if (elem->neighbor_ptr(s)->level() < elem->level()) // constrain dofs shared between
+        {                                                 // this element and ones coarser
           // than this element.
           // Get pointers to the elements of interest and its parent.
           const Elem * parent = elem->parent();
@@ -706,8 +706,8 @@ void lagrange_compute_constraints (DofConstraints & constraints,
           // level than their neighbors!
           libmesh_assert(parent);
 
-          const UniquePtr<Elem> my_side     (elem->build_side(s));
-          const UniquePtr<Elem> parent_side (parent->build_side(s));
+          const UniquePtr<const Elem> my_side     (elem->build_side_ptr(s));
+          const UniquePtr<const Elem> parent_side (parent->build_side_ptr(s));
 
           // This function gets called element-by-element, so there
           // will be a lot of memory allocation going on.  We can

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -404,7 +404,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                                      const std::vector<Real> & qw,
                                      const Elem * elem,
                                      unsigned int p,
-                                     const std::vector<Node *> & elem_nodes,
+                                     const std::vector<const Node *> & elem_nodes,
                                      bool compute_second_derivatives)
 {
   libmesh_assert(elem);
@@ -1235,7 +1235,7 @@ void FEMap::compute_affine_map(const unsigned int dim,
   this->resize_quadrature_map_vectors(dim, n_qp);
 
   // Determine the nodes contributing to element elem
-  std::vector<Node *> elem_nodes(elem->n_nodes(), libmesh_nullptr);
+  std::vector<const Node *> elem_nodes(elem->n_nodes(), libmesh_nullptr);
   for (unsigned int i=0; i<elem->n_nodes(); i++)
     elem_nodes[i] = elem->node_ptr(i);
 
@@ -1403,7 +1403,7 @@ void FEMap::compute_map(const unsigned int dim,
   this->resize_quadrature_map_vectors(dim, n_qp);
 
   // Determine the nodes contributing to element elem
-  std::vector<Node *> elem_nodes;
+  std::vector<const Node *> elem_nodes;
   if (elem->type() == TRI3SUBDIVISION)
     {
       // Subdivision surface FE require the 1-ring around elem

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -407,8 +407,8 @@ void nedelec_one_compute_constraints (DofConstraints & /*constraints*/,
   // level than their neighbors!
   libmesh_assert(parent);
 
-  const UniquePtr<Elem> my_side     (elem->build_side(s));
-  const UniquePtr<Elem> parent_side (parent->build_side(s));
+  const UniquePtr<const Elem> my_side     (elem->build_side_ptr(s));
+  const UniquePtr<const Elem> parent_side (parent->build_side_ptr(s));
 
   // This function gets called element-by-element, so there
   // will be a lot of memory allocation going on.  We can

--- a/src/fe/fe_xyz_boundary.C
+++ b/src/fe/fe_xyz_boundary.C
@@ -76,7 +76,7 @@ void FEXYZ<Dim>::reinit(const Elem * elem,
   libmesh_assert_not_equal_to (Dim, 1);
 
   // Build the side of interest
-  const UniquePtr<Elem> side(elem->build_side(s));
+  const UniquePtr<const Elem> side(elem->build_side_ptr(s));
 
   // Initialize the shape functions at the user-specified
   // points

--- a/src/fe/inf_fe_base_radial.C
+++ b/src/fe/inf_fe_base_radial.C
@@ -35,8 +35,13 @@ namespace libMesh
 template <unsigned int Dim, FEFamily T_radial, InfMapType T_base>
 Elem * InfFE<Dim,T_radial,T_base>::Base::build_elem (const Elem * inf_elem)
 {
-  UniquePtr<Elem> ape(inf_elem->build_side(0));
-  return ape.release();
+  UniquePtr<const Elem> ape(inf_elem->build_side_ptr(0));
+
+  // The incoming inf_elem is const, but this function is required to
+  // return a non-const Elem * so that it can be used by
+  // update_base_elem().  Therefore a const_cast seems to be
+  // unavoidable here.
+  return const_cast<Elem *>(ape.release());
 }
 
 

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -59,7 +59,7 @@ void InfFE<Dim,T_radial,T_base>::reinit(const Elem * inf_elem,
   libmesh_assert_not_equal_to (s, 0);
 
   // Build the side of interest
-  const UniquePtr<Elem> side(inf_elem->build_side(s));
+  const UniquePtr<const Elem> side(inf_elem->build_side_ptr(s));
 
   // set the element type
   elem_type = inf_elem->type();

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -213,9 +213,9 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType & fet,
     }
 #endif
 
-  const Order        o_radial (fet.radial_order);
-  const Real         v        (p(Dim-1));
-  UniquePtr<Elem>      base_el  (inf_elem->build_side(0));
+  const Order o_radial (fet.radial_order);
+  const Real v (p(Dim-1));
+  UniquePtr<const Elem> base_el (inf_elem->build_side_ptr(0));
 
   unsigned int i_base, i_radial;
   compute_shape_indices(fet, inf_elem->type(), i, i_base, i_radial);
@@ -245,9 +245,9 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
 
   const Order        o_radial             (fet.radial_order);
   const Order        radial_mapping_order (Radial::mapping_order());
-  const Point &       p                    (data.p);
+  const Point &      p                    (data.p);
   const Real         v                    (p(Dim-1));
-  UniquePtr<Elem>      base_el              (inf_elem->build_side(0));
+  UniquePtr<const Elem> base_el (inf_elem->build_side_ptr(0));
 
   /*
    * compute \p interpolated_dist containing the mapping-interpolated

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -83,7 +83,7 @@ dof_id_type Hex::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> Hex::side (const unsigned int i) const
+UniquePtr<Elem> Hex::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -142,8 +142,8 @@ bool Hex20::has_affine_map() const
 
 
 
-UniquePtr<Elem> Hex20::build_side (const unsigned int i,
-                                   bool proxy ) const
+UniquePtr<Elem> Hex20::build_side_ptr (const unsigned int i,
+                                       bool proxy )
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -167,7 +167,7 @@ UniquePtr<Elem> Hex20::build_side (const unsigned int i,
 
 
 
-UniquePtr<Elem> Hex20::build_edge (const unsigned int i) const
+UniquePtr<Elem> Hex20::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -202,8 +202,8 @@ dof_id_type Hex27::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> Hex27::build_side (const unsigned int i,
-                                   bool proxy) const
+UniquePtr<Elem> Hex27::build_side_ptr (const unsigned int i,
+                                       bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -227,7 +227,7 @@ UniquePtr<Elem> Hex27::build_side (const unsigned int i,
 
 
 
-UniquePtr<Elem> Hex27::build_edge (const unsigned int i) const
+UniquePtr<Elem> Hex27::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -117,8 +117,8 @@ bool Hex8::has_affine_map() const
 
 
 
-UniquePtr<Elem> Hex8::build_side (const unsigned int i,
-                                  bool proxy) const
+UniquePtr<Elem> Hex8::build_side_ptr (const unsigned int i,
+                                      bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -142,7 +142,7 @@ UniquePtr<Elem> Hex8::build_side (const unsigned int i,
 
 
 
-UniquePtr<Elem> Hex8::build_edge (const unsigned int i) const
+UniquePtr<Elem> Hex8::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -83,7 +83,7 @@ dof_id_type InfHex::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> InfHex::side (const unsigned int i) const
+UniquePtr<Elem> InfHex::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -103,7 +103,7 @@ UniquePtr<Elem> InfHex::side_ptr (const unsigned int i)
         // elements point outwards -- and this is the exception:
         // For the side built from the base face,
         // the normal is pointing _into_ the element!
-        // Why is that? - In agreement with build_side(),
+        // Why is that? - In agreement with build_side_ptr(),
         // which in turn _has_ to build the face in this
         // way as to enable the cool way \p InfFE re-uses \p FE.
         face = new Quad4;

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -104,8 +104,8 @@ bool InfHex16::is_node_on_edge(const unsigned int n,
   return false;
 }
 
-UniquePtr<Elem> InfHex16::build_side (const unsigned int i,
-                                      bool proxy) const
+UniquePtr<Elem> InfHex16::build_side_ptr (const unsigned int i,
+                                          bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -171,7 +171,7 @@ UniquePtr<Elem> InfHex16::build_side (const unsigned int i,
   return UniquePtr<Elem>();
 }
 
-UniquePtr<Elem> InfHex16::build_edge (const unsigned int i) const
+UniquePtr<Elem> InfHex16::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -131,8 +131,8 @@ dof_id_type InfHex18::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> InfHex18::build_side (const unsigned int i,
-                                      bool proxy) const
+UniquePtr<Elem> InfHex18::build_side_ptr (const unsigned int i,
+                                          bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -200,7 +200,7 @@ UniquePtr<Elem> InfHex18::build_side (const unsigned int i,
 
 
 
-UniquePtr<Elem> InfHex18::build_edge (const unsigned int i) const
+UniquePtr<Elem> InfHex18::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -102,8 +102,8 @@ bool InfHex8::is_node_on_edge(const unsigned int n,
   return false;
 }
 
-UniquePtr<Elem> InfHex8::build_side (const unsigned int i,
-                                     bool proxy) const
+UniquePtr<Elem> InfHex8::build_side_ptr (const unsigned int i,
+                                         bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -169,7 +169,7 @@ UniquePtr<Elem> InfHex8::build_side (const unsigned int i,
 }
 
 
-UniquePtr<Elem> InfHex8::build_edge (const unsigned int i) const
+UniquePtr<Elem> InfHex8::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -87,7 +87,7 @@ dof_id_type InfPrism::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> InfPrism::side (const unsigned int i) const
+UniquePtr<Elem> InfPrism::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -101,8 +101,8 @@ bool InfPrism12::is_node_on_edge(const unsigned int n,
   return false;
 }
 
-UniquePtr<Elem> InfPrism12::build_side (const unsigned int i,
-                                        bool proxy) const
+UniquePtr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
+                                            bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -164,7 +164,7 @@ UniquePtr<Elem> InfPrism12::build_side (const unsigned int i,
 }
 
 
-UniquePtr<Elem> InfPrism12::build_edge (const unsigned int i) const
+UniquePtr<Elem> InfPrism12::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -100,8 +100,8 @@ bool InfPrism6::is_node_on_edge(const unsigned int n,
 }
 
 
-UniquePtr<Elem> InfPrism6::build_side (const unsigned int i,
-                                       bool proxy) const
+UniquePtr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
+                                           bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -163,7 +163,7 @@ UniquePtr<Elem> InfPrism6::build_side (const unsigned int i,
 }
 
 
-UniquePtr<Elem> InfPrism6::build_edge (const unsigned int i) const
+UniquePtr<Elem> InfPrism6::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, n_edges());
 

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -90,7 +90,7 @@ dof_id_type Prism::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> Prism::side (const unsigned int i) const
+UniquePtr<Elem> Prism::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -129,8 +129,8 @@ bool Prism15::has_affine_map() const
 
 
 
-UniquePtr<Elem> Prism15::build_side (const unsigned int i,
-                                     bool proxy) const
+UniquePtr<Elem> Prism15::build_side_ptr (const unsigned int i,
+                                         bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -190,7 +190,7 @@ UniquePtr<Elem> Prism15::build_side (const unsigned int i,
 }
 
 
-UniquePtr<Elem> Prism15::build_edge (const unsigned int i) const
+UniquePtr<Elem> Prism15::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -174,8 +174,8 @@ dof_id_type Prism18::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> Prism18::build_side (const unsigned int i,
-                                     bool proxy) const
+UniquePtr<Elem> Prism18::build_side_ptr (const unsigned int i,
+                                         bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -236,7 +236,7 @@ UniquePtr<Elem> Prism18::build_side (const unsigned int i,
 
 
 
-UniquePtr<Elem> Prism18::build_edge (const unsigned int i) const
+UniquePtr<Elem> Prism18::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -116,8 +116,8 @@ bool Prism6::has_affine_map() const
 
 
 
-UniquePtr<Elem> Prism6::build_side (const unsigned int i,
-                                    bool proxy) const
+UniquePtr<Elem> Prism6::build_side_ptr (const unsigned int i,
+                                        bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -178,7 +178,7 @@ UniquePtr<Elem> Prism6::build_side (const unsigned int i,
 
 
 
-UniquePtr<Elem> Prism6::build_edge (const unsigned int i) const
+UniquePtr<Elem> Prism6::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -84,7 +84,7 @@ dof_id_type Pyramid::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> Pyramid::side (const unsigned int i) const
+UniquePtr<Elem> Pyramid::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -115,7 +115,7 @@ bool Pyramid13::has_affine_map() const
 
 
 
-UniquePtr<Elem> Pyramid13::build_side (const unsigned int i, bool proxy) const
+UniquePtr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -176,7 +176,7 @@ UniquePtr<Elem> Pyramid13::build_side (const unsigned int i, bool proxy) const
 
 
 
-UniquePtr<Elem> Pyramid13::build_edge (const unsigned int i) const
+UniquePtr<Elem> Pyramid13::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -144,7 +144,7 @@ dof_id_type Pyramid14::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> Pyramid14::build_side (const unsigned int i, bool proxy) const
+UniquePtr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -205,7 +205,7 @@ UniquePtr<Elem> Pyramid14::build_side (const unsigned int i, bool proxy) const
 
 
 
-UniquePtr<Elem> Pyramid14::build_edge (const unsigned int i) const
+UniquePtr<Elem> Pyramid14::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -105,8 +105,8 @@ bool Pyramid5::has_affine_map() const
 
 
 
-UniquePtr<Elem> Pyramid5::build_side (const unsigned int i,
-                                      bool proxy) const
+UniquePtr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
+                                          bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -167,7 +167,7 @@ UniquePtr<Elem> Pyramid5::build_side (const unsigned int i,
 
 
 
-UniquePtr<Elem> Pyramid5::build_edge (const unsigned int i) const
+UniquePtr<Elem> Pyramid5::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -63,7 +63,7 @@ dof_id_type Tet::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> Tet::side (const unsigned int i) const
+UniquePtr<Elem> Tet::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -153,8 +153,8 @@ bool Tet10::has_affine_map() const
 
 
 
-UniquePtr<Elem> Tet10::build_side (const unsigned int i,
-                                   bool proxy) const
+UniquePtr<Elem> Tet10::build_side_ptr (const unsigned int i,
+                                       bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -178,7 +178,7 @@ UniquePtr<Elem> Tet10::build_side (const unsigned int i,
 
 
 
-UniquePtr<Elem> Tet10::build_edge (const unsigned int i) const
+UniquePtr<Elem> Tet10::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -406,7 +406,7 @@ float Tet4::embedding_matrix (const unsigned int i,
 //  available.  */
 //       for (unsigned int c=4; c<this->n_children(); c++)
 // {
-//   Elem * child = this->child(c);
+//   Elem * child = this->child_ptr(c);
 //   for (unsigned int nc=0; nc<child->n_nodes(); nc++)
 //     {
 //       /* Unassign the current node.  */
@@ -438,7 +438,7 @@ float Tet4::embedding_matrix (const unsigned int i,
 // {
 //   /* Second time, so we know now which node to
 //      use.  */
-//   child->set_node(nc) = this->child(n)->node_ptr(first_05_in_embedding_matrix);
+//   child->set_node(nc) = this->child_ptr(n)->node_ptr(first_05_in_embedding_matrix);
 // }
 //
 //     }

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -126,8 +126,8 @@ bool Tet4::is_node_on_side(const unsigned int n,
   return false;
 }
 
-UniquePtr<Elem> Tet4::build_side (const unsigned int i,
-                                  bool proxy) const
+UniquePtr<Elem> Tet4::build_side_ptr (const unsigned int i,
+                                      bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 
@@ -150,7 +150,7 @@ UniquePtr<Elem> Tet4::build_side (const unsigned int i,
 }
 
 
-UniquePtr<Elem> Tet4::build_edge (const unsigned int i) const
+UniquePtr<Elem> Tet4::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());
 

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -35,7 +35,7 @@ UniquePtr<Elem> Edge::side_ptr (const unsigned int i)
 }
 
 
-UniquePtr<Elem> Edge::build_side (const unsigned int i, bool) const
+UniquePtr<Elem> Edge::build_side_ptr (const unsigned int i, bool)
 {
   libmesh_assert_less (i, 2);
   const Elem * the_parent = this;

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -25,7 +25,7 @@ namespace libMesh
 {
 
 
-UniquePtr<Elem> Edge::side (const unsigned int i) const
+UniquePtr<Elem> Edge::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, 2);
   const Elem * the_parent = this;

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -613,7 +613,7 @@ void Elem::find_point_neighbors(const Point & p,
 
           for (unsigned int s=0; s<elem->n_sides(); s++)
             {
-              const Elem * current_neighbor = elem->neighbor(s);
+              const Elem * current_neighbor = elem->neighbor_ptr(s);
               if (current_neighbor &&
                   current_neighbor != remote_elem)    // we have a real neighbor on this side
                 {
@@ -700,7 +700,7 @@ void Elem::find_point_neighbors(std::set<const Elem *> & neighbor_set,
 
           for (unsigned int s=0; s<elem->n_sides(); s++)
             {
-              const Elem * current_neighbor = elem->neighbor(s);
+              const Elem * current_neighbor = elem->neighbor_ptr(s);
               if (current_neighbor &&
                   current_neighbor != remote_elem)    // we have a real neighbor on this side
                 {
@@ -803,7 +803,7 @@ void Elem::find_edge_neighbors(std::set<const Elem *> & neighbor_set) const
 
           for (unsigned int s=0; s<elem->n_sides(); s++)
             {
-              const Elem * current_neighbor = elem->neighbor(s);
+              const Elem * current_neighbor = elem->neighbor_ptr(s);
               if (current_neighbor &&
                   current_neighbor != remote_elem)    // we have a real neighbor on this side
                 {
@@ -873,10 +873,10 @@ void Elem::find_interior_neighbors(std::set<const Elem *> & neighbor_set) const
 
 #ifdef LIBMESH_ENABLE_AMR
   while (!ip->active()) // only possible with AMR, be careful because
-    {                   // ip->child(c) is only good with AMR.
+    {                   // ip->child_ptr(c) is only good with AMR.
       for (unsigned int c = 0; c != ip->n_children(); ++c)
         {
-          const Elem * child = ip->child(c);
+          const Elem * child = ip->child_ptr(c);
           if (child->contains_vertex_of(this) ||
               this->contains_vertex_of(child))
             {
@@ -1018,7 +1018,7 @@ Elem * Elem::topological_neighbor (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_neighbors());
 
-  Elem * neighbor_i = this->neighbor(i);
+  Elem * neighbor_i = this->neighbor_ptr(i);
   if (neighbor_i != libmesh_nullptr)
     return neighbor_i;
 
@@ -1056,7 +1056,7 @@ const Elem * Elem::topological_neighbor (const unsigned int i,
 {
   libmesh_assert_less (i, this->n_neighbors());
 
-  const Elem * neighbor_i = this->neighbor(i);
+  const Elem * neighbor_i = this->neighbor_ptr(i);
   if (neighbor_i != libmesh_nullptr)
     return neighbor_i;
 
@@ -1123,7 +1123,7 @@ void Elem::libmesh_assert_valid_neighbors() const
 {
   for (unsigned int s=0; s<this->n_neighbors(); s++)
     {
-      const Elem * neigh = this->neighbor(s);
+      const Elem * neigh = this->neighbor_ptr(s);
 
       // Any element might have a remote neighbor; checking
       // to make sure that's not inaccurate is tough.
@@ -1154,7 +1154,7 @@ void Elem::libmesh_assert_valid_neighbors() const
 
               if (this->subactive() && !neigh->subactive())
                 {
-                  while (neigh->neighbor(rev) != elem)
+                  while (neigh->neighbor_ptr(rev) != elem)
                     {
                       libmesh_assert(elem->parent());
                       elem = elem->parent();
@@ -1162,7 +1162,7 @@ void Elem::libmesh_assert_valid_neighbors() const
                 }
               else
                 {
-                  Elem * nn = neigh->neighbor(rev);
+                  const Elem * nn = neigh->neighbor_ptr(rev);
                   libmesh_assert(nn);
 
                   for (; elem != nn; elem = elem->parent())
@@ -1182,7 +1182,7 @@ void Elem::libmesh_assert_valid_neighbors() const
               // is an interior mesh element for which we're on a side.
               // Nothing to test for in that case.
               (my_parent->dim() == this->dim()))
-            libmesh_assert (!my_parent->neighbor(s));
+            libmesh_assert (!my_parent->neighbor_ptr(s));
         }
     }
 }
@@ -1193,7 +1193,7 @@ void Elem::libmesh_assert_valid_neighbors() const
 
 void Elem::make_links_to_me_local(unsigned int n)
 {
-  Elem * neigh = this->neighbor(n);
+  Elem * neigh = this->neighbor_ptr(n);
 
   // Don't bother calling this function unless it's necessary
   libmesh_assert(neigh);
@@ -1226,11 +1226,11 @@ void Elem::make_links_to_me_local(unsigned int n)
 
   // What side of neigh are we on?  We can't use the usual Elem
   // method because we're in the middle of restoring topology
-  const UniquePtr<Elem> my_side = this->side(n);
+  const UniquePtr<Elem> my_side = this->side_ptr(n);
   unsigned int nn = 0;
   for (; nn != neigh->n_sides(); ++nn)
     {
-      const UniquePtr<Elem> neigh_side = neigh->side(nn);
+      const UniquePtr<Elem> neigh_side = neigh->side_ptr(nn);
       if (*my_side == *neigh_side)
         break;
     }
@@ -1260,16 +1260,16 @@ void Elem::make_links_to_me_local(unsigned int n)
       // neighbor links, we might have an out of date neighbor
       // link to elem's parent instead.
 #ifdef LIBMESH_ENABLE_AMR
-      libmesh_assert((neigh_family_member->neighbor(nn) &&
-                      (neigh_family_member->neighbor(nn)->active() ||
-                       neigh_family_member->neighbor(nn)->is_ancestor_of(this))) ||
-                     (neigh_family_member->neighbor(nn) == remote_elem) ||
+      libmesh_assert((neigh_family_member->neighbor_ptr(nn) &&
+                      (neigh_family_member->neighbor_ptr(nn)->active() ||
+                       neigh_family_member->neighbor_ptr(nn)->is_ancestor_of(this))) ||
+                     (neigh_family_member->neighbor_ptr(nn) == remote_elem) ||
                      ((this->refinement_flag() == JUST_REFINED) &&
                       (this->parent() != libmesh_nullptr) &&
-                      (neigh_family_member->neighbor(nn) == this->parent())));
+                      (neigh_family_member->neighbor_ptr(nn) == this->parent())));
 #else
-      libmesh_assert((neigh_family_member->neighbor(nn) == this) ||
-                     (neigh_family_member->neighbor(nn) == remote_elem));
+      libmesh_assert((neigh_family_member->neighbor_ptr(nn) == this) ||
+                     (neigh_family_member->neighbor_ptr(nn) == remote_elem));
 #endif
 
       neigh_family_member->set_neighbor(nn, this);
@@ -1286,7 +1286,7 @@ void Elem::make_links_to_me_remote()
   if (this->has_children())
     for (unsigned int c = 0; c != this->n_children(); ++c)
       {
-        Elem * current_child = this->child(c);
+        Elem * current_child = this->child_ptr(c);
         libmesh_assert_equal_to (current_child, remote_elem);
       }
 #endif
@@ -1296,7 +1296,7 @@ void Elem::make_links_to_me_remote()
     {
       for (unsigned int s = 0; s != this->n_sides(); ++s)
         {
-          Elem * neigh = this->neighbor(s);
+          Elem * neigh = this->neighbor_ptr(s);
           if (neigh && neigh != remote_elem && !neigh->subactive())
             {
               // My neighbor should never be more refined than me; my real
@@ -1323,7 +1323,7 @@ void Elem::make_links_to_me_remote()
                         continue;
                       unsigned int my_s = n->which_neighbor_am_i(this);
                       libmesh_assert_less (my_s, n->n_neighbors());
-                      libmesh_assert_equal_to (n->neighbor(my_s), this);
+                      libmesh_assert_equal_to (n->neighbor_ptr(my_s), this);
                       n->set_neighbor(my_s, const_cast<RemoteElem *>(remote_elem));
                     }
 #else
@@ -1369,7 +1369,7 @@ void Elem::make_links_to_me_remote()
                         continue;
                       unsigned int my_s = n->which_neighbor_am_i(this);
                       libmesh_assert_less (my_s, n->n_neighbors());
-                      libmesh_assert_equal_to (n->neighbor(my_s), this);
+                      libmesh_assert_equal_to (n->neighbor_ptr(my_s), this);
                       n->set_neighbor(my_s, const_cast<RemoteElem *>(remote_elem));
                     }
                 }
@@ -1388,7 +1388,7 @@ void Elem::make_links_to_me_remote()
       this->dim() == my_parent->dim())
     {
       unsigned int me = my_parent->which_child_am_i(this);
-      libmesh_assert_equal_to (my_parent->child(me), this);
+      libmesh_assert_equal_to (my_parent->child_ptr(me), this);
       my_parent->set_child(me, const_cast<RemoteElem *>(remote_elem));
     }
 #endif
@@ -1480,7 +1480,7 @@ bool Elem::ancestor() const
     {
       for (unsigned int c=0; c != this->n_children(); ++c)
         {
-          const Elem * kid = this->child(c);
+          const Elem * kid = this->child_ptr(c);
           if (kid != remote_elem)
             {
               libmesh_assert(!kid->active());
@@ -1536,7 +1536,7 @@ void Elem::add_child (Elem * elem, unsigned int c)
         this->set_child(i, libmesh_nullptr);
     }
 
-  libmesh_assert (this->_children[c] == libmesh_nullptr || this->child(c) == remote_elem);
+  libmesh_assert (this->_children[c] == libmesh_nullptr || this->child_ptr(c) == remote_elem);
   libmesh_assert (elem == remote_elem || this == elem->parent());
 
   this->set_child(c, elem);
@@ -1548,7 +1548,7 @@ void Elem::replace_child (Elem * elem, unsigned int c)
 {
   libmesh_assert(this->has_children());
 
-  libmesh_assert(this->child(c));
+  libmesh_assert(this->child_ptr(c));
 
   this->set_child(c, elem);
 }
@@ -1561,8 +1561,8 @@ bool Elem::is_child_on_edge(const unsigned int libmesh_dbg_var(c),
   libmesh_assert_less (c, this->n_children());
   libmesh_assert_less (e, this->n_edges());
 
-  UniquePtr<Elem> my_edge = this->build_edge(e);
-  UniquePtr<Elem> child_edge = this->build_edge(e);
+  UniquePtr<const Elem> my_edge = this->build_edge_ptr(e);
+  UniquePtr<const Elem> child_edge = this->build_edge_ptr(e);
 
   // We're assuming that an overlapping child edge has the same
   // number and orientation as its parent
@@ -1588,8 +1588,8 @@ void Elem::family_tree (std::vector<const Elem *> & family,
   // Do not clear the vector any more.
   if (!this->active())
     for (unsigned int c=0; c<this->n_children(); c++)
-      if (!this->child(c)->is_remote())
-        this->child(c)->family_tree (family, false);
+      if (!this->child_ptr(c)->is_remote())
+        this->child_ptr(c)->family_tree (family, false);
 }
 
 
@@ -1608,8 +1608,8 @@ void Elem::total_family_tree (std::vector<const Elem *> & family,
   // Do not clear the vector any more.
   if (this->has_children())
     for (unsigned int c=0; c<this->n_children(); c++)
-      if (!this->child(c)->is_remote())
-        this->child(c)->total_family_tree (family, false);
+      if (!this->child_ptr(c)->is_remote())
+        this->child_ptr(c)->total_family_tree (family, false);
 }
 
 
@@ -1632,8 +1632,8 @@ void Elem::active_family_tree (std::vector<const Elem *> & active_family,
   // Do not clear the vector any more.
   else
     for (unsigned int c=0; c<this->n_children(); c++)
-      if (!this->child(c)->is_remote())
-        this->child(c)->active_family_tree (active_family, false);
+      if (!this->child_ptr(c)->is_remote())
+        this->child_ptr(c)->active_family_tree (active_family, false);
 }
 
 
@@ -1658,8 +1658,8 @@ void Elem::family_tree_by_side (std::vector<const Elem *> & family,
   // Do not clear the vector any more.
   if (!this->active())
     for (unsigned int c=0; c<this->n_children(); c++)
-      if (!this->child(c)->is_remote() && this->is_child_on_side(c, s))
-        this->child(c)->family_tree_by_side (family, s, false);
+      if (!this->child_ptr(c)->is_remote() && this->is_child_on_side(c, s))
+        this->child_ptr(c)->family_tree_by_side (family, s, false);
 }
 
 
@@ -1685,8 +1685,8 @@ void Elem::active_family_tree_by_side (std::vector<const Elem *> & family,
   // Do not clear the vector any more.
   else
     for (unsigned int c=0; c<this->n_children(); c++)
-      if (!this->child(c)->is_remote() && this->is_child_on_side(c, s))
-        this->child(c)->active_family_tree_by_side (family, s, false);
+      if (!this->child_ptr(c)->is_remote() && this->is_child_on_side(c, s))
+        this->child_ptr(c)->active_family_tree_by_side (family, s, false);
 }
 
 
@@ -1713,7 +1713,7 @@ void Elem::family_tree_by_neighbor (std::vector<const Elem *> & family,
   if (!this->active())
     for (unsigned int c=0; c<this->n_children(); c++)
       {
-        Elem * current_child = this->child(c);
+        const Elem * current_child = this->child_ptr(c);
         if (current_child != remote_elem && current_child->has_neighbor(neighbor_in))
           current_child->family_tree_by_neighbor (family, neighbor_in, false);
       }
@@ -1752,11 +1752,11 @@ void Elem::family_tree_by_subneighbor (std::vector<const Elem *> & family,
   if (!this->active())
     for (unsigned int c=0; c != this->n_children(); ++c)
       {
-        Elem * current_child = this->child(c);
+        const Elem * current_child = this->child_ptr(c);
         if (current_child != remote_elem)
           for (unsigned int s=0; s != current_child->n_sides(); ++s)
             {
-              Elem * child_neigh = current_child->neighbor(s);
+              const Elem * child_neigh = current_child->neighbor_ptr(s);
               if (child_neigh &&
                   (child_neigh == neighbor_in ||
                    (child_neigh->parent() == neighbor_in &&
@@ -1793,7 +1793,7 @@ void Elem::active_family_tree_by_neighbor (std::vector<const Elem *> & family,
   else if (!this->active())
     for (unsigned int c=0; c<this->n_children(); c++)
       {
-        Elem * current_child = this->child(c);
+        const Elem * current_child = this->child_ptr(c);
         if (current_child != remote_elem && current_child->has_neighbor(neighbor_in))
           current_child->active_family_tree_by_neighbor (family, neighbor_in, false);
       }
@@ -1823,7 +1823,7 @@ unsigned int Elem::min_p_level_by_neighbor(const Elem * neighbor_in,
 
   for (unsigned int c=0; c<this->n_children(); c++)
     {
-      const Elem * const current_child = this->child(c);
+      const Elem * const current_child = this->child_ptr(c);
       if (current_child != remote_elem && current_child->has_neighbor(neighbor_in))
         min_p_level =
           current_child->min_p_level_by_neighbor(neighbor_in,
@@ -1860,7 +1860,7 @@ unsigned int Elem::min_new_p_level_by_neighbor(const Elem * neighbor_in,
 
   for (unsigned int c=0; c<this->n_children(); c++)
     {
-      const Elem * const current_child = this->child(c);
+      const Elem * const current_child = this->child_ptr(c);
       if (current_child && current_child != remote_elem)
         if (current_child->has_neighbor(neighbor_in))
           min_p_level =
@@ -2190,20 +2190,18 @@ Elem::bracketing_nodes(unsigned int child,
                   {
                     // We should be consistent
                     if (pt1 != DofObject::invalid_id)
-                      libmesh_assert_equal_to
-                        (pt1, this->child(c)->node_id(n));
+                      libmesh_assert_equal_to(pt1, this->child_ptr(c)->node_id(n));
 
-                    pt1 = this->child(c)->node_id(n);
+                    pt1 = this->child_ptr(c)->node_id(n);
                   }
 
                 if (pbc[i].second == full_elem->as_parent_node(c,n))
                   {
                     // We should be consistent
                     if (pt2 != DofObject::invalid_id)
-                      libmesh_assert_equal_to
-                        (pt2, this->child(c)->node_id(n));
+                      libmesh_assert_equal_to(pt2, this->child_ptr(c)->node_id(n));
 
-                    pt2 = this->child(c)->node_id(n);
+                    pt2 = this->child_ptr(c)->node_id(n);
                   }
               }
 
@@ -2411,8 +2409,8 @@ std::string Elem::get_info () const
   for (unsigned int s=0; s != this->n_sides(); ++s)
     {
       oss << "    neighbor(" << s << ")=";
-      if (this->neighbor(s))
-        oss << this->neighbor(s)->id() << '\n';
+      if (this->neighbor_ptr(s))
+        oss << this->neighbor_ptr(s)->id() << '\n';
       else
         oss << "NULL\n";
     }
@@ -2460,7 +2458,7 @@ void Elem::nullify_neighbors ()
   // Looks strange, huh?
   for (unsigned int n=0; n<this->n_neighbors(); n++)
     {
-      Elem * current_neighbor = this->neighbor(n);
+      Elem * current_neighbor = this->neighbor_ptr(n);
       if (current_neighbor && current_neighbor != remote_elem)
         {
           // Note:  it is possible that I see the neighbor

--- a/src/geom/elem_cutter.C
+++ b/src/geom/elem_cutter.C
@@ -160,7 +160,7 @@ void ElemCutter::find_intersection_points(const Elem & elem,
 
   for (unsigned int e=0; e<elem.n_edges(); e++)
     {
-      UniquePtr<Elem> edge (elem.build_edge(e));
+      UniquePtr<const Elem> edge (elem.build_edge_ptr(e));
 
       // find the element nodes el0, el1 that map
       unsigned int

--- a/src/geom/elem_refinement.C
+++ b/src/geom/elem_refinement.C
@@ -52,7 +52,7 @@ void Elem::refine (MeshRefinement & mesh_refinement)
       for (unsigned int c=0; c<this->n_children(); c++)
         {
           _children[c] = Elem::build(this->type(), this).release();
-          Elem * current_child = this->child(c);
+          Elem * current_child = this->child_ptr(c);
 
           current_child->set_refinement_flag(Elem::JUST_REFINED);
           current_child->set_p_level(parent_p_level);
@@ -76,7 +76,7 @@ void Elem::refine (MeshRefinement & mesh_refinement)
       unsigned int parent_p_level = this->p_level();
       for (unsigned int c=0; c<this->n_children(); c++)
         {
-          Elem * current_child = this->child(c);
+          Elem * current_child = this->child_ptr(c);
           libmesh_assert(current_child->subactive());
           current_child->set_refinement_flag(Elem::JUST_REFINED);
           current_child->set_p_level(parent_p_level);
@@ -93,8 +93,8 @@ void Elem::refine (MeshRefinement & mesh_refinement)
 
   for (unsigned int c=0; c<this->n_children(); c++)
     {
-      libmesh_assert_equal_to (this->child(c)->parent(), this);
-      libmesh_assert(this->child(c)->active());
+      libmesh_assert_equal_to (this->child_ptr(c)->parent(), this);
+      libmesh_assert(this->child_ptr(c)->active());
     }
   libmesh_assert (this->ancestor());
 }
@@ -115,7 +115,7 @@ void Elem::coarsen()
   // re-compute hanging node nodal locations
   for (unsigned int c=0; c<this->n_children(); c++)
     {
-      Elem * mychild = this->child(c);
+      Elem * mychild = this->child_ptr(c);
       if (mychild == remote_elem)
         continue;
       for (unsigned int nc=0; nc<mychild->n_nodes(); nc++)
@@ -150,7 +150,7 @@ void Elem::coarsen()
 
   for (unsigned int c=0; c<this->n_children(); c++)
     {
-      Elem * mychild = this->child(c);
+      Elem * mychild = this->child_ptr(c);
       if (mychild == remote_elem)
         continue;
       libmesh_assert_equal_to (mychild->refinement_flag(), Elem::COARSEN);

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -62,7 +62,7 @@ dof_id_type InfQuad::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> InfQuad::side (const unsigned int i) const
+UniquePtr<Elem> InfQuad::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -163,8 +163,8 @@ bool InfQuad4::contains_point (const Point & p, Real tol) const
 
 
 
-UniquePtr<Elem> InfQuad4::build_side (const unsigned int i,
-                                      bool proxy) const
+UniquePtr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
+                                          bool proxy)
 {
   // libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -133,8 +133,8 @@ dof_id_type InfQuad6::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> InfQuad6::build_side (const unsigned int i,
-                                      bool proxy) const
+UniquePtr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
+                                          bool proxy)
 {
   // libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -70,7 +70,7 @@ dof_id_type Quad::key () const
 
 
 
-UniquePtr<Elem> Quad::side (const unsigned int i) const
+UniquePtr<Elem> Quad::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -124,8 +124,8 @@ bool Quad4::has_affine_map() const
 
 
 
-UniquePtr<Elem> Quad4::build_side (const unsigned int i,
-                                   bool proxy) const
+UniquePtr<Elem> Quad4::build_side_ptr (const unsigned int i,
+                                       bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -190,8 +190,8 @@ dof_id_type Quad8::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> Quad8::build_side (const unsigned int i,
-                                   bool proxy) const
+UniquePtr<Elem> Quad8::build_side_ptr (const unsigned int i,
+                                       bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -208,8 +208,8 @@ dof_id_type Quad9::key () const
 
 
 
-UniquePtr<Elem> Quad9::build_side (const unsigned int i,
-                                   bool proxy) const
+UniquePtr<Elem> Quad9::build_side_ptr (const unsigned int i,
+                                       bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -68,7 +68,7 @@ dof_id_type Tri::key () const
 
 
 
-UniquePtr<Elem> Tri::side (const unsigned int i) const
+UniquePtr<Elem> Tri::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -106,8 +106,8 @@ bool Tri3::is_node_on_side(const unsigned int n,
   return false;
 }
 
-UniquePtr<Elem> Tri3::build_side (const unsigned int i,
-                                  bool proxy) const
+UniquePtr<Elem> Tri3::build_side_ptr (const unsigned int i,
+                                      bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -174,8 +174,8 @@ dof_id_type Tri6::key (const unsigned int s) const
 
 
 
-UniquePtr<Elem> Tri6::build_side (const unsigned int i,
-                                  bool proxy) const
+UniquePtr<Elem> Tri6::build_side_ptr (const unsigned int i,
+                                      bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());
 

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -1022,7 +1022,7 @@ void AbaqusIO::assign_sideset_ids()
                        s_it != range.second; ++s_it)
                     {
                       // We'll need to compare the lower dimensional element against the current side.
-                      UniquePtr<Elem> side (elem->build_side(sn));
+                      UniquePtr<Elem> side (elem->build_side_ptr(sn));
 
                       // Get the value mapped by the iterator.
                       std::pair<Elem *, boundary_id_type> p = s_it->second;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -47,7 +47,7 @@ const boundary_id_type BoundaryInfo::invalid_id = -123;
 
 //------------------------------------------------------
 // BoundaryInfo functions
-BoundaryInfo::BoundaryInfo(const MeshBase & m) :
+BoundaryInfo::BoundaryInfo(MeshBase & m) :
   ParallelObject(m.comm()),
   _mesh (m)
 {
@@ -412,12 +412,12 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
     {
       const dof_id_type elem_id = it->first;
       const unsigned char s = it->second;
-      const Elem * elem = _mesh.elem_ptr(elem_id);
+      Elem * elem = _mesh.elem_ptr(elem_id);
 
       // Build the side - do not use a "proxy" element here:
       // This will be going into the boundary_mesh and needs to
       // stand on its own.
-      UniquePtr<Elem> side (elem->build_side(s, false));
+      UniquePtr<Elem> side (elem->build_side_ptr(s, false));
 
       side->processor_id() = elem->processor_id();
 

--- a/src/mesh/diva_io.C
+++ b/src/mesh/diva_io.C
@@ -158,9 +158,9 @@ void DivaIO::write_stream (std::ostream & out_file)
         const Elem & elem = the_mesh.elem_ref(e);
         if (elem.active())
           for (unsigned int s=0; s<elem.n_sides(); s++)
-            if (elem.neighbor(s) == libmesh_nullptr)
+            if (elem.neighbor_ptr(s) == libmesh_nullptr)
               {
-                const UniquePtr<Elem> side(elem.build_side(s));
+                const UniquePtr<const Elem> side(elem.build_side_ptr(s));
 
                 if (side->type() == TRI3)
                   {
@@ -198,9 +198,9 @@ void DivaIO::write_stream (std::ostream & out_file)
         const Elem & elem = the_mesh.elem_ref(e);
         if (elem.active())
           for (unsigned int s=0; s<elem.n_sides(); s++)
-            if (elem.neighbor(s) == libmesh_nullptr)
+            if (elem.neighbor_ptr(s) == libmesh_nullptr)
               {
-                const UniquePtr<Elem> side(elem.build_side(s));
+                const UniquePtr<const Elem> side(elem.build_side_ptr(s));
 
                 if ((side->type() == QUAD4) ||
                     (side->type() == QUAD8)  )
@@ -250,9 +250,9 @@ void DivaIO::write_stream (std::ostream & out_file)
         const Elem & elem = the_mesh.elem_ref(e);
         if (elem.active())
           for (unsigned short s=0; s<elem.n_sides(); s++)
-            if (elem.neighbor(s) == libmesh_nullptr)
+            if (elem.neighbor_ptr(s) == libmesh_nullptr)
               {
-                const UniquePtr<Elem> side(elem.build_side(s));
+                const UniquePtr<const Elem> side(elem.build_side_ptr(s));
 
                 if ((side->type() == TRI3) ||
                     (side->type() == TRI6)  )
@@ -271,9 +271,9 @@ void DivaIO::write_stream (std::ostream & out_file)
         const Elem & elem = the_mesh.elem_ref(e);
         if (elem.active())
           for (unsigned short s=0; s<elem.n_sides(); s++)
-            if (elem.neighbor(s) == libmesh_nullptr)
+            if (elem.neighbor_ptr(s) == libmesh_nullptr)
               {
-                const UniquePtr<Elem> side(elem.build_side(s));
+                const UniquePtr<const Elem> side(elem.build_side_ptr(s));
 
                 if ((side->type() == QUAD4) ||
                     (side->type() == QUAD8) ||

--- a/src/mesh/fro_io.C
+++ b/src/mesh/fro_io.C
@@ -138,8 +138,8 @@ void FroIO::write (const std::string & fname)
                   // "backward_edges" map n1-->n0
                   // and then start with one chain link, and add on...
                   //
-                  UniquePtr<Elem> side =
-                    the_mesh.elem_ref(el[e]).build_side(sl[e]);
+                  UniquePtr<const Elem> side =
+                    the_mesh.elem_ref(el[e]).build_side_ptr(sl[e]);
 
                   const dof_id_type
                     n0 = side->node_id(0),

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -575,7 +575,7 @@ void GmshIO::read_mesh(std::istream & in)
                                      iter != rng.second; ++iter)
                                   {
                                     // Construct the side for hash verification.
-                                    UniquePtr<Elem> side (elem->build_side(sn));
+                                    UniquePtr<Elem> side (elem->build_side_ptr(sn));
 
                                     // Construct the lower-dimensional element to compare to the side.
                                     Elem * lower_dim_elem = iter->second;
@@ -780,7 +780,7 @@ void GmshIO::write_mesh (std::ostream & out_stream)
           {
             const Elem & elem = mesh.elem_ref(element_id_list[idx]);
 
-            UniquePtr<Elem> side = elem.build_side(side_list[idx]);
+            UniquePtr<const Elem> side = elem.build_side_ptr(side_list[idx]);
 
             // Map from libmesh elem type to gmsh elem type.
             std::map<ElemType, ElementDefinition>::iterator def_it =

--- a/src/mesh/gnuplot_io.C
+++ b/src/mesh/gnuplot_io.C
@@ -120,12 +120,12 @@ void GnuPlotIO::write_solution(const std::string & fname,
           const Elem * el = *it;
 
           // if el is the left edge of the mesh, print its left node position
-          if(el->neighbor(0) == libmesh_nullptr)
+          if (el->neighbor_ptr(0) == libmesh_nullptr)
             {
               x_min = (el->point(0))(0);
               xtics_stream << "\"\" " << x_min << ", \\\n";
             }
-          if(el->neighbor(1) == libmesh_nullptr)
+          if (el->neighbor_ptr(1) == libmesh_nullptr)
             {
               x_max = (el->point(1))(0);
             }

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -207,7 +207,7 @@ const Point InfElemBuilder::build_inf_elem (const InfElemOriginValue & origin_x,
           std::pair<dof_id_type,unsigned int> p = *face_it;
 
           // build a full-ordered side element to get _all_ the base nodes
-          UniquePtr<Elem> side( this->_mesh.elem_ref(p.first).build_side(p.second) );
+          UniquePtr<Elem> side(this->_mesh.elem_ref(p.first).build_side_ptr(p.second));
 
           // insert all the node numbers in inner_boundary_node_numbers
           for (unsigned int n=0; n< side->n_nodes(); n++)
@@ -345,7 +345,7 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
               {
                 // note that it is safe to use the Elem::side() method,
                 // which gives a non-full-ordered element
-                UniquePtr<Elem> side(elem->build_side(s));
+                UniquePtr<Elem> side(elem->build_side_ptr(s));
 
                 // bool flags for symmetry detection
                 bool sym_side=false;
@@ -435,7 +435,7 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
 
       // This has to be a full-ordered side element,
       // since we need the correct n_nodes,
-      UniquePtr<Elem> side(this->_mesh.elem_ref(p.first).build_side(p.second));
+      UniquePtr<Elem> side(this->_mesh.elem_ref(p.first).build_side_ptr(p.second));
 
       bool found=false;
       for(unsigned int sn=0; sn<side->n_nodes(); sn++)
@@ -539,7 +539,7 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
       std::pair<dof_id_type,unsigned int> p = *face_it;
 
       // build a full-ordered side element to get the base nodes
-      UniquePtr<Elem> side(this->_mesh.elem_ref(p.first).build_side(p.second));
+      UniquePtr<Elem> side(this->_mesh.elem_ref(p.first).build_side_ptr(p.second));
 
       // create cell depending on side type, assign nodes,
       // use braces to force scope.

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -94,7 +94,7 @@ struct SyncNeighbors
         neighbors[i].resize(n_neigh);
         for (unsigned int n = 0; n != n_neigh; ++n)
           {
-            const Elem * neigh = elem.neighbor(n);
+            const Elem * neigh = elem.neighbor_ptr(n);
             if (neigh)
               {
                 libmesh_assert_not_equal_to(neigh, remote_elem);
@@ -121,7 +121,7 @@ struct SyncNeighbors
         for (unsigned int n = 0; n != n_neigh; ++n)
           {
             const dof_id_type new_neigh_id = new_neigh[n];
-            const Elem * old_neigh = elem.neighbor(n);
+            const Elem * old_neigh = elem.neighbor_ptr(n);
             if (old_neigh && old_neigh != remote_elem)
               {
                 libmesh_assert_equal_to(old_neigh->id(), new_neigh_id);
@@ -485,9 +485,9 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
             my_interface_elements.push_back(elem); // add the element, but only once, even
             // if there are multiple NULL neighbors
             for (unsigned int s=0; s<elem->n_sides(); s++)
-              if (elem->neighbor(s) == libmesh_nullptr)
+              if (elem->neighbor_ptr(s) == libmesh_nullptr)
                 {
-                  UniquePtr<Elem> side(elem->build_side(s));
+                  UniquePtr<const Elem> side(elem->build_side_ptr(s));
 
                   for (unsigned int n=0; n<side->n_vertices(); n++)
                     my_interface_node_set.insert (side->node_id(n));
@@ -1267,7 +1267,7 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
 
       for (unsigned int s=0; s != elem->n_sides(); ++s)
         {
-          const Elem * neighbor = elem->neighbor(s);
+          const Elem * neighbor = elem->neighbor_ptr(s);
           if (neighbor)
             semilocal_elems[neighbor->id()] = true;
         }

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1309,7 +1309,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                       boundary_id_type b_id = boundary_info.boundary_id(*el, s);
 
                       // Need to build the full-ordered side!
-                      UniquePtr<Elem> side = base_hex->build_side(s);
+                      UniquePtr<Elem> side = base_hex->build_side_ptr(s);
 
                       if ((type == TET4) || (type == TET10))
                         {
@@ -1880,9 +1880,9 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
           Elem * elem = *it;
 
           for (unsigned int s=0; s<elem->n_sides(); s++)
-            if (elem->neighbor(s) == libmesh_nullptr || (mesh.mesh_dimension() == 2 && !flat))
+            if (elem->neighbor_ptr(s) == libmesh_nullptr || (mesh.mesh_dimension() == 2 && !flat))
               {
-                UniquePtr<Elem> side(elem->build_side(s));
+                UniquePtr<Elem> side(elem->build_side_ptr(s));
 
                 // Pop each point to the sphere boundary
                 for (unsigned int n=0; n<side->n_nodes(); n++)
@@ -1927,9 +1927,9 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
           Elem * elem = *it;
 
           for (unsigned int s=0; s<elem->n_sides(); s++)
-            if (elem->neighbor(s) == libmesh_nullptr)
+            if (elem->neighbor_ptr(s) == libmesh_nullptr)
               {
-                UniquePtr<Elem> side(elem->build_side(s));
+                UniquePtr<Elem> side(elem->build_side_ptr(s));
 
                 // Pop each point to the sphere boundary
                 for (unsigned int n=0; n<side->n_nodes(); n++)
@@ -1953,7 +1953,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
       {
         Elem * elem = *it;
         for (unsigned short s=0; s != elem->n_sides(); ++s)
-          if (!elem->neighbor(s))
+          if (!elem->neighbor_ptr(s))
             boundary_info.add_side(elem, s, 0);
       }
   }
@@ -2290,9 +2290,9 @@ void MeshTools::Generation::build_delaunay_square(UnstructuredMesh & mesh,
       const Elem * elem = *el;
 
       for (unsigned int s=0; s<elem->n_sides(); s++)
-        if (elem->neighbor(s) == libmesh_nullptr)
+        if (elem->neighbor_ptr(s) == libmesh_nullptr)
           {
-            UniquePtr<Elem> side (elem->build_side(s));
+            UniquePtr<const Elem> side (elem->build_side_ptr(s));
 
             // Check the location of the side's midpoint.  Since
             // the square has straight sides, the midpoint is not

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -551,12 +551,14 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
    * them with an equivalent second-order element.  Don't
    * forget to delete the low-order element, or else it will leak!
    */
-  const_element_iterator endit = elements_end();
-  for (const_element_iterator it = elements_begin();
-       it != endit; ++it)
+  element_iterator
+    it = elements_begin(),
+    endit = elements_end();
+
+  for (; it != endit; ++it)
     {
       // the linear-order element
-      const Elem * lo_elem = *it;
+      Elem * lo_elem = *it;
 
       libmesh_assert(lo_elem);
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -339,7 +339,7 @@ void UnstructuredMesh::all_first_order ()
          (so_elem->type()), so_elem->parent()).release();
 
       for (unsigned int s=0; s != so_elem->n_sides(); ++s)
-        if (so_elem->neighbor(s) == remote_elem)
+        if (so_elem->neighbor_ptr(s) == remote_elem)
           lo_elem->set_neighbor(s, const_cast<RemoteElem *>(remote_elem));
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -349,8 +349,8 @@ void UnstructuredMesh::all_first_order ()
       if (so_elem->has_children())
         for (unsigned int c=0; c != so_elem->n_children(); ++c)
           {
-            so_elem->child(c)->set_parent(lo_elem);
-            lo_elem->add_child(so_elem->child(c), c);
+            so_elem->child_ptr(c)->set_parent(lo_elem);
+            lo_elem->add_child(so_elem->child_ptr(c), c);
           }
 
       /*
@@ -1427,7 +1427,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                       continue;
 
                     // Make a sorted list of node ids for elem->side(sn)
-                    UniquePtr<Elem> elem_side = elem->build_side(sn);
+                    UniquePtr<Elem> elem_side = elem->build_side_ptr(sn);
                     std::vector<dof_id_type> elem_side_nodes(elem_side->n_nodes());
                     for (unsigned int esn=0; esn<elem_side_nodes.size(); ++esn)
                       elem_side_nodes[esn] = elem_side->node_id(esn);
@@ -1438,7 +1438,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                         {
                           for (unsigned int subside=0; subside < subelem[i]->n_sides(); ++subside)
                             {
-                              UniquePtr<Elem> subside_elem = subelem[i]->build_side(subside);
+                              UniquePtr<Elem> subside_elem = subelem[i]->build_side_ptr(subside);
 
                               // Make a list of *vertex* node ids for this subside, see if they are all present
                               // in elem->side(sn).  Note 1: we can't just compare elem->key(sn) to
@@ -1465,7 +1465,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
 
                                   // If the original element had a RemoteElem neighbor on side 'sn',
                                   // then the subelem has one on side 'subside'.
-                                  if (elem->neighbor(sn) == remote_elem)
+                                  if (elem->neighbor_ptr(sn) == remote_elem)
                                     subelem[i]->set_neighbor(subside, const_cast<RemoteElem*>(remote_elem));
                                 }
                             }
@@ -1625,13 +1625,13 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
                          * id is greater than its neighbor's.
                          * Sides get only built once.
                          */
-                        if ((elem->neighbor(s) != libmesh_nullptr) &&
-                            (elem->id() > elem->neighbor(s)->id()) )
+                        if ((elem->neighbor_ptr(s) != libmesh_nullptr) &&
+                            (elem->id() > elem->neighbor_ptr(s)->id()))
                           {
-                            UniquePtr<Elem> side(elem->build_side(s));
+                            UniquePtr<const Elem> side(elem->build_side_ptr(s));
 
-                            Node & node0 = side->node_ref(0);
-                            Node & node1 = side->node_ref(1);
+                            const Node & node0 = side->node_ref(0);
+                            const Node & node1 = side->node_ref(1);
 
                             Real node_weight = 1.;
                             // calculate the weight of the nodes
@@ -1665,7 +1665,7 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
                      */
                     for (unsigned int c=0; c < parent->n_children(); c++)
                       {
-                        if (parent->child(c) == elem)
+                        if (parent->child_ptr(c) == elem)
                           {
                             /*
                              *loop over the childs (that is, the current elements) nodes
@@ -1805,7 +1805,7 @@ void MeshTools::Modification::flatten(MeshBase & mesh)
         // side, bc_id) triples and those links
         for (unsigned short s=0; s<elem->n_sides(); s++)
           {
-            if (elem->neighbor(s) == remote_elem)
+            if (elem->neighbor_ptr(s) == remote_elem)
               copy->set_neighbor(s, const_cast<RemoteElem *>(remote_elem));
 
             mesh.get_boundary_info().boundary_ids(elem, s, bc_ids);

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -102,7 +102,7 @@ void MeshRefinement::clear ()
 
 
 
-Node * MeshRefinement::add_node(const Elem & parent,
+Node * MeshRefinement::add_node(Elem & parent,
                                 unsigned int child,
                                 unsigned int node,
                                 processor_id_type proc_id)

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1030,7 +1030,7 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
                               libmesh_assert(neighbor->has_children());
                               for (unsigned int c=0; c!=neighbor->n_children(); c++)
                                 {
-                                  Elem * subneighbor = neighbor->child(c);
+                                  const Elem * subneighbor = neighbor->child_ptr(c);
                                   if (subneighbor != remote_elem &&
                                       subneighbor->active() &&
                                       has_topological_neighbor(subneighbor, point_locator.get(), elem))
@@ -1080,8 +1080,8 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
                     // test all descendants
                     if (neigh->has_children())
                       for (unsigned int c=0; c != neigh->n_children(); ++c)
-                        if (neigh->child(c) == remote_elem ||
-                            neigh->child(c)->processor_id() !=
+                        if (neigh->child_ptr(c) == remote_elem ||
+                            neigh->child_ptr(c)->processor_id() !=
                             this->processor_id())
                           {
                             compatible_with_refinement = false;
@@ -1118,7 +1118,7 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
 
               for (unsigned int c=0; c<elem->n_children(); c++)
                 {
-                  Elem * child = elem->child(c);
+                  Elem * child = elem->child_ptr(c);
                   if (child == remote_elem)
                     found_remote_child = true;
                   else if ((child->refinement_flag() != Elem::COARSEN) ||
@@ -1132,7 +1132,7 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
 
                   for (unsigned int c=0; c<elem->n_children(); c++)
                     {
-                      Elem * child = elem->child(c);
+                      Elem * child = elem->child_ptr(c);
                       if (child == remote_elem)
                         continue;
                       if (child->refinement_flag() == Elem::COARSEN)
@@ -1166,7 +1166,7 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
 
           for (unsigned int c=0; c<elem->n_children(); c++)
             {
-              Elem * child = elem->child(c);
+              Elem * child = elem->child_ptr(c);
               if (child == remote_elem)
                 found_remote_child = true;
               else if (child->refinement_flag() != Elem::COARSEN)
@@ -1342,7 +1342,7 @@ bool MeshRefinement::make_refinement_compatible(const bool maintain_level_one)
                               libmesh_assert(neighbor->has_children());
                               for (unsigned int c=0; c!=neighbor->n_children(); c++)
                                 {
-                                  Elem * subneighbor = neighbor->child(c);
+                                  Elem * subneighbor = neighbor->child_ptr(c);
                                   if (subneighbor == remote_elem)
                                     continue;
                                   if (subneighbor->active() &&
@@ -1770,14 +1770,14 @@ Elem * MeshRefinement::topological_neighbor(Elem * elem,
       return elem->topological_neighbor(side, _mesh, *point_locator, _periodic_boundaries);
     }
 #endif
-  return elem->neighbor(side);
+  return elem->neighbor_ptr(side);
 }
 
 
 
-bool MeshRefinement::has_topological_neighbor(Elem * elem,
+bool MeshRefinement::has_topological_neighbor(const Elem * elem,
                                               const PointLocatorBase * point_locator,
-                                              Elem * neighbor)
+                                              const Elem * neighbor)
 {
 #ifdef LIBMESH_ENABLE_PERIODIC
   if (_periodic_boundaries && !_periodic_boundaries->empty())

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -429,7 +429,7 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector & error_pe
           libmesh_assert(parent->has_children());
           for (unsigned int c=0; c != parent->n_children(); ++c)
             {
-              Elem * elem = parent->child(c);
+              Elem * elem = parent->child_ptr(c);
               if (elem && elem != remote_elem)
                 {
                   libmesh_assert(elem->active());

--- a/src/mesh/mesh_refinement_smoothing.C
+++ b/src/mesh/mesh_refinement_smoothing.C
@@ -167,7 +167,7 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
         // Set the max_level at each edge
         for (unsigned int n=0; n<elem->n_edges(); n++)
           {
-            UniquePtr<Elem> edge = elem->build_edge(n);
+            UniquePtr<const Elem> edge = elem->build_edge_ptr(n);
             dof_id_type childnode0 = edge->node_id(0);
             dof_id_type childnode1 = edge->node_id(1);
             if (childnode1 < childnode0)
@@ -175,7 +175,7 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
 
             for (const Elem * p = elem; p != libmesh_nullptr; p = p->parent())
               {
-                UniquePtr<Elem> pedge = p->build_edge(n);
+                UniquePtr<const Elem> pedge = p->build_edge_ptr(n);
                 dof_id_type node0 = pedge->node_id(0);
                 dof_id_type node1 = pedge->node_id(1);
 
@@ -237,7 +237,7 @@ bool MeshRefinement::limit_level_mismatch_at_edge (const unsigned int max_mismat
         // Loop over the nodes, check for possible mismatch
         for (unsigned int n=0; n<elem->n_edges(); n++)
           {
-            UniquePtr<Elem> edge = elem->build_edge(n);
+            UniquePtr<Elem> edge = elem->build_edge_ptr(n);
             dof_id_type node0 = edge->node_id(0);
             dof_id_type node1 = edge->node_id(1);
             if (node1 < node0)
@@ -470,7 +470,7 @@ bool MeshRefinement::eliminate_unrefined_patches ()
       // Check all the element neighbors
       for (unsigned int n=0; n<elem->n_neighbors(); n++)
         {
-          const Elem * neighbor = elem->neighbor(n);
+          const Elem * neighbor = elem->neighbor_ptr(n);
           // Quit if the element is on a local boundary
           if (neighbor == libmesh_nullptr || neighbor == remote_elem)
             {
@@ -550,9 +550,9 @@ bool MeshRefinement::eliminate_unrefined_patches ()
             {
               for (unsigned int c=0; c<elem->n_children(); c++)
                 {
-                  libmesh_assert_equal_to (elem->child(c)->refinement_flag(),
+                  libmesh_assert_equal_to (elem->child_ptr(c)->refinement_flag(),
                                            Elem::COARSEN);
-                  elem->child(c)->set_refinement_flag(Elem::DO_NOTHING);
+                  elem->child_ptr(c)->set_refinement_flag(Elem::DO_NOTHING);
                 }
               elem->set_refinement_flag(Elem::INACTIVE);
             }

--- a/src/mesh/mesh_smoother_laplace.C
+++ b/src/mesh/mesh_smoother_laplace.C
@@ -199,10 +199,10 @@ void LaplaceMeshSmoother::init()
                 // boundary or for which the current element's
                 // id is greater than its neighbor's.
                 // Sides get only built once.
-                if ((elem->neighbor(s) == libmesh_nullptr) ||
-                    (elem->id() > elem->neighbor(s)->id()))
+                if ((elem->neighbor_ptr(s) == libmesh_nullptr) ||
+                    (elem->id() > elem->neighbor_ptr(s)->id()))
                   {
-                    UniquePtr<Elem> side(elem->build_side(s));
+                    UniquePtr<const Elem> side(elem->build_side_ptr(s));
                     _graph[side->node_id(0)].push_back(side->node_id(1));
                     _graph[side->node_id(1)].push_back(side->node_id(0));
                   }
@@ -226,17 +226,17 @@ void LaplaceMeshSmoother::init()
             const Elem * elem = *el;
 
             for (unsigned int f=0; f<elem->n_neighbors(); f++) // Loop over faces
-              if ((elem->neighbor(f) == libmesh_nullptr) ||
-                  (elem->id() > elem->neighbor(f)->id()))
+              if ((elem->neighbor_ptr(f) == libmesh_nullptr) ||
+                  (elem->id() > elem->neighbor_ptr(f)->id()))
                 {
                   // We need a full (i.e. non-proxy) element for the face, since we will
                   // be looking at its sides as well!
-                  UniquePtr<Elem> face = elem->build_side(f, /*proxy=*/false);
+                  UniquePtr<const Elem> face = elem->build_side_ptr(f, /*proxy=*/false);
 
                   for (unsigned int s=0; s<face->n_neighbors(); s++) // Loop over face's edges
                     {
                       // Here we can use a proxy
-                      UniquePtr<Elem> side = face->build_side(s);
+                      UniquePtr<const Elem> side = face->build_side_ptr(s);
 
                       // At this point, we just insert the node numbers
                       // again.  At the end we'll call sort and unique

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1261,9 +1261,9 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
       // Loop over element's neighbors, see if it has a neighbor which is off-processor
       for (unsigned int n=0; n<elem->n_neighbors(); ++n)
         {
-          if (elem->neighbor(n) != libmesh_nullptr)
+          if (elem->neighbor_ptr(n) != libmesh_nullptr)
             {
-              unsigned neighbor_proc_id = elem->neighbor(n)->processor_id();
+              unsigned neighbor_proc_id = elem->neighbor_ptr(n)->processor_id();
 
               // If my neighbor has a different processor ID, I must be a border element.
               // Also track the neighboring processor ID if it is are different from our processor ID

--- a/src/mesh/patch.C
+++ b/src/mesh/patch.C
@@ -45,9 +45,9 @@ void Patch::find_face_neighbors(std::set<const Elem *> & new_neighbors)
     {
       const Elem * elem = *it;
       for (unsigned int s=0; s<elem->n_sides(); s++)
-        if (elem->neighbor(s) != libmesh_nullptr)        // we have a neighbor on this side
+        if (elem->neighbor_ptr(s) != libmesh_nullptr)        // we have a neighbor on this side
           {
-            const Elem * neighbor = elem->neighbor(s);
+            const Elem * neighbor = elem->neighbor_ptr(s);
 
 #ifdef LIBMESH_ENABLE_AMR
             if (!neighbor->active())          // the neighbor is *not* active,

--- a/src/mesh/postscript_io.C
+++ b/src/mesh/postscript_io.C
@@ -239,7 +239,7 @@ void PostscriptIO::plot_quadratic_elem(const Elem * elem)
   for (unsigned int ns=0; ns<elem->n_sides(); ++ns)
     {
       // Build the quadratic side
-      UniquePtr<Elem> side = elem->build_side(ns);
+      UniquePtr<const Elem> side = elem->build_side_ptr(ns);
 
       // Be sure it's quadratic (Edge2).  Eventually we could
       // handle cubic elements as well...

--- a/src/mesh/serial_mesh.C
+++ b/src/mesh/serial_mesh.C
@@ -927,14 +927,14 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
 
                 // Now check whether elem has a face on the specified boundary
                 for (unsigned char side_id=0; side_id<el->n_sides(); ++side_id)
-                  if (el->neighbor(side_id) == libmesh_nullptr)
+                  if (el->neighbor_ptr(side_id) == libmesh_nullptr)
                     {
                       // Get *all* boundary IDs on this side, not just the first one!
                       mesh_array[i]->get_boundary_info().boundary_ids (el, side_id, bc_ids);
 
                       if (std::find(bc_ids.begin(), bc_ids.end(), id_array[i]) != bc_ids.end())
                         {
-                          UniquePtr<Elem> side (el->build_side(side_id));
+                          UniquePtr<Elem> side (el->build_side_ptr(side_id));
                           for (unsigned int node_i=0; node_i<side->n_nodes(); ++node_i)
                             set_array[i]->insert( side->node_id(node_i) );
 
@@ -973,7 +973,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
 
                               if (std::find(bc_ids.begin(), bc_ids.end(), id_array[i]) != bc_ids.end())
                                 {
-                                  UniquePtr<Elem> edge (el->build_edge(edge_id));
+                                  UniquePtr<Elem> edge (el->build_edge_ptr(edge_id));
                                   for (unsigned int node_i=0; node_i<edge->n_nodes(); ++node_i)
                                     set_array[i]->insert( edge->node_id(node_i) );
 
@@ -1355,7 +1355,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
                   fixed_elems.insert(elem_id);
                   for(unsigned int s = 0; s < el->n_neighbors(); ++s)
                     {
-                      if(el->neighbor(s) == libmesh_nullptr)
+                      if (el->neighbor_ptr(s) == libmesh_nullptr)
                         {
                           key_type key = el->key(s);
                           typedef map_type::iterator key_val_it_type;
@@ -1365,7 +1365,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
                           if(bounds.first != bounds.second)
                             {
                               // Get the side for this element
-                              const UniquePtr<Elem> my_side(el->side(s));
+                              const UniquePtr<Elem> my_side(el->side_ptr(s));
 
                               // Look at all the entries with an equivalent key
                               while (bounds.first != bounds.second)
@@ -1375,7 +1375,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
 
                                   // Get the side for the neighboring element
                                   const unsigned int ns = bounds.first->second.second;
-                                  const UniquePtr<Elem> their_side(neighbor->side(ns));
+                                  const UniquePtr<Elem> their_side(neighbor->side_ptr(ns));
                                   //libmesh_assert(my_side.get());
                                   //libmesh_assert(their_side.get());
 
@@ -1444,7 +1444,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
 
           for (unsigned short side_id=0; side_id<el->n_sides(); side_id++)
             {
-              if (el->neighbor(side_id) != libmesh_nullptr)
+              if (el->neighbor_ptr(side_id) != libmesh_nullptr)
                 {
                   // Completely remove the side from the boundary_info object if it has either
                   // this_mesh_boundary_id or other_mesh_boundary_id.

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -134,13 +134,13 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
         el->subdomain_id() = old->subdomain_id();
 
         for (unsigned int s=0; s != old->n_sides(); ++s)
-          if (old->neighbor(s) == remote_elem)
+          if (old->neighbor_ptr(s) == remote_elem)
             el->set_neighbor(s, const_cast<RemoteElem *>(remote_elem));
 
 #ifdef LIBMESH_ENABLE_AMR
         if (old->has_children())
           for (unsigned int c=0; c != old->n_children(); ++c)
-            if (old->child(c) == remote_elem)
+            if (old->child_ptr(c) == remote_elem)
               el->add_child(const_cast<RemoteElem *>(remote_elem), c);
 
         //Create the parent's child pointers if necessary
@@ -200,7 +200,7 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
             Elem * new_elem = old_elems_to_new_elems[old_elem];
             for (unsigned int s=0; s != old_elem->n_neighbors(); ++s)
               {
-                const Elem * old_neighbor = old_elem->neighbor(s);
+                const Elem * old_neighbor = old_elem->neighbor_ptr(s);
                 Elem * new_neighbor = old_elems_to_new_elems[old_neighbor];
                 new_elem->set_neighbor(s, new_neighbor);
               }
@@ -252,7 +252,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
       {
         Elem * e = *el;
         for (unsigned int s=0; s<e->n_neighbors(); s++)
-          if (e->neighbor(s) != remote_elem ||
+          if (e->neighbor_ptr(s) != remote_elem ||
               reset_remote_elements)
             e->set_neighbor(s, libmesh_nullptr);
       }
@@ -283,8 +283,8 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
             // If we haven't yet found a neighbor on this side, try.
             // Even if we think our neighbor is remote, that
             // information may be out of date.
-            if (element->neighbor(ms) == libmesh_nullptr ||
-                element->neighbor(ms) == remote_elem)
+            if (element->neighbor_ptr(ms) == libmesh_nullptr ||
+                element->neighbor_ptr(ms) == remote_elem)
               {
                 // Get the key for the side of this element
                 const unsigned int key = element->key(ms);
@@ -298,7 +298,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                 if (bounds.first != bounds.second)
                   {
                     // Get the side for this element
-                    const UniquePtr<Elem> my_side(element->side(ms));
+                    const UniquePtr<Elem> my_side(element->side_ptr(ms));
 
                     // Look at all the entries with an equivalent key
                     while (bounds.first != bounds.second)
@@ -308,7 +308,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
 
                         // Get the side for the neighboring element
                         const unsigned int ns = bounds.first->second.second;
-                        const UniquePtr<Elem> their_side(neighbor->side(ns));
+                        const UniquePtr<Elem> their_side(neighbor->side_ptr(ns));
                         //libmesh_assert(my_side.get());
                         //libmesh_assert(their_side.get());
 
@@ -420,11 +420,11 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
 
           for (unsigned int s=0; s < current_elem->n_neighbors(); s++)
             {
-              if (current_elem->neighbor(s) == libmesh_nullptr ||
-                  (current_elem->neighbor(s) == remote_elem &&
+              if (current_elem->neighbor_ptr(s) == libmesh_nullptr ||
+                  (current_elem->neighbor_ptr(s) == remote_elem &&
                    parent->is_child_on_side(my_child_num, s)))
                 {
-                  Elem * neigh = parent->neighbor(s);
+                  Elem * neigh = parent->neighbor_ptr(s);
 
                   // If neigh was refined and had non-subactive children
                   // made remote earlier, then a non-subactive elem should
@@ -439,7 +439,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                       bool neigh_has_remote_children = false;
                       for (unsigned int c = 0; c != neigh->n_children(); ++c)
                         {
-                          if (neigh->child(c) == remote_elem)
+                          if (neigh->child_ptr(c) == remote_elem)
                             neigh_has_remote_children = true;
                         }
                       libmesh_assert(neigh_has_remote_children);
@@ -517,7 +517,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
           // parent's interior_parent.
           for (unsigned int c=0; c != pip->n_children(); ++c)
             {
-              Elem * child = pip->child(c);
+              Elem * child = pip->child_ptr(c);
 
               // If we have a remote_elem, that might be our
               // interior_parent.  We'll set it provisionally now and

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -586,7 +586,7 @@ void UNVIO::groups_in (std::istream & in_file)
                      iter != range.second; ++iter)
                   {
                     // Build a side to confirm the hash mapped to the correct side.
-                    UniquePtr<Elem> side (elem->build_side(sn));
+                    UniquePtr<Elem> side (elem->build_side_ptr(sn));
 
                     // Get a pointer to the lower-dimensional element
                     Elem * lower_dim_elem = iter->second;

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -531,7 +531,7 @@ void XdrIO::write_serialized_connectivity (Xdr & io, const dof_id_type libmesh_d
 
             for (unsigned int c=0; c<parent->n_children(); c++, my_next_elem++)
               {
-                const Elem * child = parent->child(c);
+                const Elem * child = parent->child_ptr(c);
                 pack_element (xfer_conn, child, parent_id, parent_pid);
 
                 // this aproach introduces the possibility that we write

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -269,7 +269,7 @@ Packing<const Elem *>::pack (const Elem * const & elem,
 
   for (unsigned int n=0; n<elem->n_neighbors(); n++)
     {
-      const Elem * neigh = elem->neighbor(n);
+      const Elem * neigh = elem->neighbor_ptr(n);
       if (neigh)
         *data_out++ = (neigh->id());
       else
@@ -494,7 +494,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
 
       libmesh_assert (!level || elem->parent() != libmesh_nullptr);
       libmesh_assert (!level || elem->parent()->id() == parent_id);
-      libmesh_assert (!level || elem->parent()->child(which_child_am_i) == elem);
+      libmesh_assert (!level || elem->parent()->child_ptr(which_child_am_i) == elem);
 #endif
       // Our interior_parent link should be "close to" correct - we
       // may have to update it, but we can check for some
@@ -560,7 +560,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
             // we'd better agree.
             if (neighbor_id == DofObject::invalid_id)
               {
-                libmesh_assert (!(elem->neighbor(n)));
+                libmesh_assert (!(elem->neighbor_ptr(n)));
                 continue;
               }
 
@@ -569,7 +569,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
             // boundary.
             if (neighbor_id == remote_elem->id())
               {
-                libmesh_assert(elem->neighbor(n));
+                libmesh_assert(elem->neighbor_ptr(n));
                 continue;
               }
 
@@ -580,7 +580,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
             // have a remote_elem signifying that fact.
             if (!neigh)
               {
-                libmesh_assert_equal_to (elem->neighbor(n), remote_elem);
+                libmesh_assert_equal_to (elem->neighbor_ptr(n), remote_elem);
                 continue;
               }
 
@@ -589,13 +589,13 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
             // linking to it.  Perhaps we initially received both elem
             // and neigh from processors on which their mutual link was
             // remote?
-            libmesh_assert(elem->neighbor(n) == neigh ||
-                           elem->neighbor(n) == remote_elem);
+            libmesh_assert(elem->neighbor_ptr(n) == neigh ||
+                           elem->neighbor_ptr(n) == remote_elem);
 
             // If the link was originally remote, we should update it,
             // and make sure the appropriate parts of its family link
             // back to us.
-            if (elem->neighbor(n) == remote_elem)
+            if (elem->neighbor_ptr(n) == remote_elem)
               {
                 elem->set_neighbor(n, neigh);
 
@@ -654,7 +654,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
         {
           // Since this is a newly created element, the parent must
           // have previously thought of this child as a remote element.
-          libmesh_assert_equal_to (parent->child(which_child_am_i), remote_elem);
+          libmesh_assert_equal_to (parent->child_ptr(which_child_am_i), remote_elem);
 
           parent->add_child(elem, which_child_am_i);
         }

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -238,7 +238,7 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
             // adjacency corresponds to a face neighbor
             for (unsigned int ms=0; ms<elem->n_neighbors(); ms++)
               {
-                const Elem * neighbor = elem->neighbor(ms);
+                const Elem * neighbor = elem->neighbor_ptr(ms);
 
                 if (neighbor != libmesh_nullptr)
                   {
@@ -284,7 +284,7 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
                             // This does not assume a level-1 mesh.
                             // Note that since children have sides numbered
                             // coincident with the parent then this is a sufficient test.
-                            if (child->neighbor(ns) == elem)
+                            if (child->neighbor_ptr(ns) == elem)
                               {
                                 libmesh_assert (child->active());
                                 num_neighbors++;
@@ -338,7 +338,7 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
             // adjacency corresponds to a face neighbor
             for (unsigned int ms=0; ms<elem->n_neighbors(); ms++)
               {
-                const Elem * neighbor = elem->neighbor(ms);
+                const Elem * neighbor = elem->neighbor_ptr(ms);
 
                 if (neighbor != libmesh_nullptr)
                   {
@@ -375,7 +375,7 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
                             // This does not assume a level-1 mesh.
                             // Note that since children have sides numbered
                             // coincident with the parent then this is a sufficient test.
-                            if (child->neighbor(ns) == elem)
+                            if (child->neighbor_ptr(ns) == elem)
                               {
                                 libmesh_assert (child->active());
 

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -489,7 +489,7 @@ void ParmetisPartitioner::build_graph (const MeshBase & mesh)
       // adjacency corresponds to a face neighbor
       for (unsigned int ms=0; ms<elem->n_neighbors(); ms++)
         {
-          const Elem * neighbor = elem->neighbor(ms);
+          const Elem * neighbor = elem->neighbor_ptr(ms);
 
           if (neighbor != libmesh_nullptr)
             {
@@ -542,7 +542,7 @@ void ParmetisPartitioner::build_graph (const MeshBase & mesh)
                       // This does not assume a level-1 mesh.
                       // Note that since children have sides numbered
                       // coincident with the parent then this is a sufficient test.
-                      if (child->neighbor(ns) == elem)
+                      if (child->neighbor_ptr(ns) == elem)
                         {
                           libmesh_assert (child->active());
                           libmesh_assert (_global_index_by_pid_map.count(child->id()));

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -301,9 +301,9 @@ void Partitioner::set_parent_processor_ids(MeshBase & mesh)
               // than all the children!
               parent->invalidate_processor_id();
 
-              for(unsigned int c=0; c<parent->n_children(); c++)
+              for (unsigned int c=0; c<parent->n_children(); c++)
                 {
-                  child = parent->child(c);
+                  child = parent->child_ptr(c);
                   libmesh_assert(child);
                   libmesh_assert(!child->is_remote());
                   libmesh_assert_not_equal_to (child->processor_id(), DofObject::invalid_processor_id);

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -697,7 +697,7 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
            ++context.side )
         {
           // May not need to apply fluxes on non-boundary elements
-          if( (context.get_elem().neighbor(context.get_side()) != libmesh_nullptr) && !impose_internal_fluxes )
+          if( (context.get_elem().neighbor_ptr(context.get_side()) != libmesh_nullptr) && !impose_internal_fluxes )
             continue;
 
           // Impose boundary (e.g. Neumann) term

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -138,7 +138,7 @@ void assemble_unconstrained_element_system(const FEMSystem & _sys,
     {
       // Don't compute on non-boundary sides unless requested
       if (!_sys.get_physics()->compute_internal_sides &&
-          _femcontext.get_elem().neighbor(_femcontext.side) != libmesh_nullptr)
+          _femcontext.get_elem().neighbor_ptr(_femcontext.side) != libmesh_nullptr)
         continue;
 
       // Any mesh movement has already been done (and restored,
@@ -425,7 +425,7 @@ public:
             // Don't compute on non-boundary sides unless requested
             if (!_sys.postprocess_sides ||
                 (!_sys.get_physics()->compute_internal_sides &&
-                 _femcontext.get_elem().neighbor(_femcontext.side) != libmesh_nullptr))
+                 _femcontext.get_elem().neighbor_ptr(_femcontext.side) != libmesh_nullptr))
               continue;
 
             // Optionally initialize all the FE objects on this side.
@@ -553,7 +553,7 @@ public:
             // Don't compute on non-boundary sides unless requested
             if (!_diff_qoi.assemble_qoi_sides ||
                 (!_diff_qoi.assemble_qoi_internal_sides &&
-                 _femcontext.get_elem().neighbor(_femcontext.side) != libmesh_nullptr))
+                 _femcontext.get_elem().neighbor_ptr(_femcontext.side) != libmesh_nullptr))
               continue;
 
             _femcontext.side_fe_reinit();
@@ -724,7 +724,7 @@ public:
             // Don't compute on non-boundary sides unless requested
             if (!_qoi.assemble_qoi_sides ||
                 (!_qoi.assemble_qoi_internal_sides &&
-                 _femcontext.get_elem().neighbor(_femcontext.side) != libmesh_nullptr))
+                 _femcontext.get_elem().neighbor_ptr(_femcontext.side) != libmesh_nullptr))
               continue;
 
             _femcontext.side_fe_reinit();

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -326,9 +326,9 @@ protected:
             const Real master_tol = out_of_elem_tol / elem.hmax() * 2;
 
             for (unsigned int c=0; c != elem.n_children(); ++c)
-              if (elem.child(c)->close_to_point(p, master_tol))
+              if (elem.child_ptr(c)->close_to_point(p, master_tol))
                 {
-                  old_context.pre_fe_reinit(sys, elem.child(c));
+                  old_context.pre_fe_reinit(sys, elem.child_ptr(c));
                   break;
                 }
 
@@ -357,9 +357,9 @@ protected:
               (elem.refinement_flag(), Elem::JUST_COARSENED);
 
             for (unsigned int c=0; c != elem.n_children(); ++c)
-              if (elem.child(c)->close_to_point(p, master_tol))
+              if (elem.child_ptr(c)->close_to_point(p, master_tol))
                 {
-                  old_context.pre_fe_reinit(sys, elem.child(c));
+                  old_context.pre_fe_reinit(sys, elem.child_ptr(c));
                   break;
                 }
 
@@ -1533,7 +1533,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
                           if (!elem->is_child_on_edge(c, e))
                             continue;
 
-                          fine_fe->edge_reinit(elem->child(c), e);
+                          fine_fe->edge_reinit(elem->child_ptr(c), e);
                           fine_points.insert(fine_points.end(),
                                              child_xyz.begin(),
                                              child_xyz.end());
@@ -1722,7 +1722,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
                           if (!elem->is_child_on_side(c, s))
                             continue;
 
-                          fine_fe->reinit(elem->child(c), s);
+                          fine_fe->reinit(elem->child_ptr(c), s);
                           fine_points.insert(fine_points.end(),
                                              child_xyz.begin(),
                                              child_xyz.end());
@@ -1853,7 +1853,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
                   for (unsigned int c = 0;
                        c != elem->n_children(); ++c)
                     {
-                      fine_fe->reinit(elem->child(c));
+                      fine_fe->reinit(elem->child_ptr(c));
                       fine_points.insert(fine_points.end(),
                                          child_xyz.begin(),
                                          child_xyz.end());
@@ -2051,7 +2051,7 @@ void BuildProjectionList::operator()(const ConstElemRange & range)
           di.clear();
           for (unsigned int c=0; c != elem->n_children(); ++c)
             {
-              dof_map.old_dof_indices (elem->child(c), di_child);
+              dof_map.old_dof_indices (elem->child_ptr(c), di_child);
               di.insert(di.end(), di_child.begin(), di_child.end());
             }
         }

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -155,7 +155,7 @@ void TopologyMap::fill(const MeshBase & mesh)
 
       for (unsigned int c = 0; c != elem->n_children(); ++c)
         {
-          if (elem->child(c)->is_remote())
+          if (elem->child_ptr(c)->is_remote())
             continue;
 
           for (unsigned int n = 0; n != elem->n_nodes_in_child(c); ++n)
@@ -163,7 +163,7 @@ void TopologyMap::fill(const MeshBase & mesh)
               const std::vector<std::pair<dof_id_type, dof_id_type> >
                 bracketing_nodes = elem->bracketing_nodes(c,n);
 
-              this->add_node(elem->child(c)->node_ref(n),
+              this->add_node(elem->child_ptr(c)->node_ref(n),
                              bracketing_nodes);
             }
         }

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -389,8 +389,8 @@ public:
 
             for (unsigned int n=0; n != elem->n_nodes(); ++n)
               {
-                Node & node       = elem->node_ref(n);
-                Node & mesh1_node = mesh1_elem->node_ref(n);
+                const Node & node       = elem->node_ref(n);
+                const Node & mesh1_node = mesh1_elem->node_ref(n);
                 CPPUNIT_ASSERT_EQUAL( node.unique_id(),
                                       mesh1_node.unique_id() );
               }


### PR DESCRIPTION
This PR addresses some const-incorrectness issues we've had in the `Elem` class interface for a long time.  Given a `const Elem`, one could formerly obtain:

* A *non-const* pointer to all of its Nodes.
* A *non-const* pointer to all of its children.
* A *non-const* pointer to its neighbors.
* A *non-const* pointer to an Elem representing one of its sides.

all without an explicit `const cast`.  One could then modify these non-const objects (e.g. reposition nodes, etc.) and thereby indirectly modify the original `const Elem`.  This PR addresses these issues in a backwards-compatible way by adding const-correct versions of the various interfaces, e.g. `Elem::child()` now becomes `Elem::child_ptr()`, etc.  For the time being, the old interfaces are not even officially deprecated, but eventually they will be (and some day they'll even be removed!).  This PR also removes all instances of the old const-incorrect interfaces from the library and examples.