### PR TITLE
Add BoundaryVolumeSolutionTransfer class.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -425,6 +425,7 @@ am__libmesh_dbg_la_SOURCES_DIST = src/base/dof_map.C \
 	src/reduced_basis/transient_rb_construction.C \
 	src/reduced_basis/transient_rb_evaluation.C \
 	src/reduced_basis/transient_rb_theta_expansion.C \
+	src/solution_transfer/boundary_volume_solution_transfer.C \
 	src/solution_transfer/direct_solution_transfer.C \
 	src/solution_transfer/dtk_adapter.C \
 	src/solution_transfer/dtk_evaluator.C \
@@ -818,6 +819,7 @@ am__objects_1 = src/base/libmesh_dbg_la-dof_map.lo \
 	src/reduced_basis/libmesh_dbg_la-transient_rb_construction.lo \
 	src/reduced_basis/libmesh_dbg_la-transient_rb_evaluation.lo \
 	src/reduced_basis/libmesh_dbg_la-transient_rb_theta_expansion.lo \
+	src/solution_transfer/libmesh_dbg_la-boundary_volume_solution_transfer.lo \
 	src/solution_transfer/libmesh_dbg_la-direct_solution_transfer.lo \
 	src/solution_transfer/libmesh_dbg_la-dtk_adapter.lo \
 	src/solution_transfer/libmesh_dbg_la-dtk_evaluator.lo \
@@ -1135,6 +1137,7 @@ am__libmesh_devel_la_SOURCES_DIST = src/base/dof_map.C \
 	src/reduced_basis/transient_rb_construction.C \
 	src/reduced_basis/transient_rb_evaluation.C \
 	src/reduced_basis/transient_rb_theta_expansion.C \
+	src/solution_transfer/boundary_volume_solution_transfer.C \
 	src/solution_transfer/direct_solution_transfer.C \
 	src/solution_transfer/dtk_adapter.C \
 	src/solution_transfer/dtk_evaluator.C \
@@ -1527,6 +1530,7 @@ am__objects_2 = src/base/libmesh_devel_la-dof_map.lo \
 	src/reduced_basis/libmesh_devel_la-transient_rb_construction.lo \
 	src/reduced_basis/libmesh_devel_la-transient_rb_evaluation.lo \
 	src/reduced_basis/libmesh_devel_la-transient_rb_theta_expansion.lo \
+	src/solution_transfer/libmesh_devel_la-boundary_volume_solution_transfer.lo \
 	src/solution_transfer/libmesh_devel_la-direct_solution_transfer.lo \
 	src/solution_transfer/libmesh_devel_la-dtk_adapter.lo \
 	src/solution_transfer/libmesh_devel_la-dtk_evaluator.lo \
@@ -1841,6 +1845,7 @@ am__libmesh_oprof_la_SOURCES_DIST = src/base/dof_map.C \
 	src/reduced_basis/transient_rb_construction.C \
 	src/reduced_basis/transient_rb_evaluation.C \
 	src/reduced_basis/transient_rb_theta_expansion.C \
+	src/solution_transfer/boundary_volume_solution_transfer.C \
 	src/solution_transfer/direct_solution_transfer.C \
 	src/solution_transfer/dtk_adapter.C \
 	src/solution_transfer/dtk_evaluator.C \
@@ -2233,6 +2238,7 @@ am__objects_3 = src/base/libmesh_oprof_la-dof_map.lo \
 	src/reduced_basis/libmesh_oprof_la-transient_rb_construction.lo \
 	src/reduced_basis/libmesh_oprof_la-transient_rb_evaluation.lo \
 	src/reduced_basis/libmesh_oprof_la-transient_rb_theta_expansion.lo \
+	src/solution_transfer/libmesh_oprof_la-boundary_volume_solution_transfer.lo \
 	src/solution_transfer/libmesh_oprof_la-direct_solution_transfer.lo \
 	src/solution_transfer/libmesh_oprof_la-dtk_adapter.lo \
 	src/solution_transfer/libmesh_oprof_la-dtk_evaluator.lo \
@@ -2547,6 +2553,7 @@ am__libmesh_opt_la_SOURCES_DIST = src/base/dof_map.C \
 	src/reduced_basis/transient_rb_construction.C \
 	src/reduced_basis/transient_rb_evaluation.C \
 	src/reduced_basis/transient_rb_theta_expansion.C \
