### PR TITLE
Do not set VTK_LEGACY_REMOVE.

### DIFF
--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -32,9 +32,6 @@
 
 #ifdef LIBMESH_HAVE_VTK
 
-// Tell VTK not to use old header files
-#define VTK_LEGACY_REMOVE
-
 // I get a lot of "warning: extra ';' inside a class [-Wextra-semi]" from clang
 // on VTK header files.
 #include "libmesh/ignore_warnings.h"


### PR DESCRIPTION
This was causing strange crashes for me in VTK-7.1, we may have been
using it incorrectly all this time.

Refs #1173.