### PR TITLE
Loosen tolerance on straight-line check in Edge3::volume().

### DIFF
--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -179,7 +179,7 @@ Real Edge3::volume () const
   const Real c = B.norm_sq();
 
   // Degenerate straight line case
-  if (a < TOLERANCE*TOLERANCE*TOLERANCE)
+  if (a < TOLERANCE*TOLERANCE)
     return (this->point(1) - this->point(0)).norm();
 
   const Real ba=b/a;
@@ -190,9 +190,12 @@ Real Edge3::volume () const
   const Real s1 = std::sqrt(1. - ba + ca);
   const Real s2 = std::sqrt(1. + ba + ca);
 
+  Real log_term = (1. - 0.5*ba + s1) / (-1. - 0.5*ba + s2);
+  libmesh_assert(!libmesh_isnan(log_term) && log_term > 0.);
+
   return 0.5*std::sqrt(a)*((1.-0.5*ba)*s1 +
                            (1.+0.5*ba)*s2 +
-                           (ca - 0.25*ba*ba)*std::log( (1.-0.5*ba+s1)/(-1.-0.5*ba+s2) )
+                           (ca - 0.25*ba*ba)*std::log(log_term)
                            );
 }
 

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -175,13 +175,13 @@ Real Edge3::volume () const
   Point B = (this->point(1) - this->point(0))/2;
 
   const Real a = A.norm_sq();
-  const Real b = 2.*(A*B);
   const Real c = B.norm_sq();
 
   // Degenerate straight line case
   if (a < TOLERANCE*TOLERANCE)
-    return (this->point(1) - this->point(0)).norm();
+    return 2. * std::sqrt(c);
 
+  const Real b = 2.*(A*B);
   const Real ba=b/a;
   const Real ca=c/a;
 


### PR DESCRIPTION
A user [reported](https://groups.google.com/d/topic/moose-users/-8eC6TVwT5g/discussion) a failure in Edge3::volume() for the otherwise normal element:

x0 = (0.0041755731555024704, 0.02103, 0.)
x1 = (0.0042782212723039047, 0.02103, 0.)
x2 = (0.0042268963965901322, 0.02103, 0.)

Loosening the straight-line tolerance check is sufficient to fix this
particular case, but the failure was actually caused by passing a nan
to the std::log function.  In debug mode, we now verify that the
argument is valid before calling std::log.

