### PR TITLE
Two fixes while debugging Nemesis reading/writing issues

### DIFF
--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -104,7 +104,15 @@ INT_TYPE(unsigned int,MPI_UNSIGNED);
 INT_TYPE(long,MPI_LONG);
 INT_TYPE(long long,MPI_LONG_LONG_INT);
 INT_TYPE(unsigned long,MPI_UNSIGNED_LONG);
-INT_TYPE(unsigned long long,MPI_LONG_LONG_INT);
+#if MPI_VERSION > 1
+INT_TYPE(unsigned long long,MPI_UNSIGNED_LONG_LONG);
+#else
+// MPI 1.0 did not have an unsigned long long type, so we have to use
+// MPI_UNSIGNED_LONG in this case.  If "unsigned long" and "unsigned
+// long long" are different sizes on your system, we detect this and
+// throw an error rather than communicating values incorrectly.
+INT_TYPE(unsigned long long,MPI_UNSIGNED_LONG);
+#endif
 FLOAT_TYPE(float,MPI_FLOAT);
 FLOAT_TYPE(double,MPI_DOUBLE);
 FLOAT_TYPE(long double,MPI_LONG_DOUBLE);

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -69,9 +69,13 @@ Nemesis_IO_Helper::Nemesis_IO_Helper(const ParallelObject & parent,
 Nemesis_IO_Helper::~Nemesis_IO_Helper()
 {
   // Our destructor is called from Nemesis_IO.  We close the Exodus file here since we have
-  // responsibility for managing the file's lifetime.
-  this->ex_err = exII::ex_update(this->ex_id);
-  EX_EXCEPTIONLESS_CHECK_ERR(ex_err, "Error flushing buffers to file.");
+  // responsibility for managing the file's lifetime.  Only call ex_update() if the file was
+  // opened for writing!
+  if (this->opened_for_writing)
+    {
+      this->ex_err = exII::ex_update(this->ex_id);
+      EX_EXCEPTIONLESS_CHECK_ERR(ex_err, "Error flushing buffers to file.");
+    }
   this->close();
 }
 


### PR DESCRIPTION
1. Can't call `ex_update()` on a file opened read-only.
2. Fix bug where `MPI_LONG_LONG_INT` was used to wrap `unsigned long long`, causing signed comparison issues.

Refs #1087. 