### PR TITLE
NemesisIO Arbitrary Processor Writing

### DIFF
--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -67,6 +67,24 @@ public:
   virtual ~Nemesis_IO ();
 
   /**
+   * Used to set the processor_id to use when reading writing.
+   *
+   * By default the processor_id will be set from the communicator.
+   * This is used to override that behavior so you can write the
+   * mesh for any processor.
+   */
+  void set_processor_id(processor_id_type processor_id);
+
+  /**
+   * Used to set the number of processors to use when reading writing.
+   *
+   * The default will be set from the communicator.
+   * This is used to override that behavior so you can write the
+   * mesh for any processor.
+   */
+  void set_n_processors(processor_id_type n_processors);
+
+  /**
    * Implements reading the mesh from several different files.
    * You provide the basename, then LibMesh appends the ".size.rank"
    * depending on this->n_processors() and this->processor_id().

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -77,6 +77,24 @@ public:
   virtual ~Nemesis_IO_Helper();
 
   /**
+   * Used to set the processor_id to use when reading writing.
+   *
+   * By default the processor_id will be set from the communicator.
+   * This is used to override that behavior so you can write the
+   * mesh for any processor.
+   */
+  void set_processor_id(processor_id_type processor_id);
+
+  /**
+   * Used to set the number of processors to use when reading writing.
+   *
+   * The default will be set from the communicator.
+   * This is used to override that behavior so you can write the
+   * mesh for any processor.
+   */
+  void set_n_processors(processor_id_type n_processors);
+
+  /**
    * Reading functions.  These just allocate memory for you and call the Nemesis
    * routines of the same name.  They also handle error checking for the Nemesis
    * return value.  Be careful calling these at random, some depend on others
@@ -329,6 +347,16 @@ public:
   /**
    * Member data
    */
+
+  /**
+   * The current processor_id this object should work with.  Use this instead of processor_id()
+   */
+  processor_id_type current_processor_id;
+
+  /**
+   * The current number of processors this object should use.  Use this instead of n_processors()
+   */
+  processor_id_type current_n_processors;
 
   /**
    * All (?) Nemesis functions return an int.  If it's negative that signals an error!

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -111,6 +111,19 @@ Nemesis_IO::~Nemesis_IO ()
 }
 
 
+void
+Nemesis_IO::set_processor_id(processor_id_type processor_id)
+{
+  nemhelper->set_processor_id(processor_id);
+}
+
+
+void
+Nemesis_IO::set_n_processors(processor_id_type n_processors)
+{
+  nemhelper->set_n_processors(n_processors);
+}
+
 
 void Nemesis_IO::verbose (bool set_verbosity)
 {
@@ -1031,7 +1044,7 @@ void Nemesis_IO::read (const std::string & base_filename)
       // mesh, we would have to search the (unsorted) elem_list vector
       // for each entry!  We'll settle for doing some error checking instead.
       Elem * elem = mesh.elem_ptr
-        (my_elem_offset + 
+        (my_elem_offset +
          (nemhelper->elem_list[e]-1)/*Exodus numbering is 1-based!*/);
 
       // The side numberings in libmesh and exodus are not 1:1, so we need to map

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -44,6 +44,8 @@ namespace libMesh
 Nemesis_IO_Helper::Nemesis_IO_Helper(const ParallelObject & parent,
                                      bool verbose_in, bool single_precision) :
   ExodusII_IO_Helper(parent, verbose_in, /*run_only_on_proc0=*/false, /*single_precision=*/single_precision),
+  current_processor_id(processor_id()),
+  current_n_processors(n_processors()),
   nemesis_err_flag(0),
   num_nodes_global(0),
   num_elems_global(0),
@@ -80,6 +82,19 @@ Nemesis_IO_Helper::~Nemesis_IO_Helper()
 }
 
 
+void
+Nemesis_IO_Helper::set_processor_id(processor_id_type processor_id)
+{
+  current_processor_id = processor_id;
+}
+
+
+void
+Nemesis_IO_Helper::set_n_processors(processor_id_type n_processors)
+{
+  current_n_processors = n_processors;
+}
+
 
 void Nemesis_IO_Helper::get_init_global()
 {
@@ -94,11 +109,11 @@ void Nemesis_IO_Helper::get_init_global()
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] " << "num_nodes_global=" << num_nodes_global << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_elems_global=" << num_elems_global << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_elem_blks_global=" << num_elem_blks_global << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_node_sets_global=" << num_node_sets_global << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_side_sets_global=" << num_side_sets_global << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_nodes_global=" << num_nodes_global << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_elems_global=" << num_elems_global << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_elem_blks_global=" << num_elem_blks_global << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_node_sets_global=" << num_node_sets_global << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_side_sets_global=" << num_side_sets_global << std::endl;
     }
 }
 
