### PR TITLE
VTK-7.1 fixes involving vtkMPIController

### DIFF
--- a/configure
+++ b/configure
@@ -40070,7 +40070,7 @@ $as_echo "VTK header files not found!" >&6; }
          fi
 
                   if (test $vtkmajor -eq 5); then
-           VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
+           VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging -lvtkParallel"
 
                            elif (test $vtkmajor -eq 6 -a $vtkminor -le 1); then
            VTK_LIBRARY_WITH_VERSION="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
@@ -40185,6 +40185,8 @@ rm -f core conftest.err conftest.$ac_objext \
                       if (test x$enablevtk = xno); then
              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Linking a test program against the VTK libraries failed >>>" >&5
 $as_echo "<<< Linking a test program against the VTK libraries failed >>>" >&6; }
+             { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< libMesh requires VTK to be configured with -DVTK_Group_MPI:BOOL=ON >>>" >&5
+$as_echo "<<< libMesh requires VTK to be configured with -DVTK_Group_MPI:BOOL=ON >>>" >&6; }
            fi
 
                       LIBS="$old_LIBS"
@@ -40194,119 +40196,47 @@ $as_echo "<<< Linking a test program against the VTK libraries failed >>>" >&6; 
            LIBS="$old_LIBS $VTK_RPATH_FLAGS $VTK_LIBRARY"
            CPPFLAGS="$CPPFLAGS -I$VTK_INC"
 
