### PR TITLE
MatSetTransposeNullSpace requires PETSc >= 3.6.

### DIFF
--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -628,6 +628,9 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  jac_in,  // System Jacobian M
   // Only set the transpose nullspace if we have a way of computing it and the result is non-empty.
   if (this->transpose_nullspace || this->transpose_nullspace_object)
     {
+#if PETSC_VERSION_LESS_THAN(3,6,0)
+      libmesh_warning("MatSetTransposeNullSpace is only supported for PETSc >= 3.6, transpose nullspace will be ignored.");
+#else
       MatNullSpace msp = PETSC_NULL;
       this->build_mat_null_space(this->transpose_nullspace_object, this->transpose_nullspace, &msp);
       if (msp)
@@ -638,6 +641,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  jac_in,  // System Jacobian M
           ierr = MatNullSpaceDestroy(&msp);
           LIBMESH_CHKERR(ierr);
         }
+#endif
     }
 
   // Only set the nearnullspace if we have a way of computing it and the result is non-empty.


### PR DESCRIPTION
This feature is currently only used by MOOSE, but we never noticed it because we moved on from the PETSc 3.5.x series quite a while ago.