### PR TITLE
Ghosting functors

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -208,11 +208,12 @@ am__DEPENDENCIES_2 = $(am__DEPENDENCIES_1)
 @LIBMESH_DBG_MODE_TRUE@	$(am__DEPENDENCIES_2)
 am__libmesh_dbg_la_SOURCES_DIST = src/base/dof_map.C \
 	src/base/dof_map_constraints.C src/base/dof_object.C \
-	src/base/libmesh.C src/base/libmesh_common.C \
-	src/base/libmesh_isnan.c src/base/libmesh_singleton.C \
-	src/base/libmesh_version.C src/base/periodic_boundaries.C \
-	src/base/periodic_boundary.C src/base/periodic_boundary_base.C \
-	src/base/print_trace.C src/base/reference_counted_object.C \
+	src/base/ghost_point_neighbors.C src/base/libmesh.C \
+	src/base/libmesh_common.C src/base/libmesh_isnan.c \
+	src/base/libmesh_singleton.C src/base/libmesh_version.C \
+	src/base/periodic_boundaries.C src/base/periodic_boundary.C \
+	src/base/periodic_boundary_base.C src/base/print_trace.C \
+	src/base/reference_counted_object.C \
 	src/base/reference_counter.C src/base/sparsity_pattern.C \
 	src/error_estimation/adjoint_refinement_estimator.C \
 	src/error_estimation/adjoint_residual_error_estimator.C \
@@ -488,6 +489,7 @@ am__dirstamp = $(am__leading_dot)dirstamp
 am__objects_1 = src/base/libmesh_dbg_la-dof_map.lo \
 	src/base/libmesh_dbg_la-dof_map_constraints.lo \
 	src/base/libmesh_dbg_la-dof_object.lo \
+	src/base/libmesh_dbg_la-ghost_point_neighbors.lo \
 	src/base/libmesh_dbg_la-libmesh.lo \
 	src/base/libmesh_dbg_la-libmesh_common.lo \
 	src/base/libmesh_dbg_la-libmesh_isnan.lo \
@@ -916,11 +918,12 @@ libmesh_dbg_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 @LIBMESH_DEVEL_MODE_TRUE@	$(am__DEPENDENCIES_2)
 am__libmesh_devel_la_SOURCES_DIST = src/base/dof_map.C \
 	src/base/dof_map_constraints.C src/base/dof_object.C \
-	src/base/libmesh.C src/base/libmesh_common.C \
-	src/base/libmesh_isnan.c src/base/libmesh_singleton.C \
-	src/base/libmesh_version.C src/base/periodic_boundaries.C \
-	src/base/periodic_boundary.C src/base/periodic_boundary_base.C \
-	src/base/print_trace.C src/base/reference_counted_object.C \
+	src/base/ghost_point_neighbors.C src/base/libmesh.C \
+	src/base/libmesh_common.C src/base/libmesh_isnan.c \
+	src/base/libmesh_singleton.C src/base/libmesh_version.C \
+	src/base/periodic_boundaries.C src/base/periodic_boundary.C \
+	src/base/periodic_boundary_base.C src/base/print_trace.C \
+	src/base/reference_counted_object.C \
 	src/base/reference_counter.C src/base/sparsity_pattern.C \
 	src/error_estimation/adjoint_refinement_estimator.C \
 	src/error_estimation/adjoint_residual_error_estimator.C \
@@ -1195,6 +1198,7 @@ am__libmesh_devel_la_SOURCES_DIST = src/base/dof_map.C \
 am__objects_2 = src/base/libmesh_devel_la-dof_map.lo \
 	src/base/libmesh_devel_la-dof_map_constraints.lo \
 	src/base/libmesh_devel_la-dof_object.lo \
+	src/base/libmesh_devel_la-ghost_point_neighbors.lo \
 	src/base/libmesh_devel_la-libmesh.lo \
 	src/base/libmesh_devel_la-libmesh_common.lo \
 	src/base/libmesh_devel_la-libmesh_isnan.lo \
@@ -1620,11 +1624,12 @@ libmesh_devel_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 @LIBMESH_OPROF_MODE_TRUE@	$(am__DEPENDENCIES_2)
 am__libmesh_oprof_la_SOURCES_DIST = src/base/dof_map.C \
 	src/base/dof_map_constraints.C src/base/dof_object.C \
-	src/base/libmesh.C src/base/libmesh_common.C \
-	src/base/libmesh_isnan.c src/base/libmesh_singleton.C \
-	src/base/libmesh_version.C src/base/periodic_boundaries.C \
-	src/base/periodic_boundary.C src/base/periodic_boundary_base.C \
-	src/base/print_trace.C src/base/reference_counted_object.C \
+	src/base/ghost_point_neighbors.C src/base/libmesh.C \
+	src/base/libmesh_common.C src/base/libmesh_isnan.c \
+	src/base/libmesh_singleton.C src/base/libmesh_version.C \
+	src/base/periodic_boundaries.C src/base/periodic_boundary.C \
+	src/base/periodic_boundary_base.C src/base/print_trace.C \
+	src/base/reference_counted_object.C \
 	src/base/reference_counter.C src/base/sparsity_pattern.C \
 	src/error_estimation/adjoint_refinement_estimator.C \
 	src/error_estimation/adjoint_residual_error_estimator.C \
@@ -1899,6 +1904,7 @@ am__libmesh_oprof_la_SOURCES_DIST = src/base/dof_map.C \
 am__objects_3 = src/base/libmesh_oprof_la-dof_map.lo \
 	src/base/libmesh_oprof_la-dof_map_constraints.lo \
 	src/base/libmesh_oprof_la-dof_object.lo \
+	src/base/libmesh_oprof_la-ghost_point_neighbors.lo \
 	src/base/libmesh_oprof_la-libmesh.lo \
 	src/base/libmesh_oprof_la-libmesh_common.lo \
 	src/base/libmesh_oprof_la-libmesh_isnan.lo \
@@ -2324,11 +2330,12 @@ libmesh_oprof_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 @LIBMESH_OPT_MODE_TRUE@	$(am__DEPENDENCIES_2)
 am__libmesh_opt_la_SOURCES_DIST = src/base/dof_map.C \
 	src/base/dof_map_constraints.C src/base/dof_object.C \
