### PR TITLE
Fix recent unit tests with --enable-complex

### DIFF
--- a/tests/numerics/petsc_vector_test.C
+++ b/tests/numerics/petsc_vector_test.C
@@ -55,13 +55,13 @@ public:
 
     // Check the values through the interface
     for (unsigned int i=0; i<local_size; i++)
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(v(my_comm->rank()*2 + i), i, TOLERANCE*TOLERANCE);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(std::abs(v(my_comm->rank()*2 + i)), i, TOLERANCE*TOLERANCE);
 
     // Check that we can see the same thing with get_array_read
     const PetscScalar * read_only_values = v.get_array_read();
 
     for (unsigned int i=0; i<local_size; i++)
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(read_only_values[i], i, TOLERANCE*TOLERANCE);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(std::abs(read_only_values[i]), i, TOLERANCE*TOLERANCE);
 
     v.restore_array();
 

--- a/tests/solvers/time_solver_test_common.h
+++ b/tests/solvers/time_solver_test_common.h
@@ -27,9 +27,9 @@ protected:
     es.init();
 
     DiffSolver & solver = *(system.time_solver->diff_solver().get());
-    solver.relative_step_tolerance = std::numeric_limits<Number>::epsilon()*10;
-    solver.relative_residual_tolerance = std::numeric_limits<Number>::epsilon()*10;
-    solver.absolute_residual_tolerance = std::numeric_limits<Number>::epsilon()*10;
+    solver.relative_step_tolerance = std::numeric_limits<Real>::epsilon()*10;
+    solver.relative_residual_tolerance = std::numeric_limits<Real>::epsilon()*10;
+    solver.absolute_residual_tolerance = std::numeric_limits<Real>::epsilon()*10;
 
     system.deltat = deltat;
 
@@ -53,11 +53,11 @@ protected:
           {
             // Use relative error for comparison, so "exact" is 0
             Number exact_soln = system.u(system.time);
-            Number rel_error =  std::abs((exact_soln - (*system.solution)(0))/exact_soln);
+            Real rel_error =  std::abs((exact_soln - (*system.solution)(0))/exact_soln);
 
             CPPUNIT_ASSERT_DOUBLES_EQUAL( 0.0,
                                           rel_error,
-                                          std::numeric_limits<Number>::epsilon()*10 );
+                                          std::numeric_limits<Real>::epsilon()*10 );
           }
       }
   }


### PR DESCRIPTION
Apparently it's time for me to give up on getting BuildBot SingleBranchScheduler to work properly with github, and just reenable our Periodic scheduler for all the non-default configuration tests.