### PR TITLE
libmesh_assert() the result of verify() calls

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2933,7 +2933,7 @@ void SparsityPattern::Build::join (const SparsityPattern::Build & other)
 void SparsityPattern::Build::parallel_sync ()
 {
   parallel_object_only();
-  this->comm().verify(need_full_sparsity_pattern);
+  libmesh_assert(this->comm().verify(need_full_sparsity_pattern));
 
   const dof_id_type n_global_dofs   = dof_map.n_dofs();
   const dof_id_type n_dofs_on_proc  = dof_map.n_dofs_on_processor(this->processor_id());

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -4034,13 +4034,13 @@ void DofMap::check_dirichlet_bcid_consistency (const MeshBase & mesh,
   const std::set<boundary_id_type>& dbc_bcids = boundary.b;
 
   // DirichletBoundary id sets should be consistent across all ranks
-  mesh.comm().verify(dbc_bcids.size());
+  libmesh_assert(mesh.comm().verify(dbc_bcids.size()));
 
   for (std::set<boundary_id_type>::const_iterator bid = dbc_bcids.begin();
        bid != dbc_bcids.end(); ++bid)
     {
       // DirichletBoundary id sets should be consistent across all ranks
-      mesh.comm().verify(*bid);
+      libmesh_assert(mesh.comm().verify(*bid));
 
       bool found_bcid = (mesh_bcids.find(*bid) != mesh_bcids.end());
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1346,8 +1346,8 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
 #ifdef DEBUG
   // We expect maximum ids to be in sync so we can use them to size
   // vectors
-  mesh.comm().verify(mesh.max_node_id());
-  mesh.comm().verify(mesh.max_elem_id());
+  libmesh_assert(mesh.comm().verify(mesh.max_node_id()));
+  libmesh_assert(mesh.comm().verify(mesh.max_elem_id()));
   const dof_id_type par_max_node_id = mesh.parallel_max_node_id();
   const dof_id_type par_max_elem_id = mesh.parallel_max_elem_id();
   libmesh_assert_equal_to (par_max_node_id, mesh.max_node_id());

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2030,12 +2030,12 @@ Number System::point_value(unsigned int var, const Point & p, const bool insist_
   // And every processor had better agree about which point we're
   // looking for
 #ifndef NDEBUG
-  this->comm().verify(p(0));
+  libmesh_assert(this->comm().verify(p(0)));
 #if LIBMESH_DIM > 1
-  this->comm().verify(p(1));
+  libmesh_assert(this->comm().verify(p(1)));
 #endif
 #if LIBMESH_DIM > 2
-  this->comm().verify(p(2));
+  libmesh_assert(this->comm().verify(p(2)));
 #endif
 #endif // NDEBUG
 
@@ -2141,12 +2141,12 @@ Gradient System::point_gradient(unsigned int var, const Point & p, const bool in
   // And every processor had better agree about which point we're
   // looking for
 #ifndef NDEBUG
-  this->comm().verify(p(0));
+  libmesh_assert(this->comm().verify(p(0)));
 #if LIBMESH_DIM > 1
-  this->comm().verify(p(1));
+  libmesh_assert(this->comm().verify(p(1)));
 #endif
 #if LIBMESH_DIM > 2
-  this->comm().verify(p(2));
+  libmesh_assert(this->comm().verify(p(2)));
 #endif
 #endif // NDEBUG
 
@@ -2255,12 +2255,12 @@ Tensor System::point_hessian(unsigned int var, const Point & p, const bool insis
   // And every processor had better agree about which point we're
   // looking for
 #ifndef NDEBUG
-  this->comm().verify(p(0));
+  libmesh_assert(this->comm().verify(p(0)));
 #if LIBMESH_DIM > 1
-  this->comm().verify(p(1));
+  libmesh_assert(this->comm().verify(p(1)));
 #endif
 #if LIBMESH_DIM > 2
-  this->comm().verify(p(2));
+  libmesh_assert(this->comm().verify(p(2)));
 #endif
 #endif // NDEBUG
 


### PR DESCRIPTION
verify() returns a bool rather than asserts it.  This was done for
flexibility but has mostly just caused confusion.