### PR TITLE
Set _initialized flag to false on clear()

### DIFF
--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -81,6 +81,9 @@ void PointLocatorTree::clear ()
       else
         // someone else owns and therefore deletes the tree
         this->_tree = libmesh_nullptr;
+
+      // make sure operator () throws an assertion
+      this->_initialized = false;
     }
 }
 


### PR DESCRIPTION
PointLocatorTree sets `_initialized` to true in `init()` but it never ever sets it to false again, which I think it should do in `clear()`  where the tree is deleted (and that's a public method).