### PR TITLE
CheckpointIO test barrier between read and write

### DIFF
--- a/tests/mesh/checkpoint.C
+++ b/tests/mesh/checkpoint.C
@@ -84,6 +84,8 @@ public:
         }
     }
 
+    TestCommWorld->barrier();
+
     // Test that we can read in the files we wrote and sum up to the
     // same total number of elements.
     {


### PR DESCRIPTION
It looks as if my failure here was due to a race condition.  It's no longer repeatable after adding the barrier(), anyway.