### PR TITLE
Add '-Wunused -Wunused-parameter' for clang in all modes.

### DIFF
--- a/configure
+++ b/configure
@@ -8133,14 +8133,14 @@ $as_echo "Unknown Intel complier" >&6; }
           ;;
 
       clang)
-          CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -Qunused-arguments"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
-          CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+          CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -Qunused-arguments -Wunused-parameter -Wunused"
+          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+          CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
           NODEPRECATEDFLAG="-Wno-deprecated"
 
-          CFLAGS_OPT="-O2 -Qunused-arguments"
-          CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -fno-limit-debug-info"
-          CFLAGS_DBG="-g -Wimplicit -Qunused-arguments -fno-limit-debug-info"
+          CFLAGS_OPT="-O2 -Qunused-arguments -Wunused-parameter -Wunused"
+          CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -fno-limit-debug-info -Wunused-parameter -Wunused"
+          CFLAGS_DBG="-g -Wimplicit -Qunused-arguments -fno-limit-debug-info -Wunused-parameter -Wunused"
           ;;
 
       *)

--- a/contrib/gmv/gmvread.c
+++ b/contrib/gmv/gmvread.c
@@ -61,9 +61,10 @@
 #define IECXI8R4 7
 #define IECXI8R8 8
 
-static int charsize = CHARSIZE, shortsize = SHORTSIZE, intsize = INTSIZE, 
-           wordsize = WORDSIZE, floatsize = FLOATSIZE,
-           longsize = LONGSIZE, doublesize = DOUBLESIZE,
+static int charsize = CHARSIZE,
+           intsize = INTSIZE,
+           floatsize = FLOATSIZE,
+           doublesize = DOUBLESIZE,
            longlongsize = LONGLONGSIZE, charsize_in;
 
 static long numnodes, numcells, lncells, numcellsin, numfaces, lnfaces,

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -140,7 +140,7 @@ public:
   typename boostcopy::enable_if_c<
     ScalarTraits<Scalar>::value,
     TypeTensor &>::type
