### PR TITLE
Fix -Wdeprecated-declarations warnings from CPPUnit 

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -21,7 +21,6 @@
 
 #include "libmesh/libmesh_config.h"
 
-#ifndef NDEBUG
 // TODO: icpc options
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -30,12 +29,14 @@
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)
-#if __GNUC__ > 3 && __GNUC_MINOR__ > 1
+// GCC > 4.1 supports diagnostic pragmas
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 1)
 // These two don't work?
 #pragma GCC diagnostic ignored "-pedantic"
 #pragma GCC diagnostic ignored "-Wdeprecated"
 // But this is helpful with some MPI stacks
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif //__GNUC__ > 3 && __GNUC_MINOR__ > 1
+// Ignore warnings from code that uses deprecated members of std, like std::auto_ptr.
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif // GCC > 4.1
 #endif // __GNUC__ && !__INTEL_COMPILER
-#endif // NDEBUG

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -21,18 +21,17 @@
 
 #include "libmesh/libmesh_config.h"
 
-#ifndef NDEBUG
-
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)
-#if __GNUC__ > 3 && __GNUC_MINOR__ > 1
+// GCC > 4.1 supports diagnostic pragmas
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 1)
 // TODO: use the gcc 4.6 push/pop when available
 #pragma GCC diagnostic warning "-Wunused-parameter"
 #pragma GCC diagnostic warning "-Wdeprecated"
 #pragma GCC diagnostic warning "-pedantic"
-#endif //__GNUC__ > 3 && __GNUC_MINOR__ > 1
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
+#endif // GCC > 4.1
 #endif // __GNUC__ && !__INTEL_COMPILER
-#endif // NDEBUG

--- a/tests/base/auto_ptr_test.C
+++ b/tests/base/auto_ptr_test.C
@@ -7,6 +7,16 @@
 #include <iomanip>
 #include <libmesh/auto_ptr.h>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class AutoPtrTest : public CppUnit::TestCase

--- a/tests/base/getpot_test.C
+++ b/tests/base/getpot_test.C
@@ -6,6 +6,16 @@
 
 #include <libmesh/getpot.h>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class GetPotTest : public CppUnit::TestCase {

