### PR TITLE
Fix binary GMV file writing

### DIFF
--- a/include/mesh/gmv_io.h
+++ b/include/mesh/gmv_io.h
@@ -40,8 +40,7 @@ class MeshBase;
 /**
  * This class implements writing meshes in the GMV format.
  * For a full description of the GMV format and to obtain the
- * GMV software see
- * <a href="http://laws.lanl.gov/XCM/gmv/GMVHome.html">the GMV home page</a>
+ * GMV software see http://www.generalmeshviewer.com
  *
  * \author Benjamin S. Kirk
  * \date 2004
@@ -105,14 +104,10 @@ public:
                                  const std::vector<std::string> &) libmesh_override;
 
   /**
-   * Flag indicating whether or not to write a binary file.  While binary
-   * files may end up being smaller than equivalent ASCII files, they will
-   * almost certainly take longer to write.  The reason for this is that
-   * the ostream::write() function which is used to write "binary" data to
-   * streams, only takes a pointer to char as its first argument.  This means
-   * if you want to write anything other than a buffer of chars, you first
-   * have to use a strange memcpy hack to get the data into the desired format.
-   * See the templated to_binary_stream() function below.
+   * Flag indicating whether or not to write a binary file.  While
+   * binary files may end up being smaller than equivalent ASCII
+   * files, they are harder to debug if anything goes wrong, since
+   * they are not human-readable.
    */
   bool & binary ();
 
@@ -206,14 +201,6 @@ private:
   void write_binary (const std::string &,
                      const std::vector<Number> * = libmesh_nullptr,
                      const std::vector<std::string> * = libmesh_nullptr);
-
-  /**
-   * Helper function for writing unsigned ints to an ostream in binary format.
-   * Implemented via memcpy as suggested in the standard.
-   */
-  template <typename T>
-  void to_binary_stream(std::ostream & out,
-                        const T i);
 
   /**
    * Flag to write binary data.
@@ -342,17 +329,6 @@ inline
 bool & GMVIO::p_levels()
 {
   return _p_levels;
-}
-
-
-
-template <typename T>
-void GMVIO::to_binary_stream(std::ostream & out_str,
-                             const T i)
-{
-  static char buf[sizeof(T)];
-  memcpy(buf, &i, sizeof(T));
-  out_str.write(buf, sizeof(T));
 }
 
 } // namespace libMesh

--- a/include/mesh/gmv_io.h
+++ b/include/mesh/gmv_io.h
@@ -27,8 +27,6 @@
 #include "libmesh/enum_elem_type.h"
 
 // C++ includes
-#include <cstddef>
-#include <cstring>  // for memcpy
 #include <map>
 
 namespace libMesh
@@ -74,21 +72,6 @@ public:
    */
   virtual void read (const std::string & mesh_file) libmesh_override;
 
-  //   /**
-  //    * This method implements reading a mesh from a specified file.
-  //    */
-  //   virtual void read (const std::string & mesh_file)
-  //   { this->read_mesh_and_nodal_data(mesh_file, libmesh_nullptr); }
-
-  //   /**
-  //    * Extension of the MeshInput::read() routine which
-  //    * also takes an optional EquationSystems pointer and
-  //    * tries to read field variables from the GMV file
-  //    * into the EquationSystems object.
-  //    */
-  //   virtual void read_mesh_and_nodal_data (const std::string & ,
-  //  EquationSystems * es=libmesh_nullptr);
-
   /**
    * Bring in base class functionality for name resolution and to
    * avoid warnings about hidden overloaded virtual functions.
@@ -109,38 +92,38 @@ public:
    * files, they are harder to debug if anything goes wrong, since
    * they are not human-readable.
    */
-  bool & binary ();
+  bool & binary () { return _binary; }
 
   /**
    * Flag indicating whether or not to write the mesh
    * as discontinuous cell patches
    */
