### PR TITLE
More accurate echo in example run script messages

### DIFF
--- a/examples/run_common.sh
+++ b/examples/run_common.sh
@@ -10,7 +10,7 @@ message_running() {
 
     echo "***************************************************************"
     echo "* Running Example $example_name:" 
-    echo "*  $LIBMESH_RUN $executable $options $LIBMESH_OPTIONS"
+    echo "*  $LIBMESH_RUN ./$executable $options $LIBMESH_OPTIONS"
     echo "***************************************************************"
     echo " "
 }
@@ -27,7 +27,7 @@ message_done_running() {
     echo " "
     echo "***************************************************************"
     echo "* Done Running Example $example_name:" 
-    echo "*  $LIBMESH_RUN $executable $options $LIBMESH_OPTIONS"
+    echo "*  $LIBMESH_RUN ./$executable $options $LIBMESH_OPTIONS"
     echo "***************************************************************"
 }
 


### PR DESCRIPTION
Now you can copy-and-paste the command and not have it break when the
current directory isn't in your PATH.