@@ -124,10 +139,10 @@ void Nemesis_IO_Helper::get_ss_param_global()
 
       if (verbose)
         {
-          libMesh::out << "[" << this->processor_id() << "] " << "Global Sideset IDs, Side Counts, and DF counts:" << std::endl;
+          libMesh::out << "[" << this->current_processor_id << "] " << "Global Sideset IDs, Side Counts, and DF counts:" << std::endl;
           for (unsigned int bn=0; bn<global_sideset_ids.size(); ++bn)
             {
-              libMesh::out << "  [" << this->processor_id() << "] "
+              libMesh::out << "  [" << this->current_processor_id << "] "
                            << "global_sideset_ids["<<bn<<"]=" << global_sideset_ids[bn]
                            << ", num_global_side_counts["<<bn<<"]=" << num_global_side_counts[bn]
                            << ", num_global_side_df_counts["<<bn<<"]=" << num_global_side_df_counts[bn]
@@ -157,10 +172,10 @@ void Nemesis_IO_Helper::get_ns_param_global()
 
       if (verbose)
         {
-          libMesh::out << "[" << this->processor_id() << "] " << "Global Nodeset IDs, Node Counts, and DF counts:" << std::endl;
+          libMesh::out << "[" << this->current_processor_id << "] " << "Global Nodeset IDs, Node Counts, and DF counts:" << std::endl;
           for (unsigned int bn=0; bn<global_nodeset_ids.size(); ++bn)
             {
-              libMesh::out << "  [" << this->processor_id() << "] "
+              libMesh::out << "  [" << this->current_processor_id << "] "
                            << "global_nodeset_ids["<<bn<<"]=" << global_nodeset_ids[bn]
                            << ", num_global_node_counts["<<bn<<"]=" << num_global_node_counts[bn]
                            << ", num_global_node_df_counts["<<bn<<"]=" << num_global_node_df_counts[bn]
@@ -188,10 +203,10 @@ void Nemesis_IO_Helper::get_eb_info_global()
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] " << "Global Element Block IDs and Counts:" << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "Global Element Block IDs and Counts:" << std::endl;
       for (unsigned int bn=0; bn<global_elem_blk_ids.size(); ++bn)
         {
-          libMesh::out << "  [" << this->processor_id() << "] "
+          libMesh::out << "  [" << this->current_processor_id << "] "
                        << "global_elem_blk_ids["<<bn<<"]=" << global_elem_blk_ids[bn]
                        << ", global_elem_blk_cnts["<<bn<<"]=" << global_elem_blk_cnts[bn]
                        << std::endl;
@@ -212,9 +227,9 @@ void Nemesis_IO_Helper::get_init_info()
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] " << "num_proc=" << num_proc << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_proc_in_file=" << num_proc_in_file << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "ftype=" << ftype << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_proc=" << num_proc << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_proc_in_file=" << num_proc_in_file << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "ftype=" << ftype << std::endl;
     }
 }
 
@@ -231,20 +246,20 @@ void Nemesis_IO_Helper::get_loadbal_param()
                                   &num_border_elems,
                                   &num_node_cmaps,
                                   &num_elem_cmaps,
-                                  this->processor_id() // The ID of the processor for which info is to be read
+                                  this->current_processor_id // The ID of the processor for which info is to be read
                                   );
   EX_CHECK_ERR(nemesis_err_flag, "Error reading load balance parameters!");
 
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] " << "num_internal_nodes=" << num_internal_nodes << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_border_nodes=" << num_border_nodes << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_external_nodes=" << num_external_nodes << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_internal_elems=" << num_internal_elems << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_border_elems=" << num_border_elems << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_node_cmaps=" << num_node_cmaps << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "num_elem_cmaps=" << num_elem_cmaps << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_internal_nodes=" << num_internal_nodes << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_border_nodes=" << num_border_nodes << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_external_nodes=" << num_external_nodes << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_internal_elems=" << num_internal_elems << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_border_elems=" << num_border_elems << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_node_cmaps=" << num_node_cmaps << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "num_elem_cmaps=" << num_elem_cmaps << std::endl;
     }
 }
 
@@ -259,19 +274,19 @@ void Nemesis_IO_Helper::get_elem_map()
     Nemesis::ne_get_elem_map(ex_id,
                              elem_mapi.empty() ? libmesh_nullptr : &elem_mapi[0],
                              elem_mapb.empty() ? libmesh_nullptr : &elem_mapb[0],
-                             this->processor_id()
+                             this->current_processor_id
                              );
   EX_CHECK_ERR(nemesis_err_flag, "Error reading element maps!");
 
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] elem_mapi[i] = ";
+      libMesh::out << "[" << this->current_processor_id << "] elem_mapi[i] = ";
       for (unsigned int i=0; i< static_cast<unsigned int>(num_internal_elems-1); ++i)
         libMesh::out << elem_mapi[i] << ", ";
       libMesh::out << "... " << elem_mapi.back() << std::endl;
 
-      libMesh::out << "[" << this->processor_id() << "] elem_mapb[i] = ";
+      libMesh::out << "[" << this->current_processor_id << "] elem_mapb[i] = ";
       for (unsigned int i=0; i< static_cast<unsigned int>(std::min(10, num_border_elems-1)); ++i)
         libMesh::out << elem_mapb[i] << ", ";
       libMesh::out << "... " << elem_mapb.back() << std::endl;
@@ -292,7 +307,7 @@ void Nemesis_IO_Helper::get_node_map()
                              node_mapi.empty() ? libmesh_nullptr : &node_mapi[0],
                              node_mapb.empty() ? libmesh_nullptr : &node_mapb[0],
                              node_mape.empty() ? libmesh_nullptr : &node_mape[0],
-                             this->processor_id()
+                             this->current_processor_id
                              );
   EX_CHECK_ERR(nemesis_err_flag, "Error reading node maps!");
 
