### PR TITLE
Reduced Basis change: Removed "extra" interpolation data from EIM.

### DIFF
--- a/contrib/capnproto/rb_data.capnp
+++ b/contrib/capnproto/rb_data.capnp
@@ -116,10 +116,6 @@ struct RBEIMEvaluationReal @0xf8121d2237427a80 {
   interpolationPointsElems    @3 :List(MeshElem);
   interpolationPointsVar      @4 :List(Integer);
   interpolationPoints         @5 :List(Point3D);
-  extraInterpolationMatrixRow @6 :List(Real);
-  extraInterpolationPointElem @7 :MeshElem;
-  extraInterpolationPointVar  @8 :Integer;
-  extraInterpolationPoint     @9 :Point3D;
 }
 struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   rbEvaluation                @0 :RBEvaluationComplex;
@@ -128,8 +124,4 @@ struct RBEIMEvaluationComplex @0xc35a5eb004965455 {
   interpolationPointsElems    @3 :List(MeshElem);
   interpolationPointsVar      @4 :List(Integer);
   interpolationPoints         @5 :List(Point3D);
-  extraInterpolationMatrixRow @6 :List(Complex);
-  extraInterpolationPointElem @7 :MeshElem;
-  extraInterpolationPointVar  @8 :Integer;
-  extraInterpolationPoint     @9 :Point3D;
 }

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -297,14 +297,6 @@ private:
   MeshFunction * _mesh_function;
 
   /**
-   * This flag indicates that we're in the process of
-   * performing one extra Greedy step in order to compute
-   * the data needed for the EIM a posteriori error bound
-   * in the case that we use all of our basis functions.
-   */
-  bool _performing_extra_greedy_step;
-
-  /**
    * We also need an extra vector in which we can store a ghosted
    * copy of the vector that we wish to use MeshFunction on.
    */

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -192,21 +192,6 @@ public:
    */
   std::vector<Elem *> interpolation_points_elem;
 
