### PR TITLE
Fix multisystem reads

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1737,10 +1737,12 @@ private:
    * This method may safely be called on a distributed-memory mesh.
    *
    * Returns the length of the vector read.
+   *
+   * Reads data and discards it if \p vec is a null pointer.
    */
   template <typename InValType>
   numeric_index_type read_serialized_vector (Xdr & io,
-                                             NumericVector<Number> & vec);
+                                             NumericVector<Number> * vec);
 
   /**
    * Non-templated version for backward compatibility.
@@ -1752,7 +1754,7 @@ private:
    */
   numeric_index_type read_serialized_vector (Xdr & io,
                                              NumericVector<Number> & vec)
-  { return read_serialized_vector<Number>(io, vec); }
+  { return read_serialized_vector<Number>(io, &vec); }
 
   /**
    * Writes an output vector to the stream \p io for a set of \p DofObjects.

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1722,10 +1722,12 @@ private:
    * to the appropriate entries of \p vec.
    *
    * Returns the number of dofs read.
+   *
+   * Reads data and discards it if \p vec is a null pointer.
    */
   unsigned int read_SCALAR_dofs (const unsigned int var,
                                  Xdr & io,
-                                 NumericVector<Number> & vec) const;
+                                 NumericVector<Number> * vec) const;
 
   /**
    * Reads a vector for this System.

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1707,6 +1707,9 @@ private:
    * the values to a set of \p DofObjects.  This method uses
    * blocked input and is safe to call on a distributed memory-mesh.
    * Unless otherwise specified, all variables are read.
+   *
+   * If an entry in \p vecs is a null pointer, the corresponding data
+   * is read (incrementing the file read location) but discarded.
    */
   template <typename iterator_type, typename InValType>
   std::size_t read_serialized_blocked_dof_objects (const dof_id_type n_objects,

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1948,10 +1948,10 @@ private:
 
   /**
    * This flag is used only when *reading* in a system from file.
-   * Based on the system header, it keeps track of whether or not
+   * Based on the system header, it keeps track of how many
    * additional vectors were actually written for this file.
    */
-  bool _additional_data_written;
+  unsigned int _additional_data_written;
 
   /**
    * This vector is used only when *reading* in a system from file.

--- a/src/systems/equation_systems_io.C
+++ b/src/systems/equation_systems_io.C
@@ -217,7 +217,7 @@ void EquationSystems::_read_impl (const std::string & name,
   const bool read_basic_only      = read_flags & EquationSystems::READ_BASIC_ONLY;
   bool read_parallel_files  = false;
 
-  std::map<std::string, System *> xda_systems;
+  std::vector<std::pair<std::string, System *> > xda_systems;
 
   // This will unzip a file with .bz2 as the extension, otherwise it
   // simply returns the name if the file need not be unzipped.
@@ -302,7 +302,7 @@ void EquationSystems::_read_impl (const std::string & name,
                                 read_additional_data,
                                 read_legacy_format);
 
-        xda_systems.insert(std::make_pair(sys_name, &new_system));
+        xda_systems.push_back(std::make_pair(sys_name, &new_system));
 
         // If we're only creating "basic" systems, we need to tell
         // each system that before we call init() later.
@@ -334,7 +334,7 @@ void EquationSystems::_read_impl (const std::string & name,
 
       Xdr local_io (read_parallel_files ? local_file_name(this->processor_id(),name) : "", mode);
 
-      std::map<std::string, System *>::iterator
+      std::vector<std::pair<std::string, System *> >::iterator
         pos = xda_systems.begin();
 
       for (; pos != xda_systems.end(); ++pos)

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -1066,7 +1066,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
               // unpack & set the values
               for (vec_iterator_type vec_it=vecs.begin(); vec_it!=vecs.end(); ++vec_it)
                 {
-                  NumericVector<Number> & vec(**vec_it);
+                  NumericVector<Number> * vec(*vec_it);
 
                   for (std::vector<unsigned int>::const_iterator var_it=vars_to_read.begin();
                        var_it!=vars_to_read.end(); ++var_it)
@@ -1077,10 +1077,13 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
                         {
                           const dof_id_type dof_index = (*it)->dof_number (sys_num, *var_it, comp);
                           libmesh_assert (val_it != vals.end());
-                          libmesh_assert_greater_equal (dof_index, vec.first_local_index());
-                          libmesh_assert_less (dof_index, vec.last_local_index());
-                          //libMesh::out << "dof_index, *val_it = \t" << dof_index << ", " << *val_it << '\n';
-                          vec.set (dof_index, *val_it);
+                          if (vec)
+                            {
+                              libmesh_assert_greater_equal (dof_index, vec->first_local_index());
+                              libmesh_assert_less (dof_index, vec->last_local_index());
+                              //libMesh::out << "dof_index, *val_it = \t" << dof_index << ", " << *val_it << '\n';
+                              vec->set (dof_index, *val_it);
+                            }
                         }
                     }
                 }

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -1098,7 +1098,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
 
 unsigned int System::read_SCALAR_dofs (const unsigned int var,
                                        Xdr & io,
-                                       NumericVector<Number> & vec) const
+                                       NumericVector<Number> * vec) const
 {
   unsigned int n_assigned_vals = 0; // the number of values assigned, this will be returned.
 
@@ -1134,7 +1134,8 @@ unsigned int System::read_SCALAR_dofs (const unsigned int var,
 
       for(unsigned int i=0; i<SCALAR_dofs.size(); i++)
         {
-          vec.set (SCALAR_dofs[i], input_buffer[i]);
+          if (vec)
+            vec->set (SCALAR_dofs[i], input_buffer[i]);
           ++n_assigned_vals;
         }
     }
@@ -1258,7 +1259,7 @@ numeric_index_type System::read_serialized_vector (Xdr & io,
 #ifndef NDEBUG
           n_assigned_vals +=
 #endif
-            this->read_SCALAR_dofs (var, io, vec);
+            this->read_SCALAR_dofs (var, io, &vec);
         }
     }
 
@@ -2279,7 +2280,7 @@ std::size_t System::read_serialized_vectors (Xdr & io,
           libmesh_assert_not_equal_to (vectors[vec], 0);
 
           read_length +=
-            this->read_SCALAR_dofs (var, io, *vectors[vec]);
+            this->read_SCALAR_dofs (var, io, vectors[vec]);
         }
 
   //---------------------------------------


### PR DESCRIPTION
This fixes two bugs in the EquationSystems::read() code for multi-System problems:

1. When reading multiple systems, their data vectors could potentially be read in the wrong order.

2. Doing EquationSystems::write() with the WRITE_ADDITIONAL_DATA option on, then using the output in EquationSystems::read() with READ_ADDITIONAL_DATA off, would result in assertion failures in some cases and potentially result in data vectors read in the wrong order in other cases.

This latter bug (not a data corruption case, just an assertion failure) was triggered by me in GRINS in https://github.com/grinsfem/grins/pull/455 but it turned out to be a libMesh level error.  @pbauman, if you've hit it yet, I apologize.  I'm glad I dug into the error at the libMesh level rather than just redoing the app-level changes, though.

This passes all the tests I've run so far but I haven't thrown MOOSE at it yet.