### PR TITLE
Fix Hypre check in petsc.m4.

### DIFF
--- a/configure
+++ b/configure
@@ -34889,6 +34889,8 @@ $as_echo "<<< Could not find a viable PETSc Makefile to determine PETSC_CC_INCLU
             HYPRE_LIB=`grep "HYPRE_LIB" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables`
           elif (test -r $PETSC_DIR/conf/petscvariables) ; then # 3.0.x
             HYPRE_LIB=`grep "HYPRE_LIB" $PETSC_DIR/conf/petscvariables`
+          elif (test -r $PETSC_DIR/lib/petsc/conf/petscvariables) ; then # 3.6.x
+            HYPRE_LIB=`grep "HYPRE_LIB" $PETSC_DIR/lib/petsc/conf/petscvariables`
           fi
 
           if test "x$HYPRE_LIB" != x ; then

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -206,6 +206,8 @@ AC_DEFUN([CONFIGURE_PETSC],
             HYPRE_LIB=`grep "HYPRE_LIB" $PETSC_DIR/$PETSC_ARCH/conf/petscvariables`
           elif (test -r $PETSC_DIR/conf/petscvariables) ; then # 3.0.x
             HYPRE_LIB=`grep "HYPRE_LIB" $PETSC_DIR/conf/petscvariables`
+          elif (test -r $PETSC_DIR/lib/petsc/conf/petscvariables) ; then # 3.6.x
+            HYPRE_LIB=`grep "HYPRE_LIB" $PETSC_DIR/lib/petsc/conf/petscvariables`
           fi
 
           if test "x$HYPRE_LIB" != x ; then


### PR DESCRIPTION
I never noticed this because we don't actually use the #define
for anything, but we haven't properly been setting LIBMESH_HAVE_PETSC_HYPRE
since the location of the petscvariables file moved in 3.6.x.