### PR TITLE
Fix deprecated messages in some examples

### DIFF
--- a/include/systems/parameter_vector.h
+++ b/include/systems/parameter_vector.h
@@ -165,7 +165,7 @@ inline
 void
 ParameterVector::clear()
 {
-  if (_is_shallow_copy)
+  if (!_is_shallow_copy)
     for (unsigned int i=0; i != _params.size(); ++i)
       delete _params[i];
 
@@ -178,6 +178,8 @@ ParameterVector::clear()
 inline
 void ParameterVector::push_back(UniquePtr<ParameterAccessor<Number> > new_accessor)
 {
+  // Can't append stuff we are responsible for if we're already a shallow copy.
+  libmesh_assert(!_is_shallow_copy);
   libmesh_assert(new_accessor.get());
   _params.push_back(new_accessor.release());
 }

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -85,7 +85,6 @@ VTKIO::VTKIO (MeshBase & mesh, MeshData * mesh_data) :
 {
   // Ignore unused parameters when !LIBMESH_HAVE_VTK
   libmesh_ignore(mesh_data);
-  libmesh_experimental();
 }
 
 
@@ -101,7 +100,6 @@ VTKIO::VTKIO (const MeshBase & mesh, MeshData * mesh_data) :
 {
   // Ignore unused parameters when !LIBMESH_HAVE_VTK
   libmesh_ignore(mesh_data);
-  libmesh_experimental();
 }
 
 


### PR DESCRIPTION
Also fix a memory leak uncovered in ParameterVector.