### PR TITLE
Parallel CheckpointIO and Splitter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -486,6 +486,24 @@ solution_components_dbg_CPPFLAGS   = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
 solution_components_dbg_CXXFLAGS   = $(CXXFLAGS_DBG)
 solution_components_dbg_LDADD      = libmesh_dbg.la
 
+# splitter
+opt_programs           += splitter-opt
+splitter_opt_SOURCES    = src/apps/splitter.C
+splitter_opt_CPPFLAGS   = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
+splitter_opt_CXXFLAGS   = $(CXXFLAGS_OPT)
+splitter_opt_LDADD      = libmesh_opt.la
+
+devel_programs         += splitter-devel
+splitter_devel_SOURCES  = src/apps/splitter.C
+splitter_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
+splitter_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
+splitter_devel_LDADD    = libmesh_devel.la
+
+dbg_programs           += splitter-dbg
+splitter_dbg_SOURCES    = src/apps/splitter.C
+splitter_dbg_CPPFLAGS   = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
+splitter_dbg_CXXFLAGS   = $(CXXFLAGS_DBG)
+splitter_dbg_LDADD      = libmesh_dbg.la
 
 if LIBMESH_OPT_MODE
   bin_PROGRAMS += $(opt_programs)

--- a/Makefile.in
+++ b/Makefile.in
@@ -3771,7 +3771,7 @@ am__EXEEXT_1 = fparser_parse-opt$(EXEEXT) getpot_parse-opt$(EXEEXT) \
 	meshavg-opt$(EXEEXT) meshdiff-opt$(EXEEXT) \
 	meshnorm-opt$(EXEEXT) projection-opt$(EXEEXT) \
 	output_libmesh_version-opt$(EXEEXT) meshplot-opt$(EXEEXT) \
-	solution_components-opt$(EXEEXT)
+	solution_components-opt$(EXEEXT) splitter-opt$(EXEEXT)
 @LIBMESH_OPT_MODE_TRUE@am__EXEEXT_2 = $(am__EXEEXT_1)
 am__EXEEXT_3 = fparser_parse-devel$(EXEEXT) \
 	getpot_parse-devel$(EXEEXT) meshtool-devel$(EXEEXT) \
@@ -3780,7 +3780,7 @@ am__EXEEXT_3 = fparser_parse-devel$(EXEEXT) \
 	meshavg-devel$(EXEEXT) meshdiff-devel$(EXEEXT) \
 	meshnorm-devel$(EXEEXT) projection-devel$(EXEEXT) \
 	output_libmesh_version-devel$(EXEEXT) meshplot-devel$(EXEEXT) \
-	solution_components-devel$(EXEEXT)
+	solution_components-devel$(EXEEXT) splitter-devel$(EXEEXT)
 @LIBMESH_DEVEL_MODE_TRUE@am__EXEEXT_4 = $(am__EXEEXT_3)
 am__EXEEXT_5 = fparser_parse-dbg$(EXEEXT) getpot_parse-dbg$(EXEEXT) \
 	meshtool-dbg$(EXEEXT) calculator-dbg$(EXEEXT) \
@@ -3788,7 +3788,7 @@ am__EXEEXT_5 = fparser_parse-dbg$(EXEEXT) getpot_parse-dbg$(EXEEXT) \
 	meshavg-dbg$(EXEEXT) meshdiff-dbg$(EXEEXT) \
 	meshnorm-dbg$(EXEEXT) projection-dbg$(EXEEXT) \
 	output_libmesh_version-dbg$(EXEEXT) meshplot-dbg$(EXEEXT) \
-	solution_components-dbg$(EXEEXT)
+	solution_components-dbg$(EXEEXT) splitter-dbg$(EXEEXT)
 @LIBMESH_DBG_MODE_TRUE@am__EXEEXT_6 = $(am__EXEEXT_5)
 PROGRAMS = $(bin_PROGRAMS)
 am_calculator_dbg_OBJECTS =  \
