### PR TITLE
Write named entities to Nemesis files

### DIFF
--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -949,6 +949,17 @@ void Nemesis_IO::read (const std::string & base_filename)
 
       libMesh::out << "[" << this->processor_id() << "] "
                    << "nemhelper->num_elem_all_sidesets = " << nemhelper->num_elem_all_sidesets << std::endl;
+
+      if (nemhelper->num_side_sets > 0)
+        {
+          libMesh::out << "Sideset names are: ";
+          std::map<int, std::string>::iterator
+            it = nemhelper->id_to_ss_names.begin(),
+            end = nemhelper->id_to_ss_names.end();
+          for (; it != end; ++it)
+            libMesh::out << "(" << it->first << "," << it->second << ") ";
+          libMesh::out << std::endl;
+        }
     }
 
 #ifdef DEBUG

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1063,6 +1063,16 @@ void Nemesis_IO::read (const std::string & base_filename)
     {
       libMesh::out << "[" << this->processor_id() << "] ";
       libMesh::out << "nemhelper->num_node_sets=" << nemhelper->num_node_sets << std::endl;
+      if (nemhelper->num_node_sets > 0)
+        {
+          libMesh::out << "Nodeset names are: ";
+          std::map<int, std::string>::iterator
+            it = nemhelper->id_to_ns_names.begin(),
+            end = nemhelper->id_to_ns_names.end();
+          for (; it != end; ++it)
+            libMesh::out << "(" << it->first << "," << it->second << ") ";
+          libMesh::out << std::endl;
+        }
     }
 
   //  // Debugging, what is currently in nemhelper->node_num_map anyway?

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2283,8 +2283,13 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
     {
       if (verbose)
         {
+          const std::string & current_ss_name =
+            mesh.get_boundary_info().get_sideset_name(global_sideset_ids[i]);
+
           libMesh::out << "[" << this->processor_id()
-                       << "] Writing out Exodus sideset info for ID: " << global_sideset_ids[i] << std::endl;
+                       << "] Writing out Exodus sideset info for ID: " << global_sideset_ids[i]
+                       << ", Name: " << current_ss_name
+                       << std::endl;
         }
 
       // Convert current global_sideset_id into an exodus ID, which can't be zero...


### PR DESCRIPTION
Whenever we added named entity writing support to the `ExodusII_IO_Helper`, we never added it to the `Nemesis_IO_Helper`, which has to specialize those functions.

Fixes #1094.  