### PR TITLE
Reenable p refinement of HERMITE elements

### DIFF
--- a/examples/adaptivity/adaptivity_ex3/run.sh
+++ b/examples/adaptivity/adaptivity_ex3/run.sh
@@ -13,3 +13,15 @@ run_example "$example_name" refinement_type=p
 # Some solvers still give us trouble with too much hp
 run_example "$example_name" refinement_type=hp max_r_steps=8
 run_example "$example_name" refinement_type=matchedhp max_r_steps=4
+
+# Let's get some 1D coverage too; that's cheap.
+run_example "$example_name" dimension=1 refinement_type=h
+run_example "$example_name" dimension=1 refinement_type=p
+run_example "$example_name" dimension=1 refinement_type=hp max_r_steps=8
+run_example "$example_name" dimension=1 refinement_type=matchedhp max_r_steps=4
+
+# And try out another element type
+run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=h
+run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=p
+run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=hp max_r_steps=8
+run_example "$example_name" dimension=1 approx_type=HERMITE approx_order=3 refinement_type=matchedhp max_r_steps=4

--- a/examples/adaptivity/adaptivity_ex4/run.sh
+++ b/examples/adaptivity/adaptivity_ex4/run.sh
@@ -7,5 +7,5 @@ source $LIBMESH_DIR/examples/run_common.sh
 example_name=adaptivity_ex4
 
 run_example "$example_name" approx_type=HERMITE
-run_example "$example_name" approx_type=CLOUGH
+run_example_no_extra_options "$example_name" approx_type=CLOUGH $LIBMESH_OPTIONS --n_threads=1
 #run_example "$example_name" approx_type=SECOND  # Broken?

