### PR TITLE
NonlinearImplicitSystem::ComputeVectorSubspace as an abstract class

### DIFF
--- a/include/systems/nonlinear_implicit_system.h
+++ b/include/systems/nonlinear_implicit_system.h
@@ -145,7 +145,7 @@ public:
      * It must be implemented by the user in a derived class.
      */
     virtual void operator()(std::vector<NumericVector<Number> *> & sp,
-                            sys_type & s);
+                            sys_type & s) = 0;
   };
 
   /**


### PR DESCRIPTION
Declaring void operator()(std::vector<NumericVector<Number> *> & sp, sys_type & s) as a pure virtual function to make the class abstract, otherwise it needs an implementation.