### PR TITLE
get() underlying pointer before testing smart ptr

### DIFF
--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -69,7 +69,7 @@ void RBEIMAssembly::evaluate_basis_function(unsigned int var,
   LOG_SCOPE("evaluate_basis_function", "RBEIMAssembly");
 
   bool repeated_qrule = false;
-  if (_qrule != libmesh_nullptr)
+  if (_qrule.get() != libmesh_nullptr)
     {
       repeated_qrule =
         ( (element_qrule.type()      == _qrule->type()) &&


### PR DESCRIPTION
C++11 defines operator==(unique_ptr, nullptr_t), but that's not
available for anyone who has to fall back on auto_ptr.

Thanks to Simone Rossi for catching this.