--- a/src/fe/fe_hermite_shape_1D.C
+++ b/src/fe/fe_hermite_shape_1D.C
@@ -209,42 +209,34 @@ Real FE<1,HERMITE>::shape(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+#ifndef NDEBUG
+  const unsigned int totalorder = order + elem->p_level();
+#endif
 
-  switch (totalorder)
+  switch (type)
     {
-      // Hermite cubic shape functions
-    case THIRD:
+      // C1 functions on the C1 cubic edge
+    case EDGE2:
+    case EDGE3:
       {
-        switch (type)
-          {
-            // C1 functions on the C1 cubic edge
-          case EDGE2:
-          case EDGE3:
-            {
-              libmesh_assert_less (i, 4);
+        libmesh_assert_less (i, totalorder+1);
 
-              switch (i)
-                {
-                case 0:
-                  return FEHermite<1>::hermite_raw_shape(0, p(0));
-                case 1:
-                  return d1xd1x * FEHermite<1>::hermite_raw_shape(2, p(0));
-                case 2:
-                  return FEHermite<1>::hermite_raw_shape(1, p(0));
-                case 3:
-                  return d2xd2x * FEHermite<1>::hermite_raw_shape(3, p(0));
-                default:
-                  return FEHermite<1>::hermite_raw_shape(i, p(0));
-                }
-            }
+        switch (i)
+          {
+          case 0:
+            return FEHermite<1>::hermite_raw_shape(0, p(0));
+          case 1:
+            return d1xd1x * FEHermite<1>::hermite_raw_shape(2, p(0));
+          case 2:
+            return FEHermite<1>::hermite_raw_shape(1, p(0));
+          case 3:
+            return d2xd2x * FEHermite<1>::hermite_raw_shape(3, p(0));
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            return FEHermite<1>::hermite_raw_shape(i, p(0));
           }
       }
-      // by default throw an error
     default:
-      libmesh_error_msg("ERROR: Unsupported polynomial order = " << totalorder);
+      libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
 
   libmesh_error_msg("We'll never get here!");
@@ -284,40 +276,34 @@ Real FE<1,HERMITE>::shape_deriv(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+#ifndef NDEBUG
+  const unsigned int totalorder = order + elem->p_level();
+#endif
 
-  switch (totalorder)
+  switch (type)
     {
-      // Hermite cubic shape functions
-    case THIRD:
+      // C1 functions on the C1 cubic edge
+    case EDGE2:
+    case EDGE3:
       {
-        switch (type)
+        libmesh_assert_less (i, totalorder+1);
+
+        switch (i)
           {
-            // C1 functions on the C1 cubic edge
-          case EDGE2:
-          case EDGE3:
-            {
-              switch (i)
-                {
-                case 0:
-                  return FEHermite<1>::hermite_raw_shape_deriv(0, p(0));
-                case 1:
-                  return d1xd1x * FEHermite<1>::hermite_raw_shape_deriv(2, p(0));
-                case 2:
-                  return FEHermite<1>::hermite_raw_shape_deriv(1, p(0));
-                case 3:
-                  return d2xd2x * FEHermite<1>::hermite_raw_shape_deriv(3, p(0));
-                default:
-                  return FEHermite<1>::hermite_raw_shape_deriv(i, p(0));
-                }
-            }
+          case 0:
+            return FEHermite<1>::hermite_raw_shape_deriv(0, p(0));
+          case 1:
+            return d1xd1x * FEHermite<1>::hermite_raw_shape_deriv(2, p(0));
+          case 2:
+            return FEHermite<1>::hermite_raw_shape_deriv(1, p(0));
+          case 3:
+            return d2xd2x * FEHermite<1>::hermite_raw_shape_deriv(3, p(0));
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            return FEHermite<1>::hermite_raw_shape_deriv(i, p(0));
           }
       }
-      // by default throw an error
     default:
-      libmesh_error_msg("ERROR: Unsupported polynomial order = " << totalorder);
+      libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
 
   libmesh_error_msg("We'll never get here!");
@@ -344,40 +330,34 @@ Real FE<1,HERMITE>::shape_second_deriv(const Elem * elem,
 
   const ElemType type = elem->type();
 
-  const Order totalorder = static_cast<Order>(order + elem->p_level());
+#ifndef NDEBUG
+  const unsigned int totalorder = order + elem->p_level();
+#endif
 
-  switch (totalorder)
+  switch (type)
     {
-      // Hermite cubic shape functions
-    case THIRD:
+      // C1 functions on the C1 cubic edge
+    case EDGE2:
+    case EDGE3:
       {
-        switch (type)
+        libmesh_assert_less (i, totalorder+1);
+
+        switch (i)
           {
-            // C1 functions on the C1 cubic edge
-          case EDGE2:
-          case EDGE3:
-            {
-              switch (i)
-                {
-                case 0:
-                  return FEHermite<1>::hermite_raw_shape_second_deriv(0, p(0));
-                case 1:
-                  return d1xd1x * FEHermite<1>::hermite_raw_shape_second_deriv(2, p(0));
-                case 2:
-                  return FEHermite<1>::hermite_raw_shape_second_deriv(1, p(0));
-                case 3:
-                  return d2xd2x * FEHermite<1>::hermite_raw_shape_second_deriv(3, p(0));
-                default:
-                  return FEHermite<1>::hermite_raw_shape_second_deriv(i, p(0));
-                }
-            }
+          case 0:
+            return FEHermite<1>::hermite_raw_shape_second_deriv(0, p(0));
+          case 1:
+            return d1xd1x * FEHermite<1>::hermite_raw_shape_second_deriv(2, p(0));
+          case 2:
+            return FEHermite<1>::hermite_raw_shape_second_deriv(1, p(0));
+          case 3:
+            return d2xd2x * FEHermite<1>::hermite_raw_shape_second_deriv(3, p(0));
           default:
-            libmesh_error_msg("ERROR: Unsupported element type = " << type);
+            return FEHermite<1>::hermite_raw_shape_second_deriv(i, p(0));
           }
       }
-      // by default throw an error
     default:
-      libmesh_error_msg("ERROR: Unsupported polynomial order = " << totalorder);
+      libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
 
   libmesh_error_msg("We'll never get here!");

--- a/src/fe/fe_hermite_shape_1D.C
+++ b/src/fe/fe_hermite_shape_1D.C
@@ -194,7 +194,7 @@ Real FE<1,HERMITE>::shape(const ElemType,
 
 template <>
 Real FE<1,HERMITE>::shape(const Elem * elem,
-                          const Order order,
+                          const Order libmesh_dbg_var(order),
                           const unsigned int i,
                           const Point & p)
 {
@@ -260,7 +260,7 @@ Real FE<1,HERMITE>::shape_deriv(const ElemType,
 
 template <>
 Real FE<1,HERMITE>::shape_deriv(const Elem * elem,
-                                const Order order,
+                                const Order libmesh_dbg_var(order),
                                 const unsigned int i,
                                 const unsigned int,
                                 const Point & p)
@@ -314,7 +314,7 @@ Real FE<1,HERMITE>::shape_deriv(const Elem * elem,
 
 template <>
 Real FE<1,HERMITE>::shape_second_deriv(const Elem * elem,
-                                       const Order order,
+                                       const Order libmesh_dbg_var(order),
                                        const unsigned int i,
                                        const unsigned int,
                                        const Point & p)


### PR DESCRIPTION
I need to go through the 2D and 3D codes too, which may be more complicated, but this should get @jwpeterson going on his 3rd order problem.

While I'm at it I manually disabled threads in our CLOUGH example test; that should get us clean in BuildBot again.