### PR TITLE
Manage lifetime of more class members with UniquePtrs

### DIFF
--- a/include/partitioning/parmetis_partitioner.h
+++ b/include/partitioning/parmetis_partitioner.h
@@ -117,7 +117,7 @@ private:
    * Pointer to the Parmetis-specific data structures.  Lets us avoid
    * including parmetis.h here.
    */
-  ParmetisHelper * _pmetis;
+  UniquePtr<ParmetisHelper> _pmetis;
 
 #endif
 };

--- a/include/reduced_basis/rb_eim_assembly.h
+++ b/include/reduced_basis/rb_eim_assembly.h
@@ -110,9 +110,8 @@ private:
   /**
    * We store an FE object and an associated quadrature rule.
    */
-  FEBase * _fe;
-  QBase * _qrule;
-
+  UniquePtr<FEBase> _fe;
+  UniquePtr<QBase> _qrule;
 };
 
 }

--- a/include/reduced_basis/rb_eim_construction.h
+++ b/include/reduced_basis/rb_eim_construction.h
@@ -305,7 +305,7 @@ private:
   /**
    * A mesh function to interpolate on the mesh.
    */
-  MeshFunction * _mesh_function;
+  UniquePtr<MeshFunction> _mesh_function;
 
   /**
    * We also need an extra vector in which we can store a ghosted
@@ -349,7 +349,6 @@ private:
    * The point locator tolerance.
    */
   Real _point_locator_tol;
-
 };
 
 } // namespace libMesh

--- a/include/systems/eigen_system.h
+++ b/include/systems/eigen_system.h
@@ -145,12 +145,12 @@ public:
   /**
    * The system matrix for standard eigenvalue problems.
    */
-  SparseMatrix<Number> * matrix_A;
+  UniquePtr<SparseMatrix<Number> > matrix_A;
 
   /**
    * A second system matrix for generalized eigenvalue problems.
    */
-  SparseMatrix<Number> * matrix_B;
+  UniquePtr<SparseMatrix<Number> > matrix_B;
 
   /**
    * The EigenSolver, definig which interface, i.e solver

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -1076,7 +1076,7 @@ protected:
    * Because edge rules only apply to 3D elements, we don't need to
    * worry about multiple dimensions
    */
-  QBase * _edge_qrule;
+  UniquePtr<QBase> _edge_qrule;
 
 private:
   /**

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -213,7 +213,7 @@ private:
    * header file rpc/rpc.h
    * for more information.
    */
