### PR TITLE
Use a const_cast in one final MPI call

### DIFF
--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -385,7 +385,7 @@ inline void send_receive_vec_of_vec(const unsigned int dest_processor_id,
       // ... the contents of the ith inner buffer
       if (!send[i].empty())
         libmesh_call_mpi
-          (MPI_Pack (&send[i][0],
+          (MPI_Pack (const_cast<T1*>(&send[i][0]),
                      libMesh::cast_int<int>(send[i].size()),
                      libMesh::Parallel::StandardType<T1>(&send[i][0]),
                      &sendbuf[0],


### PR DESCRIPTION
I never found an MPI-1 stack to test with, but this does fix libMesh
compilation with the not-quite-MPI-2 interface in OpenMPI 1.2.9, the
oldest version that would compile cleanly for me.