@@ -300,18 +315,18 @@ void Nemesis_IO_Helper::get_node_map()
     {
       // Remark: The Exodus/Nemesis node numbring is always (?) 1-based!  This means the first interior node id will
       // always be == 1.
-      libMesh::out << "[" << this->processor_id() << "] " << "first interior node id=" << node_mapi[0] << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "last interior node id=" << node_mapi.back() << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "first interior node id=" << node_mapi[0] << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "last interior node id=" << node_mapi.back() << std::endl;
 
-      libMesh::out << "[" << this->processor_id() << "] " << "first boundary node id=" << node_mapb[0] << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] " << "last boundary node id=" << node_mapb.back() << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "first boundary node id=" << node_mapb[0] << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] " << "last boundary node id=" << node_mapb.back() << std::endl;
 
       // The number of external nodes is sometimes zero, don't try to access
       // node_mape.back() in this case!
       if (num_external_nodes > 0)
         {
-          libMesh::out << "[" << this->processor_id() << "] " << "first external node id=" << node_mape[0] << std::endl;
-          libMesh::out << "[" << this->processor_id() << "] " << "last external node id=" << node_mape.back() << std::endl;
+          libMesh::out << "[" << this->current_processor_id << "] " << "first external node id=" << node_mape[0] << std::endl;
+          libMesh::out << "[" << this->current_processor_id << "] " << "last external node id=" << node_mape.back() << std::endl;
         }
     }
 }
@@ -331,28 +346,28 @@ void Nemesis_IO_Helper::get_cmap_params()
                                 node_cmap_node_cnts.empty() ? libmesh_nullptr : &node_cmap_node_cnts[0],
                                 elem_cmap_ids.empty()       ? libmesh_nullptr : &elem_cmap_ids[0],
                                 elem_cmap_elem_cnts.empty() ? libmesh_nullptr : &elem_cmap_elem_cnts[0],
-                                this->processor_id());
+                                this->current_processor_id);
   EX_CHECK_ERR(nemesis_err_flag, "Error reading cmap parameters!");
 
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] ";
+      libMesh::out << "[" << this->current_processor_id << "] ";
       for (unsigned int i=0; i<node_cmap_ids.size(); ++i)
         libMesh::out << "node_cmap_ids["<<i<<"]=" << node_cmap_ids[i] << " ";
       libMesh::out << std::endl;
 
-      libMesh::out << "[" << this->processor_id() << "] ";
+      libMesh::out << "[" << this->current_processor_id << "] ";
       for (unsigned int i=0; i<node_cmap_node_cnts.size(); ++i)
         libMesh::out << "node_cmap_node_cnts["<<i<<"]=" << node_cmap_node_cnts[i] << " ";
       libMesh::out << std::endl;
 
-      libMesh::out << "[" << this->processor_id() << "] ";
+      libMesh::out << "[" << this->current_processor_id << "] ";
       for (unsigned int i=0; i<elem_cmap_ids.size(); ++i)
         libMesh::out << "elem_cmap_ids["<<i<<"]=" << elem_cmap_ids[i] << " ";
       libMesh::out << std::endl;
 
-      libMesh::out << "[" << this->processor_id() << "] ";
+      libMesh::out << "[" << this->current_processor_id << "] ";
       for (unsigned int i=0; i<elem_cmap_elem_cnts.size(); ++i)
         libMesh::out << "elem_cmap_elem_cnts["<<i<<"]=" << elem_cmap_elem_cnts[i] << " ";
       libMesh::out << std::endl;
@@ -380,20 +395,20 @@ void Nemesis_IO_Helper::get_node_cmap()
                                       node_cmap_ids[i],
                                       &node_cmap_node_ids[i][0],
                                       &node_cmap_proc_ids[i][0],
-                                      this->processor_id());
+                                      this->current_processor_id);
           EX_CHECK_ERR(nemesis_err_flag, "Error reading node cmap node and processor ids!");
         }
 
       if (verbose)
         {
-          libMesh::out << "[" << this->processor_id() << "] node_cmap_node_ids["<<i<<"]=";
+          libMesh::out << "[" << this->current_processor_id << "] node_cmap_node_ids["<<i<<"]=";
           for (unsigned int j=0; j<node_cmap_node_ids[i].size(); ++j)
             libMesh::out << node_cmap_node_ids[i][j] << " ";
           libMesh::out << std::endl;
 
           // This is basically a vector, all entries of which are = node_cmap_ids[i]
           // Not sure if it's always guaranteed to be that or what...
-          libMesh::out << "[" << this->processor_id() << "] node_cmap_proc_ids["<<i<<"]=";
+          libMesh::out << "[" << this->current_processor_id << "] node_cmap_proc_ids["<<i<<"]=";
           for (unsigned int j=0; j<node_cmap_proc_ids[i].size(); ++j)
             libMesh::out << node_cmap_proc_ids[i][j] << " ";
           libMesh::out << std::endl;
@@ -423,27 +438,27 @@ void Nemesis_IO_Helper::get_elem_cmap()
                                       &elem_cmap_elem_ids[i][0],
                                       &elem_cmap_side_ids[i][0],
                                       &elem_cmap_proc_ids[i][0],
-                                      this->processor_id());
+                                      this->current_processor_id);
           EX_CHECK_ERR(nemesis_err_flag, "Error reading elem cmap elem, side, and processor ids!");
         }
 
       if (verbose)
         {
-          libMesh::out << "[" << this->processor_id() << "] elem_cmap_elem_ids["<<i<<"]=";
+          libMesh::out << "[" << this->current_processor_id << "] elem_cmap_elem_ids["<<i<<"]=";
           for (unsigned int j=0; j<elem_cmap_elem_ids[i].size(); ++j)
             libMesh::out << elem_cmap_elem_ids[i][j] << " ";
           libMesh::out << std::endl;
 
           // These must be the (local) side IDs (in the ExodusII face numbering scheme)
           // of the sides shared across processors.
-          libMesh::out << "[" << this->processor_id() << "] elem_cmap_side_ids["<<i<<"]=";
+          libMesh::out << "[" << this->current_processor_id << "] elem_cmap_side_ids["<<i<<"]=";
           for (unsigned int j=0; j<elem_cmap_side_ids[i].size(); ++j)
             libMesh::out << elem_cmap_side_ids[i][j] << " ";
           libMesh::out << std::endl;
 
           // This is basically a vector, all entries of which are = elem_cmap_ids[i]
           // Not sure if it's always guaranteed to be that or what...
-          libMesh::out << "[" << this->processor_id() << "] elem_cmap_proc_ids["<<i<<"]=";
+          libMesh::out << "[" << this->current_processor_id << "] elem_cmap_proc_ids["<<i<<"]=";
           for (unsigned int j=0; j<elem_cmap_proc_ids[i].size(); ++j)
             libMesh::out << elem_cmap_proc_ids[i][j] << " ";
           libMesh::out << std::endl;
@@ -560,7 +575,7 @@ void Nemesis_IO_Helper::put_loadbal_param(unsigned num_internal_nodes_in,
                                   num_border_elems_in,
                                   num_node_cmaps_in,
                                   num_elem_cmaps_in,
-                                  this->processor_id());
+                                  this->current_processor_id);
 
   EX_CHECK_ERR(nemesis_err_flag, "Error writing loadbal parameters!");
 }