-	src/base/libmesh.C src/base/libmesh_common.C \
-	src/base/libmesh_isnan.c src/base/libmesh_singleton.C \
-	src/base/libmesh_version.C src/base/periodic_boundaries.C \
-	src/base/periodic_boundary.C src/base/periodic_boundary_base.C \
-	src/base/print_trace.C src/base/reference_counted_object.C \
+	src/base/ghost_point_neighbors.C src/base/libmesh.C \
+	src/base/libmesh_common.C src/base/libmesh_isnan.c \
+	src/base/libmesh_singleton.C src/base/libmesh_version.C \
+	src/base/periodic_boundaries.C src/base/periodic_boundary.C \
+	src/base/periodic_boundary_base.C src/base/print_trace.C \
+	src/base/reference_counted_object.C \
 	src/base/reference_counter.C src/base/sparsity_pattern.C \
 	src/error_estimation/adjoint_refinement_estimator.C \
 	src/error_estimation/adjoint_residual_error_estimator.C \
@@ -2603,6 +2610,7 @@ am__libmesh_opt_la_SOURCES_DIST = src/base/dof_map.C \
 am__objects_4 = src/base/libmesh_opt_la-dof_map.lo \
 	src/base/libmesh_opt_la-dof_map_constraints.lo \
 	src/base/libmesh_opt_la-dof_object.lo \
+	src/base/libmesh_opt_la-ghost_point_neighbors.lo \
 	src/base/libmesh_opt_la-libmesh.lo \
 	src/base/libmesh_opt_la-libmesh_common.lo \
 	src/base/libmesh_opt_la-libmesh_isnan.lo \
@@ -3027,11 +3035,12 @@ libmesh_opt_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 @LIBMESH_PROF_MODE_TRUE@	$(am__DEPENDENCIES_2)
 am__libmesh_prof_la_SOURCES_DIST = src/base/dof_map.C \
 	src/base/dof_map_constraints.C src/base/dof_object.C \
-	src/base/libmesh.C src/base/libmesh_common.C \
-	src/base/libmesh_isnan.c src/base/libmesh_singleton.C \
-	src/base/libmesh_version.C src/base/periodic_boundaries.C \
-	src/base/periodic_boundary.C src/base/periodic_boundary_base.C \
-	src/base/print_trace.C src/base/reference_counted_object.C \
+	src/base/ghost_point_neighbors.C src/base/libmesh.C \
+	src/base/libmesh_common.C src/base/libmesh_isnan.c \
+	src/base/libmesh_singleton.C src/base/libmesh_version.C \
+	src/base/periodic_boundaries.C src/base/periodic_boundary.C \
+	src/base/periodic_boundary_base.C src/base/print_trace.C \
+	src/base/reference_counted_object.C \
 	src/base/reference_counter.C src/base/sparsity_pattern.C \
 	src/error_estimation/adjoint_refinement_estimator.C \
 	src/error_estimation/adjoint_residual_error_estimator.C \
@@ -3306,6 +3315,7 @@ am__libmesh_prof_la_SOURCES_DIST = src/base/dof_map.C \
 am__objects_5 = src/base/libmesh_prof_la-dof_map.lo \
 	src/base/libmesh_prof_la-dof_map_constraints.lo \
 	src/base/libmesh_prof_la-dof_object.lo \
+	src/base/libmesh_prof_la-ghost_point_neighbors.lo \
 	src/base/libmesh_prof_la-libmesh.lo \
 	src/base/libmesh_prof_la-libmesh_common.lo \
 	src/base/libmesh_prof_la-libmesh_isnan.lo \
@@ -4675,6 +4685,7 @@ libmesh_SOURCES = \
         src/base/dof_map.C \
         src/base/dof_map_constraints.C \
         src/base/dof_object.C \
+        src/base/ghost_point_neighbors.C \
         src/base/libmesh.C \
         src/base/libmesh_common.C \
         src/base/libmesh_isnan.c \
@@ -5454,6 +5465,8 @@ src/base/libmesh_dbg_la-dof_map_constraints.lo:  \
 	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_dbg_la-dof_object.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
+src/base/libmesh_dbg_la-ghost_point_neighbors.lo:  \
+	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_dbg_la-libmesh.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_dbg_la-libmesh_common.lo: src/base/$(am__dirstamp) \
@@ -6553,6 +6566,8 @@ src/base/libmesh_devel_la-dof_map_constraints.lo:  \
 	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_devel_la-dof_object.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
+src/base/libmesh_devel_la-ghost_point_neighbors.lo:  \
+	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_devel_la-libmesh.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_devel_la-libmesh_common.lo: src/base/$(am__dirstamp) \
@@ -7571,6 +7586,8 @@ src/base/libmesh_oprof_la-dof_map_constraints.lo:  \
 	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_oprof_la-dof_object.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
+src/base/libmesh_oprof_la-ghost_point_neighbors.lo:  \
+	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_oprof_la-libmesh.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_oprof_la-libmesh_common.lo: src/base/$(am__dirstamp) \
@@ -8589,6 +8606,8 @@ src/base/libmesh_opt_la-dof_map_constraints.lo:  \
 	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_opt_la-dof_object.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
+src/base/libmesh_opt_la-ghost_point_neighbors.lo:  \
+	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_opt_la-libmesh.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_opt_la-libmesh_common.lo: src/base/$(am__dirstamp) \
@@ -9604,6 +9623,8 @@ src/base/libmesh_prof_la-dof_map_constraints.lo:  \
 	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_prof_la-dof_object.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
+src/base/libmesh_prof_la-ghost_point_neighbors.lo:  \
+	src/base/$(am__dirstamp) src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_prof_la-libmesh.lo: src/base/$(am__dirstamp) \
 	src/base/$(DEPDIR)/$(am__dirstamp)
 src/base/libmesh_prof_la-libmesh_common.lo: src/base/$(am__dirstamp) \
