### PR TITLE
Allow mesh function to return multiple values when point is near face

### DIFF
--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -123,6 +123,15 @@ public:
                      const Real time=0.) libmesh_override;
 
   /**
+   * @returns a map of values of variable 0 at point
+   * \p p and for \p time.
+   * map is from element to Number and accounts for double defined
+   * values on faces if discontinuous variables are used
+   */
+  std::map<const Elem *, Number> discontinuous_value (const Point & p,
+                                                      const Real time=0.);
+
+  /**
    * @returns the first derivatives of variable 0 at point
    * \p p and for \p time, which defaults to zero.
    */
@@ -157,6 +166,25 @@ public:
                    const Real time,
                    DenseVector<Number> & output,
                    const std::set<subdomain_id_type> * subdomain_ids);
+
+  /**
+   * Similar to operator() with the same parameter list, but with the difference
+   * that multiple values on faces are explicitly permitted. This is useful for
+   * discontinuous shape functions that are evaluated on faces.
+   */
+  void discontinuous_value (const Point & p,
+                            const Real time,
+                            std::map<const Elem *, DenseVector<Number> > & output);
+
+  /**
+   * Similar to operator() with the same parameter list, but with the difference
+   * that multiple values on faces are explicitly permitted. This is useful for
+   * discontinuous shape functions that are evaluated on faces.
+   */
+  void discontinuous_value (const Point & p,
+                            const Real time,
+                            std::map<const Elem *, DenseVector<Number> > & output,
+                            const std::set<subdomain_id_type> * subdomain_ids);
 
   /**
    * Computes gradients at coordinate \p p and for time \p time, which
@@ -236,6 +264,13 @@ protected:
    */
   const Elem * find_element(const Point & p,
                             const std::set<subdomain_id_type> * subdomain_ids = libmesh_nullptr) const;
+
+  /**
+   * Similar to find_element but returns all elements that are close to a point
+   * to cover cases where p is on the boundary
+   */
+  std::set<const Elem *> find_elements(const Point & p,
+                                       const std::set<subdomain_id_type> * subdomain_ids = libmesh_nullptr) const;
 
   /**
    * The equation systems handler, from which

--- a/include/mesh/mesh_function.h
+++ b/include/mesh/mesh_function.h
@@ -138,6 +138,15 @@ public:
   Gradient gradient (const Point & p,
                      const Real time=0.);
 
+  /**
+   * @returns a map of first derivatives (gradients) of variable 0 at point
+   * \p p and for \p time.
+   * map is from element to Gradient and accounts for double defined
+   * values on faces if the gradient is discontinuous
+   */
+  std::map<const Elem *, Gradient> discontinuous_gradient (const Point & p,
+                                                           const Real time=0.);
+
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
    * @returns the second derivatives of variable 0 at point
@@ -196,6 +205,25 @@ public:
                  const Real time,
                  std::vector<Gradient> & output,
                  const std::set<subdomain_id_type> * subdomain_ids = libmesh_nullptr);
+
+  /**
+   * Similar to gradient, but with the difference
+   * that multiple values on faces are explicitly permitted. This is useful for
+   * evaluating gradients on faces where the values to the left and right are different.
+   */
+  void discontinuous_gradient (const Point & p,
+                               const Real time,
+                               std::map<const Elem *, std::vector<Gradient> > & output);
+
+  /**
+   * Similar to gradient, but with the difference
+   * that multiple values on faces are explicitly permitted. This is useful for
+   * evaluating gradients on faces where the values to the left and right are different.
+   */
+  void discontinuous_gradient (const Point & p,
+                               const Real time,
+                               std::map<const Elem *, std::vector<Gradient> > & output,
+                               const std::set<subdomain_id_type> * subdomain_ids);
 
   /**
    * Computes gradients at coordinate \p p and for time \p time, which

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -99,6 +99,14 @@ public:
                                    const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr) const = 0;
 
   /**
+   * Locates a set of elements in proximity to the point with global coordinates
+   * \p p  Pure virtual. Optionally allows the user to restrict the subdomains searched.
+   */
+  virtual void operator() (const Point & p,
+                           std::set<const Elem *> & candidate_elements,
+                           const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr) const = 0;
+
+  /**
    * @returns \p true when this object is properly initialized
    * and ready for use, \p false otherwise.
    */