+	src/solution_transfer/boundary_volume_solution_transfer.C \
 	src/solution_transfer/direct_solution_transfer.C \
 	src/solution_transfer/dtk_adapter.C \
 	src/solution_transfer/dtk_evaluator.C \
@@ -2939,6 +2946,7 @@ am__objects_4 = src/base/libmesh_opt_la-dof_map.lo \
 	src/reduced_basis/libmesh_opt_la-transient_rb_construction.lo \
 	src/reduced_basis/libmesh_opt_la-transient_rb_evaluation.lo \
 	src/reduced_basis/libmesh_opt_la-transient_rb_theta_expansion.lo \
+	src/solution_transfer/libmesh_opt_la-boundary_volume_solution_transfer.lo \
 	src/solution_transfer/libmesh_opt_la-direct_solution_transfer.lo \
 	src/solution_transfer/libmesh_opt_la-dtk_adapter.lo \
 	src/solution_transfer/libmesh_opt_la-dtk_evaluator.lo \
@@ -3252,6 +3260,7 @@ am__libmesh_prof_la_SOURCES_DIST = src/base/dof_map.C \
 	src/reduced_basis/transient_rb_construction.C \
 	src/reduced_basis/transient_rb_evaluation.C \
 	src/reduced_basis/transient_rb_theta_expansion.C \
+	src/solution_transfer/boundary_volume_solution_transfer.C \
 	src/solution_transfer/direct_solution_transfer.C \
 	src/solution_transfer/dtk_adapter.C \
 	src/solution_transfer/dtk_evaluator.C \
@@ -3644,6 +3653,7 @@ am__objects_5 = src/base/libmesh_prof_la-dof_map.lo \
 	src/reduced_basis/libmesh_prof_la-transient_rb_construction.lo \
 	src/reduced_basis/libmesh_prof_la-transient_rb_evaluation.lo \
 	src/reduced_basis/libmesh_prof_la-transient_rb_theta_expansion.lo \
+	src/solution_transfer/libmesh_prof_la-boundary_volume_solution_transfer.lo \
 	src/solution_transfer/libmesh_prof_la-direct_solution_transfer.lo \
 	src/solution_transfer/libmesh_prof_la-dtk_adapter.lo \
 	src/solution_transfer/libmesh_prof_la-dtk_evaluator.lo \
@@ -5015,6 +5025,7 @@ libmesh_SOURCES = \
         src/reduced_basis/transient_rb_construction.C \
         src/reduced_basis/transient_rb_evaluation.C \
         src/reduced_basis/transient_rb_theta_expansion.C \
+        src/solution_transfer/boundary_volume_solution_transfer.C \
         src/solution_transfer/direct_solution_transfer.C \
         src/solution_transfer/dtk_adapter.C \
         src/solution_transfer/dtk_evaluator.C \
@@ -6309,6 +6320,9 @@ src/solution_transfer/$(am__dirstamp):
 src/solution_transfer/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/solution_transfer/$(DEPDIR)
 	@: > src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
+src/solution_transfer/libmesh_dbg_la-boundary_volume_solution_transfer.lo:  \
+	src/solution_transfer/$(am__dirstamp) \
+	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
 src/solution_transfer/libmesh_dbg_la-direct_solution_transfer.lo:  \
 	src/solution_transfer/$(am__dirstamp) \
 	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
@@ -7345,6 +7359,9 @@ src/reduced_basis/libmesh_devel_la-transient_rb_evaluation.lo:  \
 src/reduced_basis/libmesh_devel_la-transient_rb_theta_expansion.lo:  \
 	src/reduced_basis/$(am__dirstamp) \
 	src/reduced_basis/$(DEPDIR)/$(am__dirstamp)
+src/solution_transfer/libmesh_devel_la-boundary_volume_solution_transfer.lo:  \
+	src/solution_transfer/$(am__dirstamp) \
+	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
 src/solution_transfer/libmesh_devel_la-direct_solution_transfer.lo:  \
 	src/solution_transfer/$(am__dirstamp) \
 	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
@@ -8365,6 +8382,9 @@ src/reduced_basis/libmesh_oprof_la-transient_rb_evaluation.lo:  \
 src/reduced_basis/libmesh_oprof_la-transient_rb_theta_expansion.lo:  \
 	src/reduced_basis/$(am__dirstamp) \
 	src/reduced_basis/$(DEPDIR)/$(am__dirstamp)
