### PR TITLE
Fix CheckpointIO issues

### DIFF
--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -175,8 +175,10 @@ void CheckpointIO::build_elem_list()
 
     _local_elements.insert(elem->id());
 
-    // Also need to add in all the point neighbors of this element
-    elem->find_point_neighbors(neighbors);
+    // Also need to add in all the point neighbors of this element.
+    // Point neighbors can only be found for active elements...
+    if (elem->active())
+      elem->find_point_neighbors(neighbors);
 
     std::set<const Elem *>::iterator
       set_it = neighbors.begin(),

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -175,6 +175,10 @@ void CheckpointIO::build_elem_list()
 
     _local_elements.insert(elem->id());
 
+    // Make sure the neighbors vector is cleared out in case this Elem
+    // isn't active and we skip calling find_point_neighbors().
+    neighbors.clear();
+
     // Also need to add in all the point neighbors of this element.
     // Point neighbors can only be found for active elements...
     if (elem->active())

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -338,6 +338,10 @@ void CheckpointIO::write_connectivity (Xdr & io) const
         {
           const Elem & elem = mesh.elem_ref(*it);
 
+          // Only write elements of the current level.
+          if (elem.level() != level)
+            continue;
+
           unsigned int n_nodes = elem.n_nodes();
 
           elem_data[0] = elem.id();

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -178,10 +178,12 @@ void CheckpointIO::build_elem_list()
     // Also need to add in all the point neighbors of this element
     elem->find_point_neighbors(neighbors);
 
-    for (std::set<const Elem *>::iterator it = neighbors.begin();
-         it != neighbors.end();
-         ++it)
-      _local_elements.insert((*it)->id());
+    std::set<const Elem *>::iterator
+      set_it = neighbors.begin(),
+      set_end = neighbors.end();
+
+    for (; set_it != set_end; ++set_it)
+      _local_elements.insert((*set_it)->id());
   }
 }
 


### PR DESCRIPTION
This PR fixes two issues:
* *All* elements were being written out for each level instead of just elements of a given level.
* You can't call `find_point_neighbors()` on inactive elements.

This fixes most of the failures in the libmesh update PR over in idaholab/moose#8132, but I think there are still a few more remaining.