### PR TITLE
Fix warnings

### DIFF
--- a/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
+++ b/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
@@ -196,7 +196,7 @@ void assemble_mass(EquationSystems & es,
   const unsigned int dim = mesh.mesh_dimension();
 
   // Get a reference to our system.
-  EigenSystem & eigen_system = es.get_system<EigenSystem> (system_name);
+  EigenSystem & eigen_system = es.get_system<EigenSystem> ("Eigensystem");
 
   // Get a constant reference to the Finite Element type
   // for the first (and only) variable in the system.

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -216,7 +216,7 @@ void assemble_mass(EquationSystems & es,
   const unsigned int dim = mesh.mesh_dimension();
 
   // Get a reference to our system.
-  EigenSystem & eigen_system = es.get_system<EigenSystem> (system_name);
+  EigenSystem & eigen_system = es.get_system<EigenSystem> ("Eigensystem");
 
   // Get a constant reference to the Finite Element type
   // for the first (and only) variable in the system.

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -303,7 +303,7 @@ void assemble_matrices(EquationSystems & es,
   const unsigned int dim = mesh.mesh_dimension();
 
   // Get a reference to our system.
-  EigenSystem & eigen_system = es.get_system<EigenSystem> (system_name);
+  EigenSystem & eigen_system = es.get_system<EigenSystem> ("Eigensystem");
 
   // Get a constant reference to the Finite Element type
   // for the first (and only) variable in the system.

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -25,6 +25,7 @@
 #ifdef LIBMESH_HAVE_TRILINOS
 
 // Trilinos includes
+#include "libmesh/ignore_warnings.h"
 #include <Epetra_FECrsMatrix.h>
 #include <Epetra_Map.h>
 #include <Epetra_MpiComm.h>
@@ -33,6 +34,7 @@
 #ifdef LIBMESH_TRILINOS_HAVE_EPETRAEXT
 #  include <EpetraExt_MatrixMatrix.h>
 #endif
+#include "libmesh/restore_warnings.h"
 
 // Local includes
 #include "libmesh/sparse_matrix.h"

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -29,11 +29,13 @@
 #include "libmesh/parallel.h"
 
 // Trilinos includes
+#include "libmesh/ignore_warnings.h"
 #include <Epetra_CombineMode.h>
 #include <Epetra_Map.h>
 #include <Epetra_MultiVector.h>
 #include <Epetra_Vector.h>
 #include <Epetra_MpiComm.h>
+#include "libmesh/restore_warnings.h"
 
 // C++ includes
 #include <cstddef>

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -28,6 +28,7 @@
 #pragma clang diagnostic ignored "-Wextra-semi"
 #pragma clang diagnostic ignored "-Wvariadic-macros"
 #pragma clang diagnostic ignored "-Wc++11-extensions"
+#pragma clang diagnostic ignored "-Wmacro-redefined"
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -29,6 +29,9 @@
 #pragma clang diagnostic ignored "-Wvariadic-macros"
 #pragma clang diagnostic ignored "-Wc++11-extensions"
 #pragma clang diagnostic ignored "-Wmacro-redefined"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wunused-private-field"
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -66,8 +66,11 @@
 #include "libmesh/petscdmlibmesh.h"
 #endif
 # if defined(LIBMESH_HAVE_SLEPC)
+// Ignore unused variable warnings from SLEPc
+#  include "libmesh/ignore_warnings.h"
 #  include "libmesh/slepc_macro.h"
 #  include <slepc.h>
+#  include "libmesh/restore_warnings.h"
 # endif // #if defined(LIBMESH_HAVE_SLEPC)
 #endif // #if defined(LIBMESH_HAVE_PETSC)
 

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -30,6 +30,7 @@
 #include "libmesh/utility.h"
 
 // Trilinos Includes
+#include "libmesh/ignore_warnings.h"
 #include <Epetra_LocalMap.h>
 #include <Epetra_Comm.h>
 #include <Epetra_Map.h>
@@ -40,6 +41,7 @@
 #include <Epetra_IntSerialDenseVector.h>
 #include <Epetra_SerialDenseVector.h>
 #include <Epetra_Vector.h>
+#include "libmesh/restore_warnings.h"
 
 namespace libMesh
 {

--- a/src/numerics/trilinos_preconditioner.C
+++ b/src/numerics/trilinos_preconditioner.C
@@ -27,8 +27,8 @@
 #include "libmesh/trilinos_epetra_vector.h"
 #include "libmesh/libmesh_common.h"
 
-#ifdef LIBMESH_TRILINOS_HAVE_IFPACK
 #include "libmesh/ignore_warnings.h"
+#ifdef LIBMESH_TRILINOS_HAVE_IFPACK
 #include "Ifpack.h"
 #include "Ifpack_DiagPreconditioner.h"
 #include "Ifpack_AdditiveSchwarz.h"
@@ -36,12 +36,12 @@
 #include "Ifpack_ILUT.h"
 #include "Ifpack_IC.h"
 #include "Ifpack_ICT.h"
-#include "libmesh/ignore_warnings.h"
 #endif
 
 #ifdef LIBMESH_TRILINOS_HAVE_ML
 #include "ml_MultiLevelPreconditioner.h"
 #endif
+#include "libmesh/restore_warnings.h"
 
 namespace libMesh
 {


### PR DESCRIPTION
I inadvertently broke SLEPc-enabled builds while trying to fix warnings.  That should be fixed by this branch as well as ignoring other warnings from the SLEPc and Trilinos headers.