+src/solution_transfer/libmesh_oprof_la-boundary_volume_solution_transfer.lo:  \
+	src/solution_transfer/$(am__dirstamp) \
+	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
 src/solution_transfer/libmesh_oprof_la-direct_solution_transfer.lo:  \
 	src/solution_transfer/$(am__dirstamp) \
 	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
@@ -9384,6 +9404,9 @@ src/reduced_basis/libmesh_opt_la-transient_rb_evaluation.lo:  \
 src/reduced_basis/libmesh_opt_la-transient_rb_theta_expansion.lo:  \
 	src/reduced_basis/$(am__dirstamp) \
 	src/reduced_basis/$(DEPDIR)/$(am__dirstamp)
+src/solution_transfer/libmesh_opt_la-boundary_volume_solution_transfer.lo:  \
+	src/solution_transfer/$(am__dirstamp) \
+	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
 src/solution_transfer/libmesh_opt_la-direct_solution_transfer.lo:  \
 	src/solution_transfer/$(am__dirstamp) \
 	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
@@ -10401,6 +10424,9 @@ src/reduced_basis/libmesh_prof_la-transient_rb_evaluation.lo:  \
 src/reduced_basis/libmesh_prof_la-transient_rb_theta_expansion.lo:  \
 	src/reduced_basis/$(am__dirstamp) \
 	src/reduced_basis/$(DEPDIR)/$(am__dirstamp)
+src/solution_transfer/libmesh_prof_la-boundary_volume_solution_transfer.lo:  \
+	src/solution_transfer/$(am__dirstamp) \
+	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
 src/solution_transfer/libmesh_prof_la-direct_solution_transfer.lo:  \
 	src/solution_transfer/$(am__dirstamp) \
 	src/solution_transfer/$(DEPDIR)/$(am__dirstamp)
@@ -12796,6 +12822,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/reduced_basis/$(DEPDIR)/libmesh_prof_la-transient_rb_construction.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/reduced_basis/$(DEPDIR)/libmesh_prof_la-transient_rb_evaluation.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/reduced_basis/$(DEPDIR)/libmesh_prof_la-transient_rb_theta_expansion.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-boundary_volume_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-direct_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-dtk_adapter.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-dtk_evaluator.Plo@am__quote@
@@ -12805,6 +12832,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-meshfunction_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-radial_basis_interpolation.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-solution_transfer.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_devel_la-boundary_volume_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_devel_la-direct_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_devel_la-dtk_adapter.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_devel_la-dtk_evaluator.Plo@am__quote@
@@ -12814,6 +12842,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_devel_la-meshfunction_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_devel_la-radial_basis_interpolation.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_devel_la-solution_transfer.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-boundary_volume_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-direct_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-dtk_adapter.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-dtk_evaluator.Plo@am__quote@
@@ -12823,6 +12852,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-meshfunction_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-radial_basis_interpolation.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-solution_transfer.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_opt_la-boundary_volume_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_opt_la-direct_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_opt_la-dtk_adapter.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_opt_la-dtk_evaluator.Plo@am__quote@
@@ -12832,6 +12862,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_opt_la-meshfunction_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_opt_la-radial_basis_interpolation.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_opt_la-solution_transfer.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_prof_la-boundary_volume_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_prof_la-direct_solution_transfer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_prof_la-dtk_adapter.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solution_transfer/$(DEPDIR)/libmesh_prof_la-dtk_evaluator.Plo@am__quote@
@@ -15557,6 +15588,13 @@ src/reduced_basis/libmesh_dbg_la-transient_rb_theta_expansion.lo: src/reduced_ba
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/reduced_basis/transient_rb_theta_expansion.C' object='src/reduced_basis/libmesh_dbg_la-transient_rb_theta_expansion.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/reduced_basis/libmesh_dbg_la-transient_rb_theta_expansion.lo `test -f 'src/reduced_basis/transient_rb_theta_expansion.C' || echo '$(srcdir)/'`src/reduced_basis/transient_rb_theta_expansion.C
+
+src/solution_transfer/libmesh_dbg_la-boundary_volume_solution_transfer.lo: src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_dbg_la-boundary_volume_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-boundary_volume_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_dbg_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-boundary_volume_solution_transfer.Tpo src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-boundary_volume_solution_transfer.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solution_transfer/boundary_volume_solution_transfer.C' object='src/solution_transfer/libmesh_dbg_la-boundary_volume_solution_transfer.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solution_transfer/libmesh_dbg_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
 
 src/solution_transfer/libmesh_dbg_la-direct_solution_transfer.lo: src/solution_transfer/direct_solution_transfer.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_dbg_la-direct_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_dbg_la-direct_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_dbg_la-direct_solution_transfer.lo `test -f 'src/solution_transfer/direct_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/direct_solution_transfer.C
@@ -18463,6 +18501,13 @@ src/reduced_basis/libmesh_devel_la-transient_rb_theta_expansion.lo: src/reduced_
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/reduced_basis/libmesh_devel_la-transient_rb_theta_expansion.lo `test -f 'src/reduced_basis/transient_rb_theta_expansion.C' || echo '$(srcdir)/'`src/reduced_basis/transient_rb_theta_expansion.C
 
+src/solution_transfer/libmesh_devel_la-boundary_volume_solution_transfer.lo: src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_devel_la-boundary_volume_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_devel_la-boundary_volume_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_devel_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solution_transfer/$(DEPDIR)/libmesh_devel_la-boundary_volume_solution_transfer.Tpo src/solution_transfer/$(DEPDIR)/libmesh_devel_la-boundary_volume_solution_transfer.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solution_transfer/boundary_volume_solution_transfer.C' object='src/solution_transfer/libmesh_devel_la-boundary_volume_solution_transfer.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solution_transfer/libmesh_devel_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
+
 src/solution_transfer/libmesh_devel_la-direct_solution_transfer.lo: src/solution_transfer/direct_solution_transfer.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_devel_la-direct_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_devel_la-direct_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_devel_la-direct_solution_transfer.lo `test -f 'src/solution_transfer/direct_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/direct_solution_transfer.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solution_transfer/$(DEPDIR)/libmesh_devel_la-direct_solution_transfer.Tpo src/solution_transfer/$(DEPDIR)/libmesh_devel_la-direct_solution_transfer.Plo