-  XDR * xdrs;
+  UniquePtr<XDR> xdrs;
 
   /**
    * File pointer.

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -73,9 +73,6 @@ ParmetisPartitioner::ParmetisPartitioner()
 
 ParmetisPartitioner::~ParmetisPartitioner()
 {
-#ifdef LIBMESH_HAVE_PARMETIS
-  delete _pmetis;
-#endif
 }
 
 

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -53,7 +53,6 @@ RBEIMConstruction::RBEIMConstruction (EquationSystems & es,
   : Parent(es, name_in, number_in),
     best_fit_type_flag(PROJECTION_BEST_FIT),
     _parametrized_functions_in_training_set_initialized(false),
-    _mesh_function(libmesh_nullptr),
     _point_locator_tol(TOLERANCE)
 {
   _explicit_system_name = name_in + "_explicit_sys";
@@ -95,8 +94,7 @@ void RBEIMConstruction::clear()
   Parent::clear();
 
   // clear the mesh function
-  delete _mesh_function;
-  _mesh_function = libmesh_nullptr;
+  _mesh_function.reset();
 
   // clear the eim assembly vector
   for(unsigned int i=0; i<_rb_eim_assembly_objects.size(); i++)
@@ -197,10 +195,10 @@ void RBEIMConstruction::initialize_rb_construction(bool skip_matrix_assembly,
   // solution vector at quadrature points
   std::vector<unsigned int> vars;
   get_explicit_system().get_all_variable_numbers(vars);
-  _mesh_function = new MeshFunction(get_equation_systems(),
-                                    *_ghosted_meshfunction_vector,
-                                    get_explicit_system().get_dof_map(),
-                                    vars);
+  _mesh_function.reset(new MeshFunction(get_equation_systems(),
+                                        *_ghosted_meshfunction_vector,
+                                        get_explicit_system().get_dof_map(),
+                                        vars));
   _mesh_function->init();
 
   // inner_product_solver performs solves with the same matrix every time

--- a/src/solution_transfer/meshfunction_solution_transfer.C
+++ b/src/solution_transfer/meshfunction_solution_transfer.C
@@ -54,7 +54,7 @@ MeshFunctionSolutionTransfer::transfer(const Variable & from_var,
   EquationSystems & from_es = from_sys->get_equation_systems();
 
   //Create a serialized version of the solution vector
-  NumericVector<Number> * serialized_solution = NumericVector<Number>::build(from_sys->get_mesh().comm()).release();
+  UniquePtr<NumericVector<Number> > serialized_solution = NumericVector<Number>::build(from_sys->get_mesh().comm());
   serialized_solution->init(from_sys->n_dofs(), false, SERIAL);
 
   // Need to pull down a full copy of this vector on every processor
@@ -74,8 +74,6 @@ MeshFunctionSolutionTransfer::transfer(const Variable & from_var,
 
   to_sys->solution->close();
   to_sys->update();
-
-  delete serialized_solution;
 }
 
 } // namespace libMesh

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -422,7 +422,7 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
   Vec subrhs = libmesh_nullptr;
   Vec subsolution = libmesh_nullptr;
   VecScatter scatter = libmesh_nullptr;
-  PetscMatrix<Number> * subprecond_matrix = libmesh_nullptr;
+  UniquePtr<PetscMatrix<Number> > subprecond_matrix;
 
   // Set operators.  Also restrict rhs and solution vector to
   // subdomain if neccessary.
@@ -542,10 +542,9 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
 #endif
       LIBMESH_CHKERR(ierr);
 
-      if(this->_preconditioner)
+      if (this->_preconditioner)
         {
-          subprecond_matrix = new PetscMatrix<Number>(subprecond,
-                                                      this->comm());
+          subprecond_matrix.reset(new PetscMatrix<Number>(subprecond, this->comm()));
           this->_preconditioner->set_matrix(*subprecond_matrix);
           this->_preconditioner->init();
         }
@@ -636,14 +635,12 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
       ierr = LibMeshVecScatterDestroy(&scatter);
       LIBMESH_CHKERR(ierr);
 
-      if(this->_preconditioner)
+      if (this->_preconditioner)
         {
-          /* Before we delete subprecond_matrix, we should give the
-             _preconditioner a different matrix.  */
+          // Before subprecond_matrix gets cleaned up, we should give
+          // the _preconditioner a different matrix.
           this->_preconditioner->set_matrix(matrix_in);
           this->_preconditioner->init();
-          delete subprecond_matrix;
-          subprecond_matrix = libmesh_nullptr;
         }
 
       ierr = LibMeshVecDestroy(&subsolution);
@@ -694,7 +691,7 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
   Vec subrhs = libmesh_nullptr;
   Vec subsolution = libmesh_nullptr;
   VecScatter scatter = libmesh_nullptr;
-  PetscMatrix<Number> * subprecond_matrix = libmesh_nullptr;
+  UniquePtr<PetscMatrix<Number> > subprecond_matrix;
 
   // Set operators.  Also restrict rhs and solution vector to
   // subdomain if neccessary.
@@ -814,10 +811,9 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
 #endif
       LIBMESH_CHKERR(ierr);
 
-      if(this->_preconditioner)
+      if (this->_preconditioner)
         {
-          subprecond_matrix = new PetscMatrix<Number>(subprecond,
-                                                      this->comm());
+          subprecond_matrix.reset(new PetscMatrix<Number>(subprecond, this->comm()));
           this->_preconditioner->set_matrix(*subprecond_matrix);
           this->_preconditioner->init();
         }
@@ -901,14 +897,12 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
       ierr = LibMeshVecScatterDestroy(&scatter);
       LIBMESH_CHKERR(ierr);
 
-      if(this->_preconditioner)
+      if (this->_preconditioner)
         {
-          /* Before we delete subprecond_matrix, we should give the
-             _preconditioner a different matrix.  */
+          // Before subprecond_matrix gets cleaned up, we should give
+          // the _preconditioner a different matrix.
           this->_preconditioner->set_matrix(matrix_in);
           this->_preconditioner->init();
-          delete subprecond_matrix;
-          subprecond_matrix = libmesh_nullptr;
         }
 
       ierr = LibMeshVecDestroy(&subsolution);
@@ -1231,7 +1225,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
   Vec subrhs = libmesh_nullptr;
   Vec subsolution = libmesh_nullptr;
   VecScatter scatter = libmesh_nullptr;
-  PetscMatrix<Number> * subprecond_matrix = libmesh_nullptr;
+  UniquePtr<PetscMatrix<Number> > subprecond_matrix;
 
   // Close the matrices and vectors in case this wasn't already done.
   solution->close ();
