### PR TITLE
Remove libmesh_parallel_only() from libMeshInit destructor.

### DIFF
--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -638,10 +638,6 @@ LibMeshInit::~LibMeshInit()
   // Clear the thread task manager we started
   task_scheduler.reset();
 
-  // Let's be sure we properly close on every processor at once:
-  libmesh_parallel_only(this->comm());
-
-
   // Force the \p ReferenceCounter to print
   // its reference count information.  This allows
   // us to find memory leaks.  By default the


### PR DESCRIPTION
As (correctly) pointed out by the GCC 6.1 compiler, you generally
don't want to throw from a destructor, and this function, if it
failed, would throw via the following chain of macro calls:

~LibMeshInit -> libmesh_parallel_only() -> libmesh_assert -> libmesh_error_msg -> LIBMESH_THROW

This commit implements @roystgnr's suggestion of just removing it.

Closes #1073.