### PR TITLE
Adding configure tests for Boost Move's unique_ptr

### DIFF
--- a/configure
+++ b/configure
@@ -33768,6 +33768,51 @@ else
 fi
 
 
+
+  have_boost_unique_ptr=no
+  if (test x$enableboost = xyes); then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for boost::movelib::unique_ptr support" >&5
+$as_echo_n "checking for boost::movelib::unique_ptr support... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include "boost/move/unique_ptr.hpp"
+
+int
+main ()
+{
+
+        boost::movelib::unique_ptr<double> x(new double);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+        have_boost_unique_ptr=yes
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_BOOST_MOVELIB_UNIQUE_PTR 1" >>confdefs.h
+
+
+else
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  fi
+
 ac_config_files="$ac_config_files contrib/boost/include/Makefile"
 
 # --------------------------------------------------------------
@@ -33792,6 +33837,10 @@ fi
 
   # Shell variable that will eventually be used to set the AM_CONDITIONAL
   install_hinnant_unique_ptr=no
+
+  if (test x$have_boost_unique_ptr = xyes); then
+    enablehinnant=no
+  fi
 
   # If the user did not explicitly disable it, do some more testing
   if (test x$enablehinnant = xyes); then

--- a/configure
+++ b/configure
@@ -33780,6 +33780,11 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
+    # Store the old value of CXXFLAGS, then append BOOST_CPPFLAGS which was
+    # determined by AX_BOOST_BASE.
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $BOOST_CPPFLAGS"
+
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -33811,6 +33816,15 @@ $as_echo "no" >&6; }
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+    # Reset old flags
+    CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
   fi
 
 ac_config_files="$ac_config_files contrib/boost/include/Makefile"

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -501,18 +501,14 @@ void set_system_parameters(FEMSystem & system,
           timesolver->upper_tolerance  = param.timesolver_upper_tolerance;
           timesolver->component_norm   = SystemNorm(param.timesolver_norm);
 
-          timesolver->core_time_solver =
-            UniquePtr<UnsteadySolver>(innersolver);
-          system.time_solver =
-            UniquePtr<UnsteadySolver>(timesolver);
+          timesolver->core_time_solver.reset(innersolver);
+          system.time_solver.reset(timesolver);
         }
       else
-        system.time_solver =
-          UniquePtr<TimeSolver>(innersolver);
+        system.time_solver.reset(innersolver);
     }
   else
-    system.time_solver =
-      UniquePtr<TimeSolver>(new SteadySolver(system));
+    system.time_solver.reset(new SteadySolver(system));
 
   system.time_solver->reduce_deltat_on_diffsolver_failure =
     param.deltat_reductions;
@@ -529,7 +525,7 @@ void set_system_parameters(FEMSystem & system,
     {
 #ifdef LIBMESH_HAVE_PETSC
       PetscDiffSolver *solver = new PetscDiffSolver(system);
-      system.time_solver->diff_solver() = UniquePtr<DiffSolver>(solver);
+      system.time_solver->diff_solver().reset(solver);
 #else
       libmesh_error_msg("This example requires libMesh to be compiled with PETSc support.");
 #endif
@@ -537,7 +533,7 @@ void set_system_parameters(FEMSystem & system,
   else
     {
       NewtonSolver *solver = new NewtonSolver(system);
-      system.time_solver->diff_solver() = UniquePtr<DiffSolver>(solver);
+      system.time_solver->diff_solver().reset(solver);
 
       solver->quiet                       = param.solver_quiet;
       solver->verbose                     = !param.solver_quiet;

--- a/include/base/auto_ptr.h
+++ b/include/base/auto_ptr.h
@@ -45,6 +45,14 @@ namespace libMesh
 template<typename T>
 using UniquePtr = std::unique_ptr<T>;
 }
+#elif LIBMESH_HAVE_BOOST_MOVELIB_UNIQUE_PTR
+#  include "boost/move/unique_ptr.hpp"
+#  define UniquePtr unique_ptr
+namespace libMesh
+{
+// Declare that we are using boost Move's unique_ptr type
+using boost::movelib::unique_ptr;
+}
 #elif LIBMESH_HAVE_HINNANT_UNIQUE_PTR
 // As per Roy's suggestion, use a combination of a macro and a 'using'
 // statement to make libMesh's UniquePtr type equivalent to the

--- a/include/base/auto_ptr.h
+++ b/include/base/auto_ptr.h
@@ -46,7 +46,15 @@ template<typename T>
 using UniquePtr = std::unique_ptr<T>;
 }
 #elif LIBMESH_HAVE_BOOST_MOVELIB_UNIQUE_PTR
+// Disable warnings from boost header files under clang
+#  ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wunused-local-typedef"
+#  endif
 #  include "boost/move/unique_ptr.hpp"
+#  ifdef __clang__
+#    pragma clang diagnostic pop
+#  endif
 #  define UniquePtr unique_ptr
 namespace libMesh
 {

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -190,6 +190,10 @@
 /* define if the Boost library is available */
 #undef HAVE_BOOST
 
+/* Flag indicating whether the library will use Boost Move's unique_ptr
+   implementation */
+#undef HAVE_BOOST_MOVELIB_UNIQUE_PTR
+
 /* Flag indicating bzip2/bunzip2 are available for handling compressed .bz2
    files */
 #undef HAVE_BZIP

--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -63,3 +63,24 @@ AC_DEFUN([CONFIGURE_BOOST],
 
   AM_CONDITIONAL(LIBMESH_INSTALL_INTERNAL_BOOST, test x$install_internal_boost = xyes)
 ])
+
+AC_DEFUN([LIBMESH_TEST_BOOST_MOVELIB_UNIQUE_PTR],
+[
+  have_boost_unique_ptr=no
+  if (test x$enableboost = xyes); then
+    AC_MSG_CHECKING(for boost::movelib::unique_ptr support)
+    AC_LANG_PUSH([C++])
+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include "boost/move/unique_ptr.hpp"
+    ]], [[
+        boost::movelib::unique_ptr<double> x(new double);
+    ]])],[
+        have_boost_unique_ptr=yes
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_BOOST_MOVELIB_UNIQUE_PTR, 1, [Flag indicating whether the library will use Boost Move's unique_ptr implementation])
+    ],[
+        AC_MSG_RESULT(no)
+    ])
+  fi
+])