@@ -21367,6 +21412,13 @@ src/reduced_basis/libmesh_oprof_la-transient_rb_theta_expansion.lo: src/reduced_
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/reduced_basis/transient_rb_theta_expansion.C' object='src/reduced_basis/libmesh_oprof_la-transient_rb_theta_expansion.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/reduced_basis/libmesh_oprof_la-transient_rb_theta_expansion.lo `test -f 'src/reduced_basis/transient_rb_theta_expansion.C' || echo '$(srcdir)/'`src/reduced_basis/transient_rb_theta_expansion.C
+
+src/solution_transfer/libmesh_oprof_la-boundary_volume_solution_transfer.lo: src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_oprof_la-boundary_volume_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-boundary_volume_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_oprof_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-boundary_volume_solution_transfer.Tpo src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-boundary_volume_solution_transfer.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solution_transfer/boundary_volume_solution_transfer.C' object='src/solution_transfer/libmesh_oprof_la-boundary_volume_solution_transfer.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solution_transfer/libmesh_oprof_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
 
 src/solution_transfer/libmesh_oprof_la-direct_solution_transfer.lo: src/solution_transfer/direct_solution_transfer.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_oprof_la-direct_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_oprof_la-direct_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_oprof_la-direct_solution_transfer.lo `test -f 'src/solution_transfer/direct_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/direct_solution_transfer.C
@@ -24273,6 +24325,13 @@ src/reduced_basis/libmesh_opt_la-transient_rb_theta_expansion.lo: src/reduced_ba
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/reduced_basis/libmesh_opt_la-transient_rb_theta_expansion.lo `test -f 'src/reduced_basis/transient_rb_theta_expansion.C' || echo '$(srcdir)/'`src/reduced_basis/transient_rb_theta_expansion.C
 
+src/solution_transfer/libmesh_opt_la-boundary_volume_solution_transfer.lo: src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_opt_la-boundary_volume_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_opt_la-boundary_volume_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_opt_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solution_transfer/$(DEPDIR)/libmesh_opt_la-boundary_volume_solution_transfer.Tpo src/solution_transfer/$(DEPDIR)/libmesh_opt_la-boundary_volume_solution_transfer.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solution_transfer/boundary_volume_solution_transfer.C' object='src/solution_transfer/libmesh_opt_la-boundary_volume_solution_transfer.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solution_transfer/libmesh_opt_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
+
 src/solution_transfer/libmesh_opt_la-direct_solution_transfer.lo: src/solution_transfer/direct_solution_transfer.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_opt_la-direct_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_opt_la-direct_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_opt_la-direct_solution_transfer.lo `test -f 'src/solution_transfer/direct_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/direct_solution_transfer.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solution_transfer/$(DEPDIR)/libmesh_opt_la-direct_solution_transfer.Tpo src/solution_transfer/$(DEPDIR)/libmesh_opt_la-direct_solution_transfer.Plo
