### PR TITLE
Use UniquePtr to manage helper class lifetimes in ExodusII_IO and Nemesis_IO.

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -245,7 +245,7 @@ private:
    * functionality when LIBMESH_HAVE_EXODUS_API is not defined.
    */
 #ifdef LIBMESH_HAVE_EXODUS_API
-  ExodusII_IO_Helper * exio_helper;
+  UniquePtr<ExodusII_IO_Helper> exio_helper;
 #endif
 
   /**

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -125,10 +125,18 @@ public:
 
 private:
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
-  Nemesis_IO_Helper * nemhelper;
-  int _timestep;
+  UniquePtr<Nemesis_IO_Helper> nemhelper;
 #endif
 
+  /**
+   * Keeps track of the current timestep index being written. Used
+   * when calling write_nodal_data() and other functions.
+   */
+  int _timestep;
+
+  /**
+   * Controls whether extra debugging information is printed to the screen or not.
+   */
   bool _verbose;
 
   /**

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -103,7 +103,6 @@ void ExodusII_IO::write_discontinuous_exodusII(const std::string & name,
 ExodusII_IO::~ExodusII_IO ()
 {
   exio_helper->close();
-  delete exio_helper;
 }
 
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -94,20 +94,19 @@ Nemesis_IO::Nemesis_IO (MeshBase & mesh,
   ParallelObject (mesh),
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
   nemhelper(new Nemesis_IO_Helper(*this, false, single_precision)),
-  _timestep(1),
 #endif
+  _timestep(1),
   _verbose (false),
   _append(false)
 {
 }
 
 
+
+// Destructor.  Defined in the C file so we can be sure to get away
+// with a forward declaration of Nemesis_IO_Helper in the header file.
 Nemesis_IO::~Nemesis_IO ()
 {
-#if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
-
-  delete nemhelper;
-#endif
 }
 
 


### PR DESCRIPTION
We no longer have to explicitly call `delete` in the destructors to avoid a memory leak.