### PR TITLE
Removed overzealous assert

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -76,7 +76,6 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
 {
   // We're assuming our subclass data needs no copy
   libmesh_assert_equal_to (_n_parts, other_mesh._n_parts);
-  libmesh_assert (std::equal(_elem_dims.begin(), _elem_dims.end(), other_mesh._elem_dims.begin()));
   libmesh_assert_equal_to (_is_prepared, other_mesh._is_prepared);
 
   // We're assuming the other mesh has proper element number ordering,


### PR DESCRIPTION
I hit this assert when I called ReplicatedMesh::stitch_meshes to connect a 1D mesh and 2D mesh. It looks like it's an overzealous assert, now that we support multi-dimensional meshes.