### PR TITLE
Add option to add an initial guess for the SLEPc eigensolver

### DIFF
--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -41,6 +41,7 @@
 #include "libmesh/exodusII_io.h"
 #include "libmesh/eigen_system.h"
 #include "libmesh/equation_systems.h"
+#include "libmesh/slepc_eigen_solver.h"
 #include "libmesh/fe.h"
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/dense_matrix.h"

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -165,12 +165,16 @@ int main (int argc, char ** argv)
   // Prints information about the system to the screen.
   equation_systems.print_info();
 
+#if SLEPC_VERSION_LESS_THAN(3,1,0)
+  libmesh_error_msg("SLEPc 3.1 is required to call EigenSolver::set_initial_space()");
+#else
   // Get the SLEPc solver object and set initial guess for one basis vector
   // this has to be done _after_ the EquationSystems object is initialized
   UniquePtr<EigenSolver<Number> > & slepc_eps = eigen_system.eigen_solver;
   NumericVector<Number> & initial_space = eigen_system.add_vector("initial_space");
   initial_space.add(1.0);
   slepc_eps->set_initial_space(initial_space);
+#endif
 
   // Solve the system "Eigensystem".
   eigen_system.solve();

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -165,6 +165,13 @@ int main (int argc, char ** argv)
   // Prints information about the system to the screen.
   equation_systems.print_info();
 
+  // Get the SLEPc solver object and set initial guess for one basis vector
+  // this has to be done _after_ the EquationSystems object is initialized
+  UniquePtr<EigenSolver<Number> > & slepc_eps = eigen_system.eigen_solver;
+  NumericVector<Number> & initial_space = eigen_system.add_vector("initial_space");
+  initial_space.add(1.0);
+  slepc_eps->set_initial_space(initial_space);
+
   // Solve the system "Eigensystem".
   eigen_system.solve();
 

--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -214,6 +214,11 @@ public:
   virtual void attach_deflation_space(NumericVector<T> & deflation_vector) = 0;
 
   /**
+   * Provide one basis vector for the initial guess
+   */
+  virtual void set_initial_space(NumericVector<T> & initial_space_in) = 0;
+
+  /**
    * Set the solver configuration object.
    */
   void set_solver_configuration(SolverConfiguration & solver_configuration);

--- a/include/solvers/slepc_eigen_solver.h
+++ b/include/solvers/slepc_eigen_solver.h
@@ -205,6 +205,12 @@ public:
   virtual void attach_deflation_space(NumericVector<T> & deflation_vector) libmesh_override;
 
   /**
+   * Provide one basis vector for the initial guess
+   */
+  virtual void
+  set_initial_space(NumericVector<T> & initial_space_in) libmesh_override;
+  
+  /**
    * Returns the raw SLEPc eps context pointer.
    */
   EPS eps() { this->init(); return _eps; }

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -752,8 +752,7 @@ void SlepcEigenSolver<T>::set_initial_space(NumericVector<T> & initial_space_in)
   
   PetscErrorCode ierr = 0;
   Vec initial_vector = (cast_ptr<PetscVector<T> *>(&initial_space_in))->vec();
-  Vec * initial_space = &initial_vector;
-  ierr = EPSSetInitialSpace(_eps, 1, initial_space);
+  ierr = EPSSetInitialSpace(_eps, 1, &initial_vector);
   LIBMESH_CHKERR(ierr);
 #endif
 }

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -745,6 +745,9 @@ void SlepcEigenSolver<T>::attach_deflation_space(NumericVector<T> & deflation_ve
 template <typename T>
 void SlepcEigenSolver<T>::set_initial_space(NumericVector<T> & initial_space_in)
 {
+#if SLEPC_VERSION_LESS_THAN(3,1,0)
+  libmesh_error_msg("SLEPc 3.1 is required to call EigenSolver::set_initial_space()");
+#else
   this->init();
   
   PetscErrorCode ierr = 0;
@@ -752,6 +755,7 @@ void SlepcEigenSolver<T>::set_initial_space(NumericVector<T> & initial_space_in)
   Vec * initial_space = &initial_vector;
   ierr = EPSSetInitialSpace(_eps, 1, initial_space);
   LIBMESH_CHKERR(ierr);
+#endif
 }
 
 template <typename T>

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -743,6 +743,18 @@ void SlepcEigenSolver<T>::attach_deflation_space(NumericVector<T> & deflation_ve
 }
 
 template <typename T>
+void SlepcEigenSolver<T>::set_initial_space(NumericVector<T> & initial_space_in)
+{
+  this->init();
+  
+  PetscErrorCode ierr = 0;
+  Vec initial_vector = (cast_ptr<PetscVector<T> *>(&initial_space_in))->vec();
+  Vec * initial_space = &initial_vector;
+  ierr = EPSSetInitialSpace(_eps, 1, initial_space);
+  LIBMESH_CHKERR(ierr);
+}
+
+template <typename T>
 PetscErrorCode SlepcEigenSolver<T>::_petsc_shell_matrix_mult(Mat mat, Vec arg, Vec dest)
 {
   /* Get the matrix context.  */


### PR DESCRIPTION
Pull request for issue #1130 

I decided to just implement the EigenSolver interface for now and just used eigenproblems_ex2 for the demonstration to keep eigenproblems_ex1 as simple as possible.

EDIT: As i'm thinking about it afterwards, a new example with two solves and checking for the number of iterations would make sene.