### PR TITLE
Allow virtual methods for edge_fe_reinit() and elem_fe_reinit()

### DIFF
--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -679,7 +679,7 @@ public:
   /**
    * Reinitializes interior FE objects on the current geometric element
    */
-  void elem_fe_reinit(const std::vector<Point> * const pts = libmesh_nullptr);
+  virtual void elem_fe_reinit(const std::vector<Point> * const pts = libmesh_nullptr);
 
   /**
    * Reinitializes side FE objects on the current geometric element
@@ -689,7 +689,7 @@ public:
   /**
    * Reinitializes edge FE objects on the current geometric element
    */
-  void edge_fe_reinit();
+  virtual void edge_fe_reinit();
 
   /**
    * Accessor for element interior quadrature rule for the dimension of the


### PR DESCRIPTION
This way I can derive a class from fem_context() for specific cases when I don't need to recalculate the shape functions for each element. For instance, a linear QUAD4 in a uniform grid with all elements having the same shape. This saves a lot of time.

Edit: I don't understand why it fails on the check stage. I didn't make other changes. I can run the check on my machine though.