### PR TITLE
Resolved issue with linear dependence in inverse_map().

### DIFF
--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -29,6 +29,18 @@
 namespace libMesh
 {
 
+bool libmesh_isfinite(Real value)
+{
+  // check if \p value is infinite
+  if( value > std::numeric_limits<Real>::max()
+         || value <  std::numeric_limits<Real>::min() )
+     return false;
+  // check if \p value is nan
+  if( value != value)
+     return false;
+  // \p value is finite
+  return true;
+}
 
 
 // ------------------------------------------------------------
@@ -187,6 +199,13 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
            +o(2)*p1(0)*p0(1)+o(0)*p0(2)*p1(1));
 
 
+        if( !libmesh_isfinite(c_factor)){
+           // The above system is badly posed.
+           // It should only happen when \p physical_point is not
+           // in \p inf_elem. In this case, any point that is not in the
+           // element is a valid answer.
+           return o;
+        }
         // Compute the intersection with
         // {intersection} = {fp} + c*({fp}-{o}).
         intersection.add_scaled(fp,1.+c_factor);


### PR DESCRIPTION
I used the inverse_map() scheme quite intensely in the last weeks for infinite elements and there seem to be some instabilities left.
The main problem I had is fixed with this patch.
I hope, it looks reasonable.
Best,
Hubert