### PR TITLE
Better default-values for system-parameters and error-handling in misc. 12

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -84,6 +84,10 @@ int main (int argc, char ** argv)
   libmesh_example_requires (false, "ExodusII support");
 #endif
 
+#ifndef LIBMESH_ENABLE_SECOND_DERIVATIVES
+  libmesh_example_requires (false, "second derivatives enabled");
+#endif
+
   // This example does a bunch of linear algebra during assembly, and
   // therefore requires Eigen.
 #ifndef LIBMESH_HAVE_EIGEN

--- a/src/fe/fe_compute_data.C
+++ b/src/fe/fe_compute_data.C
@@ -28,12 +28,13 @@ void FEComputeData::clear ()
   this->shape.clear();
 #if defined(LIBMESH_ENABLE_INFINITE_ELEMENTS) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
   this->phase = 0.;
-  this->speed = 0.;
+  this->speed = 1.;
 #endif
 
 #if defined (LIBMESH_ENABLE_INFINITE_ELEMENTS) && defined(LIBMESH_USE_COMPLEX_NUMBERS)
-  this->speed = 0.;
-  this->frequency = 0.;
+  //lets default speed and frequency to 1; 0 leads to troubles with the wavenumber.
+  this->speed = 1.;
+  this->frequency = 1.;
 
 #endif
 }
@@ -60,6 +61,12 @@ void FEComputeData::init ()
     this->frequency = this->equation_systems.parameters.get<Real>("current frequency");
 
 #endif
+   // ensure that the wavenumber k=2. * libMesh::pi * this->frequency / this->speed
+   // in src/fe/inf_fe_static.C: 310
+   // is well-defined. 0 as well as NaN will lead to problems here.
+   libmesh_assert_not_equal_to(this->frequency,0);
+   libmesh_assert_not_equal_to(this->speed,0 );
+
 }
 
 

--- a/src/fe/fe_compute_data.C
+++ b/src/fe/fe_compute_data.C
@@ -64,8 +64,10 @@ void FEComputeData::init ()
    // ensure that the wavenumber k=2. * libMesh::pi * this->frequency / this->speed
    // in src/fe/inf_fe_static.C: 310
    // is well-defined. 0 as well as NaN will lead to problems here.
+#if defined (LIBMESH_ENABLE_INFINITE_ELEMENTS) 
    libmesh_assert_not_equal_to(this->frequency,0);
    libmesh_assert_not_equal_to(this->speed,0 );
+#endif
 
 }
 


### PR DESCRIPTION
Hi,
I have a small correction for the example miscellaneous-12: Here, second derivatives are used in the assemble-function but there is no exception in case of compile-option --disable-second.

The second issue concerns the compute_data() function for infinite elements: If the parameters speed and frequency are not set, they default to 0 and hence the wavelength=speed/frequency becomes 0 or NaN respectively. I would therefore suggest to default both values to 1 instead and tell the user to set them according to his needs.

(btw: concerning the InfFE::compute_data() function I think there is an error at the moment, I will write a report soon but need to study it a bit more).

Sorry for mixing two different topics into one request, but since they are only few lines...