### PR TITLE
Better System::point_*() methods

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1570,7 +1570,7 @@ public:
    * point \p p contained in local Elem \p e
    *
    * This version of point_value can be run in serial, but assumes \p e is in
-   * the local mesh partition.
+   * the local mesh partition or is algebraically ghosted.
    */
   Number point_value(unsigned int var, const Point & p, const Elem & e) const;
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2054,7 +2054,7 @@ Number System::point_value(unsigned int var, const Point & p, const bool insist_
 
   Number u = 0;
 
-  if (e && e->processor_id() == this->processor_id())
+  if (e && this->get_dof_map().is_evaluable(*e, var))
     u = point_value(var, p, *e);
 
   // If I have an element containing p, then let's let everyone know
@@ -2166,7 +2166,7 @@ Gradient System::point_gradient(unsigned int var, const Point & p, const bool in
 
   Gradient grad_u;
 
-  if (e && e->processor_id() == this->processor_id())
+  if (e && this->get_dof_map().is_evaluable(*e, var))
     grad_u = point_gradient(var, p, *e);
 
   // If I have an element containing p, then let's let everyone know
@@ -2281,7 +2281,7 @@ Tensor System::point_hessian(unsigned int var, const Point & p, const bool insis
 
   Tensor hess_u;
 
-  if (e && e->processor_id() == this->processor_id())
+  if (e && this->get_dof_map().is_evaluable(*e, var))
     hess_u = point_hessian(var, p, *e);
 
   // If I have an element containing p, then let's let everyone know

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2076,8 +2076,6 @@ Number System::point_value(unsigned int var, const Point & p, const bool insist_
 
 Number System::point_value(unsigned int var, const Point & p, const Elem & e) const
 {
-  libmesh_assert_equal_to (e.processor_id(), this->processor_id());
-
   // Ensuring that the given point is really in the element is an
   // expensive assert, but as long as debugging is turned on we might
   // as well try to catch a particularly nasty potential error
@@ -2085,6 +2083,9 @@ Number System::point_value(unsigned int var, const Point & p, const Elem & e) co
 
   // Get the dof map to get the proper indices for our computation
   const DofMap & dof_map = this->get_dof_map();
+
+  // Make sure we can evaluate on this element.
+  libmesh_assert (dof_map.is_evaluable(e, var));
 
   // Need dof_indices for phi[i][j]
   std::vector<dof_id_type> dof_indices;
@@ -2188,8 +2189,6 @@ Gradient System::point_gradient(unsigned int var, const Point & p, const bool in
 
 Gradient System::point_gradient(unsigned int var, const Point & p, const Elem & e) const
 {
-  libmesh_assert_equal_to (e.processor_id(), this->processor_id());
-
   // Ensuring that the given point is really in the element is an
   // expensive assert, but as long as debugging is turned on we might
   // as well try to catch a particularly nasty potential error
@@ -2197,6 +2196,9 @@ Gradient System::point_gradient(unsigned int var, const Point & p, const Elem & 
 
   // Get the dof map to get the proper indices for our computation
   const DofMap & dof_map = this->get_dof_map();
+
+  // Make sure we can evaluate on this element.
+  libmesh_assert (dof_map.is_evaluable(e, var));
 
   // Need dof_indices for phi[i][j]
   std::vector<dof_id_type> dof_indices;
@@ -2301,8 +2303,6 @@ Tensor System::point_hessian(unsigned int var, const Point & p, const bool insis
 
 Tensor System::point_hessian(unsigned int var, const Point & p, const Elem & e) const
 {
-  libmesh_assert_equal_to (e.processor_id(), this->processor_id());
-
   // Ensuring that the given point is really in the element is an
   // expensive assert, but as long as debugging is turned on we might
   // as well try to catch a particularly nasty potential error
@@ -2310,6 +2310,9 @@ Tensor System::point_hessian(unsigned int var, const Point & p, const Elem & e) 
 
   // Get the dof map to get the proper indices for our computation
   const DofMap & dof_map = this->get_dof_map();
+
+  // Make sure we can evaluate on this element.
+  libmesh_assert (dof_map.is_evaluable(e, var));
 
   // Need dof_indices for phi[i][j]
   std::vector<dof_id_type> dof_indices;


### PR DESCRIPTION
This fixes a bug in the new DefaultCoupling unit tests on my laptop, and makes System::point_value() and kin more useful.  I'm not sure why I didn't manage to trigger the bug sooner.