### PR TITLE
Set up SLEPc defines for major, minor, subminor version numbers.

### DIFF
--- a/configure
+++ b/configure
@@ -36925,6 +36925,24 @@ $as_echo "#define HAVE_SLEPC 1" >>confdefs.h
 
 
 
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_SLEPC_VERSION_MAJOR $slepcmajor
+_ACEOF
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_SLEPC_VERSION_MINOR $slepcminor
+_ACEOF
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_SLEPC_VERSION_SUBMINOR $slepcsubminor
+_ACEOF
+
+
 else
 
             { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -85,6 +85,15 @@
 /* PETSc's subminor version number, as detected by petsc.m4 */
 #undef DETECTED_PETSC_VERSION_SUBMINOR
 
+/* SLEPc's major version number, as detected by slepc.m4 */
+#undef DETECTED_SLEPC_VERSION_MAJOR
+
+/* SLEPc's minor version number, as detected by slepc.m4 */
+#undef DETECTED_SLEPC_VERSION_MINOR
+
+/* SLEPc's subminor version number, as detected by slepc.m4 */
+#undef DETECTED_SLEPC_VERSION_SUBMINOR
+
 /* TBB's major version number, as detected by tbb.m4 */
 #undef DETECTED_TBB_VERSION_MAJOR
 

--- a/include/solvers/slepc_macro.h
+++ b/include/solvers/slepc_macro.h
@@ -20,26 +20,21 @@
 #ifndef LIBMESH_SLEPC_MACRO_H
 #define LIBMESH_SLEPC_MACRO_H
 
-// C++ includes
-
 // Local includes
+#include "libmesh/libmesh_config.h"
 
-/**
- * SLEPc include files. SLEPc can only be used
- * together with PETSc.
- */
+// SLEPc include files. SLEPc can only be used
+// together with PETSc.
 #ifdef LIBMESH_HAVE_SLEPC
-
-# include <slepcversion.h>
 
 // A convenient macro for comparing SLEPc versions.
 // Returns 1 if the current SLEPc version is < major.minor.subminor
 // and zero otherwise.
 #define SLEPC_VERSION_LESS_THAN(major,minor,subminor)                   \
-  ((SLEPC_VERSION_MAJOR < (major) ||                                    \
-    (SLEPC_VERSION_MAJOR == (major) && (SLEPC_VERSION_MINOR < (minor) || \
-                                        (SLEPC_VERSION_MINOR == (minor) && \
-                                         SLEPC_VERSION_SUBMINOR < (subminor))))) ? 1 : 0)
+  ((LIBMESH_DETECTED_SLEPC_VERSION_MAJOR < (major) ||                   \
+    (LIBMESH_DETECTED_SLEPC_VERSION_MAJOR == (major) && (LIBMESH_DETECTED_SLEPC_VERSION_MINOR < (minor) || \
+                                                         (LIBMESH_DETECTED_SLEPC_VERSION_MINOR == (minor) && \
+                                                          LIBMESH_DETECTED_SLEPC_VERSION_SUBMINOR < (subminor))))) ? 1 : 0)
 
 // Make up for missing extern "C" in old SLEPc versions
 #if !defined(LIBMESH_USE_COMPLEX_NUMBERS) && SLEPC_VERSION_LESS_THAN(3,0,0)

--- a/m4/slepc.m4
+++ b/m4/slepc.m4
@@ -143,6 +143,15 @@ AC_DEFUN([CONFIGURE_SLEPC],
             AC_DEFINE(HAVE_SLEPC, 1, [Flag indicating whether or not SLEPc is available])
             AC_SUBST(SLEPC_INCLUDE)
             AC_SUBST(SLEPC_LIBS)
+
+            AC_DEFINE_UNQUOTED(DETECTED_SLEPC_VERSION_MAJOR, [$slepcmajor],
+              [SLEPc's major version number, as detected by slepc.m4])
+
+            AC_DEFINE_UNQUOTED(DETECTED_SLEPC_VERSION_MINOR, [$slepcminor],
+              [SLEPc's minor version number, as detected by slepc.m4])
+
+            AC_DEFINE_UNQUOTED(DETECTED_SLEPC_VERSION_SUBMINOR, [$slepcsubminor],
+              [SLEPc's subminor version number, as detected by slepc.m4])
           ],[
             AC_MSG_RESULT(no)
             AC_MSG_RESULT(<<< Compiling trivial SLEPc program failed. SLEPc disabled. >>>)


### PR DESCRIPTION
We had also been getting away with not including "libmesh/libmesh_config.h" in slepc_macro.h all this time (slepc_macro.h was only ever included after libmesh_config.h whenever it was used) so fixed that issue as well.

Refs #1174.