### PR TITLE
fix n_levels for multi-processor, serial, multi-level adaptivity cases

### DIFF
--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -638,8 +638,14 @@ unsigned int MeshTools::n_levels(const MeshBase & mesh)
 
   MeshBase::const_element_iterator el =
     mesh.unpartitioned_elements_begin();
-  const MeshBase::const_element_iterator end_el =
+  MeshBase::const_element_iterator end_el =
     mesh.unpartitioned_elements_end();
+
+  if (mesh.is_serial())
+  {
+    el = mesh.elements_begin();
+    end_el = mesh.elements_end();
+  }
 
   for( ; el != end_el; ++el)
     nl = std::max((*el)->level() + 1, nl);


### PR DESCRIPTION
Previously, ``MooseUtils::n_levels`` assumed that all processors had their own local elements for calculating the number of mesh adaptivity levels.  This assumption is violated in the following scenario (i.e. when all the following are true):

* performing mesh initialization
* using replicated mesh
* running on multiple processors
* initial mesh has multiple adaptivity levels already (e.g. via ``CheckpointIO``).
* initial mesh has elements partitioned onto multiple processor already

CheckpointIO, for example, skips initialization of the mesh from a file for all processors except processor 0.  This previously resulted in the n_levels function only looping over elements local to a processor to determine the level and unpartitioned elements.  The rendezvous ``max`` call at the end of ``n_levels`` doesn't help because the non processor 0 processes all have zero element meshes.  This was discovered when investigating idaholab/moose#8410