-  bool & discontinuous();
+  bool & discontinuous() { return _discontinuous; }
 
   /**
    * Flag indicating whether or not to write the partitioning
    * information for the mesh.
    */
-  bool & partitioning();
+  bool & partitioning() { return _partitioning; }
 
   /**
    * Flag to write element subdomain_id's as GMV "materials" instead
    * of element processor_id's.  Allows you to generate exploded views
    * on user-defined subdomains, potentially creating a pretty picture.
    */
-  bool & write_subdomain_id_as_material();
+  bool & write_subdomain_id_as_material() { return _write_subdomain_id_as_material; }
 
   /**
    * Flag indicating whether or not to subdivide second order
    * elements
    */
-  bool & subdivide_second_order();
+  bool & subdivide_second_order() { return _subdivide_second_order; }
 
   /**
    * Flag indicating whether or not to write p level
    * information for p refined meshes
    */
-  bool & p_levels();
+  bool & p_levels() { return _p_levels; }
 
   /**
    * Writes a GMV file with discontinuous data
@@ -252,84 +235,6 @@ private:
   void _read_var();
   std::map<std::string, std::vector<Number> > _nodal_data;
 };
-
-
-
-// ------------------------------------------------------------
-// GMVIO inline members
-inline
-GMVIO::GMVIO (const MeshBase & mesh) :
-  MeshOutput<MeshBase>    (mesh),
-  _binary                 (false),
-  _discontinuous          (false),
-  _partitioning           (true),
-  _write_subdomain_id_as_material (false),
-  _subdivide_second_order (true),
-  _p_levels               (true),
-  _next_elem_id           (0)
-{
-}
-
-inline
-GMVIO::GMVIO (MeshBase & mesh) :
-  MeshInput<MeshBase> (mesh),
-  MeshOutput<MeshBase>(mesh),
-  _binary (false),
-  _discontinuous          (false),
-  _partitioning           (true),
-  _write_subdomain_id_as_material (false),
-  _subdivide_second_order (true),
-  _p_levels               (true),
-  _next_elem_id           (0)
-{
-}
-
-
-
-inline
-bool & GMVIO::binary ()
-{
-  return _binary;
-}
-
-
-
-inline
-bool & GMVIO::discontinuous ()
-{
-  return _discontinuous;
-}
-
-
-
-inline
-bool & GMVIO::partitioning ()
-{
-  return _partitioning;
-}
-
-
-inline
-bool & GMVIO::write_subdomain_id_as_material ()
-{
-  return _write_subdomain_id_as_material;
-}
-
-
-
-inline
-bool & GMVIO::subdivide_second_order ()
-{
-  return _subdivide_second_order;
-}
-
-
-
-inline
-bool & GMVIO::p_levels()
-{
-  return _p_levels;
-}
 
 } // namespace libMesh
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1206,8 +1206,11 @@ void MeshCommunication::make_node_ids_parallel_consistent (MeshBase & mesh)
 
 
 
-void MeshCommunication::make_node_unique_ids_parallel_consistent (MeshBase &mesh)
+void MeshCommunication::make_node_unique_ids_parallel_consistent (MeshBase & mesh)
 {
+  // Avoid unused variable warnings if unique ids aren't enabled.
+  libmesh_ignore(mesh);
+
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -586,10 +586,8 @@ void UnstructuredMesh::read (const std::string & name,
   // during prepare_for_use() for certain types of mesh files.
   // This is required in cases where there is an associated solution
   // file which expects a certain ordering of the nodes.
-  if(name.rfind(".gmv")+4==name.size())
-    {
-      skip_renumber_nodes_and_elements =  true;
-    }
+  if (name.rfind(".gmv") + 4 == name.size())
+    this->allow_renumbering(false);
 
   if (mesh_data)
     {


### PR DESCRIPTION
Paraview can read the ASCII and binary GMV files libmesh writes, the binary file output was not working correctly before.  Also removed some C-style string handling and manual `new`/`delete` memory management code. 