### PR TITLE
fix detection of vtk 6.0

### DIFF
--- a/configure
+++ b/configure
@@ -40029,7 +40029,7 @@ _ACEOF
                   if (test $vtkmajor -eq 5); then
            VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
 
-                  elif (test $vtkmajor -eq 6 -a $vtkminor -eq 1); then
+                  elif (test $vtkmajor -eq 6 -a $vtkminor -le 1); then
            VTK_LIBRARY_WITH_VERSION="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                      -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
                                      -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor"

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -164,7 +164,7 @@ AC_DEFUN([CONFIGURE_VTK],
            VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
 
          dnl VTK 6.1.x
-         elif (test $vtkmajor -eq 6 -a $vtkminor -eq 1); then
+         elif (test $vtkmajor -eq 6 -a $vtkminor -le 1); then
            VTK_LIBRARY_WITH_VERSION="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                      -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
                                      -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor"


### PR DESCRIPTION
vtk in version 6.0 was improperly detected: the test
designed for vtk 6.2 was run and failed. This fix changes
the code for detecting vtk 6.1 to also match on vtk 6.0