### PR TITLE
Add libmesh_isinf()

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -176,6 +176,13 @@ inline bool libmesh_isnan(long double a) { return libmesh_C_isnan_longdouble(a);
 template <typename T>
 inline bool libmesh_isnan(std::complex<T> a) { return (libmesh_isnan(std::real(a)) || libmesh_isnan(std::imag(a))); }
 
+// Same goes for isinf, which can be implemented in terms of isnan.
+// http://stackoverflow.com/a/2249173/659433
+template <typename T>
+inline bool libmesh_isinf(T x) { return !libmesh_isnan(x) && libmesh_isnan(x - x); }
+
+template <typename T>
+inline bool libmesh_isinf(std::complex<T> a) { return (libmesh_isinf(std::real(a)) || libmesh_isinf(std::imag(a))); }
 
 // Define the value type for unknowns in simulations.
 // This is either Real or Complex, depending on how

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -29,18 +29,6 @@
 namespace libMesh
 {
 
-bool libmesh_isfinite(Real value)
-{
-  // check if \p value is infinite
-  if( value > std::numeric_limits<Real>::max()
-         || value <  std::numeric_limits<Real>::min() )
-     return false;
-  // check if \p value is nan
-  if( value != value)
-     return false;
-  // \p value is finite
-  return true;
-}
 
 
 // ------------------------------------------------------------
@@ -199,13 +187,13 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
            +o(2)*p1(0)*p0(1)+o(0)*p0(2)*p1(1));
 
 
-        if( !libmesh_isfinite(c_factor)){
-           // The above system is badly posed.
-           // It should only happen when \p physical_point is not
-           // in \p inf_elem. In this case, any point that is not in the
-           // element is a valid answer.
-           return o;
-        }
+        // Check whether the above system is ill-posed.  It should
+        // only happen when \p physical_point is not in \p
+        // inf_elem. In this case, any point that is not in the
+        // element is a valid answer.
+        if (libmesh_isinf(c_factor))
+          return o;
+
         // Compute the intersection with
         // {intersection} = {fp} + c*({fp}-{o}).
         intersection.add_scaled(fp,1.+c_factor);

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -29,6 +29,18 @@
 namespace libMesh
 {
 
+bool libmesh_isfinite(Real value)
+{
+  // check if \p value is infinite
+  if( value > std::numeric_limits<Real>::max()
+         || value <  std::numeric_limits<Real>::min() )
+     return false;
+  // check if \p value is nan
+  if( value != value)
+     return false;
+  // \p value is finite
+  return true;
+}
 
 
 // ------------------------------------------------------------
@@ -187,6 +199,13 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
            +o(2)*p1(0)*p0(1)+o(0)*p0(2)*p1(1));
 
 
+        if( !libmesh_isfinite(c_factor)){
+           // The above system is badly posed.
+           // It should only happen when \p physical_point is not
+           // in \p inf_elem. In this case, any point that is not in the
+           // element is a valid answer.
+           return o;
+        }
         // Compute the intersection with
         // {intersection} = {fp} + c*({fp}-{o}).
         intersection.add_scaled(fp,1.+c_factor);


### PR DESCRIPTION
The original idea is from this Stack Overflow [question](http://stackoverflow.com/a/2249173/659433).  The implementation described there works for the following test code, even for somewhat tricky cases like inf/inf which is actually nan.
```
#include "libmesh/libmesh_common.h"

using namespace libMesh;

// For compilers that do support isinf, our result should always agree
// with it.  From the clang man page:
//
// The isinf(), isnan(), and isnormal() macros return non-zero if
// and only if x is an infinity, NaN, or a non-zero normalized
// number, respectively.
//
// However this appears to be incorrect, as isinf() returns zero for NaN.
template <typename T>
void test(T val)
{
  bool
    ours   = libmesh_isinf(val),
    theirs = static_cast<bool>(isinf(val));

  if (ours != theirs)
    libmesh_error_msg("libmesh_isinf and inf disagree for val = " << val << ", ours=" << ours << ", theirs=" << theirs << ".");
  else
    libMesh::out << "libmesh_isinf and inf agree for val = " << val << ", ours=" << ours << ", theirs=" << theirs << "." << std::endl;
}

int main (int argc, char ** argv)
{
  test(12.);
  double a = 0.;
  test(1./a);
  test(std::log(a));
  test(-std::log(a));
  test(std::log(a)/std::log(a)); // This is nan, not inf!
  test(0./std::log(a)); // 0/inf == 0
  test(std::sqrt(-1)); // nan
  test(std::pow(-2, 1./3)); // nan
  test(std::numeric_limits<double>::max()); // not inf
  test(1 + std::numeric_limits<double>::max()); // greater than max, but not inf
  test(std::numeric_limits<double>::max() * std::numeric_limits<double>::max()); // max * max is inf though!

  return 0;
}
```

This builds on #1198, merging this should also flag that other PR as being merged.  Let me know if there are any other special test cases that should be tried...