### PR TITLE
Update to how we use _use_close_to_point_tol in PointLocatorTree.

### DIFF
--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -758,11 +758,6 @@ void MeshFunction::disable_out_of_mesh_mode(void)
 
 void MeshFunction::set_point_locator_tolerance(Real tol)
 {
-  // We need to enable out_of_mesh mode in the point_locator
-  // in order for the point locator tolerance to be used.
-  _point_locator->enable_out_of_mesh_mode();
-
-  // Set the tolerance
   _point_locator->set_close_to_point_tol(tol);
 }
 

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -205,25 +205,8 @@ const Elem * PointLocatorTree::operator() (const Point & p,
 
       if (this->_element == libmesh_nullptr)
         {
-          // No element seems to contain this point. Thus:
-          // 1.) If _out_of_mesh_mode == true, we can just return NULL
-          //     without searching further.
-          // 2.) If _out_of_mesh_mode == false, we perform a linear
-          //     search over all active (possibly local) elements.
-          //     The idea here is that, in the case of curved elements,
-          //     the bounding box computed in \p TreeNode::insert(const
-          //     Elem *) might be slightly inaccurate and therefore we may
-          //     have generated a false negative.
-          if (_out_of_mesh_mode == false)
-            {
-              this->_element = this->perform_linear_search(p, allowed_subdomains, /*use_close_to_point*/ false);
-              return this->_element;
-            }
-
           // If we haven't found the element, we may want to do a linear
-          // search using a tolerance. We only do this if _out_of_mesh_mode == true,
-          // since we're looking for a point that may be outside of the mesh (within the
-          // specified tolerance).
+          // search using a tolerance.
           if( _use_close_to_point_tol )
             {
               if(_verbose)
@@ -239,6 +222,24 @@ const Elem * PointLocatorTree::operator() (const Point & p,
                                             /*use_close_to_point*/ true,
                                             _close_to_point_tol);
 
+              return this->_element;
+            }
+
+          // No element seems to contain this point. Thus:
+          // 1.) If _out_of_mesh_mode == true, we can just return NULL
+          //     without searching further.
+          // 2.) If _out_of_mesh_mode == false, we perform a linear
+          //     search over all active (possibly local) elements.
+          //     The idea here is that, in the case of curved elements,
+          //     the bounding box computed in \p TreeNode::insert(const
+          //     Elem *) might be slightly inaccurate and therefore we may
+          //     have generated a false negative.
+          //
+          // Note that we skip the _use_close_to_point_tol case below, because
+          // we already did a linear search in that case above.
+          if (_out_of_mesh_mode == false && !_use_close_to_point_tol)
+            {
+              this->_element = this->perform_linear_search(p, allowed_subdomains, /*use_close_to_point*/ false);
               return this->_element;
             }
         }


### PR DESCRIPTION
Previously we only used _use_close_to_point_tol if _out_of_mesh_mode was true. However, there is an assertion that prevents us from using _out_of_mesh_mode when we have non-affine elements.

This change enables us to use _use_close_to_point_tol regardless of the value of _out_of_mesh_mode, which means that we can use the tolerance-based back-up search with non-affine elements.