@@ -11118,6 +11139,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-dof_map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-dof_map_constraints.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-dof_object.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-ghost_point_neighbors.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-libmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-libmesh_common.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-libmesh_isnan.Plo@am__quote@
@@ -11133,6 +11155,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_devel_la-dof_map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_devel_la-dof_map_constraints.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_devel_la-dof_object.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_devel_la-ghost_point_neighbors.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_devel_la-libmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_devel_la-libmesh_common.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_devel_la-libmesh_isnan.Plo@am__quote@
@@ -11148,6 +11171,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_oprof_la-dof_map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_oprof_la-dof_map_constraints.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_oprof_la-dof_object.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_oprof_la-ghost_point_neighbors.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_oprof_la-libmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_oprof_la-libmesh_common.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_oprof_la-libmesh_isnan.Plo@am__quote@
@@ -11163,6 +11187,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_opt_la-dof_map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_opt_la-dof_map_constraints.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_opt_la-dof_object.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_opt_la-ghost_point_neighbors.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_opt_la-libmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_opt_la-libmesh_common.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_opt_la-libmesh_isnan.Plo@am__quote@
@@ -11178,6 +11203,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_prof_la-dof_map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_prof_la-dof_map_constraints.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_prof_la-dof_object.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_prof_la-ghost_point_neighbors.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_prof_la-libmesh.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_prof_la-libmesh_common.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_prof_la-libmesh_isnan.Plo@am__quote@
@@ -13235,6 +13261,13 @@ src/base/libmesh_dbg_la-dof_object.lo: src/base/dof_object.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/base/dof_object.C' object='src/base/libmesh_dbg_la-dof_object.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_dbg_la-dof_object.lo `test -f 'src/base/dof_object.C' || echo '$(srcdir)/'`src/base/dof_object.C
+
+src/base/libmesh_dbg_la-ghost_point_neighbors.lo: src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_dbg_la-ghost_point_neighbors.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_dbg_la-ghost_point_neighbors.Tpo -c -o src/base/libmesh_dbg_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/base/$(DEPDIR)/libmesh_dbg_la-ghost_point_neighbors.Tpo src/base/$(DEPDIR)/libmesh_dbg_la-ghost_point_neighbors.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/base/ghost_point_neighbors.C' object='src/base/libmesh_dbg_la-ghost_point_neighbors.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_dbg_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
 
 src/base/libmesh_dbg_la-libmesh.lo: src/base/libmesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_dbg_la-libmesh.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_dbg_la-libmesh.Tpo -c -o src/base/libmesh_dbg_la-libmesh.lo `test -f 'src/base/libmesh.C' || echo '$(srcdir)/'`src/base/libmesh.C
@@ -16134,6 +16167,13 @@ src/base/libmesh_devel_la-dof_object.lo: src/base/dof_object.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_devel_la-dof_object.lo `test -f 'src/base/dof_object.C' || echo '$(srcdir)/'`src/base/dof_object.C
 
+src/base/libmesh_devel_la-ghost_point_neighbors.lo: src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_devel_la-ghost_point_neighbors.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_devel_la-ghost_point_neighbors.Tpo -c -o src/base/libmesh_devel_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/base/$(DEPDIR)/libmesh_devel_la-ghost_point_neighbors.Tpo src/base/$(DEPDIR)/libmesh_devel_la-ghost_point_neighbors.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/base/ghost_point_neighbors.C' object='src/base/libmesh_devel_la-ghost_point_neighbors.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_devel_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
+
 src/base/libmesh_devel_la-libmesh.lo: src/base/libmesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_devel_la-libmesh.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_devel_la-libmesh.Tpo -c -o src/base/libmesh_devel_la-libmesh.lo `test -f 'src/base/libmesh.C' || echo '$(srcdir)/'`src/base/libmesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/base/$(DEPDIR)/libmesh_devel_la-libmesh.Tpo src/base/$(DEPDIR)/libmesh_devel_la-libmesh.Plo
@@ -19031,6 +19071,13 @@ src/base/libmesh_oprof_la-dof_object.lo: src/base/dof_object.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/base/dof_object.C' object='src/base/libmesh_oprof_la-dof_object.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_oprof_la-dof_object.lo `test -f 'src/base/dof_object.C' || echo '$(srcdir)/'`src/base/dof_object.C
+
+src/base/libmesh_oprof_la-ghost_point_neighbors.lo: src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_oprof_la-ghost_point_neighbors.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_oprof_la-ghost_point_neighbors.Tpo -c -o src/base/libmesh_oprof_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/base/$(DEPDIR)/libmesh_oprof_la-ghost_point_neighbors.Tpo src/base/$(DEPDIR)/libmesh_oprof_la-ghost_point_neighbors.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/base/ghost_point_neighbors.C' object='src/base/libmesh_oprof_la-ghost_point_neighbors.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_oprof_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
 
 src/base/libmesh_oprof_la-libmesh.lo: src/base/libmesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_oprof_la-libmesh.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_oprof_la-libmesh.Tpo -c -o src/base/libmesh_oprof_la-libmesh.lo `test -f 'src/base/libmesh.C' || echo '$(srcdir)/'`src/base/libmesh.C
@@ -21930,6 +21977,13 @@ src/base/libmesh_opt_la-dof_object.lo: src/base/dof_object.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_opt_la-dof_object.lo `test -f 'src/base/dof_object.C' || echo '$(srcdir)/'`src/base/dof_object.C
 
+src/base/libmesh_opt_la-ghost_point_neighbors.lo: src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_opt_la-ghost_point_neighbors.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_opt_la-ghost_point_neighbors.Tpo -c -o src/base/libmesh_opt_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/base/$(DEPDIR)/libmesh_opt_la-ghost_point_neighbors.Tpo src/base/$(DEPDIR)/libmesh_opt_la-ghost_point_neighbors.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/base/ghost_point_neighbors.C' object='src/base/libmesh_opt_la-ghost_point_neighbors.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_opt_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
+
 src/base/libmesh_opt_la-libmesh.lo: src/base/libmesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_opt_la-libmesh.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_opt_la-libmesh.Tpo -c -o src/base/libmesh_opt_la-libmesh.lo `test -f 'src/base/libmesh.C' || echo '$(srcdir)/'`src/base/libmesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/base/$(DEPDIR)/libmesh_opt_la-libmesh.Tpo src/base/$(DEPDIR)/libmesh_opt_la-libmesh.Plo
@@ -24827,6 +24881,13 @@ src/base/libmesh_prof_la-dof_object.lo: src/base/dof_object.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/base/dof_object.C' object='src/base/libmesh_prof_la-dof_object.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_prof_la-dof_object.lo `test -f 'src/base/dof_object.C' || echo '$(srcdir)/'`src/base/dof_object.C
+
+src/base/libmesh_prof_la-ghost_point_neighbors.lo: src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_prof_la-ghost_point_neighbors.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_prof_la-ghost_point_neighbors.Tpo -c -o src/base/libmesh_prof_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/base/$(DEPDIR)/libmesh_prof_la-ghost_point_neighbors.Tpo src/base/$(DEPDIR)/libmesh_prof_la-ghost_point_neighbors.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/base/ghost_point_neighbors.C' object='src/base/libmesh_prof_la-ghost_point_neighbors.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/base/libmesh_prof_la-ghost_point_neighbors.lo `test -f 'src/base/ghost_point_neighbors.C' || echo '$(srcdir)/'`src/base/ghost_point_neighbors.C
 
 src/base/libmesh_prof_la-libmesh.lo: src/base/libmesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/base/libmesh_prof_la-libmesh.lo -MD -MP -MF src/base/$(DEPDIR)/libmesh_prof_la-libmesh.Tpo -c -o src/base/libmesh_prof_la-libmesh.lo `test -f 'src/base/libmesh.C' || echo '$(srcdir)/'`src/base/libmesh.C

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -592,6 +592,7 @@ include_HEADERS = \
         base/dof_object.h \
         base/factory.h \
         base/getpot.h \