-  operator = (const Scalar & p)
+  operator = (const Scalar & libmesh_dbg_var(p))
   { libmesh_assert_equal_to (p, Scalar(0)); this->zero(); return *this; }
 
   /**

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -134,7 +134,7 @@ public:
   typename boostcopy::enable_if_c<
     ScalarTraits<Scalar>::value,
     TypeVector &>::type
-  operator = (const Scalar & p)
+  operator = (const Scalar & libmesh_dbg_var(p))
   { libmesh_assert_equal_to (p, Scalar(0)); this->zero(); return *this; }
 
   /**

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -1130,14 +1130,14 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
           ;;
 
       clang)
-          CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -Qunused-arguments"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
-          CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+          CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -Qunused-arguments -Wunused-parameter -Wunused"
+          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+          CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
           NODEPRECATEDFLAG="-Wno-deprecated"
 
-          CFLAGS_OPT="-O2 -Qunused-arguments"
-          CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -fno-limit-debug-info"
-          CFLAGS_DBG="-g -Wimplicit -Qunused-arguments -fno-limit-debug-info"
+          CFLAGS_OPT="-O2 -Qunused-arguments -Wunused-parameter -Wunused"
+          CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -fno-limit-debug-info -Wunused-parameter -Wunused"
+          CFLAGS_DBG="-g -Wimplicit -Qunused-arguments -fno-limit-debug-info -Wunused-parameter -Wunused"
           ;;
 
       *)

--- a/src/apps/calculator.C
+++ b/src/apps/calculator.C
@@ -128,12 +128,11 @@ int main(int argc, char ** argv)
 
   old_es.print_info();
 
-  const unsigned int n_systems = old_es.n_systems();
 
   const unsigned int sysnum =
     cl.follow(0, "--insys");
 
-  libmesh_assert_less(sysnum, n_systems);
+  libmesh_assert_less(sysnum, old_es.n_systems());
 
   System & old_sys = old_es.get_system(sysnum);
   std::string current_sys_name = old_sys.name();

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2333,10 +2333,12 @@ DofMap::max_constraint_error (const System & system,
               global_dof >= vec.first_local_index() &&
               global_dof < vec.last_local_index())
             {
+#ifdef DEBUG
               DofConstraints::const_iterator
                 pos = _dof_constraints.find(global_dof);
 
               libmesh_assert (pos != _dof_constraints.end());
+#endif
 
               Number exact_value = 0;
               DofConstraintValueMap::const_iterator rhsit =

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -878,9 +878,11 @@ void DistributedMesh::libmesh_assert_valid_parallel_object_ids(const mapvector<T
       libmesh_assert(!obj || obj->id() == i);
 
       // All processors with an object should agree on id
+#ifdef DEBUG
       const dof_id_type dofid = obj && obj->valid_id() ?
         obj->id() : DofObject::invalid_id;
       libmesh_assert(this->comm().semiverify(obj ? &dofid : libmesh_nullptr));
+#endif
 
       // All processors with an object should agree on processor id
       const dof_id_type procid = obj && obj->valid_processor_id() ?
@@ -905,7 +907,7 @@ void DistributedMesh::libmesh_assert_valid_parallel_object_ids(const mapvector<T
                       (min_procid != this->processor_id())
                       );
 
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
+#if defined(LIBMESH_ENABLE_UNIQUE_ID) && defined(DEBUG)
       // All processors with an object should agree on unique id
       const unique_id_type uniqueid = obj ? obj->unique_id() : 0;
       libmesh_assert(this->comm().semiverify(obj ? &uniqueid : libmesh_nullptr));
@@ -925,6 +927,7 @@ void DistributedMesh::libmesh_assert_valid_parallel_ids () const
 
 void DistributedMesh::libmesh_assert_valid_parallel_p_levels () const
 {
+#ifdef DEBUG
   // This function must be run on all processors at once
   parallel_object_only();
 
@@ -939,6 +942,7 @@ void DistributedMesh::libmesh_assert_valid_parallel_p_levels () const
       // All processors with an active element should agree on p level
       libmesh_assert(this->comm().semiverify((el && el->active()) ? &p_level : libmesh_nullptr));
     }
+#endif
 }
 
 
@@ -946,7 +950,7 @@ void DistributedMesh::libmesh_assert_valid_parallel_p_levels () const
 
 void DistributedMesh::libmesh_assert_valid_parallel_flags () const
 {
-#ifdef LIBMESH_ENABLE_AMR
+#if defined(LIBMESH_ENABLE_AMR) && defined(DEBUG)
   // This function must be run on all processors at once
   parallel_object_only();
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -68,7 +68,7 @@ inline unsigned int to_uint ( const T & t )
 
 // test equality for a.first -> a.second mapping.  since we can only map to one
 // value only test the first entry
-#if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
+#if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API) && defined(DEBUG)
 inline bool global_idx_mapping_equality (const std::pair<unsigned int, unsigned int> & a,
                                          const std::pair<unsigned int, unsigned int> & b)
 {

--- a/src/numerics/coupling_matrix.C
+++ b/src/numerics/coupling_matrix.C
@@ -59,10 +59,9 @@ CouplingMatrix & CouplingMatrix::operator&= (const CouplingMatrix & other)
 
       // We did find a range which might contain the start of the new
       // range.
-      const std::size_t firstloc = lb->first;
       const std::size_t lastloc  = lb->second;
-      libmesh_assert_less_equal(firstloc, lastloc);
-      libmesh_assert_less_equal(firstloc, other_range_start);
+      libmesh_assert_less_equal(lb->first, lastloc);
+      libmesh_assert_less_equal(lb->first, other_range_start);
 
 #ifdef DEBUG
       {

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -119,7 +119,7 @@ template <typename T>
 void EpetraMatrix<T>::init (const numeric_index_type m,
                             const numeric_index_type n,
                             const numeric_index_type m_l,
-                            const numeric_index_type n_l,
+                            const numeric_index_type libmesh_dbg_var(n_l),
                             const numeric_index_type nnz,
                             const numeric_index_type noz,
                             const numeric_index_type /* blocksize */)

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -40,7 +40,10 @@ static const unsigned int header_size = 12;
 static const unsigned int header_size = 11;
 #endif
 
