### PR TITLE
Fix unused variable warning in ParsedFEMFunction

### DIFF
--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -450,7 +450,7 @@ ParsedFEMFunction<Output>::get_inline_value(const std::string & inline_var_name)
 #ifndef NDEBUG
   bool found_var_name = false;
 #endif
-  Output old_var_value;
+  Output old_var_value(0.);
 
   for (unsigned int s=0; s != _subexpressions.size(); ++s)
     {


### PR DESCRIPTION
@jwpeterson added a workaround for nearly the same overzealous warning in
https://github.com/libMesh/libmesh/pull/1157
but missed this one.