### PR TITLE
Add configure test for C++11 noexcept and libmesh_noexcept macro

### DIFF
--- a/configure
+++ b/configure
@@ -895,6 +895,8 @@ EGREP
 GREP
 SED
 LIBTOOL
+HAVE_CXX11_NOEXCEPT_FALSE
+HAVE_CXX11_NOEXCEPT_TRUE
 HAVE_CXX11_TO_STRING_FALSE
 HAVE_CXX11_TO_STRING_TRUE
 HAVE_CXX11_NULLPTR_WORKAROUND_FALSE
@@ -11147,6 +11149,92 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 else
   HAVE_CXX11_TO_STRING_TRUE='#'
   HAVE_CXX11_TO_STRING_FALSE=
+fi
+
+
+
+    have_cxx11_noexcept=no
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 noexcept support" >&5
+$as_echo_n "checking for C++11 noexcept support... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    # Save the original flags before appending the $switch determined
+    # by AX_CXX_COMPILE_STDCXX_11.  Note that this might append the
+    # same flag twice, but that shouldn't matter...
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch"
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      #include <stdexcept>
+
+      class MyException : public std::exception
+      {
+      public:
+        virtual const char * what() const noexcept
+        {
+          return "MyException description";
+        }
+      };
+
+int
+main ()
+{
+
+      throw MyException();
+      return 0;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+      if (test "x$enablecxx11" = "xyes"); then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_CXX11_NOEXCEPT 1" >>confdefs.h
+
+        have_cxx11_noexcept=yes
+      else
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, but disabled." >&5
+$as_echo "yes, but disabled." >&6; }
+
+$as_echo "#define HAVE_CXX11_NOEXCEPT_BUT_DISABLED 1" >>confdefs.h
+
+      fi
+
+else
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+    # Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+     if test x$have_cxx11_noexcept == xyes; then
+  HAVE_CXX11_NOEXCEPT_TRUE=
+  HAVE_CXX11_NOEXCEPT_FALSE='#'
+else
+  HAVE_CXX11_NOEXCEPT_TRUE='#'
+  HAVE_CXX11_NOEXCEPT_FALSE=
 fi
 
 
@@ -43209,6 +43297,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX11_TO_STRING_TRUE}" && test -z "${HAVE_CXX11_TO_STRING_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_TO_STRING\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${HAVE_CXX11_NOEXCEPT_TRUE}" && test -z "${HAVE_CXX11_NOEXCEPT_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_CXX11_NOEXCEPT\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${LIBMESH_ENABLE_INFINITE_ELEMENTS_TRUE}" && test -z "${LIBMESH_ENABLE_INFINITE_ELEMENTS_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -223,6 +223,7 @@ LIBMESH_TEST_CXX11_DELETED_FUNCTIONS
 LIBMESH_TEST_CXX11_FINAL
 LIBMESH_TEST_CXX11_NULLPTR
 LIBMESH_TEST_CXX11_TO_STRING
+LIBMESH_TEST_CXX11_NOEXCEPT
 
 #-----------------------------------------------------
 # Initialize libtool.  By default, we will build

--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -27,6 +27,12 @@
 #include <string>
 #include <sstream>
 
+#ifdef LIBMESH_HAVE_CXX11_NOEXCEPT
+#define libmesh_noexcept noexcept
+#else
+#define libmesh_noexcept throw()
+#endif
+
 namespace libMesh {
 
 /**
@@ -116,12 +122,12 @@ public:
   /**
    * Virtual destructor, gotta have one of those.
    */
-  virtual ~SolverException() throw() {};
+  virtual ~SolverException() libmesh_noexcept {};
 
   /**
    * Override the what() function to provide a generic error message.
    */
-  virtual const char * what() const throw()
+  virtual const char * what() const libmesh_noexcept
   {
     // std::string::c_str() is noexcept in C++11, so it's safe to call
     // in what() because it can't throw.

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -311,6 +311,12 @@
 /* Compiler supports std::move, but it is disabled in libmesh */
 #undef HAVE_CXX11_MOVE_BUT_DISABLED
 
+/* Flag indicating whether compiler supports noexcept */
+#undef HAVE_CXX11_NOEXCEPT
+
+/* Compiler supports noexcept, but it is disabled in libmesh */
+#undef HAVE_CXX11_NOEXCEPT_BUT_DISABLED
+
 /* Flag indicating whether compiler supports nullptr */
 #undef HAVE_CXX11_NULLPTR
 

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -1478,3 +1478,52 @@ AC_DEFUN([LIBMESH_TEST_CXX11_TO_STRING],
 
     AM_CONDITIONAL(HAVE_CXX11_TO_STRING, test x$have_cxx11_to_string == xyes)
   ])
+
+
+
+AC_DEFUN([LIBMESH_TEST_CXX11_NOEXCEPT],
+  [
+    have_cxx11_noexcept=no
+
+    AC_MSG_CHECKING(for C++11 noexcept support)
+    AC_LANG_PUSH([C++])
+
+    # Save the original flags before appending the $switch determined
+    # by AX_CXX_COMPILE_STDCXX_11.  Note that this might append the
+    # same flag twice, but that shouldn't matter...
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch"
+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      @%:@include <stdexcept>
+
+      class MyException : public std::exception
+      {
+      public:
+        virtual const char * what() const noexcept
+        {
+          return "MyException description";
+        }
+      };
+    ]], [[
+      throw MyException();
+      return 0;
+    ]])],[
+      if (test "x$enablecxx11" = "xyes"); then
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_CXX11_NOEXCEPT, 1, [Flag indicating whether compiler supports noexcept])
+        have_cxx11_noexcept=yes
+      else
+        AC_MSG_RESULT([yes, but disabled.])
+        AC_DEFINE(HAVE_CXX11_NOEXCEPT_BUT_DISABLED, 1, [Compiler supports noexcept, but it is disabled in libmesh])
+      fi
+    ],[
+      AC_MSG_RESULT(no)
+    ])
+
+    # Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    AC_LANG_POP([C++])
+
+    AM_CONDITIONAL(HAVE_CXX11_NOEXCEPT, test x$have_cxx11_noexcept == xyes)
+  ])


### PR DESCRIPTION
When C++11 is not available, we fall back on the C++03 `throw()` specification.

Refs #655. 