### PR TITLE
Reorder paths starting with /lib too

### DIFF
--- a/contrib/bin/strip_dup_libs.pl
+++ b/contrib/bin/strip_dup_libs.pl
@@ -73,6 +73,18 @@ foreach( @cleaned_up_libs_third ) {
     {
         push @system_lib_paths, $_;
     }
+    # Discard library paths starting with /lib. This directory is not
+    # even present on OSX and it is typically fairly empty on Linux,
+    # but it may be present on other UNIX systems.
+    elsif( ($_=~/-L\/lib/) )
+    {
+        push @system_lib_paths, $_;
+    }
+    # Discard -Wl,* flags starting with /lib
+    elsif( ($_=~/-Wl,.*\/lib/) )
+    {
+        push @system_lib_paths, $_;
+    }
     # Otherwise, keep the path.
     else
     {

--- a/contrib/bin/strip_dup_libs.pl
+++ b/contrib/bin/strip_dup_libs.pl
@@ -69,7 +69,7 @@ foreach( @cleaned_up_libs_third ) {
         push @system_lib_paths, $_;
     }
     # Discard -Wl,* flags starting with /usr
-    elsif( ($_=~/-Wl,.*\/usr/) )
+    elsif( ($_=~/-Wl,[^\/]*\/usr/) )
     {
         push @system_lib_paths, $_;
     }
@@ -81,7 +81,7 @@ foreach( @cleaned_up_libs_third ) {
         push @system_lib_paths, $_;
     }
     # Discard -Wl,* flags starting with /lib
-    elsif( ($_=~/-Wl,.*\/lib/) )
+    elsif( ($_=~/-Wl,[^\/]*\/lib/) )
     {
         push @system_lib_paths, $_;
     }


### PR DESCRIPTION
Linux and OSX don't really use `/lib` for much (or at all), but other UNIX systems might?  At least one user on ANL's "Blues" machine seemed to have HDF5 installed in /lib.  So it shouldn't hurt anything to reorder these paths to the end of the list of libraries as well.

In the process of testing the script, I also figured out that some of our regexes were too greedy, that is now fixed as well.