### PR TITLE
Add get_array() capability to PetscVector 

### DIFF
--- a/tests/numerics/petsc_vector_test.C
+++ b/tests/numerics/petsc_vector_test.C
@@ -27,7 +27,52 @@ public:
 
   NUMERICVECTORTEST
 
+  CPPUNIT_TEST( testGetArray );
+
   CPPUNIT_TEST_SUITE_END();
+
+  void testGetArray()
+  {
+    unsigned int block_size  = 2;
+
+    // a different size on each processor.
+    unsigned int local_size  = block_size;
+    unsigned int global_size = 0;
+
+    for (libMesh::processor_id_type p=0; p<my_comm->size(); p++)
+      global_size += (block_size + static_cast<unsigned int>(p));
+
+    PetscVector<Number> v(*my_comm, global_size, local_size);
+
+    PetscScalar * values = v.get_array();
+
+    for (unsigned int i=0; i<local_size; i++)
+      values[i] = i;
+
+    v.restore_array();
+
+    v.close();
+
+    // Check the values through the interface
+    for (unsigned int i=0; i<local_size; i++)
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(v(my_comm->rank()*2 + i), i, TOLERANCE*TOLERANCE);
+
+    // Check that we can see the same thing with get_array_read
+    const PetscScalar * read_only_values = v.get_array_read();
+
+    for (unsigned int i=0; i<local_size; i++)
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(read_only_values[i], i, TOLERANCE*TOLERANCE);
+
+    v.restore_array();
+
+    // Test getting a read only array after getting a writeable array
+    values = v.get_array();
+    read_only_values = v.get_array_read();
+    CPPUNIT_ASSERT_EQUAL((intptr_t)read_only_values, (intptr_t)values);
+
+    v.restore_array();
+  }
+
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( PetscVectorTest );


### PR DESCRIPTION
Ads a new interface `PetscVector` to allow getting the raw array.

There are two ways to retrieve the array: `get_array()` and `get_array_read()` associated with whether or not you want read/write or just read only.  There is also `restore_array()` for when you're finished.

One important thing is that the state of that array is now stored... and error checking is done to make sure the new API interoperates with the existing API.  In particular, if you use `get_array()` and then attempt to use one of the other API functions that needs to restore the array... it will produce an error (i.e. a manual "getting" of the array requires a manual "restore").

closes #1050