### PR TITLE
Only serialize the mesh to processor 0 for Exodus

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -166,6 +166,12 @@ public:
   virtual void allgather() libmesh_override;
 
   /**
+   * Gathers all elements and nodes of the mesh onto
+   * processor zero
+   */
+  virtual void gather_to_zero() libmesh_override;
+
+  /**
    * Deletes all nonlocal elements of the mesh
    * except for "ghosts" which touch a local element, and deletes
    * all nodes which are not part of a local or ghost element
@@ -479,6 +485,11 @@ protected:
    * A boolean remembering whether we're serialized or not
    */
   bool _is_serial;
+
+  /**
+   * A boolean remembering whether we're serialized to proc 0 or not
+   */
+  bool _is_serial_on_proc_0;
 
   /**
    * Cached data from the last renumber_nodes_and_elements call

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -142,6 +142,12 @@ public:
   virtual void allgather () {}
 
   /**
+   * Gathers all elements and nodes of the mesh onto
+   * processor zero
+   */
+  virtual void gather_to_zero() {}
+
+  /**
    * When supported, deletes all nonlocal elements of the mesh
    * except for "ghosts" which touch a local element, and deletes
    * all nodes which are not part of a local or ghost element

--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -59,14 +59,14 @@ protected:
    * rendering this object useless.
    */
   explicit
-  MeshOutput (const bool is_parallel_format = false);
+  MeshOutput (const bool is_parallel_format = false, const bool serial_only_needed_on_proc_0 = false);
 
   /**
    * Constructor.  Takes a reference to a constant object.
    * This constructor will only allow us to write the object.
    */
   explicit
-  MeshOutput (const MT &, const bool is_parallel_format = false);
+  MeshOutput (const MT &, const bool is_parallel_format = false, const bool serial_only_needed_on_proc_0 = false);
 
 
 public:
@@ -140,6 +140,14 @@ protected:
    */
   const bool _is_parallel_format;
 
+  /**
+   * Flag specifying whether this format can be written by only
+   * serializing the mesh to processor zero
+   *
+   * If this is false (default) the mesh will be serialized to
+   * all processors
+   */
+  const bool _serial_only_needed_on_proc_0;
 
 private:
 
@@ -165,8 +173,9 @@ private:
 // MeshOutput inline members
 template <class MT>
 inline
-MeshOutput<MT>::MeshOutput (const bool is_parallel_format) :
+MeshOutput<MT>::MeshOutput (const bool is_parallel_format, const bool serial_only_needed_on_proc_0) :
   _is_parallel_format(is_parallel_format),
+  _serial_only_needed_on_proc_0(serial_only_needed_on_proc_0),
   _obj(libmesh_nullptr),
   _ascii_precision (std::numeric_limits<Real>::digits10 + 2)
 {}
@@ -175,8 +184,9 @@ MeshOutput<MT>::MeshOutput (const bool is_parallel_format) :
 
 template <class MT>
 inline
-MeshOutput<MT>::MeshOutput (const MT & obj, const bool is_parallel_format) :
+MeshOutput<MT>::MeshOutput (const MT & obj, const bool is_parallel_format, const bool serial_only_needed_on_proc_0) :
   _is_parallel_format(is_parallel_format),
