### PR TITLE
UniquePtr test

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,7 +15,7 @@ unit_tests_sources = \
   base/default_coupling_test.C \
   base/getpot_test.C \
   base/point_neighbor_coupling_test.C \
-  base/auto_ptr_test.C \
+  base/unique_ptr_test.C \
   fe/fe_bernstein_test.C \
   fe/fe_clough_test.C \
   fe/fe_hermite_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -177,7 +177,7 @@ PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/auto_ptr_test.C fe/fe_bernstein_test.C \
+	base/unique_ptr_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -212,7 +212,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	base/unit_tests_dbg-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_dbg-getpot_test.$(OBJEXT) \
 	base/unit_tests_dbg-point_neighbor_coupling_test.$(OBJEXT) \
-	base/unit_tests_dbg-auto_ptr_test.$(OBJEXT) \
+	base/unit_tests_dbg-unique_ptr_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_hermite_test.$(OBJEXT) \
@@ -273,7 +273,7 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/auto_ptr_test.C fe/fe_bernstein_test.C \
+	base/unique_ptr_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -307,7 +307,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	base/unit_tests_devel-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_devel-getpot_test.$(OBJEXT) \
 	base/unit_tests_devel-point_neighbor_coupling_test.$(OBJEXT) \
-	base/unit_tests_devel-auto_ptr_test.$(OBJEXT) \
+	base/unit_tests_devel-unique_ptr_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_hermite_test.$(OBJEXT) \
@@ -366,7 +366,7 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/auto_ptr_test.C fe/fe_bernstein_test.C \
+	base/unique_ptr_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -400,7 +400,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	base/unit_tests_oprof-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_oprof-getpot_test.$(OBJEXT) \
 	base/unit_tests_oprof-point_neighbor_coupling_test.$(OBJEXT) \
-	base/unit_tests_oprof-auto_ptr_test.$(OBJEXT) \
+	base/unit_tests_oprof-unique_ptr_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_hermite_test.$(OBJEXT) \
@@ -459,7 +459,7 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/auto_ptr_test.C fe/fe_bernstein_test.C \
+	base/unique_ptr_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -493,7 +493,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	base/unit_tests_opt-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_opt-getpot_test.$(OBJEXT) \
 	base/unit_tests_opt-point_neighbor_coupling_test.$(OBJEXT) \
-	base/unit_tests_opt-auto_ptr_test.$(OBJEXT) \
+	base/unit_tests_opt-unique_ptr_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_hermite_test.$(OBJEXT) \
@@ -550,7 +550,7 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	base/dof_object_test.h base/default_coupling_test.C \
 	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/auto_ptr_test.C fe/fe_bernstein_test.C \
+	base/unique_ptr_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -584,7 +584,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	base/unit_tests_prof-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_prof-getpot_test.$(OBJEXT) \
 	base/unit_tests_prof-point_neighbor_coupling_test.$(OBJEXT) \
-	base/unit_tests_prof-auto_ptr_test.$(OBJEXT) \
+	base/unit_tests_prof-unique_ptr_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_hermite_test.$(OBJEXT) \
@@ -1058,7 +1058,7 @@ AM_CPPFLAGS = $(libmesh_optional_INCLUDES) -I$(top_builddir)/include \
 AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	base/default_coupling_test.C base/getpot_test.C \
-	base/point_neighbor_coupling_test.C base/auto_ptr_test.C \
+	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
 	fe/fe_bernstein_test.C fe/fe_clough_test.C \
 	fe/fe_hermite_test.C fe/fe_hierarchic_test.C \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
@@ -1177,7 +1177,7 @@ base/unit_tests_dbg-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_dbg-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
-base/unit_tests_dbg-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
+base/unit_tests_dbg-unique_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 fe/$(am__dirstamp):
 	@$(MKDIR_P) fe
@@ -1342,7 +1342,7 @@ base/unit_tests_devel-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_devel-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
-base/unit_tests_devel-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
+base/unit_tests_devel-unique_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_devel-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
@@ -1447,7 +1447,7 @@ base/unit_tests_oprof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_oprof-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
-base/unit_tests_oprof-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
+base/unit_tests_oprof-unique_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_oprof-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
@@ -1552,7 +1552,7 @@ base/unit_tests_opt-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_opt-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
-base/unit_tests_opt-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
+base/unit_tests_opt-unique_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_opt-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
@@ -1657,7 +1657,7 @@ base/unit_tests_prof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_prof-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
-base/unit_tests_prof-auto_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
+base/unit_tests_prof-unique_ptr_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_prof-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
@@ -1779,26 +1779,26 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_oprof-driver.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_opt-driver.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unit_tests_prof-driver.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-auto_ptr_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-point_neighbor_coupling_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-unique_ptr_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-point_neighbor_coupling_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-unique_ptr_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-point_neighbor_coupling_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-unique_ptr_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-point_neighbor_coupling_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-auto_ptr_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-unique_ptr_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-getpot_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-point_neighbor_coupling_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-unique_ptr_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-fe_bernstein_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-fe_clough_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-fe_hermite_test.Po@am__quote@
@@ -2110,19 +2110,19 @@ base/unit_tests_dbg-point_neighbor_coupling_test.obj: base/point_neighbor_coupli
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
 
