### PR TITLE
Add --redirect-ouput [filename] option

### DIFF
--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -1765,7 +1765,7 @@ GetPot::search(const char* Option)
     return false;
 
   // (*) second loop from 0 to old cursor position
-  for (unsigned c = 1; c < OldCursor; c++)
+  for (unsigned c = 1; c <= OldCursor; c++)
     {
       if (argv[c] == SearchTerm)
         {


### PR DESCRIPTION
This turned out to be a bit more involved than I thought it was going to be, and I ended up fixing two other bugs in the process.

1. The first was that we were calling `command_line->parse_command_line()` without first clearing the existing `command_line` object, so the `GetPot` object actually had two copies of `argv`.  No telling what else this might affect, but hopefully nothing.
1. Fixing the first bug led me to uncover an off-by-one bug in `GetPot` which had been covered up by us having two copies of all the command line args all this time.

Refs #1159.
