### PR TITLE
Stop GCC 6.1 screaming like a banshee

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -34,7 +34,7 @@
 // GCC > 4.1 supports diagnostic pragmas
 #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 1)
 // These two don't work?
-#pragma GCC diagnostic ignored "-pedantic"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #pragma GCC diagnostic ignored "-Wdeprecated"
 // But this is helpful with some MPI stacks
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -31,7 +31,7 @@
 // TODO: use the gcc 4.6 push/pop when available
 #pragma GCC diagnostic warning "-Wunused-parameter"
 #pragma GCC diagnostic warning "-Wdeprecated"
-#pragma GCC diagnostic warning "-pedantic"
+#pragma GCC diagnostic warning "-Wpedantic"
 #pragma GCC diagnostic warning "-Wdeprecated-declarations"
 #endif // GCC > 4.1
 #endif // __GNUC__ && !__INTEL_COMPILER


### PR DESCRIPTION
Apparently "-pedantic" isn't a warning so it can't be ignored;
"-Wpedantic" is the best we can do.