--- a/tests/fparser/autodiff.C
+++ b/tests/fparser/autodiff.C
@@ -6,6 +6,16 @@
 #include <cppunit/TestCase.h>
 #include <libmesh/restore_warnings.h>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 class FParserAutodiffTest : public CppUnit::TestCase
 {
 public:

--- a/tests/geom/node_test.C
+++ b/tests/geom/node_test.C
@@ -9,6 +9,16 @@
 #include "../geom/point_test.h"
 #include "../base/dof_object_test.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class NodeTest : public PointTestBase<Node>, public DofObjectTest<Node> {

--- a/tests/geom/point_test.C
+++ b/tests/geom/point_test.C
@@ -8,6 +8,16 @@
 
 #include "point_test.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class PointTest : public PointTestBase<Point> {

--- a/tests/mesh/all_tri.C
+++ b/tests/mesh/all_tri.C
@@ -12,6 +12,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class AllTriTest : public CppUnit::TestCase

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -16,6 +16,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class BoundaryInfoTest : public CppUnit::TestCase {

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -12,6 +12,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class BoundaryMeshTest : public CppUnit::TestCase {

--- a/tests/mesh/contains_point.C
+++ b/tests/mesh/contains_point.C
@@ -9,6 +9,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class ContainsPointTest : public CppUnit::TestCase

--- a/tests/mesh/mesh_extruder.C
+++ b/tests/mesh/mesh_extruder.C
@@ -11,6 +11,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class MeshExtruderTest : public CppUnit::TestCase

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -17,6 +17,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class MixedDimensionMeshTest : public CppUnit::TestCase {

--- a/tests/mesh/nodal_neighbors.C
+++ b/tests/mesh/nodal_neighbors.C
@@ -12,6 +12,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class NodalNeighborsTest : public CppUnit::TestCase

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -16,6 +16,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class SlitFunc : public FEMFunctionBase<Number>

--- a/tests/mesh/spatial_dimension_test.C
+++ b/tests/mesh/spatial_dimension_test.C
@@ -11,6 +11,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class MeshSpatialDimensionTest : public CppUnit::TestCase

--- a/tests/numerics/composite_function_test.C
+++ b/tests/numerics/composite_function_test.C
@@ -11,6 +11,16 @@
 #include <libmesh/parsed_function.h>
 #include <libmesh/zero_function.h>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class CompositeFunctionTest : public CppUnit::TestCase

--- a/tests/numerics/coupling_matrix_test.C
+++ b/tests/numerics/coupling_matrix_test.C
@@ -7,6 +7,16 @@
 // libmesh includes
 #include <libmesh/coupling_matrix.h>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class CouplingMatrixTest : public CppUnit::TestCase

--- a/tests/numerics/dense_matrix_test.C
+++ b/tests/numerics/dense_matrix_test.C
@@ -12,6 +12,16 @@
 #include "libmesh/petsc_macro.h"
 #endif
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 #ifdef LIBMESH_USE_REAL_NUMBERS
 
 using namespace libMesh;

--- a/tests/numerics/distributed_vector_test.C
+++ b/tests/numerics/distributed_vector_test.C
@@ -5,6 +5,16 @@
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class DistributedVectorTest : public NumericVectorTest<DistributedVector<Number> > {

--- a/tests/numerics/eigen_sparse_vector_test.C
+++ b/tests/numerics/eigen_sparse_vector_test.C
@@ -4,8 +4,20 @@
 
 #include "numeric_vector_test.h"
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
 
 using namespace libMesh;
 

--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -17,6 +17,16 @@
 // test includes
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class ParsedFEMFunctionTest : public CppUnit::TestCase

--- a/tests/numerics/parsed_function_test.C
+++ b/tests/numerics/parsed_function_test.C
@@ -17,6 +17,16 @@
 // test includes
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class ParsedFunctionTest : public CppUnit::TestCase

--- a/tests/numerics/petsc_vector_test.C
+++ b/tests/numerics/petsc_vector_test.C
@@ -4,8 +4,20 @@
 
 #include "numeric_vector_test.h"
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
 
 using namespace libMesh;
 
@@ -21,4 +33,3 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION( PetscVectorTest );
 
 #endif // #ifdef LIBMESH_HAVE_PETSC
-

--- a/tests/numerics/type_tensor_test.C
+++ b/tests/numerics/type_tensor_test.C
@@ -7,6 +7,16 @@
 // libmesh includes
 #include <libmesh/tensor_value.h>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class TypeTensorTest : public CppUnit::TestCase

--- a/tests/numerics/vector_value_test.C
+++ b/tests/numerics/vector_value_test.C
@@ -8,6 +8,16 @@
 
 #include "type_vector_test.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 #define VECTORVALUETEST                         \

--- a/tests/parallel/packed_range_test.C
+++ b/tests/parallel/packed_range_test.C
@@ -11,6 +11,16 @@
 
 #include <vector>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 namespace libMesh {
 namespace Parallel {
 template <typename T>

--- a/tests/parallel/parallel_point_test.C
+++ b/tests/parallel/parallel_point_test.C
@@ -9,6 +9,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class ParallelPointTest : public CppUnit::TestCase {

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -8,6 +8,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class ParallelTest : public CppUnit::TestCase {

--- a/tests/quadrature/quadrature_test.C
+++ b/tests/quadrature/quadrature_test.C
@@ -10,6 +10,16 @@
 
 #include <iomanip>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 #define MACROCOMMA ,

--- a/tests/systems/equation_systems_test.C
+++ b/tests/systems/equation_systems_test.C
@@ -12,6 +12,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class EquationSystemsTest : public CppUnit::TestCase {

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -13,6 +13,16 @@
 
 #include "test_comm.h"
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 Number cubic_test (const Point& p,

--- a/tests/utils/vectormap_test.C
+++ b/tests/utils/vectormap_test.C
@@ -6,6 +6,16 @@
 #include <cppunit/TestCase.h>
 #include <libmesh/restore_warnings.h>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 #define VECTORMAPOBJECTTEST                     \
   CPPUNIT_TEST( testCreate );                   \
 


### PR DESCRIPTION
There is a CPPUnit macro that expands to code containing `std::auto_ptr`, and triggers a warning on GCC 5.x (and maybe other) compilers.  This branch disables that warning as well as fixes some long-standing issues with our ignore/restore_warnings.h headers that were preventing them from working with certain compiler versions.