### PR TITLE
Reduce overghosting

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -924,6 +924,14 @@ public:
   virtual const_element_iterator unpartitioned_elements_end () const = 0;
 
   /**
+   * Iterate over active unpartitioned elements in the Mesh.
+   */
+  virtual element_iterator active_unpartitioned_elements_begin () = 0;
+  virtual element_iterator active_unpartitioned_elements_end () = 0;
+  virtual const_element_iterator active_unpartitioned_elements_begin () const = 0;
+  virtual const_element_iterator active_unpartitioned_elements_end () const = 0;
+
+  /**
    * Iterate over "ghost" elements in the Mesh.  A ghost element is
    * one which is *not* local, but *is* semilocal.
    */

--- a/include/mesh/parallel_mesh.h
+++ b/include/mesh/parallel_mesh.h
@@ -363,6 +363,11 @@ public:
   virtual const_element_iterator unpartitioned_elements_begin () const libmesh_override;
   virtual const_element_iterator unpartitioned_elements_end () const libmesh_override;
 
+  virtual element_iterator active_unpartitioned_elements_begin () libmesh_override;
+  virtual element_iterator active_unpartitioned_elements_end () libmesh_override;
+  virtual const_element_iterator active_unpartitioned_elements_begin () const libmesh_override;
+  virtual const_element_iterator active_unpartitioned_elements_end () const libmesh_override;
+
   virtual element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) libmesh_override;
   virtual element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) libmesh_override;
   virtual const_element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) const libmesh_override;

--- a/include/mesh/serial_mesh.h
+++ b/include/mesh/serial_mesh.h
@@ -334,6 +334,11 @@ public:
   virtual const_element_iterator unpartitioned_elements_begin () const libmesh_override;
   virtual const_element_iterator unpartitioned_elements_end () const libmesh_override;
 
+  virtual element_iterator active_unpartitioned_elements_begin () libmesh_override;
+  virtual element_iterator active_unpartitioned_elements_end () libmesh_override;
+  virtual const_element_iterator active_unpartitioned_elements_begin () const libmesh_override;
+  virtual const_element_iterator active_unpartitioned_elements_end () const libmesh_override;
+
   virtual element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) libmesh_override;
   virtual element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) libmesh_override;
   virtual const_element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) const libmesh_override;

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -22,6 +22,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/elem.h"
+#include "libmesh/remote_elem.h"
 #include "libmesh/threads.h"
 #include "libmesh/string_to_enum.h"
 
@@ -694,7 +695,8 @@ void lagrange_compute_constraints (DofConstraints & constraints,
   // Look at the element faces.  Check to see if we need to
   // build constraints.
   for (unsigned int s=0; s<elem->n_sides(); s++)
-    if (elem->neighbor_ptr(s) != libmesh_nullptr)
+    if (elem->neighbor_ptr(s) != libmesh_nullptr &&
+        elem->neighbor_ptr(s) != remote_elem)
       if (elem->neighbor_ptr(s)->level() < elem->level()) // constrain dofs shared between
         {                                                 // this element and ones coarser
           // than this element.

--- a/src/mesh/mesh_iterators.C
+++ b/src/mesh/mesh_iterators.C
@@ -151,6 +151,7 @@ INSTANTIATE_ELEM_ACCESSORS(active_pid_elements,             ActivePID,          
 INSTANTIATE_ELEM_ACCESSORS(active_subdomain_elements,       ActiveSubdomain,      subdomain_id_type subdomain_id, subdomain_id)
 INSTANTIATE_ELEM_ACCESSORS(ghost_elements,                  Ghost,                EMPTY,                          this->processor_id())
 INSTANTIATE_ELEM_ACCESSORS(unpartitioned_elements,          PID,                  EMPTY,                          DofObject::invalid_processor_id)
+INSTANTIATE_ELEM_ACCESSORS(active_unpartitioned_elements,   ActivePID,            EMPTY,                          DofObject::invalid_processor_id)
 INSTANTIATE_ELEM_ACCESSORS(local_level_elements,            LocalLevel,           unsigned int level,             this->processor_id(), level)
 INSTANTIATE_ELEM_ACCESSORS(local_not_level_elements,        LocalNotLevel,        unsigned int level,             this->processor_id(), level)
 INSTANTIATE_ELEM_ACCESSORS(active_local_subdomain_elements, ActiveLocalSubdomain, subdomain_id_type subdomain_id, this->processor_id(), subdomain_id)

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1128,8 +1128,13 @@ void MeshTools::libmesh_assert_valid_remote_elems(const MeshBase & mesh)
     {
       const Elem * elem = *el;
       libmesh_assert (elem);
-      for (unsigned int n=0; n != elem->n_neighbors(); ++n)
-        libmesh_assert_not_equal_to (elem->neighbor_ptr(n), remote_elem);
+
+      // We currently don't allow active_local_elements to have
+      // remote_elem neighbors
+      if (elem->active())
+        for (unsigned int n=0; n != elem->n_neighbors(); ++n)
+          libmesh_assert_not_equal_to (elem->neighbor_ptr(n), remote_elem);
+
 #ifdef LIBMESH_ENABLE_AMR
       const Elem * parent = elem->parent();
       if (parent)

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1138,11 +1138,13 @@ void MeshTools::libmesh_assert_valid_remote_elems(const MeshBase & mesh)
 #ifdef LIBMESH_ENABLE_AMR
       const Elem * parent = elem->parent();
       if (parent)
-        {
-          libmesh_assert_not_equal_to (parent, remote_elem);
-          for (unsigned int c=0; c != elem->n_children(); ++c)
-            libmesh_assert_not_equal_to (parent->child_ptr(c), remote_elem);
-        }
+        libmesh_assert_not_equal_to (parent, remote_elem);
+
+      // We can only be strict about active elements' subactive
+      // children
+      if (elem->active() && elem->has_children())
+        for (unsigned int c=0; c != elem->n_children(); ++c)
+          libmesh_assert_not_equal_to (elem->child_ptr(c), remote_elem);
 #endif
     }
 }

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -445,9 +445,10 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                       libmesh_assert(neigh_has_remote_children);
 
                       // And let's double-check that we don't have
-                      // a remote_elem neighboring a local element
-                      libmesh_assert_not_equal_to (current_elem->processor_id(),
-                                                   this->processor_id());
+                      // a remote_elem neighboring an active local element
+                      if (current_elem->active())
+                        libmesh_assert_not_equal_to (current_elem->processor_id(),
+                                                     this->processor_id());
 #endif // DEBUG
                       neigh = const_cast<RemoteElem *>(remote_elem);
                     }


### PR DESCRIPTION
I'll be adding the new GhostingFunctor interface as discussed in #1028 eventually, but while getting that ready I noticed that we were grossly over-ghosting elements on AMR meshes, by getting point neighbors of not just our active local elements but also of their ancestors.

This PR eliminates some overzealous assertions which were being enabled by overghosting, eliminates the overghosting, and does a little refactoring because redistribute() and delete_remote_elements() should really be using the same ghosting criteria.