--- a/include/utils/point_locator_list.h
+++ b/include/utils/point_locator_list.h
@@ -103,6 +103,14 @@ public:
                                    const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr) const libmesh_override;
 
   /**
+   * Locates a set of elements in proximity to the point with global coordinates
+   * \p p  Pure virtual. Optionally allows the user to restrict the subdomains searched.
+   */
+  virtual void operator() (const Point & p,
+                           std::set<const Elem *> & candidate_elements,
+                           const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr) const libmesh_override;
+
+  /**
    * Enables out-of-mesh mode.  In this mode, if asked to find a point
    * that is contained in no mesh at all, the point locator will
    * return a NULL pointer instead of crashing.  Per default, this

--- a/include/utils/point_locator_tree.h
+++ b/include/utils/point_locator_tree.h
@@ -108,6 +108,14 @@ public:
                                    const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr) const libmesh_override;
 
   /**
+   * Locates a set of elements in proximity to the point with global coordinates
+   * \p p  Pure virtual. Optionally allows the user to restrict the subdomains searched.
+   */
+  virtual void operator() (const Point & p,
+                           std::set<const Elem *> & candidate_elements,
+                           const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr) const libmesh_override;
+
+  /**
    * As a fallback option, it's helpful to be able to do a linear
    * search over the entire mesh. This can be used if operator()
    * fails to find an element that contains \p p, for example.
@@ -119,6 +127,15 @@ public:
                                      const std::set<subdomain_id_type> * allowed_subdomains,
                                      bool use_close_to_point,
                                      Real close_to_point_tolerance=TOLERANCE) const;
+
+  /**
+  * A method to check if "fat" point p is in multiple elements. This would happen
+  * if p is close to a face or node. This is important for evaluating MeshFunction
+  * on faces when discontinuous shape functions are used.
+  */
+  std::set<const Elem *> perform_fuzzy_linear_search(const Point & p,
+                                                     const std::set<subdomain_id_type> * allowed_subdomains,
+                                                     Real close_to_point_tolerance=TOLERANCE) const;
 
   /**
    * Enables out-of-mesh mode.  In this mode, if asked to find a point

--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -192,6 +192,15 @@ const Elem * PointLocatorList::operator() (const Point & p,
 }
 
 
+void PointLocatorList::operator() (const Point & p,
+                                   std::set<const Elem *> & candidate_elements,
+                                   const std::set<subdomain_id_type> * allowed_subdomains) const
+{
+  // This functionality is not yet implemented for PointLocatorList (and will never be...).
+  libmesh_not_implemented();
+}
+
+
 
 void PointLocatorList::enable_out_of_mesh_mode ()
 {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,6 +26,7 @@ unit_tests_sources = \
   mesh/mesh_extruder.C \
   mesh/slit_mesh_test.C \
   mesh/spatial_dimension_test.C \
+  mesh/mesh_function_dfem.C \
   numerics/composite_function_test.C \
   numerics/coupling_matrix_test.C \
   numerics/distributed_vector_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -176,7 +176,7 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -206,6 +206,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT) \
+	mesh/unit_tests_dbg-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_dbg-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-distributed_vector_test.$(OBJEXT) \
@@ -244,7 +245,7 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -273,6 +274,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_devel-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_devel-spatial_dimension_test.$(OBJEXT) \
+	mesh/unit_tests_devel-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_devel-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_devel-distributed_vector_test.$(OBJEXT) \
@@ -309,7 +311,7 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -338,6 +340,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT) \
+	mesh/unit_tests_oprof-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_oprof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-distributed_vector_test.$(OBJEXT) \
@@ -374,7 +377,7 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -403,6 +406,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_opt-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_opt-spatial_dimension_test.$(OBJEXT) \
+	mesh/unit_tests_opt-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_opt-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_opt-distributed_vector_test.$(OBJEXT) \
@@ -437,7 +441,7 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -466,6 +470,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT) \
+	mesh/unit_tests_prof-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_prof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-coupling_matrix_test.$(OBJEXT) \
 	numerics/unit_tests_prof-distributed_vector_test.$(OBJEXT) \
@@ -918,7 +923,7 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -1055,6 +1060,8 @@ mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-mesh_function_dfem.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/$(am__dirstamp):
 	@$(MKDIR_P) numerics
 	@: > numerics/$(am__dirstamp)
@@ -1162,6 +1169,8 @@ mesh/unit_tests_devel-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-mesh_function_dfem.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-coupling_matrix_test.$(OBJEXT):  \
@@ -1232,6 +1241,8 @@ mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -1304,6 +1315,8 @@ mesh/unit_tests_opt-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-mesh_function_dfem.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-coupling_matrix_test.$(OBJEXT):  \
@@ -1374,6 +1387,8 @@ mesh/unit_tests_prof-mesh_extruder.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-composite_function_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
@@ -1471,6 +1486,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-contains_point.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po@am__quote@
@@ -1480,6 +1496,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-contains_point.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po@am__quote@
@@ -1489,6 +1506,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-contains_point.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po@am__quote@
@@ -1498,6 +1516,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-contains_point.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po@am__quote@
@@ -1507,6 +1526,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-contains_point.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po@am__quote@
@@ -1826,6 +1846,20 @@ mesh/unit_tests_dbg-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/spatial_dimension_test.C' object='mesh/unit_tests_dbg-spatial_dimension_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
+
+mesh/unit_tests_dbg-mesh_function_dfem.o: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Tpo -c -o mesh/unit_tests_dbg-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_dbg-mesh_function_dfem.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+
+mesh/unit_tests_dbg-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_function_dfem.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Tpo -c -o mesh/unit_tests_dbg-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_dbg-mesh_function_dfem.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
 
 numerics/unit_tests_dbg-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Tpo -c -o numerics/unit_tests_dbg-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
@@ -2303,6 +2337,20 @@ mesh/unit_tests_devel-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
 
+mesh/unit_tests_devel-mesh_function_dfem.o: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Tpo -c -o mesh/unit_tests_devel-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_devel-mesh_function_dfem.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+
+mesh/unit_tests_devel-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_function_dfem.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Tpo -c -o mesh/unit_tests_devel-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_devel-mesh_function_dfem.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
+
 numerics/unit_tests_devel-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Tpo -c -o numerics/unit_tests_devel-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po
@@ -2778,6 +2826,20 @@ mesh/unit_tests_oprof-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/spatial_dimension_test.C' object='mesh/unit_tests_oprof-spatial_dimension_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
+
+mesh/unit_tests_oprof-mesh_function_dfem.o: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Tpo -c -o mesh/unit_tests_oprof-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_oprof-mesh_function_dfem.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+
+mesh/unit_tests_oprof-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_function_dfem.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Tpo -c -o mesh/unit_tests_oprof-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_oprof-mesh_function_dfem.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
 
 numerics/unit_tests_oprof-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Tpo -c -o numerics/unit_tests_oprof-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
@@ -3255,6 +3317,20 @@ mesh/unit_tests_opt-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
 
+mesh/unit_tests_opt-mesh_function_dfem.o: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Tpo -c -o mesh/unit_tests_opt-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_opt-mesh_function_dfem.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+
+mesh/unit_tests_opt-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_function_dfem.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Tpo -c -o mesh/unit_tests_opt-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_opt-mesh_function_dfem.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
+
 numerics/unit_tests_opt-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Tpo -c -o numerics/unit_tests_opt-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po
@@ -3730,6 +3806,20 @@ mesh/unit_tests_prof-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/spatial_dimension_test.C' object='mesh/unit_tests_prof-spatial_dimension_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
+
+mesh/unit_tests_prof-mesh_function_dfem.o: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Tpo -c -o mesh/unit_tests_prof-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_prof-mesh_function_dfem.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
+
+mesh/unit_tests_prof-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_function_dfem.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Tpo -c -o mesh/unit_tests_prof-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_prof-mesh_function_dfem.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
 
 numerics/unit_tests_prof-composite_function_test.o: numerics/composite_function_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-composite_function_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Tpo -c -o numerics/unit_tests_prof-composite_function_test.o `test -f 'numerics/composite_function_test.C' || echo '$(srcdir)/'`numerics/composite_function_test.C

--- a/tests/mesh/mesh_function_dfem.C
+++ b/tests/mesh/mesh_function_dfem.C
@@ -1,0 +1,220 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/equation_systems.h>
+#include <libmesh/serial_mesh.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/edge_edge2.h>
+#include <libmesh/face_quad4.h>
+#include <libmesh/face_tri3.h>
+#include <libmesh/cell_hex8.h>
+#include <libmesh/dof_map.h>
+#include <libmesh/linear_implicit_system.h>
+#include <libmesh/mesh_refinement.h>
+#include <libmesh/mesh_function.h>
+#include <libmesh/numeric_vector.h>
+
+#include "test_comm.h"
+
+using namespace libMesh;
+
+Number position_function (const Point& p,
+                          const Parameters&,
+                          const std::string&,
+                          const std::string&)
+{
+  if (p(1) > 0.0)
+    return 0.0;
+  else
+    return 1.0;
+}
+
+class MeshfunctionDFEM : public CppUnit::TestCase
+{
+  /**
+   * The goal of this test is to verify proper operation of mesh function
+   * for discontinuous shape functions and points close to the boundary
+   */
+public:
+  CPPUNIT_TEST_SUITE( MeshfunctionDFEM );
+
+  CPPUNIT_TEST( test_point_locator_dfem );
+
+  CPPUNIT_TEST( test_mesh_function_dfem );
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+  SerialMesh * _mesh;
+  UniquePtr<PointLocatorBase> _point_locator;
+
+  void build_mesh()
+  {
+    _mesh = new SerialMesh(*TestCommWorld);
+
+    /*
+      (0,1)           (1,1)
+        x---------------x
+        |               |
+        |               |
+        |               |
+        |               |
+        |               |
+        x---------------x
+       (0,0)           (1,0)
+        |               |
+        |               |
+        |               |
+        |               |
+        x---------------x
+       (0,-1)          (1,-1)
+     */
+
+    _mesh->set_mesh_dimension(2);
+
+    _mesh->add_point( Point(0.0,-1.0), 4 );
+    _mesh->add_point( Point(1.0,-1.0), 5 );
+    _mesh->add_point( Point(1.0, 0.0), 1 );
+    _mesh->add_point( Point(1.0, 1.0), 2 );
+    _mesh->add_point( Point(0.0, 1.0), 3 );
+    _mesh->add_point( Point(0.0, 0.0), 0 );
+
+    {
+      Elem* elem_top = _mesh->add_elem( new Quad4 );
+      elem_top->set_node(0) = _mesh->node_ptr(0);
+      elem_top->set_node(1) = _mesh->node_ptr(1);
+      elem_top->set_node(2) = _mesh->node_ptr(2);
+      elem_top->set_node(3) = _mesh->node_ptr(3);
+
+      Elem* elem_bottom = _mesh->add_elem( new Quad4 );
+      elem_bottom->set_node(0) = _mesh->node_ptr(4);
+      elem_bottom->set_node(1) = _mesh->node_ptr(5);
+      elem_bottom->set_node(2) = _mesh->node_ptr(1);
+      elem_bottom->set_node(3) = _mesh->node_ptr(0);
+    }
+
+    // libMesh will renumber, but we numbered according to its scheme
+    // anyway. We do this because when we call uniformly_refine subsequenly,
+    // it's going use skip_renumber=false.
+    _mesh->prepare_for_use(false /*skip_renumber*/);
+
+    // get a point locator
+    _point_locator = _mesh->sub_point_locator();
+  }
+
+public:
+  void setUp()
+  {
+    this->build_mesh();
+  }
+
+  void tearDown()
+  {
+    delete _mesh;
+  }
+
+  // test that point locator works correctly
+  void test_point_locator_dfem()
+  {
+    // this point is in bottom element only
+    Point interior(0.5, -0.5, 0.0);
+
+    // this point is on the face between bottom and top
+    Point face(0.5, 0.0, 0.0);
+
+    // test interior point
+    std::set<const Elem *> int_cand;
+    (*_point_locator)(interior, int_cand, libmesh_nullptr);
+    CPPUNIT_ASSERT (int_cand.size() == 1);
+    for (std::set<const Elem *>::iterator it = int_cand.begin(); it != int_cand.end(); ++it)
+      CPPUNIT_ASSERT ((*it)->id() == 1);
+
+    // test interior point
+    std::set<const Elem *> face_cand;
+    (*_point_locator)(face, face_cand, libmesh_nullptr);
+    CPPUNIT_ASSERT (face_cand.size() == 2);
+    int array[2] = {0, 0};
+    for (std::set<const Elem *>::iterator it = face_cand.begin(); it != face_cand.end(); ++it)
+    {
+      // first test that array entry hasn't been set before
+      CPPUNIT_ASSERT (array[(*it)->id()] == 0);
+      array[(*it)->id()] = 1;
+    }
+    CPPUNIT_ASSERT (array[0] == 1);
+    CPPUNIT_ASSERT (array[1] == 1);
+  }
+
+  // test that mesh function works correctly
+  void test_mesh_function_dfem()
+  {
+    // this point is in top element only
+    Point top(0.5, 0.5, 0.0);
+
+    // this point is in bottom element only
+    Point bottom(0.5, -0.5, 0.0);
+
+    // this point is on the face between bottom and top
+    Point face(0.5, 0.0, 0.0);
+
+    // set up some necessary objects
+    EquationSystems es(*_mesh);
+    System & sys = es.add_system<System> ("SimpleSystem");
+    sys.add_variable("u", CONSTANT, MONOMIAL);
+
+    es.init();
+    sys.project_solution(position_function, NULL, es.parameters);
+
+    std::vector<unsigned int> variables;
+    sys.get_all_variable_numbers(variables);
+    UniquePtr< NumericVector<Number> > mesh_function_vector =
+      NumericVector<Number>::build(es.comm());
+    mesh_function_vector->init(sys.n_dofs(), false, SERIAL);
+    sys.solution->localize(*mesh_function_vector);
+
+    MeshFunction mesh_function (es, *mesh_function_vector,
+                                sys.get_dof_map(), variables);
+    mesh_function.init();
+
+    // test mesh function in top
+    std::map<const Elem *, Number> top_val = mesh_function.discontinuous_value(top);
+
+    // check that there is only one value
+    CPPUNIT_ASSERT (top_val.size() == 1);
+
+    // check that this one value is the right one
+    for (std::map<const Elem *, Number>::const_iterator it = top_val.begin(); it != top_val.end(); ++it)
+      CPPUNIT_ASSERT (it->first->id() == 0 && std::abs(it->second) < 1.0e-10);
+
+    // test mesh function in bottom
+    std::map<const Elem *, Number> bottom_val = mesh_function.discontinuous_value(bottom);
+
+    // check that there is only one value
+    CPPUNIT_ASSERT (bottom_val.size() == 1);
+
+    // check that this one value is the right one
+    for (std::map<const Elem *, Number>::const_iterator it = bottom_val.begin(); it != bottom_val.end(); ++it)
+      CPPUNIT_ASSERT (it->first->id() == 1 && std::abs(it->second - 1.0) < 1.0e-10);
+
+    // test mesh function in face
+    std::map<const Elem *, Number> face_val = mesh_function.discontinuous_value(face);
+
+    // check that there are two values
+    CPPUNIT_ASSERT (face_val.size() == 2);
+
+    // check that the two values are attached to the right element
+    for (std::map<const Elem *, Number>::const_iterator it = face_val.begin(); it != face_val.end(); ++it)
+      if (it->first->id() == 0)
+        CPPUNIT_ASSERT (std::abs(it->second) < 1.0e-10);
+      else if (it->first->id() == 1)
+        CPPUNIT_ASSERT (std::abs(it->second - 1.0) < 1.0e-10);
+      else
+        CPPUNIT_ASSERT (false);
+
+  }
+};
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION( MeshfunctionDFEM );


### PR DESCRIPTION
1. Allow `PoinLocator` to return multiple elements containing a point for covering cases where the
point is on (aka close) to a face or node. This is necessary if mesh function is discontinuous.

2. Modify `MeshFunction`  to allow multiple values for a single point. 