### PR TITLE
Remove deprecated MeshRefinement APIs

### DIFF
--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -685,14 +685,20 @@ private:
   /**
    * Take user-specified coarsening flags and augment them
    * so that level-one dependency is satisfied.
+   *
+   * This function used to take an argument, \p maintain_level_one -
+   * new code should use face_level_mismatch_limit() instead.
    */
-  bool make_coarsening_compatible (const bool);
+  bool make_coarsening_compatible ();
 
   /**
    * Take user-specified refinement flags and augment them
    * so that level-one dependency is satisfied.
+   *
+   * This function used to take an argument, \p maintain_level_one -
+   * new code should use face_level_mismatch_limit() instead.
    */
-  bool make_refinement_compatible (const bool);
+  bool make_refinement_compatible ();
 
   /**
    * Local dispatch function for getting the correct topological

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -848,7 +848,7 @@ bool MeshRefinement::make_flags_parallel_consistent()
 
 
 
-bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
+bool MeshRefinement::make_coarsening_compatible()
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -868,18 +868,6 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
 #endif
 
   LOG_SCOPE ("make_coarsening_compatible()", "MeshRefinement");
-
-  bool _maintain_level_one = maintain_level_one;
-
-  // If the user used non-default parameters, let's warn that they're
-  // deprecated
-  if (!maintain_level_one)
-    {
-      libmesh_deprecated();
-    }
-  else
-    _maintain_level_one = _face_level_mismatch_limit;
-
 
   // Unless we encounter a specific situation level-one
   // will be satisfied after executing this loop just once
@@ -938,7 +926,7 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
   // conflict.  By convention refinement wins, so we un-mark the element for
   // coarsening.  Level-one would be violated in this case so we need to re-run
   // the loop.
-  if (_maintain_level_one)
+  if (_face_level_mismatch_limit)
     {
 
     repeat:
@@ -1090,7 +1078,7 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
         }
       while (!level_one_satisfied);
 
-    } // end if (_maintain_level_one)
+    } // end if (_face_level_mismatch_limit)
 
 
   // Next we look at all of the ancestor cells.
@@ -1144,7 +1132,7 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
         }
     }
 
-  if (!level_one_satisfied && _maintain_level_one) goto repeat;
+  if (!level_one_satisfied && _face_level_mismatch_limit) goto repeat;
 
 
   // If all the children of a parent are set to be coarsened
@@ -1193,7 +1181,7 @@ bool MeshRefinement::make_coarsening_compatible(const bool maintain_level_one)
 
 
 
-bool MeshRefinement::make_refinement_compatible(const bool maintain_level_one)
+bool MeshRefinement::make_refinement_compatible()
 {
   // This function must be run on all processors at once
   parallel_object_only();
@@ -1214,24 +1202,13 @@ bool MeshRefinement::make_refinement_compatible(const bool maintain_level_one)
 
   LOG_SCOPE ("make_refinement_compatible()", "MeshRefinement");
 
-  bool _maintain_level_one = maintain_level_one;
-
-  // If the user used non-default parameters, let's warn that they're
-  // deprecated
-  if (!maintain_level_one)
-    {
-      libmesh_deprecated();
-    }
-  else
-    _maintain_level_one = _face_level_mismatch_limit;
-
   // Unless we encounter a specific situation we will be compatible
   // with any selected coarsening flags
   bool compatible_with_coarsening = true;
 
   // This loop enforces the level-1 rule.  We should only
   // execute it if the user indeed wants level-1 satisfied!
-  if (_maintain_level_one)
+  if (_face_level_mismatch_limit)
     {
       // Unless we encounter a specific situation level-one
       // will be satisfied after executing this loop just once
@@ -1374,7 +1351,7 @@ bool MeshRefinement::make_refinement_compatible(const bool maintain_level_one)
         }
 
       while (!level_one_satisfied);
-    } // end if (_maintain_level_one)
+    } // end if (_face_level_mismatch_limit)
 
   // If we're not compatible on one processor, we're globally not
   // compatible

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -533,10 +533,8 @@ bool MeshRefinement::refine_and_coarsen_elements ()
   // invalidated by _coarsen_elements() and hasn't yet been cleared by
   // prepare_for_use().
 
-  //  if (_maintain_level_one)
-  //    libmesh_assert(test_level_one(true));
-  //  libmesh_assert(this->make_coarsening_compatible(maintain_level_one));
-  //  libmesh_assert(this->make_refinement_compatible(maintain_level_one));
+  //  libmesh_assert(this->make_coarsening_compatible());
+  //  libmesh_assert(this->make_refinement_compatible());
 
   // FIXME: This won't pass unless we add a redundant find_neighbors()
   // call or replace find_neighbors() with on-the-fly neighbor updating

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -565,8 +565,8 @@ bool MeshRefinement::refine_and_coarsen_elements ()
       if (_face_level_mismatch_limit)
         libmesh_assert(test_level_one(true));
       libmesh_assert(test_unflagged(true));
-      libmesh_assert(this->make_coarsening_compatible(_face_level_mismatch_limit));
-      libmesh_assert(this->make_refinement_compatible(_face_level_mismatch_limit));
+      libmesh_assert(this->make_coarsening_compatible());
+      libmesh_assert(this->make_refinement_compatible());
       // FIXME: This won't pass unless we add a redundant find_neighbors()
       // call or replace find_neighbors() with on-the-fly neighbor updating
       // libmesh_assert(!this->eliminate_unrefined_patches());
@@ -578,8 +578,8 @@ bool MeshRefinement::refine_and_coarsen_elements ()
       if (_face_level_mismatch_limit)
         libmesh_assert(test_level_one(true));
       libmesh_assert(test_unflagged(true));
-      libmesh_assert(this->make_coarsening_compatible(_face_level_mismatch_limit));
-      libmesh_assert(this->make_refinement_compatible(_face_level_mismatch_limit));
+      libmesh_assert(this->make_coarsening_compatible());
+      libmesh_assert(this->make_refinement_compatible());
     }
 
   // Otherwise there was no change in the mesh,
@@ -654,7 +654,7 @@ bool MeshRefinement::coarsen_elements ()
 
   if (_face_level_mismatch_limit)
     libmesh_assert(test_level_one(true));
-  libmesh_assert(this->make_coarsening_compatible(_face_level_mismatch_limit));
+  libmesh_assert(this->make_coarsening_compatible());
   // FIXME: This won't pass unless we add a redundant find_neighbors()
   // call or replace find_neighbors() with on-the-fly neighbor updating
   // libmesh_assert(!this->eliminate_unrefined_patches());
@@ -737,7 +737,7 @@ bool MeshRefinement::refine_elements ()
 
   if (_face_level_mismatch_limit)
     libmesh_assert(test_level_one(true));
-  libmesh_assert(this->make_refinement_compatible(_face_level_mismatch_limit));
+  libmesh_assert(this->make_refinement_compatible());
   // FIXME: This won't pass unless we add a redundant find_neighbors()
   // call or replace find_neighbors() with on-the-fly neighbor updating
   // libmesh_assert(!this->eliminate_unrefined_patches());
@@ -1616,11 +1616,11 @@ void MeshRefinement::_smooth_flags(bool refining, bool coarsening)
           // face level test code.  Short-circuiting || is our friend
           const bool coarsening_satisfied =
             !coarsening ||
-            this->make_coarsening_compatible(_face_level_mismatch_limit);
+            this->make_coarsening_compatible();
 
           const bool refinement_satisfied =
             !refining ||
-            this->make_refinement_compatible(_face_level_mismatch_limit);
+            this->make_refinement_compatible();
 
           bool smoothing_satisfied =
             !this->eliminate_unrefined_patches();// &&


### PR DESCRIPTION
We were accidentally using this argument internally, creating a bunch of spurious warnings, but it's an API that's been deprecated for years so let's remove it altogether.

This should resolve #1095