### PR TITLE
Add optimized version of Tet4::contains_point()

### DIFF
--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -187,6 +187,12 @@ public:
    */
   virtual dof_id_type key () const libmesh_override;
 
+  /**
+   * Uses simple geometric tests to determine if the point p is inside
+   * the tetrahedron.
+   */
+  virtual bool contains_point (const Point & p, Real tol) const libmesh_override;
+
 protected:
 
   /**

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -23,6 +23,7 @@
 #include "libmesh/cell_tet4.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/face_tri3.h"
+#include "libmesh/tensor_value.h"
 
 namespace libMesh
 {
@@ -332,6 +333,31 @@ dof_id_type Tet4::key () const
                            this->node_id(1),
                            this->node_id(2),
                            this->node_id(3));
+}
+
+
+
+bool Tet4::contains_point (const Point & p, Real tol) const
+{
+  // See the response by Tony Noe on this thread.
+  // http://bbs.dartmouth.edu/~fangq/MATH/download/source/Point_in_Tetrahedron.htm
+  Point
+    col1 = point(1) - point(0),
+    col2 = point(2) - point(0),
+    col3 = point(3) - point(0);
+
+  RealTensorValue V(col1(0), col2(0), col3(0),
+                    col1(1), col2(1), col3(1),
+                    col1(2), col2(2), col3(2));
+  Point r = V.inverse() * (p - point(0));
+
+  // The point p is inside the tetrahedron if r1 + r2 + r3 < 1 and
+  // 0 <= ri <= 1 for i = 1,2,3.
+  return
+    r(0) > -tol &&
+    r(1) > -tol &&
+    r(2) > -tol &&
+    r(0) + r(1) + r(2) < 1.0 + tol;
 }
 
 

--- a/tests/mesh/contains_point.C
+++ b/tests/mesh/contains_point.C
@@ -23,6 +23,8 @@ public:
 
   CPPUNIT_TEST( testContainsPointTri3 );
 
+  CPPUNIT_TEST( testContainsPointTet4 );
+
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -64,6 +66,76 @@ public:
     CPPUNIT_ASSERT (!elem->contains_point(a + va * TOLERANCE * 10));
     CPPUNIT_ASSERT (!elem->contains_point(b + vb * TOLERANCE * 10));
     CPPUNIT_ASSERT (!elem->contains_point(c - (va + vb) * TOLERANCE * 10));
+  }
+
+
+
+  // TET4 test
+  void testContainsPointTet4()
+  {
+    // Construct unit Tet.
+    {
+      Node zero  (0., 0., 0., 0);
+      Node one   (1., 0., 0., 1);
+      Node two   (0., 1., 0., 2);
+      Node three (0., 0., 1., 3);
+
+      UniquePtr<Elem> elem = Elem::build(TET4);
+      elem->set_node(0) = &zero;
+      elem->set_node(1) = &one;
+      elem->set_node(2) = &two;
+      elem->set_node(3) = &three;
+
+      // The centroid must be inside the element.
+      CPPUNIT_ASSERT (elem->contains_point(elem->centroid()));
+
+      // The vertices must be contained in the element.
+      CPPUNIT_ASSERT (elem->contains_point(zero));
+      CPPUNIT_ASSERT (elem->contains_point(one));
+      CPPUNIT_ASSERT (elem->contains_point(two));
+      CPPUNIT_ASSERT (elem->contains_point(three));
+
+      // Make sure that outside points are not contained.
+      CPPUNIT_ASSERT (!elem->contains_point(Point(.34, .34, .34)));
+      CPPUNIT_ASSERT (!elem->contains_point(Point(.33, .33, -.1)));
+      CPPUNIT_ASSERT (!elem->contains_point(Point(0., -.1, .5)));
+    }
+
+
+    // Construct a nearly degenerate (sliver) tet.  A unit tet with
+    // nodes "one" and "two" moved to within a distance of epsilon
+    // from the origin.
+    {
+      Real epsilon = 1.e-4;
+
+      Node zero  (0., 0., 0., 0);
+      Node one   (epsilon, 0., 0., 1);
+      Node two   (0., epsilon, 0., 2);
+      Node three (0., 0., 1., 3);
+
+      UniquePtr<Elem> elem = Elem::build(TET4);
+      elem->set_node(0) = &zero;
+      elem->set_node(1) = &one;
+      elem->set_node(2) = &two;
+      elem->set_node(3) = &three;
+
+      // The centroid must be inside the element.
+      CPPUNIT_ASSERT (elem->contains_point(elem->centroid()));
+
+      // The vertices must be contained in the element.
+      CPPUNIT_ASSERT (elem->contains_point(zero));
+      CPPUNIT_ASSERT (elem->contains_point(one));
+      CPPUNIT_ASSERT (elem->contains_point(two));
+      CPPUNIT_ASSERT (elem->contains_point(three));
+
+      // Verify that a point which is on a mid-edge is contained in the element.
+      CPPUNIT_ASSERT (elem->contains_point(Point(epsilon/2, 0, 0.5)));
+
+      // Make sure that "just barely" outside points are outside.
+      CPPUNIT_ASSERT (!elem->contains_point(Point(epsilon, epsilon, epsilon/2)));
+      CPPUNIT_ASSERT (!elem->contains_point(Point(epsilon/10, epsilon/10, 1.0)));
+      CPPUNIT_ASSERT (!elem->contains_point(Point(epsilon/2, -epsilon/10, 0.5)));
+    }
   }
 };
 


### PR DESCRIPTION
Following on the heels of #990, this is a related optimization for Tet4.  I also added some unit tests.  

@dschwen If the volume of the Tet is identically zero, the call to `inverse()` divides by zero and either asserts in dbg mode, or produces NaNs. In the latter case, the function always returns false, which I think is reasonable for a degenerate element (no points are ever contained in such an element).
