### PR TITLE
Add allgather string specialization

### DIFF
--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -1098,6 +1098,14 @@ public:
                      T send,
                      std::vector<T> & recv) const;
 
+   /**
+    * Gather overload for string types
+    */
+   template <typename T>
+   inline void gather(const unsigned int root_id,
+                      std::basic_string<T> send,
+                      std::vector<std::basic_string<T> > & recv) const;
+
   /**
    * Take a vector of local variables and expand it on processor root_id
    * to include values from all processors
@@ -1131,6 +1139,13 @@ public:
   template <typename T>
   inline void allgather(T send,
                         std::vector<T> & recv) const;
+
+  /**
+  * AllGather overload for string types
+   */
+  template <typename T>
+  inline void allgather(std::basic_string<T> send,
+                        std::vector<std::basic_string<T> > & recv) const;
 
 
   /**

--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -1103,7 +1103,7 @@ public:
     */
    template <typename T>
    inline void gather(const unsigned int root_id,
-                      std::basic_string<T> send,
+                      const std::basic_string<T> & send,
                       std::vector<std::basic_string<T> > & recv,
                       const bool identical_buffer_sizes=false) const;
 
@@ -1145,7 +1145,7 @@ public:
   * AllGather overload for string types
    */
   template <typename T>
-  inline void allgather(std::basic_string<T> send,
+  inline void allgather(const std::basic_string<T> & send,
                         std::vector<std::basic_string<T> > & recv,
                         const bool identical_buffer_sizes=false) const;
 

--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -1104,7 +1104,8 @@ public:
    template <typename T>
    inline void gather(const unsigned int root_id,
                       std::basic_string<T> send,
-                      std::vector<std::basic_string<T> > & recv) const;
+                      std::vector<std::basic_string<T> > & recv,
+                      const bool identical_buffer_sizes=false) const;
 
   /**
    * Take a vector of local variables and expand it on processor root_id
@@ -1145,7 +1146,8 @@ public:
    */
   template <typename T>
   inline void allgather(std::basic_string<T> send,
-                        std::vector<std::basic_string<T> > & recv) const;
+                        std::vector<std::basic_string<T> > & recv,
+                        const bool identical_buffer_sizes=false) const;
 
 
   /**

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -2950,7 +2950,7 @@ inline void Communicator::gather(const unsigned int root_id,
 
 template <typename T>
 inline void Communicator::gather(const unsigned int root_id,
-                                 std::basic_string<T> sendval,
+                                 const std::basic_string<T> & sendval,
                                  std::vector<std::basic_string<T> > & recv,
                                  const bool identical_buffer_sizes) const
 {
@@ -3084,7 +3084,7 @@ inline void Communicator::allgather(T sendval,
 
 
 template <typename T>
-inline void Communicator::allgather(std::basic_string<T> sendval,
+inline void Communicator::allgather(const std::basic_string<T> & sendval,
                                     std::vector<std::basic_string<T> > & recv,
                                     const bool identical_buffer_sizes) const
 {

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -2950,6 +2950,60 @@ inline void Communicator::gather(const unsigned int root_id,
 
 template <typename T>
 inline void Communicator::gather(const unsigned int root_id,
+                                 std::basic_string<T> sendval,
+                                 std::vector<std::basic_string<T> > & recv) const
+{
+  libmesh_assert_less (root_id, this->size());
+
+  if (this->rank() == root_id)
+    recv.resize(this->size());
+
+  if (this->size() > 1)
+    {
+      LOG_SCOPE ("gather()","Parallel");
+
+      std::vector<int>
+        sendlengths  (this->size(), 0),
+        displacements(this->size(), 0);
+
+      // first comm step to determine buffer sizes from all processors
+      const int mysize = static_cast<int>(sendval.size());
+      this->gather(root_id, mysize, sendlengths);
+
+      // Find the total size of the final array and
+      // set up the displacement offsets for each processor
+      unsigned int globalsize = 0;
+      for (unsigned int i=0; i < this->size(); ++i)
+        {
+          displacements[i] = globalsize;
+          globalsize += sendlengths[i];
+        }
+
+      // monolithic receive buffer
+      std::string r;
+      if (this->rank() == root_id)
+        r.resize(globalsize, 0);
+
+      // and get the data from the remote processors.
+      libmesh_call_mpi
+        (MPI_Gatherv (&sendval[0], mysize, StandardType<T>(),
+                      this->rank() == root_id ? &r[0] : libmesh_nullptr,
+                      &sendlengths[0], &displacements[0],
+                      StandardType<T>(), root_id, this->get()));
+
+      // slice receive buffer up
+      if (this->rank() == root_id)
+        for (unsigned int i=0; i != this->size(); ++i)
+          recv[i] = r.substr(displacements[i], sendlengths[i]);
+    }
+  else
+    recv[0] = sendval;
+}
+
+
+
+template <typename T>
+inline void Communicator::gather(const unsigned int root_id,
                                  std::vector<T> & r) const
 {
   if (this->size() == 1)
@@ -3020,6 +3074,60 @@ inline void Communicator::allgather(T sendval,
     }
   else if (comm_size > 0)
     recv[0] = sendval;
+}
+
+
+
+template <typename T>
+inline void Communicator::allgather(std::basic_string<T> sendval,
+                                    std::vector<std::basic_string<T> > & recv) const
+{
+  LOG_SCOPE ("allgather()","Parallel");
+
+  libmesh_assert(this->size());
+  recv.assign(this->size(), "");
+
+  // serial case
+  if (this->size() < 2)
+    {
+      recv.resize(1);
+      recv[0] = sendval;
+      return;
+    }
+
+  std::vector<int>
+    sendlengths  (this->size(), 0),
+    displacements(this->size(), 0);
+
+  // first comm step to determine buffer sizes from all processors
+  const int mysize = static_cast<int>(sendval.size());
+  this->allgather(mysize, sendlengths);
+
+  // Find the total size of the final array and
+  // set up the displacement offsets for each processor
+  unsigned int globalsize = 0;
+  for (unsigned int i=0; i != this->size(); ++i)
+    {
+      displacements[i] = globalsize;
+      globalsize += sendlengths[i];
+    }
+
+  // Check for quick return
+  if (globalsize == 0)
+    return;
+
+  // monolithic receive buffer
+  std::string r(globalsize, 0);
+
+  // and get the data from the remote processors.
+  libmesh_call_mpi
+    (MPI_Allgatherv (&sendval[0], mysize, StandardType<T>(),
+                     &r[0], &sendlengths[0], &displacements[0],
+                     StandardType<T>(), this->get()));
+
+  // slice receive buffer up
+  for (unsigned int i=0; i != this->size(); ++i)
+    recv[i] = r.substr(displacements[i], sendlengths[i]);
 }
 
 

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -2951,7 +2951,8 @@ inline void Communicator::gather(const unsigned int root_id,
 template <typename T>
 inline void Communicator::gather(const unsigned int root_id,
                                  std::basic_string<T> sendval,
-                                 std::vector<std::basic_string<T> > & recv) const
+                                 std::vector<std::basic_string<T> > & recv,
+                                 const bool identical_buffer_sizes) const
 {
   libmesh_assert_less (root_id, this->size());
 
@@ -2966,9 +2967,13 @@ inline void Communicator::gather(const unsigned int root_id,
         sendlengths  (this->size(), 0),
         displacements(this->size(), 0);
 
-      // first comm step to determine buffer sizes from all processors
       const int mysize = static_cast<int>(sendval.size());
-      this->gather(root_id, mysize, sendlengths);
+
+      if (identical_buffer_sizes)
+        sendlengths.assign(this->size(), mysize);
+      else
+        // first comm step to determine buffer sizes from all processors
+        this->gather(root_id, mysize, sendlengths);
 
       // Find the total size of the final array and
       // set up the displacement offsets for each processor
@@ -3080,7 +3085,8 @@ inline void Communicator::allgather(T sendval,
 
 template <typename T>
 inline void Communicator::allgather(std::basic_string<T> sendval,
-                                    std::vector<std::basic_string<T> > & recv) const
+                                    std::vector<std::basic_string<T> > & recv,
+                                    const bool identical_buffer_sizes) const
 {
   LOG_SCOPE ("allgather()","Parallel");
 
@@ -3099,9 +3105,13 @@ inline void Communicator::allgather(std::basic_string<T> sendval,
     sendlengths  (this->size(), 0),
     displacements(this->size(), 0);
 
-  // first comm step to determine buffer sizes from all processors
   const int mysize = static_cast<int>(sendval.size());
-  this->allgather(mysize, sendlengths);
+
+  if (identical_buffer_sizes)
+    sendlengths.assign(this->size(), mysize);
+  else
+    // first comm step to determine buffer sizes from all processors
+    this->allgather(mysize, sendlengths);
 
   // Find the total size of the final array and
   // set up the displacement offsets for each processor

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -26,6 +26,8 @@ public:
 
   CPPUNIT_TEST( testGather );
   CPPUNIT_TEST( testAllGather );
+  CPPUNIT_TEST( testGatherString );
+  CPPUNIT_TEST( testAllGatherString );
   CPPUNIT_TEST( testBroadcast );
   CPPUNIT_TEST( testScatter );
   CPPUNIT_TEST( testBarrier );
@@ -41,10 +43,23 @@ public:
   CPPUNIT_TEST_SUITE_END();
 
 private:
+  std::vector<std::string> _number;
 
 public:
   void setUp()
-  {}
+  {
+    _number.resize(10);
+    _number[0] = "Zero";
+    _number[1] = "One";
+    _number[2] = "Two";
+    _number[3] = "Three";
+    _number[4] = "Four";
+    _number[5] = "Five";
+    _number[6] = "Six";
+    _number[7] = "Seven";
+    _number[8] = "Eight";
+    _number[9] = "Nine";
+  }
 
   void tearDown()
   {}
@@ -63,6 +78,18 @@ public:
 
 
 
+  void testGatherString()
+  {
+    std::vector<std::string> vals;
+    TestCommWorld->gather(0, "Processor" + _number[TestCommWorld->rank() % 10], vals);
+
+    if (TestCommWorld->rank() == 0)
+      for (processor_id_type i=0; i<vals.size(); i++)
+        CPPUNIT_ASSERT_EQUAL( "Processor" + _number[i % 10] , vals[i] );
+  }
+
+
+
   void testAllGather()
   {
     std::vector<processor_id_type> vals;
@@ -70,6 +97,17 @@ public:
 
     for (processor_id_type i=0; i<vals.size(); i++)
       CPPUNIT_ASSERT_EQUAL( i , vals[i] );
+  }
+
+
+
+  void testAllGatherString()
+  {
+    std::vector<std::string> vals;
+    TestCommWorld->gather(0, "Processor" + _number[TestCommWorld->rank() % 10], vals);
+
+    for (processor_id_type i=0; i<vals.size(); i++)
+      CPPUNIT_ASSERT_EQUAL( "Processor" + _number[i % 10] , vals[i] );
   }
 
 


### PR DESCRIPTION
Specialization to allgather strings into a vector of strings. Will be used for communicating serialized data in MOOSE. This will replace the current use of `allgather_packed_range` and skips the _packing_ aspect as we already serialize the data in binary form on the MOOSE side.