### PR TITLE
Fix unit test

### DIFF
--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -175,9 +175,10 @@ CONFIG_CLEAN_VPATH_FILES =
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__EXEEXT_7 = unit_tests-dbg$(EXEEXT)
 PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -201,6 +202,7 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 am__dirstamp = $(am__leading_dot)dirstamp
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_1 = fparser/unit_tests_dbg-autodiff.$(OBJEXT)
 am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
+	base/unit_tests_dbg-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_dbg-getpot_test.$(OBJEXT) \
 	base/unit_tests_dbg-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_dbg-node_test.$(OBJEXT) \
@@ -249,9 +251,10 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -274,6 +277,7 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_3 = fparser/unit_tests_devel-autodiff.$(OBJEXT)
 am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
+	base/unit_tests_devel-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_devel-getpot_test.$(OBJEXT) \
 	base/unit_tests_devel-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_devel-node_test.$(OBJEXT) \
@@ -320,9 +324,10 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -345,6 +350,7 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_5 = fparser/unit_tests_oprof-autodiff.$(OBJEXT)
 am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
+	base/unit_tests_oprof-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_oprof-getpot_test.$(OBJEXT) \
 	base/unit_tests_oprof-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_oprof-node_test.$(OBJEXT) \
@@ -391,9 +397,10 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -416,6 +423,7 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_7 = fparser/unit_tests_opt-autodiff.$(OBJEXT)
 am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
+	base/unit_tests_opt-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_opt-getpot_test.$(OBJEXT) \
 	base/unit_tests_opt-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_opt-node_test.$(OBJEXT) \
@@ -460,9 +468,10 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -485,6 +494,7 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_9 = fparser/unit_tests_prof-autodiff.$(OBJEXT)
 am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
+	base/unit_tests_prof-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_prof-getpot_test.$(OBJEXT) \
 	base/unit_tests_prof-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_prof-node_test.$(OBJEXT) \
@@ -947,13 +957,14 @@ AM_CPPFLAGS = $(libmesh_optional_INCLUDES) -I$(top_builddir)/include \
 
 AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
-	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h mesh/all_tri.C \
-	mesh/boundary_mesh.C mesh/boundary_info.C \
-	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
+	base/default_coupling_test.C base/getpot_test.C \
+	base/auto_ptr_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h mesh/all_tri.C mesh/boundary_mesh.C \
+	mesh/boundary_info.C mesh/contains_point.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	mesh/spatial_dimension_test.C mesh/mesh_function_dfem.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -1051,6 +1062,8 @@ base/$(am__dirstamp):
 base/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) base/$(DEPDIR)
 	@: > base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_dbg-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_dbg-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_dbg-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1182,6 +1195,8 @@ fparser/unit_tests_dbg-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-dbg$(EXEEXT): $(unit_tests_dbg_OBJECTS) $(unit_tests_dbg_DEPENDENCIES) $(EXTRA_unit_tests_dbg_DEPENDENCIES) 
 	@rm -f unit_tests-dbg$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_dbg_LINK) $(unit_tests_dbg_OBJECTS) $(unit_tests_dbg_LDADD) $(LIBS)
+base/unit_tests_devel-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_devel-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_devel-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1259,6 +1274,8 @@ fparser/unit_tests_devel-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-devel$(EXEEXT): $(unit_tests_devel_OBJECTS) $(unit_tests_devel_DEPENDENCIES) $(EXTRA_unit_tests_devel_DEPENDENCIES) 
 	@rm -f unit_tests-devel$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_devel_LINK) $(unit_tests_devel_OBJECTS) $(unit_tests_devel_LDADD) $(LIBS)
+base/unit_tests_oprof-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_oprof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_oprof-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1336,6 +1353,8 @@ fparser/unit_tests_oprof-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-oprof$(EXEEXT): $(unit_tests_oprof_OBJECTS) $(unit_tests_oprof_DEPENDENCIES) $(EXTRA_unit_tests_oprof_DEPENDENCIES) 
 	@rm -f unit_tests-oprof$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_oprof_LINK) $(unit_tests_oprof_OBJECTS) $(unit_tests_oprof_LDADD) $(LIBS)