@@ -1385,10 +1379,9 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
 #endif
       LIBMESH_CHKERR(ierr);
 
-      if(this->_preconditioner)
+      if (this->_preconditioner)
         {
-          subprecond_matrix = new PetscMatrix<Number>(subprecond,
-                                                      this->comm());
+          subprecond_matrix.reset(new PetscMatrix<Number>(subprecond, this->comm()));
           this->_preconditioner->set_matrix(*subprecond_matrix);
           this->_preconditioner->init();
         }
@@ -1469,14 +1462,12 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       ierr = LibMeshVecScatterDestroy(&scatter);
       LIBMESH_CHKERR(ierr);
 
-      if(this->_preconditioner)
+      if (this->_preconditioner)
         {
-          /* Before we delete subprecond_matrix, we should give the
-             _preconditioner a different matrix.  */
+          // Before subprecond_matrix gets cleaned up, we should give
+          // the _preconditioner a different matrix.
           this->_preconditioner->set_matrix(const_cast<SparseMatrix<Number> &>(precond_matrix));
           this->_preconditioner->init();
-          delete subprecond_matrix;
-          subprecond_matrix = libmesh_nullptr;
         }
 
       ierr = LibMeshVecDestroy(&subsolution);

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -49,8 +49,7 @@ FEMContext::FEMContext (const System & sys)
     _elem_dim(0), /* This will be reset in set_elem(). */
     _elem_dims(sys.get_mesh().elem_dimensions()),
     _element_qrule(4,libmesh_nullptr),
-    _side_qrule(4,libmesh_nullptr),
-    _edge_qrule(libmesh_nullptr)
+    _side_qrule(4,libmesh_nullptr)
 {
   // Reserve space for the FEAbstract and QBase objects for each
   // element dimension possiblity (0,1,2,3)
@@ -109,8 +108,8 @@ FEMContext::FEMContext (const System & sys)
       _side_qrule[dim] = hardest_fe_type.default_quadrature_rule
         (dim-1, sys.extra_quadrature_order).release();
       if (dim == 3)
-        _edge_qrule = hardest_fe_type.default_quadrature_rule
-          (1, sys.extra_quadrature_order).release();
+        _edge_qrule.reset(hardest_fe_type.default_quadrature_rule
+                          (1, sys.extra_quadrature_order).release());
 
       // Next, create finite element objects
       _element_fe_var[dim].resize(nv);
@@ -133,7 +132,7 @@ FEMContext::FEMContext (const System & sys)
               if (dim == 3)
                 {
                   _edge_fe[fe_type] = FEAbstract::build(dim, fe_type).release();
-                  _edge_fe[fe_type]->attach_quadrature_rule(_edge_qrule);
+                  _edge_fe[fe_type]->attach_quadrature_rule(_edge_qrule.get());
                 }
             }
 
@@ -176,9 +175,6 @@ FEMContext::~FEMContext()
        i != _side_qrule.end(); ++i)
     delete *i;
   _side_qrule.clear();
