### PR TITLE
Deprecate ImplicitSystem::get_linear_solver().

### DIFF
--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -109,9 +109,15 @@ public:
    * Returns a pointer to a linear solver appropriate for use in
    * adjoint and/or sensitivity solves
    *
-   * In \p ImplicitSystem this just gives us a default LinearSolver;
-   * but it may be overridden in derived systems, e.g. to set solver
-   * parameters
+   * This function must be overridden in derived classes, since this
+   * base class does not have a valid LinearSolver to hand back a
+   * pointer to.  Its current behavior, i.e. allocating a LinearSolver
+   * and handing it back to the user, makes it very easy to leak
+   * memory, and probably won't have the intended effect, i.e. of
+   * setting some parameters on a LinearSolver that the System would
+   * later use internally.  This function is currently
+   * libmesh_deprecated() but will eventually become a libmesh_error()
+   * to call.
    */
   virtual LinearSolver<Number> * get_linear_solver() const;
 
@@ -126,6 +132,10 @@ public:
   /**
    * Releases a pointer to a linear solver acquired by
    * \p this->get_linear_solver()
+   *
+   * This function is designed to work with the now deprecated
+   * get_linear_solver() function, so its use is now deprecated as
+   * well.
    */
   virtual void release_linear_solver(LinearSolver<Number> *) const;
 

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -1381,6 +1381,17 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
 
 LinearSolver<Number> * ImplicitSystem::get_linear_solver() const
 {
+  // This function allocates memory and hands it back to the user as a
+  // naked pointer.  This makes it too easy to leak memory, and
+  // therefore this function is deprecated.  After a period of
+  // deprecation, this function will eventually be marked with a
+  // libmesh_error_msg().
+  libmesh_deprecated();
+  // libmesh_error_msg("This function should be overridden by derived classes. "
+  //                   "It does not contain a valid LinearSolver to hand back to "
+  //                   "the user, so it creates one, opening up the possibility "
+  //                   "of a memory leak.");
+
   LinearSolver<Number> * new_solver =
     LinearSolver<Number>::build(this->comm()).release();
 
@@ -1404,6 +1415,9 @@ std::pair<unsigned int, Real> ImplicitSystem::get_linear_solve_parameters() cons
 
 void ImplicitSystem::release_linear_solver(LinearSolver<Number> * s) const
 {
+  // This is the counterpart of the get_linear_solver() function, which is now deprecated.
+  libmesh_deprecated();
+
   delete s;
 }
 


### PR DESCRIPTION
Add libmesh_error_msg() that will eventually be turned on after the
function has been deprecated for a while.