@@ -584,7 +599,7 @@ void Nemesis_IO_Helper::put_cmap_params(std::vector<int> & node_cmap_ids_in,
                                     &node_cmap_node_cnts_in[0],
                                     &elem_cmap_ids_in[0],
                                     &elem_cmap_elem_cnts_in[0],
-                                    this->processor_id());
+                                    this->current_processor_id);
     }
 
   EX_CHECK_ERR(nemesis_err_flag, "Error writing cmap parameters!");
@@ -602,7 +617,7 @@ void Nemesis_IO_Helper::put_node_cmap(std::vector<std::vector<int> > & node_cmap
     {
       for (unsigned i=0; i<node_cmap_node_ids_in.size(); ++i)
         {
-          libMesh::out << "[" << this->processor_id() << "] put_node_cmap() : nodes communicated to proc "
+          libMesh::out << "[" << this->current_processor_id << "] put_node_cmap() : nodes communicated to proc "
                        << this->node_cmap_ids[i]
                        << " = ";
           for (unsigned j=0; j<node_cmap_node_ids_in[i].size(); ++j)
@@ -612,7 +627,7 @@ void Nemesis_IO_Helper::put_node_cmap(std::vector<std::vector<int> > & node_cmap
 
       for (unsigned i=0; i<node_cmap_node_ids_in.size(); ++i)
         {
-          libMesh::out << "[" << this->processor_id() << "] put_node_cmap() : processor IDs = ";
+          libMesh::out << "[" << this->current_processor_id << "] put_node_cmap() : processor IDs = ";
           for (unsigned j=0; j<node_cmap_proc_ids_in[i].size(); ++j)
             libMesh::out << node_cmap_proc_ids_in[i][j] << " ";
           libMesh::out << std::endl;
@@ -626,7 +641,7 @@ void Nemesis_IO_Helper::put_node_cmap(std::vector<std::vector<int> > & node_cmap
                                   this->node_cmap_ids[i],
                                   &node_cmap_node_ids_in[i][0],
                                   &node_cmap_proc_ids_in[i][0],
-                                  this->processor_id());
+                                  this->current_processor_id);
 
       EX_CHECK_ERR(nemesis_err_flag, "Error writing node communication map to file!");
     }
@@ -644,7 +659,7 @@ void Nemesis_IO_Helper::put_node_map(std::vector<int> & node_mapi_in,
                              node_mapi_in.empty() ? libmesh_nullptr : &node_mapi_in[0],
                              node_mapb_in.empty() ? libmesh_nullptr : &node_mapb_in[0],
                              node_mape_in.empty() ? libmesh_nullptr : &node_mape_in[0], // Don't take address of empty vector...
-                             this->processor_id());
+                             this->current_processor_id);
 
   EX_CHECK_ERR(nemesis_err_flag, "Error writing Nemesis internal and border node maps to file!");
 }
@@ -664,7 +679,7 @@ void Nemesis_IO_Helper::put_elem_cmap(std::vector<std::vector<int> > & elem_cmap
                                   &elem_cmap_elem_ids_in[i][0],
                                   &elem_cmap_side_ids_in[i][0],
                                   &elem_cmap_proc_ids_in[i][0],
-                                  this->processor_id());
+                                  this->current_processor_id);
 
       EX_CHECK_ERR(nemesis_err_flag, "Error writing elem communication map to file!");
     }
@@ -680,7 +695,7 @@ void Nemesis_IO_Helper::put_elem_map(std::vector<int> & elem_mapi_in,
     Nemesis::ne_put_elem_map(ex_id,
                              elem_mapi_in.empty() ? libmesh_nullptr : &elem_mapi_in[0],
                              elem_mapb_in.empty() ? libmesh_nullptr : &elem_mapb_in[0],
-                             this->processor_id());
+                             this->current_processor_id);
 
   EX_CHECK_ERR(nemesis_err_flag, "Error writing Nemesis internal and border element maps to file!");
 }
