### PR TITLE
Send coarse ghosts

### DIFF
--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -103,6 +103,12 @@ public:
   void gather_neighboring_elements (DistributedMesh &) const;
 
   /**
+   * Examine a just-coarsened mesh, and for any newly-coarsened elements,
+   * send the associated ghosted elements to the processor which needs them.
+   */
+  void send_coarse_ghosts (MeshBase &) const;
+
+  /**
    * This method takes an input \p DistributedMesh which may be
    * distributed among all the processors.  Each processor then
    * sends its local nodes and elements to processor \p root_id.

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1448,7 +1448,11 @@ bool MeshRefinement::_coarsen_elements ()
 
   // And we may need to update DistributedMesh values reflecting the changes
   if (mesh_changed)
-    _mesh.update_parallel_id_counts();
+    {
+      _mesh.update_parallel_id_counts();
+
+      MeshCommunication().send_coarse_ghosts(_mesh);
+    }
 
   // Node processor ids may need to change if an element of that id
   // was coarsened away


### PR DESCRIPTION
This fixes the last remaining bug I know about with DistributedMesh AMR/C: when coarsening, it was possible for a newly-activated coarse element to not have all the ghost elements it needed, and nothing would communicate those ghost elements to it.  This was causing even one of the libMesh examples to fail on 24 processors for me, when a coarsened element happened to straddle a partition boundary.