--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -71,6 +71,11 @@ AC_DEFUN([LIBMESH_TEST_BOOST_MOVELIB_UNIQUE_PTR],
     AC_MSG_CHECKING(for boost::movelib::unique_ptr support)
     AC_LANG_PUSH([C++])
 
+    # Store the old value of CXXFLAGS, then append BOOST_CPPFLAGS which was
+    # determined by AX_BOOST_BASE.
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $BOOST_CPPFLAGS"
+
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     @%:@include "boost/move/unique_ptr.hpp"
     ]], [[
@@ -82,5 +87,9 @@ AC_DEFUN([LIBMESH_TEST_BOOST_MOVELIB_UNIQUE_PTR],
     ],[
         AC_MSG_RESULT(no)
     ])
+
+    # Reset old flags
+    CXXFLAGS="$old_CXXFLAGS"
+    AC_LANG_POP([C++])
   fi
 ])

--- a/m4/hinnant_unique_ptr.m4
+++ b/m4/hinnant_unique_ptr.m4
@@ -18,6 +18,10 @@ AC_DEFUN([CONFIGURE_HINNANT_UNIQUE_PTR],
   # Shell variable that will eventually be used to set the AM_CONDITIONAL
   install_hinnant_unique_ptr=no
 
+  if (test x$have_boost_unique_ptr = xyes); then
+    enablehinnant=no
+  fi
+
   # If the user did not explicitly disable it, do some more testing
   if (test x$enablehinnant = xyes); then
 

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -89,6 +89,7 @@ AC_ARG_ENABLE(nested,
 # Boost -- enabled by default
 # -------------------------------------------------------------
 CONFIGURE_BOOST
+LIBMESH_TEST_BOOST_MOVELIB_UNIQUE_PTR
 AC_CONFIG_FILES([contrib/boost/include/Makefile])
 # --------------------------------------------------------------
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -402,13 +402,17 @@ void MeshTools::find_boundary_nodes (const MeshBase & mesh,
 
   for (; el != end; ++el)
     for (unsigned int s=0; s<(*el)->n_neighbors(); s++)
-      if ((*el)->neighbor_ptr(s) == libmesh_nullptr) // on the boundary
-        {
-          const UniquePtr<const Elem> side((*el)->build_side_ptr(s));
+      {
+        const Elem * elem = *el;
 
-          for (unsigned int n=0; n<side->n_nodes(); n++)
-            on_boundary[side->node_id(n)] = true;
-        }
+        if (elem->neighbor_ptr(s) == libmesh_nullptr) // on the boundary
+          {
+            const UniquePtr<const Elem> side = elem->build_side_ptr(s);
+
+            for (unsigned int n=0; n<side->n_nodes(); n++)
+              on_boundary[side->node_id(n)] = true;
+          }
+      }
 }
 
 


### PR DESCRIPTION
This tries to use Boost Move's unique_ptr implementation if available instead of the bundled unique_ptr, to avoid namespace clashes when using an external Boost lib that includes boost::move.