### PR TITLE
paranoid_n_levels()

### DIFF
--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -242,8 +242,9 @@ dof_id_type n_non_subactive_elem_of_type_at_level(const MeshBase & mesh,
 
 /**
  * Return the number of levels of refinement in the mesh.
- * Implemented by looping over all the local elements and finding the
- * maximum level, then summing in parallel.
+ * Implemented by looping over all the local elements and
+ * unpartitioned elements and finding the maximum level, then summing
+ * in parallel.
  */
 unsigned int n_levels(const MeshBase & mesh);
 
@@ -274,6 +275,17 @@ unsigned int n_active_local_levels(const MeshBase & mesh);
  * maximum p-level, then summing in parallel.
  */
 unsigned int n_p_levels (const MeshBase & mesh);
+
+/**
+ * Return the number of levels of refinement in the mesh, even if that
+ * mesh is not currently properly distributed or properly serialized.
+ *
+ * Implemented by looping over all elements and finding the maximum
+ * level, then summing in parallel.  This is much slower than
+ * n_levels() but will return correct values even when the mesh is in
+ * an inconsistent parallel state.
+ */
+unsigned int paranoid_n_levels(const MeshBase & mesh);
 
 /**
  * Builds a set of node IDs for nodes which belong to non-subactive

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -956,8 +956,12 @@ void MeshCommunication::broadcast (MeshBase & mesh) const
 
   // Broadcast elements from coarsest to finest, so that child
   // elements will see their parents already in place.
-  unsigned int n_levels = MeshTools::n_levels(mesh);
-  mesh.comm().broadcast(n_levels);
+  //
+  // When restarting from a checkpoint, we may have elements which are
+  // assigned to a processor but which have not yet been sent to that
+  // processor, so we need to use a paranoid n_levels() count and not
+  // the usual fast algorithm.
+  const unsigned int n_levels = MeshTools::paranoid_n_levels(mesh);
 
   for (unsigned int l=0; l != n_levels; ++l)
     mesh.comm().broadcast_packed_range(&mesh,
@@ -1025,10 +1029,7 @@ void MeshCommunication::gather (const processor_id_type root_id, DistributedMesh
 
   // Gather elements from coarsest to finest, so that child
   // elements will see their parents already in place.
-  // rank 0 should know n_levels regardless, so this is
-  // safe independent of root_id
-  unsigned int n_levels = MeshTools::n_levels(mesh);
-  mesh.comm().broadcast(n_levels);
+  const unsigned int n_levels = MeshTools::n_levels(mesh);
 
   for (unsigned int l=0; l != n_levels; ++l)
     (root_id == DofObject::invalid_processor_id) ?

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -645,6 +645,33 @@ unsigned int MeshTools::n_levels(const MeshBase & mesh)
     nl = std::max((*el)->level() + 1, nl);
 
   mesh.comm().max(nl);
+
+  // n_levels() is only valid and should only be called in cases where
+  // the mesh is validly distributed (or serialized).  Let's run an
+  // expensive test in debug mode to make sure this is such a case.
+#ifdef DEBUG
+  const unsigned int paranoid_nl = MeshTools::paranoid_n_levels(mesh);
+  libmesh_assert_equal_to(nl, paranoid_nl);
+#endif
+  return nl;
+}
+
+
+
+unsigned int MeshTools::paranoid_n_levels(const MeshBase & mesh)
+{
+  libmesh_parallel_only(mesh.comm());
+
+  MeshBase::const_element_iterator el =
+    mesh.elements_begin();
+  const MeshBase::const_element_iterator end_el =
+    mesh.elements_end();
+
+  unsigned int nl = 0;
+  for( ; el != end_el; ++el)
+    nl = std::max((*el)->level() + 1, nl);
+
+  mesh.comm().max(nl);
   return nl;
 }
 


### PR DESCRIPTION
This should replace #1222 

We retain the old n_levels() algorithm, but in dbg mode (where we're already throwing away even asymptotic complexity guarantees) we test the result against the slower paranoid_n_levels() before returning.

I checked through everything in libMesh and MOOSE, and MeshCommunication::broadcast() appears to be the only place where we should ever expect to need paranoid_n_levels().