### PR TITLE
Fix compilation errors with --disable-exceptions

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
+++ b/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
@@ -144,14 +144,11 @@ int main (int argc, char** argv)
       // Compute the reduced basis space by computing "snapshots", i.e.
       // "truth" solves, at well-chosen parameter values and employing
       // these snapshots as basis functions.
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
-      try
+      libmesh_try
         {
-#endif
           rb_con.train_reduced_basis();
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
         }
-      catch (LogicError & e)
+      libmesh_catch (LogicError & e)
         {
           libMesh::err << "\n\n"
                        << "********************************************************************************\n"
@@ -161,7 +158,6 @@ int main (int argc, char** argv)
                        << std::endl;
           return 77;
         }
-#endif
 
       // Write out the data that will subsequently be required for the Evaluation stage
 #if defined(LIBMESH_HAVE_CAPNPROTO)

--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -148,10 +148,14 @@ public:
 }
 
 #define LIBMESH_THROW(e) do { throw e; } while (0)
+#define libmesh_try try
+#define libmesh_catch(e) catch(e)
 
 #else
 
 #define LIBMESH_THROW(e) do { std::abort(); } while (0)
+#define libmesh_try
+#define libmesh_catch(e) if (0)
 
 #endif // LIBMESH_ENABLE_EXCEPTIONS
 

