### PR TITLE
Workaround for Doxygen not generating documentation for libmesh_final classes

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1908,7 +1908,7 @@ PERLMOD_MAKEVAR_PREFIX =
 # C-preprocessor directives found in the sources and include files.
 # The default value is: YES.
 
-ENABLE_PREPROCESSING   = YES
+ENABLE_PREPROCESSING   = NO
 
 # If the MACRO_EXPANSION tag is set to YES doxygen will expand all macro names
 # in the source code. If set to NO only conditional compilation will be
@@ -1925,7 +1925,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = YES
+EXPAND_ONLY_PREDEF     = NO
 
 # If the SEARCH_INCLUDES tag is set to YES the includes files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -1957,7 +1957,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = "libmesh_final=" "libmesh_override="
+PREDEFINED             =
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1908,7 +1908,7 @@ PERLMOD_MAKEVAR_PREFIX =
 # C-preprocessor directives found in the sources and include files.
 # The default value is: YES.
 
-ENABLE_PREPROCESSING   = NO
+ENABLE_PREPROCESSING   = YES
 
 # If the MACRO_EXPANSION tag is set to YES doxygen will expand all macro names
 # in the source code. If set to NO only conditional compilation will be
@@ -1925,7 +1925,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES the includes files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -1957,7 +1957,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = "libmesh_final=" "libmesh_override="
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doc/html/Makefile.am
+++ b/doc/html/Makefile.am
@@ -49,10 +49,14 @@ support.html: src/$@ src/simple_header.html src/simple_footer.html
 
 #
 # doxygen documentation - be sure to generate symlinks in include/libmesh!
+# doxygen does not correctly handle 'libmesh_final' directives in class declarations,
+# so we do a pre/postprocessing step with perl to temporarily remove these.
 doc html: doxygen
 doxygen:
 	@cd $(top_builddir)/include/libmesh && $(MAKE)
+	perl -pli -e 's/ libmesh_final : / \/\*\*\/ : /g' $(top_srcdir)/include/*/*.h
 	$(DOXYGEN) $(top_builddir)/doc/Doxyfile
+	perl -pli -e 's/ \/\*\*\/ : / libmesh_final : /g' $(top_srcdir)/include/*/*.h
 
 #  need to link files for VPATH builds
 if LIBMESH_VPATH_BUILD

--- a/doc/html/Makefile.in
+++ b/doc/html/Makefile.in
@@ -766,10 +766,14 @@ support.html: src/$@ src/simple_header.html src/simple_footer.html
 
 #
 # doxygen documentation - be sure to generate symlinks in include/libmesh!
+# doxygen does not correctly handle 'libmesh_final' directives in class declarations,
+# so we do a pre/postprocessing step with perl to temporarily remove these.
 doc html: doxygen
 doxygen:
 	@cd $(top_builddir)/include/libmesh && $(MAKE)
+	perl -pli -e 's/ libmesh_final : / \/\*\*\/ : /g' $(top_srcdir)/include/*/*.h
 	$(DOXYGEN) $(top_builddir)/doc/Doxyfile
+	perl -pli -e 's/ \/\*\*\/ : / libmesh_final : /g' $(top_srcdir)/include/*/*.h
 @LIBMESH_VPATH_BUILD_TRUE@.linkstamp:
 @LIBMESH_VPATH_BUILD_TRUE@	-rm -rf examples              && cp -r $(srcdir)/examples . && chmod -R u+rw examples
 @LIBMESH_VPATH_BUILD_TRUE@	-rm -rf images                && cp -r $(srcdir)/images .   && chmod -R u+rw images

--- a/include/geom/cell.h
+++ b/include/geom/cell.h
@@ -31,6 +31,8 @@ namespace libMesh
  * The \p Cell is an abstract element type that lives in
  * three dimensions.  A cell could be a tetrahedron, a hexahedron,
  * a pyramid, a prism, etc...