-
-  delete _edge_qrule;
-  _edge_qrule = libmesh_nullptr;
 }
 
 

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -483,18 +483,21 @@ template <>
 bool xdr_translate(XDR * x,
                    std::string & s)
 {
-  char * sptr = new char[xdr_MAX_STRING_LENGTH+1];
+  char sptr[xdr_MAX_STRING_LENGTH+1];
   std::copy(s.begin(), s.end(), sptr);
   sptr[s.size()] = 0;
   unsigned int length = xdr_MAX_STRING_LENGTH;
-  bool b = xdr_string(x, &sptr, length);
+
+  // Get a pointer to the beginning of the buffer.  We need to pass
+  // its address to the xdr API.
+  char * begin = sptr;
+  bool b = xdr_string(x, &begin, length);
 
   // This is necessary when reading, but inefficient when writing...
   length = cast_int<unsigned int>(std::strlen(sptr));
   s.resize(length);
   std::copy(sptr, sptr+length, s.begin());
 
-  delete [] sptr;
   return b;
 }
 

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -136,7 +136,6 @@ Xdr::Xdr (const std::string & name,
   mode(m),
   file_name(name),
 #ifdef LIBMESH_HAVE_XDR
-  xdrs(libmesh_nullptr),
   fp(libmesh_nullptr),
 #endif
   in(),
@@ -175,8 +174,8 @@ void Xdr::open (const std::string & name)
         fp = fopen(name.c_str(), (mode == ENCODE) ? "w" : "r");
         if (!fp)
           libmesh_file_error(name.c_str());
-        xdrs = new XDR;
-        xdrstdio_create (xdrs, fp, (mode == ENCODE) ? XDR_ENCODE : XDR_DECODE);
+        xdrs.reset(new XDR);
+        xdrstdio_create (xdrs.get(), fp, (mode == ENCODE) ? XDR_ENCODE : XDR_DECODE);
 #else
 
         libmesh_error_msg("ERROR: Functionality is not available.\n" \
@@ -280,9 +279,8 @@ void Xdr::close ()
 
         if (xdrs)
           {
-            xdr_destroy (xdrs);
-            delete xdrs;
-            xdrs = libmesh_nullptr;
+            xdr_destroy (xdrs.get());
+            xdrs.reset();
           }
 
         if (fp)
@@ -713,7 +711,7 @@ void Xdr::data (T & a, const char * comment_in)
 
         libmesh_assert (is_open());
 
-        xdr_translate(xdrs, a);
+        xdr_translate(xdrs.get(), a);
 
 #else
 
@@ -780,7 +778,7 @@ void Xdr::data_stream (T * val, const unsigned int len, const unsigned int line_
 
         if (size_of_type <= 4) // 32-bit types
           {
-            xdr_vector(xdrs,
+            xdr_vector(xdrs.get(),
                        (char *) val,
                        len,
                        size_of_type,
@@ -788,7 +786,7 @@ void Xdr::data_stream (T * val, const unsigned int len, const unsigned int line_
           }
         else // 64-bit types
           {
-            xdr_vector(xdrs,
+            xdr_vector(xdrs.get(),
                        (char *) val,
                        len,
                        size_of_type,
@@ -816,7 +814,7 @@ void Xdr::data_stream (T * val, const unsigned int len, const unsigned int line_
         if (size_of_type <= 4) // 32-bit types
           {
             if (len > 0)
-              xdr_vector(xdrs,
+              xdr_vector(xdrs.get(),
                          (char *) val,
                          len,
                          size_of_type,
@@ -825,7 +823,7 @@ void Xdr::data_stream (T * val, const unsigned int len, const unsigned int line_
         else // 64-bit types
           {
             if (len > 0)
-              xdr_vector(xdrs,
+              xdr_vector(xdrs.get(),
                          (char *) val,
                          len,
                          size_of_type,
@@ -921,7 +919,7 @@ void Xdr::data_stream (double * val, const unsigned int len, const unsigned int 
         libmesh_assert (this->is_open());
 
         if (len > 0)
-          xdr_vector(xdrs,
+          xdr_vector(xdrs.get(),
                      (char *) val,
                      len,
                      sizeof(double),
@@ -1020,7 +1018,7 @@ void Xdr::data_stream (float * val, const unsigned int len, const unsigned int l
         libmesh_assert (this->is_open());
 
         if (len > 0)
-          xdr_vector(xdrs,
+          xdr_vector(xdrs.get(),
                      (char *) val,
                      len,
                      sizeof(float),
@@ -1122,7 +1120,7 @@ void Xdr::data_stream (long double * val, const unsigned int len, const unsigned
         // doubles drops back to double precision, but you can still
         // write long double ASCII files of course.
         // if (len > 0)
-        //   xdr_vector(xdrs,
+        //   xdr_vector(xdrs.get(),
         //      (char *) val,
         //      len,
         //      sizeof(double),
@@ -1137,7 +1135,7 @@ void Xdr::data_stream (long double * val, const unsigned int len, const unsigned
               for (unsigned int i=0, cnt=0; i<len; i++)
                 io_buffer[cnt++] = val[i];
 
-            xdr_vector(xdrs,
+            xdr_vector(xdrs.get(),
                        (char *) &io_buffer[0],
                        len,
                        sizeof(double),
@@ -1257,7 +1255,7 @@ void Xdr::data_stream (std::complex<double> * val, const unsigned int len, const
                   io_buffer[cnt++] = val[i].imag();
                 }
 
-            xdr_vector(xdrs,
+            xdr_vector(xdrs.get(),
                        (char *) &io_buffer[0],
                        2*len,
                        sizeof(double),
@@ -1386,7 +1384,7 @@ void Xdr::data_stream (std::complex<long double> * val, const unsigned int len, 
                   io_buffer[cnt++] = val[i].imag();
                 }
 
-            xdr_vector(xdrs,
+            xdr_vector(xdrs.get(),
                        (char *) &io_buffer[0],
                        2*len,
                        sizeof(double),


### PR DESCRIPTION
This gets rid of most of the remaining manual memory management (new/delete) stuff in libmesh.