+#ifdef DEBUG
+// Currently this constant is only used for debugging.
 static const largest_id_type elem_magic_header = 987654321;
+#endif
 }
 
 

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -43,7 +43,10 @@ static const unsigned int header_size = 2;
 static const unsigned int idtypes_per_Real =
   (sizeof(Real) + sizeof(largest_id_type) - 1) / sizeof(largest_id_type);
 
+#ifdef DEBUG
+// Currently this constant is only used for debugging.
 static const largest_id_type node_magic_header = 1234567890;
+#endif
 }
 
 

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -1037,8 +1037,7 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
 
   unsigned int n_files = multiple_vectors.size();
   unsigned int n_directories = multiple_directory_names.size();
-  unsigned int n_data_names = multiple_data_names.size();
-  libmesh_assert( (n_files == n_directories) && (n_files == n_data_names) );
+  libmesh_assert((n_files == n_directories) && (n_files == multiple_data_names.size()));
 
   if (n_files == 0)
     return;

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1432,6 +1432,7 @@ void FEMContext::elem_position_get()
   //    {
   unsigned int n_nodes = this->get_elem().n_nodes();
 
+#ifdef DEBUG
   const unsigned char dim = this->get_elem_dim();
 
   // For simplicity we demand that mesh coordinates be stored
@@ -1451,6 +1452,7 @@ void FEMContext::elem_position_get()
                   == LAGRANGE &&
                   this->get_element_fe(this->get_mesh_z_var(), dim)->get_fe_type().order.get_order()
                   == this->get_elem().default_order()));
+#endif
 
   // Get degree of freedom coefficients from point coordinates
   if (this->get_mesh_x_var() != libMesh::invalid_uint)
@@ -1489,13 +1491,15 @@ void FEMContext::_do_elem_position_set(Real)
   // operating on elements which share a node
   libmesh_assert_equal_to (libMesh::n_threads(), 1);
 
-  const unsigned char dim = this->get_elem_dim();
-
   // If the coordinate data is in our own system, it's already
   // been set up for us, and we can ignore our input parameter theta
   //  if (_mesh_sys == this->number())
   //    {
   unsigned int n_nodes = this->get_elem().n_nodes();
+
+#ifdef DEBUG
+  const unsigned char dim = this->get_elem_dim();
+
   // For simplicity we demand that mesh coordinates be stored
   // in a format that allows a direct copy
   libmesh_assert(this->get_mesh_x_var() == libMesh::invalid_uint ||
@@ -1510,6 +1514,7 @@ void FEMContext::_do_elem_position_set(Real)
                  (this->get_element_fe(this->get_mesh_z_var(), dim)->get_fe_type().family
                   == LAGRANGE &&
                   this->get_elem_solution(this->get_mesh_z_var()).size() == n_nodes));
+#endif
 
   // Set the new point coordinates
   if (this->get_mesh_x_var() != libMesh::invalid_uint)


### PR DESCRIPTION
These need to be enabled in optimized mode to catch parameters which are
only used for debugging.  Such parameters need to be wrapped in the
libmesh_dbg_var() macro.

Note: previously we were using -Wunused in dbg and devel modes, but
that apparently does not imply -Wunused-parameter, at least in the
version of clang I'm using.  There is a fairly comprehensive list of
warnings at http://fuckingclangwarnings.com, but -Wunused is not
listed there. -Wunused *does* imply -Wunused-variable, however.

Refs idaholab/moose#8388.