@@ -4094,6 +4094,26 @@ solution_components_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(solution_components_opt_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
+am_splitter_dbg_OBJECTS = src/apps/splitter_dbg-splitter.$(OBJEXT)
+splitter_dbg_OBJECTS = $(am_splitter_dbg_OBJECTS)
+splitter_dbg_DEPENDENCIES = libmesh_dbg.la
+splitter_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(splitter_dbg_CXXFLAGS) \
+	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
+am_splitter_devel_OBJECTS =  \
+	src/apps/splitter_devel-splitter.$(OBJEXT)
+splitter_devel_OBJECTS = $(am_splitter_devel_OBJECTS)
+splitter_devel_DEPENDENCIES = libmesh_devel.la
+splitter_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
+	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
+	$(splitter_devel_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
+	$(LDFLAGS) -o $@
+am_splitter_opt_OBJECTS = src/apps/splitter_opt-splitter.$(OBJEXT)
+splitter_opt_OBJECTS = $(am_splitter_opt_OBJECTS)
+splitter_opt_DEPENDENCIES = libmesh_opt.la
+splitter_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(splitter_opt_CXXFLAGS) \
+	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 SCRIPTS = $(bin_SCRIPTS) $(contribbin_SCRIPTS) \
 	$(libmesh_config_SCRIPTS)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -4173,7 +4193,8 @@ SOURCES = $(libmesh_dbg_la_SOURCES) $(libmesh_devel_la_SOURCES) \
 	$(projection_dbg_SOURCES) $(projection_devel_SOURCES) \
 	$(projection_opt_SOURCES) $(solution_components_dbg_SOURCES) \
 	$(solution_components_devel_SOURCES) \
-	$(solution_components_opt_SOURCES)
+	$(solution_components_opt_SOURCES) $(splitter_dbg_SOURCES) \
+	$(splitter_devel_SOURCES) $(splitter_opt_SOURCES)
 DIST_SOURCES = $(am__libmesh_dbg_la_SOURCES_DIST) \
 	$(am__libmesh_devel_la_SOURCES_DIST) \
 	$(am__libmesh_oprof_la_SOURCES_DIST) \
@@ -4201,7 +4222,8 @@ DIST_SOURCES = $(am__libmesh_dbg_la_SOURCES_DIST) \
 	$(projection_dbg_SOURCES) $(projection_devel_SOURCES) \
 	$(projection_opt_SOURCES) $(solution_components_dbg_SOURCES) \
 	$(solution_components_devel_SOURCES) \
-	$(solution_components_opt_SOURCES)
+	$(solution_components_opt_SOURCES) $(splitter_dbg_SOURCES) \
+	$(splitter_devel_SOURCES) $(splitter_opt_SOURCES)
 RECURSIVE_TARGETS = all-recursive check-recursive cscopelist-recursive \
 	ctags-recursive dvi-recursive html-recursive info-recursive \
 	install-data-recursive install-dvi-recursive \
@@ -5198,21 +5220,23 @@ CLEANFILES = $(am__append_11)
 # meshplot
 
 # solution_components
+
+# splitter
 opt_programs = fparser_parse-opt getpot_parse-opt meshtool-opt \
 	calculator-opt compare-opt meshbcid-opt meshid-opt meshavg-opt \
 	meshdiff-opt meshnorm-opt projection-opt \
 	output_libmesh_version-opt meshplot-opt \
-	solution_components-opt
+	solution_components-opt splitter-opt
 devel_programs = fparser_parse-devel getpot_parse-devel meshtool-devel \
 	calculator-devel compare-devel meshbcid-devel meshid-devel \
 	meshavg-devel meshdiff-devel meshnorm-devel projection-devel \
 	output_libmesh_version-devel meshplot-devel \
-	solution_components-devel
+	solution_components-devel splitter-devel
 dbg_programs = fparser_parse-dbg getpot_parse-dbg meshtool-dbg \
 	calculator-dbg compare-dbg meshbcid-dbg meshid-dbg meshavg-dbg \
 	meshdiff-dbg meshnorm-dbg projection-dbg \
 	output_libmesh_version-dbg meshplot-dbg \
-	solution_components-dbg
+	solution_components-dbg splitter-dbg
 prof_programs = # empty, append below
 oprof_programs = # empty, append below
 fparser_parse_opt_SOURCES = src/apps/fparser_parse.C
@@ -5386,6 +5410,18 @@ solution_components_dbg_SOURCES = src/apps/solution_components.C
 solution_components_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
 solution_components_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
 solution_components_dbg_LDADD = libmesh_dbg.la
+splitter_opt_SOURCES = src/apps/splitter.C
+splitter_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
+splitter_opt_CXXFLAGS = $(CXXFLAGS_OPT)
+splitter_opt_LDADD = libmesh_opt.la
+splitter_devel_SOURCES = src/apps/splitter.C
+splitter_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
+splitter_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
+splitter_devel_LDADD = libmesh_devel.la
+splitter_dbg_SOURCES = src/apps/splitter.C
+splitter_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
+splitter_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
+splitter_dbg_LDADD = libmesh_dbg.la
 
 # -------------------------------------------
 # Optional support for code coverage analysis
@@ -11027,6 +11063,24 @@ src/apps/solution_components_opt-solution_components.$(OBJEXT):  \
 solution_components-opt$(EXEEXT): $(solution_components_opt_OBJECTS) $(solution_components_opt_DEPENDENCIES) $(EXTRA_solution_components_opt_DEPENDENCIES) 
 	@rm -f solution_components-opt$(EXEEXT)
 	$(AM_V_CXXLD)$(solution_components_opt_LINK) $(solution_components_opt_OBJECTS) $(solution_components_opt_LDADD) $(LIBS)
+src/apps/splitter_dbg-splitter.$(OBJEXT): src/apps/$(am__dirstamp) \
+	src/apps/$(DEPDIR)/$(am__dirstamp)
+
+splitter-dbg$(EXEEXT): $(splitter_dbg_OBJECTS) $(splitter_dbg_DEPENDENCIES) $(EXTRA_splitter_dbg_DEPENDENCIES) 
+	@rm -f splitter-dbg$(EXEEXT)
+	$(AM_V_CXXLD)$(splitter_dbg_LINK) $(splitter_dbg_OBJECTS) $(splitter_dbg_LDADD) $(LIBS)
+src/apps/splitter_devel-splitter.$(OBJEXT): src/apps/$(am__dirstamp) \
+	src/apps/$(DEPDIR)/$(am__dirstamp)
+
+splitter-devel$(EXEEXT): $(splitter_devel_OBJECTS) $(splitter_devel_DEPENDENCIES) $(EXTRA_splitter_devel_DEPENDENCIES) 
+	@rm -f splitter-devel$(EXEEXT)
+	$(AM_V_CXXLD)$(splitter_devel_LINK) $(splitter_devel_OBJECTS) $(splitter_devel_LDADD) $(LIBS)
+src/apps/splitter_opt-splitter.$(OBJEXT): src/apps/$(am__dirstamp) \
+	src/apps/$(DEPDIR)/$(am__dirstamp)
+
+splitter-opt$(EXEEXT): $(splitter_opt_OBJECTS) $(splitter_opt_DEPENDENCIES) $(EXTRA_splitter_opt_DEPENDENCIES) 
+	@rm -f splitter-opt$(EXEEXT)
+	$(AM_V_CXXLD)$(splitter_opt_LINK) $(splitter_opt_OBJECTS) $(splitter_opt_LDADD) $(LIBS)
 install-binSCRIPTS: $(bin_SCRIPTS)
 	@$(NORMAL_INSTALL)
 	@list='$(bin_SCRIPTS)'; test -n "$(bindir)" || list=; \
@@ -11215,6 +11269,9 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/apps/$(DEPDIR)/solution_components_dbg-solution_components.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/apps/$(DEPDIR)/solution_components_devel-solution_components.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/apps/$(DEPDIR)/solution_components_opt-solution_components.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/apps/$(DEPDIR)/splitter_dbg-splitter.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/apps/$(DEPDIR)/splitter_devel-splitter.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/apps/$(DEPDIR)/splitter_opt-splitter.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-default_coupling.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-dof_map.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/base/$(DEPDIR)/libmesh_dbg_la-dof_map_constraints.Plo@am__quote@
@@ -28634,6 +28691,48 @@ src/apps/solution_components_opt-solution_components.obj: src/apps/solution_comp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/apps/solution_components.C' object='src/apps/solution_components_opt-solution_components.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(solution_components_opt_CPPFLAGS) $(CPPFLAGS) $(solution_components_opt_CXXFLAGS) $(CXXFLAGS) -c -o src/apps/solution_components_opt-solution_components.obj `if test -f 'src/apps/solution_components.C'; then $(CYGPATH_W) 'src/apps/solution_components.C'; else $(CYGPATH_W) '$(srcdir)/src/apps/solution_components.C'; fi`
+
+src/apps/splitter_dbg-splitter.o: src/apps/splitter.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_dbg_CPPFLAGS) $(CPPFLAGS) $(splitter_dbg_CXXFLAGS) $(CXXFLAGS) -MT src/apps/splitter_dbg-splitter.o -MD -MP -MF src/apps/$(DEPDIR)/splitter_dbg-splitter.Tpo -c -o src/apps/splitter_dbg-splitter.o `test -f 'src/apps/splitter.C' || echo '$(srcdir)/'`src/apps/splitter.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/apps/$(DEPDIR)/splitter_dbg-splitter.Tpo src/apps/$(DEPDIR)/splitter_dbg-splitter.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/apps/splitter.C' object='src/apps/splitter_dbg-splitter.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_dbg_CPPFLAGS) $(CPPFLAGS) $(splitter_dbg_CXXFLAGS) $(CXXFLAGS) -c -o src/apps/splitter_dbg-splitter.o `test -f 'src/apps/splitter.C' || echo '$(srcdir)/'`src/apps/splitter.C
+
+src/apps/splitter_dbg-splitter.obj: src/apps/splitter.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_dbg_CPPFLAGS) $(CPPFLAGS) $(splitter_dbg_CXXFLAGS) $(CXXFLAGS) -MT src/apps/splitter_dbg-splitter.obj -MD -MP -MF src/apps/$(DEPDIR)/splitter_dbg-splitter.Tpo -c -o src/apps/splitter_dbg-splitter.obj `if test -f 'src/apps/splitter.C'; then $(CYGPATH_W) 'src/apps/splitter.C'; else $(CYGPATH_W) '$(srcdir)/src/apps/splitter.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/apps/$(DEPDIR)/splitter_dbg-splitter.Tpo src/apps/$(DEPDIR)/splitter_dbg-splitter.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/apps/splitter.C' object='src/apps/splitter_dbg-splitter.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_dbg_CPPFLAGS) $(CPPFLAGS) $(splitter_dbg_CXXFLAGS) $(CXXFLAGS) -c -o src/apps/splitter_dbg-splitter.obj `if test -f 'src/apps/splitter.C'; then $(CYGPATH_W) 'src/apps/splitter.C'; else $(CYGPATH_W) '$(srcdir)/src/apps/splitter.C'; fi`
+
+src/apps/splitter_devel-splitter.o: src/apps/splitter.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_devel_CPPFLAGS) $(CPPFLAGS) $(splitter_devel_CXXFLAGS) $(CXXFLAGS) -MT src/apps/splitter_devel-splitter.o -MD -MP -MF src/apps/$(DEPDIR)/splitter_devel-splitter.Tpo -c -o src/apps/splitter_devel-splitter.o `test -f 'src/apps/splitter.C' || echo '$(srcdir)/'`src/apps/splitter.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/apps/$(DEPDIR)/splitter_devel-splitter.Tpo src/apps/$(DEPDIR)/splitter_devel-splitter.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/apps/splitter.C' object='src/apps/splitter_devel-splitter.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_devel_CPPFLAGS) $(CPPFLAGS) $(splitter_devel_CXXFLAGS) $(CXXFLAGS) -c -o src/apps/splitter_devel-splitter.o `test -f 'src/apps/splitter.C' || echo '$(srcdir)/'`src/apps/splitter.C
+
+src/apps/splitter_devel-splitter.obj: src/apps/splitter.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_devel_CPPFLAGS) $(CPPFLAGS) $(splitter_devel_CXXFLAGS) $(CXXFLAGS) -MT src/apps/splitter_devel-splitter.obj -MD -MP -MF src/apps/$(DEPDIR)/splitter_devel-splitter.Tpo -c -o src/apps/splitter_devel-splitter.obj `if test -f 'src/apps/splitter.C'; then $(CYGPATH_W) 'src/apps/splitter.C'; else $(CYGPATH_W) '$(srcdir)/src/apps/splitter.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/apps/$(DEPDIR)/splitter_devel-splitter.Tpo src/apps/$(DEPDIR)/splitter_devel-splitter.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/apps/splitter.C' object='src/apps/splitter_devel-splitter.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_devel_CPPFLAGS) $(CPPFLAGS) $(splitter_devel_CXXFLAGS) $(CXXFLAGS) -c -o src/apps/splitter_devel-splitter.obj `if test -f 'src/apps/splitter.C'; then $(CYGPATH_W) 'src/apps/splitter.C'; else $(CYGPATH_W) '$(srcdir)/src/apps/splitter.C'; fi`
+
+src/apps/splitter_opt-splitter.o: src/apps/splitter.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_opt_CPPFLAGS) $(CPPFLAGS) $(splitter_opt_CXXFLAGS) $(CXXFLAGS) -MT src/apps/splitter_opt-splitter.o -MD -MP -MF src/apps/$(DEPDIR)/splitter_opt-splitter.Tpo -c -o src/apps/splitter_opt-splitter.o `test -f 'src/apps/splitter.C' || echo '$(srcdir)/'`src/apps/splitter.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/apps/$(DEPDIR)/splitter_opt-splitter.Tpo src/apps/$(DEPDIR)/splitter_opt-splitter.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/apps/splitter.C' object='src/apps/splitter_opt-splitter.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_opt_CPPFLAGS) $(CPPFLAGS) $(splitter_opt_CXXFLAGS) $(CXXFLAGS) -c -o src/apps/splitter_opt-splitter.o `test -f 'src/apps/splitter.C' || echo '$(srcdir)/'`src/apps/splitter.C
+
+src/apps/splitter_opt-splitter.obj: src/apps/splitter.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_opt_CPPFLAGS) $(CPPFLAGS) $(splitter_opt_CXXFLAGS) $(CXXFLAGS) -MT src/apps/splitter_opt-splitter.obj -MD -MP -MF src/apps/$(DEPDIR)/splitter_opt-splitter.Tpo -c -o src/apps/splitter_opt-splitter.obj `if test -f 'src/apps/splitter.C'; then $(CYGPATH_W) 'src/apps/splitter.C'; else $(CYGPATH_W) '$(srcdir)/src/apps/splitter.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/apps/$(DEPDIR)/splitter_opt-splitter.Tpo src/apps/$(DEPDIR)/splitter_opt-splitter.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/apps/splitter.C' object='src/apps/splitter_opt-splitter.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(splitter_opt_CPPFLAGS) $(CPPFLAGS) $(splitter_opt_CXXFLAGS) $(CXXFLAGS) -c -o src/apps/splitter_opt-splitter.obj `if test -f 'src/apps/splitter.C'; then $(CYGPATH_W) 'src/apps/splitter.C'; else $(CYGPATH_W) '$(srcdir)/src/apps/splitter.C'; fi`
 
 .c.o:
 @am__fastdepCC_TRUE@	$(AM_V_CC)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -99,6 +99,11 @@ public:
   bool   binary() const { return _binary; }
   bool & binary()       { return _binary; }
 
+  /**
+   * Get/Set the flag indicating if we should read/write binary.
+   */
+  bool   parallel() const { return _parallel; }
+  bool & parallel()       { return _parallel; }
 
   /**
    * Get/Set the version string.
@@ -109,6 +114,17 @@ public:
 private:
   //---------------------------------------------------------------------------
   // Write Implementation
+
+  /**
+   * Build up the elem list
+   */
+  void build_elem_list();
+
+  /**
+   * Build up the node list
+   */
+  void build_node_list();
+
   /**
    * Write subdomain name information - NEW in 0.9.2 format
    */
@@ -181,7 +197,11 @@ private:
   unsigned int n_active_levels_on_processor(const MeshBase & mesh) const;
 
   bool _binary;
+  bool _parallel;
   std::string _version;
+  unsigned int _mesh_dimension;
+  std::set<largest_id_type> _local_elements;
+  std::set<largest_id_type> _nodes_connected_to_local_elements;
 };
 
 

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -111,6 +111,18 @@ public:
   const std::string & version () const { return _version; }
   std::string &       version ()       { return _version; }
 
+  /**
+   * Get/Set the processor_id to use
+   */
+  const processor_id_type & current_processor_id() const { return _my_processor_id; }
+  processor_id_type & current_processor_id() { return _my_processor_id; }
+
+  /**
+   * Get/Set the n_processors to use
+   */
+  const processor_id_type & current_n_processors() const { return _my_n_processors; }
+  processor_id_type & current_n_processors() { return _my_n_processors; }
+
 private:
   //---------------------------------------------------------------------------
   // Write Implementation
@@ -202,6 +214,12 @@ private:
   unsigned int _mesh_dimension;
   std::set<largest_id_type> _local_elements;
   std::set<largest_id_type> _nodes_connected_to_local_elements;
+
+  /// The processor_id to use
+  processor_id_type _my_processor_id;
+
+  /// The number of processors to use
+  processor_id_type _my_n_processors;
 };
 
 

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -113,12 +113,20 @@ public:
 
   /**
    * Get/Set the processor_id to use
+   *
+   * This is used for m->n parallel checkpoint file writing:
+   * You can force CheckpointIO to view the world as if it is on a particular
+   * processor_id by setting it here
    */
   const processor_id_type & current_processor_id() const { return _my_processor_id; }
   processor_id_type & current_processor_id() { return _my_processor_id; }
 
   /**
    * Get/Set the n_processors to use
+   *
+   * This is used for m->n parallel checkpoint file writing:
+   * You can force CheckpointIO to view the world as if it contains this number of
+   * processors by setting it here
    */
   const processor_id_type & current_n_processors() const { return _my_n_processors; }
   processor_id_type & current_n_processors() { return _my_n_processors; }
@@ -212,6 +220,8 @@ private:
   bool _parallel;
   std::string _version;
   unsigned int _mesh_dimension;
+
+  /// These are sets of IDs to make the lookup for boundary conditions simpler
   std::set<largest_id_type> _local_elements;
   std::set<largest_id_type> _nodes_connected_to_local_elements;
 

--- a/src/apps/splitter.C
+++ b/src/apps/splitter.C
@@ -96,7 +96,7 @@ int main (int argc, char ** argv)
 
     processor_id_type my_num_chunks = num_chunks;
 
-    processor_id_type my_first_chunk = decltype(num_chunks)(0);
+    processor_id_type my_first_chunk = 0;
 
     processor_id_type rank = comm.rank();
     processor_id_type comm_size = comm.size();
@@ -136,7 +136,7 @@ int main (int argc, char ** argv)
       else
       {
         my_num_chunks = 0;
-        my_first_chunk = std::numeric_limits<decltype(my_first_chunk)>::max();
+        my_first_chunk = std::numeric_limits<processor_id_type>::max();
       }
     }
 

--- a/src/apps/splitter.C
+++ b/src/apps/splitter.C
@@ -1,0 +1,162 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2016 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+// Read in a Mesh file and write out partitionings of it that are suitable
+// for reading into a DistributedMesh
+
+
+#include "libmesh/libmesh.h"
+#include "libmesh/mesh.h"
+#include "libmesh/node.h"
+#include "libmesh/mesh_refinement.h"
+#include "libmesh/mesh.h"
+#include "libmesh/mesh_tools.h"
+#include "libmesh/equation_systems.h"
+#include "libmesh/explicit_system.h"
+#include "libmesh/elem.h"
+#include "libmesh/numeric_vector.h"
+#include "libmesh/exodusII_io.h"
+#include "libmesh/nemesis_io.h"
+#include "libmesh/checkpoint_io.h"
+#include "libmesh/mesh_generation.h"
+#include "libmesh/metis_partitioner.h"
+#include "libmesh/elem.h"
+#include "libmesh/getpot.h"
+
+using namespace libMesh;
+
+int main (int argc, char ** argv)
+{
+  LibMeshInit init (argc, argv);
+
+  if (libMesh::on_command_line("--help"))
+  {
+    libMesh::out<<"Example: ./splitter-opt --mesh=filename.e --n-procs='4 8 16' \n\n"
+                <<"--mesh             Full name of the mesh file to read in. \n"
+                <<"--n-procs          Vector of number of processors.\n"
+                <<std::endl;
+
+    return 0;
+  }
+
+  std::string filename = libMesh::command_line_value("--mesh", std::string());
+
+  std::vector<int> all_n_procs;
+  libMesh::command_line_vector("--n-procs", all_n_procs);
+
+  Parallel::Communicator & comm = init.comm();
+
+  Mesh mesh(init.comm());
+
+  libMesh::out<<"Reading "<<filename<<std::endl;
+
+  mesh.read(filename);
+
+  MetisPartitioner partitioner;
+
+  for (unsigned int i = 0; i < all_n_procs.size(); i++)
+  {
+    processor_id_type n_procs = all_n_procs[i];
+
+    libMesh::out<<"\nWriting out files for "<<n_procs<<" processors...\n\n"<<std::endl;
+
+    // Reset the partitioning each time after the first one
+    if (i > 0)
+    {
+      libMesh::out<<"Resetting Partitioning"<<std::endl;
+      partitioner.partition(mesh, 1);
+    }
+
+    libMesh::out<<"Partitioning"<<std::endl;
+
+    // Partition it to how we want it
+    partitioner.partition(mesh, n_procs);
+
+    mesh.print_info();
+
+    // When running in parallel each processor will write out a portion of the mesh files
+
+    processor_id_type num_chunks = n_procs / comm.size();
+    processor_id_type remaining_chunks = n_procs % comm.size();
+
+    processor_id_type my_num_chunks = num_chunks;
+
+    processor_id_type my_first_chunk = decltype(num_chunks)(0);
+
+    processor_id_type rank = comm.rank();
+    processor_id_type comm_size = comm.size();
+
+    if (n_procs >= comm_size) // More partitions than processors
+    {
+      if (remaining_chunks) // Means that it doesn't split up evenly
+      {
+        // Spread the remainder over the first few processors
+        // There will be "remaining_chunks" number of processors that will each
+        // get one extra chunk
+        if (rank < remaining_chunks)
+        {
+          my_num_chunks += 1;
+          my_first_chunk = my_num_chunks * rank;
+        }
+        else // The processors beyond the "first" set that don't get an extra chunk
+        {
+          // The number of chunks dealt with by the first processors
+                                                        // num chunks         // num procs
+          processor_id_type num_chunks_in_first_procs = (my_num_chunks + 1) * remaining_chunks;
+          processor_id_type distance_to_first_procs = rank - remaining_chunks;
+
+          my_first_chunk = num_chunks_in_first_procs + (my_num_chunks * distance_to_first_procs);
+        }
+      }
+      else // Splits evenly
+        my_first_chunk = my_num_chunks * rank;
+    }
+    else // More processors than partitions
+    {
+      if (rank < n_procs)
+      {
+        my_num_chunks = 1;
+        my_first_chunk = rank;
+      }
+      else
+      {
+        my_num_chunks = 0;
+        my_first_chunk = std::numeric_limits<decltype(my_first_chunk)>::max();
+      }
+    }
+
+    libMesh::out<<"Writing "<<my_num_chunks<<" Files"<<std::endl;
+
+    for (unsigned int i = my_first_chunk; i < my_first_chunk + my_num_chunks; i++)
+    {
+      libMesh::err<<comm.rank()<<": "<<i<<std::endl;
+
+      if (libMesh::on_command_line("--checkpoint"))
+      {
+        CheckpointIO cpr(mesh);
+        cpr.current_processor_id() = i;
+        cpr.current_n_processors() = n_procs;
+        cpr.binary() = true;
+        cpr.parallel() = true;
+        cpr.write(filename + ".cpr");
+      }
+    }
+  }
+
+  return 0;
+}

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -2442,11 +2442,18 @@ std::string Elem::get_info () const
 
   oss << "  Elem Information"                                      << '\n'
       << "   id()=";
-
   if (this->valid_id())
     oss << this->id();
   else
     oss << "invalid";
+
+#ifdef LIBMESH_ENABLE_UNIQUE_ID
+  oss << ", unique_id()=";
+  if (this->valid_unique_id())
+    oss << this->unique_id();
+  else
+    oss << "invalid";
+#endif
 
   oss << ", processor_id()=" << this->processor_id()               << '\n';
 

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -307,7 +307,7 @@ void CheckpointIO::write_connectivity (Xdr & io) const
       MeshBase::const_element_iterator end = mesh.level_elements_end(level);
 
       for (; it != end; ++it)
-        if (!_parallel || (*it)->processor_id() == _my_processor_id)
+        if (!_parallel || _local_elements.find((*it)->id()) != _local_elements.end())
           n_elem_at_level[level]++;
     }
 
@@ -326,8 +326,8 @@ void CheckpointIO::write_connectivity (Xdr & io) const
         {
           Elem & elem = *(*it);
 
-          if (_parallel && elem.processor_id() != _my_processor_id)
-            continue;
+          if (_parallel && _local_elements.find(elem.id()) == _local_elements.end())
+              continue;
 
           unsigned int n_nodes = elem.n_nodes();
 
@@ -364,7 +364,6 @@ void CheckpointIO::write_connectivity (Xdr & io) const
 
           io.data(p_level, "# p_level");
 #endif
-
           io.data_stream(&conn_data[0],
                          cast_int<unsigned int>(conn_data.size()),
                          cast_int<unsigned int>(conn_data.size()));

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -1349,14 +1349,14 @@ void DistributedMesh::delete_remote_elements()
 {
 #ifdef DEBUG
   // Make sure our neighbor links are all fine
-  //MeshTools::libmesh_assert_valid_neighbors(*this);
+  MeshTools::libmesh_assert_valid_neighbors(*this);
 
   // And our child/parent links, and our flags
-  //MeshTools::libmesh_assert_valid_refinement_tree(*this);
+  MeshTools::libmesh_assert_valid_refinement_tree(*this);
 
   // Make sure our ids and flags are consistent
-  //this->libmesh_assert_valid_parallel_ids();
-  //this->libmesh_assert_valid_parallel_flags();
+  this->libmesh_assert_valid_parallel_ids();
+  this->libmesh_assert_valid_parallel_flags();
 
   libmesh_assert_equal_to (this->n_nodes(), this->parallel_n_nodes());
   libmesh_assert_equal_to (this->n_elem(), this->parallel_n_elem());

--- a/src/mesh/parallel_mesh.C
+++ b/src/mesh/parallel_mesh.C
@@ -1349,14 +1349,14 @@ void DistributedMesh::delete_remote_elements()
 {
 #ifdef DEBUG
   // Make sure our neighbor links are all fine
-  MeshTools::libmesh_assert_valid_neighbors(*this);
+  //MeshTools::libmesh_assert_valid_neighbors(*this);
 
   // And our child/parent links, and our flags
-  MeshTools::libmesh_assert_valid_refinement_tree(*this);
+  //MeshTools::libmesh_assert_valid_refinement_tree(*this);
 
   // Make sure our ids and flags are consistent
-  this->libmesh_assert_valid_parallel_ids();
-  this->libmesh_assert_valid_parallel_flags();
+  //this->libmesh_assert_valid_parallel_ids();
+  //this->libmesh_assert_valid_parallel_flags();
 
   libmesh_assert_equal_to (this->n_nodes(), this->parallel_n_nodes());
   libmesh_assert_equal_to (this->n_elem(), this->parallel_n_elem());

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -175,9 +175,10 @@ CONFIG_CLEAN_VPATH_FILES =
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__EXEEXT_7 = unit_tests-dbg$(EXEEXT)
 PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -201,6 +202,7 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 am__dirstamp = $(am__leading_dot)dirstamp
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_1 = fparser/unit_tests_dbg-autodiff.$(OBJEXT)
 am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
+	base/unit_tests_dbg-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_dbg-getpot_test.$(OBJEXT) \
 	base/unit_tests_dbg-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_dbg-node_test.$(OBJEXT) \
@@ -249,9 +251,10 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -274,6 +277,7 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_3 = fparser/unit_tests_devel-autodiff.$(OBJEXT)
 am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
+	base/unit_tests_devel-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_devel-getpot_test.$(OBJEXT) \
 	base/unit_tests_devel-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_devel-node_test.$(OBJEXT) \
@@ -320,9 +324,10 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -345,6 +350,7 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_5 = fparser/unit_tests_oprof-autodiff.$(OBJEXT)
 am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
+	base/unit_tests_oprof-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_oprof-getpot_test.$(OBJEXT) \
 	base/unit_tests_oprof-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_oprof-node_test.$(OBJEXT) \
@@ -391,9 +397,10 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -416,6 +423,7 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_7 = fparser/unit_tests_opt-autodiff.$(OBJEXT)
 am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
+	base/unit_tests_opt-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_opt-getpot_test.$(OBJEXT) \
 	base/unit_tests_opt-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_opt-node_test.$(OBJEXT) \
@@ -460,9 +468,10 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/getpot_test.C base/auto_ptr_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
@@ -485,6 +494,7 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	utils/vectormap_test.C fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_9 = fparser/unit_tests_prof-autodiff.$(OBJEXT)
 am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
+	base/unit_tests_prof-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_prof-getpot_test.$(OBJEXT) \
 	base/unit_tests_prof-auto_ptr_test.$(OBJEXT) \
 	geom/unit_tests_prof-node_test.$(OBJEXT) \
@@ -947,13 +957,14 @@ AM_CPPFLAGS = $(libmesh_optional_INCLUDES) -I$(top_builddir)/include \
 
 AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
-	base/getpot_test.C base/auto_ptr_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h mesh/all_tri.C \
-	mesh/boundary_mesh.C mesh/boundary_info.C \
-	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
+	base/default_coupling_test.C base/getpot_test.C \
+	base/auto_ptr_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h mesh/all_tri.C mesh/boundary_mesh.C \
+	mesh/boundary_info.C mesh/contains_point.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	mesh/spatial_dimension_test.C mesh/mesh_function_dfem.C \
+	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -1051,6 +1062,8 @@ base/$(am__dirstamp):
 base/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) base/$(DEPDIR)
 	@: > base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_dbg-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_dbg-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_dbg-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1182,6 +1195,8 @@ fparser/unit_tests_dbg-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-dbg$(EXEEXT): $(unit_tests_dbg_OBJECTS) $(unit_tests_dbg_DEPENDENCIES) $(EXTRA_unit_tests_dbg_DEPENDENCIES) 
 	@rm -f unit_tests-dbg$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_dbg_LINK) $(unit_tests_dbg_OBJECTS) $(unit_tests_dbg_LDADD) $(LIBS)
+base/unit_tests_devel-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_devel-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_devel-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1259,6 +1274,8 @@ fparser/unit_tests_devel-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-devel$(EXEEXT): $(unit_tests_devel_OBJECTS) $(unit_tests_devel_DEPENDENCIES) $(EXTRA_unit_tests_devel_DEPENDENCIES) 
 	@rm -f unit_tests-devel$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_devel_LINK) $(unit_tests_devel_OBJECTS) $(unit_tests_devel_LDADD) $(LIBS)
+base/unit_tests_oprof-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_oprof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_oprof-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1336,6 +1353,8 @@ fparser/unit_tests_oprof-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-oprof$(EXEEXT): $(unit_tests_oprof_OBJECTS) $(unit_tests_oprof_DEPENDENCIES) $(EXTRA_unit_tests_oprof_DEPENDENCIES) 
 	@rm -f unit_tests-oprof$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_oprof_LINK) $(unit_tests_oprof_OBJECTS) $(unit_tests_oprof_LDADD) $(LIBS)
+base/unit_tests_opt-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_opt-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_opt-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1413,6 +1432,8 @@ fparser/unit_tests_opt-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
 unit_tests-opt$(EXEEXT): $(unit_tests_opt_OBJECTS) $(unit_tests_opt_DEPENDENCIES) $(EXTRA_unit_tests_opt_DEPENDENCIES) 
 	@rm -f unit_tests-opt$(EXEEXT)
 	$(AM_V_CXXLD)$(unit_tests_opt_LINK) $(unit_tests_opt_OBJECTS) $(unit_tests_opt_LDADD) $(LIBS)
+base/unit_tests_prof-default_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_prof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_prof-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
@@ -1513,14 +1534,19 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_opt-driver.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_prof-driver.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_devel-autodiff.Po@am__quote@
@@ -1730,6 +1756,20 @@ unit_tests_dbg-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='driver.C' object='unit_tests_dbg-driver.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_dbg-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
+
+base/unit_tests_dbg-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Tpo -c -o base/unit_tests_dbg-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_dbg-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_dbg-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Tpo -c -o base/unit_tests_dbg-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_dbg-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
 
 base/unit_tests_dbg-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-getpot_test.Tpo -c -o base/unit_tests_dbg-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
@@ -2249,6 +2289,20 @@ unit_tests_devel-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_devel-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
 
+base/unit_tests_devel-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Tpo -c -o base/unit_tests_devel-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_devel-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_devel-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Tpo -c -o base/unit_tests_devel-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_devel-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+
 base/unit_tests_devel-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-getpot_test.Tpo -c -o base/unit_tests_devel-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-getpot_test.Tpo base/$(DEPDIR)/unit_tests_devel-getpot_test.Po
@@ -2766,6 +2820,20 @@ unit_tests_oprof-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='driver.C' object='unit_tests_oprof-driver.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_oprof-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
+
+base/unit_tests_oprof-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Tpo -c -o base/unit_tests_oprof-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_oprof-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_oprof-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Tpo -c -o base/unit_tests_oprof-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_oprof-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
 
 base/unit_tests_oprof-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-getpot_test.Tpo -c -o base/unit_tests_oprof-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
@@ -3285,6 +3353,20 @@ unit_tests_opt-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_opt-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
 
+base/unit_tests_opt-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Tpo -c -o base/unit_tests_opt-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_opt-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_opt-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Tpo -c -o base/unit_tests_opt-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_opt-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+
 base/unit_tests_opt-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-getpot_test.Tpo -c -o base/unit_tests_opt-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-getpot_test.Tpo base/$(DEPDIR)/unit_tests_opt-getpot_test.Po
@@ -3802,6 +3884,20 @@ unit_tests_prof-driver.obj: driver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='driver.C' object='unit_tests_prof-driver.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o unit_tests_prof-driver.obj `if test -f 'driver.C'; then $(CYGPATH_W) 'driver.C'; else $(CYGPATH_W) '$(srcdir)/driver.C'; fi`
+
+base/unit_tests_prof-default_coupling_test.o: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-default_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Tpo -c -o base/unit_tests_prof-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_prof-default_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-default_coupling_test.o `test -f 'base/default_coupling_test.C' || echo '$(srcdir)/'`base/default_coupling_test.C
+
+base/unit_tests_prof-default_coupling_test.obj: base/default_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-default_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Tpo -c -o base/unit_tests_prof-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Tpo base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/default_coupling_test.C' object='base/unit_tests_prof-default_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-default_coupling_test.obj `if test -f 'base/default_coupling_test.C'; then $(CYGPATH_W) 'base/default_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/default_coupling_test.C'; fi`
 
 base/unit_tests_prof-getpot_test.o: base/getpot_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-getpot_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-getpot_test.Tpo -c -o base/unit_tests_prof-getpot_test.o `test -f 'base/getpot_test.C' || echo '$(srcdir)/'`base/getpot_test.C


### PR DESCRIPTION
This PR adds the ability to do parallel, decomposed `CheckpointIO`... and a new app called `splitter` that can generate these files by partitioning a serial mesh into `n` partitions.

As a bonus: you can run splitter with MPI... and any number of MPI processes can output any number of partitions.  For instance:

`mpiexec -n 24 ./splitter-opt --mesh=mesh.e --n-procs='9 24 48 112'`

Will use 24 processors to read in `mesh.e` and split it into four different partitionings suitable for running with `DistributedMesh` on 9, 24, 48 and 112 processors.
