### PR TITLE
Avoid vtkSmartPointer include

### DIFF
--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -33,9 +33,6 @@
 
 // For dealing with MPI stuff in VTK.
 #if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
-# include "libmesh/ignore_warnings.h"
-# include "vtkSmartPointer.h"
-# include "libmesh/restore_warnings.h"
 class vtkMPIController;
 #endif
 
@@ -90,7 +87,9 @@ private:
 
 #if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
   // VTK object for dealing with MPI stuff in VTK.
-  vtkSmartPointer<vtkMPIController> _vtk_mpi_controller;
+  // This can't be a UniquePtr because VTK makes the destructor
+  // protected and forces us to use a named destructor manually
+  vtkMPIController * _vtk_mpi_controller;
 #endif
 };
 

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -563,7 +563,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
 
 #if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
   // Do MPI initializtion for VTK.
-  _vtk_mpi_controller = vtkSmartPointer<vtkMPIController>::New();
+  _vtk_mpi_controller = vtkMPIController::New();
   _vtk_mpi_controller->Initialize(&argc, const_cast<char ***>(&argv), /*initialized_externally=*/1);
   _vtk_mpi_controller->SetGlobalController(_vtk_mpi_controller);
 #endif
@@ -804,6 +804,7 @@ LibMeshInit::~LibMeshInit()
 
 #if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
   _vtk_mpi_controller->Finalize(/*finalized_externally=*/1);
+  _vtk_mpi_controller->Delete();
 #endif
 
 #if defined(LIBMESH_HAVE_MPI)


### PR DESCRIPTION
My old VTK version uses the deprecated strstream header, and
ignore_warnings.h isn't enough to stop gcc from complaining about
that.

We can't use UniquePtr instead, because VTK objects have protected
destructors, but we can do cleanup manually.

This doesn't completely get rid of the gcc screaming, but it limits it to libmesh.C rather than every_single_source_file.C

I'm following the VTK examples for manual cleanup, but I'd appreciate @jwpeterson taking a look to make sure I haven't just added a memory leak or somehow regressed #1179