### PR TITLE
PointLocatorBase::locate_node()

### DIFF
--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -117,10 +117,15 @@ public:
    * Optionally allows the user to restrict the subdomains searched;
    * with such a restriction, only a Node belonging to an element on
    * one or more of those subdomains will be returned.
+   *
+   * Will only return a Node whose distance from \p p is less than
+   * \p tol multiplied by the size of a semilocal element which
+   * contains \p p.
    */
   virtual const Node * locate_node
     (const Point & p,
-     const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr) const;
+     const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr,
+     Real tol = TOLERANCE) const;
 
   /**
    * @returns \p true when this object is properly initialized

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -41,6 +41,7 @@ class MeshBase;
 class Point;
 class TreeBase;
 class Elem;
+class Node;
 
 
 
@@ -105,6 +106,21 @@ public:
   virtual void operator() (const Point & p,
                            std::set<const Elem *> & candidate_elements,
                            const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr) const = 0;
+
+  /**
+   * Locates a Node with global coordinates \p p or returns NULL if no
+   * such Node can be found.
+   *
+   * Virtual so subclasses can override for efficiency, but has a
+   * default implementation that works based on element lookup.
+   *
+   * Optionally allows the user to restrict the subdomains searched;
+   * with such a restriction, only a Node belonging to an element on
+   * one or more of those subdomains will be returned.
+   */
+  virtual const Node * locate_node
+    (const Point & p,
+     const std::set<subdomain_id_type> * allowed_subdomains = libmesh_nullptr) const;
 
   /**
    * @returns \p true when this object is properly initialized

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -24,6 +24,8 @@
 #include "libmesh/point_locator_base.h"
 #include "libmesh/point_locator_tree.h"
 
+#include "libmesh/elem.h"
+
 namespace libMesh
 {
 
@@ -94,6 +96,29 @@ void PointLocatorBase::unset_close_to_point_tol ()
 {
   _use_close_to_point_tol = false;
   _close_to_point_tol = TOLERANCE;
+}
+
+
+const Node *
+PointLocatorBase::locate_node
+  (const Point & p,
+   const std::set<subdomain_id_type> * allowed_subdomains) const
+{
+  std::set<const Elem *> candidate_elements;
+  this->operator()(p, candidate_elements, allowed_subdomains);
+
+  for (std::set<const Elem *>::const_iterator
+         it = candidate_elements.begin();
+         it != candidate_elements.end(); ++it)
+    {
+      const Elem * elem = *it;
+      const int elem_n_nodes = elem->n_nodes();
+      for (int n=0; n != elem_n_nodes; ++n)
+        if (elem->point(n) == p)
+          return elem->node_ptr(n);
+    }
+
+  return libmesh_nullptr;
 }
 
 } // namespace libMesh

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -102,7 +102,8 @@ void PointLocatorBase::unset_close_to_point_tol ()
 const Node *
 PointLocatorBase::locate_node
   (const Point & p,
-   const std::set<subdomain_id_type> * allowed_subdomains) const
+   const std::set<subdomain_id_type> * allowed_subdomains,
+   Real tol) const
 {
   std::set<const Elem *> candidate_elements;
   this->operator()(p, candidate_elements, allowed_subdomains);
@@ -113,8 +114,11 @@ PointLocatorBase::locate_node
     {
       const Elem * elem = *it;
       const int elem_n_nodes = elem->n_nodes();
+      const Real hmax = elem->hmax();
+      const Real dist_tol_sq = (tol * hmax) * (tol * hmax);
+
       for (int n=0; n != elem_n_nodes; ++n)
-        if (elem->point(n) == p)
+        if ((elem->point(n) - p).norm_sq() < dist_tol_sq)
           return elem->node_ptr(n);
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,6 +64,7 @@ unit_tests_sources = \
   solvers/second_order_unsteady_solver_test.C \
   systems/equation_systems_test.C \
   systems/systems_test.C \
+  utils/point_locator_test.C \
   utils/vectormap_test.C
 
 #EXTRA_DIST = base/getpot_test_input.in

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -204,7 +204,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/vectormap_test.C fparser/autodiff.C
+	utils/point_locator_test.C utils/vectormap_test.C \
+	fparser/autodiff.C
 am__dirstamp = $(am__leading_dot)dirstamp
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_1 = fparser/unit_tests_dbg-autodiff.$(OBJEXT)
 am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
@@ -255,6 +256,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	solvers/unit_tests_dbg-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_dbg-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_dbg-systems_test.$(OBJEXT) \
+	utils/unit_tests_dbg-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_dbg-vectormap_test.$(OBJEXT) $(am__objects_1)
 @LIBMESH_DBG_MODE_TRUE@am_unit_tests_dbg_OBJECTS = $(am__objects_2)
 unit_tests_dbg_OBJECTS = $(am_unit_tests_dbg_OBJECTS)
@@ -298,7 +300,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/vectormap_test.C fparser/autodiff.C
+	utils/point_locator_test.C utils/vectormap_test.C \
+	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_3 = fparser/unit_tests_devel-autodiff.$(OBJEXT)
 am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	base/unit_tests_devel-default_coupling_test.$(OBJEXT) \
@@ -348,6 +351,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	solvers/unit_tests_devel-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_devel-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_devel-systems_test.$(OBJEXT) \
+	utils/unit_tests_devel-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_devel-vectormap_test.$(OBJEXT) \
 	$(am__objects_3)
 @LIBMESH_DEVEL_MODE_TRUE@am_unit_tests_devel_OBJECTS =  \
@@ -389,7 +393,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/vectormap_test.C fparser/autodiff.C
+	utils/point_locator_test.C utils/vectormap_test.C \
+	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_5 = fparser/unit_tests_oprof-autodiff.$(OBJEXT)
 am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	base/unit_tests_oprof-default_coupling_test.$(OBJEXT) \
@@ -439,6 +444,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	solvers/unit_tests_oprof-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_oprof-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_oprof-systems_test.$(OBJEXT) \
+	utils/unit_tests_oprof-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_oprof-vectormap_test.$(OBJEXT) \
 	$(am__objects_5)
 @LIBMESH_OPROF_MODE_TRUE@am_unit_tests_oprof_OBJECTS =  \
@@ -480,7 +486,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/vectormap_test.C fparser/autodiff.C
+	utils/point_locator_test.C utils/vectormap_test.C \
+	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_7 = fparser/unit_tests_opt-autodiff.$(OBJEXT)
 am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	base/unit_tests_opt-default_coupling_test.$(OBJEXT) \
@@ -530,6 +537,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	solvers/unit_tests_opt-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_opt-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_opt-systems_test.$(OBJEXT) \
+	utils/unit_tests_opt-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_opt-vectormap_test.$(OBJEXT) $(am__objects_7)
 @LIBMESH_OPT_MODE_TRUE@am_unit_tests_opt_OBJECTS = $(am__objects_8)
 unit_tests_opt_OBJECTS = $(am_unit_tests_opt_OBJECTS)
@@ -569,7 +577,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/vectormap_test.C fparser/autodiff.C
+	utils/point_locator_test.C utils/vectormap_test.C \
+	fparser/autodiff.C
 @LIBMESH_ENABLE_FPARSER_TRUE@am__objects_9 = fparser/unit_tests_prof-autodiff.$(OBJEXT)
 am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	base/unit_tests_prof-default_coupling_test.$(OBJEXT) \
@@ -619,6 +628,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	solvers/unit_tests_prof-second_order_unsteady_solver_test.$(OBJEXT) \
 	systems/unit_tests_prof-equation_systems_test.$(OBJEXT) \
 	systems/unit_tests_prof-systems_test.$(OBJEXT) \
+	utils/unit_tests_prof-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_prof-vectormap_test.$(OBJEXT) \
 	$(am__objects_9)
 @LIBMESH_PROF_MODE_TRUE@am_unit_tests_prof_OBJECTS =  \
@@ -1076,7 +1086,8 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
 	systems/equation_systems_test.C systems/systems_test.C \
-	utils/vectormap_test.C $(am__append_1)
+	utils/point_locator_test.C utils/vectormap_test.C \
+	$(am__append_1)
 @LIBMESH_OPT_MODE_TRUE@unit_tests_opt_SOURCES = $(unit_tests_sources)
 @LIBMESH_OPT_MODE_TRUE@unit_tests_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
 @LIBMESH_OPT_MODE_TRUE@unit_tests_opt_CXXFLAGS = $(CXXFLAGS_OPT)
@@ -1309,6 +1320,8 @@ utils/$(am__dirstamp):
 utils/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) utils/$(DEPDIR)
 	@: > utils/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_dbg-point_locator_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_dbg-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 fparser/$(am__dirstamp):
@@ -1418,6 +1431,8 @@ systems/unit_tests_devel-equation_systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
 systems/unit_tests_devel-systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_devel-point_locator_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_devel-vectormap_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 fparser/unit_tests_devel-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
@@ -1521,6 +1536,8 @@ systems/unit_tests_oprof-equation_systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
 systems/unit_tests_oprof-systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_oprof-point_locator_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_oprof-vectormap_test.$(OBJEXT):  \
 	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 fparser/unit_tests_oprof-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
@@ -1624,6 +1641,8 @@ systems/unit_tests_opt-equation_systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
 systems/unit_tests_opt-systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_opt-point_locator_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_opt-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 fparser/unit_tests_opt-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
@@ -1727,6 +1746,8 @@ systems/unit_tests_prof-equation_systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
 systems/unit_tests_prof-systems_test.$(OBJEXT):  \
 	systems/$(am__dirstamp) systems/$(DEPDIR)/$(am__dirstamp)
+utils/unit_tests_prof-point_locator_test.$(OBJEXT):  \
+	utils/$(am__dirstamp) utils/$(DEPDIR)/$(am__dirstamp)
 utils/unit_tests_prof-vectormap_test.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 fparser/unit_tests_prof-autodiff.$(OBJEXT): fparser/$(am__dirstamp) \
@@ -1998,10 +2019,15 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@systems/$(DEPDIR)/unit_tests_opt-systems_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@systems/$(DEPDIR)/unit_tests_prof-equation_systems_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@systems/$(DEPDIR)/unit_tests_prof-systems_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Po@am__quote@
 
 .C.o:
@@ -2699,6 +2725,20 @@ systems/unit_tests_dbg-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='systems/systems_test.C' object='systems/unit_tests_dbg-systems_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_dbg-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
+
+utils/unit_tests_dbg-point_locator_test.o: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Tpo -c -o utils/unit_tests_dbg-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_dbg-point_locator_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+
+utils/unit_tests_dbg-point_locator_test.obj: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-point_locator_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Tpo -c -o utils/unit_tests_dbg-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_dbg-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_dbg-point_locator_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_dbg-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
 
 utils/unit_tests_dbg-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_dbg-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_dbg-vectormap_test.Tpo -c -o utils/unit_tests_dbg-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C
@@ -3400,6 +3440,20 @@ systems/unit_tests_devel-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_devel-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
 
+utils/unit_tests_devel-point_locator_test.o: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Tpo -c -o utils/unit_tests_devel-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_devel-point_locator_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+
+utils/unit_tests_devel-point_locator_test.obj: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-point_locator_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Tpo -c -o utils/unit_tests_devel-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_devel-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_devel-point_locator_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_devel-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+
 utils/unit_tests_devel-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_devel-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Tpo -c -o utils/unit_tests_devel-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Tpo utils/$(DEPDIR)/unit_tests_devel-vectormap_test.Po
@@ -4099,6 +4153,20 @@ systems/unit_tests_oprof-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='systems/systems_test.C' object='systems/unit_tests_oprof-systems_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_oprof-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
+
+utils/unit_tests_oprof-point_locator_test.o: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Tpo -c -o utils/unit_tests_oprof-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_oprof-point_locator_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+
+utils/unit_tests_oprof-point_locator_test.obj: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-point_locator_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Tpo -c -o utils/unit_tests_oprof-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_oprof-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_oprof-point_locator_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_oprof-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
 
 utils/unit_tests_oprof-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_oprof-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_oprof-vectormap_test.Tpo -c -o utils/unit_tests_oprof-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C
@@ -4800,6 +4868,20 @@ systems/unit_tests_opt-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_opt-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
 
+utils/unit_tests_opt-point_locator_test.o: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Tpo -c -o utils/unit_tests_opt-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_opt-point_locator_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+
+utils/unit_tests_opt-point_locator_test.obj: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-point_locator_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Tpo -c -o utils/unit_tests_opt-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_opt-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_opt-point_locator_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_opt-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+
 utils/unit_tests_opt-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_opt-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Tpo -c -o utils/unit_tests_opt-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Tpo utils/$(DEPDIR)/unit_tests_opt-vectormap_test.Po
@@ -5499,6 +5581,20 @@ systems/unit_tests_prof-systems_test.obj: systems/systems_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='systems/systems_test.C' object='systems/unit_tests_prof-systems_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o systems/unit_tests_prof-systems_test.obj `if test -f 'systems/systems_test.C'; then $(CYGPATH_W) 'systems/systems_test.C'; else $(CYGPATH_W) '$(srcdir)/systems/systems_test.C'; fi`
+
+utils/unit_tests_prof-point_locator_test.o: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-point_locator_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Tpo -c -o utils/unit_tests_prof-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_prof-point_locator_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-point_locator_test.o `test -f 'utils/point_locator_test.C' || echo '$(srcdir)/'`utils/point_locator_test.C
+
+utils/unit_tests_prof-point_locator_test.obj: utils/point_locator_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-point_locator_test.obj -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Tpo -c -o utils/unit_tests_prof-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Tpo utils/$(DEPDIR)/unit_tests_prof-point_locator_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='utils/point_locator_test.C' object='utils/unit_tests_prof-point_locator_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o utils/unit_tests_prof-point_locator_test.obj `if test -f 'utils/point_locator_test.C'; then $(CYGPATH_W) 'utils/point_locator_test.C'; else $(CYGPATH_W) '$(srcdir)/utils/point_locator_test.C'; fi`
 
 utils/unit_tests_prof-vectormap_test.o: utils/vectormap_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT utils/unit_tests_prof-vectormap_test.o -MD -MP -MF utils/$(DEPDIR)/unit_tests_prof-vectormap_test.Tpo -c -o utils/unit_tests_prof-vectormap_test.o `test -f 'utils/vectormap_test.C' || echo '$(srcdir)/'`utils/vectormap_test.C

--- a/tests/utils/point_locator_test.C
+++ b/tests/utils/point_locator_test.C
@@ -1,0 +1,122 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/mesh.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/elem.h>
+#include <libmesh/node.h>
+
+#include "test_comm.h"
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+using namespace libMesh;
+
+
+
+class PointLocatorTest : public CppUnit::TestCase {
+public:
+  CPPUNIT_TEST_SUITE( PointLocatorTest );
+
+  CPPUNIT_TEST( testLocatorOnEdge3 );
+  CPPUNIT_TEST( testLocatorOnQuad9 );
+  CPPUNIT_TEST( testLocatorOnTri6 );
+  CPPUNIT_TEST( testLocatorOnHex27 );
+
+  CPPUNIT_TEST_SUITE_END();
+
+private:
+
+public:
+  void setUp()
+  {}
+
+  void tearDown()
+  {}
+
+  void testLocator(const ElemType elem_type)
+  {
+    Mesh mesh(*TestCommWorld);
+
+    const unsigned n_elem_per_side = 5;
+    const UniquePtr<Elem> test_elem = Elem::build(elem_type);
+    const Real ymax = test_elem->dim() > 1;
+    const Real zmax = test_elem->dim() > 2;
+    const unsigned int ny = ymax * n_elem_per_side;
+    const unsigned int nz = zmax * n_elem_per_side;
+
+    MeshTools::Generation::build_cube (mesh,
+                                       n_elem_per_side,
+                                       ny,
+                                       nz,
+                                       0., 1.,
+                                       0., ymax,
+                                       0., zmax,
+                                       elem_type);
+
+    UniquePtr<PointLocatorBase> locator = mesh.sub_point_locator();
+
+    for (unsigned int i=0; i != n_elem_per_side+1; ++i)
+      {
+        for (unsigned int j=0; j != ny+1; ++j)
+          {
+            for (unsigned int k=0; k != nz+1; ++k)
+              {
+                const libMesh::Real h = libMesh::Real(1)/n_elem_per_side;
+                Point p(i*h, j*h, k*h);
+
+                const Elem *elem = locator->operator()(p);
+
+                bool found_elem = elem;
+                if (!mesh.is_serial())
+                  mesh.comm().max(found_elem);
+
+                CPPUNIT_ASSERT(found_elem);
+                if (elem)
+                  {
+                    CPPUNIT_ASSERT(elem->contains_point(p));
+                  }
+
+                const Node *node = locator->locate_node(p);
+
+                bool found_node = node;
+                if (!mesh.is_serial())
+                  mesh.comm().max(found_node);
+
+                CPPUNIT_ASSERT(found_node);
+
+                if (node)
+                  {
+                    CPPUNIT_ASSERT_DOUBLES_EQUAL((*node)(0), i*h,
+                                                 TOLERANCE*TOLERANCE);
+                    CPPUNIT_ASSERT_DOUBLES_EQUAL((*node)(1), j*h,
+                                                 TOLERANCE*TOLERANCE);
+                    CPPUNIT_ASSERT_DOUBLES_EQUAL((*node)(2), k*h,
+                                                 TOLERANCE*TOLERANCE);
+                  }
+              }
+          }
+      }
+  }
+
+
+
+  void testLocatorOnEdge3() { testLocator(EDGE3); }
+  void testLocatorOnQuad9() { testLocator(QUAD9); }
+  void testLocatorOnTri6()  { testLocator(TRI6); }
+  void testLocatorOnHex27() { testLocator(HEX27); }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( PointLocatorTest );


### PR DESCRIPTION
I found myself writing this in an app code, then realizing how easy it was to get wrong due to AMR and tolerance corner cases, then moving it into libMesh because if I ever have to write it again I don't want to have to make and fix the same mistakes again.