### PR TITLE
FEInterface::map() did fail for infinite elements

### DIFF
--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -394,6 +394,11 @@ private:
                               const std::vector<Number> & elem_soln,
                               std::vector<Number> & nodal_soln);
 
+  static Point ifem_map (const unsigned int dim, 
+                         const FEType& fe_t,
+                         const Elem * elem,
+                         const Point & p);
+
   static Point ifem_inverse_map (const unsigned int dim,
                                  const FEType & fe_t,
                                  const Elem * elem,

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -352,6 +352,14 @@ public:
                          const Elem * elem,
                          const std::vector<Number> & elem_soln,
                          std::vector<Number> & nodal_soln);
+  
+  /**
+   * @returns the location (in physical space) of the point
+   * \p p located on the reference element. 
+   * // I don't see a reason why it should be protected.
+   */
+  static Point map (const Elem * inf_elem,
+                    const Point & reference_point);
 
   /**
    * @returns the location (on the reference element) of the
@@ -564,13 +572,6 @@ protected:
 
   //-------------------------------------------------------------
   // Miscellaneous static members
-
-  /**
-   * @returns the location (in physical space) of the point
-   * \p p located on the reference element.
-   */
-  static Point map (const Elem * inf_elem,
-                    const Point & reference_point);
 
   /**
    * Computes the indices in the base \p base_node and in radial

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -539,6 +539,11 @@ Point FEInterface::map(unsigned int dim,
                        const Elem * elem,
                        const Point & p)
 {
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (is_InfFE_elem(elem->type()))
+     return ifem_map(dim, fe_t, elem, p); //new function now.
+#endif
   fe_with_vec_switch(map(elem, p));
 
   libmesh_error_msg("We'll never get here!");

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -425,6 +425,33 @@ void FEInterface::ifem_nodal_soln(const unsigned int dim,
 
 
 
+Point FEInterface::ifem_map (const unsigned int dim, 
+                             const FEType& fe_t,
+                             const Elem * elem,
+                             const Point & p)
+{
+   switch (fe_t.inf_map)
+   {
+      case CARTESIAN:{
+         switch (dim)
+         {
+         case 1:
+            return InfFE<1,JACOBI_20_00,CARTESIAN>::map(elem, p);
+         case 2:
+            return InfFE<2,JACOBI_20_00,CARTESIAN>::map(elem, p);
+         case 3:
+            return InfFE<3,JACOBI_20_00,CARTESIAN>::map(elem, p);
+         default:
+            libmesh_error_msg("Invalid dim = " << dim);
+         }
+      }
+      case SPHERICAL:
+      case ELLIPSOIDAL:
+         libmesh_not_implemented_msg("ERROR: Spherical and Ellipsoidal IFEMs not (yet) implemented.");
+      default:
+         libmesh_error_msg("Invalid map = " << fe_t.inf_map);
+   }
+}
 
 
 

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -642,6 +642,10 @@ void InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * elem,
 
 //INSTANTIATE_INF_FE(3,CARTESIAN);
 
+INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, Point, map(const Elem *, const Point &));
+INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, Point, map(const Elem *, const Point &));
+INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, Point, map(const Elem *, const Point &));
+
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, Point, inverse_map(const Elem *, const Point &, const Real, const bool, const bool));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, Point, inverse_map(const Elem *, const Point &, const Real, const bool, const bool));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, Point, inverse_map(const Elem *, const Point &, const Real, const bool, const bool));

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2374,7 +2374,7 @@ Tensor System::point_hessian(unsigned int, const Point &, const Elem &) const
   return Tensor();
 }
 
-Tensor System::point_hessian(unsigned int var, const Point & p, const Elem * e) const
+Tensor System::point_hessian(unsigned int , const Point &, const Elem *) const
 {
   libmesh_error_msg("We can only accumulate a hessian with --enable-second");
 


### PR DESCRIPTION
I figured out that FEInterface::map() does not work for infinite elements. Supposing this is not a feature, I added the respective functions. Therefore, I needed to change InfFE::map() from protected to public, but I don't see problems with it. Are there?

Best,
Hubert