+base/unit_tests_opt-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_opt-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_opt-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1413,6 +1432,8 @@ fparser/unit_tests_opt-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-opt$(EXEEXT): $(unit_tests_opt_OBJECTS) $(unit_tests_opt_DEPENDENCIES) $(EXTRA_unit_tests_opt_DEPENDENCIES) 
 	@rm -f unit_tests-opt$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_opt_LINK) $(unit_tests_opt_OBJECTS) $(unit_tests_opt_LDADD) $(LIBS)
+base/unit_tests_prof-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_prof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_prof-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1513,14 +1534,19 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_opt-driver.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_prof-driver.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_devel-autodiff.Po@am__quote@
@@ -1730,6 +1756,20 @@ unit_tests_dbg-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='driver.C' object='unit_tests_dbg-driver.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_dbg-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
+
+base/unit_tests_dbg-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Tpo -c -o base/unit_tests_dbg-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_dbg-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_dbg-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Tpo -c -o base/unit_tests_dbg-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_dbg-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
 
 base/unit_tests_dbg-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-getpot_test.Tpo -c -o base/unit_tests_dbg-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
@@ -2249,6 +2289,20 @@ unit_tests_devel-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_devel-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
 
+base/unit_tests_devel-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Tpo -c -o base/unit_tests_devel-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_devel-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_devel-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Tpo -c -o base/unit_tests_devel-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_devel-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+
 base/unit_tests_devel-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-getpot_test.Tpo -c -o base/unit_tests_devel-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-getpot_test.Tpo base/$(DEPDIR)/unit_tests_devel-getpot_test.Po
@@ -2766,6 +2820,20 @@ unit_tests_oprof-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='driver.C' object='unit_tests_oprof-driver.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_oprof-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
+
+base/unit_tests_oprof-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Tpo -c -o base/unit_tests_oprof-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_oprof-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_oprof-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Tpo -c -o base/unit_tests_oprof-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_oprof-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
 
 base/unit_tests_oprof-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-getpot_test.Tpo -c -o base/unit_tests_oprof-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
@@ -3285,6 +3353,20 @@ unit_tests_opt-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_opt-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
 
+base/unit_tests_opt-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Tpo -c -o base/unit_tests_opt-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_opt-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_opt-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Tpo -c -o base/unit_tests_opt-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_opt-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+
 base/unit_tests_opt-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-getpot_test.Tpo -c -o base/unit_tests_opt-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-getpot_test.Tpo base/$(DEPDIR)/unit_tests_opt-getpot_test.Po
@@ -3802,6 +3884,20 @@ unit_tests_prof-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='driver.C' object='unit_tests_prof-driver.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_prof-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
+
+base/unit_tests_prof-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Tpo -c -o base/unit_tests_prof-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_prof-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_prof-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Tpo -c -o base/unit_tests_prof-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_prof-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
 
 base/unit_tests_prof-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-getpot_test.Tpo -c -o base/unit_tests_prof-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C

--- a/tests/base/default_coupling_test.C
+++ b/tests/base/default_coupling_test.C
@@ -71,14 +71,17 @@ public:
     sys.add_variable("u", THIRD, HIERARCHIC);
     sys.get_dof_map().default_algebraic_ghosting().set_n_levels(3);
 
+    const unsigned n_elem_per_side = 5;
     const UniquePtr<Elem> test_elem = Elem::build(elem_type);
     const Real ymax = test_elem->dim() > 1;
     const Real zmax = test_elem->dim() > 2;
-    const unsigned int ny = ymax * 15;
-    const unsigned int nz = zmax * 15;
+    const unsigned int ny = ymax * n_elem_per_side;
+    const unsigned int nz = zmax * n_elem_per_side;
 
     MeshTools::Generation::build_cube (mesh,
-                                       15, ny, nz,
+                                       n_elem_per_side,
+                                       ny,
+                                       nz,
                                        0., 1.,
                                        0., ymax,
                                        0., zmax,


### PR DESCRIPTION
This unit test was never actually added by the branch merged in 4813964.  Once I re-ran bootstrap and enabled it, it would not even compile.  Those issues are both now fixed and the test does pass, but it makes the unit tests take a lot longer to run, about 36 seconds on my system in debug mode, so we may want to revisit the size of the test. @roystgnr 