### PR TITLE
Add TypeTensor::solve()

### DIFF
--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -1761,9 +1761,9 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
             //  {dp} = [J]^-1 ({X} - {X_n})
             //
             //  which involves the inversion of the 3x3 matrix [J]
-            dp = RealTensorValue(dxi(0), deta(0), dzeta(0),
-                                 dxi(1), deta(1), dzeta(1),
-                                 dxi(2), deta(2), dzeta(2)).inverse() * delta;
+            RealTensorValue(dxi(0), deta(0), dzeta(0),
+                            dxi(1), deta(1), dzeta(1),
+                            dxi(2), deta(2), dzeta(2)).solve(delta, dp);
 
             // No master elements have radius > 4, but sometimes we
             // can take a step that big while still converging

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -346,10 +346,10 @@ bool Tet4::contains_point (const Point & p, Real tol) const
     col2 = point(2) - point(0),
     col3 = point(3) - point(0);
 
-  RealTensorValue V(col1(0), col2(0), col3(0),
-                    col1(1), col2(1), col3(1),
-                    col1(2), col2(2), col3(2));
-  Point r = V.inverse() * (p - point(0));
+  Point r;
+  RealTensorValue(col1(0), col2(0), col3(0),
+                  col1(1), col2(1), col3(1),
+                  col1(2), col2(2), col3(2)).solve(p - point(0), r);
 
   // The point p is inside the tetrahedron if r1 + r2 + r3 < 1 and
   // 0 <= ri <= 1 for i = 1,2,3.


### PR DESCRIPTION
This knocked a further 3.7 seconds off the test discussed in #996.  Also replaced a call in `FE::inverse_map` so that should speed up a bit as well.