### PR TITLE
Update to TreeNode to avoid infinite regression

### DIFF
--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -209,6 +209,15 @@ private:
   const unsigned int tgt_bin_size;
 
   /**
+   * This specifies the refinement level beyond which we will
+   * scale up the target bin size in child TreeNodes. We set
+   * the default to be 10, which should be large enough such
+   * that in most cases the target bin size does not need to
+   * be increased.
+   */
+  unsigned int target_bin_size_increase_level;
+
+  /**
    * Does this node contain any infinite elements.
    */
   bool contains_ifems;
@@ -228,6 +237,7 @@ TreeNode<N>::TreeNode (const MeshBase & m,
   mesh           (m),
   parent         (p),
   tgt_bin_size   (tbs),
+  target_bin_size_increase_level(10),
   contains_ifems (false)
 {
   // libmesh_assert our children are empty, thus we are active.

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -148,10 +148,18 @@ void TreeNode<N>::refine ()
   // A TreeNode<N> has by definition N children
   children.resize(N);
 
+  // Scale up the target bin size in child TreeNodes if we have reached
+  // the maximum number of refinement levels.
+  unsigned int new_target_bin_size = tgt_bin_size;
+  if(level() >= target_bin_size_increase_level)
+    {
+      new_target_bin_size *= 2;
+    }
+
   for (unsigned int c=0; c<N; c++)
     {
       // Create the child and set its bounding box.
-      children[c] = new TreeNode<N> (mesh, tgt_bin_size, this);
+      children[c] = new TreeNode<N> (mesh, new_target_bin_size, this);
       children[c]->set_bounding_box(this->create_bounding_box(c));
 
       // Pass off our nodes to our children


### PR DESCRIPTION
The motivation here is to avoid an infinite regression that can occur if you have many elements connected to one node. In this case it can happen that refining the TreeNode does not reduce the number of elements in the child TreeNode, and hence we never get below the target_bin_size threshold.

The fix proposed here is to increase the target bin size when we reach a specified refinement level.