### PR TITLE
pack_range should stop just *after* buffer_size

### DIFF
--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -579,13 +579,17 @@ inline void unpack_range (const typename std::vector<buffertype> & buffer,
 /**
  * Encode a range of potentially-variable-size objects to a data
  * array.
+ *
+ * The data will be buffered in vectors with lengths that do not
+ * exceed the sum of \p approx_buffer_size and the size of an
+ * individual packed object.
  */
 template <typename Context, typename buffertype, typename Iter>
 inline Iter pack_range (const Context * context,
                         Iter range_begin,
                         const Iter range_end,
                         typename std::vector<buffertype> & buffer,
-                        std::size_t max_buffer_size = 1000000);
+                        std::size_t approx_buffer_size = 1000000);
 
 /**
  * Return the total buffer size needed to encode a range of

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -476,7 +476,7 @@ inline Iter pack_range (const Context * context,
                         // bandwidth, but not so large as to risk allocation failures.  max_buffer_size
                         // is measured in number of buffer type entries; number of bytes may be 4 or 8
                         // times larger depending on configuration.
-                        std::size_t max_buffer_size)
+                        std::size_t approx_buffer_size)
 {
   typedef typename std::iterator_traits<Iter>::value_type T;
 
@@ -484,14 +484,12 @@ inline Iter pack_range (const Context * context,
   // Prepare to stop early if the buffer would be too large.
   std::size_t buffer_size = 0;
   Iter range_stop = range_begin;
-  for (; range_stop != range_end; ++range_stop)
+  for (; range_stop != range_end && buffer_size < approx_buffer_size;
+       ++range_stop)
     {
       std::size_t next_buffer_size =
         Parallel::Packing<T>::packable_size(*range_stop, context);
-      if (buffer_size + next_buffer_size >= max_buffer_size)
-        break;
-      else
-        buffer_size += next_buffer_size;
+      buffer_size += next_buffer_size;
     }
   buffer.reserve(buffer.size() + buffer_size);
 


### PR DESCRIPTION
If we stop just *before*, then we break if we ever try to pack a
single object that won't fit into the buffer.

In theory this should fix the bug @dschwen pinned down in https://github.com/idaholab/moose/pull/7729

In practice, touching parallel*.h requires rebuilding everything and I haven't even made sure this finishes compiling yet.