@@ -27177,6 +27236,13 @@ src/reduced_basis/libmesh_prof_la-transient_rb_theta_expansion.lo: src/reduced_b
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/reduced_basis/transient_rb_theta_expansion.C' object='src/reduced_basis/libmesh_prof_la-transient_rb_theta_expansion.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/reduced_basis/libmesh_prof_la-transient_rb_theta_expansion.lo `test -f 'src/reduced_basis/transient_rb_theta_expansion.C' || echo '$(srcdir)/'`src/reduced_basis/transient_rb_theta_expansion.C
+
+src/solution_transfer/libmesh_prof_la-boundary_volume_solution_transfer.lo: src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_prof_la-boundary_volume_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_prof_la-boundary_volume_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_prof_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solution_transfer/$(DEPDIR)/libmesh_prof_la-boundary_volume_solution_transfer.Tpo src/solution_transfer/$(DEPDIR)/libmesh_prof_la-boundary_volume_solution_transfer.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solution_transfer/boundary_volume_solution_transfer.C' object='src/solution_transfer/libmesh_prof_la-boundary_volume_solution_transfer.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solution_transfer/libmesh_prof_la-boundary_volume_solution_transfer.lo `test -f 'src/solution_transfer/boundary_volume_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/boundary_volume_solution_transfer.C
 
 src/solution_transfer/libmesh_prof_la-direct_solution_transfer.lo: src/solution_transfer/direct_solution_transfer.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solution_transfer/libmesh_prof_la-direct_solution_transfer.lo -MD -MP -MF src/solution_transfer/$(DEPDIR)/libmesh_prof_la-direct_solution_transfer.Tpo -c -o src/solution_transfer/libmesh_prof_la-direct_solution_transfer.lo `test -f 'src/solution_transfer/direct_solution_transfer.C' || echo '$(srcdir)/'`src/solution_transfer/direct_solution_transfer.C

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -884,6 +884,7 @@ include_HEADERS = \
         reduced_basis/transient_rb_construction.h \
         reduced_basis/transient_rb_evaluation.h \
         reduced_basis/transient_rb_theta_expansion.h \
+        solution_transfer/boundary_volume_solution_transfer.h \
         solution_transfer/direct_solution_transfer.h \
         solution_transfer/dtk_adapter.h \
         solution_transfer/dtk_evaluator.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -316,6 +316,7 @@ include_HEADERS =  \
         reduced_basis/transient_rb_construction.h \
         reduced_basis/transient_rb_evaluation.h \
         reduced_basis/transient_rb_theta_expansion.h \
+        solution_transfer/boundary_volume_solution_transfer.h \
         solution_transfer/direct_solution_transfer.h \
         solution_transfer/dtk_adapter.h \
         solution_transfer/dtk_evaluator.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -311,6 +311,7 @@ BUILT_SOURCES = \
         transient_rb_construction.h \
         transient_rb_evaluation.h \
         transient_rb_theta_expansion.h \
+        boundary_volume_solution_transfer.h \
         direct_solution_transfer.h \
         dtk_adapter.h \
         dtk_evaluator.h \
@@ -1433,6 +1434,9 @@ transient_rb_evaluation.h: $(top_srcdir)/include/reduced_basis/transient_rb_eval
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 transient_rb_theta_expansion.h: $(top_srcdir)/include/reduced_basis/transient_rb_theta_expansion.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+boundary_volume_solution_transfer.h: $(top_srcdir)/include/solution_transfer/boundary_volume_solution_transfer.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 direct_solution_transfer.h: $(top_srcdir)/include/solution_transfer/direct_solution_transfer.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -585,7 +585,8 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	rb_scm_evaluation.h rb_temporal_discretization.h rb_theta.h \
 	rb_theta_expansion.h transient_rb_assembly_expansion.h \
 	transient_rb_construction.h transient_rb_evaluation.h \
-	transient_rb_theta_expansion.h direct_solution_transfer.h \
+	transient_rb_theta_expansion.h \
+	boundary_volume_solution_transfer.h direct_solution_transfer.h \
 	dtk_adapter.h dtk_evaluator.h dtk_solution_transfer.h \
 	meshfree_interpolation.h meshfree_solution_transfer.h \
 	meshfunction_solution_transfer.h radial_basis_functions.h \
@@ -1783,6 +1784,9 @@ transient_rb_evaluation.h: $(top_srcdir)/include/reduced_basis/transient_rb_eval
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 transient_rb_theta_expansion.h: $(top_srcdir)/include/reduced_basis/transient_rb_theta_expansion.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+boundary_volume_solution_transfer.h: $(top_srcdir)/include/solution_transfer/boundary_volume_solution_transfer.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 direct_solution_transfer.h: $(top_srcdir)/include/solution_transfer/direct_solution_transfer.h

--- a/include/solution_transfer/boundary_volume_solution_transfer.h
+++ b/include/solution_transfer/boundary_volume_solution_transfer.h
@@ -1,0 +1,79 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2016 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef BOUNDARY_VOLUME_SOLUTION_TRANSFER
+#define BOUNDARY_VOLUME_SOLUTION_TRANSFER
+
+#include "libmesh/solution_transfer.h"
+
+
+namespace libMesh {
+
+/**
+ * SolutionTransfer derived class which is specifically for
+ * transferring solutions back and forth between a VolumeMesh and its
+ * associated BoundaryMesh.  That is, when calling transfer() below,
+ * we must have either:
+ *
+ * .) Transfer from the boundary of a VolumeMesh to its associated
+ *    BoundaryMesh, or
+ * .) Transfer from a BoundaryMesh to its corresponding VolumeMesh.
+ *
+ * Because of this assumption, we can use the interior_parent() to
+ * directly define the mapping between solutions.  The transfer()
+ * function internally determines which direction the transfer is
+ * going, and calls the appropriate algorithm internally.
+ *
+ * \author Xikai Jiang
+ * \author John W. Peterson
+ * \date 2016
+ */
+class BoundaryVolumeSolutionTransfer : public SolutionTransfer
+{
+public:
+  BoundaryVolumeSolutionTransfer (const Parallel::Communicator & comm_in LIBMESH_CAN_DEFAULT_TO_COMMWORLD) :
+    SolutionTransfer(comm_in)
+  {}
+
+  virtual ~BoundaryVolumeSolutionTransfer() {}
+
+  /**
+   * Transfer values from a Variable in a System associated with a
+   * volume mesh to a Variable in a System associated with the
+   * corresponding BoundaryMesh, or vice-versa.
+   */
+  virtual void transfer(const Variable & from_var, const Variable & to_var) libmesh_override;
+
+private:
+  /**
+   * Transfer values *from* volume mesh *to* boundary mesh.  Called
+   * when needed from transfer().
+   */
+  void transfer_volume_boundary(const Variable & from_var, const Variable & to_var);
+
+  /**
+   * Transfer values *from* boundary mesh *to* volume mesh.  Called
+   * when needed from transfer().
+   */
+  void transfer_boundary_volume(const Variable & from_var, const Variable & to_var);
+};
+
+} // namespace libMesh
+
+#endif

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -333,6 +333,7 @@ libmesh_SOURCES =  \
         src/reduced_basis/transient_rb_construction.C \
         src/reduced_basis/transient_rb_evaluation.C \
         src/reduced_basis/transient_rb_theta_expansion.C \
+        src/solution_transfer/boundary_volume_solution_transfer.C \
         src/solution_transfer/direct_solution_transfer.C \
         src/solution_transfer/dtk_adapter.C \
         src/solution_transfer/dtk_evaluator.C \

--- a/src/solution_transfer/boundary_volume_solution_transfer.C
+++ b/src/solution_transfer/boundary_volume_solution_transfer.C
@@ -1,0 +1,227 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2016 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/boundary_volume_solution_transfer.h"
+#include "libmesh/elem.h"
+#include "libmesh/numeric_vector.h"
+#include "libmesh/dof_map.h"
+
+namespace libMesh {
+
+void BoundaryVolumeSolutionTransfer::transfer(const Variable & from_var,
+                                              const Variable & to_var)
+{
+  // Determine which direction the tranfer is in
+  System * from_sys = from_var.system();
+  System * to_sys = to_var.system();
+
+  unsigned int
+    from_dimension = from_sys->get_mesh().mesh_dimension(),
+    to_dimension = to_sys->get_mesh().mesh_dimension();
+
+  // Sanity check
+  if (from_dimension == to_dimension)
+    libmesh_error_msg("Error: Transfer must be from volume mesh to its boundary or vice-versa!");
+
+  if (from_dimension > to_dimension)
+    this->transfer_volume_boundary(from_var, to_var);
+  else
+    this->transfer_boundary_volume(from_var, to_var);
+}
+
+
+
+void BoundaryVolumeSolutionTransfer::
+transfer_volume_boundary(const Variable & from_var, const Variable & to_var)
+{
+  // Get references to the Systems from the Variables
+  System * from_sys = from_var.system(); // volume system
+  System * to_sys = to_var.system();     // boundary system
+
+  // Get reference to the BoundaryMesh.  Note: we always loop over the
+  // BoundaryMesh since, by definition, it has fewer dofs than the
+  // volume mesh.
+  const MeshBase & to_mesh = to_sys->get_mesh();
+
+  // Get system number and variable numbers
+  const unsigned short int from_sys_number = from_sys->number();
+  const unsigned short int from_var_number = from_var.number();
+
+  const unsigned short int to_sys_number = to_sys->number();
+  const unsigned short int to_var_number = to_var.number();
+
+  // Get a constant reference to variables, get their number of components
+  const unsigned short int from_n_comp = from_var.n_components();
+  const unsigned short int to_n_comp = to_var.n_components();
+
+  // Sanity check that the variables have the same number of components
+  libmesh_assert_equal_to(from_n_comp, to_n_comp);
+
+  // Iterator for BoundaryMesh.
+  MeshBase::const_element_iterator       el     = to_mesh.active_local_elements_begin();
+  const MeshBase::const_element_iterator end_el = to_mesh.active_local_elements_end();
+
+  // Construct map from "from" dofs to "to" dofs.
+  typedef std::map<numeric_index_type, numeric_index_type> DofMapping;
+  DofMapping dof_mapping;
+
+  // Loop through all boundary elements.
+  for ( ; el != end_el; ++el)
+    {
+      const Elem * to_elem = *el;
+      const Elem * from_elem = to_elem->interior_parent();
+
+      if (!from_elem)
+        libmesh_error_msg("Error, transfer must be between a Mesh and its associated BoundaryMesh.");
+
+      // loop through all nodes in each boundary element.
+      for (unsigned int node=0; node < to_elem->n_nodes(); node++)
+        {
+          // Node in boundary element.
+          const Node * to_node = to_elem->node_ptr(node);
+
+          for (unsigned int node_id=0; node_id < from_elem->n_nodes(); node_id++)
+            {
+              // Nodes in interior_parent element.
+              const Node * from_node = from_elem->node_ptr(node_id);
+
+              const dof_id_type from_dof = from_node->dof_number(from_sys_number,
+                                                                 from_var_number,
+                                                                 from_n_comp - 1);
+
+              // See if we've already encountered this DOF in the loop
+              // over boundary elements.
+              DofMapping::iterator it = dof_mapping.find(from_dof);
+
+              // If we've already mapped this dof, we don't need to map
+              // it again or do floating point comparisons.
+              if (it == dof_mapping.end() &&
+                  from_node->absolute_fuzzy_equals(*to_node, TOLERANCE))
+                {
+                  // Global dof_index for node in BoundaryMesh.
+                  const dof_id_type to_dof = to_node->dof_number(to_sys_number,
+                                                                 to_var_number,
+                                                                 to_n_comp - 1);
+
+                  // Keep track of the volume system dof index which is needed.
+                  dof_mapping[from_dof] = to_dof;
+                }
+            }
+        }
+    }
+
+  // Construct a vector of the indices needed from the Volume system's
+  // global solution vector on this processor.
+  std::vector<numeric_index_type> needed_indices;
+  needed_indices.reserve(dof_mapping.size());
+  {
+    DofMapping::iterator
+      it = dof_mapping.begin(),
+      end = dof_mapping.end();
+
+    for (; it!=end; ++it)
+      needed_indices.push_back(it->first);
+  }
+
+  // Communicate just the required values without making a copy of the
+  // global solution vector.
+  std::vector<Number> needed_values;
+  from_sys->solution->localize(needed_values, needed_indices);
+
+  // Loop over DofMapping again, assigning values in the
+  // Boundary System solution vector.
+  {
+    DofMapping::iterator
+      it = dof_mapping.begin(),
+      end = dof_mapping.end();
+
+    for (unsigned idx=0; it!=end; ++it, ++idx)
+      to_sys->solution->set(it->second, needed_values[idx]);
+  }
+}
+
+
+void BoundaryVolumeSolutionTransfer::
+transfer_boundary_volume(const Variable & from_var, const Variable & to_var)
+{
+  // Get references to the Systems from the Variables
+  System * from_sys = from_var.system(); // boundary system
+  System * to_sys = to_var.system();     // volume system
+
+  // Get reference to BoundaryMesh.
+  const MeshBase & from_mesh = from_sys->get_mesh();
+
+  // DofMap for BoundaryMesh
+  const DofMap & dof_map = from_sys->get_dof_map();
+
+  // Get system number and variable numbers
+  const unsigned short int to_sys_number = to_sys->number();
+  const unsigned short int to_var_number = to_var.number();
+  const unsigned short int from_var_number = from_var.number();
+  const unsigned short int to_n_comp = to_var.n_components();
+
+  // Iterator for BoundaryMesh.
+  MeshBase::const_element_iterator       el     = from_mesh.active_local_elements_begin();
+  const MeshBase::const_element_iterator end_el = from_mesh.active_local_elements_end();
+
+  // In order to get solution vectors from BoundaryMesh
+  std::vector<dof_id_type> from_dof_indices;
+  std::vector<Real> value;
+
+  // Loop through all boundary elements.
+  for (; el != end_el; ++el)
+    {
+      const Elem * from_elem = *el;
+      const Elem * to_elem = from_elem->interior_parent();
+
+      if (!to_elem)
+        libmesh_error_msg("Error, transfer must be between a Mesh and its associated BoundaryMesh.");
+
+      // Get dof indices for phi2 for all nodes on this boundary element
+      dof_map.dof_indices(from_elem, from_dof_indices, from_var_number);
+
+      // Get values from BoundaryMesh for this element
+      from_sys->current_local_solution->get(from_dof_indices, value);
+
+      // loop through all nodes in each boundary element.
+      for (unsigned int node=0; node < from_elem->n_nodes(); node++)
+        {
+          // Node in boundary element.
+          const Node * from_node = from_elem->node_ptr(node);
+
+          for (unsigned int node_id=0; node_id < to_elem->n_nodes(); node_id++)
+            {
+              // Nodes in interior_parent element.
+              const Node * to_node = to_elem->node_ptr(node_id);
+
+              // Match BoundaryNode & VolumeNode.
+              if (to_node->absolute_fuzzy_equals(*from_node, TOLERANCE))
+                {
+                  // Global dof_index for node in VolumeMesh.
+                  const dof_id_type to_dof = to_node->dof_number(to_sys_number,
+                                                                 to_var_number,
+                                                                 to_n_comp - 1);
+
+                  // Assign values to boundary in VolumeMesh.
+                  to_sys->solution->set(to_dof, value[node]);
+                }
+            }
+        }
+    }
+}
+
+} // namespace libMesh


### PR DESCRIPTION
This class can be used for transferring solutions between the surface
of a volume mesh and the BoundaryMesh associated with that surface.
This is joint work with with Xikai Jiang from Argonne National
Laboratory (@xikaij) who is the original author of the transfer.

See also: X. Jiang et al., "An O(N) and parallel approach to integral
problems by a kernel-independent fast multipole method: Application to
polarization and magnetization of interacting particles," The Journal
of Chemical Physics vol. 145, 064307, http://dx.doi.org/10.1063/1.4960436.
