### PR TITLE
Prefer UniquePtr to manual delete

### DIFF
--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -111,7 +111,7 @@ Number exact_value (const Point & p,
 
 // With --enable-fparser, the user can also optionally set their own
 // exact solution equations.
-FunctionBase<Number> * parsed_solution = libmesh_nullptr;
+UniquePtr<FunctionBase<Number> > parsed_solution;
 
 
 // Returns a string with 'number' formatted and placed directly
@@ -213,7 +213,8 @@ int main (int argc, char ** argv)
   const bool have_expression = false;
 #endif
   if (have_expression)
-    parsed_solution = new ParsedFunction<Number>(command_line.next(std::string()));
+    parsed_solution.reset
+      (new ParsedFunction<Number>(command_line.next(std::string())));
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
@@ -526,9 +527,6 @@ int main (int argc, char ** argv)
     }
 #endif // #ifndef LIBMESH_ENABLE_AMR
 
-  // We might have a parser to clean up
-  delete parsed_solution;
-
   return 0;
 }
 
@@ -550,8 +548,8 @@ void init_cd (EquationSystems & es,
   // Project initial conditions at time 0
   es.parameters.set<Real> ("time") = system.time = 0;
 
-  if (parsed_solution)
-    system.project_solution(parsed_solution, libmesh_nullptr);
+  if (parsed_solution.get())
+    system.project_solution(parsed_solution.get(), libmesh_nullptr);
   else
     system.project_solution(exact_value, libmesh_nullptr, es.parameters);
 }

--- a/examples/reduced_basis/reduced_basis_ex7/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex7/rb_classes.h
@@ -39,6 +39,7 @@ using libMesh::RBConstruction;
 using libMesh::RBEvaluation;
 using libMesh::Real;
 using libMesh::SECOND;
+using libMesh::UniquePtr;
 
 
 // A simple subclass of RBEvaluation, which just needs to specify
@@ -87,7 +88,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~SimpleRBConstruction () { delete acoustics_rb_assembly_expansion; }
+  virtual ~SimpleRBConstruction () {}
 
   /**
    * The type of system.
@@ -108,7 +109,8 @@ public:
 
     Parent::init_data();
 
-    acoustics_rb_assembly_expansion = new AcousticsRBAssemblyExpansion;
+    acoustics_rb_assembly_expansion.reset
+      (new AcousticsRBAssemblyExpansion);
 
     // Set the rb_assembly_expansion for this Construction object.
     // The theta expansion comes from the RBEvaluation object.
@@ -148,7 +150,7 @@ public:
    * i.e. the objects that define how to assemble the set of parameter-independent
    * operators in the affine expansion of the PDE.
    */
-  AcousticsRBAssemblyExpansion * acoustics_rb_assembly_expansion;
+  UniquePtr<AcousticsRBAssemblyExpansion> acoustics_rb_assembly_expansion;
 };
 
 #endif


### PR DESCRIPTION
As with the unit test @jwpeterson caught, we should probably be
teaching new users to use smart pointers rather than manual
deallocation.

Let's not merge this until I can test it manually - reduced_basis_ex7 isn't even compiled unless we build with --enable-complex.