### PR TITLE
InfFE::inverse_map() - removed interpolated==true

### DIFF
--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -378,8 +378,7 @@ public:
   static Point inverse_map (const Elem * elem,
                             const Point & p,
                             const Real tolerance = TOLERANCE,
-                            const bool secure = true,
-                            const bool interpolated = true);
+                            const bool secure = true);
 
 
   /**


### PR DESCRIPTION
Hi, 
with this commit, issue #1084 should be resolved.
I removed the parameter interpolated (which was to my knowledge not used in any function anyway) and the part of the code where the interpolated scheme was used.
Should one still provide a function with the old interface for compatibility?
Best