-  /**
-   * We also need an extra interpolation point and associated
-   * variable and Elem for the "extra" solve we do at the end of
-   * the Greedy algorithm.
-   */
-  Point extra_interpolation_point;
-  unsigned int extra_interpolation_point_var;
-  Elem * extra_interpolation_point_elem;
-
-  /**
-   * We also need a DenseVector to represent the corresponding
-   * "extra" row of the interpolation matrix.
-   */
-  DenseVector<Number> extra_interpolation_matrix_row;
-
 private:
 
   /**

--- a/src/reduced_basis/rb_data_deserialization.C
+++ b/src/reduced_basis/rb_data_deserialization.C
@@ -636,7 +636,7 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
 
   unsigned int n_bfs = rb_eim_evaluation.get_n_basis_functions();
 
-  // EIM interpolation matrix (with extra row for EIM error bound)
+  // EIM interpolation matrix
   {
     auto interpolation_matrix_list = rb_eim_evaluation_reader.getInterpolationMatrix();
 
@@ -650,19 +650,9 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
           rb_eim_evaluation.interpolation_matrix(i,j) =
             load_scalar_value(interpolation_matrix_list[offset]);
         }
-
-    auto extra_interpolation_matrix_row_list =
-      rb_eim_evaluation_reader.getExtraInterpolationMatrixRow();
-
-    if (extra_interpolation_matrix_row_list.size() != n_bfs)
-      libmesh_error_msg("Size error while reading the eim inner product matrix.");
-
-    for(unsigned int j=0; j<n_bfs; ++j)
-      rb_eim_evaluation.extra_interpolation_matrix_row(j) =
-        load_scalar_value(extra_interpolation_matrix_row_list[j]);
   }
 
-  // Interpolation points (including the extra point)
+  // Interpolation points
   {
     auto interpolation_points_list =
       rb_eim_evaluation_reader.getInterpolationPoints();
@@ -676,14 +666,9 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
         load_point(interpolation_points_list[i],
                    rb_eim_evaluation.interpolation_points[i]);
       }
-
-    auto extra_interpolation_point_reader =
-      rb_eim_evaluation_reader.getExtraInterpolationPoint();
-    load_point(extra_interpolation_point_reader,
-               rb_eim_evaluation.extra_interpolation_point);
   }
 
-  // Interpolation points variables (including the "extra one")
+  // Interpolation points variables
   {
     auto interpolation_points_var_list =
       rb_eim_evaluation_reader.getInterpolationPointsVar();
@@ -697,12 +682,9 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
         rb_eim_evaluation.interpolation_points_var[i] =
           interpolation_points_var_list[i];
       }
-
-    rb_eim_evaluation.extra_interpolation_point_var =
-      rb_eim_evaluation_reader.getExtraInterpolationPointVar();
   }
 
-  // Interpolation elements (including the "extra one")
+  // Interpolation elements
   {
     libMesh::dof_id_type elem_id = 0;
     libMesh::ReplicatedMesh & interpolation_points_mesh =
@@ -731,21 +713,6 @@ void load_rb_eim_evaluation_data(RBEIMEvaluation & rb_eim_evaluation,
 
         rb_eim_evaluation.interpolation_points_elem[i] = elem;
       }
-
-    auto extra_interpolation_point_elem_reader =
-      rb_eim_evaluation_reader.getExtraInterpolationPointElem();
-    std::string elem_type_name =
-      extra_interpolation_point_elem_reader.getType().cStr();
-    libMesh::ElemType elem_type =
-      libMesh::Utility::string_to_enum<libMesh::ElemType>(elem_type_name);
-
-    libMesh::Elem * elem = libMesh::Elem::build(elem_type).release();
-    elem->set_id(elem_id++);
-    load_elem_into_mesh(extra_interpolation_point_elem_reader,
-                        elem,
-                        interpolation_points_mesh);
-
-    rb_eim_evaluation.extra_interpolation_point_elem = elem;
   }
 }
 

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -606,7 +606,7 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
 
   unsigned int n_bfs = rb_eim_evaluation.get_n_basis_functions();
 
-  // EIM interpolation matrix (with extra row for EIM error bound)
+  // EIM interpolation matrix
   {
     // We store the lower triangular part of an NxN matrix, the size of which is given by
     // (N(N + 1))/2
@@ -622,41 +622,27 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
                              offset,
                              rb_eim_evaluation.interpolation_matrix(i,j));
         }
-
-    auto extra_interpolation_matrix_row_list =
-      rb_eim_evaluation_builder.initExtraInterpolationMatrixRow(n_bfs);
-    for(unsigned int j=0; j < n_bfs; ++j)
-      set_scalar_in_list(extra_interpolation_matrix_row_list,
-                         j,
-                         rb_eim_evaluation.extra_interpolation_matrix_row(j));
   }
 
-  // Interpolation points (including the extra point)
+  // Interpolation points
   {
     auto interpolation_points_list =
       rb_eim_evaluation_builder.initInterpolationPoints(n_bfs);
     for(unsigned int i=0; i < n_bfs; ++i)
       add_point_to_builder(rb_eim_evaluation.interpolation_points[i],
                            interpolation_points_list[i]);
-
-    auto extra_interpolation_point_builder =
-      rb_eim_evaluation_builder.initExtraInterpolationPoint();
-    add_point_to_builder(rb_eim_evaluation.extra_interpolation_point,
-                         extra_interpolation_point_builder);
   }
 
-  // Interpolation points variables (including the "extra one")
+  // Interpolation points variables
   {
     auto interpolation_points_var_list =
       rb_eim_evaluation_builder.initInterpolationPointsVar(n_bfs);
     for(unsigned int i=0; i<n_bfs; ++i)
       interpolation_points_var_list.set(i,
                                         rb_eim_evaluation.interpolation_points_var[i]);
-
-    rb_eim_evaluation_builder.setExtraInterpolationPointVar(rb_eim_evaluation.extra_interpolation_point_var);
   }
 
-  // Interpolation elements (including the "extra one")
+  // Interpolation elements
   {
     unsigned int n_interpolation_elems =
       rb_eim_evaluation.interpolation_points_elem.size();
@@ -672,11 +658,6 @@ void add_rb_eim_evaluation_data_to_builder(RBEIMEvaluation & rb_eim_evaluation,
         auto mesh_elem_builder = interpolation_points_elem_list[i];
         add_elem_to_builder(elem, mesh_elem_builder);
       }
-
-    auto extra_interpolation_point_elem_builder =
-      rb_eim_evaluation_builder.initExtraInterpolationPointElem();
-    add_elem_to_builder(*rb_eim_evaluation.extra_interpolation_point_elem,
-                        extra_interpolation_point_elem_builder);
   }
 }
 


### PR DESCRIPTION
This extra interpolation data is not necessary and it complicates the code.
Also, it can cause errors during the Greedy algorithm if the "extra" sample
point is linearly dependent with the other points. Therefore it's better
to get rid of it.