@@ -762,7 +777,7 @@ void Nemesis_IO_Helper::initialize(std::string title_in, const MeshBase & mesh, 
   // According to Nemesis documentation, first call when writing should be to
   // ne_put_init_info().  Our reader doesn't actually call this, but we should
   // strive to be as close to a normal nemesis file as possible...
-  this->put_init_info(this->n_processors(), 1, "p");
+  this->put_init_info(this->current_n_processors, 1, "p");
 
 
   // Gather global "initial" information for Nemesis.  This consists of
@@ -929,8 +944,8 @@ void Nemesis_IO_Helper::write_exodus_initialization_info(const MeshBase & pmesh,
   // even if it is 2D...
   this->num_dim = LIBMESH_DIM;
 
-  this->num_elem = static_cast<unsigned int>(std::distance (pmesh.active_local_elements_begin(),
-                                                            pmesh.active_local_elements_end()));
+  this->num_elem = static_cast<unsigned int>(std::distance (pmesh.active_pid_elements_begin(current_processor_id),
+                                                            pmesh.active_pid_elements_end(current_processor_id)));
 
   // Exodus will also use *global* number of side and node sets,
   // though it will not write out entries for all of them...
@@ -1154,7 +1169,7 @@ void Nemesis_IO_Helper::compute_node_communication_maps()
     {
       for (unsigned i=0; i<this->node_cmap_node_ids.size(); ++i)
         {
-          libMesh::out << "[" << this->processor_id() << "] nodes communicated to proc "
+          libMesh::out << "[" << this->current_processor_id << "] nodes communicated to proc "
                        << this->node_cmap_ids[i]
                        << " = ";
           for (unsigned j=0; j<this->node_cmap_node_ids[i].size(); ++j)
@@ -1164,7 +1179,7 @@ void Nemesis_IO_Helper::compute_node_communication_maps()
 
       for (unsigned i=0; i<this->node_cmap_node_ids.size(); ++i)
         {
-          libMesh::out << "[" << this->processor_id() << "] processor ID node communicated to = ";
+          libMesh::out << "[" << this->current_processor_id << "] processor ID node communicated to = ";
           for (unsigned j=0; j<this->node_cmap_proc_ids[i].size(); ++j)
             libMesh::out << this->node_cmap_proc_ids[i][j] << " ";
           libMesh::out << std::endl;
@@ -1202,12 +1217,12 @@ void Nemesis_IO_Helper::compute_communication_map_parameters()
   // Print the packed vectors we just filled
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] node_cmap_node_cnts = ";
+      libMesh::out << "[" << this->current_processor_id << "] node_cmap_node_cnts = ";
       for (unsigned i=0; i<node_cmap_node_cnts.size(); ++i)
         libMesh::out << node_cmap_node_cnts[i] << ", ";
       libMesh::out << std::endl;
 
-      libMesh::out << "[" << this->processor_id() << "] node_cmap_ids = ";
+      libMesh::out << "[" << this->current_processor_id << "] node_cmap_ids = ";
       for (unsigned i=0; i<node_cmap_ids.size(); ++i)
         libMesh::out << node_cmap_ids[i] << ", ";
       libMesh::out << std::endl;
@@ -1237,12 +1252,12 @@ void Nemesis_IO_Helper::compute_communication_map_parameters()
   // Print the packed vectors we just filled
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] elem_cmap_elem_cnts = ";
+      libMesh::out << "[" << this->current_processor_id << "] elem_cmap_elem_cnts = ";
       for (unsigned i=0; i<elem_cmap_elem_cnts.size(); ++i)
         libMesh::out << elem_cmap_elem_cnts[i] << ", ";
       libMesh::out << std::endl;
 
-      libMesh::out << "[" << this->processor_id() << "] elem_cmap_ids = ";
+      libMesh::out << "[" << this->current_processor_id << "] elem_cmap_ids = ";
       for (unsigned i=0; i<elem_cmap_ids.size(); ++i)
         libMesh::out << elem_cmap_ids[i] << ", ";
       libMesh::out << std::endl;
@@ -1269,8 +1284,8 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
   // element numberings into Nemesis numberings.
   ExodusII_IO_Helper::ElementMaps element_mapper;
 
-  MeshBase::const_element_iterator elem_it = pmesh.active_local_elements_begin();
-  MeshBase::const_element_iterator elem_end = pmesh.active_local_elements_end();
+  MeshBase::const_element_iterator elem_it = pmesh.active_pid_elements_begin(current_processor_id);
+  MeshBase::const_element_iterator elem_end = pmesh.active_pid_elements_end(current_processor_id);
 
   for (; elem_it != elem_end; ++elem_it)
     {
@@ -1312,7 +1327,7 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
 
               // If my neighbor has a different processor ID, I must be a border element.
               // Also track the neighboring processor ID if it is are different from our processor ID
-              if (neighbor_proc_id != this->processor_id())
+              if (neighbor_proc_id != this->current_processor_id)
                 {
                   is_border_elem = true;
                   neighboring_processor_ids.insert(neighbor_proc_id);
@@ -1321,7 +1336,7 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
                   unsigned nemesis_side_id = conv.get_inverse_side_map(n);
 
                   if (verbose)
-                    libMesh::out << "[" << this->processor_id() << "] LibMesh side "
+                    libMesh::out << "[" << this->current_processor_id << "] LibMesh side "
                                  << n
                                  << " mapped to (1-based) Exodus side "
                                  << nemesis_side_id
@@ -1354,7 +1369,7 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] neighboring_processor_ids = ";
+      libMesh::out << "[" << this->current_processor_id << "] neighboring_processor_ids = ";
       for (std::set<unsigned>::iterator it = neighboring_processor_ids.begin();
            it != neighboring_processor_ids.end();
            ++it)
@@ -1369,7 +1384,7 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
     cast_int<int>(neighboring_processor_ids.size());
 
   if (verbose)
-    libMesh::out << "[" << this->processor_id() << "] "
+    libMesh::out << "[" << this->current_processor_id << "] "
                  << "Number of neighboring processor IDs="
                  << this->num_elem_cmaps
                  << std::endl;
@@ -1380,7 +1395,7 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
       for (proc_border_elem_sets_iterator it=this->proc_border_elem_sets.begin();
            it != this->proc_border_elem_sets.end(); ++it)
         {
-          libMesh::out << "[" << this->processor_id() << "] "
+          libMesh::out << "[" << this->current_processor_id << "] "
                        << "Proc "
                        << (*it).first << " communicates "
                        << (*it).second.size() << " elements." << std::endl;
@@ -1398,10 +1413,10 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] num_internal_nodes=" << this->num_internal_nodes << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] num_border_nodes=" << this->num_border_nodes << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] num_border_elems=" << this->num_border_elems << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] num_internal_elems=" << this->num_internal_elems << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] num_internal_nodes=" << this->num_internal_nodes << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] num_border_nodes=" << this->num_border_nodes << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] num_border_elems=" << this->num_border_elems << std::endl;
+      libMesh::out << "[" << this->current_processor_id << "] num_internal_elems=" << this->num_internal_elems << std::endl;
     }
 }
 