+ *
+ * \brief The base class for all 3D geometric element types.
  */
 class Cell : public Elem
 {

--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -31,6 +31,8 @@ namespace libMesh
 
 /**
  * The \p Hex is an element in 3D with 6 sides.
+ *
+ * \brief The base class for all hexahedral element types.
  */
 class Hex : public Cell
 {

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -64,6 +64,8 @@ namespace libMesh
  *     o--------------o--------------o
  *     0              8              1
  *   \endverbatim
+ *
+ * \brief A 3D hexahedral element with 20 nodes.
  */
 class Hex20 libmesh_final : public Hex
 {

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -64,6 +64,8 @@ namespace libMesh
  *    o--------------o--------------o
  *    0              8              1
  *  \endverbatim
+ *
+ * \brief A 3D hexahedral element with 27 nodes.
  */
 class Hex27 libmesh_final : public Hex
 {

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -50,6 +50,8 @@ namespace libMesh
  *    0        1
  *
  * \endverbatim
+ *
+ * \brief A 3D hexahedral element with 8 nodes.
  */
 class Hex8 libmesh_final : public Hex
 {

--- a/include/geom/cell_inf.h
+++ b/include/geom/cell_inf.h
@@ -37,6 +37,8 @@ namespace libMesh
  * The \p InfCell is an abstract element type that lives in
  * three dimensions.  An infinite cell could be an infinite hexahedron,
  * or an infinite prism.
+ *
+ * \brief The base class for all 3D infinite geometric element types.
  */
 class InfCell : public Elem
 {

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -38,6 +38,8 @@ namespace libMesh
  * @e does exist in the mesh, since the outer nodes are located
  * at a specific distance from the mesh origin (and therefore
  * define a side).  Still, this face is not to be used!
+ *
+ * \brief The base class for all 3D infinite hexahedral element types.
  */
 class InfHex : public InfCell
 {

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -68,6 +68,8 @@ namespace libMesh
  *   o--------------o--------------o
  *   0              8              1
  * \endverbatim
+ *
+ * \brief A 3D infinite hexahedral element with 16 nodes.
  */
 class InfHex16 libmesh_final : public InfHex
 {

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -68,6 +68,8 @@ namespace libMesh
  *   o--------------o--------------o
  *   0              8              1
  * \endverbatim
+ *
+ * \brief A 3D infinite hexahedral element with 18 nodes.
  */
 class InfHex18 libmesh_final : public InfHex
 {

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -54,6 +54,8 @@ namespace libMesh
  *      0        1
  *
  * \endverbatim
+ *
+ * \brief A 3D infinite hexahedral element with 8 nodes.
  */
 class InfHex8 libmesh_final : public InfHex
 {

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -41,6 +41,8 @@ namespace libMesh
  * @e does exist in the mesh, since the outer nodes are located
  * at a specific distance from the mesh origin (and therefore
  * define a side).  Still, this face is not to be used!
+ *
+ * \brief The base class for all 3D infinite prismatic element types.
  */
 class InfPrism : public InfCell
 {

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -52,6 +52,8 @@ namespace libMesh
  *     o-------o     base face
  *     0       1
  * \endverbatim
+ *
+ * \brief A 3D infinite prismatic element with 6 nodes.
  */
 class InfPrism6 libmesh_final : public InfPrism
 {

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -31,6 +31,8 @@ namespace libMesh
 
 /**
  * The \p Prism is an element in 3D with 5 sides.
+ *
+ * \brief The base class for all prismatic element types.
  */
 class Prism : public Cell
 {

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -70,6 +70,8 @@ namespace libMesh
  *    0         6         1
  *
  * \endverbatim
+ *
+ * \brief A 3D prismatic element with 15 nodes.
  */
 class Prism15 libmesh_final : public Prism
 {

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -70,6 +70,8 @@ namespace libMesh
  *   0         6         1
  *
  * \endverbatim
+ *
+ * \brief A 3D prismatic element with 18 nodes.
  */
 class Prism18 libmesh_final : public Prism
 {

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -48,6 +48,8 @@ namespace libMesh
  *     o-------o
  *     0       1
  * \endverbatim
+ *
+ * \brief A 3D prismatic element with 6 nodes.
  */
 class Prism6 libmesh_final : public Prism
 {

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -31,6 +31,8 @@ namespace libMesh
 
 /**
  * The \p Pyramid is an element in 3D with 5 sides.
+ *
+ * \brief The base class for all pyramid element types.
  */
 class Pyramid : public Cell
 {

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -68,6 +68,8 @@ namespace libMesh
  *  0        5         1
  *
  * \endverbatim
+ *
+ * \brief A 3D pyramid element with 13 nodes.
  */
 class Pyramid13 libmesh_final : public Pyramid
 {

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -71,6 +71,8 @@ namespace libMesh
  *  0        5         1
  *
  * \endverbatim
+ *
+ * \brief A 3D pyramid element with 14 nodes.
  */
 class Pyramid14 libmesh_final : public Pyramid
 {

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -49,6 +49,8 @@ namespace libMesh
  *  0        1
  *
  * \endverbatim
+ *
+ * \brief A 3D pyramid element with 5 nodes.
  */
 class Pyramid5 libmesh_final : public Pyramid
 {

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -31,6 +31,8 @@ namespace libMesh
 
 /**
  * The \p Tet is an element in 3D composed of 4 sides.
+ *
+ * \brief The base class for all tetrahedral element types.
  */
 class Tet : public Cell
 {

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -56,6 +56,8 @@ namespace libMesh
  *             o
  *             1
  *  \endverbatim
+ *
+ * \brief A 3D tetrahedral element with 10 nodes.
  */
 class Tet10 libmesh_final : public Tet
 {

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -49,6 +49,8 @@ namespace libMesh
  *       o
  *       1
  * \endverbatim
+ *
+ * \brief A 3D tetrahedral element with 4 nodes.
  */
 class Tet4 libmesh_final : public Tet
 {

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -38,6 +38,8 @@ class Mesh;
 /**
  * The \p Edge is an element in 1D. It can be thought of as a
  * line segment.
+ *
+ * \brief The base class for all 1D geometric element types.
  */
 class Edge : public Elem
 {

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -39,6 +39,8 @@ namespace libMesh
  *  EDGE2: o--------o
  *         0        1
  * \endverbatim
+ *
+ * \brief A 1D geometric element with 2 nodes.
  */
 class Edge2 : public Edge
 {

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -41,6 +41,8 @@ namespace libMesh
  *  EGDE3: o----o----o
  *         0    2    1
  * \endverbatim
+ *
+ * \brief A 1D geometric element with 3 nodes.
  */
 class Edge3 : public Edge
 {

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -33,15 +33,16 @@ namespace libMesh
 /**
  * The \p Edge4 is an element in 1D composed of 4 nodes.
  *
- * \author David Knezevic
- * \date 2005
- *
  * It is numbered like this:
  *
  * \verbatim
  *  EGDE4: o----o----o----o
  *         0    2    3    1
  * \endverbatim
+ *
+ * \author David Knezevic
+ * \date 2005
+ * \brief A 1D geometric element with 4 nodes.
  */
 class Edge4 libmesh_final : public Edge
 {

--- a/include/geom/edge_inf_edge2.h
+++ b/include/geom/edge_inf_edge2.h
@@ -49,6 +49,8 @@ namespace libMesh
  *     o         base node
  *       0
  * \endverbatim
+ *
+ * \brief A 1D infinite element with 2 nodes.
  */
 class InfEdge2 : public Edge
 {

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -87,6 +87,7 @@ class PointLocatorBase;
  *
  * \author Benjamin S. Kirk
  * \date 2002-2007
+ * \brief The base class for all geometric element types.
  */
 class Elem : public ReferenceCountedObject<Elem>,
              public DofObject

--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -56,6 +56,7 @@ class SerialMesh;
  *
  * \author Benjamin S. Kirk
  * \date 2013
+ * \brief Subdivides a single element using a mesh generator.
  */
 class ElemCutter
 {

--- a/include/geom/elem_hash.h
+++ b/include/geom/elem_hash.h
@@ -28,14 +28,20 @@
 namespace libMesh
 {
 
-// The ElemHashUtils struct defines functions used for the "Hash" and
-// "Pred" template arguments of the various "unordered" containers,
-// e.g.
-// template <class Key,                         // unordered_multiset::key_type/value_type
-//           class Hash = hash<Key>,            // unordered_multiset::hasher
-//           class Pred = equal_to<Key>,        // unordered_multiset::key_equal
-//           class Alloc = allocator<Key>       // unordered_multiset::allocator_type
-//           > class unordered_multiset;
+/**
+ * The ElemHashUtils struct defines functions used for the "Hash" and
+ * "Pred" template arguments of the various "unordered" containers,
+ * e.g.
+ * template <class Key,                         // unordered_multiset::key_type/value_type
+ *           class Hash = hash<Key>,            // unordered_multiset::hasher
+ *           class Pred = equal_to<Key>,        // unordered_multiset::key_equal
+ *           class Alloc = allocator<Key>       // unordered_multiset::allocator_type
+ *           > class unordered_multiset;
+ *
+ * \author John W. Peterson
+ * \date 2015
+ * \brief A struct providing convenience functions for hashing elements.
+ */
 struct ElemHashUtils
 {
 public:

--- a/include/geom/elem_quality.h
+++ b/include/geom/elem_quality.h
@@ -34,6 +34,8 @@ namespace libMesh
 
 /**
  * A namespace for quality utility functions.
+ *
+ * \brief Utilty functions for computing element quality indicators.
  */
 namespace Quality
 {

--- a/include/geom/face.h
+++ b/include/geom/face.h
@@ -36,6 +36,8 @@ class Mesh;
  * The \p Face is an abstract element type that lives in
  * two dimensions.  A face could be a triangle, a quadrilateral,
  * a pentagon, etc...
+ *
+ * \brief The base class for all 2D geometric element types.
  */
 class Face : public Elem
 {

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -32,11 +32,6 @@
 namespace libMesh
 {
 
-
-// Forward declarations
-
-
-
 /**
  * The \p InfQuad is an abstract element type that lives in
  * two dimensions.  Here, an infinite face is @e always a quadrilateral,
@@ -56,6 +51,8 @@ namespace libMesh
  *           side 0
  *
  * \endverbatim
+ *
+ * \brief The base class for all 2D infinite quadrilateral element types.
  */
 class InfQuad : public Elem
 {

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -47,6 +47,8 @@ namespace libMesh
  *              o-----------o   base side
  *              0           1
  * \endverbatim
+ *
+ * \brief A 2D infinite quadrilateral element with 4 nodes.
  */
 class InfQuad4 : public InfQuad
 {

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -50,6 +50,8 @@ namespace libMesh
  *           o-----o-----o   base side
  *           0     4     1
  * \endverbatim
+ *
+ * \brief A 2D infinite quadrilateral element with 6 nodes.
  */
 class InfQuad6 : public InfQuad
 {

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -48,6 +48,8 @@ namespace libMesh
  *        o-----------o
  *
  * \endverbatim
+ *
+ * \brief The base class for all quadrilateral element types.
  */
 class Quad : public Face
 {

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -45,6 +45,8 @@ namespace libMesh
  *        o-----------o
  *        0           1
  * \endverbatim
+ *
+ * \brief A 2D quadrilateral element with 4 nodes.
  */
 class Quad4 : public Quad
 {

--- a/include/geom/face_quad4_shell.h
+++ b/include/geom/face_quad4_shell.h
@@ -31,6 +31,7 @@ namespace libMesh
  *
  * \author David Knezevic
  * \date 2016
+ * \brief A 2D quadrilateral shell element with 4 nodes.
  */
 class QuadShell4 : public Quad4
 {

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -52,6 +52,8 @@ class Mesh;
  *        o-----o-----o
  *        0     4     1
  * \endverbatim
+ *
+ * \brief A 2D quadrilateral element with 8 nodes.
  */
 class Quad8 : public Quad
 {

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -51,6 +51,8 @@ namespace libMesh
  *        o-----o-----o
  *        0     4     1
  * \endverbatim
+ *
+ * \brief A 2D quadrilateral element with 9 nodes.
  */
 class Quad9 : public Quad
 {

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -30,13 +30,6 @@
 namespace libMesh
 {
 
-
-// Forward declarations
-
-
-
-
-
 /**
  * The \p Tri is an element in 2D composed of 3 sides.
  * It looks like this:
@@ -51,6 +44,8 @@ namespace libMesh
  *     -----------
  *
  * \endverbatim
+ *
+ * \brief The base class for all triangular element types.
  */
 class Tri : public Face
 {

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -49,6 +49,8 @@ namespace libMesh
  *    o-----o
  *    0      1
  * \endverbatim
+ *
+ * \brief A 2D triangular element with 3 nodes.
  */
 class Tri3 : public Tri
 {

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -31,13 +31,6 @@
 namespace libMesh
 {
 
-
-
-// Forward declarations
-
-
-
-
 /**
  * The \p Tri6 is an element in 2D composed of 6 nodes.
  * It is numbered like this:
@@ -52,6 +45,8 @@ namespace libMesh
  *   o-----o-----o
  *   0     3     1
  * \endverbatim
+ *
+ * \brief A 2D triangular element with 6 nodes.
  */
 class Tri6 : public Tri
 {

--- a/include/geom/node.h
+++ b/include/geom/node.h
@@ -49,6 +49,7 @@ class MeshRefinement;
  *
  * \author Benjamin S. Kirk
  * \date 2003
+ * \brief A geometric point in (x,y,z) space associated with a DOF.
  */
 class Node : public Point,
              public DofObject,

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -29,13 +29,13 @@
 namespace libMesh
 {
 
-
-// Forward declarations
-
-
 /**
  * The \p NodeElem is a point element, generally used as
  * a side of a 1D element.
+ *
+ * \author Roy H. Stogner
+ * \date 2006
+ * \brief A zero-dimensional geometric entity implementing the Elem interface.
  */
 class NodeElem : public Elem
 {

--- a/include/geom/plane.h
+++ b/include/geom/plane.h
@@ -33,6 +33,7 @@ namespace libMesh
  *
  * \author Benjamin S. Kirk
  * \date 2002
+ * \brief A geometric object representing a planar surface.
  */
 class Plane : public Surface
 {

--- a/include/geom/point.h
+++ b/include/geom/point.h
@@ -35,6 +35,7 @@ namespace libMesh
  *
  * \author Benjamin S. Kirk
  * \date 2003
+ * \brief A geometric point in (x,y,z) space.
  */
 class Point : public TypeVector<Real>
 {

--- a/include/geom/reference_elem.h
+++ b/include/geom/reference_elem.h
@@ -38,6 +38,7 @@ class Elem;
  *
  * \author Benjamin S. Kirk
  * \date 2013
+ * \brief Namespace providing access to reference geoemtric element types.
  */
 namespace ReferenceElem
 {

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -40,6 +40,7 @@ namespace libMesh
  *
  * \author Roy H. Stogner
  * \date 2007
+ * \brief Used by ParallelMesh to represent an Elem owned by another processor.
  */
 class RemoteElem : public Elem,
                    public Singleton

--- a/include/geom/side.h
+++ b/include/geom/side.h
@@ -44,7 +44,9 @@ class Node;
  * Similarly, you cannot access the neighbors of a side since it
  * does not store any.
  *
- * \author  Benjamin S. Kirk
+ * \author Benjamin S. Kirk
+ * \date 2004
+ * \brief Proxy class for efficiently representing an Elem's side.
  */
 template <class SideType, class ParentType>
 class Side : public SideType

--- a/include/geom/sphere.h
+++ b/include/geom/sphere.h
@@ -68,6 +68,7 @@ namespace libMesh
  *
  * \author Benjamin S. Kirk, Daniel Dreyer
  * \date 2002-2007
+ * \brief A geometric object representing a sphere.
  */
 class Sphere : public Surface
 {

--- a/include/geom/stored_range.h
+++ b/include/geom/stored_range.h
@@ -46,6 +46,7 @@ namespace libMesh
  *
  * \author Benjamin S. Kirk
  * \date 2008
+ * \brief Utility class for defining generic ranges for threading.
  */
 template <typename iterator_type, typename object_type>
 class StoredRange

--- a/include/geom/surface.h
+++ b/include/geom/surface.h
@@ -38,6 +38,7 @@ namespace libMesh
  *
  * \author Benjamin S. Kirk
  * \date 2002
+ * \brief Base class for Plane and Sphere classes.
  */
 class Surface
 {

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -646,21 +646,21 @@ public:
   /**
    * Resets the current time in the context. Additionally, reinitialize Elem
    * and FE objects if there's a moving mesh present in the system such that
-   * the mesh is deformed to its position at t_{\theta}.
+   * the mesh is deformed to its position at \f$ t_{\theta} \f$.
    */
   virtual void elem_reinit(Real theta) libmesh_override;
 
   /**
    * Resets the current time in the context. Additionally, reinitialize Elem
    * and FE objects if there's a moving mesh present in the system such that
-   * the mesh is deformed to its position at t_{\theta}.
+   * the mesh is deformed to its position at \f$ t_{\theta} \f$.
    */
   virtual void elem_side_reinit(Real theta) libmesh_override;
 
   /**
    * Resets the current time in the context. Additionally, reinitialize Elem
    * and FE objects if there's a moving mesh present in the system such that
-   * the mesh is deformed to its position at t_{\theta}.
+   * the mesh is deformed to its position at \f$ t_{\theta} \f$.
    */
   virtual void elem_edge_reinit(Real theta) libmesh_override;
 


### PR DESCRIPTION
I tried to fix this using Doxyfile options, but nothing helped.  I ended up just stripping the `libmesh_final` directives from the source, running Doxygen, and then replacing them.  The [site docs](http://libmesh.github.io/doxygen/index.html) have already been updated with the html files generated using this PR.

This should close #926.