-base/unit_tests_dbg-auto_ptr_test.o: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-auto_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-auto_ptr_test.Tpo -c -o base/unit_tests_dbg-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_dbg-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_dbg-auto_ptr_test.o' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_dbg-unique_ptr_test.o: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-unique_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-unique_ptr_test.Tpo -c -o base/unit_tests_dbg-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_dbg-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_dbg-unique_ptr_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
 
-base/unit_tests_dbg-auto_ptr_test.obj: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-auto_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-auto_ptr_test.Tpo -c -o base/unit_tests_dbg-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_dbg-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_dbg-auto_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_dbg-unique_ptr_test.obj: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-unique_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-unique_ptr_test.Tpo -c -o base/unit_tests_dbg-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_dbg-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_dbg-unique_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
 
 fe/unit_tests_dbg-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_dbg-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_dbg-fe_bernstein_test.Tpo -c -o fe/unit_tests_dbg-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -2824,19 +2824,19 @@ base/unit_tests_devel-point_neighbor_coupling_test.obj: base/point_neighbor_coup
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
 
-base/unit_tests_devel-auto_ptr_test.o: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-auto_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-auto_ptr_test.Tpo -c -o base/unit_tests_devel-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_devel-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_devel-auto_ptr_test.o' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_devel-unique_ptr_test.o: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-unique_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-unique_ptr_test.Tpo -c -o base/unit_tests_devel-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_devel-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_devel-unique_ptr_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
 
-base/unit_tests_devel-auto_ptr_test.obj: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-auto_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-auto_ptr_test.Tpo -c -o base/unit_tests_devel-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_devel-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_devel-auto_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_devel-unique_ptr_test.obj: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-unique_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-unique_ptr_test.Tpo -c -o base/unit_tests_devel-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_devel-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_devel-unique_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
 
 fe/unit_tests_devel-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_devel-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Tpo -c -o fe/unit_tests_devel-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -3538,19 +3538,19 @@ base/unit_tests_oprof-point_neighbor_coupling_test.obj: base/point_neighbor_coup
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
 
-base/unit_tests_oprof-auto_ptr_test.o: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-auto_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-auto_ptr_test.Tpo -c -o base/unit_tests_oprof-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_oprof-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_oprof-auto_ptr_test.o' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_oprof-unique_ptr_test.o: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-unique_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-unique_ptr_test.Tpo -c -o base/unit_tests_oprof-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_oprof-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_oprof-unique_ptr_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
 
-base/unit_tests_oprof-auto_ptr_test.obj: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-auto_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-auto_ptr_test.Tpo -c -o base/unit_tests_oprof-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_oprof-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_oprof-auto_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_oprof-unique_ptr_test.obj: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-unique_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-unique_ptr_test.Tpo -c -o base/unit_tests_oprof-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_oprof-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_oprof-unique_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
 
 fe/unit_tests_oprof-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_oprof-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_oprof-fe_bernstein_test.Tpo -c -o fe/unit_tests_oprof-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -4252,19 +4252,19 @@ base/unit_tests_opt-point_neighbor_coupling_test.obj: base/point_neighbor_coupli
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
 
-base/unit_tests_opt-auto_ptr_test.o: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-auto_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-auto_ptr_test.Tpo -c -o base/unit_tests_opt-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_opt-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_opt-auto_ptr_test.o' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_opt-unique_ptr_test.o: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-unique_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-unique_ptr_test.Tpo -c -o base/unit_tests_opt-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_opt-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_opt-unique_ptr_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
 
-base/unit_tests_opt-auto_ptr_test.obj: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-auto_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-auto_ptr_test.Tpo -c -o base/unit_tests_opt-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_opt-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_opt-auto_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_opt-unique_ptr_test.obj: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-unique_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-unique_ptr_test.Tpo -c -o base/unit_tests_opt-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_opt-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_opt-unique_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
 
 fe/unit_tests_opt-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_opt-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Tpo -c -o fe/unit_tests_opt-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -4966,19 +4966,19 @@ base/unit_tests_prof-point_neighbor_coupling_test.obj: base/point_neighbor_coupl
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
 
