### PR TITLE
Treat empty _dof_coupling as full _dof_coupling

### DIFF
--- a/include/base/default_coupling.h
+++ b/include/base/default_coupling.h
@@ -55,8 +55,7 @@ public:
  {}
 
   // Change coupling matrix after construction
-  void set_dof_coupling(const CouplingMatrix * dof_coupling)
-  { _dof_coupling = dof_coupling; }
+  void set_dof_coupling(const CouplingMatrix * dof_coupling);
 
   // Return number of levels of neighbors we will couple.
   unsigned int n_levels()

--- a/src/base/default_coupling.C
+++ b/src/base/default_coupling.C
@@ -20,6 +20,7 @@
 // Local Includes -----------------------------------
 #include "libmesh/default_coupling.h"
 
+#include "libmesh/coupling_matrix.h"
 #include "libmesh/elem.h"
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/remote_elem.h"
@@ -29,6 +30,24 @@
 
 namespace libMesh
 {
+
+void DefaultCoupling::set_dof_coupling(const CouplingMatrix * dof_coupling)
+{
+  // We used to treat an empty 0x0 _dof_coupling matrix as if it
+  // were an NxN all-ones matrix.  We'd like to stop supporting this
+  // behavior, but for now we'll just warn about it, while supporting
+  // it via the preferred mechanism: a NULL _dof_coupling
+  // matrix pointer is interpreted as a full coupling matrix.
+  if (dof_coupling && dof_coupling->empty())
+    {
+      libmesh_deprecated();
+      _dof_coupling = NULL;
+    }
+  else
+    _dof_coupling = dof_coupling;
+}
+
+
 
 void DefaultCoupling::mesh_reinit()
 {


### PR DESCRIPTION
Hopefully this will be sufficient to fix the regression in support that Yak triggered in https://github.com/idaholab/moose/pull/7912