### PR TITLE
A few Elem::volume() optimizations

### DIFF
--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -1036,6 +1036,43 @@ T triple_product(const TypeVector<T> & a,
     a(2)*(b(0)*c(1) - b(1)*c(0));
 }
 
+
+
+/**
+ * Compute |b x c|^2 without creating the extra temporary produced by
+ * calling b.cross(c).norm_sq().
+ */
+template <typename T>
+inline
+T cross_norm_sq(const TypeVector<T> & b,
+                const TypeVector<T> & c)
+{
+  // We only support cross products when LIBMESH_DIM==3, same goes for this.
+  libmesh_assert_equal_to (LIBMESH_DIM, 3);
+
+  T x = b(1)*c(2) - b(2)*c(1),
+    y = b(0)*c(2) - b(2)*c(0),
+    z = b(0)*c(1) - b(1)*c(0);
+
+  return x*x + y*y + z*z;
+}
+
+
+
+/**
+ * Calls cross_norm_sq() and takes the square root of the result.
+ */
+template <typename T>
+inline
+T cross_norm(const TypeVector<T> & b,
+             const TypeVector<T> & c)
+{
+  // We only support cross products when LIBMESH_DIM==3, same goes for this.
+  libmesh_assert_equal_to (LIBMESH_DIM, 3);
+
+  return std::sqrt(cross_norm_sq(b,c));
+}
+
 } // namespace libMesh
 
 #endif // LIBMESH_TYPE_VECTOR_H

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -331,28 +331,25 @@ Real Hex8::volume () const
   // \vec{x}_{\eta}  = \vec{a2}*xi*zeta  + \vec{b2}*xi  + \vec{c2}*zeta + \vec{d2}
   // \vec{x}_{\zeta} = \vec{a3}*xi*eta   + \vec{b3}*xi  + \vec{c3}*eta  + \vec{d3}
   // but it turns out that a1, a2, and a3 are not needed for the volume calculation.
-  // This is copy-pasted directly from the output of a Python script, other
-  // than division by 8, which is done at the end when the volume is returned.
-  Point
-    b1 = x0 - x1 + x2 - x3 + x4 - x5 + x6 - x7,
-    c1 = x0 - x1 - x2 + x3 - x4 + x5 + x6 - x7,
-    d1 = -x0 + x1 + x2 - x3 - x4 + x5 + x6 - x7,
 
-    b2 = b1,
-    c2 = x0 + x1 - x2 - x3 - x4 - x5 + x6 + x7,
-    d2 = -x0 - x1 + x2 + x3 - x4 - x5 + x6 + x7,
+  // Build up the 6 unique vectors which make up dx/dxi, dx/deta, and dx/dzeta.
+  Point q[6] =
+    {
+      /*b1*/  x0 - x1 + x2 - x3 + x4 - x5 + x6 - x7, /*=b2*/
+      /*c1*/  x0 - x1 - x2 + x3 - x4 + x5 + x6 - x7, /*=b3*/
+      /*d1*/ -x0 + x1 + x2 - x3 - x4 + x5 + x6 - x7,
+      /*c2*/  x0 + x1 - x2 - x3 - x4 - x5 + x6 + x7, /*=c3*/
+      /*d2*/ -x0 - x1 + x2 + x3 - x4 - x5 + x6 + x7,
+      /*d3*/ -x0 - x1 - x2 - x3 + x4 + x5 + x6 + x7
+    };
 
-    b3 = c1,
-    c3 = c2,
-    d3 = -x0 - x1 - x2 - x3 + x4 + x5 + x6 + x7;
-
-  // We could check for a quick return, but it's almost faster to just
-  // compute the result...
+  // We could check for a linear element, but it's probably faster to
+  // just compute the result...
   return
-    (triple_product(b1,d2,c3) +
-     triple_product(d1,b2,b3) +
-     triple_product(c1,c2,d3)) / 192. +
-    triple_product(d1,d2,d3) / 64.;
+    (triple_product(q[0], q[4], q[3]) +
+     triple_product(q[2], q[0], q[1]) +
+     triple_product(q[1], q[3], q[5])) / 192. +
+    triple_product(q[2], q[4], q[5]) / 64.;
 }
 
 } // namespace libMesh

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -220,7 +220,8 @@ Real Quad4::volume () const
   Real vol=0.;
   for (unsigned int i=0; i<2; ++i)
     for (unsigned int j=0; j<2; ++j)
-      vol += (q[j]*a1 + b1).cross(q[i]*a2 + b2).norm();
+      vol += cross_norm(q[j]*a1 + b1,
+                        q[i]*a2 + b2);
 
   return vol;
 }

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -403,8 +403,8 @@ Real Quad8::volume () const
   Real vol=0.;
   for (unsigned int i=0; i<N; ++i)
     for (unsigned int j=0; j<N; ++j)
-      vol += (q[j]*q[j]*a1 + q[i]*q[j]*b1 + q[i]*c1 + q[j]*d1 + e1).
-        cross(q[i]*q[i]*a2 + q[i]*q[j]*b2 + q[i]*c2 + q[j]*d2 + e2).norm() * w[i] * w[j];
+      vol += w[i] * w[j] * cross_norm(q[j]*q[j]*a1 + q[i]*q[j]*b1 + q[i]*c1 + q[j]*d1 + e1,
+                                      q[i]*q[i]*a2 + q[i]*q[j]*b2 + q[i]*c2 + q[j]*d2 + e2);
 
   return vol;
 }

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -390,8 +390,9 @@ Real Quad9::volume () const
   Real vol=0.;
   for (unsigned int i=0; i<N; ++i)
     for (unsigned int j=0; j<N; ++j)
-      vol += (q[i]*q[j]*q[j]*a1 + q[j]*q[j]*b1 + q[j]*q[i]*c1 + q[i]*d1 + q[j]*e1 + f1).
-        cross(q[i]*q[i]*q[j]*a2 + q[i]*q[i]*b2 + q[j]*q[i]*c2 + q[i]*d2 + q[j]*e2 + f2).norm() * w[i] * w[j];
+      vol += w[i] * w[j] *
+        cross_norm(q[i]*q[j]*q[j]*a1 + q[j]*q[j]*b1 + q[j]*q[i]*c1 + q[i]*d1 + q[j]*e1 + f1,
+                   q[i]*q[i]*q[j]*a2 + q[i]*q[i]*b2 + q[j]*q[i]*c2 + q[i]*d2 + q[j]*e2 + f2);
 
   return vol;
 }

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -172,11 +172,8 @@ void Tri3::connectivity(const unsigned int libmesh_dbg_var(sf),
 Real Tri3::volume () const
 {
   // 3-node triangles have the following formula for computing the area
-  Point v10 ( this->point(1) - this->point(0) );
-
-  Point v20 ( this->point(2) - this->point(0) );
-
-  return 0.5 * (v10.cross(v20)).norm() ;
+  return 0.5 * cross_norm(point(1) - point(0),
+                          point(2) - point(0));
 }
 
 


### PR DESCRIPTION
Avoid making a few unnecessary `Point` copies and add `TypeVector::cross_norm(a,b)` which is slightly more efficient than doing `a.cross(b).norm()`.