### PR TITLE
Checkpoint splitter

### DIFF
--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -99,6 +99,11 @@ public:
   bool   binary() const { return _binary; }
   bool & binary()       { return _binary; }
 
+  /**
+   * Get/Set the flag indicating if we should read/write binary.
+   */
+  bool   parallel() const { return _parallel; }
+  bool & parallel()       { return _parallel; }
 
   /**
    * Get/Set the version string.
@@ -109,6 +114,17 @@ public:
 private:
   //---------------------------------------------------------------------------
   // Write Implementation
+
+  /**
+   * Build up the elem list
+   */
+  void build_elem_list();
+
+  /**
+   * Build up the node list
+   */
+  void build_node_list();
+
   /**
    * Write subdomain name information - NEW in 0.9.2 format
    */
@@ -181,7 +197,11 @@ private:
   unsigned int n_active_levels_on_processor(const MeshBase & mesh) const;
 
   bool _binary;
+  bool _parallel;
   std::string _version;
+  unsigned int _mesh_dimension;
+  std::set<largest_id_type> _local_elements;
+  std::set<largest_id_type> _nodes_connected_to_local_elements;
 };
 
 

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -111,6 +111,18 @@ public:
   const std::string & version () const { return _version; }
   std::string &       version ()       { return _version; }
 
+  /**
+   * Get/Set the processor_id to use
+   */
+  const processor_id_type & current_processor_id() const { return _my_processor_id; }
+  processor_id_type & current_processor_id() { return _my_processor_id; }
+
+  /**
+   * Get/Set the n_processors to use
+   */
+  const processor_id_type & current_n_processors() const { return _my_n_processors; }
+  processor_id_type & current_n_processors() { return _my_n_processors; }
+
 private:
   //---------------------------------------------------------------------------
   // Write Implementation
@@ -202,6 +214,12 @@ private:
   unsigned int _mesh_dimension;
   std::set<largest_id_type> _local_elements;
   std::set<largest_id_type> _nodes_connected_to_local_elements;
+
+  /// The processor_id to use
+  processor_id_type _my_processor_id;
+
+  /// The number of processors to use
+  processor_id_type _my_n_processors;
 };
 
 

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -113,12 +113,20 @@ public:
 
   /**
    * Get/Set the processor_id to use
+   *
+   * This is used for m->n parallel checkpoint file writing:
+   * You can force CheckpointIO to view the world as if it is on a particular
+   * processor_id by setting it here
    */
   const processor_id_type & current_processor_id() const { return _my_processor_id; }
   processor_id_type & current_processor_id() { return _my_processor_id; }
 
   /**
    * Get/Set the n_processors to use
+   *
+   * This is used for m->n parallel checkpoint file writing:
+   * You can force CheckpointIO to view the world as if it contains this number of
+   * processors by setting it here
    */
   const processor_id_type & current_n_processors() const { return _my_n_processors; }
   processor_id_type & current_n_processors() { return _my_n_processors; }
@@ -212,6 +220,8 @@ private:
   bool _parallel;
   std::string _version;
   unsigned int _mesh_dimension;
+
+  /// These are sets of IDs to make the lookup for boundary conditions simpler
   std::set<largest_id_type> _local_elements;
   std::set<largest_id_type> _nodes_connected_to_local_elements;
 

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -2389,11 +2389,18 @@ std::string Elem::get_info () const
 
   oss << "  Elem Information"                                      << '\n'
       << "   id()=";
-
   if (this->valid_id())
     oss << this->id();
   else
     oss << "invalid";
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  oss << ", unique_id()=";
+  if (this->valid_unique_id())
+    oss << this->unique_id();
+  else
+    oss << "invalid";
+#endif
 
   oss << ", processor_id()=" << this->processor_id()               << '\n';
 

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -307,7 +307,7 @@ void CheckpointIO::write_connectivity (Xdr & io) const
       MeshBase::const_element_iterator end = mesh.level_elements_end(level);
 
       for (; it != end; ++it)
