### PR TITLE
Better CheckpointIO error message

### DIFF
--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -560,7 +560,11 @@ void CheckpointIO::read (const std::string & name)
         io.data(parallel, "# parallel");
 
         if (_parallel != parallel)
-          libmesh_error_msg("Attempted to utilize a checkpoint file with an incompatible mesh distribution!");
+          libmesh_error_msg("Attempted to read a " <<
+                            (parallel ? "parallel" : "non-parallel")
+                            << " checkpoint file with a " <<
+                            (_parallel ? "parallel" : "non-parallel")
+                            << " checkpoint object!");
       }
 
       // If this is a parallel mesh then we need to check to ensure we're reading this on the same number of procs

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -562,6 +562,7 @@ void CheckpointIO::read (const std::string & name)
         if (_parallel != parallel)
           libmesh_error_msg("Attempted to read a " <<
                             (parallel ? "parallel" : "non-parallel")
+                            << " (" << parallel << ')'
                             << " checkpoint file with a " <<
                             (_parallel ? "parallel" : "non-parallel")
                             << " checkpoint object!");


### PR DESCRIPTION
I'm trying to understand why I'm getting non-deterministic failures
with this error from our CheckpointIO unit test at high processor
counts; might as well preserve the best of my printf debugging for
future users too.