### PR TITLE
Fixed bug in InfFE::inverse_map() concerning v being out of range.

### DIFF
--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -351,11 +351,15 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
 
   // the distance from the intersection on the
   // base to the origin
-  const Real a_dist = intersection.norm();
+  const Real a_dist = Point(o-intersection).norm();
 
   // element coordinate in radial direction
   // here our first guess is 0.
   Real v = 0.;
+  if (T_map==CARTESIAN)
+    // we know the analytic answer to this:
+    v=1.-2.*a_dist/fp_o_dist;
+  //other schemes than CARTESIAN are not yet defined.
 
   // the order of the radial mapping
   const Order radial_mapping_order (Radial::mapping_order());
@@ -366,6 +370,12 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
   // Newton iteration in 1-D
   do
     {
+      if (v<-1.){
+         // in this case, physical_point is not in this element.
+         // We therefore give back the best approximation:
+         p(Dim-1)=-1;
+         return p;
+      }
       // the mapping in radial direction
       // note that we only have two mapping functions in
       // radial direction


### PR DESCRIPTION
Hi,
I found two further bugs in the inverse_map() function:
First, the distance of the intersection should be taken to the origin of infinite elements, not to the origin of the coordinate system.

Moreover, the function is called from the PointLocator where the physical point might be far away from the element. In this case I had the problem that the InfFE::eval() function failed due to v<-1-1e-5.
To circumvent this, I added the respective check and just leave the loop, if v<-1.

Finally,  the parameter v can be assigned analytically in my point of view, at least in the CARTESIAN mapping.
Probably you can have a look at this part to see whether I am right or if there is some configuration currently available, where this does not hold. However, one can use this knowledge for a better guess anyway.