### PR TITLE
*Really* fix the shell boundary test

### DIFF
--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -221,11 +221,12 @@ public:
     elem_bottom->set_node(2) = mesh.node_ptr(1);
     elem_bottom->set_node(3) = mesh.node_ptr(0);
 
-    mesh.prepare_for_use(false /*skip_renumber*/);
-
     BoundaryInfo & bi = mesh.get_boundary_info();
     bi.add_shellface(elem_top, 0, 10);
     bi.add_shellface(elem_bottom, 1, 20);
+
+    mesh.prepare_for_use(false /*skip_renumber*/);
+
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(2), bi.n_shellface_conds());
 
     EquationSystems es(mesh);

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -52,23 +52,41 @@ public:
                                         0., 1.,
                                         QUAD4);
 
-    // build_square adds boundary_ids 0,1,2,3 for the bottom, right,
-    // top, and left sides, respectively.  Let's test that we can
-    // remove them successfully.
     BoundaryInfo & bi = mesh.get_boundary_info();
+
+    // Side lists should be cleared and refilled by each call
+    std::vector<dof_id_type> element_id_list;
+    std::vector<unsigned short int> side_list;
+    std::vector<boundary_id_type> bc_id_list;
+
+    // build_square adds boundary_ids 0,1,2,3 for the bottom, right,
+    // top, and left sides, respectively.
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(4), bi.n_boundary_ids());
+
+    // Build the side list
+    bi.build_side_list (element_id_list, side_list, bc_id_list);
+
+    // Check that there are exactly 8 sides in the BoundaryInfo for a
+    // replicated mesh
+    if (mesh.is_serial())
+      CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(8), element_id_list.size());
+
+    // Let's test that we can remove them successfully.
     bi.remove_id(0);
 
     // Check that there are now only 3 boundary ids total on the Mesh.
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(3), bi.n_boundary_ids());
 
-    // Build the side list
-    std::vector<dof_id_type> element_id_list;
-    std::vector<unsigned short int> side_list;
-    std::vector<boundary_id_type> bc_id_list;
+    // Build the side list again
     bi.build_side_list (element_id_list, side_list, bc_id_list);
 
-    // Check that there are now exactly 6 sides left in the BoundaryInfo
-    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(6), element_id_list.size());
+    // Check that there are now exactly 6 sides left in the
+    // BoundaryInfo on a replicated mesh
+    if (mesh.is_serial())
+      CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(6), element_id_list.size());
+
+    // Check that the removed ID is really removed
+    CPPUNIT_ASSERT(std::find(bc_id_list.begin(), bc_id_list.end(), 0) == bc_id_list.end());
 
     // Remove the same id again, make sure nothing changes.
     bi.remove_id(0);

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -5,7 +5,6 @@
 #include <libmesh/restore_warnings.h>
 
 #include <libmesh/mesh.h>
-#include <libmesh/serial_mesh.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/boundary_info.h>
 #include <libmesh/elem.h>
@@ -165,7 +164,7 @@ public:
   void testShellFaceConstraints()
   {
     // Make a simple two element mesh that we can use to test constraints
-    ReplicatedMesh mesh(*TestCommWorld, 3);
+    Mesh mesh(*TestCommWorld, 3);
 
     /*
       (0,1)           (1,1)
@@ -233,11 +232,15 @@ public:
     std::vector<dof_id_type> dof_indices;
     system.get_dof_map().dof_indices(elem_bottom, dof_indices);
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(4), dof_indices.size());
-    for(unsigned int i=0; i<dof_indices.size(); i++)
-      {
-        dof_id_type dof_id = dof_indices[i];
-        CPPUNIT_ASSERT( system.get_dof_map().is_constrained_dof(dof_id) );
-      }
+
+    // But we may only know about that constraint on the processor
+    // which owns elem_bottom
+    if (elem_bottom->processor_id() == mesh.processor_id())
+      for(unsigned int i=0; i<dof_indices.size(); i++)
+        {
+          dof_id_type dof_id = dof_indices[i];
+          CPPUNIT_ASSERT( system.get_dof_map().is_constrained_dof(dof_id) );
+        }
   }
 
 };


### PR DESCRIPTION
We don't actually need to enforce mesh serialization here, we just need to make sure we're only testing for constraints on processors that know about the constraints.