@@ -1429,7 +1444,7 @@ void Nemesis_IO_Helper::compute_num_global_sidesets(const MeshBase & pmesh)
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] global_sideset_ids = ";
+      libMesh::out << "[" << this->current_processor_id << "] global_sideset_ids = ";
       for (unsigned i=0; i<this->global_sideset_ids.size(); ++i)
         libMesh::out << this->global_sideset_ids[i] << ", ";
       libMesh::out << std::endl;
@@ -1454,7 +1469,7 @@ void Nemesis_IO_Helper::compute_num_global_sidesets(const MeshBase & pmesh)
 
   for ( ; it_elem != new_bndry_elem_list_end; )
     {
-      if (pmesh.elem_ref(*it_elem).processor_id() != this->processor_id())
+      if (pmesh.elem_ref(*it_elem).processor_id() != this->current_processor_id)
         {
           // Back up the new end iterators to prepare for swap
           --new_bndry_elem_list_end;
@@ -1493,7 +1508,7 @@ void Nemesis_IO_Helper::compute_num_global_sidesets(const MeshBase & pmesh)
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] num_global_side_counts = ";
+      libMesh::out << "[" << this->current_processor_id << "] num_global_side_counts = ";
       for (unsigned i=0; i<this->num_global_side_counts.size(); ++i)
         libMesh::out << this->num_global_side_counts[i] << ", ";
       libMesh::out << std::endl;
@@ -1504,7 +1519,7 @@ void Nemesis_IO_Helper::compute_num_global_sidesets(const MeshBase & pmesh)
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] num_global_side_counts = ";
+      libMesh::out << "[" << this->current_processor_id << "] num_global_side_counts = ";
       for (unsigned i=0; i<this->num_global_side_counts.size(); ++i)
         libMesh::out << this->num_global_side_counts[i] << ", ";
       libMesh::out << std::endl;
@@ -1543,12 +1558,12 @@ void Nemesis_IO_Helper::compute_num_global_nodesets(const MeshBase & pmesh)
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] global_nodeset_ids = ";
+      libMesh::out << "[" << this->current_processor_id << "] global_nodeset_ids = ";
       for (unsigned i=0; i<global_nodeset_ids.size(); ++i)
         libMesh::out << global_nodeset_ids[i] << ", ";
       libMesh::out << std::endl;
 
-      libMesh::out << "[" << this->processor_id() << "] local_node_boundary_ids = ";
+      libMesh::out << "[" << this->current_processor_id << "] local_node_boundary_ids = ";
       for (std::set<boundary_id_type>::iterator it = local_node_boundary_ids.begin();
            it != local_node_boundary_ids.end();
            ++it)
@@ -1565,9 +1580,9 @@ void Nemesis_IO_Helper::compute_num_global_nodesets(const MeshBase & pmesh)
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] boundary_node_list.size()="
+      libMesh::out << "[" << this->current_processor_id << "] boundary_node_list.size()="
                    << boundary_node_list.size() << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] (boundary_node_id, boundary_id) = ";
