### PR TITLE
TypeTensor::solve,inverse() should throw an exception on zero determinant

### DIFF
--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -177,7 +177,7 @@ int main(int argc, char ** argv)
 
 // Define the matrix assembly function for the 1D PDE we are solving
 void assemble_1D(EquationSystems & es,
-                 const std::string & system_name)
+                 const std::string & libmesh_dbg_var(system_name))
 {
 
 #ifdef LIBMESH_ENABLE_AMR

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -449,7 +449,7 @@ int main (int argc, char ** argv)
 // responsible for applying the initial conditions to
 // the system.
 void init_cd (EquationSystems & es,
-              const std::string & system_name)
+              const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are initializing
   // the proper system.
@@ -473,7 +473,7 @@ void init_cd (EquationSystems & es,
 // element stiffness matrices and right-hand sides.
 #ifdef LIBMESH_ENABLE_AMR
 void assemble_cd (EquationSystems & es,
-                  const std::string & system_name)
+                  const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -595,13 +595,12 @@ Gradient exact_derivative(const Point & p,
 // account the boundary conditions, which will be handled
 // via a penalty method.
 void assemble_laplace(EquationSystems & es,
-                      const std::string & system_name)
+                      const std::string & libmesh_dbg_var(system_name))
 {
 #ifdef LIBMESH_ENABLE_AMR
   // It is a good idea to make sure we are assembling
   // the proper system.
   libmesh_assert_equal_to (system_name, "Laplace");
-
 
   // Declare a performance log.  Give it a descriptive
   // string to identify what part of the code we are

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -561,7 +561,7 @@ Number forcing_function_3D(const Point & p)
 // account the boundary conditions, which will be handled
 // via a penalty method.
 void assemble_biharmonic(EquationSystems & es,
-                         const std::string & system_name)
+                         const std::string & libmesh_dbg_var(system_name))
 {
 #ifdef LIBMESH_ENABLE_AMR
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -540,7 +540,7 @@ int main (int argc, char ** argv)
 // responsible for applying the initial conditions to
 // the system.
 void init_cd (EquationSystems & es,
-              const std::string & system_name)
+              const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are initializing
   // the proper system.
@@ -567,7 +567,7 @@ void init_cd (EquationSystems & es,
 // element stiffness matrices and right-hand sides.
 #ifdef LIBMESH_ENABLE_AMR
 void assemble_cd (EquationSystems & es,
-                  const std::string & system_name)
+                  const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/introduction/introduction_ex3/introduction_ex3.C
+++ b/examples/introduction/introduction_ex3/introduction_ex3.C
@@ -172,13 +172,12 @@ int main (int argc, char ** argv)
 // account the boundary conditions, which will be handled
 // via a penalty method.
 void assemble_poisson(EquationSystems & es,
-                      const std::string & system_name)
+                      const std::string & libmesh_dbg_var(system_name))
 {
 
   // It is a good idea to make sure we are assembling
   // the proper system.
   libmesh_assert_equal_to (system_name, "Poisson");
-
 
   // Get a constant reference to the mesh object.
   const MeshBase & mesh = es.get_mesh();

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -229,12 +229,11 @@ int main (int argc, char ** argv)
 // This function assembles the system matrix and right-hand-side
 // for the discrete form of our wave equation.
 void assemble_wave(EquationSystems & es,
-                   const std::string & system_name)
+                   const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are assembling
   // the proper system.
   libmesh_assert_equal_to (system_name, "Wave");
-
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 

--- a/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
+++ b/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
@@ -234,7 +234,7 @@ void assemble_and_solve(MeshBase & mesh,
 }
 
 void assemble_poisson(EquationSystems & es,
-                      const std::string & system_name)
+                      const std::string & libmesh_dbg_var(system_name))
 {
   libmesh_assert_equal_to (system_name, "Poisson");
 

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -251,7 +251,7 @@ int main (int argc, char ** argv)
 // end we also take into account the boundary conditions
 // here, using the penalty method.
 void assemble_shell (EquationSystems & es,
-                     const std::string & system_name)
+                     const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -58,7 +58,9 @@
 
 // Eigen includes
 #ifdef LIBMESH_HAVE_EIGEN
+#include "libmesh/ignore_warnings.h"
 # include <Eigen/Dense>
+#include "libmesh/restore_warnings.h"
 #endif
 
 // Bring in everything from the libMesh namespace

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -139,7 +139,7 @@ Gradient exact_derivative(const Point & p,
 // conditions and the flux integrals, which will be handled
 // via an interior penalty method.
 void assemble_ellipticdg(EquationSystems & es,
-                         const std::string & system_name)
+                         const std::string & libmesh_dbg_var(system_name))
 {
   libMesh::out << " assembling elliptic dg system... ";
   libMesh::out.flush();

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -290,7 +290,7 @@ int main (int argc, char ** argv)
 // account the boundary conditions, which will be handled
 // via a penalty method.
 void assemble_poisson(EquationSystems & es,
-                      const std::string & system_name)
+                      const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -141,7 +141,7 @@ int main (int argc, char ** argv)
 }
 
 void assemble_stokes (EquationSystems & es,
-                      const std::string & system_name)
+                      const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -291,7 +291,7 @@ int main (int argc, char** argv)
 // The matrix assembly function to be called at each time step to
 // prepare for the linear solve.
 void assemble_stokes (EquationSystems & es,
-                      const std::string & system_name)
+                      const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -285,7 +285,7 @@ int main (int argc, char ** argv)
 // The matrix assembly function to be called at each time step to
 // prepare for the linear solve.
 void assemble_stokes (EquationSystems & es,
-                      const std::string & system_name)
+                      const std::string & libmesh_dbg_var(system_name))
 {
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -150,7 +150,7 @@ int main (int argc, char ** argv)
 
 
 void assemble_elasticity(EquationSystems & es,
-                         const std::string & system_name)
+                         const std::string & libmesh_dbg_var(system_name))
 {
   libmesh_assert_equal_to (system_name, "Elasticity");
 

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -58,7 +58,7 @@ public:
    * @returns the \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.
    */
-  virtual Point master_point (const unsigned int i) const libmesh_override
+  virtual Point master_point (const unsigned int libmesh_dbg_var(i)) const libmesh_override
   {
     libmesh_assert_equal_to (i, 0);
     return Point(0,0,0);

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -989,7 +989,8 @@ inline
 TypeTensor<T> TypeTensor<T>::inverse() const
 {
 #if LIBMESH_DIM == 1
-  libmesh_assert_not_equal_to(_coords[0], static_cast<T>(0.));
+  if (_coords[0] == static_cast<T>(0.))
+    libmesh_convergence_failure();
   return TypeTensor(1. / _coords[0]);
 #endif
 
@@ -1003,7 +1004,9 @@ TypeTensor<T> TypeTensor<T>::inverse() const
 
   // Make sure det = ad - bc is not zero
   T my_det = a*d - b*c;
-  libmesh_assert_not_equal_to(my_det, static_cast<T>(0.));
+
+  if (my_det == static_cast<T>(0.))
+    libmesh_convergence_failure();
 
   return TypeTensor(d/my_det, -b/my_det, -c/my_det, a/my_det);
 #endif
@@ -1017,7 +1020,9 @@ TypeTensor<T> TypeTensor<T>::inverse() const
     a31 = A(2,0), a32 = A(2,1), a33 = A(2,2);
 
   T my_det = a11*(a33*a22-a32*a23) - a21*(a33*a12-a32*a13) + a31*(a23*a12-a22*a13);
-  libmesh_assert_not_equal_to(my_det, static_cast<T>(0.));
+
+  if (my_det == static_cast<T>(0.))
+    libmesh_convergence_failure();
 
   // Inline comment characters are for lining up columns.
   return TypeTensor(/**/  (a33*a22-a32*a23)/my_det, -(a33*a12-a32*a13)/my_det,  (a23*a12-a22*a13)/my_det,
@@ -1033,14 +1038,16 @@ inline
 void TypeTensor<T>::solve(const TypeVector<T> & b, TypeVector<T> & x) const
 {
 #if LIBMESH_DIM == 1
-  libmesh_assert_not_equal_to(_coords[0], static_cast<T>(0.));
+  if (_coords[0] == static_cast<T>(0.))
+    libmesh_convergence_failure();
   x(0) = b(0) / _coords[0];
 #endif
 
 #if LIBMESH_DIM == 2
   T my_det = _coords[0]*_coords[3] - _coords[1]*_coords[2];
 
-  libmesh_assert_not_equal_to(my_det, static_cast<T>(0.));
+  if (my_det == static_cast<T>(0.))
+    libmesh_convergence_failure();
 
   T my_det_inv = 1./my_det;
 
@@ -1057,7 +1064,8 @@ void TypeTensor<T>::solve(const TypeVector<T> & b, TypeVector<T> & x) const
     //          +a31*(a23       *a12        - a22       *a13)
     /**/ +_coords[6]*(_coords[5]*_coords[1] - _coords[4]*_coords[2]);
 
-  libmesh_assert_not_equal_to(my_det, static_cast<T>(0.));
+  if (my_det == static_cast<T>(0.))
+    libmesh_convergence_failure();
 
   T my_det_inv = 1./my_det;
   x(0) = my_det_inv*((_coords[8]*_coords[4] - _coords[7]*_coords[5])*b(0) -

--- a/src/apps/meshbcid.C
+++ b/src/apps/meshbcid.C
@@ -146,6 +146,10 @@ int main(int argc, char ** argv)
     {
       Elem * elem = *el;
       unsigned int n_sides = elem->n_sides();
+
+      // Container to catch ids handed back from BoundaryInfo
+      std::vector<boundary_id_type> ids;
+
       for (unsigned short s=0; s != n_sides; ++s)
         {
           if (elem->neighbor_ptr(s))
@@ -167,9 +171,19 @@ int main(int argc, char ** argv)
               n(1) > minnormal(1) && n(1) < maxnormal(1) &&
               n(2) > minnormal(2) && n(2) < maxnormal(2))
             {
-              if (matcholdbcid &&
-                  mesh.get_boundary_info().boundary_id(elem, s) != oldbcid)
+              // Get the list of boundary ids for this side
+              mesh.get_boundary_info().boundary_ids(elem, s, ids);
+
+              // There should be at most one value present, otherwise the
+              // logic here won't work.
+              libmesh_assert(ids.size() <= 1);
+
+              // A convenient name for the side's ID.
+              boundary_id_type b_id = ids.empty() ? BoundaryInfo::invalid_id : ids[0];
+
+              if (matcholdbcid && b_id != oldbcid)
                 continue;
+
               mesh.get_boundary_info().remove_side(elem, s);
               mesh.get_boundary_info().add_side(elem, s, bcid);
               //libMesh::out << "Set element " << elem->id() << " side " << s <<

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -347,9 +347,23 @@ bool Tet4::contains_point (const Point & p, Real tol) const
     col3 = point(3) - point(0);
 
   Point r;
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
+            try
+              {
+#endif
   RealTensorValue(col1(0), col2(0), col3(0),
                   col1(1), col2(1), col3(1),
                   col1(2), col2(2), col3(2)).solve(p - point(0), r);
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
+              }
+            catch (ConvergenceFailure &)
+              {
+                // The Jacobian was singular, therefore the Tet had
+                // zero volume.  In this degenerate case, it is not
+                // possible for the Tet to contain any points.
+                return false;
+              }
+#endif
 
   // The point p is inside the tetrahedron if r1 + r2 + r3 < 1 and
   // 0 <= ri <= 1 for i = 1,2,3.

--- a/src/geom/elem_cutter.C
+++ b/src/geom/elem_cutter.C
@@ -56,7 +56,7 @@ ElemCutter::~ElemCutter()
 
 
 
-bool ElemCutter::is_inside (const Elem & elem,
+bool ElemCutter::is_inside (const Elem & libmesh_dbg_var(elem),
                             const std::vector<Real> & vertex_distance_func) const
 {
   libmesh_assert_equal_to (elem.n_vertices(), vertex_distance_func.size());
@@ -71,7 +71,7 @@ bool ElemCutter::is_inside (const Elem & elem,
 
 
 
-bool ElemCutter::is_outside (const Elem & elem,
+bool ElemCutter::is_outside (const Elem & libmesh_dbg_var(elem),
                              const std::vector<Real> & vertex_distance_func) const
 {
   libmesh_assert_equal_to (elem.n_vertices(), vertex_distance_func.size());
@@ -86,7 +86,7 @@ bool ElemCutter::is_outside (const Elem & elem,
 
 
 
-bool ElemCutter::is_cut (const Elem & elem,
+bool ElemCutter::is_cut (const Elem & libmesh_dbg_var(elem),
                          const std::vector<Real> & vertex_distance_func) const
 {
   libmesh_assert_equal_to (elem.n_vertices(), vertex_distance_func.size());

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1303,10 +1303,19 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                   // Get a pointer to the node located at the HEX27 centroid
                   Node * apex_node = base_hex->node_ptr(26);
 
+                  // Container to catch ids handed back from BoundaryInfo
+                  std::vector<boundary_id_type> ids;
+
                   for (unsigned short s=0; s<base_hex->n_sides(); ++s)
                     {
-                      // Get the boundary ID for this side
-                      boundary_id_type b_id = boundary_info.boundary_id(*el, s);
+                      // Get the boundary ID(s) for this side
+                      boundary_info.boundary_ids(*el, s, ids);
+
+                      // We're creating this Mesh, so there should be 0 or 1 boundary IDs.
+                      libmesh_assert(ids.size() <= 1);
+
+                      // A convenient name for the side's ID.
+                      boundary_id_type b_id = ids.empty() ? BoundaryInfo::invalid_id : ids[0];
 
                       // Need to build the full-ordered side!
                       UniquePtr<Elem> side = base_hex->build_side_ptr(s);

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -98,6 +98,9 @@ void MeshTools::Subdivision::all_subdivision(MeshBase & mesh)
   std::vector<short int> new_boundary_sides;
   std::vector<boundary_id_type> new_boundary_ids;
 
+  // Container to catch ids handed back from BoundaryInfo
+  std::vector<boundary_id_type> ids;
+
   MeshBase::const_element_iterator       el     = mesh.elements_begin();
   const MeshBase::const_element_iterator end_el = mesh.elements_end();
   for (; el != end_el; ++el)
@@ -116,12 +119,12 @@ void MeshTools::Subdivision::all_subdivision(MeshBase & mesh)
         {
           for (unsigned short side = 0; side < elem->n_sides(); ++side)
             {
-              const boundary_id_type boundary_id =
-                mesh.get_boundary_info().boundary_id(elem, side);
-              if (boundary_id != BoundaryInfo::invalid_id)
+              mesh.get_boundary_info().boundary_ids(elem, side, ids);
+
+              for (unsigned id=0; id<ids.size(); ++id)
                 {
                   // add the boundary id to the list of new boundary ids
-                  new_boundary_ids.push_back(boundary_id);
+                  new_boundary_ids.push_back(ids[id]);
                   new_boundary_elements.push_back(tri);
                   new_boundary_sides.push_back(side);
                 }

--- a/src/utils/point_locator_list.C
+++ b/src/utils/point_locator_list.C
@@ -192,9 +192,9 @@ const Elem * PointLocatorList::operator() (const Point & p,
 }
 
 
-void PointLocatorList::operator() (const Point & p,
-                                   std::set<const Elem *> & candidate_elements,
-                                   const std::set<subdomain_id_type> * allowed_subdomains) const
+void PointLocatorList::operator() (const Point & /*p*/,
+                                   std::set<const Elem *> & /*candidate_elements*/,
+                                   const std::set<subdomain_id_type> * /*allowed_subdomains*/) const
 {
   // This functionality is not yet implemented for PointLocatorList (and will never be...).
   libmesh_not_implemented();

--- a/tests/numerics/laspack_vector_test.C
+++ b/tests/numerics/laspack_vector_test.C
@@ -4,8 +4,20 @@
 
 #include "numeric_vector_test.h"
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
 
 using namespace libMesh;
 


### PR DESCRIPTION
I don't expect this to be a very common situation, but the way we were handling it before wasn't great: in debug mode we would assert, while in opt mode we would continue on and divide by zero.  This branch throws an exception (regardless of METHOD) in case of a zero determinant, and handles the exception at the call sites in an appropriate way.  I also came across some new warnings while compiling with GCC (usually I use clang) and a few deprecated function calls, so those are fixed as well.