-base/unit_tests_prof-auto_ptr_test.o: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-auto_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-auto_ptr_test.Tpo -c -o base/unit_tests_prof-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_prof-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_prof-auto_ptr_test.o' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_prof-unique_ptr_test.o: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-unique_ptr_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-unique_ptr_test.Tpo -c -o base/unit_tests_prof-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_prof-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_prof-unique_ptr_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-auto_ptr_test.o `test -f 'base/auto_ptr_test.C' || echo '$(srcdir)/'`base/auto_ptr_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-unique_ptr_test.o `test -f 'base/unique_ptr_test.C' || echo '$(srcdir)/'`base/unique_ptr_test.C
 
-base/unit_tests_prof-auto_ptr_test.obj: base/auto_ptr_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-auto_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-auto_ptr_test.Tpo -c -o base/unit_tests_prof-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-auto_ptr_test.Tpo base/$(DEPDIR)/unit_tests_prof-auto_ptr_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/auto_ptr_test.C' object='base/unit_tests_prof-auto_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
+base/unit_tests_prof-unique_ptr_test.obj: base/unique_ptr_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-unique_ptr_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-unique_ptr_test.Tpo -c -o base/unit_tests_prof-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-unique_ptr_test.Tpo base/$(DEPDIR)/unit_tests_prof-unique_ptr_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/unique_ptr_test.C' object='base/unit_tests_prof-unique_ptr_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-auto_ptr_test.obj `if test -f 'base/auto_ptr_test.C'; then $(CYGPATH_W) 'base/auto_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/auto_ptr_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-unique_ptr_test.obj `if test -f 'base/unique_ptr_test.C'; then $(CYGPATH_W) 'base/unique_ptr_test.C'; else $(CYGPATH_W) '$(srcdir)/base/unique_ptr_test.C'; fi`
 
 fe/unit_tests_prof-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_prof-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_prof-fe_bernstein_test.Tpo -c -o fe/unit_tests_prof-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C

--- a/tests/base/unique_ptr_test.C
+++ b/tests/base/unique_ptr_test.C
@@ -19,12 +19,12 @@
 
 using namespace libMesh;
 
-class AutoPtrTest : public CppUnit::TestCase
+class UniquePtrTest : public CppUnit::TestCase
 {
 public:
-  CPPUNIT_TEST_SUITE( AutoPtrTest );
+  CPPUNIT_TEST_SUITE( UniquePtrTest );
 
-  // Test that we can call if (!foo) for AutoPtr
+  // Test that we can call if (!foo) for UniquePtr
   CPPUNIT_TEST( testComparison );
 
   // Test that the libmesh_make_unique macro works.
@@ -45,10 +45,11 @@ public:
   void testComparison ()
   {
     // Test that if(foo) and if (!foo) compile and do the right thing
-    // for AutoPtr.  This tests that the safe_bool thing that AutoPtr
-    // uses is actually working.
+    // for UniquePtr.  This tests that the safe_bool thing that our
+    // internal AutoPtr uses is actually working, in cases where users
+    // are configured to use that.
     {
-      AutoPtr<int> foo(new int(42));
+      UniquePtr<int> foo(new int(42));
 
       bool test1_passed = false;
       if (foo)
@@ -63,7 +64,7 @@ public:
 
     // Test the converse for when foo holds a NULL pointer.
     {
-      AutoPtr<int> foo(NULL);
+      UniquePtr<int> foo;
 
       bool test3_passed = true;
       if (foo)
@@ -81,7 +82,7 @@ public:
     // so it's commented out for now, but if you uncomment this test,
     // you should get a compiler error.  This is probably a candidate
     // for a configure-time test instead.
-    // AutoPtr<int> bar(new int(21));
+    // UniquePtr<int> bar(new int(21));
     // if (foo == bar)
     //   std::cerr << "This should not compile." << std::endl;
   }
@@ -96,4 +97,4 @@ public:
   }
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION( AutoPtrTest );
+CPPUNIT_TEST_SUITE_REGISTRATION( UniquePtrTest );


### PR DESCRIPTION
We use UniquePtr rather than AutoPtr now; our test coverage should probably reflect that.

Noticed this due to the AutoPtr libmesh_deprecated() warning getting called from "make check".