+      libMesh::out << "[" << this->current_processor_id << "] (boundary_node_id, boundary_id) = ";
       for (unsigned i=0; i<boundary_node_list.size(); ++i)
         {
           libMesh::out << "(" << boundary_node_list[i] << ", " << boundary_node_boundary_id_list[i] << ") ";
@@ -1594,7 +1609,7 @@ void Nemesis_IO_Helper::compute_num_global_nodesets(const MeshBase & pmesh)
   std::vector<boundary_id_type>::iterator new_boundary_id_list_end = boundary_node_boundary_id_list.end();
   for ( ; it_node != new_node_list_end; )
     {
-      if (pmesh.node_ptr( *it_node )->processor_id() != this->processor_id())
+      if (pmesh.node_ptr( *it_node )->processor_id() != this->current_processor_id)
         {
           // Back up the new end iterators to prepare for swap
           --new_node_list_end;
@@ -1629,7 +1644,7 @@ void Nemesis_IO_Helper::compute_num_global_nodesets(const MeshBase & pmesh)
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] num_global_node_counts = ";
+      libMesh::out << "[" << this->current_processor_id << "] num_global_node_counts = ";
       for (unsigned i=0; i<num_global_node_counts.size(); ++i)
         libMesh::out << num_global_node_counts[i] << ", ";
       libMesh::out << std::endl;
@@ -1647,8 +1662,8 @@ void Nemesis_IO_Helper::compute_num_global_elem_blocks(const MeshBase & pmesh)
   // This map keeps track of the number of elements in each subdomain over all processors
   std::map<subdomain_id_type, unsigned> global_subdomain_counts;
 
-  MeshBase::const_element_iterator elem_it = pmesh.active_local_elements_begin();
-  MeshBase::const_element_iterator elem_end = pmesh.active_local_elements_end();
+  MeshBase::const_element_iterator elem_it = pmesh.active_pid_elements_begin(current_processor_id);
+  MeshBase::const_element_iterator elem_end = pmesh.active_pid_elements_end(current_processor_id);
 
   for (; elem_it != elem_end; ++elem_it)
     {
@@ -1692,7 +1707,7 @@ void Nemesis_IO_Helper::compute_num_global_elem_blocks(const MeshBase & pmesh)
   // Print the number of elements found locally in each subdomain
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] ";
+      libMesh::out << "[" << this->current_processor_id << "] ";
       for (std::map<subdomain_id_type, unsigned>::iterator it=global_subdomain_counts.begin();
            it != global_subdomain_counts.end();
            ++it)
@@ -1722,7 +1737,7 @@ void Nemesis_IO_Helper::compute_num_global_elem_blocks(const MeshBase & pmesh)
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] global_elem_blk_cnts = ";
+      libMesh::out << "[" << this->current_processor_id << "] global_elem_blk_cnts = ";
       for (unsigned i=0; i<this->global_elem_blk_cnts.size(); ++i)
         libMesh::out << this->global_elem_blk_cnts[i] << ", ";
       libMesh::out << std::endl;
@@ -1736,7 +1751,7 @@ void Nemesis_IO_Helper::compute_num_global_elem_blocks(const MeshBase & pmesh)
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] global_elem_blk_ids = ";
+      libMesh::out << "[" << this->current_processor_id << "] global_elem_blk_ids = ";
       for (unsigned i=0; i<this->global_elem_blk_ids.size(); ++i)
         libMesh::out << this->global_elem_blk_ids[i] << ", ";
       libMesh::out << std::endl;
@@ -1756,8 +1771,8 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
 #ifdef DEBUG
   if (local_subdomain_counts.empty())
     {
-      libmesh_assert(pmesh.active_local_elements_begin() ==
-                     pmesh.active_local_elements_end());
+      libmesh_assert(pmesh.active_pid_elements_begin(current_processor_id) ==
+                     pmesh.active_pid_elements_end(current_processor_id));
       libmesh_assert(this->nodes_attached_to_local_elems.empty());
     }
 #endif