-                      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkIO" >&5
-$as_echo_n "checking for main in -lvtkIO... " >&6; }
-if ${ac_cv_lib_vtkIO_main+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+                                 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
+             #include "vtkSmartPointer.h"
+             #include "vtkCellArray.h"
+             #include "vtkUnstructuredGrid.h"
+             #include "vtkPoints.h"
+             #include "vtkDoubleArray.h"
+             #include "vtkXMLPUnstructuredGridWriter.h"
+             #include "vtkImageThreshold.h"
+             #include "vtkMPIController.h"
 
 int
 main ()
 {
-return main ();
+
+             vtkSmartPointer<vtkCellArray> cells = vtkSmartPointer<vtkCellArray>::New();
+             vtkSmartPointer<vtkUnstructuredGrid> grid = vtkSmartPointer<vtkUnstructuredGrid>::New();
+             vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+             vtkSmartPointer<vtkDoubleArray> pcoords = vtkSmartPointer<vtkDoubleArray>::New();
+             vtkSmartPointer<vtkXMLPUnstructuredGridWriter> writer = vtkSmartPointer<vtkXMLPUnstructuredGridWriter>::New();
+             vtkSmartPointer<vtkImageThreshold> threshold = vtkSmartPointer<vtkImageThreshold>::New();
+             vtkSmartPointer<vtkMPIController> controller = vtkSmartPointer<vtkMPIController>::New();
+
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_cxx_try_link "$LINENO"; then :
-  ac_cv_lib_vtkIO_main=yes
-else
-  ac_cv_lib_vtkIO_main=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkIO_main" >&5
-$as_echo "$ac_cv_lib_vtkIO_main" >&6; }
-if test "x$ac_cv_lib_vtkIO_main" = xyes; then :
   enablevtk=yes
 else
   enablevtk=no
 fi
-
-
-           if (test $enablevtk = yes); then
-             { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkCommon" >&5
-$as_echo_n "checking for main in -lvtkCommon... " >&6; }
-if ${ac_cv_lib_vtkCommon_main+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lvtkCommon  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-int
-main ()
-{
-return main ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"; then :
-  ac_cv_lib_vtkCommon_main=yes
-else
-  ac_cv_lib_vtkCommon_main=no
-fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkCommon_main" >&5
-$as_echo "$ac_cv_lib_vtkCommon_main" >&6; }
-if test "x$ac_cv_lib_vtkCommon_main" = xyes; then :
-  enablevtk=yes
-else
-  enablevtk=no
-fi
 
-           fi
-
-                      if (test $enablevtk = yes); then
-             { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkFiltering" >&5
-$as_echo_n "checking for main in -lvtkFiltering... " >&6; }
-if ${ac_cv_lib_vtkFiltering_main+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lvtkFiltering  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-int
-main ()
-{
-return main ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"; then :
-  ac_cv_lib_vtkFiltering_main=yes
-else
-  ac_cv_lib_vtkFiltering_main=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkFiltering_main" >&5
-$as_echo "$ac_cv_lib_vtkFiltering_main" >&6; }
-if test "x$ac_cv_lib_vtkFiltering_main" = xyes; then :
-  enablevtk=yes
-else
-  enablevtk=no
-fi
-
+                      if (test x$enablevtk = xno); then
+             { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Linking a test program against the VTK libraries failed >>>" >&5
+$as_echo "<<< Linking a test program against the VTK libraries failed >>>" >&6; }
+             { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< libMesh requires VTK to be configured with -DVTK_USE_PARALLEL:BOOL=ON -DVTK_USE_MPI:BOOL=ON >>>" >&5
+$as_echo "<<< libMesh requires VTK to be configured with -DVTK_USE_PARALLEL:BOOL=ON -DVTK_USE_MPI:BOOL=ON >>>" >&6; }
            fi
 
                       LIBS="$old_LIBS"

--- a/configure
+++ b/configure
@@ -40051,28 +40051,6 @@ $as_echo "VTK header files not found!" >&6; }
 
          vtkversion=$vtkmajor.$vtkminor.$vtkbuild
          vtkmajorminor=$vtkmajor.$vtkminor
-
-
-
-
-
-
-cat >>confdefs.h <<_ACEOF
-#define DETECTED_VTK_VERSION_MAJOR $vtkmajor
-_ACEOF
-
-
-
-cat >>confdefs.h <<_ACEOF
-#define DETECTED_VTK_VERSION_MINOR $vtkminor
-_ACEOF
-
-
-
-cat >>confdefs.h <<_ACEOF
-#define DETECTED_VTK_VERSION_SUBMINOR $vtkbuild
-_ACEOF
-
        fi
 
        if (test x$enablevtk = xyes); then
@@ -40094,29 +40072,33 @@ _ACEOF
                   if (test $vtkmajor -eq 5); then
            VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
 
-                  elif (test $vtkmajor -eq 6 -a $vtkminor -le 1); then
+                           elif (test $vtkmajor -eq 6 -a $vtkminor -le 1); then
            VTK_LIBRARY_WITH_VERSION="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                      -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
-                                     -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor"
+                                     -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor \
+                                     -lvtkParallelMPI-$vtkmajorminor -lvtkParallelCore-$vtkmajorminor"
 
            # Some Linux distributions (Arch) install VTK without the
            # "libfoo-6.x.so" naming scheme, so we try to handle that
            # situation as well.
            VTK_LIBRARY_NO_VERSION="-L$VTK_LIB -lvtkIOCore -lvtkCommonCore -lvtkCommonDataModel \
                                    -lvtkFiltersCore -lvtkIOXML -lvtkImagingCore \
-                                   -lvtkIOImage -lvtkImagingMath"
+                                   -lvtkIOImage -lvtkImagingMath \
+                                   -lvtkParallelMPI -lvtkParallelCore"
 
-                  else # elif (test $vtkmajor -eq 6 -a $vtkminor -eq 2); then
+                           else
            VTK_LIBRARY_WITH_VERSION="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                      -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
-                                     -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor -lvtkIOParallelXML-$vtkmajorminor"
+                                     -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor -lvtkIOParallelXML-$vtkmajorminor \
+                                     -lvtkParallelMPI-$vtkmajorminor -lvtkParallelCore-$vtkmajorminor"
 
            # Some Linux distributions (Arch) install VTK without the
            # "libfoo-6.x.so" naming scheme, so we try to handle that
            # situation as well.
            VTK_LIBRARY_NO_VERSION="-L$VTK_LIB -lvtkIOCore -lvtkCommonCore -lvtkCommonDataModel \
                                    -lvtkFiltersCore -lvtkIOXML -lvtkImagingCore \
-                                   -lvtkIOImage -lvtkImagingMath -lvtkIOParallelXML"
+                                   -lvtkIOImage -lvtkImagingMath -lvtkIOParallelXML \
+                                   -lvtkParallelMPI -lvtkParallelCore"
          fi
 
                            if (test $vtkmajor -gt 5); then
@@ -40133,6 +40115,7 @@ _ACEOF
              #include "vtkDoubleArray.h"
              #include "vtkXMLPUnstructuredGridWriter.h"
              #include "vtkImageThreshold.h"
+             #include "vtkMPIController.h"
 
 int
 main ()
@@ -40144,6 +40127,7 @@ main ()
              vtkSmartPointer<vtkDoubleArray> pcoords = vtkSmartPointer<vtkDoubleArray>::New();
              vtkSmartPointer<vtkXMLPUnstructuredGridWriter> writer = vtkSmartPointer<vtkXMLPUnstructuredGridWriter>::New();
              vtkSmartPointer<vtkImageThreshold> threshold = vtkSmartPointer<vtkImageThreshold>::New();
+             vtkSmartPointer<vtkMPIController> controller = vtkSmartPointer<vtkMPIController>::New();
 
   ;
   return 0;
@@ -40170,6 +40154,7 @@ rm -f core conftest.err conftest.$ac_objext \
              #include "vtkDoubleArray.h"
              #include "vtkXMLPUnstructuredGridWriter.h"
              #include "vtkImageThreshold.h"
+             #include "vtkMPIController.h"
 
 int
 main ()
@@ -40181,6 +40166,7 @@ main ()
              vtkSmartPointer<vtkDoubleArray> pcoords = vtkSmartPointer<vtkDoubleArray>::New();
              vtkSmartPointer<vtkXMLPUnstructuredGridWriter> writer = vtkSmartPointer<vtkXMLPUnstructuredGridWriter>::New();
              vtkSmartPointer<vtkImageThreshold> threshold = vtkSmartPointer<vtkImageThreshold>::New();
+             vtkSmartPointer<vtkMPIController> controller = vtkSmartPointer<vtkMPIController>::New();
 
   ;
   return 0;
@@ -40334,6 +40320,28 @@ fi
          if (test "x$RPATHFLAG" != "x" -a -d $VTK_LIB); then # add the VTK_LIB to the linker run path, if it is a directory
            VTK_LIBRARY="${RPATHFLAG}${VTK_LIB} $VTK_LIBRARY"
          fi
+
+
+
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_VTK_VERSION_MAJOR $vtkmajor
+_ACEOF
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_VTK_VERSION_MINOR $vtkminor
+_ACEOF
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_VTK_VERSION_SUBMINOR $vtkbuild
+_ACEOF
+
 
 
 $as_echo "#define HAVE_VTK 1" >>confdefs.h

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -33,7 +33,9 @@
 
 // For dealing with MPI stuff in VTK.
 #if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
+# include "libmesh/ignore_warnings.h"
 # include "vtkSmartPointer.h"
+# include "libmesh/restore_warnings.h"
 class vtkMPIController;
 #endif
 

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -31,6 +31,12 @@
 #include <string>
 #include <vector>
 
+// For dealing with MPI stuff in VTK.
+#if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
+# include "vtkSmartPointer.h"
+class vtkMPIController;
+#endif
+
 /**
  * The \p libMesh namespace provides an interface to certain functionality
  * in the library.  It provides a uniform \p init() method that
@@ -79,6 +85,11 @@ public:
 
 private:
   Parallel::Communicator _comm;
+
+#if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
+  // VTK object for dealing with MPI stuff in VTK.
+  vtkSmartPointer<vtkMPIController> _vtk_mpi_controller;
+#endif
 };
 
 /**

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -9,6 +9,7 @@ m4_define([_AX_CXX_COMPILE_VTK_preamble],
              @%:@include "vtkDoubleArray.h"
              @%:@include "vtkXMLPUnstructuredGridWriter.h"
              @%:@include "vtkImageThreshold.h"
+             @%:@include "vtkMPIController.h"
           ]])
 
 dnl Declare compilation test function body to
@@ -21,6 +22,7 @@ m4_define([_AX_CXX_COMPILE_VTK_body],
              vtkSmartPointer<vtkDoubleArray> pcoords = vtkSmartPointer<vtkDoubleArray>::New();
              vtkSmartPointer<vtkXMLPUnstructuredGridWriter> writer = vtkSmartPointer<vtkXMLPUnstructuredGridWriter>::New();
              vtkSmartPointer<vtkImageThreshold> threshold = vtkSmartPointer<vtkImageThreshold>::New();
+             vtkSmartPointer<vtkMPIController> controller = vtkSmartPointer<vtkMPIController>::New();
           ]])
 
 dnl ----------------------------------------------------------------
@@ -164,30 +166,36 @@ AC_DEFUN([CONFIGURE_VTK],
            VTK_LIBRARY="-L$VTK_LIB -lvtkIO -lvtkCommon -lvtkFiltering -lvtkImaging"
 
          dnl VTK 6.1.x
+         dnl Not sure if -lvtkParallelMPI and -lvtkParallelCore existed in VTK-6.1.x
          elif (test $vtkmajor -eq 6 -a $vtkminor -le 1); then
            VTK_LIBRARY_WITH_VERSION="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                      -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
-                                     -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor"
+                                     -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor \
+                                     -lvtkParallelMPI-$vtkmajorminor -lvtkParallelCore-$vtkmajorminor"
 
            # Some Linux distributions (Arch) install VTK without the
            # "libfoo-6.x.so" naming scheme, so we try to handle that
            # situation as well.
            VTK_LIBRARY_NO_VERSION="-L$VTK_LIB -lvtkIOCore -lvtkCommonCore -lvtkCommonDataModel \
                                    -lvtkFiltersCore -lvtkIOXML -lvtkImagingCore \
-                                   -lvtkIOImage -lvtkImagingMath"
+                                   -lvtkIOImage -lvtkImagingMath \
+                                   -lvtkParallelMPI -lvtkParallelCore"
 
          dnl VTK 6.2.x and above
-         else # elif (test $vtkmajor -eq 6 -a $vtkminor -eq 2); then
+         dnl Not sure if -lvtkParallelMPI and -lvtkParallelCore existed in VTK-6.2.x, but it does in VTK-7.x.
+         else
            VTK_LIBRARY_WITH_VERSION="-L$VTK_LIB -lvtkIOCore-$vtkmajorminor -lvtkCommonCore-$vtkmajorminor -lvtkCommonDataModel-$vtkmajorminor \
                                      -lvtkFiltersCore-$vtkmajorminor -lvtkIOXML-$vtkmajorminor -lvtkImagingCore-$vtkmajorminor \
-                                     -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor -lvtkIOParallelXML-$vtkmajorminor"
+                                     -lvtkIOImage-$vtkmajorminor -lvtkImagingMath-$vtkmajorminor -lvtkIOParallelXML-$vtkmajorminor \
+                                     -lvtkParallelMPI-$vtkmajorminor -lvtkParallelCore-$vtkmajorminor"
 
            # Some Linux distributions (Arch) install VTK without the
            # "libfoo-6.x.so" naming scheme, so we try to handle that
            # situation as well.
            VTK_LIBRARY_NO_VERSION="-L$VTK_LIB -lvtkIOCore -lvtkCommonCore -lvtkCommonDataModel \
                                    -lvtkFiltersCore -lvtkIOXML -lvtkImagingCore \
-                                   -lvtkIOImage -lvtkImagingMath -lvtkIOParallelXML"
+                                   -lvtkIOImage -lvtkImagingMath -lvtkIOParallelXML \
+                                   -lvtkParallelMPI -lvtkParallelCore"
          fi
 
          dnl Try to compile test prog to check for existence of VTK libraries.

--- a/m4/vtk.m4
+++ b/m4/vtk.m4
@@ -129,19 +129,6 @@ AC_DEFUN([CONFIGURE_VTK],
 
          vtkversion=$vtkmajor.$vtkminor.$vtkbuild
          vtkmajorminor=$vtkmajor.$vtkminor
-
-         AC_SUBST(vtkversion)
-         AC_SUBST(vtkmajor)
-         AC_SUBST(vtkbuild)
-
-         AC_DEFINE_UNQUOTED(DETECTED_VTK_VERSION_MAJOR, [$vtkmajor],
-           [VTK's major version number, as detected by vtk.m4])
-
-         AC_DEFINE_UNQUOTED(DETECTED_VTK_VERSION_MINOR, [$vtkminor],
-           [VTK's minor version number, as detected by vtk.m4])
-
-         AC_DEFINE_UNQUOTED(DETECTED_VTK_VERSION_SUBMINOR, [$vtkbuild],
-           [VTK's subminor version number, as detected by vtk.m4])
        fi
 
        if (test x$enablevtk = xyes); then
@@ -258,6 +245,19 @@ AC_DEFUN([CONFIGURE_VTK],
          if (test "x$RPATHFLAG" != "x" -a -d $VTK_LIB); then # add the VTK_LIB to the linker run path, if it is a directory
            VTK_LIBRARY="${RPATHFLAG}${VTK_LIB} $VTK_LIBRARY"
          fi
+
+         AC_SUBST(vtkversion)
+         AC_SUBST(vtkmajor)
+         AC_SUBST(vtkbuild)
+
+         AC_DEFINE_UNQUOTED(DETECTED_VTK_VERSION_MAJOR, [$vtkmajor],
+           [VTK's major version number, as detected by vtk.m4])
+
+         AC_DEFINE_UNQUOTED(DETECTED_VTK_VERSION_MINOR, [$vtkminor],
+           [VTK's minor version number, as detected by vtk.m4])
+
+         AC_DEFINE_UNQUOTED(DETECTED_VTK_VERSION_SUBMINOR, [$vtkbuild],
+           [VTK's subminor version number, as detected by vtk.m4])
 
          AC_DEFINE(HAVE_VTK, 1, [Flag indicating whether the library will be compiled with VTK support])
          AC_MSG_RESULT(<<< Configuring library with VTK version $vtkversion support >>>)


### PR DESCRIPTION
This PR gets our use of `vtkXMLPUnstructuredGridWriter` into a more conformant state, and fixes the MOOSE test broken by VTK-7.1 described in #1179.

~~I'm pretty sure this will work for all VTK-6.x and 7.x versions, have not had a chance to test 5.x yet, but hopefully not many people are still using that old version.  The worst that will happen is that VTK support will not be enabled for 5.x~~.

This also works in VTK-5.10.1.  Have not tested VTK-6.x, but it should be the same as 7.x.