+        base/ghosting_functor.h \
         base/id_types.h \
         base/libmesh.h \
         base/libmesh_C_isnan.h \

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -592,6 +592,7 @@ include_HEADERS = \
         base/dof_object.h \
         base/factory.h \
         base/getpot.h \
+        base/ghost_point_neighbors.h \
         base/ghosting_functor.h \
         base/id_types.h \
         base/libmesh.h \

--- a/include/base/ghost_point_neighbors.h
+++ b/include/base/ghost_point_neighbors.h
@@ -1,0 +1,62 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2016 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_GHOST_POINT_NEIGHBORS_H
+#define LIBMESH_GHOST_POINT_NEIGHBORS_H
+
+// Local Includes -----------------------------------
+#include "libmesh/ghosting_functor.h"
+
+namespace libMesh
+{
+
+/**
+ * This class implements the default geometry ghosting in libMesh:
+ * point neighbors and interior_parent elements are ghosted.
+ *
+ * \author Roy H. Stogner
+ * \date 2016
+ */
+class GhostPointNeighbors : public GhostingFunctor
+{
+public:
+
+  /**
+   * Constructor.
+   */
+  GhostPointNeighbors(const MeshBase & mesh) : _mesh(mesh) {}
+
+  /**
+   * For the specified range of active elements, find their point
+   * neighbors and interior_parent elements, ignoring those on
+   * processor p.
+   */
+  virtual void operator() (const MeshBase::const_element_iterator & range_begin,
+                           const MeshBase::const_element_iterator & range_end,
+                           processor_id_type p,
+                           map_type & coupled_elements);
+
+private:
+
+  const MeshBase & _mesh;
+};
+
+} // namespace libMesh
+
+#endif // LIBMESH_GHOST_POINT_NEIGHBORS_H

--- a/include/base/ghosting_functor.h
+++ b/include/base/ghosting_functor.h
@@ -144,6 +144,10 @@ public:
    * currently living (whether local or ghosted) on this processor
    * need to be coupled/ghosted to accomodate them?  Don't bother to
    * return any results which already have processor_id p.