@@ -1785,7 +1800,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
 
       if (verbose)
         {
-          libMesh::out << "[" << this->processor_id() << "] "
+          libMesh::out << "[" << this->current_processor_id << "] "
                        << "local_subdomain_counts [" << static_cast<unsigned>(cur_subdomain) << "]= "
                        << (*it).second
                        << std::endl;
@@ -1797,8 +1812,8 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
 
 
   // First loop over the elements to figure out which elements are in which subdomain
-  MeshBase::const_element_iterator elem_it = pmesh.active_local_elements_begin();
-  MeshBase::const_element_iterator elem_end = pmesh.active_local_elements_end();
+  MeshBase::const_element_iterator elem_it = pmesh.active_pid_elements_begin(current_processor_id);
+  MeshBase::const_element_iterator elem_end = pmesh.active_pid_elements_end(current_processor_id);
 
   for (; elem_it != elem_end; ++elem_it)
     {
@@ -1973,11 +1988,11 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
 
     // We can't be connecting to more processors than exist outside
     // ourselves
-    libmesh_assert_less (static_cast<unsigned>(this->num_node_cmaps), this->n_processors());
+    libmesh_assert_less (static_cast<unsigned>(this->num_node_cmaps), this->current_n_processors);
 
     if (verbose)
       {
-        libMesh::out << "[" << this->processor_id()
+        libMesh::out << "[" << this->current_processor_id
                      << "] proc_nodes_touched contains "
                      << proc_nodes_touched.size()
                      << " sets of nodes."
@@ -1987,7 +2002,7 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
              it != proc_nodes_touched.end();
              ++it)
           {
-            libMesh::out << "[" << this->processor_id()
+            libMesh::out << "[" << this->current_processor_id
                          << "] proc_nodes_touched[" << (*it).first << "] has "
                          << (*it).second.size()
                          << " entries."
@@ -2003,11 +2018,11 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
          ++it)
       {
         // Don't compute intersections with ourself
-        if ((*it).first == this->processor_id())
+        if ((*it).first == this->current_processor_id)
           continue;
 
         // Otherwise, compute intersection with other processor and ourself
-        std::set<unsigned> & my_set = proc_nodes_touched[this->processor_id()];
+        std::set<unsigned> & my_set = proc_nodes_touched[this->current_processor_id];
         std::set<unsigned> & other_set = (*it).second;
         std::set<unsigned> & result_set = this->proc_nodes_touched_intersections[ (*it).first ]; // created if does not exist
 
@@ -2022,7 +2037,7 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
              it != this->proc_nodes_touched_intersections.end();
              ++it)
           {
-            libMesh::out << "[" << this->processor_id()
+            libMesh::out << "[" << this->current_processor_id
                          << "] this->proc_nodes_touched_intersections[" << (*it).first << "] has "
                          << (*it).second.size()
                          << " entries."
@@ -2049,7 +2064,7 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
 
     if (verbose)
       {
-        libMesh::out << "[" << this->processor_id()
+        libMesh::out << "[" << this->current_processor_id
                      << "] border_node_ids.size()=" << this->border_node_ids.size()
                      << std::endl;
       }
@@ -2084,9 +2099,9 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
 
   if (verbose)
     {
-      libMesh::out << "[" << this->processor_id() << "] boundary_node_list.size()="
+      libMesh::out << "[" << this->current_processor_id << "] boundary_node_list.size()="
                    << boundary_node_list.size() << std::endl;
-      libMesh::out << "[" << this->processor_id() << "] (boundary_node_id, boundary_id) = ";
+      libMesh::out << "[" << this->current_processor_id << "] (boundary_node_id, boundary_id) = ";
       for (unsigned i=0; i<boundary_node_list.size(); ++i)
         {
           libMesh::out << "(" << boundary_node_list[i] << ", " << boundary_node_boundary_id_list[i] << ") ";
@@ -2122,7 +2137,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
            it != local_node_boundary_id_lists.end();
            ++it)
         {
-          libMesh::out << "[" << this->processor_id() << "] ID: " << (*it).first << ", ";
+          libMesh::out << "[" << this->current_processor_id << "] ID: " << (*it).first << ", ";
 
           std::vector<int> & current_id_set = (*it).second;
 
@@ -2151,7 +2166,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
 
       if (verbose)
         {
-          libMesh::out << "[" << this->processor_id()
+          libMesh::out << "[" << this->current_processor_id
                        << "] Writing out Exodus nodeset info for ID: " << global_nodeset_ids[i]
                        << ", Name: " << current_ns_name
                        << std::endl;
@@ -2175,7 +2190,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
       if (it == local_node_boundary_id_lists.end())
         {
           if (verbose)
-            libMesh::out << "[" << this->processor_id()
+            libMesh::out << "[" << this->current_processor_id
                          << "] No nodeset data for ID: " << global_nodeset_ids[i]
                          << " on this processor." << std::endl;
 
@@ -2271,7 +2286,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
           const Elem & f = mesh.elem_ref(f_id);
 
           // If element is local, process it
-          if (f.processor_id() == this->processor_id())
+          if (f.processor_id() == this->current_processor_id)
             {
               const ExodusII_IO_Helper::Conversion conv = em.assign_conversion(f.type());
 
@@ -2290,7 +2305,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
                 libmesh_error_msg("Error, no Exodus mapping for Elem " \
                                   << f_id                              \
                                   << " on processor "                 \
-                                  << this->processor_id());
+                                  << this->current_processor_id);
             }
         }
     }
@@ -2312,7 +2327,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
 
       if (verbose)
         {
-          libMesh::out << "[" << this->processor_id()
+          libMesh::out << "[" << this->current_processor_id
                        << "] Writing out Exodus sideset info for ID: " << global_sideset_ids[i]
                        << ", Name: " << current_ss_name
                        << std::endl;
@@ -2336,7 +2351,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
       if (it == local_elem_boundary_id_lists.end())
         {
           if (verbose)
-            libMesh::out << "[" << this->processor_id()
+            libMesh::out << "[" << this->current_processor_id
                          << "] No sideset data for ID: " << global_sideset_ids[i]
                          << " on this processor." << std::endl;
 
@@ -2663,7 +2678,7 @@ std::string Nemesis_IO_Helper::construct_nemesis_filename(const std::string & ba
   // mesh.e.128.099
 
   // Find the length of the highest processor ID
-  file_oss << (this->n_processors());
+  file_oss << (this->current_n_processors);
   unsigned int field_width = cast_int<unsigned int>(file_oss.str().size());
 
   if (verbose)
@@ -2671,8 +2686,8 @@ std::string Nemesis_IO_Helper::construct_nemesis_filename(const std::string & ba
 
   file_oss.str(""); // reset the string stream
   file_oss << base_filename
-           << '.' << this->n_processors()
-           << '.' << std::setfill('0') << std::setw(field_width) << this->processor_id();
+           << '.' << this->current_n_processors
+           << '.' << std::setfill('0') << std::setw(field_width) << this->current_processor_id;
 
   // Return the resulting string
   return file_oss.str();


### PR DESCRIPTION
Adds a capability to NemesisIO to specify the number of processors and the current processor_id.

This allows a mesh to be read in using just one processor... partitioned for `N` processors and then written out to `N` Nemesis files... giving us the ability to "pre-split" meshes for parallel mesh capability.