### PR TITLE
Some small updates to read_ref_elem().

### DIFF
--- a/include/geom/reference_elem.h
+++ b/include/geom/reference_elem.h
@@ -45,7 +45,7 @@ namespace ReferenceElem
  * @returns a constant reference to the reference element of
  * the user-requested type.
  */
-const Elem & get (const ElemType Type);
+const Elem & get (const ElemType type_in);
 
 } // namespace ReferenceElem
 

--- a/src/geom/reference_elem.C
+++ b/src/geom/reference_elem.C
@@ -23,6 +23,7 @@
 #include "libmesh/reference_elem.h"
 #include "libmesh/libmesh_singleton.h"
 #include "libmesh/threads.h"
+#include "libmesh/string_to_enum.h"
 
 // C++ includes
 #include <map>
@@ -89,35 +90,32 @@ SingletonCache * singleton_cache = libmesh_nullptr;
 
 
 
-Elem * read_ref_elem (const ElemType Type,
-                      std::istream & in)
+void read_ref_elem (const ElemType type_in,
+                    std::istream & in)
 {
   libmesh_assert (singleton_cache != libmesh_nullptr);
 
-  static const unsigned int comm_len = 1024;
-  char comm[comm_len];
-
-  std::string foo;
-  unsigned int n_elem, n_nodes, elem_type, nn;
+  std::string dummy;
+  unsigned int n_elem, n_nodes, elem_type_read, nn;
   double x, y, z;
 
-  in >> foo;
-  in >> n_elem;  /**/ in.getline (comm, comm_len); libmesh_assert_equal_to (n_elem, 1);
-  in >> n_nodes; /**/ in.getline (comm, comm_len);
-  in >> foo;     /**/ in.getline (comm, comm_len);
-  in >> foo;     /**/ in.getline (comm, comm_len);
-  in >> foo;     /**/ in.getline (comm, comm_len);
-  in >> foo;     /**/ in.getline (comm, comm_len);
-  in >> n_elem;  /**/ in.getline (comm, comm_len); libmesh_assert_equal_to (n_elem, 1);
+  in >> dummy;
+  in >> n_elem;  /**/ std::getline (in, dummy); libmesh_assert_equal_to (n_elem, 1);
+  in >> n_nodes; /**/ std::getline (in, dummy);
+  in >> dummy;   /**/ std::getline (in, dummy);
+  in >> dummy;   /**/ std::getline (in, dummy);
+  in >> dummy;   /**/ std::getline (in, dummy);
+  in >> dummy;   /**/ std::getline (in, dummy);
+  in >> n_elem;  /**/ std::getline (in, dummy); libmesh_assert_equal_to (n_elem, 1);
 
-  in >> elem_type;
+  in >> elem_type_read;
 
-  libmesh_assert_less (elem_type, INVALID_ELEM);
-  libmesh_assert_equal_to (elem_type, static_cast<unsigned int>(Type));
-  libmesh_assert_equal_to (n_nodes, Elem::type_to_n_nodes_map[elem_type]);
+  libmesh_assert_less (elem_type_read, INVALID_ELEM);
+  libmesh_assert_equal_to (elem_type_read, static_cast<unsigned int>(type_in));
+  libmesh_assert_equal_to (n_nodes, Elem::type_to_n_nodes_map[elem_type_read]);
 
-  // Construct the elem
-  Elem * elem = Elem::build(static_cast<ElemType>(elem_type)).release();
+  // Construct elem of appropriate type
+  UniquePtr<Elem> uelem = Elem::build(type_in);
 
   // We are expecing an identity map, so assert it!
   for (unsigned int n=0; n<n_nodes; n++)
@@ -133,25 +131,20 @@ Elem * read_ref_elem (const ElemType Type,
       Node * node = new Node(x,y,z,n);
       singleton_cache->node_list.push_back(node);
 
-      elem->set_node(n) = node;
+      uelem->set_node(n) = node;
     }
-
 
   // it is entirely possible we ran out of file or encountered
-  // another error.  If so, cleanly abort.
+  // another error.  If so, throw an error.
   if (!in)
-    {
-      delete elem;
-      elem = libmesh_nullptr;
-      libmesh_error_msg("ERROR while creating element singleton!");
-    }
+    libmesh_error_msg("ERROR while creating element singleton!");
 
+  // Release the pointer into the care of the singleton_cache
   else
-    singleton_cache->elem_list.push_back (elem);
+    singleton_cache->elem_list.push_back (uelem.release());
 
-  ref_elem_map[Type] = elem;
-
-  return elem;
+  // Also store it in the array.
+  ref_elem_map[type_in] = singleton_cache->elem_list.back();
 }
 
 
@@ -179,7 +172,7 @@ void init_ref_elem_table()
   {
     ref_elem_file.clear();
 
-    // // 1D elements
+    // 1D elements
     ref_elem_file[EDGE2]    = ElemDataStrings::one_edge;
     ref_elem_file[EDGE3]    = ElemDataStrings::one_edge3;
     ref_elem_file[EDGE4]    = ElemDataStrings::one_edge4;
@@ -243,24 +236,25 @@ namespace libMesh
 {
 namespace ReferenceElem
 {
-const Elem & get (const ElemType Type)
+const Elem & get (const ElemType type_in)
 {
-  libmesh_assert_less (Type, INVALID_ELEM);
-
-  ElemType BaseType = Type;
+  ElemType base_type = type_in;
 
   // For shell elements, use non shell type as the base type
-  if (Type == TRISHELL3)
-    BaseType = TRI3;
+  if (type_in == TRISHELL3)
+    base_type = TRI3;
 
-  if (Type == QUADSHELL4)
-    BaseType = QUAD4;
+  if (type_in == QUADSHELL4)
+    base_type = QUAD4;
 
   init_ref_elem_table();
 
-  libmesh_assert (ref_elem_map[BaseType] != libmesh_nullptr);
+  // Throw an error if the user asked for an ElemType that we don't
+  // have a reference element for.
+  if (ref_elem_map[base_type] == libmesh_nullptr || type_in == INVALID_ELEM)
+    libmesh_error_msg("No reference elem data available for ElemType " << type_in << " = " << Utility::enum_to_string(type_in) << ".");
 
-  return *ref_elem_map[BaseType];
+  return *ref_elem_map[base_type];
 }
 } // namespace ReferenceElem
 } // namespace libMesh


### PR DESCRIPTION
* This function is only called locally and the return value is not
  caught, so there's no reason to return it.
* There's no reason to manually clean up memory in case of an error,
  that's what destructors and exceptions do.
* Use std::getline(), avoid manually sized char arrays.
* Print a human-readable error message when passed a Type without an
  associated reference Elem.
* Rename some variables. Using capitalized variable names does not
  match the rest of libMesh and is a bit confusing since we typically
  use capitalized names to refer to types.