### PR TITLE
Use only VTK header that's needed

### DIFF
--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -40,7 +40,7 @@
 #include "vtkXMLUnstructuredGridWriter.h"
 #include "vtkXMLPUnstructuredGridWriter.h"
 #include "vtkUnstructuredGrid.h"
-#include "vtkGenericGeometryFilter.h"
+#include "vtkIntArray.h"
 #include "vtkCellArray.h"
 #include "vtkCellData.h"
 #include "vtkConfigure.h"


### PR DESCRIPTION
In trying to compile VTK without OpenGL and then using that with
libMesh, I found that I only needed the vtkIntArray header and
not the existing geometry header. Note that I'd get a compile
time error with the geometry header with VTK compiled with the
following options (which enables what need from MPI parts of VTK
and disables the OpenGL parts of VTK; from what I can tell, the
geometry stuff can trigger the OpenGL parts, but these were found
through trial-and-error):

<pre>
cmake \
-DBUILD_SHARED_LIBS:BOOL=ON \
-DCMAKE_INSTALL_PREFIX:PATH=$VTK_DIR \
-DCMAKE_BUILD_TYPE:STRING=Release \
-DBUILD_EXAMPLES:BOOL=OFF \
-DBUILD_TESTING:BOOL=OFF \
-DModule_vtkCommonDataModel:BOOL=ON \
-DVTK_BUILD_ALL_MODULES_FOR_TESTS:BOOL=OFF \
-DVTK_Group_Rendering:BOOL=OFF \
-DVTK_Group_StandAlone:BOOL=OFF \
-DModule_vtkCommonCore:BOOL=ON \
-DModule_vtkCommonDataModel:BOOL=ON \
-DModule_vtkImagingCore:BOOL=ON \
-DModule_vtkImagingMath:BOOL=ON \
-DModule_vtkIOImage:BOOL=ON \
-DModule_vtkFiltersCore:BOOL=ON \
-DVTK_Group_MPI:BOOL=OFF \
-DModule_vtkParallelMPI:BOOL=ON \
-DModule_vtkParallelCore:BOOL=ON \
-DModule_vtkIOParallelXML:BOOL=ON \
$BUILDDIR/VTK-$VTK_VERSION
</pre>

I did not do any other searching for other possibly unnecessary headers, just this one that fixed the issue I was having.