### PR TITLE
Fix issue with errno.h inclusion in a namespace.

### DIFF
--- a/configure
+++ b/configure
@@ -31842,8 +31842,8 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler has working errno_t declaration" >&5
-$as_echo_n "checking if compiler has working errno_t declaration... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if errno.h can be wrapped in namespace" >&5
+$as_echo_n "checking if errno.h can be wrapped in namespace... " >&6; }
 
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -31876,18 +31876,18 @@ $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-  # If errno_t does not work, verify that "typedef int errno_t;" fixes it.
+  # If that test failed, verify that including the header outside of any namespace fixes the issue.
   if (test x$errno_t_works = xno); then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if errno_t typedef fixes the issue" >&5
-$as_echo_n "checking if errno_t typedef fixes the issue... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if workaround fixes the issue" >&5
+$as_echo_n "checking if workaround fixes the issue... " >&6; }
 
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
+    #include <errno.h> // the fix
     namespace Foo {
     #include <errno.h>
     }
-    typedef int errno_t; // the fix
     #include <cstring>
 
 int
@@ -31921,16 +31921,16 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-  # If the compiler has the errno_t issue and the typedef fixes it, set the #define
+  # If the compiler has the issue and the workaround fixes it, set the #define
   if (test "x$errno_t_works" = "xno" -a "x$typedef_errno_t_fixes_issue" = "xyes"); then
 
 $as_echo "#define COMPILER_HAS_BROKEN_ERRNO_T 1" >>confdefs.h
 
   fi
 
-  # On the other hand, if the compiler has the errno_t issue and the typedef *doesn't* fix it, error out.
+  # On the other hand, if the compiler has the issue and the workaround *doesn't* fix it, error out.
   if (test "x$errno_t_works" = "xno" -a "x$typedef_errno_t_fixes_issue" = "x"); then
-    as_fn_error $? "Compiler has the errno_t issue, but typedef does not fix it.  This
+    as_fn_error $? "Cannot work around errno.h inclusion issue.  This
                   compiler will most likely not be able to build libmesh correctly." "$LINENO" 5
   fi
 

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -39,7 +39,7 @@
 /* SVN revision */
 #undef BUILD_VERSION
 
-/* define if the compiler has a broken errno_t */
+/* define if errno.h cannot be included in a namespace */
 #undef COMPILER_HAS_BROKEN_ERRNO_T
 
 /* Configuration information. */

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -49,24 +49,22 @@
 
 
 
+// Through several subsequent levels of includes, the exodusII.h
+// header includes <errno.h>.  On very specific system/compiler combinations
+// (currently GCC 5.2.0+ OSX Yosemite, El Capitan, possibly others) errno.h
+// cannot be included while wrapped in a namespace (as we do with the exII
+// namespace below).  A workaround for this is to simply include errno.h
+// not in any namespace prior to including exodusII.h.
+#ifdef LIBMESH_COMPILER_HAS_BROKEN_ERRNO_T
+#include <errno.h>
+#endif
+
+
 namespace exII {
 extern "C" {
 #include "exodusII.h" // defines MAX_LINE_LENGTH, MAX_STR_LENGTH used later
 }
 }
-
-// Through several subsequent levels of includes, the exodusII.h
-// header includes <errno.h>.  If <cstring> is subsequently included
-// in the same translation unit, there is an issue with GCC 5.2.0+ on
-// OSX which somehow causes errno_t to then be undefined.  This
-// typedef, which is controlled by an autoconf test, seems to fix the
-// issue and should be safe, since errno_t should have the same type as
-// errno, which according to the C99 standard is a "macro that expands
-// to a modifiable lvalue that has type int".
-#ifdef LIBMESH_COMPILER_HAS_BROKEN_ERRNO_T
-typedef int errno_t;
-#endif
-
 
 namespace libMesh
 {

--- a/m4/errno_test.m4
+++ b/m4/errno_test.m4
@@ -1,15 +1,15 @@
 # --------------------------------------------------------------
-# Test for compiler with broken errno_t.  This is currently only known
-# to affect GCC 5.2.0 on OSX Yosemite and above.  It seems to be
-# possible to workaround the issue by declaring an errno_t type of our
-# own as necessary.
+# Test for compiler which does not support namespace-wrapped inclusion
+# of errno.h.  This is currently only known to affect GCC 5.2.0 on OSX
+# Yosemite and above.  One can work around the issue by simply
+# including errno.h separately, outside of any namespace.
 # --------------------------------------------------------------
 AC_DEFUN([CHECK_FOR_BROKEN_ERRNO_T],
 [
   # Try to compile a test program that exhibits the error.
   AC_LANG_PUSH([C++])
 
-  AC_MSG_CHECKING([if compiler has working errno_t declaration])
+  AC_MSG_CHECKING([if errno.h can be wrapped in namespace])
 
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   namespace Foo {
@@ -24,15 +24,15 @@ AC_DEFUN([CHECK_FOR_BROKEN_ERRNO_T],
     AC_MSG_RESULT(no)
   ])
 
-  # If errno_t does not work, verify that "typedef int errno_t;" fixes it.
+  # If that test failed, verify that including the header outside of any namespace fixes the issue.
   if (test x$errno_t_works = xno); then
-    AC_MSG_CHECKING([if errno_t typedef fixes the issue])
+    AC_MSG_CHECKING([if workaround fixes the issue])
 
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include <errno.h> // the fix
     namespace Foo {
     @%:@include <errno.h>
     }
-    typedef int errno_t; // the fix
     @%:@include <cstring>
     ]], [[
     ]])],[
@@ -45,14 +45,14 @@ AC_DEFUN([CHECK_FOR_BROKEN_ERRNO_T],
 
   AC_LANG_POP([C++])
 
-  # If the compiler has the errno_t issue and the typedef fixes it, set the #define
+  # If the compiler has the issue and the workaround fixes it, set the #define
   if (test "x$errno_t_works" = "xno" -a "x$typedef_errno_t_fixes_issue" = "xyes"); then
-    AC_DEFINE(COMPILER_HAS_BROKEN_ERRNO_T, 1, [define if the compiler has a broken errno_t])
+    AC_DEFINE(COMPILER_HAS_BROKEN_ERRNO_T, 1, [define if errno.h cannot be included in a namespace])
   fi
 
-  # On the other hand, if the compiler has the errno_t issue and the typedef *doesn't* fix it, error out.
+  # On the other hand, if the compiler has the issue and the workaround *doesn't* fix it, error out.
   if (test "x$errno_t_works" = "xno" -a "x$typedef_errno_t_fixes_issue" = "x"); then
-    AC_MSG_ERROR([Compiler has the errno_t issue, but typedef does not fix it.  This
+    AC_MSG_ERROR([Cannot work around errno.h inclusion issue.  This
                   compiler will most likely not be able to build libmesh correctly.])
   fi
 ])


### PR DESCRIPTION
This issue was fixed in 7169d43, but only partially.  After switching to a different version of PETSc, which triggered the inclusion of `mm_malloc.h`, a related-but-different error occurred.  The new fix should be more correct, portable, and complete going forward. It works on my system which exhibits the problem.

It's also interesting to note that this issue was raised as far back as [2010](http://www.mail-archive.com/libmesh-users@lists.sourceforge.net/msg02657.html) but we never really fixed it... and then no one encountered it for 6+ years?