--- a/include/numerics/petsc_solver_exception.h
+++ b/include/numerics/petsc_solver_exception.h
@@ -28,6 +28,9 @@
 namespace libMesh
 {
 
+// The SolverException class is only defined when exceptions are enabled.
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
+
 /**
  * A specialization of the SolverException class for PETSc.
  */
@@ -48,8 +51,6 @@ public:
 
 
 // Macro which we call after every PETSc function that returns an error code.
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
-
 #define LIBMESH_CHKERR(ierr)                    \
   do {                                          \
     if (ierr != 0) {                            \

--- a/src/base/print_trace.C
+++ b/src/base/print_trace.C
@@ -131,7 +131,7 @@ bool gdb_backtrace(std::ostream & out_stream)
 
       int exit_status = 1;
 
-      try
+      libmesh_try
         {
           std::string gdb_command =
             libMesh::command_line_value("gdb",std::string(LIBMESH_GDB_COMMAND));
@@ -144,7 +144,7 @@ bool gdb_backtrace(std::ostream & out_stream)
                   << temp_file;
           exit_status = std::system(command.str().c_str());
         }
-      catch (...)
+      libmesh_catch (...)
         {
           std::cerr << "Unable to run gdb" << std::endl;
         }

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -1761,16 +1761,13 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
             //  {dp} = [J]^-1 ({X} - {X_n})
             //
             //  which involves the inversion of the 3x3 matrix [J]
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
-            try
+            libmesh_try
               {
-#endif
                 RealTensorValue(dxi(0), deta(0), dzeta(0),
                                 dxi(1), deta(1), dzeta(1),
                                 dxi(2), deta(2), dzeta(2)).solve(delta, dp);
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
               }
-            catch (ConvergenceFailure &)
+            libmesh_catch (ConvergenceFailure &)
               {
                 // We encountered a singular Jacobian.  The value of
                 // dp is zero, since it was never changed during the
@@ -1798,7 +1795,6 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
                     return p;
                   }
               }
-#endif
 
             // No master elements have radius > 4, but sometimes we
             // can take a step that big while still converging

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -347,23 +347,20 @@ bool Tet4::contains_point (const Point & p, Real tol) const
     col3 = point(3) - point(0);
 
   Point r;
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
-            try
-              {
-#endif
-  RealTensorValue(col1(0), col2(0), col3(0),
-                  col1(1), col2(1), col3(1),
-                  col1(2), col2(2), col3(2)).solve(p - point(0), r);
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
-              }
-            catch (ConvergenceFailure &)
-              {
-                // The Jacobian was singular, therefore the Tet had
-                // zero volume.  In this degenerate case, it is not
-                // possible for the Tet to contain any points.
-                return false;
-              }
-#endif
+
+  libmesh_try
+    {
+      RealTensorValue(col1(0), col2(0), col3(0),
+                      col1(1), col2(1), col3(1),
+                      col1(2), col2(2), col3(2)).solve(p - point(0), r);
+    }
+  libmesh_catch (ConvergenceFailure &)
+    {
+      // The Jacobian was singular, therefore the Tet had
+      // zero volume.  In this degenerate case, it is not
+      // possible for the Tet to contain any points.
+      return false;
+    }
 
   // The point p is inside the tetrahedron if r1 + r2 + r3 < 1 and
   // 0 <= ri <= 1 for i = 1,2,3.

--- a/src/quadrature/quadrature_composite.C
+++ b/src/quadrature/quadrature_composite.C
@@ -129,19 +129,16 @@ void QComposite<QSubCell>::add_subelem_values (const std::vector<Elem const *> &
       // tetgen seems to create 0-volume cells on occasion, but we *should*
       // be catching that appropriately now inside the ElemCutter class.
       // Just in case trap here, describe the error, and abort.
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
-      try
+      libmesh_try
         {
-#endif
           _lagrange_fe->reinit(*it);
           _weights.insert(_weights.end(),
                           subelem_weights.begin(), subelem_weights.end());
 
           _points.insert(_points.end(),
                          subelem_points.begin(), subelem_points.end());
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
         }
-      catch (...)
+      libmesh_catch (...)
         {
           libMesh::err << "ERROR: found a bad cut cell!\n";
 
@@ -150,7 +147,6 @@ void QComposite<QSubCell>::add_subelem_values (const std::vector<Elem const *> &
 
           libmesh_error_msg("Tetgen may have created a 0-volume cell during Cutcell integration.");
         }
-#endif
     }
 }
 

--- a/src/systems/equation_systems_io.C
+++ b/src/systems/equation_systems_io.C
@@ -94,21 +94,19 @@ void EquationSystems::read (const std::string & name,
                             const unsigned int read_flags,
                             bool partition_agnostic)
 {
-#ifdef LIBMESH_ENABLE_EXCEPTIONS
-
   // If we have exceptions enabled we can be considerate and try
   // to read old restart files which contain infinite element
   // information but do not have the " with infinite elements"
   // string in the version information.
 
   // First try the read the user requested
-  try
+  libmesh_try
     {
       this->_read_impl<InValType> (name, mode, read_flags, partition_agnostic);
     }
 
   // If that fails, try it again but explicitly request we look for infinite element info
-  catch (...)
+  libmesh_catch (...)
     {
       libMesh::out << "\n*********************************************************************\n"
                    << "READING THE FILE \"" << name << "\" FAILED.\n"
@@ -118,29 +116,22 @@ void EquationSystems::read (const std::string & name,
                    << "*********************************************************************\n"
                    << std::endl;
 
-      try
+      libmesh_try
         {
           this->_read_impl<InValType> (name, mode, read_flags | EquationSystems::TRY_READ_IFEMS, partition_agnostic);
         }
 
       // If all that failed, we are out of ideas here...
-      catch (...)
+      libmesh_catch (...)
         {
           libMesh::out << "\n*********************************************************************\n"
                        << "Well, at least we tried!\n"
                        << "Good Luck!!\n"
                        << "*********************************************************************\n"
                        << std::endl;
-          throw;
+          LIBMESH_THROW();
         }
     }
-
-#else
-
-  // no exceptions - cross your fingers...
-  this->_read_impl<InValType> (name, mode, read_flags, partition_agnostic);
-
-#endif // #ifdef LIBMESH_ENABLE_EXCEPTIONS
 
 #ifdef LIBMESH_ENABLE_AMR
   MeshRefinement mesh_refine(_mesh);


### PR DESCRIPTION
Also add `libmesh_try` and `libmesh_catch` macros which expand differently depending on the value of `LIBMESH_ENABLE_EXCEPTIONS`.