### PR TITLE
Fix "maybe uninitialized" warning from GCC 5.3.0.

### DIFF
--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -319,7 +319,7 @@ ParsedFunction<Output,OutputGradient>::get_inline_value (const std::string & inl
 #ifndef NDEBUG
   bool found_var_name = false;
 #endif
-  Output old_var_value;
+  Output old_var_value(0.);
 
   for (unsigned int s=0; s != _subexpressions.size(); ++s)
     {


### PR DESCRIPTION
The logic in this function ensures that it asserts in debug mode
rather than using an uninitialized variable.  In optimized mode,
old_var_value could be returned without being initialized, at best
leading to non-repeatable results.

This type of initialization should work for Real, TypeVector, and
TypeTensor.  Not sure if we really need to worry about anything
else...

```
../include/libmesh/parsed_fem_function.h: In member function 'Output libMesh::ParsedFEMFunction<Output>::get_inline_value(const string&) const [with Output = double; std::__cxx11::string = std::__cxx11::basic_string<char>]':
../include/libmesh/parsed_fem_function.h:514:10: warning: 'old_var_value' may be used uninitialized in this function [-Wmaybe-uninitialized]
   return old_var_value;
```
