### PR TITLE
Remove memory churn in compute_affine_map

### DIFF
--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -884,6 +884,11 @@ private:
    * compute second derivatives of the inverse map.
    */
   void compute_inverse_map_second_derivs(unsigned p);
+
+  /**
+   * Work vector for compute_affine_map()
+   */
+  std::vector<const Node *> elem_nodes;
 };
 
 }

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -1235,8 +1235,9 @@ void FEMap::compute_affine_map(const unsigned int dim,
   this->resize_quadrature_map_vectors(dim, n_qp);
 
   // Determine the nodes contributing to element elem
-  std::vector<const Node *> elem_nodes(elem->n_nodes(), libmesh_nullptr);
-  for (unsigned int i=0; i<elem->n_nodes(); i++)
+  unsigned int n_nodes = elem->n_nodes();
+  elem_nodes.resize(elem->n_nodes());
+  for (unsigned int i=0; i<n_nodes; i++)
     elem_nodes[i] = elem->node_ptr(i);
 
   // Compute map at quadrature point 0


### PR DESCRIPTION
I've been using Open SpeedShop (OSS: https://openspeedshop.org if you don't know about it you should!) to do some threading optimization and `free()` kept showing up as I went to more and more threads (showing, once again, that memory churn is the death of threading).

I was able to get OSS to show me the "hot path" to `free()` that was generating the churn... and it was in `FEMap::compute_affine_map()`.  A quick inspection later and I spotted the `std::vector<const Node*>` getting created and destroyed...

To fix it I've just added it as a persistent member variable.  Works perfectly!

Here are the timings before and after this fix for 20 "residual evaluations" (in a toy code) using a 2000x2000 generated mesh:

| threads | original (s) | optimized (s) |
|---------|----------|-----------|
| 1       | 55.96    | 52.50     |
| 2       | 36.58    | 29.96     |
| 4       | 18.32    | 19.33     |
| 8       | 21.76    | 16.61     |
| 12      | 18.89    | 9.96      |
| 16      | 17.53    | 7.81      |
| 24      | 18.86    | 6.10      |

And a plot (why not?):

![affine_map_optimization](https://cloud.githubusercontent.com/assets/870705/17952898/634b7a02-6a3c-11e6-975f-f821dd891300.png)

Here is what I saw in Open SpeedShop on 12 threads for this problem:

![affine_map_origin](https://cloud.githubusercontent.com/assets/870705/17952906/7655776a-6a3c-11e6-933a-5bf2117d4c73.png)

And here's what the same run looks like on 12 procs now:

![affine_map_optimized](https://cloud.githubusercontent.com/assets/870705/17952913/804eba7e-6a3c-11e6-9126-404f059e2ff5.png)

Note: `OldVar` is the name of the testing object I was using



