### PR TITLE
Use UniquePtr to manage lifetimes of more stuff.

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1096,12 +1096,12 @@ public:
 
   const DirichletBoundaries * get_dirichlet_boundaries() const
   {
-    return _dirichlet_boundaries;
+    return _dirichlet_boundaries.get();
   }
 
   DirichletBoundaries * get_dirichlet_boundaries()
   {
-    return _dirichlet_boundaries;
+    return _dirichlet_boundaries.get();
   }
 
   bool has_adjoint_dirichlet_boundaries(unsigned int q) const;
@@ -1577,7 +1577,7 @@ private:
    * Data structure containing Dirichlet functions.  The ith
    * entry is the constraint matrix row for boundaryid i.
    */
-  DirichletBoundaries * _dirichlet_boundaries;
+  UniquePtr<DirichletBoundaries> _dirichlet_boundaries;
 
   /**
    * Data structure containing Dirichlet functions.  The ith

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1058,7 +1058,7 @@ public:
 
   PeriodicBoundaries * get_periodic_boundaries()
   {
-    return _periodic_boundaries;
+    return _periodic_boundaries.get();
   }
 
 #endif // LIBMESH_ENABLE_PERIODIC
@@ -1563,7 +1563,7 @@ private:
    * Data structure containing periodic boundaries.  The ith
    * entry is the constraint matrix row for boundaryid i.
    */
-  PeriodicBoundaries * _periodic_boundaries;
+  UniquePtr<PeriodicBoundaries> _periodic_boundaries;
 #endif
 
 #ifdef LIBMESH_ENABLE_DIRICHLET

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -184,8 +184,8 @@ DofMap::DofMap(const unsigned int number,
   _default_evaluating->set_n_levels(1);
 
 #ifdef LIBMESH_ENABLE_PERIODIC
-  _default_coupling->set_periodic_boundaries(_periodic_boundaries);
-  _default_evaluating->set_periodic_boundaries(_periodic_boundaries);
+  _default_coupling->set_periodic_boundaries(_periodic_boundaries.get());
+  _default_evaluating->set_periodic_boundaries(_periodic_boundaries.get());
 #endif
 
   this->add_coupling_functor(*_default_coupling);
@@ -204,9 +204,6 @@ DofMap::~DofMap()
   _mesh.remove_ghosting_functor(*_default_coupling);
   _mesh.remove_ghosting_functor(*_default_evaluating);
 
-#ifdef LIBMESH_ENABLE_PERIODIC
-  delete _periodic_boundaries;
-#endif
 #ifdef LIBMESH_ENABLE_DIRICHLET
   delete _dirichlet_boundaries;
   for (unsigned int q = 0; q != _adjoint_dirichlet_boundaries.size(); ++q)

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -205,7 +205,6 @@ DofMap::~DofMap()
   _mesh.remove_ghosting_functor(*_default_evaluating);
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  delete _dirichlet_boundaries;
   for (unsigned int q = 0; q != _adjoint_dirichlet_boundaries.size(); ++q)
     delete _adjoint_dirichlet_boundaries[q];
 #endif


### PR DESCRIPTION
This prevents us from needing to call delete manually in destructors.