### PR TITLE
Add missing rehash call in Automatic Differentiation

### DIFF
--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -397,7 +397,7 @@ int FunctionParserADBase<Value_t>::AutoDiff(const std::string& var_name)
 
     // should and can we load a cached derivative?
     std::string cache_file;
-    const std::string jitdir = ".jitdir";
+    const std::string jitdir = ".jitcache";
     if (cached)
     {
       // generate a sha1 hash of the Value type size, byte code, and immediate list

--- a/contrib/fparser/fparser_ad.cc
+++ b/contrib/fparser/fparser_ad.cc
@@ -188,14 +188,14 @@ typename ADImplementation<Value_t>::CodeTreeAD ADImplementation<Value_t>::D(cons
 {
   // derivative of a constant number is 0
   if (func.IsImmed())
-    return CodeTreeAD(CodeTreeImmed(Value_t(0)));
+    return CodeTreeAD(0);
 
   // derivative of a variable is 1 for the variable we are diffing w.r.t. and 0 otherwise
   if (func.IsVar())
   {
     if (func.GetVar() == var) {
       // dx/dx = 1
-      return CodeTreeAD(CodeTreeImmed(Value_t(1)));
+      return CodeTreeAD(1);
     } else {
       // check if this derivative is registered
       typename std::vector<typename FunctionParserADBase<Value_t>::VariableDerivative>::const_iterator it;
@@ -205,7 +205,7 @@ typename ADImplementation<Value_t>::CodeTreeAD ADImplementation<Value_t>::D(cons
           return CodeTreeAD(CodeTreeVar<Value_t>(it->derivative));
 
       // otherwise return zero
-      return CodeTreeAD(CodeTreeImmed(Value_t(0)));
+      return CodeTreeAD(0);
     }
   }
 
@@ -249,6 +249,7 @@ typename ADImplementation<Value_t>::CodeTreeAD ADImplementation<Value_t>::D(cons
         sub.SetOpcode(cMul);
         for (j = 0; j < nparam; ++j)
           sub.AddParam(i==j ? D(param[j]) : param[j]);
+        sub.Rehash();
         diff.AddParam(sub);
       }
       diff.Rehash();
@@ -297,7 +298,7 @@ typename ADImplementation<Value_t>::CodeTreeAD ADImplementation<Value_t>::D(cons
         if (exponent == Value_t(1))
           return D(a);
         if (exponent == Value_t(0))
-          return CodeTreeAD(CodeTreeImmed(Value_t(0)));
+          return CodeTreeAD(0);
         return MakeTree(cPow, a, CodeTreeAD(exponent - Value_t(1))) * b * D(a);
       }
       return MakeTree(cPow, a, b) * (D(b) * MakeTree(cLog, a) + b * D(a)/a);
@@ -356,7 +357,7 @@ typename ADImplementation<Value_t>::CodeTreeAD ADImplementation<Value_t>::D(cons
     case cLessOrEq:
     case cGreater:
     case cGreaterOrEq:
-      return CodeTreeAD(CodeTreeImmed(Value_t(0)));
+      return CodeTreeAD(0);
 
     // these opcodes will never appear in the tree when building with keep_powi == false
     // they will be replaced by cPow, cMul, cDiv etc.:
@@ -508,13 +509,7 @@ template<typename Value_t>
 int ADImplementation<Value_t>::AutoDiff(unsigned int _var, typename FunctionParserADBase<Value_t>::Data * mData, bool autoOptimize)
 {
   CodeTreeAD orig;
-
-  std::vector<CodeTree<Value_t> > var_trees;
-  var_trees.reserve(mData->mVariablesAmount);
-  for(unsigned n=0; n<mData->mVariablesAmount; ++n)
-    var_trees.push_back(CodeTreeVar<Value_t>(n + VarBegin));
-
-  orig.GenerateFrom(*mData, var_trees, false);
+  orig.GenerateFrom(*mData, false);
 
   // store variable we are diffing for as a member
   var = _var;


### PR DESCRIPTION
Ok, rehash issue was right on the money. Still took me only six more hours to pin it down and fix it :-(
This is actually quite a critical bug, that is exposed by a recent change that causes AD results to be immediately optimized without an expensive round-trip via the bytecode representation. 

The immediate optimize speeds up the AD process considerably, but leaves my with the responsibility to build all hashes for the code tree of the derived expression. Stale hashes can fool the optimizer into thinking that terms are the same that are not at all the same, leading to possible eliminations of expressions that are not really zero.

The crucial change is on line 252, where the subexpressions in a multiplication were _not_ rehashed, the rest are simplifications.

Closes #998