### PR TITLE
MeshBase option to stop delete_remote_elements()

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -646,6 +646,10 @@ public:
    *
    * The argument to skip renumbering is now deprecated - to prevent a
    * mesh from being renumbered, set allow_renumbering(false).
+   *
+   * If this is a distributed mesh, local copies of remote elements
+   * will be deleted here - to keep those elements replicated during
+   * preparation, set allow_remote_element_removal(false).
    */
   void prepare_for_use (const bool skip_renumber_nodes_and_elements=false, const bool skip_find_neighbors=false);
 
@@ -678,6 +682,15 @@ public:
    */
   void allow_renumbering(bool allow) { _skip_renumber_nodes_and_elements = !allow; }
   bool allow_renumbering() const { return !_skip_renumber_nodes_and_elements; }
+
+  /**
+   * If false is passed in then this mesh will no longer have remote
+   * elements deleted when being prepared for use; i.e. even a
+   * DistributedMesh will remain (if it is already) serialized.
+   * This may adversely affect performance and memory use.
+   */
+  void allow_remote_element_removal(bool allow) { _allow_remote_element_removal = allow; }
+  bool allow_remote_element_removal() const { return _allow_remote_element_removal; }
 
   /**
    * If true is passed in then this mesh will no longer be (re)partitioned.
@@ -1243,6 +1256,14 @@ protected:
    * This is set when prepare_for_use() is called.
    */
   bool _skip_renumber_nodes_and_elements;
+
+  /**
+   * If this is false then even on DistributedMesh remote elements
+   * will not be deleted during mesh preparation.
+   *
+   * This is true by default.
+   */
+  bool _allow_remote_element_removal;
 
   /**
    * This structure maintains the mapping of named blocks

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -60,6 +60,7 @@ MeshBase::MeshBase (const Parallel::Communicator & comm_in,
 #endif
   _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false),
+  _allow_remote_element_removal(true),
   _spatial_dimension(d),
   _default_ghosting(new GhostPointNeighbors(*this))
 {
@@ -84,6 +85,7 @@ MeshBase::MeshBase (unsigned char d) :
 #endif
   _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false),
+  _allow_remote_element_removal(true),
   _spatial_dimension(d),
   _default_ghosting(new GhostPointNeighbors(*this))
 {
@@ -109,6 +111,7 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
 #endif
   _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false),
+  _allow_remote_element_removal(true),
   _elem_dims(other_mesh._elem_dims),
   _spatial_dimension(other_mesh._spatial_dimension),
   _default_ghosting(new GhostPointNeighbors(*this)),
@@ -256,8 +259,10 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
   // Partition the mesh.
   this->partition();
 
-  // If we're using DistributedMesh, we'll want it parallelized.
-  this->delete_remote_elements();
+  // If we're using DistributedMesh, we'll probably want it
+  // parallelized.
+  if (this->_allow_remote_element_removal)
+    this->delete_remote_elements();
 
   if(!_skip_renumber_nodes_and_elements)
     this->renumber_nodes_and_elements();


### PR DESCRIPTION
This ought to be useful in cases where users don't want to add
GhostingFunctors and limit remote element deletion until after the
initial Mesh preparation.