### PR TITLE
SNESSetFromOptions already calls KSPSetFromOptions.

### DIFF
--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -657,7 +657,9 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  jac_in,  // System Jacobian M
   LIBMESH_CHKERR(ierr);
 
   //Pull in command-line options
+#ifdef PETSC_VERSION_LESS_THAN(3,7,0)
   KSPSetFromOptions(ksp);
+#endif
   SNESSetFromOptions(_snes);
 
   if (this->user_presolve)


### PR DESCRIPTION
In older versions of PETSc, this was fine, but in 3.7.0 it seems that
when you pass -ksp_monitor on the command line, and KSPSetFromOptions
is called twice, it causes the residuals to be printed to the screen
twice.

Issue originally reported by @fdkong.