+   *
+   * This API is new, and we should replace "ignoring those on
+   * processor p" with "ignoring those which match a predicate
+   * functor" eventually.
    */
   virtual void operator() (const MeshBase::const_element_iterator & range_begin,
                            const MeshBase::const_element_iterator & range_end,

--- a/include/base/ghosting_functor.h
+++ b/include/base/ghosting_functor.h
@@ -1,0 +1,182 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2016 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_GHOSTING_FUNCTOR_H
+#define LIBMESH_GHOSTING_FUNCTOR_H
+
+// Local Includes -----------------------------------
+#include "libmesh/libmesh_common.h"
+#include "libmesh/id_types.h"
+#include "libmesh/mesh_base.h"
+#include "libmesh/reference_counted_object.h"
+
+// C++ Includes   -----------------------------------
+#include LIBMESH_INCLUDE_UNORDERED_MAP
+
+namespace libMesh
+{
+
+// Forward Declarations
+class CouplingMatrix;
+class Elem;
+
+
+/**
+ * This abstract base class defines the interface by which library
+ * code and user code can report associations between elements.  These
+ * associations between elements may be used to keep copies of
+ * non-local elements retained on a distributed mesh, may be used to
+ * keep element degrees of freedom properly communicated on a
+ * distributed vector, and/or may be used to insert coupling entries
+ * between elements' degrees of freedom to a sparsity matrix.
+ *
+ *
+ * We can think of three levels of "element dependencies". An element
+ * K1 has a coupling dependency on K2 if the dofs on K1 might (modulo
+ * the coupling matrix) need sparsity pattern entries for dofs on K2.
+ * An element K1 has an algebraic dependency on K2 if a processor
+ * which owns K1 might need to examine the solution dof values on K2.
+ * An element K1 has a geometric dependency on K2 if a processor which
+ * owns K1 might need to examine the geometry of K2. For any element
+ * K, we could call the set of algebraic-ghosted("coupled") elements
+ * C(K), call the set of solution-ghosted ("evaluable") elements E(K),
+ * and call the set of geometry-ghosted ("ghosted") elements G(K).
+ *
+ * It should be safe to assume that, for any element K, C(K) implies
+ * E(K) implies G(K). These will be one-way implications in some
+ * problems and equality relations in others.
+ *
+ * We can think of these as operators on sets of elements in the
+ * obvious way, e.g.: G({K}) = {G(Ki) for all Ki in {K}}.
+ *
+ * The user should omit from their implementations relations which we
+ * already have enough information to understand implicitly. For
+ * instance, K is obviously in C(K), so a GhostingFunctor should never
+ * bother telling us so. We may have a PeriodicBoundary, a hanging
+ * node constraint equation, or a user-defined constraint equation
+ * which creates a dependency between two elements; if so then we
+ * don't need the user to also tell us about that relation (although
+ * a PeriodicBoundary use will cause the library to create its own
+ * PeriodicGhostingFunctor for internal use).
+ *
+ * Users may only care about a subset of variables in distant
+ * evaluable elements, so we could imagine defining E_v(K) for each
+ * variable number v, in which case E(K) under our previous definition
+ * is the union of E_v(K) forall v, and this is what would be included
+ * in G(K) when deciding what to ghost, but our send_list would only
+ * include the subset of variables we need, so communication and
+ * memory use would be much reduced.  However, for efficiency and API
+ * simplicity, we instead define the isomorphic operator E'(K) which
+ * gives a set of ordered pairs of elements and variable-number-sets,
+ * from which a consistent E(K) would be derived by ignoring the
+ * variable-number-sets.
+ *
+ * For C(K), there are similar issues: e.g. we may want some
+ * discontinuous variables to couple only within their own element but
+ * other discontinuous variables to couple in a DG/FVM way. This could
+ * extend to more than one variable index: i.e. a dof for variable v1
+ * in element K1 would depend on a dof for variable v2 in element K2
+ * iff K2 is in C_v1_v2(K1). This would induce a consistent E_v(K) =
+ * union of C_w_v(K) forall variable indices w. Again, the equivalent
+ * API alternative we use here is for C'(K) to return a set of ordered
+ * pairs of elements and variable-number-pair-sets.
+ *
+ * We return variable-stuff-sets as pointers to CouplingMatrix.  That
+ * way, in the common case where the user cares about all variables and
+ * couple to all variables, all the functor needs to return for
+ * variable-number-sets and variable-number-pair-sets is a NULL (which
+ * as in other libMesh APIs will be interpreted and documented to mean
+ * the full set). In the common case where the user wants coupling
+ * between elements to match coupling within elements, the functor can
+ * return the same pointer as DofMap::_coupling_matrix. Even in the
+ * less common cases, the user can store common variable-number-sets
+ * and variable-number-pair sets as CouplingMatrix members of a
+ * functor object of their subclass, and setting up a few of those
+ * matrices then setting lots of those pointers is cheap.
+ *
+ * The definition of the CouplingMatrix for a variable-dependent E'
+ * should be consistent with the requirements that would have been
+ * imposed had that matrix been used for a C'.  In other words, if the
+ * returned CouplingMatrix CM has CM(i,j)==true for any i, then
+ * variable j will be evaluable on the algebraically ghosted element.
+ *
+ * \author Roy H. Stogner
+ * \date 2016
+ */
+class GhostingFunctor : public ReferenceCountedObject<GhostingFunctor>
+{
+public:
+
+  /**
+   * Constructor.  Empty in the base class.
+   */
+  GhostingFunctor() {}
+
+  /**
+   * Virtual destructor; this is an abstract base class.
+   */
+  virtual ~GhostingFunctor() {}
+
+  /**
+   * What elements do we care about and what variables do we care
+   * about on each element?
+   */
+  typedef LIBMESH_BEST_UNORDERED_MAP<const Elem*, const CouplingMatrix*> map_type;
+
+  /**
+   * For the specified range of active elements, what other elements
+   * currently living (whether local or ghosted) on this processor
+   * need to be coupled/ghosted to accomodate them?  Don't bother to
+   * return any results which already have processor_id p.
+   */
+  virtual void operator() (const MeshBase::const_element_iterator & range_begin,
+                           const MeshBase::const_element_iterator & range_end,
+                           processor_id_type p,
+                           map_type & coupled_elements) = 0;
+
+  /**
+   * GhostingFunctor subclasses which cache data will need to
+   * initialize that cache.  We call reinit() whenever the relevant
+   * Mesh or DofMap has changed.
+   */
+  virtual void reinit () {};
+
+  /**
+   * GhostingFunctor subclasses with relatively long-lasting caches
+   * may want to redistribute those caches whenever the relevant Mesh
+   * is redistributed; we will give them an opportunity when that
+   * happens.  At the point in the code where this is called, element
+   * processor ids have been set to their new destinations, and those
+   * elements have been copied to their new destinations, but the
+   * elements have not yet been deleted by the processors which
+   * previously held them..
+   */
+  virtual void redistribute () {};
+
+  /**
+   * GhostingFunctor subclasses with relatively long-lasting caches
+   * may want to delete the no-longer-relevant parts of those caches
+   * after a redistribution is complete.
+   */
+  virtual void delete_remote_elements () {};
+};
+
+} // namespace libMesh
+
+#endif // LIBMESH_GHOSTING_FUNCTOR_H

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -24,6 +24,7 @@ include_HEADERS =  \
         base/dof_object.h \
         base/factory.h \
         base/getpot.h \
+        base/ghosting_functor.h \
         base/id_types.h \
         base/libmesh.h \
         base/libmesh_C_isnan.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -24,6 +24,7 @@ include_HEADERS =  \
         base/dof_object.h \
         base/factory.h \
         base/getpot.h \
+        base/ghost_point_neighbors.h \
         base/ghosting_functor.h \
         base/id_types.h \
         base/libmesh.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -12,6 +12,7 @@ BUILT_SOURCES = \
         dof_object.h \
         factory.h \
         getpot.h \
+        ghost_point_neighbors.h \
         ghosting_functor.h \
         id_types.h \
         libmesh.h \
@@ -535,6 +536,9 @@ factory.h: $(top_srcdir)/include/base/factory.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 getpot.h: $(top_srcdir)/include/base/getpot.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+ghost_point_neighbors.h: $(top_srcdir)/include/base/ghost_point_neighbors.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 ghosting_functor.h: $(top_srcdir)/include/base/ghosting_functor.h

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -12,6 +12,7 @@ BUILT_SOURCES = \
         dof_object.h \
         factory.h \
         getpot.h \
+        ghosting_functor.h \
         id_types.h \
         libmesh.h \
         libmesh_C_isnan.h \
@@ -534,6 +535,9 @@ factory.h: $(top_srcdir)/include/base/factory.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 getpot.h: $(top_srcdir)/include/base/getpot.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+ghosting_functor.h: $(top_srcdir)/include/base/ghosting_functor.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 id_types.h: $(top_srcdir)/include/base/id_types.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -486,12 +486,13 @@ vtkversion = @vtkversion@
 # include the magic script!
 EXTRA_DIST = rebuild_makefile.sh
 BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
-	dof_object.h factory.h getpot.h ghosting_functor.h id_types.h \
-	libmesh.h libmesh_C_isnan.h libmesh_augment_std_namespace.h \
-	libmesh_base.h libmesh_common.h libmesh_documentation.h \
-	libmesh_exceptions.h libmesh_logging.h libmesh_singleton.h \
-	libmesh_version.h multi_predicates.h periodic_boundaries.h \
-	periodic_boundary.h periodic_boundary_base.h print_trace.h \
+	dof_object.h factory.h getpot.h ghost_point_neighbors.h \
+	ghosting_functor.h id_types.h libmesh.h libmesh_C_isnan.h \
+	libmesh_augment_std_namespace.h libmesh_base.h \
+	libmesh_common.h libmesh_documentation.h libmesh_exceptions.h \
+	libmesh_logging.h libmesh_singleton.h libmesh_version.h \
+	multi_predicates.h periodic_boundaries.h periodic_boundary.h \
+	periodic_boundary_base.h print_trace.h \
 	reference_counted_object.h reference_counter.h \
 	single_predicates.h sparsity_pattern.h variable.h \
 	variant_filter_iterator.h enum_convergence_flags.h \
@@ -885,6 +886,9 @@ factory.h: $(top_srcdir)/include/base/factory.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 getpot.h: $(top_srcdir)/include/base/getpot.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+ghost_point_neighbors.h: $(top_srcdir)/include/base/ghost_point_neighbors.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 ghosting_functor.h: $(top_srcdir)/include/base/ghosting_functor.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -486,8 +486,8 @@ vtkversion = @vtkversion@
 # include the magic script!
 EXTRA_DIST = rebuild_makefile.sh
 BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
-	dof_object.h factory.h getpot.h id_types.h libmesh.h \
-	libmesh_C_isnan.h libmesh_augment_std_namespace.h \
+	dof_object.h factory.h getpot.h ghosting_functor.h id_types.h \
+	libmesh.h libmesh_C_isnan.h libmesh_augment_std_namespace.h \
 	libmesh_base.h libmesh_common.h libmesh_documentation.h \
 	libmesh_exceptions.h libmesh_logging.h libmesh_singleton.h \
 	libmesh_version.h multi_predicates.h periodic_boundaries.h \
@@ -885,6 +885,9 @@ factory.h: $(top_srcdir)/include/base/factory.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 getpot.h: $(top_srcdir)/include/base/getpot.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+ghosting_functor.h: $(top_srcdir)/include/base/ghosting_functor.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 id_types.h: $(top_srcdir)/include/base/id_types.h

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -43,6 +43,7 @@ namespace libMesh
 
 // forward declarations
 class Elem;
+class GhostingFunctor;
 class Node;
 class Point;
 class MeshData;
@@ -694,6 +695,37 @@ public:
   bool skip_partitioning() const { return _skip_partitioning; }
 
   /**
+   * Adds a functor which can specify ghosting requirements for use on
+   * distributed meshes.  Multiple ghosting functors can be added; any
+   * element which is required by any functor will be ghosted.
+   *
+   * GhostingFunctor memory must be managed by the code which calls
+   * this function; the GhostingFunctor lifetime is expected to extend
+   * until either the functor is removed or the Mesh is destructed.
+   */
+  void add_ghosting_functor(GhostingFunctor *ghosting_functor)
+  { _ghosting_functors.insert(ghosting_functor); }
+
+  /**
+   * Removes a functor which was previously added to the set of
+   * ghosting functors.
+   */
+  void remove_ghosting_functor(GhostingFunctor *ghosting_functor)
+  { _ghosting_functors.erase(ghosting_functor); }
+
+  /**
+   * Beginning of range of ghosting functors
+   */
+  std::set<GhostingFunctor *>::iterator ghosting_functors_begin()
+  { return _ghosting_functors.begin(); }
+
+  /**
+   * End of range of ghosting functors
+   */
+  std::set<GhostingFunctor *>::iterator ghosting_functors_end()
+  { return _ghosting_functors.end(); }
+
+  /**
    * Constructs a list of all subdomain identifiers in the global mesh.
    * Subdomains correspond to separate subsets of the mesh which could correspond
    * e.g. to different materials in a solid mechanics application,
@@ -1190,6 +1222,15 @@ protected:
    * Mesh::spatial_dimension() for more information.
    */
   unsigned char _spatial_dimension;
+
+  /**
+   * The list of all GhostingFunctor objects to be used when
+   * distributing a DistributedMesh.
+   *
+   * Basically unused by ReplicatedMesh for now, but belongs to
+   * MeshBase because the cost is trivial.
+   */
+  std::set<GhostingFunctor *> _ghosting_functors;
 
   /**
    * The partitioner class is a friend so that it can set

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1224,6 +1224,13 @@ protected:
   unsigned char _spatial_dimension;
 
   /**
+   * The default geometric GhostingFunctor, used to implement standard
+   * libMesh element ghosting behavior.  We use a base class pointer
+   * here to avoid dragging in more header dependencies.
+   */
+  UniquePtr<GhostingFunctor> _default_ghosting;
+
+  /**
    * The list of all GhostingFunctor objects to be used when
    * distributing a DistributedMesh.
    *

--- a/src/base/ghost_point_neighbors.C
+++ b/src/base/ghost_point_neighbors.C
@@ -1,0 +1,153 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2016 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+// C++ Includes   -----------------------------------
+#include <set>
+#include <utility> // std::make_pair
+
+// Local Includes -----------------------------------
+#include "libmesh/ghost_point_neighbors.h"
+
+#include "libmesh/elem.h"
+#include "libmesh/remote_elem.h"
+
+namespace libMesh
+{
+
+void GhostPointNeighbors::operator()
+  (const MeshBase::const_element_iterator & range_begin,
+   const MeshBase::const_element_iterator & range_end,
+   processor_id_type p,
+   GhostPointNeighbors::map_type & coupled_elements)
+{
+  // Using the connected_nodes set rather than point_neighbors() gives
+  // us correct results even in corner cases, such as where two
+  // elements meet only at a corner.  ;-)
+
+  std::set<const Node *> connected_nodes;
+
+  // Links between boundary and interior elements on mixed
+  // dimensional meshes also give us correct ghosting in this way.
+  std::set<const Elem *> interior_parents;
+
+  // We also preserve neighbors and their neighboring children for
+  // active local elements - in most cases this is redundant with the
+  // node check, but for non-conforming Tet4 meshes and
+  // non-level-one-conforming 2D+3D meshes it is possible for an
+  // element and its coarse neighbor to not share any vertices.
+  //
+  // We also preserve interior parents for active pid elements
+
+
+  // This code is just for geometric coupling, so we use a null
+  // CouplingMatrix pointer.  We'll declare that here so as to avoid
+  // confusing the insert() calls later.
+  CouplingMatrix *nullcm = libmesh_nullptr;
+
+  for (MeshBase::const_element_iterator elem_it = range_begin;
+       elem_it!=range_end; ++elem_it)
+    {
+      const Elem * elem = *elem_it;
+
+      if (elem->processor_id() != p)
+        coupled_elements.insert (std::make_pair(elem,nullcm));
+
+      for (unsigned int s=0; s != elem->n_sides(); ++s)
+        {
+          const Elem * neigh = elem->neighbor_ptr(s);
+          if (neigh && neigh != remote_elem)
+            {
+#ifdef LIBMESH_ENABLE_AMR
+              if (!neigh->active())
+                {
+                  std::vector<const Elem*> family;
+                  neigh->active_family_tree_by_neighbor(family, elem);
+
+                  for (dof_id_type i=0; i!=family.size(); ++i)
+                    if (family[i]->processor_id() != p)
+                      coupled_elements.insert
+                        (std::make_pair(family[i], nullcm));
+                }
+              else
+#endif
+                if (neigh->processor_id() != p)
+                  coupled_elements.insert
+                    (std::make_pair(neigh, nullcm));
+            }
+        }
+
+      // It is possible that a refined boundary element will not
+      // touch any nodes of its interior_parent, in TRI3/TET4 and in
+      // non-level-one rule cases.  So we can't just rely on node
+      // connections to preserve interior_parent().  However, trying
+      // to preserve interior_parent() manually only works if it's on
+      // the same Mesh, which is *not* guaranteed!  So we'll
+      // double-check later to make sure our interior parents are in
+      // the mesh before we connect them.
+      if (elem->dim() < LIBMESH_DIM &&
+          elem->interior_parent() &&
+          elem->interior_parent()->processor_id() != p)
+        interior_parents.insert (elem->interior_parent());
+
+      // Add nodes connected to active local elements
+      for (unsigned int n=0; n<elem->n_nodes(); n++)
+        connected_nodes.insert (elem->node_ptr(n));
+    }
+
+  // Connect any interior_parents who are really in our mesh
+  {
+    MeshBase::const_element_iterator       elem_it  = _mesh.elements_begin();
+    const MeshBase::const_element_iterator elem_end = _mesh.elements_end();
+    for (; elem_it != elem_end; ++elem_it)
+      {
+        const Elem * elem = *elem_it;
+        std::set<const Elem *>::iterator ip_it =
+          interior_parents.find(elem);
+
+        if (ip_it != interior_parents.end())
+          {
+            coupled_elements.insert
+              (std::make_pair(elem, nullcm));
+
+            // Shrink the set ASAP to speed up subsequent searches
+            interior_parents.erase(ip_it);
+          }
+      }
+  }
+
+  // Connect any active elements which are connected to our range's
+  // elements' nodes
+  {
+    MeshBase::const_element_iterator       elem_it  = _mesh.active_elements_begin();
+    const MeshBase::const_element_iterator elem_end = _mesh.active_elements_end();
+
+    for (; elem_it!=elem_end; ++elem_it)
+      {
+        const Elem * elem = *elem_it;
+
+        // Add elements connected to nodes on active local elements
+        if (elem->processor_id() != p)
+          for (unsigned int n=0; n<elem->n_nodes(); n++)
+            if (connected_nodes.count(elem->node_ptr(n)))
+              coupled_elements.insert
+                (std::make_pair(elem, nullcm));
+      }
+  }
+}
+
+} // namespace libMesh

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -3,6 +3,7 @@ libmesh_SOURCES =  \
         src/base/dof_map.C \
         src/base/dof_map_constraints.C \
         src/base/dof_object.C \
+        src/base/ghost_point_neighbors.C \
         src/base/libmesh.C \
         src/base/libmesh_common.C \
         src/base/libmesh_isnan.c \

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -146,106 +146,6 @@ struct SyncNeighbors
 };
 
 
-void connect_elements (const MeshBase & mesh,
-                       const MeshBase::const_element_iterator & range_begin,
-                       const MeshBase::const_element_iterator & range_end,
-                       std::set<const Node *> & connected_nodes,
-                       std::set<const Elem *, CompareElemIdsByLevel> & connected_elements)
-{
-  // Using the connected_nodes set rather than point_neighbors() gives
-  // us correct results even in corner cases, such as where two
-  // elements meet only at a corner.  ;-)
-
-  // Links between boundary and interior elements on mixed
-  // dimensional meshes also give us correct ghosting in this way.
-  std::set<const Elem *> interior_parents;
-
-  // We also preserve neighbors and their neighboring children for
-  // active local elements - in most cases this is redundant with the
-  // node check, but for non-conforming Tet4 meshes and
-  // non-level-one-conforming 2D+3D meshes it is possible for an
-  // element and its coarse neighbor to not share any vertices.
-  //
-  // We also preserve interior parents for active pid elements
-
-  for (MeshBase::const_element_iterator elem_it = range_begin;
-       elem_it!=range_end; ++elem_it)
-    {
-      const Elem * elem = *elem_it;
-
-      connected_elements.insert (elem);
-
-      for (unsigned int s=0; s != elem->n_sides(); ++s)
-        {
-          const Elem * neigh = elem->neighbor_ptr(s);
-          if (neigh && neigh != remote_elem)
-            {
-#ifdef LIBMESH_ENABLE_AMR
-              if (!neigh->active())
-                {
-                  std::vector<const Elem*> family;
-                  neigh->active_family_tree_by_neighbor(family, elem);
-
-                  for (dof_id_type i=0; i!=family.size(); ++i)
-                    connected_elements.insert(family[i]);
-                }
-              else
-#endif
-                connected_elements.insert(neigh);
-            }
-        }
-
-      // It is possible that a refined boundary element will not
-      // touch any nodes of its interior_parent, in TRI3/TET4 and in
-      // non-level-one rule cases.  So we can't just rely on node
-      // connections to preserve interior_parent().  However, trying
-      // to preserve interior_parent() manually only works if it's on
-      // the same Mesh, which is *not* guaranteed!  So we'll
-      // double-check later to make sure our interior parents are in
-      // the mesh before we connect them.
-      if (elem->dim() < LIBMESH_DIM && elem->interior_parent())
-        interior_parents.insert (elem->interior_parent());
-
-      // Add nodes connected to active local elements
-      for (unsigned int n=0; n<elem->n_nodes(); n++)
-        connected_nodes.insert (elem->node_ptr(n));
-    }
-
-  // Connect any interior_parents who are really in our mesh
-  MeshBase::const_element_iterator       elem_it  = mesh.elements_begin();
-  const MeshBase::const_element_iterator elem_end = mesh.elements_end();
-  for (; elem_it != elem_end; ++elem_it)
-    {
-      const Elem * elem = *elem_it;
-      std::set<const Elem *>::iterator ip_it =
-        interior_parents.find(elem);
-
-      if (ip_it != interior_parents.end())
-        {
-          connected_elements.insert(elem);
-          interior_parents.erase(ip_it);
-        }
-    }
-}
-
-void connect_elements_on_nodes (const MeshBase & mesh,
-                                const std::set<const Node *> & connected_nodes,
-                                std::set<const Elem *, CompareElemIdsByLevel> & connected_elements)
-{
-  MeshBase::const_element_iterator       elem_it  = mesh.active_elements_begin();
-  const MeshBase::const_element_iterator elem_end = mesh.active_elements_end();
-
-  for (; elem_it!=elem_end; ++elem_it)
-    {
-      const Elem * elem = *elem_it;
-
-      // Add elements connected to nodes on active local elements
-      for (unsigned int n=0; n<elem->n_nodes(); n++)
-        if (connected_nodes.count(elem->node_ptr(n)))
-          connected_elements.insert (elem);
-    }
-}
-
 void query_ghosting_functors
   (MeshBase & mesh,
    processor_id_type pid,
@@ -271,6 +171,11 @@ void query_ghosting_functors
       for (; etg_it != etg_end; ++etg_it)
         connected_elements.insert(etg_it->first);
     }
+
+  // The GhostingFunctors won't be telling us about the elements from
+  // pid; we need to add those ourselves.
+  for (; elem_it != elem_end; ++elem_it)
+    connected_elements.insert(*elem_it);
 }
 
 void connect_families
@@ -434,16 +339,7 @@ void MeshCommunication::redistribute (DistributedMesh & mesh) const
         // to be ghosted and any nodes which are used by any of the
         // above.
 
-        std::set<const Node *> connected_nodes;
         std::set<const Elem *, CompareElemIdsByLevel> elements_to_send;
-
-        connect_elements(mesh,
-                         mesh.active_pid_elements_begin(pid),
-                         mesh.active_pid_elements_end(pid),
-                         connected_nodes, elements_to_send);
-
-        connect_elements_on_nodes(mesh, connected_nodes,
-                                  elements_to_send);
 
         // See which to-be-ghosted elements we need to send
         query_ghosting_functors(mesh, pid, elements_to_send);
@@ -452,6 +348,7 @@ void MeshCommunication::redistribute (DistributedMesh & mesh) const
         // subactive children present too.
         connect_families(elements_to_send);
 
+        std::set<const Node *> connected_nodes;
         reconnect_nodes(elements_to_send, connected_nodes);
 
         // the number of nodes we will ship to pid
@@ -1428,24 +1325,7 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
   libmesh_assert_equal_to (par_max_elem_id, mesh.max_elem_id());
 #endif
 
-  std::set<const Node *> connected_nodes;
   std::set<const Elem *, CompareElemIdsByLevel> elements_to_keep;
-
-  // We don't want to delete any element that shares a node
-  // with or is an ancestor of an active local or unpartitioned
-  // element.
-
-  connect_elements(mesh,
-                   mesh.active_local_elements_begin(),
-                   mesh.active_local_elements_end(),
-                   connected_nodes, elements_to_keep);
-
-  connect_elements(mesh,
-                   mesh.active_unpartitioned_elements_begin(),
-                   mesh.active_unpartitioned_elements_end(),
-                   connected_nodes, elements_to_keep);
-
-  connect_elements_on_nodes(mesh, connected_nodes, elements_to_keep);
 
   // Don't delete elements that we were explicitly told not to
   for(std::set<Elem *>::iterator it = extra_ghost_elem_ids.begin();
@@ -1467,6 +1347,7 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
   connect_families(elements_to_keep);
 
   // Don't delete nodes that our semilocal elements need
+  std::set<const Node *> connected_nodes;
   reconnect_nodes(elements_to_keep, connected_nodes);
 
   // Delete all the elements we have no reason to save,

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1392,6 +1392,17 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
         mesh.delete_node(node);
     }
 
+  // We now have all remote elements and nodes deleted; our ghosting
+  // functors should be ready to delete any now-redundant cached data
+  // they use too.
+  std::set<GhostingFunctor *>::iterator        gf_it = mesh.ghosting_functors_begin();
+  const std::set<GhostingFunctor *>::iterator gf_end = mesh.ghosting_functors_end();
+  for (; gf_it != gf_end; ++gf_it)
+    {
+      GhostingFunctor *gf = *gf_it;
+      gf->delete_remote_elements();
+    }
+
 #ifdef DEBUG
   MeshTools::libmesh_assert_valid_refinement_tree(mesh);
 #endif

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -445,12 +445,12 @@ void MeshCommunication::redistribute (DistributedMesh & mesh) const
         connect_elements_on_nodes(mesh, connected_nodes,
                                   elements_to_send);
 
+        // See which to-be-ghosted elements we need to send
+        query_ghosting_functors(mesh, pid, elements_to_send);
+
         // The elements we need should have their ancestors and their
         // subactive children present too.
         connect_families(elements_to_send);
-
-        // See which to-be-ghosted elements we need to send
-        query_ghosting_functors(mesh, pid, elements_to_send);
 
         reconnect_nodes(elements_to_send, connected_nodes);
 
@@ -1455,16 +1455,16 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
       elements_to_keep.insert(elem);
     }
 
-  // The elements we need should have their ancestors and their
-  // subactive children present too.
-  connect_families(elements_to_keep);
-
   // See which elements we still need to keep ghosted, given that
   // we're keeping local and unpartitioned elements.
   query_ghosting_functors(mesh, mesh.processor_id(),
                           elements_to_keep);
   query_ghosting_functors(mesh, DofObject::invalid_processor_id,
                           elements_to_keep);
+
+  // The elements we need should have their ancestors and their
+  // subactive children present too.
+  connect_families(elements_to_keep);
 
   // Don't delete nodes that our semilocal elements need
   reconnect_nodes(elements_to_keep, connected_nodes);

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -555,6 +555,18 @@ void MeshCommunication::redistribute (DistributedMesh & mesh) const
 
   MeshTools::libmesh_assert_valid_refinement_tree(mesh);
 #endif
+
+  // We now have all elements and nodes redistributed; our ghosting
+  // functors should be ready to redistribute and/or recompute any
+  // cached data they use too.
+  std::set<GhostingFunctor *>::iterator        gf_it = mesh.ghosting_functors_begin();
+  const std::set<GhostingFunctor *>::iterator gf_end = mesh.ghosting_functors_end();
+  for (; gf_it != gf_end; ++gf_it)
+    {
+      GhostingFunctor *gf = *gf_it;
+      gf->redistribute();
+    }
+
 }
 #endif // LIBMESH_HAVE_MPI
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -19,6 +19,7 @@
 
 // C++ Includes   -----------------------------------
 #include <numeric>
+#include <set>
 
 // Local Includes -----------------------------------
 #include "libmesh/boundary_info.h"


### PR DESCRIPTION
This abstracts out the concept of geometric ghosting (the "G" discussed in #1028), moves our default ghosting behavior into a functor, and allows user code to add its own ghosting functors to extend that behavior.

This only covers geometric ghosting, not yet algebraic ghosting or coupling, so two thirds of the work in #1028 is still to come.