### PR TITLE
AdjointRefinement ghosted adjoint compatibility

### DIFF
--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -194,10 +194,8 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
             NumericVector<Number>::build(mesh.comm()).release();
 
           // Can do "fast" init since we're overwriting this in a sec
-          coarse_adjoint->init(system.solution->size(),
-                               system.solution->local_size(),
-                               true,
-                               system.get_adjoint_solution(j).type());
+          coarse_adjoint->init(system.get_adjoint_solution(j),
+                               /* fast = */ true);
 
           *coarse_adjoint = system.get_adjoint_solution(j);
 


### PR DESCRIPTION
The init() overload we were using earlier was only appropriate for
serial or parallel adjoint vectors.

Thanks to @vikramvgarg for catching this; we should wait for him to checkout the proposed fix before merging.