-        if (!_parallel || (*it)->processor_id() == _my_processor_id)
+        if (!_parallel || _local_elements.find((*it)->id()) != _local_elements.end())
           n_elem_at_level[level]++;
     }
 
@@ -326,8 +326,8 @@ void CheckpointIO::write_connectivity (Xdr & io) const
         {
           Elem & elem = *(*it);
 
-          if (_parallel && elem.processor_id() != _my_processor_id)
-            continue;
+          if (_parallel && _local_elements.find(elem.id()) == _local_elements.end())
+              continue;
 
           unsigned int n_nodes = elem.n_nodes();
 
@@ -364,7 +364,6 @@ void CheckpointIO::write_connectivity (Xdr & io) const
 
           io.data(p_level, "# p_level");
 #endif
-
           io.data_stream(&conn_data[0],
                          cast_int<unsigned int>(conn_data.size()),
                          cast_int<unsigned int>(conn_data.size()));

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -1349,14 +1349,14 @@ void DistributedMesh::delete_remote_elements()
 {
 #ifdef DEBUG
   // Make sure our neighbor links are all fine
-  //MeshTools::libmesh_assert_valid_neighbors(*this);
+  MeshTools::libmesh_assert_valid_neighbors(*this);
 
   // And our child/parent links, and our flags
-  //MeshTools::libmesh_assert_valid_refinement_tree(*this);
+  MeshTools::libmesh_assert_valid_refinement_tree(*this);
 
   // Make sure our ids and flags are consistent
-  //this->libmesh_assert_valid_parallel_ids();
-  //this->libmesh_assert_valid_parallel_flags();
+  this->libmesh_assert_valid_parallel_ids();
+  this->libmesh_assert_valid_parallel_flags();
 
   libmesh_assert_equal_to (this->n_nodes(), this->parallel_n_nodes());
   libmesh_assert_equal_to (this->n_elem(), this->parallel_n_elem());

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -1349,14 +1349,14 @@ void DistributedMesh::delete_remote_elements()
 {
 #ifdef DEBUG
   // Make sure our neighbor links are all fine
-  MeshTools::libmesh_assert_valid_neighbors(*this);
+  //MeshTools::libmesh_assert_valid_neighbors(*this);
 
   // And our child/parent links, and our flags
-  MeshTools::libmesh_assert_valid_refinement_tree(*this);
+  //MeshTools::libmesh_assert_valid_refinement_tree(*this);
 
   // Make sure our ids and flags are consistent
-  this->libmesh_assert_valid_parallel_ids();
-  this->libmesh_assert_valid_parallel_flags();
+  //this->libmesh_assert_valid_parallel_ids();
+  //this->libmesh_assert_valid_parallel_flags();
 
   libmesh_assert_equal_to (this->n_nodes(), this->parallel_n_nodes());
   libmesh_assert_equal_to (this->n_elem(), this->parallel_n_elem());


### PR DESCRIPTION
Forget Nemesis reading.  It's too damn complicated. 

We can do this ourselves.  DistributedMesh is actually really awesome at reinitializing itself... it barely needs anything.  Just the local elements and the nodes they're connected to... along with BC info.  Done.

That said... there is still a small issue with this PR that must be resolved before it can be merged.  It currently throws an `assert()` in devel/dbg mode if you leave mesh partitioning on when you prepare the newly read-in mesh for use.

You can see the way I'm needing to do the reading over here:

https://github.com/friedmud/moose/commit/6e08eef9d7c18fa9c6675fdde46251a575489d8b

@jwpeterson @roystgnr could I get just the tiniest bit of help tracking that one down?

To easily create meshes that are split using this new capability use this branch of my `simple_libmesh_app`:

https://github.com/friedmud/simple_libmesh_app/tree/splitter

refs https://github.com/idaholab/moose/issues/7752 , https://github.com/idaholab/moose/issues/7744 , https://github.com/idaholab/moose/pull/7745 , #1087 , #1086