### PR TITLE
Don't assume interior_parents() are always part of the same Mesh.

### DIFF
--- a/include/utils/vectormap.h
+++ b/include/utils/vectormap.h
@@ -68,6 +68,8 @@ public:
   typedef std::pair<Key, Tp>                    value_type;
   typedef std::vector<value_type>               vector_type;
   typedef typename vector_type::difference_type difference_type;
+  typedef typename vector_type::iterator        iterator;
+  typedef typename vector_type::const_iterator  const_iterator;
 
 private:
 
@@ -147,8 +149,7 @@ public:
 
     FirstOrder order;
 
-    typename vectormap<Key,Tp>::const_iterator
-      lower_bound = std::lower_bound (this->begin(), this->end(), to_find, order);
+    const_iterator lower_bound = std::lower_bound (this->begin(), this->end(), to_find, order);
 
     libmesh_assert (lower_bound != this->end());
     libmesh_assert_equal_to (lower_bound->first, key);
@@ -173,8 +174,7 @@ public:
 
     FirstOrder order;
 
-    std::pair<typename vectormap<Key,Tp>::const_iterator,
-              typename vectormap<Key,Tp>::const_iterator>
+    std::pair<const_iterator, const_iterator>
       bounds = std::equal_range (this->begin(), this->end(), to_find, order);
 
     return std::distance (bounds.first, bounds.second);

--- a/include/utils/vectormap.h
+++ b/include/utils/vectormap.h
@@ -158,6 +158,46 @@ public:
   }
 
   /**
+   * Returns an iterator corresponding to key, or the end iterator if
+   * not found.
+   */
+  iterator find (const key_type & key)
+  {
+    if (!_sorted)
+      this->sort();
+
+    libmesh_assert (_sorted);
+
+    value_type to_find;
+    to_find.first = key;
+
+    FirstOrder order;
+
+    return std::lower_bound (this->begin(), this->end(), to_find, order);
+  }
+
+  /**
+   * Returns an iterator corresponding to key, or the end iterator if
+   * not found.
+   */
+  const_iterator find (const key_type & key) const
+  {
+    // This function isn't really const, we might have to sort the
+    // underlying container before we can search in it.
+    if (!_sorted)
+      const_cast<vectormap<Key, Tp> *>(this)->sort();
+
+    libmesh_assert (_sorted);
+
+    value_type to_find;
+    to_find.first = key;
+
+    FirstOrder order;
+
+    return std::lower_bound (this->begin(), this->end(), to_find, order);
+  }
+
+  /**
    * *returns the number of occurances of \p key.  For a map-like object, this should
    * be 1 or 0.
    */

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -399,20 +399,31 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
                 std::set<const Elem *>::iterator n_it = neighbor_set.begin();
                 for (; n_it != neighbor_set.end(); ++n_it)
                   {
-                    // FIXME - non-const versions of the Elem set methods
-                    // would be nice
-                    Elem * neighbor = const_cast<Elem *>(*n_it);
+                    const Elem * neighbor = *n_it;
 
                     // Not all interior neighbors are necessarily in
-                    // the global_index_map.  This will be the case
-                    // when partitioning a BoundaryMesh, whose
-                    // elements all have interior_parents() that
-                    // belong to some other Mesh.
-                    vectormap<dof_id_type, dof_id_type>::iterator global_index_map_it =
-                      global_index_map.find(neighbor->id());
+                    // the same Mesh (hence not in the global_index_map).
+                    // This will be the case when partitioning a
+                    // BoundaryMesh, whose elements all have
+                    // interior_parents() that belong to some other
+                    // Mesh.
+                    const Elem * queried_elem = mesh.query_elem_ptr(neighbor->id());
 
-                    if (global_index_map_it != global_index_map.end())
-                      csr_graph(elem_global_index, connection++) = global_index_map_it->second;
+                    // Compare the neighbor and the queried_elem
+                    // pointers, make sure they are the same.
+                    if (queried_elem && queried_elem == neighbor)
+                      {
+                        vectormap<dof_id_type, dof_id_type>::iterator global_index_map_it =
+                          global_index_map.find(neighbor->id());
+
+                        // If the interior_neighbor is in the Mesh but
+                        // not in the global_index_map, we have other issues.
+                        if (global_index_map_it == global_index_map.end())
+                          libmesh_error_msg("Interior neighbor with id " << neighbor->id() << " not found in global_index_map.");
+
+                        else
+                          csr_graph(elem_global_index, connection++) = global_index_map_it->second;
+                      }
                   }
               }
 

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -403,8 +403,18 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
                     // would be nice
                     Elem * neighbor = const_cast<Elem *>(*n_it);
 
-                    csr_graph(elem_global_index, connection++) =
-                      global_index_map[neighbor->id()];
+                    // Not all interior neighbors are necessarily in
+                    // the global_index_map.  This will be the case
+                    // when partitioning a BoundaryMesh, whose
+                    // elements all have interior_parents() that
+                    // belong to some other Mesh.
+                    //
+                    // TODO: Add vector_map::find() which can return
+                    // an end iterator instead of asserting like
+                    // operator[].
+                    if (global_index_map.count(neighbor->id()))
+                      csr_graph(elem_global_index, connection++) =
+                        global_index_map[neighbor->id()];
                   }
               }
 

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -408,13 +408,11 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
                     // when partitioning a BoundaryMesh, whose
                     // elements all have interior_parents() that
                     // belong to some other Mesh.
-                    //
-                    // TODO: Add vector_map::find() which can return
-                    // an end iterator instead of asserting like
-                    // operator[].
-                    if (global_index_map.count(neighbor->id()))
-                      csr_graph(elem_global_index, connection++) =
-                        global_index_map[neighbor->id()];
+                    vectormap<dof_id_type, dof_id_type>::iterator global_index_map_it =
+                      global_index_map.find(neighbor->id());
+
+                    if (global_index_map_it != global_index_map.end())
+                      csr_graph(elem_global_index, connection++) = global_index_map_it->second;
                   }
               }
 


### PR DESCRIPTION
The Metis partitioner code assumed this, but it's not true for e.g. BoundaryMeshes that have `interior_parent()` in another mesh entirely.