+  _serial_only_needed_on_proc_0(serial_only_needed_on_proc_0),
   _obj (&obj),
   _ascii_precision (std::numeric_limits<Real>::digits10 + 2)
 {

--- a/include/mesh/mesh_serializer.h
+++ b/include/mesh/mesh_serializer.h
@@ -42,7 +42,7 @@ class MeshBase;
 class MeshSerializer
 {
 public:
-  MeshSerializer(MeshBase & mesh, bool need_serial = true);
+  MeshSerializer(MeshBase & mesh, bool need_serial = true, bool serial_only_needed_on_proc_0 = false);
 
   ~MeshSerializer();
 

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1367,6 +1367,8 @@ void DistributedMesh::delete_remote_elements()
 #endif
 
   _is_serial = false;
+  _is_serial_on_proc_0 = false;
+
   MeshCommunication().delete_remote_elements(*this, _extra_ghost_elems);
 
   libmesh_assert_equal_to (this->max_elem_id(), this->parallel_max_elem_id());
@@ -1451,6 +1453,15 @@ void DistributedMesh::allgather()
   this->libmesh_assert_valid_parallel_ids();
   this->libmesh_assert_valid_parallel_flags();
 #endif
+}
+
+void DistributedMesh::gather_to_zero()
+{
+  if (_is_serial_on_proc_0)
+    return;
+
+  _is_serial_on_proc_0 = true;
+  MeshCommunication().gather(0, *this);
 }
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -34,6 +34,8 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/exodusII_io_helper.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/mesh_communication.h"
+#include "libmesh/parallel_mesh.h"
 
 namespace libMesh
 {
@@ -48,7 +50,9 @@ ExodusII_IO::ExodusII_IO (MeshBase & mesh,
 #endif
                           ) :
   MeshInput<MeshBase> (mesh),
-  MeshOutput<MeshBase> (mesh),
+  MeshOutput<MeshBase> (mesh,
+                        /* is_parallel_format = */ false,
+                        /* serial_only_needed_on_proc_0 = */ true),
   ParallelObject(mesh),
 #ifdef LIBMESH_HAVE_EXODUS_API
   exio_helper(new ExodusII_IO_Helper(*this, false, true, single_precision)),
@@ -543,7 +547,8 @@ void ExodusII_IO::write_element_data (const EquationSystems & es)
   // ExodusII_IO::write_element_data() when the underlying Mesh is a
   // DistributedMesh will result in an unnecessary additional
   // serialization/re-parallelization step.
-  MeshSerializer serialize(MeshInput<MeshBase>::mesh(), !MeshOutput<MeshBase>::_is_parallel_format);
+  // The "true" specifies that we only need the mesh serialized to processor 0
+  MeshSerializer serialize(MeshInput<MeshBase>::mesh(), !MeshOutput<MeshBase>::_is_parallel_format, true);
 
   // To be (possibly) filled with a filtered list of variable names to output.
   std::vector<std::string> names;
@@ -788,7 +793,8 @@ void ExodusII_IO::write (const std::string & fname)
 
   // We may need to gather a DistributedMesh to output it, making that
   // const qualifier in our constructor a dirty lie
-  MeshSerializer serialize(const_cast<MeshBase &>(mesh), !MeshOutput<MeshBase>::_is_parallel_format);
+  // The "true" specifies that we only need the mesh serialized to processor 0
+  MeshSerializer serialize(MeshInput<MeshBase>::mesh(), !MeshOutput<MeshBase>::_is_parallel_format, true);
 
   libmesh_assert( !exio_helper->opened_for_writing );
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1001,9 +1001,6 @@ void MeshCommunication::gather (const processor_id_type, DistributedMesh &) cons
 // ------------------------------------------------------------
 void MeshCommunication::gather (const processor_id_type root_id, DistributedMesh & mesh) const
 {
-  // The mesh should know it's about to be serialized
-  libmesh_assert (mesh.is_serial());
-
   // Check for quick return
   if (mesh.n_processors() == 1)
     return;
@@ -1061,9 +1058,7 @@ void MeshCommunication::gather (const processor_id_type root_id, DistributedMesh
   // Inform new elements of their neighbors,
   // while resetting all remote_elem links on
   // the appropriate ranks.
-  if ((root_id == DofObject::invalid_processor_id) ||
-      (mesh.comm().rank() == root_id))
-    mesh.find_neighbors(true);
+  mesh.find_neighbors(true);
 
   // All done!
 }

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -64,7 +64,7 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
       my_mesh.allow_renumbering(false);
     }
 
-  MeshSerializer serialize(const_cast<MT &>(*_obj), !_is_parallel_format);
+  MeshSerializer serialize(const_cast<MT &>(*_obj), !_is_parallel_format, _serial_only_needed_on_proc_0);
 
   // Build the list of variable names that will be written.
   std::vector<std::string> names;
@@ -72,9 +72,6 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
 
   if (!_is_parallel_format)
     {
-      // We need a serial mesh for MeshOutput for now
-      const_cast<EquationSystems &>(es).allgather();
-
       // Build the nodal solution values & get the variable
       // names from the EquationSystems object
       std::vector<Number> soln;

--- a/src/mesh/mesh_serializer.C
+++ b/src/mesh/mesh_serializer.C
@@ -24,14 +24,19 @@
 namespace libMesh
 {
 
-MeshSerializer::MeshSerializer(MeshBase & mesh, bool need_serial) :
+MeshSerializer::MeshSerializer(MeshBase & mesh, bool need_serial, bool serial_only_needed_on_proc_0) :
   _mesh(mesh),
   reparallelize(false)
 {
   libmesh_parallel_only(mesh.comm());
-  if (need_serial && !_mesh.is_serial()) {
+  if (need_serial && !_mesh.is_serial() && !serial_only_needed_on_proc_0) {
     reparallelize = true;
     _mesh.allgather();
+  }
+  else if (need_serial && !_mesh.is_serial() && serial_only_needed_on_proc_0) {
+    // Note: NOT reparallelizing on purpose.
+    // Just waste a bit of space on processor 0 to speed things up
+    _mesh.gather_to_zero();
   }
 }
 


### PR DESCRIPTION
This changes mesh serialization behavior from an `allgather` to a `gather_to_zero` for Exodus.

This is akin to the fix I did a while ago in #190... we only need stuff serialized to _processor 0_ to output an Exodus file.

The memory savings here will be ENORMOUS for larger meshes.  At INL we now have nodes in our cluster that have 36 processors.  So, if you serialize the mesh to all processors you get 36 copies of the mesh on every node.  If that mesh is 3GB you just destroyed yourself.  With this fix only the head node will need 3GB of room to store the mesh.

In addition, I've also slightly modified the behavior so that when Exodus is using this new capability the mesh will be serialized to processor 0 exactly _once_... and then left there.  Yes, it will hold all of that extra memory on processor zero forever... but it will also be _lightning_ fast to output each subsequent Exodus file.  I think it's a good tradeoff, but I'm definitely willing to have a conversation about it.

This capability will come in handy when you have _medium_ sized problems.  Problems where you want to use `DistributedMesh` but where the extra hassle (and lack of features) of Nemesis output can be avoided by writing Exodus (I happen to be solving a problem like that right now).