### PR TITLE
Use std::size_t consistently

### DIFF
--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -274,11 +274,11 @@ void assemble_1D(EquationSystems & es,
         {
           // Now build the element matrix and right-hand-side using loops to
           // integrate the test functions (i) against the trial functions (j).
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             {
               Fe(i) += JxW[qp]*phi[i][qp];
 
-              for (unsigned int j=0; j<phi.size(); j++)
+              for (std::size_t j=0; j<phi.size(); j++)
                 {
                   Ke(i,j) += JxW[qp]*(1.e-3*dphi[i][qp]*dphi[j][qp] +
                                       phi[i][qp]*phi[j][qp]);

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -604,7 +604,7 @@ void assemble_cd (EquationSystems & es,
           Gradient grad_u_old;
 
           // Compute the old solution & its gradient.
-          for (unsigned int l=0; l<phi.size(); l++)
+          for (std::size_t l=0; l<phi.size(); l++)
             {
               u_old += phi[l][qp]*system.old_solution (dof_indices[l]);
 
@@ -615,7 +615,7 @@ void assemble_cd (EquationSystems & es,
             }
 
           // Now compute the element matrix and RHS contributions.
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             {
               // The RHS contribution
               Fe(i) += JxW[qp]*(
@@ -631,7 +631,7 @@ void assemble_cd (EquationSystems & es,
                                         diffusivity*(grad_u_old*dphi[i][qp]))
                                 );
 
-              for (unsigned int j=0; j<phi.size(); j++)
+              for (std::size_t j=0; j<phi.size(); j++)
                 {
                   // The matrix contribution
                   Ke(i,j) += JxW[qp]*(
@@ -675,12 +675,12 @@ void assemble_cd (EquationSystems & es,
                                                        system.time);
 
                   // RHS contribution
-                  for (unsigned int i=0; i<psi.size(); i++)
+                  for (std::size_t i=0; i<psi.size(); i++)
                     Fe(i) += penalty*JxW_face[qp]*value*psi[i][qp];
 
                   // Matrix contribution
-                  for (unsigned int i=0; i<psi.size(); i++)
-                    for (unsigned int j=0; j<psi.size(); j++)
+                  for (std::size_t i=0; i<psi.size(); i++)
+                    for (std::size_t j=0; j<psi.size(); j++)
                       Ke(i,j) += penalty*JxW_face[qp]*psi[i][qp]*psi[j][qp];
                 }
             }

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -748,8 +748,8 @@ void assemble_laplace(EquationSystems & es,
       perf_log.push ("Ke");
 
       for (unsigned int qp=0; qp<qrule->n_points(); qp++)
-        for (unsigned int i=0; i<dphi.size(); i++)
-          for (unsigned int j=0; j<dphi.size(); j++)
+        for (std::size_t i=0; i<dphi.size(); i++)
+          for (std::size_t j=0; j<dphi.size(); j++)
             Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
 
       // We need a forcing function to make the 1D case interesting
@@ -759,7 +759,7 @@ void assemble_laplace(EquationSystems & es,
             Real x = q_point[qp](0);
             Real f = singularity ? sqrt(3.)/9.*pow(-x, -4./3.) :
               cos(x);
-            for (unsigned int i=0; i<dphi.size(); ++i)
+            for (std::size_t i=0; i<dphi.size(); ++i)
               Fe(i) += JxW[qp]*phi[i][qp]*f;
           }
 
@@ -801,12 +801,12 @@ void assemble_laplace(EquationSystems & es,
                                                        "void");
 
                   // RHS contribution
-                  for (unsigned int i=0; i<psi.size(); i++)
+                  for (std::size_t i=0; i<psi.size(); i++)
                     Fe(i) += penalty*JxW_face[qp]*value*psi[i][qp];
 
                   // Matrix contribution
-                  for (unsigned int i=0; i<psi.size(); i++)
-                    for (unsigned int j=0; j<psi.size(); j++)
+                  for (std::size_t i=0; i<psi.size(); i++)
+                    for (std::size_t j=0; j<psi.size(); j++)
                       Ke(i,j) += penalty*JxW_face[qp]*psi[i][qp]*psi[j][qp];
                 }
             }

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -804,7 +804,7 @@ void assemble_biharmonic(EquationSystems & es,
 
       for (unsigned int qp=0; qp<qrule->n_points(); qp++)
         {
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             {
               shape_laplacian[i] = d2phi[i][qp](0,0);
               if (dim > 1)
@@ -812,8 +812,8 @@ void assemble_biharmonic(EquationSystems & es,
               if (dim == 3)
                 shape_laplacian[i] += d2phi[i][qp](2,2);
             }
-          for (unsigned int i=0; i<phi.size(); i++)
-            for (unsigned int j=0; j<phi.size(); j++)
+          for (std::size_t i=0; i<phi.size(); i++)
+            for (std::size_t j=0; j<phi.size(); j++)
               Ke(i,j) += JxW[qp]*
                 shape_laplacian[i]*shape_laplacian[j];
         }
@@ -883,8 +883,8 @@ void assemble_biharmonic(EquationSystems & es,
                   // integrated against test function values while
                   // basis fluxes are integrated against test function
                   // fluxes.
-                  for (unsigned int i=0; i<phi_face.size(); i++)
-                    for (unsigned int j=0; j<phi_face.size(); j++)
+                  for (std::size_t i=0; i<phi_face.size(); i++)
+                    for (std::size_t j=0; j<phi_face.size(); j++)
                       Ke(i,j) += JxW_face[qp] *
                         (penalty * phi_face[i][qp] *
                          phi_face[j][qp] + penalty2
@@ -895,7 +895,7 @@ void assemble_biharmonic(EquationSystems & es,
 
                   // Right-hand-side contribution of the L2
                   // projection.
-                  for (unsigned int i=0; i<phi_face.size(); i++)
+                  for (std::size_t i=0; i<phi_face.size(); i++)
                     Fe(i) += JxW_face[qp] *
                       (penalty * value * phi_face[i][qp]
                        + penalty2 *
@@ -911,7 +911,7 @@ void assemble_biharmonic(EquationSystems & es,
       }
 
       for (unsigned int qp=0; qp<qrule->n_points(); qp++)
-        for (unsigned int i=0; i<phi.size(); i++)
+        for (std::size_t i=0; i<phi.size(); i++)
           Fe(i) += JxW[qp]*phi[i][qp]*forcing_function(q_point[qp]);
 
       // The element matrix and right-hand-side are now built

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -688,7 +688,7 @@ void assemble_cd (EquationSystems & es,
           Gradient grad_u_old;
 
           // Compute the old solution & its gradient.
-          for (unsigned int l=0; l<phi.size(); l++)
+          for (std::size_t l=0; l<phi.size(); l++)
             {
               u_old += phi[l][qp]*system.old_solution  (dof_indices[l]);
 
@@ -699,7 +699,7 @@ void assemble_cd (EquationSystems & es,
             }
 
           // Now compute the element matrix and RHS contributions.
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             {
               // The RHS contribution
               Fe(i) += JxW[qp]*(
@@ -715,7 +715,7 @@ void assemble_cd (EquationSystems & es,
                                         diffusivity*(grad_u_old*dphi[i][qp]))
                                 );
 
-              for (unsigned int j=0; j<phi.size(); j++)
+              for (std::size_t j=0; j<phi.size(); j++)
                 {
                   // The matrix contribution
                   Ke(i,j) += JxW[qp]*(

--- a/examples/adjoints/adjoints_ex1/femparameters.C
+++ b/examples/adjoints/adjoints_ex1/femparameters.C
@@ -152,7 +152,7 @@ void FEMParameters::read(GetPot & input,
 {
   std::vector<std::string> variable_names;
   if (other_variable_names)
-    for (unsigned int i=0; i != other_variable_names->size(); ++i)
+    for (std::size_t i=0; i != other_variable_names->size(); ++i)
       {
         const std::string & name = (*other_variable_names)[i];
         const std::string stringval = input(name, std::string());
@@ -397,7 +397,7 @@ void FEMParameters::read(GetPot & input,
       const std::string variable_set =
         input("dirichlet_condition_variables", empty_string, i);
 
-      for (unsigned int i=0; i != variable_set.size(); ++i)
+      for (std::size_t i=0; i != variable_set.size(); ++i)
         {
           if (variable_set[i] == '1')
             dirichlet_condition_variables[func_boundary].push_back(i);
@@ -468,7 +468,7 @@ void FEMParameters::read(GetPot & input,
       const std::string variable_set =
         input("neumann_condition_variables", empty_string, i);
 
-      for (unsigned int i=0; i != variable_set.size(); ++i)
+      for (std::size_t i=0; i != variable_set.size(); ++i)
         {
           if (variable_set[i] == '1')
             neumann_condition_variables[func_boundary].push_back(i);
@@ -708,10 +708,10 @@ void FEMParameters::read(GetPot & input,
   if (this->comm().rank() == 0 && !bad_variables.empty())
     {
       libMesh::err << "ERROR: Unrecognized variables:" << std::endl;
-      for (unsigned int i = 0; i != bad_variables.size(); ++i)
+      for (std::size_t i = 0; i != bad_variables.size(); ++i)
         libMesh::err << bad_variables[i] << std::endl;
       libMesh::err << "Not found among recognized variables:" << std::endl;
-      for (unsigned int i = 0; i != variable_names.size(); ++i)
+      for (std::size_t i = 0; i != variable_names.size(); ++i)
         libMesh::err << variable_names[i] << std::endl;
       libmesh_error();
     }

--- a/examples/adjoints/adjoints_ex2/L-shaped.h
+++ b/examples/adjoints/adjoints_ex2/L-shaped.h
@@ -36,7 +36,7 @@ public:
   {
     typedef ParameterPointer<Number> PP;
     parameter_vector.clear();
-    for (unsigned int i = 0; i != parameters.size(); ++i)
+    for (std::size_t i = 0; i != parameters.size(); ++i)
       parameter_vector.push_back(UniquePtr<ParameterAccessor<Number> >(new PP(&parameters[i])));
 
     return parameter_vector;

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -607,10 +607,10 @@ build_error_estimator_component_wise (FEMParameters & param,
   // Using the user filled error norm type vector, we pass the type of norm to be used for
   // the error in each variable, we can have different types of norms for the primal and
   // dual variables
-  unsigned int size = primal_error_norm_type.size();
+  std::size_t size = primal_error_norm_type.size();
 
   libmesh_assert_equal_to (size, dual_error_norm_type.size());
-  for (unsigned int i = 0; i != size; ++i)
+  for (std::size_t i = 0; i != size; ++i)
     {
       adjoint_residual_estimator->primal_error_estimator()->error_norm.set_type(i, primal_error_norm_type[i]);
       adjoint_residual_estimator->dual_error_estimator()->error_norm.set_type(i, dual_error_norm_type[i]);
@@ -619,11 +619,11 @@ build_error_estimator_component_wise (FEMParameters & param,
   // Now we set the right weights for each term in the error estimate, using the user provided
   // term_weights matrix
   libmesh_assert_equal_to (size, term_weights.size());
-  for (unsigned int i = 0; i != term_weights.size(); ++i)
+  for (std::size_t i = 0; i != term_weights.size(); ++i)
     {
       libmesh_assert_equal_to (size, term_weights[i].size());
       adjoint_residual_estimator->error_norm.set_weight(i, term_weights[i][i]);
-      for (unsigned int j = 0; j != size; ++j)
+      for (std::size_t j = 0; j != size; ++j)
         if (i != j)
           adjoint_residual_estimator->error_norm.set_off_diagonal_weight(i, j, term_weights[i][j]);
     }
@@ -660,7 +660,7 @@ build_weighted_error_estimator_component_wise (FEMParameters & param,
 
   // We pass the pointers to the user specified weight functions to the patch recovery
   // error estimator objects declared above
-  unsigned int size = primal_error_norm_type.size();
+  std::size_t size = primal_error_norm_type.size();
 
   libmesh_assert(coupled_system_weight_functions.size() == size);
   libmesh_assert(dual_error_norm_type.size() == size);
@@ -675,11 +675,11 @@ build_weighted_error_estimator_component_wise (FEMParameters & param,
   // Now we set the right weights for each term in the error estimate, using the user provided
   // term_weights matrix
   libmesh_assert_equal_to (size, term_weights.size());
-  for (unsigned int i = 0; i != term_weights.size(); ++i)
+  for (std::size_t i = 0; i != term_weights.size(); ++i)
     {
       libmesh_assert_equal_to (size, term_weights[i].size());
       adjoint_residual_estimator->error_norm.set_weight(i, term_weights[i][i]);
-      for (unsigned int j = 0; j != size; ++j)
+      for (std::size_t j = 0; j != size; ++j)
         if (i != j)
           adjoint_residual_estimator->error_norm.set_off_diagonal_weight(i, j, term_weights[i][j]);
     }
@@ -1060,10 +1060,8 @@ int main (int argc, char ** argv)
 
               // Now combine the contribs from the pressure and non
               // pressure terms to get the complete estimate
-              for (unsigned int i = 0; i < error.size(); i++)
-                {
-                  error[i] = error_non_pressure[i] + error_with_pressure[i] + error_convection_diffusion_x[i] + error_convection_diffusion_y[i];
-                }
+              for (std::size_t i = 0; i < error.size(); i++)
+                error[i] = error_non_pressure[i] + error_with_pressure[i] + error_convection_diffusion_x[i] + error_convection_diffusion_y[i];
             }
           else
             {

--- a/examples/adjoints/adjoints_ex3/coupled_system.h
+++ b/examples/adjoints/adjoints_ex3/coupled_system.h
@@ -53,7 +53,7 @@ public:
   ParameterVector & get_parameter_vector()
   {
     parameter_vector.resize(parameters.size());
-    for (unsigned int i = 0; i != parameters.size(); ++i)
+    for (std::size_t i = 0; i != parameters.size(); ++i)
       parameter_vector[i] = &parameters[i];
 
     return parameter_vector;

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -198,7 +198,7 @@ void set_system_parameters(HeatSystem & system,
                                                                     f));
 
       libMesh::out << "Added Dirichlet boundary " << b << " for variables ";
-      for (unsigned int vi=0; vi != param.dirichlet_condition_variables[b].size(); ++vi)
+      for (std::size_t vi=0; vi != param.dirichlet_condition_variables[b].size(); ++vi)
         libMesh::out << param.dirichlet_condition_variables[b][vi];
       libMesh::out << std::endl;
     }

--- a/examples/adjoints/adjoints_ex5/heatsystem.h
+++ b/examples/adjoints/adjoints_ex5/heatsystem.h
@@ -66,7 +66,7 @@ public:
   ParameterVector & get_parameter_vector()
   {
     parameter_vector.resize(parameters.size());
-    for (unsigned int i = 0; i != parameters.size(); ++i)
+    for (std::size_t i = 0; i != parameters.size(); ++i)
       parameter_vector[i] = &parameters[i];
 
     return parameter_vector;

--- a/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
+++ b/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
@@ -279,8 +279,8 @@ void assemble_mass(EquationSystems & es,
       // a double loop to integrate the test funcions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
-        for (unsigned int i=0; i<phi.size(); i++)
-          for (unsigned int j=0; j<phi.size(); j++)
+        for (std::size_t i=0; i<phi.size(); i++)
+          for (std::size_t j=0; j<phi.size(); j++)
             Me(i,j) += JxW[qp]*phi[i][qp]*phi[j][qp];
 
       // On an unrefined mesh, constrain_element_matrix does

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -318,8 +318,8 @@ void assemble_mass(EquationSystems & es,
       // a double loop to integrate the test funcions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
-        for (unsigned int i=0; i<phi.size(); i++)
-          for (unsigned int j=0; j<phi.size(); j++)
+        for (std::size_t i=0; i<phi.size(); i++)
+          for (std::size_t j=0; j<phi.size(); j++)
             {
               Me(i,j) += JxW[qp]*phi[i][qp]*phi[j][qp];
               Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -395,8 +395,8 @@ void assemble_matrices(EquationSystems & es,
       // a double loop to integrate the test funcions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
-        for (unsigned int i=0; i<phi.size(); i++)
-          for (unsigned int j=0; j<phi.size(); j++)
+        for (std::size_t i=0; i<phi.size(); i++)
+          for (std::size_t j=0; j<phi.size(); j++)
             {
               Me(i,j) += JxW[qp]*phi[i][qp]*phi[j][qp];
               Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);

--- a/examples/introduction/introduction_ex3/introduction_ex3.C
+++ b/examples/introduction/introduction_ex3/introduction_ex3.C
@@ -315,8 +315,8 @@ void assemble_poisson(EquationSystems & es,
           // Now we will build the element matrix.  This involves
           // a double loop to integrate the test funcions (i) against
           // the trial functions (j).
-          for (unsigned int i=0; i<phi.size(); i++)
-            for (unsigned int j=0; j<phi.size(); j++)
+          for (std::size_t i=0; i<phi.size(); i++)
+            for (std::size_t j=0; j<phi.size(); j++)
               {
                 Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
               }
@@ -351,7 +351,7 @@ void assemble_poisson(EquationSystems & es,
                                exact_solution(x+eps, y) -
                                4.*exact_solution(x, y))/eps/eps;
 
-            for (unsigned int i=0; i<phi.size(); i++)
+            for (std::size_t i=0; i<phi.size(); i++)
               Fe(i) += JxW[qp]*fxy*phi[i][qp];
           }
         }
@@ -427,13 +427,13 @@ void assemble_poisson(EquationSystems & es,
                   const Real value = exact_solution(xf, yf);
 
                   // Matrix contribution of the L2 projection.
-                  for (unsigned int i=0; i<phi_face.size(); i++)
-                    for (unsigned int j=0; j<phi_face.size(); j++)
+                  for (std::size_t i=0; i<phi_face.size(); i++)
+                    for (std::size_t j=0; j<phi_face.size(); j++)
                       Ke(i,j) += JxW_face[qp]*penalty*phi_face[i][qp]*phi_face[j][qp];
 
                   // Right-hand-side contribution of the L2
                   // projection.
-                  for (unsigned int i=0; i<phi_face.size(); i++)
+                  for (std::size_t i=0; i<phi_face.size(); i++)
                     Fe(i) += JxW_face[qp]*penalty*value*phi_face[i][qp];
                 }
             }

--- a/examples/introduction/introduction_ex4/introduction_ex4.C
+++ b/examples/introduction/introduction_ex4/introduction_ex4.C
@@ -463,8 +463,8 @@ void assemble_poisson(EquationSystems & es,
       perf_log.push ("Ke");
 
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
-        for (unsigned int i=0; i<phi.size(); i++)
-          for (unsigned int j=0; j<phi.size(); j++)
+        for (std::size_t i=0; i<phi.size(); i++)
+          for (std::size_t j=0; j<phi.size(); j++)
             Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
 
 
@@ -533,7 +533,7 @@ void assemble_poisson(EquationSystems & es,
             }
 
           // Add the RHS contribution
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             Fe(i) += JxW[qp]*fxy*phi[i][qp];
         }
 

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -319,8 +319,8 @@ void assemble_poisson(EquationSystems & es,
       for (unsigned int qp=0; qp<qrule->n_points(); qp++)
         {
           // Add the matrix contribution
-          for (unsigned int i=0; i<phi.size(); i++)
-            for (unsigned int j=0; j<phi.size(); j++)
+          for (std::size_t i=0; i<phi.size(); i++)
+            for (std::size_t j=0; j<phi.size(); j++)
               Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
 
           // fxy is the forcing function for the Poisson equation.
@@ -358,7 +358,7 @@ void assemble_poisson(EquationSystems & es,
 
 
           // Add the RHS contribution
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             Fe(i) += JxW[qp]*fxy*phi[i][qp];
         }
 

--- a/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
+++ b/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
@@ -281,10 +281,10 @@ void assemble_poisson(EquationSystems & es,
 
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         {
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             {
               Fe(i) += JxW[qp]*phi[i][qp];
-              for (unsigned int j=0; j<phi.size(); j++)
+              for (std::size_t j=0; j<phi.size(); j++)
                 Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
             }
         }

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -810,7 +810,7 @@ void assemble_shell (EquationSystems & es,
               std::vector<boundary_id_type> bids;
               mesh.get_boundary_info().shellface_boundary_ids(elem, shellface, bids);
 
-              for (unsigned int k=0; k<bids.size(); k++)
+              for (std::size_t k=0; k<bids.size(); k++)
                 if (bids[k]==11) // sideset id for surface load
                   for (unsigned int qp=0; qp<qrule.n_points(); ++qp)
                     for (unsigned int i=0; i<n_var_dofs; ++i)

--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -422,8 +422,8 @@ void assemble_helmholtz(EquationSystems & es,
           // the trial functions (j).  Note the braces on the rhs
           // of Ke(i,j): these are quite necessary to finally compute
           // Real*(Point*Point) = Real, and not something else...
-          for (unsigned int i=0; i<phi.size(); i++)
-            for (unsigned int j=0; j<phi.size(); j++)
+          for (std::size_t i=0; i<phi.size(); i++)
+            for (std::size_t j=0; j<phi.size(); j++)
               {
                 Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
                 Me(i,j) += JxW[qp]*(phi[i][qp]*phi[j][qp]);
@@ -481,8 +481,8 @@ void assemble_helmholtz(EquationSystems & es,
 
                 // Element matrix contributrion due to precribed
                 // admittance boundary conditions.
-                for (unsigned int i=0; i<phi_face.size(); i++)
-                  for (unsigned int j=0; j<phi_face.size(); j++)
+                for (std::size_t i=0; i<phi_face.size(); i++)
+                  for (std::size_t j=0; j<phi_face.size(); j++)
                     Ce(i,j) += rho*an_value*JxW_face[qp]*phi_face[i][qp]*phi_face[j][qp];
               }
           }

--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -410,7 +410,7 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
           Number u = 0;
           Gradient grad_u;
 
-          for (unsigned int j=0; j<phi.size(); j++)
+          for (std::size_t j=0; j<phi.size(); j++)
             {
               u      += phi[j][qp]*soln(dof_indices[j]);
               grad_u += dphi[j][qp]*soln(dof_indices[j]);
@@ -418,7 +418,7 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
 
           const Number K = 1./std::sqrt(1. + grad_u*grad_u);
 
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             Re(i) += JxW[qp]*(
                               K*(dphi[i][qp]*grad_u) +
                               _kappa*phi[i][qp]*u
@@ -451,7 +451,7 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
               {
                 // This is the right-hand-side contribution (f),
                 // which has to be subtracted from the current residual
-                for (unsigned int i=0; i<phi_face.size(); i++)
+                for (std::size_t i=0; i<phi_face.size(); i++)
                   Re(i) -= JxW_face[qp]*_sigma*phi_face[i][qp];
               }
           }
@@ -571,7 +571,7 @@ void LaplaceYoung::jacobian (const NumericVector<Number> & soln,
         {
           Gradient grad_u;
 
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             grad_u += dphi[i][qp]*soln(dof_indices[i]);
 
           const Number
@@ -579,8 +579,8 @@ void LaplaceYoung::jacobian (const NumericVector<Number> & soln,
             K  = 1. / std::sqrt(sa),
             dK = -K / sa;
 
-          for (unsigned int i=0; i<phi.size(); i++)
-            for (unsigned int j=0; j<phi.size(); j++)
+          for (std::size_t i=0; i<phi.size(); i++)
+            for (std::size_t j=0; j<phi.size(); j++)
               Ke(i,j) += JxW[qp]*(
                                   K * (dphi[i][qp]*dphi[j][qp]) +
                                   dK * (grad_u*dphi[j][qp]) * (grad_u*dphi[i][qp]) +

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -364,12 +364,12 @@ void assemble (EquationSystems & es,
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         {
           // Now compute the element matrix and RHS contributions.
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             {
               // The RHS contribution
               Fe(i) += JxW[qp]*phi[i][qp];
 
-              for (unsigned int j=0; j<phi.size(); j++)
+              for (std::size_t j=0; j<phi.size(); j++)
                 {
                   // The matrix contribution
                   Ke(i,j) += JxW[qp]*(
@@ -408,8 +408,8 @@ void assemble (EquationSystems & es,
               for (unsigned int qp=0; qp<qface.n_points(); qp++)
                 {
                   // Matrix contribution
-                  for (unsigned int i=0; i<psi.size(); i++)
-                    for (unsigned int j=0; j<psi.size(); j++)
+                  for (std::size_t i=0; i<psi.size(); i++)
+                    for (std::size_t j=0; j<psi.size(); j++)
                       Ke(i,j) += penalty*JxW_face[qp]*psi[i][qp]*psi[j][qp];
                 }
             }

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic.C
@@ -119,7 +119,7 @@ Biharmonic::Biharmonic(ReplicatedMesh & mesh) :
 
   // Pad
   icenter.resize(3);
-  for (unsigned int i = icenter.size(); i < _dim; ++i)
+  for (std::size_t i = icenter.size(); i < _dim; ++i)
     icenter[i] = 0.5;
 
   for (unsigned int i = _dim; i < 3; ++i)

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
@@ -310,7 +310,7 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
             M_prime_qp = 0.0,
             M_prime_old_qp = 0.0;
 
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             {
               Laplacian_phi_qp[i] = d2phi[i][qp](0, 0);
               grad_u_qp(0) += u(dof_indices[i])*dphi[i][qp](0);
@@ -343,7 +343,7 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
             }
 
           // ELEMENT RESIDUAL AND JACOBIAN
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             {
               // RESIDUAL
               if (R)
@@ -403,7 +403,7 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
                 {
                   Number M_prime_prime_qp = 0.0;
                   if (_biharmonic._degenerate) M_prime_prime_qp = -2.0;
-                  for (unsigned int j=0; j<phi.size(); j++)
+                  for (std::size_t j=0; j<phi.size(); j++)
                     {
                       Number ri_j = 0.0;
                       ri_j -= Laplacian_phi_qp[i]*M_qp*_biharmonic._kappa*Laplacian_phi_qp[j];
@@ -555,12 +555,12 @@ void Biharmonic::JR::bounds(NumericVector<Number> & XL,
       // Auxiliary variables will need to be introduced to reduce this to a "box" constraint.
       // Additional complications will arise since m might be singular (as is the case for Hermite,
       // which, however, is easily handled by inspection).
-      for (unsigned int i=0; i<phi.size(); ++i)
+      for (std::size_t i=0; i<phi.size(); ++i)
         {
           // FIXME: should be able to define INF and pass it to the solve
           Real infinity = 1.0e20;
           Real bound = infinity;
-          for (unsigned int j = 0; j < nodes.size(); ++j)
+          for (std::size_t j = 0; j < nodes.size(); ++j)
             {
               if (phi[i][j])
                 {

--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -280,7 +280,7 @@ void assemble_poisson(EquationSystems & es,
                   fe_elem_face->reinit(elem, side);
 
                   for (unsigned int qp=0; qp<qface.n_points(); qp++)
-                    for (unsigned int i=0; i<phi.size(); i++)
+                    for (std::size_t i=0; i<phi.size(); i++)
                       Fe(i) += JxW_face[qp] * phi_face[i][qp];
                 }
 

--- a/examples/optimization/optimization_ex2/optimization_ex2.C
+++ b/examples/optimization/optimization_ex2/optimization_ex2.C
@@ -293,7 +293,7 @@ void AssembleOptimization::equality_constraints (const NumericVector<Number> & X
   constraint_values[1] = (*X_localized)(23);
   constraint_values[2] = (*X_localized)(98) + (*X_localized)(185);
 
-  for (unsigned int i=0; i<constraint_values.size(); i++)
+  for (std::size_t i=0; i<constraint_values.size(); i++)
     if ((C_eq.first_local_index() <= i) &&
         (i < C_eq.last_local_index()))
       C_eq.set(i, constraint_values[i]);
@@ -325,20 +325,15 @@ void AssembleOptimization::equality_constraints_jacobian (const NumericVector<Nu
   constraint_jac_indices[2][0] = 98;
   constraint_jac_indices[2][1] = 185;
 
-  for (unsigned int i=0; i<constraint_jac_values.size(); i++)
-    {
-      for (unsigned int j=0; j<constraint_jac_values[i].size(); j++)
+  for (std::size_t i=0; i<constraint_jac_values.size(); i++)
+    for (std::size_t j=0; j<constraint_jac_values[i].size(); j++)
+      if ((sys.C_eq->first_local_index() <= i) &&
+          (i < sys.C_eq->last_local_index()))
         {
-
-          if ((sys.C_eq->first_local_index() <= i) &&
-              (i < sys.C_eq->last_local_index()))
-            {
-              dof_id_type col_index = constraint_jac_indices[i][j];
-              Number value = constraint_jac_values[i][j];
-              C_eq_jac.set(i, col_index, value);
-            }
+          dof_id_type col_index = constraint_jac_indices[i][j];
+          Number value = constraint_jac_values[i][j];
+          C_eq_jac.set(i, col_index, value);
         }
-    }
 }
 
 void AssembleOptimization::inequality_constraints (const NumericVector<Number> & X,
@@ -355,11 +350,9 @@ void AssembleOptimization::inequality_constraints (const NumericVector<Number> &
   std::vector<Number> constraint_values(1);
   constraint_values[0] = (*X_localized)(200)*(*X_localized)(200) + (*X_localized)(201) - 5.;
 
-  for (unsigned int i=0; i<constraint_values.size(); i++)
-    {
-      if ((C_ineq.first_local_index() <= i) && (i < C_ineq.last_local_index()))
-        C_ineq.set(i, constraint_values[i]);
-    }
+  for (std::size_t i=0; i<constraint_values.size(); i++)
+    if ((C_ineq.first_local_index() <= i) && (i < C_ineq.last_local_index()))
+      C_ineq.set(i, constraint_values[i]);
 }
 
 void AssembleOptimization::inequality_constraints_jacobian (const NumericVector<Number> & X,
@@ -383,20 +376,16 @@ void AssembleOptimization::inequality_constraints_jacobian (const NumericVector<
   constraint_jac_indices[0][0] = 200;
   constraint_jac_indices[0][1] = 201;
 
-  for (unsigned int i=0; i<constraint_jac_values.size(); i++)
-    {
-      for (unsigned int j=0; j<constraint_jac_values[i].size(); j++)
+  for (std::size_t i=0; i<constraint_jac_values.size(); i++)
+    for (std::size_t j=0; j<constraint_jac_values[i].size(); j++)
+      if ((sys.C_ineq->first_local_index() <= i) &&
+          (i < sys.C_ineq->last_local_index()))
         {
-          if ((sys.C_ineq->first_local_index() <= i) &&
-              (i < sys.C_ineq->last_local_index()))
-            {
-              dof_id_type col_index = constraint_jac_indices[i][j];
-              Number value = constraint_jac_values[i][j];
-              C_ineq_jac.set(i, col_index, value);
-            }
-
+          dof_id_type col_index = constraint_jac_indices[i][j];
+          Number value = constraint_jac_values[i][j];
+          C_ineq_jac.set(i, col_index, value);
         }
-    }
+
 }
 
 void AssembleOptimization::lower_and_upper_bounds (OptimizationSystem & sys)

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -498,8 +498,8 @@ void assemble_poisson(EquationSystems & es,
           perf_log.push ("Ke");
 
           for (unsigned int qp=0; qp<qrule.n_points(); qp++)
-            for (unsigned int i=0; i<phi.size(); i++)
-              for (unsigned int j=0; j<phi.size(); j++)
+            for (std::size_t i=0; i<phi.size(); i++)
+              for (std::size_t j=0; j<phi.size(); j++)
                 Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
 
 
@@ -568,7 +568,7 @@ void assemble_poisson(EquationSystems & es,
                 }
 
               // Add the RHS contribution
-              for (unsigned int i=0; i<phi.size(); i++)
+              for (std::size_t i=0; i<phi.size(); i++)
                 Fe(i) += JxW[qp]*fxy*phi[i][qp];
             }
 
@@ -640,13 +640,13 @@ void assemble_poisson(EquationSystems & es,
                       const Real value = exact_solution(xf, yf, zf);
 
                       // Matrix contribution of the L2 projection.
-                      for (unsigned int i=0; i<phi_face.size(); i++)
-                        for (unsigned int j=0; j<phi_face.size(); j++)
+                      for (std::size_t i=0; i<phi_face.size(); i++)
+                        for (std::size_t j=0; j<phi_face.size(); j++)
                           Ke(i,j) += JxW_face[qp]*penalty*phi_face[i][qp]*phi_face[j][qp];
 
                       // Right-hand-side contribution of the L2
                       // projection.
-                      for (unsigned int i=0; i<phi_face.size(); i++)
+                      for (std::size_t i=0; i<phi_face.size(); i++)
                         Fe(i) += JxW_face[qp]*penalty*value*phi_face[i][qp];
                     }
                 }

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -446,8 +446,8 @@ void assemble_poisson(EquationSystems & es,
       perf_log.push ("Ke");
 
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
-        for (unsigned int i=0; i<phi.size(); i++)
-          for (unsigned int j=0; j<phi.size(); j++)
+        for (std::size_t i=0; i<phi.size(); i++)
+          for (std::size_t j=0; j<phi.size(); j++)
             Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
 
 
@@ -516,7 +516,7 @@ void assemble_poisson(EquationSystems & es,
             }
 
           // Add the RHS contribution
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             Fe(i) += JxW[qp]*fxy*phi[i][qp];
         }
 
@@ -585,13 +585,13 @@ void assemble_poisson(EquationSystems & es,
                   const Real value = exact_solution(xf, yf, zf);
 
                   // Matrix contribution of the L2 projection.
-                  for (unsigned int i=0; i<phi_face.size(); i++)
-                    for (unsigned int j=0; j<phi_face.size(); j++)
+                  for (std::size_t i=0; i<phi_face.size(); i++)
+                    for (std::size_t j=0; j<phi_face.size(); j++)
                       Ke(i,j) += JxW_face[qp]*penalty*phi_face[i][qp]*phi_face[j][qp];
 
                   // Right-hand-side contribution of the L2
                   // projection.
-                  for (unsigned int i=0; i<phi_face.size(); i++)
+                  for (std::size_t i=0; i<phi_face.size(); i++)
                     Fe(i) += JxW_face[qp]*penalty*value*phi_face[i][qp];
                 }
             }

--- a/examples/subdomains/subdomains_ex3/subdomains_ex3.C
+++ b/examples/subdomains/subdomains_ex3/subdomains_ex3.C
@@ -155,7 +155,7 @@ void integrate_function (const MeshBase & mesh)
       // from smallest to largest JxW value to help prevent
       // ... large + small + large + large + small ...
       // type truncation errors?
-      for (unsigned int qp=0; qp<q_points.size(); qp++)
+      for (std::size_t qp=0; qp<q_points.size(); qp++)
         int_val += JxW[qp] * integrand(q_points[qp]);
     }
 

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -348,10 +348,8 @@ public:
 
         stress_dof_map.dof_indices (elem, vonmises_dof_indices_var, vonMises_var);
         std::vector< DenseMatrix<Number> > elem_sigma_vec(vonmises_dof_indices_var.size());
-        for(unsigned int index=0; index<elem_sigma_vec.size(); index++)
-        {
+        for (std::size_t index=0; index<elem_sigma_vec.size(); index++)
           elem_sigma_vec[index].resize(3,3);
-        }
 
         // Below we project each component of the stress tensor onto a L2_LAGRANGE discretization.
         // Note that this gives a discontinuous stress plot on element boundaries, which is
@@ -397,7 +395,7 @@ public:
             stress_var_index++;
           }
 
-        for(unsigned int index=0; index<elem_sigma_vec.size(); index++)
+        for (std::size_t index=0; index<elem_sigma_vec.size(); index++)
         {
           elem_sigma_vec[index](1,0) = elem_sigma_vec[index](0,1);
           elem_sigma_vec[index](2,0) = elem_sigma_vec[index](0,2);

--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
@@ -108,7 +108,7 @@ void LinearElasticityWithContact::move_mesh (MeshBase & input_mesh,
             const Point master_point = elem->master_point(node_id);
 
             Point uvw;
-            for (unsigned int index=0; index<uvw_names.size(); index++)
+            for (std::size_t index=0; index<uvw_names.size(); index++)
               {
                 const unsigned int var = _sys.variable_number(uvw_names[index]);
                 const FEType & fe_type = _sys.get_dof_map().variable_type(var);
@@ -123,7 +123,7 @@ void LinearElasticityWithContact::move_mesh (MeshBase & input_mesh,
                 std::vector<dof_id_type> dof_indices_var;
                 _sys.get_dof_map().dof_indices (orig_elem, dof_indices_var, var);
 
-                for (unsigned int i=0; i<dof_indices_var.size(); i++)
+                for (std::size_t i=0; i<dof_indices_var.size(); i++)
                   {
                     Number value = (*localized_input_solution)(dof_indices_var[i]) * data.shape[i];
 
@@ -195,14 +195,14 @@ void LinearElasticityWithContact::initialize_contact_load_paths()
 
   // Do an N^2 search to match the contact nodes
   _contact_node_map.clear();
-  for (unsigned int i=0; i<nodes_on_lower_surface.size(); i++)
+  for (std::size_t i=0; i<nodes_on_lower_surface.size(); i++)
     {
       dof_id_type lower_node_id = nodes_on_lower_surface[i];
       Point p_lower = mesh.point(lower_node_id);
 
       Real min_distance = std::numeric_limits<Real>::max();
 
-      for (unsigned int j=0; j<nodes_on_upper_surface.size(); j++)
+      for (std::size_t j=0; j<nodes_on_upper_surface.size(); j++)
         {
           dof_id_type upper_node_id = nodes_on_upper_surface[j];
           Point p_upper = mesh.point(upper_node_id);

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -415,7 +415,7 @@ void assemble_cd (EquationSystems & es,
           Gradient grad_u_old;
 
           // Compute the old solution & its gradient.
-          for (unsigned int l=0; l<phi.size(); l++)
+          for (std::size_t l=0; l<phi.size(); l++)
             {
               u_old += phi[l][qp]*system.old_solution  (dof_indices[l]);
 
@@ -426,7 +426,7 @@ void assemble_cd (EquationSystems & es,
             }
 
           // Now compute the element matrix and RHS contributions.
-          for (unsigned int i=0; i<phi.size(); i++)
+          for (std::size_t i=0; i<phi.size(); i++)
             {
               // The RHS contribution
               Fe(i) += JxW[qp]*(
@@ -442,7 +442,7 @@ void assemble_cd (EquationSystems & es,
                                         0.01*(grad_u_old*dphi[i][qp]))
                                 );
 
-              for (unsigned int j=0; j<phi.size(); j++)
+              for (std::size_t j=0; j<phi.size(); j++)
                 {
                   // The matrix contribution
                   Ke(i,j) += JxW[qp]*(
@@ -488,12 +488,12 @@ void assemble_cd (EquationSystems & es,
                                                        system.time);
 
                   // RHS contribution
-                  for (unsigned int i=0; i<psi.size(); i++)
+                  for (std::size_t i=0; i<psi.size(); i++)
                     Fe(i) += penalty*JxW_face[qp]*value*psi[i][qp];
 
                   // Matrix contribution
-                  for (unsigned int i=0; i<psi.size(); i++)
-                    for (unsigned int j=0; j<psi.size(); j++)
+                  for (std::size_t i=0; i<psi.size(); i++)
+                    for (std::size_t j=0; j<psi.size(); j++)
                       Ke(i,j) += penalty*JxW_face[qp]*psi[i][qp]*psi[j][qp];
                 }
             }

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -457,8 +457,8 @@ void assemble_wave(EquationSystems & es,
           // Now we will build the element matrix.  This involves
           // a double loop to integrate the test funcions (i) against
           // the trial functions (j).
-          for (unsigned int i=0; i<phi.size(); i++)
-            for (unsigned int j=0; j<phi.size(); j++)
+          for (std::size_t i=0; i<phi.size(); i++)
+            for (std::size_t j=0; j<phi.size(); j++)
               {
                 Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
                 Me(i,j) += JxW[qp]*phi[i][qp]*phi[j][qp]
@@ -513,7 +513,7 @@ void assemble_wave(EquationSystems & es,
                 {
                   // Right-hand-side contribution due to prescribed
                   // normal acceleration.
-                  for (unsigned int i=0; i<phi_face.size(); i++)
+                  for (std::size_t i=0; i<phi_face.size(); i++)
                     {
                       Fe(i) += acc_n_value*rho
                         *phi_face[i][qp]*JxW_face[qp];

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -309,8 +309,8 @@ void assemble_poisson(EquationSystems & es,
           // Now we will build the element matrix.  This involves
           // a double loop to integrate the test funcions (i) against
           // the trial functions (j).
-          for (unsigned int i=0; i<phi.size(); i++)
-            for (unsigned int j=0; j<phi.size(); j++)
+          for (std::size_t i=0; i<phi.size(); i++)
+            for (std::size_t j=0; j<phi.size(); j++)
               Ke(i,j) += JxW[qp] * dphi[i][qp].contract(dphi[j][qp]);
 
           // This is the end of the matrix summation loop
@@ -350,7 +350,7 @@ void assemble_poisson(EquationSystems & es,
 
             const RealGradient f(fx, fy);
 
-            for (unsigned int i=0; i<phi.size(); i++)
+            for (std::size_t i=0; i<phi.size(); i++)
               Fe(i) += JxW[qp]*f*phi[i][qp];
           }
         }
@@ -426,13 +426,13 @@ void assemble_poisson(EquationSystems & es,
                                        exact_solution(1, xf, yf));
 
                   // Matrix contribution of the L2 projection.
-                  for (unsigned int i=0; i<phi_face.size(); i++)
-                    for (unsigned int j=0; j<phi_face.size(); j++)
+                  for (std::size_t i=0; i<phi_face.size(); i++)
+                    for (std::size_t j=0; j<phi_face.size(); j++)
                       Ke(i,j) += JxW_face[qp]*penalty*phi_face[i][qp]*phi_face[j][qp];
 
                   // Right-hand-side contribution of the L2
                   // projection.
-                  for (unsigned int i=0; i<phi_face.size(); i++)
+                  for (std::size_t i=0; i<phi_face.size(); i++)
                     Fe(i) += JxW_face[qp]*penalty*f*phi_face[i][qp];
                 }
             }

--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -58,7 +58,7 @@ struct abstract_multi_predicate : multi_predicate
   virtual ~abstract_multi_predicate()
   {
     // Clean-up vector
-    for (unsigned int i=0; i<_predicates.size(); ++i)
+    for (std::size_t i=0; i<_predicates.size(); ++i)
       delete _predicates[i];
   }
 
@@ -66,7 +66,7 @@ struct abstract_multi_predicate : multi_predicate
   abstract_multi_predicate & operator=(const abstract_multi_predicate & rhs)
   {
     // First clear out the predicates vector
-    for (unsigned int i=0; i<_predicates.size(); ++i)
+    for (std::size_t i=0; i<_predicates.size(); ++i)
       delete _predicates[i];
 
     // Now copy over the information from the rhs.
@@ -78,7 +78,7 @@ struct abstract_multi_predicate : multi_predicate
   // operator() checks all the predicates in the vector.
   virtual bool operator()(const T & it) const
   {
-    for (unsigned int i=0; i<_predicates.size(); ++i)
+    for (std::size_t i=0; i<_predicates.size(); ++i)
       {
         const predicate<T> * pred = _predicates[i];
 
@@ -106,7 +106,7 @@ protected:
   // copy constructor for the predicate class.
   void deep_copy(const abstract_multi_predicate & rhs)
   {
-    for (unsigned int i=0; i<rhs._predicates.size(); ++i)
+    for (std::size_t i=0; i<rhs._predicates.size(); ++i)
       _predicates.push_back(rhs._predicates[i]->clone());
   }
 

--- a/include/numerics/composite_fem_function.h
+++ b/include/numerics/composite_fem_function.h
@@ -48,7 +48,7 @@ public:
 
   ~CompositeFEMFunction ()
   {
-    for (unsigned int i=0; i != subfunctions.size(); ++i)
+    for (std::size_t i=0; i != subfunctions.size(); ++i)
       delete subfunctions[i];
   }
 
@@ -72,7 +72,7 @@ public:
         (max_index+1, std::make_pair(libMesh::invalid_uint,
                                      libMesh::invalid_uint));
 
-    for (unsigned int j=0; j != index_map.size(); ++j)
+    for (std::size_t j=0; j != index_map.size(); ++j)
       {
         libmesh_assert_less(index_map[j], reverse_index_map.size());
         libmesh_assert_equal_to(reverse_index_map[index_map[j]].first,
@@ -104,11 +104,11 @@ public:
     output.zero();
 
     DenseVector<Output> temp;
-    for (unsigned int i=0; i != subfunctions.size(); ++i)
+    for (std::size_t i=0; i != subfunctions.size(); ++i)
       {
         temp.resize(index_maps[i].size());
         (*subfunctions[i])(c, p, time, temp);
-        for (unsigned int j=0; j != temp.size(); ++j)
+        for (std::size_t j=0; j != temp.size(); ++j)
           output(index_maps[i][j]) = temp(j);
       }
   }
@@ -137,7 +137,7 @@ public:
   virtual UniquePtr<FEMFunctionBase<Output> > clone() const libmesh_override
   {
     CompositeFEMFunction * returnval = new CompositeFEMFunction();
-    for (unsigned int i=0; i != subfunctions.size(); ++i)
+    for (std::size_t i=0; i != subfunctions.size(); ++i)
       returnval->attach_subfunction(*subfunctions[i], index_maps[i]);
     return UniquePtr<FEMFunctionBase<Output> > (returnval);
   }

--- a/include/numerics/composite_function.h
+++ b/include/numerics/composite_function.h
@@ -48,7 +48,7 @@ public:
 
   ~CompositeFunction ()
   {
-    for (unsigned int i=0; i != subfunctions.size(); ++i)
+    for (std::size_t i=0; i != subfunctions.size(); ++i)
       delete subfunctions[i];
   }
 
@@ -72,7 +72,7 @@ public:
         (max_index+1, std::make_pair(libMesh::invalid_uint,
                                      libMesh::invalid_uint));
 
-    for (unsigned int j=0; j != index_map.size(); ++j)
+    for (std::size_t j=0; j != index_map.size(); ++j)
       {
         libmesh_assert_less(index_map[j], reverse_index_map.size());
         libmesh_assert_equal_to(reverse_index_map[index_map[j]].first,
@@ -116,11 +116,11 @@ public:
     output.zero();
 
     DenseVector<Output> temp;
-    for (unsigned int i=0; i != subfunctions.size(); ++i)
+    for (std::size_t i=0; i != subfunctions.size(); ++i)
       {
         temp.resize(index_maps[i].size());
         (*subfunctions[i])(p, time, temp);
-        for (unsigned int j=0; j != temp.size(); ++j)
+        for (std::size_t j=0; j != temp.size(); ++j)
           output(index_maps[i][j]) = temp(j);
       }
   }

--- a/include/numerics/const_fem_function.h
+++ b/include/numerics/const_fem_function.h
@@ -56,8 +56,10 @@ public:
                            const Point &,
                            const Real,
                            DenseVector<Output> & output)
-  {for(unsigned int i = 0; i < output.size(); i++ )
-      output(i) = _c;}
+  {
+    for (std::size_t i = 0; i < output.size(); i++)
+      output(i) = _c;
+  }
 
 private:
   Output _c;

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -873,7 +873,7 @@ template<typename T>
 inline
 void DenseMatrix<T>::scale (const T factor)
 {
-  for (unsigned int i=0; i<_val.size(); i++)
+  for (std::size_t i=0; i<_val.size(); i++)
     _val[i] *= factor;
 }
 
@@ -920,7 +920,7 @@ template<typename T>
 inline
 bool DenseMatrix<T>::operator == (const DenseMatrix<T> & mat) const
 {
-  for (unsigned int i=0; i<_val.size(); i++)
+  for (std::size_t i=0; i<_val.size(); i++)
     if (_val[i] != mat._val[i])
       return false;
 
@@ -933,7 +933,7 @@ template<typename T>
 inline
 bool DenseMatrix<T>::operator != (const DenseMatrix<T> & mat) const
 {
-  for (unsigned int i=0; i<_val.size(); i++)
+  for (std::size_t i=0; i<_val.size(); i++)
     if (_val[i] != mat._val[i])
       return true;
 
@@ -946,7 +946,7 @@ template<typename T>
 inline
 DenseMatrix<T> & DenseMatrix<T>::operator += (const DenseMatrix<T> & mat)
 {
-  for (unsigned int i=0; i<_val.size(); i++)
+  for (std::size_t i=0; i<_val.size(); i++)
     _val[i] += mat._val[i];
 
   return *this;
@@ -958,7 +958,7 @@ template<typename T>
 inline
 DenseMatrix<T> & DenseMatrix<T>::operator -= (const DenseMatrix<T> & mat)
 {
-  for (unsigned int i=0; i<_val.size(); i++)
+  for (std::size_t i=0; i<_val.size(); i++)
     _val[i] -= mat._val[i];
 
   return *this;

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -387,7 +387,7 @@ template<typename T>
 inline
 void DenseVector<T>::scale (const T factor)
 {
-  for (unsigned int i=0; i<_val.size(); i++)
+  for (std::size_t i=0; i<_val.size(); i++)
     _val[i] *= factor;
 }
 

--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -341,7 +341,7 @@ ParsedFEMFunction<Output>::reparse (const std::string & expression)
   unsigned int offset = LIBMESH_DIM + 1 + _n_requested_vars +
     _n_requested_grad_components + _n_requested_hess_components;
 
-  for (unsigned int i=0; i < _additional_vars.size(); ++i)
+  for (std::size_t i=0; i < _additional_vars.size(); ++i)
     {
       variables += "," + _additional_vars[i];
       // Initialize extra variables to the vector passed in or zero
@@ -453,7 +453,7 @@ ParsedFEMFunction<Output>::get_inline_value(const std::string & inline_var_name)
 #endif
   Output old_var_value(0.);
 
-  for (unsigned int s=0; s != _subexpressions.size(); ++s)
+  for (std::size_t s=0; s != _subexpressions.size(); ++s)
     {
       const std::string & subexpression = _subexpressions[s];
       const std::size_t varname_i =
@@ -526,7 +526,7 @@ ParsedFEMFunction<Output>::set_inline_value (const std::string & inline_var_name
 #ifndef NDEBUG
   bool found_var_name = false;
 #endif
-  for (unsigned int s=0; s != _subexpressions.size(); ++s)
+  for (std::size_t s=0; s != _subexpressions.size(); ++s)
     {
       const std::string & subexpression = _subexpressions[s];
       const std::size_t varname_i =
@@ -570,7 +570,7 @@ ParsedFEMFunction<Output>::set_inline_value (const std::string & inline_var_name
 
   std::string new_expression;
 
-  for (unsigned int s=0; s != _subexpressions.size(); ++s)
+  for (std::size_t s=0; s != _subexpressions.size(); ++s)
     {
       new_expression += '{';
       new_expression += _subexpressions[s];
@@ -773,7 +773,7 @@ ParsedFEMFunction<Output>::eval_args (const FEMContext & c,
 #ifndef NDEBUG
       bool at_quadrature_point = false;
 #endif
-      for (unsigned int qp = 0; qp != normals.size(); ++qp)
+      for (std::size_t qp = 0; qp != normals.size(); ++qp)
         {
           if (p == xyz[qp])
             {
@@ -817,7 +817,7 @@ ParsedFEMFunction<Output>::eval (FunctionParserBase<Output> & parser,
                    << " of expression '"
                    << function_name
                    << "' with arguments:\n";
-      for (unsigned int j=0; j<_spacetime.size(); ++j)
+      for (std::size_t j=0; j<_spacetime.size(); ++j)
         libMesh::err << '\t' << _spacetime[j] << '\n';
       libMesh::err << '\n';
 

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -198,7 +198,7 @@ ParsedFunction<Output,OutputGradient>::reparse (const std::string & expression)
   // If additional vars were passed, append them to the string
   // that we send to the function parser. Also add them to the
   // end of our spacetime vector
-  for (unsigned int i=0; i < _additional_vars.size(); ++i)
+  for (std::size_t i=0; i < _additional_vars.size(); ++i)
     {
       variables += "," + _additional_vars[i];
       // Initialize extra variables to the vector passed in or zero
@@ -329,7 +329,7 @@ ParsedFunction<Output,OutputGradient>::get_inline_value (const std::string & inl
 #endif
   Output old_var_value(0.);
 
-  for (unsigned int s=0; s != _subexpressions.size(); ++s)
+  for (std::size_t s=0; s != _subexpressions.size(); ++s)
     {
       const std::string & subexpression = _subexpressions[s];
       const std::size_t varname_i =
@@ -403,7 +403,7 @@ ParsedFunction<Output,OutputGradient>::set_inline_value (const std::string & inl
 #ifndef NDEBUG
   bool found_var_name = false;
 #endif
-  for (unsigned int s=0; s != _subexpressions.size(); ++s)
+  for (std::size_t s=0; s != _subexpressions.size(); ++s)
     {
       const std::string & subexpression = _subexpressions[s];
       const std::size_t varname_i =
@@ -446,7 +446,7 @@ ParsedFunction<Output,OutputGradient>::set_inline_value (const std::string & inl
 
   std::string new_expression;
 
-  for (unsigned int s=0; s != _subexpressions.size(); ++s)
+  for (std::size_t s=0; s != _subexpressions.size(); ++s)
     {
       new_expression += '{';
       new_expression += _subexpressions[s];
@@ -622,7 +622,7 @@ ParsedFunction<Output,OutputGradient>::eval (FunctionParserADBase<Output> & pars
                    << " of expression '"
                    << function_name
                    << "' with arguments:\n";
-      for (unsigned int j=0; j<_spacetime.size(); ++j)
+      for (std::size_t j=0; j<_spacetime.size(); ++j)
         libMesh::err << '\t' << _spacetime[j] << '\n';
       libMesh::err << '\n';
 

--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -522,7 +522,7 @@ inline Status wait (Request & r) { return r.wait(); }
  * Wait for a non-blocking send or receive to finish
  */
 inline void wait (std::vector<Request> & r)
-{ for (unsigned int i=0; i<r.size(); i++) r[i].wait(); }
+{ for (std::size_t i=0; i<r.size(); i++) r[i].wait(); }
 
 
 /**

--- a/include/parallel/parallel_conversion_utils.h
+++ b/include/parallel/parallel_conversion_utils.h
@@ -52,7 +52,7 @@ bool is_sorted (const std::vector<KeyType> & v)
   if (v.empty())
     return true;
 
-  for (unsigned int i=1; i<v.size(); i++)
+  for (std::size_t i=1; i<v.size(); i++)
     if (v[i] < v[i-1])
       return false;
 

--- a/include/systems/parameter_multiaccessor.h
+++ b/include/systems/parameter_multiaccessor.h
@@ -62,7 +62,7 @@ public:
    * Destructor: delete our clones of sub-accessors
    */
   ~ParameterMultiAccessor() {
-    for (unsigned int i=0; i != _accessors.size(); ++i)
+    for (std::size_t i=0; i != _accessors.size(); ++i)
       delete _accessors[i];
   }
 
@@ -86,7 +86,7 @@ public:
     // Compare other values to the last one we'll change
     const T & val = _accessors.back()->get();
 #endif
-    for (unsigned int i=0; i != _accessors.size(); ++i)
+    for (std::size_t i=0; i != _accessors.size(); ++i)
       {
         // If you're already using inconsistent parameters we can't
         // help you.
@@ -105,7 +105,7 @@ public:
 #ifndef NDEBUG
     // If you're already using inconsistent parameters we can't help
     // you.
-    for (unsigned int i=1; i < _accessors.size(); ++i)
+    for (std::size_t i=1; i < _accessors.size(); ++i)
       libmesh_assert_equal_to(_accessors[i]->get(), val);
 #endif
     return val;
@@ -117,7 +117,7 @@ public:
   virtual UniquePtr<ParameterAccessor<T> > clone() const libmesh_override
   {
     ParameterMultiAccessor * pmp = new ParameterMultiAccessor<T>();
-    for (unsigned int i=0; i != _accessors.size(); ++i)
+    for (std::size_t i=0; i != _accessors.size(); ++i)
       pmp->_accessors.push_back(_accessors[i]->clone().release());
 
     return UniquePtr<ParameterAccessor<T> >(pmp);

--- a/include/systems/parameter_multipointer.h
+++ b/include/systems/parameter_multipointer.h
@@ -77,7 +77,7 @@ public:
     // Compare other values to the last one we'll change
     const T & val = *_ptrs.back();
 #endif
-    for (unsigned int i=0; i != _ptrs.size(); ++i)
+    for (std::size_t i=0; i != _ptrs.size(); ++i)
       {
         // If you're already using inconsistent parameters we can't
         // help you.
@@ -96,7 +96,7 @@ public:
 #ifndef NDEBUG
     // If you're already using inconsistent parameters we can't help
     // you.
-    for (unsigned int i=1; i < _ptrs.size(); ++i)
+    for (std::size_t i=1; i < _ptrs.size(); ++i)
       libmesh_assert_equal_to(*_ptrs[i], val);
 #endif
     return val;

--- a/include/systems/parameter_vector.h
+++ b/include/systems/parameter_vector.h
@@ -170,7 +170,7 @@ void
 ParameterVector::clear()
 {
   if (!_is_shallow_copy)
-    for (unsigned int i=0; i != _params.size(); ++i)
+    for (std::size_t i=0; i != _params.size(); ++i)
       delete _params[i];
 
   _params.clear();

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -561,7 +561,7 @@ void print_helper(std::ostream & os, const unsigned char * param)
 template<typename P>
 void print_helper(std::ostream & os, const std::vector<P> * param)
 {
-  for (unsigned int i=0; i<param->size(); ++i)
+  for (std::size_t i=0; i<param->size(); ++i)
     os << (*param)[i] << " ";
 }
 
@@ -569,8 +569,8 @@ void print_helper(std::ostream & os, const std::vector<P> * param)
 template<typename P>
 void print_helper(std::ostream & os, const std::vector<std::vector<P> > * param)
 {
-  for (unsigned int i=0; i<param->size(); ++i)
-    for (unsigned int j=0; j<(*param)[i].size(); ++j)
+  for (std::size_t i=0; i<param->size(); ++i)
+    for (std::size_t j=0; j<(*param)[i].size(); ++j)
       os << (*param)[i][j] << " ";
 }
 

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -258,7 +258,7 @@ TreeNode<N>::~TreeNode ()
   // When we are destructed we must delete all of our
   // children.  They will this delete their children,
   // All the way down the line...
-  for (unsigned int c=0; c<children.size(); c++)
+  for (std::size_t c=0; c<children.size(); c++)
     delete children[c];
 }
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -203,7 +203,7 @@ DofMap::~DofMap()
   _mesh.remove_ghosting_functor(*_default_evaluating);
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  for (unsigned int q = 0; q != _adjoint_dirichlet_boundaries.size(); ++q)
+  for (std::size_t q = 0; q != _adjoint_dirichlet_boundaries.size(); ++q)
     delete _adjoint_dirichlet_boundaries[q];
 #endif
 }
@@ -1675,7 +1675,7 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
           const std::vector<unsigned int> & variable_list =
             column_variable_list->second;
 
-          for (unsigned int j=0; j != variable_list.size(); ++j)
+          for (std::size_t j=0; j != variable_list.size(); ++j)
             {
               const unsigned int vj=variable_list[j];
 
@@ -2555,7 +2555,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                 FEInterface::extra_hanging_dofs(fe_type);
 
               // Get the node-based DOF numbers
-              for (unsigned int n=0; n<elem_nodes.size(); n++)
+              for (std::size_t n=0; n<elem_nodes.size(); n++)
                 {
                   const Node * node      = elem_nodes[n];
 
@@ -2717,7 +2717,7 @@ void DofMap::find_connected_dofs (std::vector<dof_id_type> & elem_dofs) const
   // in turn depend on others.  So, we need to repeat this process
   // in that case until the system depends only on unconstrained
   // degrees of freedom.
-  for (unsigned int i=0; i<elem_dofs.size(); i++)
+  for (std::size_t i=0; i<elem_dofs.size(); i++)
     if (this->is_constrained_dof(elem_dofs[i]))
       {
         // If the DOF is constrained

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -717,7 +717,7 @@ private:
               // Some edge dofs are on nodes and already
               // fixed, others are free to calculate
               unsigned int free_dofs = 0;
-              for (unsigned int i=0; i != side_dofs.size(); ++i)
+              for (std::size_t i=0; i != side_dofs.size(); ++i)
                 if (!dof_is_fixed[side_dofs[i]])
                   free_dof[free_dofs++] = i;
 
@@ -776,15 +776,13 @@ private:
                                       xyz_values[qp], time)(c);
 
                   // Form edge projection matrix
-                  for (unsigned int sidei=0, freei=0;
-                       sidei != side_dofs.size(); ++sidei)
+                  for (std::size_t sidei=0, freei=0; sidei != side_dofs.size(); ++sidei)
                     {
                       unsigned int i = side_dofs[sidei];
                       // fixed DoFs aren't test functions
                       if (dof_is_fixed[i])
                         continue;
-                      for (unsigned int sidej=0, freej=0;
-                           sidej != side_dofs.size(); ++sidej)
+                      for (std::size_t sidej=0, freej=0; sidej != side_dofs.size(); ++sidej)
                         {
                           unsigned int j = side_dofs[sidej];
                           if (dof_is_fixed[j])
@@ -839,7 +837,7 @@ private:
               // Some side dofs are on nodes/edges and already
               // fixed, others are free to calculate
               unsigned int free_dofs = 0;
-              for (unsigned int i=0; i != side_dofs.size(); ++i)
+              for (std::size_t i=0; i != side_dofs.size(); ++i)
                 if (!dof_is_fixed[side_dofs[i]])
                   free_dof[free_dofs++] = i;
 
@@ -898,15 +896,13 @@ private:
                                       xyz_values[qp], time)(c);
 
                   // Form side projection matrix
-                  for (unsigned int sidei=0, freei=0;
-                       sidei != side_dofs.size(); ++sidei)
+                  for (std::size_t sidei=0, freei=0; sidei != side_dofs.size(); ++sidei)
                     {
                       unsigned int i = side_dofs[sidei];
                       // fixed DoFs aren't test functions
                       if (dof_is_fixed[i])
                         continue;
-                      for (unsigned int sidej=0, freej=0;
-                           sidej != side_dofs.size(); ++sidej)
+                      for (std::size_t sidej=0, freej=0; sidej != side_dofs.size(); ++sidej)
                         {
                           unsigned int j = side_dofs[sidej];
                           if (dof_is_fixed[j])
@@ -962,7 +958,7 @@ private:
               // Some shellface dofs are on nodes/edges and already
               // fixed, others are free to calculate
               unsigned int free_dofs = 0;
-              for (unsigned int i=0; i != shellface_dofs.size(); ++i)
+              for (std::size_t i=0; i != shellface_dofs.size(); ++i)
                 if (!dof_is_fixed[shellface_dofs[i]])
                   free_dof[free_dofs++] = i;
 
@@ -1021,14 +1017,14 @@ private:
                                       xyz_values[qp], time)(c);
 
                   // Form shellface projection matrix
-                  for (unsigned int shellfacei=0, freei=0;
+                  for (std::size_t shellfacei=0, freei=0;
                        shellfacei != shellface_dofs.size(); ++shellfacei)
                     {
                       unsigned int i = shellface_dofs[shellfacei];
                       // fixed DoFs aren't test functions
                       if (dof_is_fixed[i])
                         continue;
-                      for (unsigned int shellfacej=0, freej=0;
+                      for (std::size_t shellfacej=0, freej=0;
                            shellfacej != shellface_dofs.size(); ++shellfacej)
                         {
                           unsigned int j = shellface_dofs[shellfacej];
@@ -1114,7 +1110,7 @@ public:
      */
 
     // Loop over all the variables we've been requested to project
-    for (unsigned int v=0; v!=dirichlet.variables.size(); v++)
+    for (std::size_t v=0; v!=dirichlet.variables.size(); v++)
       {
         const unsigned int var = dirichlet.variables[v];
 
@@ -1316,7 +1312,7 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
          );
     }
 
-  for (unsigned int qoi_index = 0;
+  for (std::size_t qoi_index = 0;
        qoi_index != _adjoint_dirichlet_boundaries.size();
        ++qoi_index)
     {
@@ -1518,7 +1514,7 @@ std::string DofMap::get_local_constraints(bool print_nonlocal) const
       os << std::endl;
     }
 
-  for (unsigned int qoi_index = 0;
+  for (std::size_t qoi_index = 0;
        qoi_index != _adjoint_dirichlet_boundaries.size();
        ++qoi_index)
     {
@@ -1588,7 +1584,7 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
       libmesh_assert_equal_to (matrix.n(), elem_dofs.size());
 
 
-      for (unsigned int i=0; i<elem_dofs.size(); i++)
+      for (std::size_t i=0; i<elem_dofs.size(); i++)
         // If the DOF is constrained
         if (this->is_constrained_dof(elem_dofs[i]))
           {
@@ -1615,7 +1611,7 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
                 for (DofConstraintRow::const_iterator
                        it=constraint_row.begin(); it != constraint_row.end();
                      ++it)
-                  for (unsigned int j=0; j<elem_dofs.size(); j++)
+                  for (std::size_t j=0; j<elem_dofs.size(); j++)
                     if (elem_dofs[j] == it->first)
                       matrix(i,j) = -it->second;
               }
@@ -1660,7 +1656,7 @@ void DofMap::constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
       libmesh_assert_equal_to (matrix.n(), elem_dofs.size());
 
 
-      for (unsigned int i=0; i<elem_dofs.size(); i++)
+      for (std::size_t i=0; i<elem_dofs.size(); i++)
         if (this->is_constrained_dof(elem_dofs[i]))
           {
             for (unsigned int j=0; j<matrix.n(); j++)
@@ -1687,7 +1683,7 @@ void DofMap::constrain_element_matrix_and_vector (DenseMatrix<Number> & matrix,
                 for (DofConstraintRow::const_iterator
                        it=constraint_row.begin(); it != constraint_row.end();
                      ++it)
-                  for (unsigned int j=0; j<elem_dofs.size(); j++)
+                  for (std::size_t j=0; j<elem_dofs.size(); j++)
                     if (elem_dofs[j] == it->first)
                       matrix(i,j) = -it->second;
               }
@@ -1760,7 +1756,7 @@ void DofMap::heterogenously_constrain_element_matrix_and_vector (DenseMatrix<Num
       libmesh_assert_equal_to (matrix.m(), elem_dofs.size());
       libmesh_assert_equal_to (matrix.n(), elem_dofs.size());
 
-      for (unsigned int i=0; i<elem_dofs.size(); i++)
+      for (std::size_t i=0; i<elem_dofs.size(); i++)
         {
           const dof_id_type dof_id = elem_dofs[i];
 
@@ -1787,7 +1783,7 @@ void DofMap::heterogenously_constrain_element_matrix_and_vector (DenseMatrix<Num
                   for (DofConstraintRow::const_iterator
                          it=constraint_row.begin(); it != constraint_row.end();
                        ++it)
-                    for (unsigned int j=0; j<elem_dofs.size(); j++)
+                    for (std::size_t j=0; j<elem_dofs.size(); j++)
                       if (elem_dofs[j] == it->first)
                         matrix(i,j) = -it->second;
 
@@ -1858,7 +1854,7 @@ void DofMap::heterogenously_constrain_element_vector (const DenseMatrix<Number> 
       F_minus_KH -= KH;
       C.vector_mult_transpose(rhs, F_minus_KH);
 
-      for (unsigned int i=0; i<elem_dofs.size(); i++)
+      for (std::size_t i=0; i<elem_dofs.size(); i++)
         {
           const dof_id_type dof_id = elem_dofs[i];
 
@@ -1941,7 +1937,7 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
       libmesh_assert_equal_to (matrix.n(), col_dofs.size());
 
 
-      for (unsigned int i=0; i<row_dofs.size(); i++)
+      for (std::size_t i=0; i<row_dofs.size(); i++)
         if (this->is_constrained_dof(row_dofs[i]))
           {
             for (unsigned int j=0; j<matrix.n(); j++)
@@ -1966,7 +1962,7 @@ void DofMap::constrain_element_matrix (DenseMatrix<Number> & matrix,
                 for (DofConstraintRow::const_iterator
                        it=constraint_row.begin(); it != constraint_row.end();
                      ++it)
-                  for (unsigned int j=0; j<col_dofs.size(); j++)
+                  for (std::size_t j=0; j<col_dofs.size(); j++)
                     if (col_dofs[j] == it->first)
                       matrix(i,j) = -it->second;
               }
@@ -2003,7 +1999,7 @@ void DofMap::constrain_element_vector (DenseVector<Number> & rhs,
 
       libmesh_assert_equal_to (row_dofs.size(), rhs.size());
 
-      for (unsigned int i=0; i<row_dofs.size(); i++)
+      for (std::size_t i=0; i<row_dofs.size(); i++)
         if (this->is_constrained_dof(row_dofs[i]))
           {
             // If the DOF is constrained
@@ -2052,7 +2048,7 @@ void DofMap::constrain_element_dyad_matrix (DenseVector<Number> & v,
 
       /* Constrain only v, not w.  */
 
-      for (unsigned int i=0; i<row_dofs.size(); i++)
+      for (std::size_t i=0; i<row_dofs.size(); i++)
         if (this->is_constrained_dof(row_dofs[i]))
           {
             // If the DOF is constrained
@@ -2384,7 +2380,7 @@ void DofMap::build_constraint_matrix (DenseMatrix<Number> & C,
   // may in turn depend on others.  So, we need to repeat this process
   // in that case until the system depends only on unconstrained
   // degrees of freedom.
-  for (unsigned int i=0; i<elem_dofs.size(); i++)
+  for (std::size_t i=0; i<elem_dofs.size(); i++)
     if (this->is_constrained_dof(elem_dofs[i]))
       {
         we_have_constraints = true;
@@ -2411,7 +2407,7 @@ void DofMap::build_constraint_matrix (DenseMatrix<Number> & C,
   if (!we_have_constraints)
     return;
 
-  for (unsigned int i=0; i != elem_dofs.size(); ++i)
+  for (std::size_t i=0; i != elem_dofs.size(); ++i)
     dof_set.erase (elem_dofs[i]);
 
   // If we added any DOFS then we need to do this recursively.
@@ -2453,7 +2449,7 @@ void DofMap::build_constraint_matrix (DenseMatrix<Number> & C,
             for (DofConstraintRow::const_iterator
                    it=constraint_row.begin(); it != constraint_row.end();
                  ++it)
-              for (unsigned int j=0; j != elem_dofs.size(); j++)
+              for (std::size_t j=0; j != elem_dofs.size(); j++)
                 if (elem_dofs[j] == it->first)
                   C(i,j) = it->second;
           }
@@ -2498,7 +2494,7 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
   // may in turn depend on others.  So, we need to repeat this process
   // in that case until the system depends only on unconstrained
   // degrees of freedom.
-  for (unsigned int i=0; i<elem_dofs.size(); i++)
+  for (std::size_t i=0; i<elem_dofs.size(); i++)
     if (this->is_constrained_dof(elem_dofs[i]))
       {
         we_have_constraints = true;
@@ -2525,7 +2521,7 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
   if (!we_have_constraints)
     return;
 
-  for (unsigned int i=0; i != elem_dofs.size(); ++i)
+  for (std::size_t i=0; i != elem_dofs.size(); ++i)
     dof_set.erase (elem_dofs[i]);
 
   // If we added any DOFS then we need to do this recursively.
@@ -2579,7 +2575,7 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
             for (DofConstraintRow::const_iterator
                    it=constraint_row.begin(); it != constraint_row.end();
                  ++it)
-              for (unsigned int j=0; j != elem_dofs.size(); j++)
+              for (std::size_t j=0; j != elem_dofs.size(); j++)
                 if (elem_dofs[j] == it->first)
                   C(i,j) = it->second;
 
@@ -3685,7 +3681,7 @@ void DofMap::scatter_constraints(MeshBase & mesh)
       std::vector<dof_id_type> element_dofs;
       this->dof_indices(elem, element_dofs);
 
-      for (unsigned int i=0; i != element_dofs.size(); ++i)
+      for (std::size_t i=0; i != element_dofs.size(); ++i)
         requested_dofs.insert(element_dofs[i]);
     }
 
@@ -3892,7 +3888,7 @@ void DofMap::gather_constraints (MeshBase & /*mesh*/,
           libmesh_assert_equal_to (dof_filled_vals.size(), requested_dof_ids[procup].size());
           libmesh_assert_equal_to (dof_filled_rhss.size(), requested_dof_ids[procup].size());
 #ifndef NDEBUG
-          for (unsigned int q=0; q != adj_filled_rhss.size(); ++q)
+          for (std::size_t q=0; q != adj_filled_rhss.size(); ++q)
             libmesh_assert_equal_to (adj_filled_rhss[q].size(), requested_dof_ids[procup].size());
 #endif
 

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -309,7 +309,7 @@ void DofObject::set_n_vars_per_group(const unsigned int s,
 #ifdef DEBUG
 
   // libMesh::out << " [ ";
-  // for (unsigned int i=0; i<_idx_buf.size(); i++)
+  // for (std::size_t i=0; i<_idx_buf.size(); i++)
   //   libMesh::out << _idx_buf[i] << " ";
   // libMesh::out << "]\n";
 
@@ -435,7 +435,7 @@ void DofObject::set_dof_number(const unsigned int s,
 
   // #ifdef DEBUG
   //   libMesh::out << " [ ";
-  //   for (unsigned int i=0; i<_idx_buf.size(); i++)
+  //   for (std::size_t i=0; i<_idx_buf.size(); i++)
   //     libMesh::out << _idx_buf[i] << " ";
   //   libMesh::out << "]\n";
   // #endif
@@ -542,7 +542,7 @@ DofObject::pack_indexing(std::back_insert_iterator<std::vector<largest_id_type> 
 void DofObject::debug_buffer () const
 {
   libMesh::out << " [ ";
-  for (unsigned int i=0; i<_idx_buf.size(); i++)
+  for (std::size_t i=0; i<_idx_buf.size(); i++)
     libMesh::out << _idx_buf[i] << " ";
   libMesh::out << "]\n";
 }

--- a/src/base/ghost_point_neighbors.C
+++ b/src/base/ghost_point_neighbors.C
@@ -78,7 +78,7 @@ void GhostPointNeighbors::operator()
                   std::vector<const Elem*> family;
                   neigh->active_family_tree_by_neighbor(family, elem);
 
-                  for (dof_id_type i=0; i!=family.size(); ++i)
+                  for (std::size_t i=0; i!=family.size(); ++i)
                     if (family[i]->processor_id() != p)
                       coupled_elements.insert
                         (std::make_pair(family[i], nullcm));

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -312,7 +312,7 @@ void Build::operator()(const ConstElemRange & range)
       // Get the row of the sparsity pattern
       SparsityPattern::Row & row = sparsity_pattern[i];
 
-      for (dof_id_type j=0; j<row.size(); j++)
+      for (std::size_t j=0; j<row.size(); j++)
         if ((row[j] < first_dof_on_proc) || (row[j] >= end_dof_on_proc))
           n_oz[i]++;
         else

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -96,7 +96,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // Loop over all the adjoint problems and, if any have heterogenous
   // Dirichlet conditions, get the corresponding coarse lift
   // function(s)
-  for (unsigned int j=0; j != system.qoi.size(); j++)
+  for (std::size_t j=0; j != system.qoi.size(); j++)
     {
       // Skip this QoI if it is not in the QoI Set or if there are no
       // heterogeneous Dirichlet boundaries for it
@@ -186,7 +186,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // Copy the projected coarse grid solutions, which will be
   // overwritten by solve()
   std::vector<NumericVector<Number> *> coarse_adjoints;
-  for (unsigned int j=0; j != system.qoi.size(); j++)
+  for (std::size_t j=0; j != system.qoi.size(); j++)
     {
       if (_qoi_set.has_index(j))
         {
@@ -222,7 +222,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // Loop over all the adjoint solutions and get the QoI error
   // contributions from all of them.  While we're looping anyway we'll
   // pull off the coarse adjoints
-  for (unsigned int j=0; j != system.qoi.size(); j++)
+  for (std::size_t j=0; j != system.qoi.size(); j++)
     {
       // Skip this QoI if not in the QoI Set
       if (_qoi_set.has_index(j))
@@ -366,7 +366,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 
   // We will loop over each adjoint solution, localize that adjoint
   // solution and then loop over local elements
-  for (unsigned int i=0; i != system.qoi.size(); i++)
+  for (std::size_t i=0; i != system.qoi.size(); i++)
     {
       // Skip this QoI if not in the QoI Set
       if (_qoi_set.has_index(i))
@@ -403,7 +403,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
               // We will have to manually do the dot products.
               Number local_contribution = 0.;
 
-              for (unsigned int j=0; j != dof_indices.size(); j++)
+              for (std::size_t j=0; j != dof_indices.size(); j++)
                 {
                   // The contribution to the error indicator for this element from the current QoI
                   local_contribution += (*localized_projected_residual)(dof_indices[j]) * (*localized_adjoint_solution)(dof_indices[j]);
@@ -423,7 +423,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 
     } // End loop over QoIs
 
-  for (unsigned int j=0; j != system.qoi.size(); j++)
+  for (std::size_t j=0; j != system.qoi.size(); j++)
     {
       if (_qoi_set.has_index(j))
         {

--- a/src/error_estimation/adjoint_residual_error_estimator.C
+++ b/src/error_estimation/adjoint_residual_error_estimator.C
@@ -113,7 +113,7 @@ void AdjointResidualErrorEstimator::estimate_error (const System & _system,
     }
 
   // Sum and weight the dual error estimate based on our QoISet
-  for (unsigned int i = 0; i != _system.qoi.size(); ++i)
+  for (std::size_t i = 0; i != _system.qoi.size(); ++i)
     {
       if (_qoi_set.has_index(i))
         {
@@ -241,7 +241,7 @@ void AdjointResidualErrorEstimator::estimate_error (const System & _system,
 
   // Weight the primal error by the dual error using the system norm object
   // FIXME: we ought to thread this
-  for (unsigned int i=0; i != error_per_cell.size(); ++i)
+  for (std::size_t i=0; i != error_per_cell.size(); ++i)
     {
       // Have we been asked to weight the variable error contributions in any specific manner
       if(!error_norm_is_identity) // If we do

--- a/src/error_estimation/error_estimator.C
+++ b/src/error_estimation/error_estimator.C
@@ -74,7 +74,7 @@ void ErrorEstimator::estimate_errors(const EquationSystems & equation_systems,
       if (s)
         {
           libmesh_assert_equal_to (error_per_cell.size(), system_error_per_cell.size());
-          for (unsigned int i=0; i != error_per_cell.size(); ++i)
+          for (std::size_t i=0; i != error_per_cell.size(); ++i)
             error_per_cell[i] += system_error_per_cell[i];
         }
       else

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -63,7 +63,7 @@ void ExactErrorEstimator::attach_exact_values (std::vector<FunctionBase<Number> 
 {
   // Clear out any previous _exact_values entries, then add a new
   // entry for each system.
-  for (unsigned int i=0; i != _exact_values.size(); ++i)
+  for (std::size_t i=0; i != _exact_values.size(); ++i)
     delete (_exact_values[i]);
 
   _exact_values.clear();
@@ -72,7 +72,7 @@ void ExactErrorEstimator::attach_exact_values (std::vector<FunctionBase<Number> 
   // We use clone() to get non-sliced copies of FunctionBase
   // subclasses, but we don't currently put the resulting UniquePtrs
   // into an STL container.
-  for (unsigned int i=0; i != f.size(); ++i)
+  for (std::size_t i=0; i != f.size(); ++i)
     if (f[i])
       _exact_values[i] = f[i]->clone().release();
 }
@@ -109,7 +109,7 @@ void ExactErrorEstimator::attach_exact_derivs (std::vector<FunctionBase<Gradient
 {
   // Clear out any previous _exact_derivs entries, then add a new
   // entry for each system.
-  for (unsigned int i=0; i != _exact_derivs.size(); ++i)
+  for (std::size_t i=0; i != _exact_derivs.size(); ++i)
     delete (_exact_derivs[i]);
 
   _exact_derivs.clear();
@@ -118,7 +118,7 @@ void ExactErrorEstimator::attach_exact_derivs (std::vector<FunctionBase<Gradient
   // We use clone() to get non-sliced copies of FunctionBase
   // subclasses, but we don't currently put the resulting UniquePtrs
   // into an STL container.
-  for (unsigned int i=0; i != g.size(); ++i)
+  for (std::size_t i=0; i != g.size(); ++i)
     if (g[i])
       _exact_derivs[i] = g[i]->clone().release();
 }
@@ -157,7 +157,7 @@ void ExactErrorEstimator::attach_exact_hessians (std::vector<FunctionBase<Tensor
 {
   // Clear out any previous _exact_hessians entries, then add a new
   // entry for each system.
-  for (unsigned int i=0; i != _exact_hessians.size(); ++i)
+  for (std::size_t i=0; i != _exact_hessians.size(); ++i)
     delete (_exact_hessians[i]);
 
   _exact_hessians.clear();
@@ -166,7 +166,7 @@ void ExactErrorEstimator::attach_exact_hessians (std::vector<FunctionBase<Tensor
   // We use clone() to get non-sliced copies of FunctionBase
   // subclasses, but we don't currently put the resulting UniquePtrs
   // into an STL container.
-  for (unsigned int i=0; i != h.size(); ++i)
+  for (std::size_t i=0; i != h.size(); ++i)
     if (h[i])
       _exact_hessians[i] = h[i]->clone().release();
 }
@@ -279,15 +279,15 @@ void ExactErrorEstimator::estimate_error (const System & system,
           fine_values->init();
         } else {
         // Initialize functors if we're using them
-        for (unsigned int i=0; i != _exact_values.size(); ++i)
+        for (std::size_t i=0; i != _exact_values.size(); ++i)
           if (_exact_values[i])
             _exact_values[i]->init();
 
-        for (unsigned int i=0; i != _exact_derivs.size(); ++i)
+        for (std::size_t i=0; i != _exact_derivs.size(); ++i)
           if (_exact_derivs[i])
             _exact_derivs[i]->init();
 
-        for (unsigned int i=0; i != _exact_hessians.size(); ++i)
+        for (std::size_t i=0; i != _exact_hessians.size(); ++i)
           if (_exact_hessians[i])
             _exact_hessians[i]->init();
       }
@@ -396,7 +396,7 @@ void ExactErrorEstimator::estimate_error (const System & system,
   // Compute the square-root of each component.
   {
     LOG_SCOPE("std::sqrt()", "ExactErrorEstimator");
-    for (dof_id_type i=0; i<error_per_cell.size(); i++)
+    for (std::size_t i=0; i<error_per_cell.size(); i++)
       if (error_per_cell[i] != 0.)
         {
           libmesh_assert_greater (error_per_cell[i], 0.);
@@ -556,13 +556,13 @@ void ExactErrorEstimator::clear_functors()
   // delete will clean up any cloned functors and no-op on any NULL
   // pointers
 
-  for (unsigned int i=0; i != _exact_values.size(); ++i)
+  for (std::size_t i=0; i != _exact_values.size(); ++i)
     delete (_exact_values[i]);
 
-  for (unsigned int i=0; i != _exact_derivs.size(); ++i)
+  for (std::size_t i=0; i != _exact_derivs.size(); ++i)
     delete (_exact_derivs[i]);
 
-  for (unsigned int i=0; i != _exact_hessians.size(); ++i)
+  for (std::size_t i=0; i != _exact_hessians.size(); ++i)
     delete (_exact_hessians[i]);
 }
 

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -73,13 +73,13 @@ ExactSolution::~ExactSolution()
   // delete will clean up any cloned functors and no-op on any NULL
   // pointers
 
-  for (unsigned int i=0; i != _exact_values.size(); ++i)
+  for (std::size_t i=0; i != _exact_values.size(); ++i)
     delete (_exact_values[i]);
 
-  for (unsigned int i=0; i != _exact_derivs.size(); ++i)
+  for (std::size_t i=0; i != _exact_derivs.size(); ++i)
     delete (_exact_derivs[i]);
 
-  for (unsigned int i=0; i != _exact_hessians.size(); ++i)
+  for (std::size_t i=0; i != _exact_hessians.size(); ++i)
     delete (_exact_hessians[i]);
 }
 
@@ -124,7 +124,7 @@ void ExactSolution::attach_exact_values (const std::vector<FunctionBase<Number> 
 {
   // Clear out any previous _exact_values entries, then add a new
   // entry for each system.
-  for (unsigned int i=0; i != _exact_values.size(); ++i)
+  for (std::size_t i=0; i != _exact_values.size(); ++i)
     delete (_exact_values[i]);
 
   _exact_values.clear();
@@ -133,7 +133,7 @@ void ExactSolution::attach_exact_values (const std::vector<FunctionBase<Number> 
   // We use clone() to get non-sliced copies of FunctionBase
   // subclasses, but we don't currently put the resulting UniquePtrs
   // into an STL container.
-  for (unsigned int i=0; i != f.size(); ++i)
+  for (std::size_t i=0; i != f.size(); ++i)
     if (f[i])
       _exact_values[i] = f[i]->clone().release();
 }
@@ -178,7 +178,7 @@ void ExactSolution::attach_exact_derivs (const std::vector<FunctionBase<Gradient
 {
   // Clear out any previous _exact_derivs entries, then add a new
   // entry for each system.
-  for (unsigned int i=0; i != _exact_derivs.size(); ++i)
+  for (std::size_t i=0; i != _exact_derivs.size(); ++i)
     delete (_exact_derivs[i]);
 
   _exact_derivs.clear();
@@ -187,7 +187,7 @@ void ExactSolution::attach_exact_derivs (const std::vector<FunctionBase<Gradient
   // We use clone() to get non-sliced copies of FunctionBase
   // subclasses, but we don't currently put the resulting UniquePtrs
   // into an STL container.
-  for (unsigned int i=0; i != g.size(); ++i)
+  for (std::size_t i=0; i != g.size(); ++i)
     if (g[i])
       _exact_derivs[i] = g[i]->clone().release();
 }
@@ -232,7 +232,7 @@ void ExactSolution::attach_exact_hessians (std::vector<FunctionBase<Tensor> *> h
 {
   // Clear out any previous _exact_hessians entries, then add a new
   // entry for each system.
-  for (unsigned int i=0; i != _exact_hessians.size(); ++i)
+  for (std::size_t i=0; i != _exact_hessians.size(); ++i)
     delete (_exact_hessians[i]);
 
   _exact_hessians.clear();
@@ -241,7 +241,7 @@ void ExactSolution::attach_exact_hessians (std::vector<FunctionBase<Tensor> *> h
   // We use clone() to get non-sliced copies of FunctionBase
   // subclasses, but we don't currently put the resulting UniquePtrs
   // into an STL container.
-  for (unsigned int i=0; i != h.size(); ++i)
+  for (std::size_t i=0; i != h.size(); ++i)
     if (h[i])
       _exact_hessians[i] = h[i]->clone().release();
 }
@@ -554,15 +554,15 @@ void ExactSolution::_compute_error(const std::string & sys_name,
     }
 
   // Initialize any functors we're going to use
-  for (unsigned int i=0; i != _exact_values.size(); ++i)
+  for (std::size_t i=0; i != _exact_values.size(); ++i)
     if (_exact_values[i])
       _exact_values[i]->init();
 
-  for (unsigned int i=0; i != _exact_derivs.size(); ++i)
+  for (std::size_t i=0; i != _exact_derivs.size(); ++i)
     if (_exact_derivs[i])
       _exact_derivs[i]->init();
 
-  for (unsigned int i=0; i != _exact_hessians.size(); ++i)
+  for (std::size_t i=0; i != _exact_hessians.size(); ++i)
     if (_exact_hessians[i])
       _exact_hessians[i]->init();
 

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -389,12 +389,12 @@ void JumpErrorEstimator::estimate_error (const System & system,
       // Sanity check: Make sure the number of flux faces is
       // always an integer value
 #ifdef DEBUG
-      for (unsigned int i=0; i<n_flux_faces.size(); ++i)
+      for (std::size_t i=0; i<n_flux_faces.size(); ++i)
         libmesh_assert_equal_to (n_flux_faces[i], static_cast<float>(static_cast<unsigned int>(n_flux_faces[i])) );
 #endif
 
       // Scale the error by the number of flux faces for each element
-      for (unsigned int i=0; i<n_flux_faces.size(); ++i)
+      for (std::size_t i=0; i<n_flux_faces.size(); ++i)
         {
           if (n_flux_faces[i] == 0.0) // inactive or non-local element
             continue;

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -451,7 +451,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                         u_h += (*phi)[i][qp]*system.current_solution (dof_indices[i]);
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         F(i) += JxW[qp]*u_h*psi[i];
 
                     }
@@ -467,7 +467,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                                              system.current_solution(dof_indices[i]));
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fx(i) += JxW[qp]*grad_u_h(0)*psi[i];
 #if LIBMESH_DIM > 1
@@ -489,7 +489,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                                              system.current_solution(dof_indices[i]));
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fx(i) += JxW[qp]*grad_u_h(0)*psi[i];
                         }
@@ -505,7 +505,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                                              system.current_solution(dof_indices[i]));
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fy(i) += JxW[qp]*grad_u_h(1)*psi[i];
                         }
@@ -521,7 +521,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                                              system.current_solution(dof_indices[i]));
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fz(i) += JxW[qp]*grad_u_h(2)*psi[i];
                         }
@@ -539,7 +539,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                                              system.current_solution(dof_indices[i]));
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fx(i)  += JxW[qp]*hess_u_h(0,0)*psi[i];
 #if LIBMESH_DIM > 1

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -213,7 +213,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
   // And it'll be best to avoid any repartitioning
   UniquePtr<Partitioner> old_partitioner(mesh.partitioner().release());
 
-  for (unsigned int i=0; i != system_list.size(); ++i)
+  for (std::size_t i=0; i != system_list.size(); ++i)
     {
       System & system = *system_list[i];
 
@@ -283,7 +283,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
       es.reinit();
     }
 
-  for (unsigned int i=0; i != system_list.size(); ++i)
+  for (std::size_t i=0; i != system_list.size(); ++i)
     {
       System & system = *system_list[i];
 
@@ -304,7 +304,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
       libmesh_assert (solution_vectors->find(sys) !=
                       solution_vectors->end());
       const NumericVector<Number> * vec = solution_vectors->find(sys)->second;
-      for (unsigned int j=0; j != sys->qoi.size(); ++j)
+      for (std::size_t j=0; j != sys->qoi.size(); ++j)
         {
           std::ostringstream adjoint_name;
           adjoint_name << "adjoint_solution" << j;
@@ -340,7 +340,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
                          !solution_vectors->find(system_list[0])->second);
 
 #ifdef DEBUG
-          for (unsigned int i=0; i != system_list.size(); ++i)
+          for (std::size_t i=0; i != system_list.size(); ++i)
             {
               System * sys = system_list[i];
               libmesh_assert (solution_vectors->find(sys) !=
@@ -349,7 +349,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
               if (solve_adjoint)
                 {
                   bool found_vec = false;
-                  for (unsigned int j=0; j != sys->qoi.size(); ++j)
+                  for (std::size_t j=0; j != sys->qoi.size(); ++j)
                     {
                       std::ostringstream adjoint_name;
                       adjoint_name << "adjoint_solution" << j;
@@ -372,13 +372,13 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
               std::vector<unsigned int> adjs(system_list.size(),
                                              libMesh::invalid_uint);
               // Set up proper initial guesses
-              for (unsigned int i=0; i != system_list.size(); ++i)
+              for (std::size_t i=0; i != system_list.size(); ++i)
                 {
                   System * sys = system_list[i];
                   libmesh_assert (solution_vectors->find(sys) !=
                                   solution_vectors->end());
                   const NumericVector<Number> * vec = solution_vectors->find(sys)->second;
-                  for (unsigned int j=0; j != sys->qoi.size(); ++j)
+                  for (std::size_t j=0; j != sys->qoi.size(); ++j)
                     {
                       std::ostringstream adjoint_name;
                       adjoint_name << "adjoint_solution" << j;
@@ -398,7 +398,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
 
               // Put the adjoint_solution into solution for
               // comparisons
-              for (unsigned int i=0; i != system_list.size(); ++i)
+              for (std::size_t i=0; i != system_list.size(); ++i)
                 {
                   system_list[i]->get_adjoint_solution(adjs[i]).swap(*system_list[i]->solution);
                   system_list[i]->update();
@@ -434,7 +434,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
           if (solve_adjoint)
             {
               unsigned int adj = libMesh::invalid_uint;
-              for (unsigned int j=0; j != sys->qoi.size(); ++j)
+              for (std::size_t j=0; j != sys->qoi.size(); ++j)
                 {
                   std::ostringstream adjoint_name;
                   adjoint_name << "adjoint_solution" << j;
@@ -462,7 +462,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
 
   // Get the error in the uniformly refined solution(s).
 
-  for (unsigned int sysnum=0; sysnum != system_list.size(); ++sysnum)
+  for (std::size_t sysnum=0; sysnum != system_list.size(); ++sysnum)
     {
       System & system = *system_list[sysnum];
 
@@ -681,7 +681,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
 
       // Compute the square-root of each component.
       LOG_SCOPE("std::sqrt()", "UniformRefinementEstimator");
-      for (unsigned int i=0; i<error_per_cell->size(); i++)
+      for (std::size_t i=0; i<error_per_cell->size(); i++)
         if ((*error_per_cell)[i] != 0.)
           (*error_per_cell)[i] = std::sqrt((*error_per_cell)[i]);
     }
@@ -696,14 +696,14 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
 
           // Compute the square-root of each component.
           LOG_SCOPE("std::sqrt()", "UniformRefinementEstimator");
-          for (unsigned int i=0; i<e->size(); i++)
+          for (std::size_t i=0; i<e->size(); i++)
             if ((*e)[i] != 0.)
               (*e)[i] = std::sqrt((*e)[i]);
         }
     }
 
   // Restore old solutions and clean up the heap
-  for (unsigned int i=0; i != system_list.size(); ++i)
+  for (std::size_t i=0; i != system_list.size(); ++i)
     {
       System & system = *system_list[i];
 

--- a/src/error_estimation/weighted_patch_recovery_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_estimator.C
@@ -364,7 +364,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                         u_h += (*phi)[i][qp]*system.current_solution (dof_indices[i]);
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         F(i) = JxW[qp]*u_h*psi[i];
 
                     }
@@ -375,14 +375,14 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                       // at the quadrature point
                       Gradient grad_u_h;
 
-                      for (unsigned int i=0; i<n_dofs; i++)
+                      for (std::size_t i=0; i<n_dofs; i++)
                         grad_u_h.add_scaled ((*dphi)[i][qp],
                                              system.current_solution(dof_indices[i]));
 
 
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fx(i) += JxW[qp]*grad_u_h(0)*psi[i];
 #if LIBMESH_DIM > 1
@@ -406,7 +406,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fx(i) += JxW[qp]*grad_u_h(0)*psi[i];
                         }
@@ -424,7 +424,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fy(i) += JxW[qp]*grad_u_h(1)*psi[i];
                         }
@@ -442,7 +442,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fz(i) += JxW[qp]*grad_u_h(2)*psi[i];
                         }
@@ -462,7 +462,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
 
                       // Patch RHS contributions
-                      for (unsigned int i=0; i<psi.size(); i++)
+                      for (std::size_t i=0; i<psi.size(); i++)
                         {
                           Fx(i)  += JxW[qp]*hess_u_h(0,0)*psi[i];
 #if LIBMESH_DIM > 1

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -719,8 +719,8 @@ void FEGenericBase<OutputType>::compute_shape_functions (const Elem * elem,
 template <typename OutputType>
 void FEGenericBase<OutputType>::print_phi(std::ostream & os) const
 {
-  for (unsigned int i=0; i<phi.size(); ++i)
-    for (unsigned int j=0; j<phi[i].size(); ++j)
+  for (std::size_t i=0; i<phi.size(); ++i)
+    for (std::size_t j=0; j<phi[i].size(); ++j)
       os << " phi[" << i << "][" << j << "]=" << phi[i][j] << std::endl;
 }
 
@@ -730,8 +730,8 @@ void FEGenericBase<OutputType>::print_phi(std::ostream & os) const
 template <typename OutputType>
 void FEGenericBase<OutputType>::print_dphi(std::ostream & os) const
 {
-  for (unsigned int i=0; i<dphi.size(); ++i)
-    for (unsigned int j=0; j<dphi[i].size(); ++j)
+  for (std::size_t i=0; i<dphi.size(); ++i)
+    for (std::size_t j=0; j<dphi[i].size(); ++j)
       os << " dphi[" << i << "][" << j << "]=" << dphi[i][j];
 }
 
@@ -788,8 +788,8 @@ void FEGenericBase<OutputType>::determine_calculations()
 template <typename OutputType>
 void FEGenericBase<OutputType>::print_d2phi(std::ostream & os) const
 {
-  for (unsigned int i=0; i<dphi.size(); ++i)
-    for (unsigned int j=0; j<dphi[i].size(); ++j)
+  for (std::size_t i=0; i<dphi.size(); ++i)
+    for (std::size_t j=0; j<dphi[i].size(); ++j)
       os << " d2phi[" << i << "][" << j << "]=" << d2phi[i][j];
 }
 
@@ -951,8 +951,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
         // Some edge dofs are on nodes and already
         // fixed, others are free to calculate
         unsigned int free_dofs = 0;
-        for (unsigned int i=0; i !=
-               new_side_dofs.size(); ++i)
+        for (std::size_t i=0; i != new_side_dofs.size(); ++i)
           if (!dof_is_fixed[new_side_dofs[i]])
             free_dof[free_dofs++] = i;
         Ke.resize (free_dofs, free_dofs); Ke.zero();
@@ -1022,17 +1021,13 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
                   }
 
                 // Form edge projection matrix
-                for (unsigned int sidei=0, freei=0;
-                     sidei != new_side_dofs.size();
-                     ++sidei)
+                for (std::size_t sidei=0, freei=0; sidei != new_side_dofs.size(); ++sidei)
                   {
                     unsigned int i = new_side_dofs[sidei];
                     // fixed DoFs aren't test functions
                     if (dof_is_fixed[i])
                       continue;
-                    for (unsigned int sidej=0, freej=0;
-                         sidej != new_side_dofs.size();
-                         ++sidej)
+                    for (std::size_t sidej=0, freej=0; sidej != new_side_dofs.size(); ++sidej)
                       {
                         unsigned int j =
                           new_side_dofs[sidej];
@@ -1094,8 +1089,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
         // Some side dofs are on nodes/edges and already
         // fixed, others are free to calculate
         unsigned int free_dofs = 0;
-        for (unsigned int i=0; i !=
-               new_side_dofs.size(); ++i)
+        for (std::size_t i=0; i != new_side_dofs.size(); ++i)
           if (!dof_is_fixed[new_side_dofs[i]])
             free_dof[free_dofs++] = i;
         Ke.resize (free_dofs, free_dofs); Ke.zero();
@@ -1165,17 +1159,13 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
                   }
 
                 // Form side projection matrix
-                for (unsigned int sidei=0, freei=0;
-                     sidei != new_side_dofs.size();
-                     ++sidei)
+                for (std::size_t sidei=0, freei=0; sidei != new_side_dofs.size(); ++sidei)
                   {
                     unsigned int i = new_side_dofs[sidei];
                     // fixed DoFs aren't test functions
                     if (dof_is_fixed[i])
                       continue;
-                    for (unsigned int sidej=0, freej=0;
-                         sidej != new_side_dofs.size();
-                         ++sidej)
+                    for (std::size_t sidej=0, freej=0; sidej != new_side_dofs.size(); ++sidej)
                       {
                         unsigned int j =
                           new_side_dofs[sidej];
@@ -1814,7 +1804,7 @@ compute_periodic_constraints (DofConstraints & constraints,
                   // Translate the quadrature points over to the
                   // neighbor's boundary
                   std::vector<Point> neigh_point(q_point.size());
-                  for (unsigned int i=0; i != neigh_point.size(); ++i)
+                  for (std::size_t i=0; i != neigh_point.size(); ++i)
                     neigh_point[i] = periodic->get_corresponding_pos(q_point[i]);
 
                   FEInterface::inverse_map (Dim, base_fe_type, neigh,

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -396,7 +396,7 @@ void FE<Dim,T>::side_map (const Elem * elem,
 
   const std::vector<std::vector<Real> > & psi_map = this->_fe_map->get_psi();
 
-  for (unsigned int i=0; i<psi_map.size(); i++) // sum over the nodes
+  for (std::size_t i=0; i<psi_map.size(); i++) // sum over the nodes
     {
       const Point & side_node = refspace_nodes[elem_nodes_map[i]];
       for (unsigned int p=0; p<n_points; p++)
@@ -982,7 +982,7 @@ void FEMap::compute_edge_map(int dim,
     }
 
   // compute x, dxdxi at the quadrature points
-  for (unsigned int i=0; i<this->psi_map.size(); i++) // sum over the nodes
+  for (std::size_t i=0; i<this->psi_map.size(); i++) // sum over the nodes
     {
       const Point & edge_point = edge->point(i);
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -449,7 +449,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
 #endif
 
         // compute x, dx, d2x at the quadrature point
-        for (unsigned int i=0; i<elem_nodes.size(); i++) // sum over the nodes
+        for (std::size_t i=0; i<elem_nodes.size(); i++) // sum over the nodes
           {
             // Reference to the point, helps eliminate
             // exessive temporaries in the inner loop
@@ -688,7 +688,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
 
 
         // compute (x,y) at the quadrature points, derivatives once
-        for (unsigned int i=0; i<elem_nodes.size(); i++) // sum over the nodes
+        for (std::size_t i=0; i<elem_nodes.size(); i++) // sum over the nodes
           {
             // Reference to the point, helps eliminate
             // exessive temporaries in the inner loop
@@ -1010,7 +1010,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         // dxdxi,   dydxi,   dzdxi,
         // dxdeta,  dydeta,  dzdeta,
         // dxdzeta, dydzeta, dzdzeta  all once
-        for (unsigned int i=0; i<elem_nodes.size(); i++) // sum over the nodes
+        for (std::size_t i=0; i<elem_nodes.size(); i++) // sum over the nodes
           {
             // Reference to the point, helps eliminate
             // exessive temporaries in the inner loop
@@ -1161,7 +1161,7 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
 
       // Inverse map second derivatives
       d2xidxyz2_map.resize(n_qp);
-      for (unsigned i=0; i<d2xidxyz2_map.size(); ++i)
+      for (std::size_t i=0; i<d2xidxyz2_map.size(); ++i)
         d2xidxyz2_map[i].assign(6, 0.);
     }
 #endif
@@ -1182,7 +1182,7 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
 
           // Inverse map second derivatives
           d2etadxyz2_map.resize(n_qp);
-          for (unsigned i=0; i<d2etadxyz2_map.size(); ++i)
+          for (std::size_t i=0; i<d2etadxyz2_map.size(); ++i)
             d2etadxyz2_map[i].assign(6, 0.);
         }
 #endif
@@ -1204,7 +1204,7 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
 
               // Inverse map second derivatives
               d2zetadxyz2_map.resize(n_qp);
-              for (unsigned i=0; i<d2zetadxyz2_map.size(); ++i)
+              for (std::size_t i=0; i<d2zetadxyz2_map.size(); ++i)
                 d2zetadxyz2_map[i].assign(6, 0.);
             }
 #endif
@@ -1248,7 +1248,7 @@ void FEMap::compute_affine_map(const unsigned int dim,
     for (unsigned int p=1; p<n_qp; p++)
       {
         xyz[p].zero();
-        for (unsigned int i=0; i<phi_map.size(); i++) // sum over the nodes
+        for (std::size_t i=0; i<phi_map.size(); i++) // sum over the nodes
           xyz[p].add_scaled        (*elem_nodes[i], phi_map[i][p]    );
       }
 
@@ -1429,7 +1429,7 @@ void FEMap::compute_map(const unsigned int dim,
 
 void FEMap::print_JxW(std::ostream & os) const
 {
-  for (unsigned int i=0; i<JxW.size(); ++i)
+  for (std::size_t i=0; i<JxW.size(); ++i)
     os << " [" << i << "]: " <<  JxW[i] << std::endl;
 }
 
@@ -1437,7 +1437,7 @@ void FEMap::print_JxW(std::ostream & os) const
 
 void FEMap::print_xyz(std::ostream & os) const
 {
-  for (unsigned int i=0; i<xyz.size(); ++i)
+  for (std::size_t i=0; i<xyz.size(); ++i)
     os << " [" << i << "]: " << xyz[i];
 }
 

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -720,12 +720,12 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
     case 1:
       {
         if (this->calculate_phi)
-          for (unsigned int i=0; i<this->phi.size(); i++)
-            for (unsigned int p=0; p<this->phi[i].size(); p++)
+          for (std::size_t i=0; i<this->phi.size(); i++)
+            for (std::size_t p=0; p<this->phi[i].size(); p++)
               this->phi[i][p] = FE<Dim,XYZ>::shape (elem, this->fe_type.order, i, xyz_qp[p]);
         if (this->calculate_dphi)
-          for (unsigned int i=0; i<this->dphi.size(); i++)
-            for (unsigned int p=0; p<this->dphi[i].size(); p++)
+          for (std::size_t i=0; i<this->dphi.size(); i++)
+            for (std::size_t p=0; p<this->dphi[i].size(); p++)
               {
                 this->dphi[i][p](0) =
                   this->dphidx[i][p] = FE<Dim,XYZ>::shape_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -735,8 +735,8 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
               }
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         if (this->calculate_d2phi)
-          for (unsigned int i=0; i<this->d2phi.size(); i++)
-            for (unsigned int p=0; p<this->d2phi[i].size(); p++)
+          for (std::size_t i=0; i<this->d2phi.size(); i++)
+            for (std::size_t p=0; p<this->d2phi[i].size(); p++)
               {
                 this->d2phi[i][p](0,0) =
                   this->d2phidx2[i][p] = FE<Dim,XYZ>::shape_second_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -763,12 +763,12 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
     case 2:
       {
         if (this->calculate_phi)
-          for (unsigned int i=0; i<this->phi.size(); i++)
-            for (unsigned int p=0; p<this->phi[i].size(); p++)
+          for (std::size_t i=0; i<this->phi.size(); i++)
+            for (std::size_t p=0; p<this->phi[i].size(); p++)
               this->phi[i][p] = FE<Dim,XYZ>::shape (elem, this->fe_type.order, i, xyz_qp[p]);
         if (this->calculate_dphi)
-          for (unsigned int i=0; i<this->dphi.size(); i++)
-            for (unsigned int p=0; p<this->dphi[i].size(); p++)
+          for (std::size_t i=0; i<this->dphi.size(); i++)
+            for (std::size_t p=0; p<this->dphi[i].size(); p++)
               {
                 this->dphi[i][p](0) =
                   this->dphidx[i][p] = FE<Dim,XYZ>::shape_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -783,8 +783,8 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
               }
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         if (this->calculate_d2phi)
-          for (unsigned int i=0; i<this->d2phi.size(); i++)
-            for (unsigned int p=0; p<this->d2phi[i].size(); p++)
+          for (std::size_t i=0; i<this->d2phi.size(); i++)
+            for (std::size_t p=0; p<this->d2phi[i].size(); p++)
               {
                 this->d2phi[i][p](0,0) =
                   this->d2phidx2[i][p] = FE<Dim,XYZ>::shape_second_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -810,13 +810,13 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
     case 3:
       {
         if (this->calculate_phi)
-          for (unsigned int i=0; i<this->phi.size(); i++)
-            for (unsigned int p=0; p<this->phi[i].size(); p++)
+          for (std::size_t i=0; i<this->phi.size(); i++)
+            for (std::size_t p=0; p<this->phi[i].size(); p++)
               this->phi[i][p] = FE<Dim,XYZ>::shape (elem, this->fe_type.order, i, xyz_qp[p]);
 
         if (this->calculate_dphi)
-          for (unsigned int i=0; i<this->dphi.size(); i++)
-            for (unsigned int p=0; p<this->dphi[i].size(); p++)
+          for (std::size_t i=0; i<this->dphi.size(); i++)
+            for (std::size_t p=0; p<this->dphi[i].size(); p++)
               {
                 this->dphi[i][p](0) =
                   this->dphidx[i][p] = FE<Dim,XYZ>::shape_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -829,8 +829,8 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
               }
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         if (this->calculate_d2phi)
-          for (unsigned int i=0; i<this->d2phi.size(); i++)
-            for (unsigned int p=0; p<this->d2phi[i].size(); p++)
+          for (std::size_t i=0; i<this->d2phi.size(); i++)
+            for (std::size_t p=0; p<this->d2phi[i].size(); p++)
               {
                 this->d2phi[i][p](0,0) =
                   this->d2phidx2[i][p] = FE<Dim,XYZ>::shape_second_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);

--- a/src/fe/fe_xyz_map.C
+++ b/src/fe/fe_xyz_map.C
@@ -58,7 +58,7 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
           }
 
         // compute x, dxdxi at the quadrature points
-        for (unsigned int i=0; i<this->psi_map.size(); i++) // sum over the nodes
+        for (std::size_t i=0; i<this->psi_map.size(); i++) // sum over the nodes
           {
             const Point & side_point = side->point(i);
 
@@ -139,7 +139,7 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
           }
 
         // compute x, dxdxi at the quadrature points
-        for (unsigned int i=0; i<this->psi_map.size(); i++) // sum over the nodes
+        for (std::size_t i=0; i<this->psi_map.size(); i++) // sum over the nodes
           {
             const Point & side_point = side->point(i);
 

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -58,40 +58,40 @@ void H1FETransformation<OutputShape>::map_phi( const unsigned int dim,
     {
     case 0:
       {
-        for (unsigned int i=0; i<phi.size(); i++)
+        for (std::size_t i=0; i<phi.size(); i++)
           {
             libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (unsigned int p=0; p<phi[i].size(); p++)
+            for (std::size_t p=0; p<phi[i].size(); p++)
               FEInterface::shape<OutputShape>(0, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
           }
         break;
       }
     case 1:
       {
-        for (unsigned int i=0; i<phi.size(); i++)
+        for (std::size_t i=0; i<phi.size(); i++)
           {
             libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (unsigned int p=0; p<phi[i].size(); p++)
+            for (std::size_t p=0; p<phi[i].size(); p++)
               FEInterface::shape<OutputShape>(1, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
           }
         break;
       }
     case 2:
       {
-        for (unsigned int i=0; i<phi.size(); i++)
+        for (std::size_t i=0; i<phi.size(); i++)
           {
             libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (unsigned int p=0; p<phi[i].size(); p++)
+            for (std::size_t p=0; p<phi[i].size(); p++)
               FEInterface::shape<OutputShape>(2, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
           }
         break;
       }
     case 3:
       {
-        for (unsigned int i=0; i<phi.size(); i++)
+        for (std::size_t i=0; i<phi.size(); i++)
           {
             libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (unsigned int p=0; p<phi[i].size(); p++)
+            for (std::size_t p=0; p<phi[i].size(); p++)
               FEInterface::shape<OutputShape>(3, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
           }
         break;
@@ -117,11 +117,9 @@ void H1FETransformation<OutputShape>::map_dphi( const unsigned int dim,
     {
     case 0: // No derivatives in 0D
       {
-        for (unsigned int i=0; i<dphi.size(); i++)
-          for (unsigned int p=0; p<dphi[i].size(); p++)
-            {
-              dphi[i][p] = 0.;
-            }
+        for (std::size_t i=0; i<dphi.size(); i++)
+          for (std::size_t p=0; p<dphi[i].size(); p++)
+            dphi[i][p] = 0.;
         break;
       }
 
@@ -137,8 +135,8 @@ void H1FETransformation<OutputShape>::map_dphi( const unsigned int dim,
         const std::vector<Real> & dxidz_map = fe.get_fe_map().get_dxidz();
 #endif
 
-        for (unsigned int i=0; i<dphi.size(); i++)
-          for (unsigned int p=0; p<dphi[i].size(); p++)
+        for (std::size_t i=0; i<dphi.size(); i++)
+          for (std::size_t p=0; p<dphi[i].size(); p++)
             {
               // dphi/dx    = (dphi/dxi)*(dxi/dx)
               dphi[i][p].slice(0) = dphidx[i][p] = dphidxi[i][p]*dxidx_map[p];
@@ -171,8 +169,8 @@ void H1FETransformation<OutputShape>::map_dphi( const unsigned int dim,
         const std::vector<Real> & detadz_map = fe.get_fe_map().get_detadz();
 #endif
 
-        for (unsigned int i=0; i<dphi.size(); i++)
-          for (unsigned int p=0; p<dphi[i].size(); p++)
+        for (std::size_t i=0; i<dphi.size(); i++)
+          for (std::size_t p=0; p<dphi[i].size(); p++)
             {
               // dphi/dx    = (dphi/dxi)*(dxi/dx) + (dphi/deta)*(deta/dx)
               dphi[i][p].slice(0) = dphidx[i][p] = (dphidxi[i][p]*dxidx_map[p] +
@@ -210,8 +208,8 @@ void H1FETransformation<OutputShape>::map_dphi( const unsigned int dim,
         const std::vector<Real> & dzetady_map = fe.get_fe_map().get_dzetady();
         const std::vector<Real> & dzetadz_map = fe.get_fe_map().get_dzetadz();
 
-        for (unsigned int i=0; i<dphi.size(); i++)
-          for (unsigned int p=0; p<dphi[i].size(); p++)
+        for (std::size_t i=0; i<dphi.size(); i++)
+          for (std::size_t p=0; p<dphi[i].size(); p++)
             {
               // dphi/dx    = (dphi/dxi)*(dxi/dx) + (dphi/deta)*(deta/dx) + (dphi/dzeta)*(dzeta/dx);
               dphi[i][p].slice(0) = dphidx[i][p] = (dphidxi[i][p]*dxidx_map[p] +
@@ -253,11 +251,9 @@ void H1FETransformation<OutputShape>::map_d2phi(const unsigned int dim,
     {
     case 0: // No derivatives in 0D
       {
-        for (unsigned int i=0; i<d2phi.size(); i++)
-          for (unsigned int p=0; p<d2phi[i].size(); p++)
-            {
-              d2phi[i][p] = 0.;
-            }
+        for (std::size_t i=0; i<d2phi.size(); i++)
+          for (std::size_t p=0; p<d2phi[i].size(); p++)
+            d2phi[i][p] = 0.;
 
         break;
       }
@@ -280,8 +276,8 @@ void H1FETransformation<OutputShape>::map_d2phi(const unsigned int dim,
         // Inverse map second derivatives
         const std::vector<std::vector<Real> > & d2xidxyz2 = fe.get_fe_map().get_d2xidxyz2();
 
-        for (unsigned int i=0; i<d2phi.size(); i++)
-          for (unsigned int p=0; p<d2phi[i].size(); p++)
+        for (std::size_t i=0; i<d2phi.size(); i++)
+          for (std::size_t p=0; p<d2phi[i].size(); p++)
             {
               // phi_{x x}
               d2phi[i][p].slice(0).slice(0) = d2phidx2[i][p] =
@@ -351,8 +347,8 @@ void H1FETransformation<OutputShape>::map_d2phi(const unsigned int dim,
         const std::vector<std::vector<Real> > & d2xidxyz2 = fe.get_fe_map().get_d2xidxyz2();
         const std::vector<std::vector<Real> > & d2etadxyz2 = fe.get_fe_map().get_d2etadxyz2();
 
-        for (unsigned int i=0; i<d2phi.size(); i++)
-          for (unsigned int p=0; p<d2phi[i].size(); p++)
+        for (std::size_t i=0; i<d2phi.size(); i++)
+          for (std::size_t p=0; p<d2phi[i].size(); p++)
             {
               // phi_{x x}
               d2phi[i][p].slice(0).slice(0) = d2phidx2[i][p] =
@@ -441,8 +437,8 @@ void H1FETransformation<OutputShape>::map_d2phi(const unsigned int dim,
         const std::vector<std::vector<Real> > & d2etadxyz2 = fe.get_fe_map().get_d2etadxyz2();
         const std::vector<std::vector<Real> > & d2zetadxyz2 = fe.get_fe_map().get_d2zetadxyz2();
 
-        for (unsigned int i=0; i<d2phi.size(); i++)
-          for (unsigned int p=0; p<d2phi[i].size(); p++)
+        for (std::size_t i=0; i<d2phi.size(); i++)
+          for (std::size_t p=0; p<d2phi[i].size(); p++)
             {
               // phi_{x x}
               d2phi[i][p].slice(0).slice(0) = d2phidx2[i][p] =
@@ -571,8 +567,8 @@ void H1FETransformation<RealGradient>::map_curl(const unsigned int dim,
 
           curl = ( -dphi_y/dz, dphi_x/dz, dphi_y/dx - dphi_x/dy )
         */
-        for (unsigned int i=0; i<curl_phi.size(); i++)
-          for (unsigned int p=0; p<curl_phi[i].size(); p++)
+        for (std::size_t i=0; i<curl_phi.size(); i++)
+          for (std::size_t p=0; p<curl_phi[i].size(); p++)
             {
 
               Real dphiy_dx = (dphidxi[i][p].slice(1))*dxidx_map[p]
@@ -618,8 +614,8 @@ void H1FETransformation<RealGradient>::map_curl(const unsigned int dim,
         /*
           In 3D: curl = ( dphi_z/dy - dphi_y/dz, dphi_x/dz - dphi_z/dx, dphi_y/dx - dphi_x/dy )
         */
-        for (unsigned int i=0; i<curl_phi.size(); i++)
-          for (unsigned int p=0; p<curl_phi[i].size(); p++)
+        for (std::size_t i=0; i<curl_phi.size(); i++)
+          for (std::size_t p=0; p<curl_phi[i].size(); p++)
             {
               Real dphiz_dy = (dphidxi[i][p].slice(2))*dxidy_map[p]
                 + (dphideta[i][p].slice(2))*detady_map[p]
@@ -695,11 +691,9 @@ void H1FETransformation<RealGradient>::map_div(const unsigned int dim,
         const std::vector<Real> & detadx_map = fe.get_fe_map().get_detadx();
         const std::vector<Real> & detady_map = fe.get_fe_map().get_detady();
 
-        /*
-          In 2D: div = dphi_x/dx + dphi_y/dy
-        */
-        for (unsigned int i=0; i<div_phi.size(); i++)
-          for (unsigned int p=0; p<div_phi[i].size(); p++)
+        // In 2D: div = dphi_x/dx + dphi_y/dy
+        for (std::size_t i=0; i<div_phi.size(); i++)
+          for (std::size_t p=0; p<div_phi[i].size(); p++)
             {
 
               Real dphix_dx = (dphidxi[i][p].slice(0))*dxidx_map[p]
@@ -733,8 +727,8 @@ void H1FETransformation<RealGradient>::map_div(const unsigned int dim,
         /*
           In 3D: div = dphi_x/dx + dphi_y/dy + dphi_z/dz
         */
-        for (unsigned int i=0; i<div_phi.size(); i++)
-          for (unsigned int p=0; p<div_phi[i].size(); p++)
+        for (std::size_t i=0; i<div_phi.size(); i++)
+          for (std::size_t p=0; p<div_phi[i].size(); p++)
             {
               Real dphix_dx = (dphidxi[i][p].slice(0))*dxidx_map[p]
                 + (dphideta[i][p].slice(0))*detadx_map[p]

--- a/src/fe/hcurl_fe_transformation.C
+++ b/src/fe/hcurl_fe_transformation.C
@@ -80,8 +80,8 @@ void HCurlFETransformation<OutputShape>::map_phi(const unsigned int dim,
 
            or in indicial notation:  phi_j = xi_{i,j}*\hat{phi}_i */
 
-        for (unsigned int i=0; i<phi.size(); i++)
-          for (unsigned int p=0; p<phi[i].size(); p++)
+        for (std::size_t i=0; i<phi.size(); i++)
+          for (std::size_t p=0; p<phi[i].size(); p++)
             {
               // Need to temporarily cache reference shape functions
               // TODO: PB: Might be worth trying to build phi_ref separately to see
@@ -123,8 +123,8 @@ void HCurlFETransformation<OutputShape>::map_phi(const unsigned int dim,
 
            or in indicial notation:  phi_j = xi_{i,j}*\hat{phi}_i */
 
-        for (unsigned int i=0; i<phi.size(); i++)
-          for (unsigned int p=0; p<phi[i].size(); p++)
+        for (std::size_t i=0; i<phi.size(); i++)
+          for (std::size_t p=0; p<phi[i].size(); p++)
             {
               // Need to temporarily cache reference shape functions
               // TODO: PB: Might be worth trying to build phi_ref separately to see
@@ -171,8 +171,8 @@ void HCurlFETransformation<OutputShape>::map_curl(const unsigned int dim,
 
         // FIXME: I don't think this is valid for 2D elements in 3D space
         /* In 2D: curl(phi) = J^{-1} * curl(\hat{phi}) */
-        for (unsigned int i=0; i<curl_phi.size(); i++)
-          for (unsigned int p=0; p<curl_phi[i].size(); p++)
+        for (std::size_t i=0; i<curl_phi.size(); i++)
+          for (std::size_t p=0; p<curl_phi[i].size(); p++)
             {
               curl_phi[i][p].slice(0) = curl_phi[i][p].slice(1) = 0.0;
 
@@ -194,8 +194,8 @@ void HCurlFETransformation<OutputShape>::map_curl(const unsigned int dim,
 
         const std::vector<Real> & J = fe.get_fe_map().get_jacobian();
 
-        for (unsigned int i=0; i<curl_phi.size(); i++)
-          for (unsigned int p=0; p<curl_phi[i].size(); p++)
+        for (std::size_t i=0; i<curl_phi.size(); i++)
+          for (std::size_t p=0; p<curl_phi[i].size(); p++)
             {
               Real dx_dxi   = dxyz_dxi[p](0);
               Real dx_deta  = dxyz_deta[p](0);

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -214,7 +214,7 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
       // right now, and it will generalize a bit, and it won't break
       // the assumptions elsewhere in InfFE.
       std::vector<Point> radial_pts;
-      for (unsigned int p=0; p != pts->size(); ++p)
+      for (std::size_t p=0; p != pts->size(); ++p)
         {
           Real radius = (*pts)[p](Dim-1);
           if (radial_pts.size() && radial_pts[0](0) == radius)
@@ -229,7 +229,7 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
 
       std::vector<Point> base_pts;
       base_pts.reserve(base_pts_size);
-      for (unsigned int p=0; p != pts->size(); p += radial_pts_size)
+      for (std::size_t p=0; p != pts->size(); p += radial_pts_size)
         {
           Point pt = (*pts)[p];
           pt(Dim-1) = 0;
@@ -899,7 +899,7 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_functions(const Elem *,
         const std::vector<Real> & dzetadz_map = this->_fe_map->get_dzetadz();
 
         // These are _all_ shape functions of this infinite element
-        for (unsigned int i=0; i<phi.size(); i++)
+        for (std::size_t i=0; i<phi.size(); i++)
           for (unsigned int p=0; p<n_total_qp; p++)
             {
               // dphi/dx    = (dphi/dxi)*(dxi/dx) + (dphi/deta)*(deta/dx) + (dphi/dzeta)*(dzeta/dx);

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -387,7 +387,7 @@ void Prism18::connectivity(const unsigned int sc,
         // VTK's VTK_BIQUADRATIC_QUADRATIC_WEDGE first 9 (vertex) and
         // last 3 (mid-face) nodes match.  The middle and top layers
         // of mid-edge nodes are reversed from LibMesh's.
-        for (unsigned i=0; i<conn.size(); ++i)
+        for (std::size_t i=0; i<conn.size(); ++i)
           conn[i] = this->node_id(i);
 
         // top "ring" of mid-edge nodes

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1252,7 +1252,7 @@ void Elem::make_links_to_me_local(unsigned int n)
     neigh_family.push_back(neigh);
 
   // And point them to elem
-  for (unsigned int i = 0; i != neigh_family.size(); ++i)
+  for (std::size_t i = 0; i != neigh_family.size(); ++i)
     {
       Elem * neigh_family_member = const_cast<Elem *>(neigh_family[i]);
 
@@ -1319,7 +1319,7 @@ void Elem::make_links_to_me_remote()
                   // FIXME - There's a lot of ugly const_casts here; we
                   // may want to make remote_elem non-const and create
                   // non-const versions of the family_tree methods
-                  for (unsigned int i=0; i != family.size(); ++i)
+                  for (std::size_t i=0; i != family.size(); ++i)
                     {
                       Elem * n = const_cast<Elem *>(family[i]);
                       libmesh_assert (n);
@@ -1365,7 +1365,7 @@ void Elem::make_links_to_me_remote()
                   // FIXME - There's a lot of ugly const_casts here; we
                   // may want to make remote_elem non-const and create
                   // non-const versions of the family_tree methods
-                  for (unsigned int i=0; i != family.size(); ++i)
+                  for (std::size_t i=0; i != family.size(); ++i)
                     {
                       Elem * n = const_cast<Elem *>(family[i]);
                       libmesh_assert (n);
@@ -2206,7 +2206,7 @@ Elem::bracketing_nodes(unsigned int child,
   const std::vector<std::pair<unsigned char, unsigned char> > & pbc =
     this->parent_bracketing_nodes(child,child_node);
 
-  for (unsigned int i = 0; i != pbc.size(); ++i)
+  for (std::size_t i = 0; i != pbc.size(); ++i)
     {
       if (pbc[i].first < this->n_nodes() &&
           pbc[i].second < this->n_nodes())

--- a/src/geom/reference_elem.C
+++ b/src/geom/reference_elem.C
@@ -63,7 +63,7 @@ class SingletonCache : public libMesh::Singleton
 public:
   ~SingletonCache()
   {
-    for (unsigned int e=0; e<elem_list.size(); e++)
+    for (std::size_t e=0; e<elem_list.size(); e++)
       {
         delete elem_list[e];
         elem_list[e] = libmesh_nullptr;
@@ -71,7 +71,7 @@ public:
 
     elem_list.clear();
 
-    for (unsigned int n=0; n<node_list.size(); n++)
+    for (std::size_t n=0; n<node_list.size(); n++)
       {
         delete node_list[n];
         node_list[n] = libmesh_nullptr;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -214,7 +214,7 @@ void BoundaryInfo::sync (const std::set<boundary_id_type> & requested_boundary_i
           // Copy over all the node's boundary IDs to boundary_mesh
           std::vector<boundary_id_type> node_boundary_ids;
           this->boundary_ids(node, node_boundary_ids);
-          for (unsigned int index=0; index<node_boundary_ids.size(); index++)
+          for (std::size_t index=0; index<node_boundary_ids.size(); index++)
             {
               boundary_mesh.boundary_info->add_node(node_id_map[node_id],
                                                     node_boundary_ids[index]);

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -260,11 +260,11 @@ void EnsightIO::write_geometry_ascii()
         mesh_stream << std::setw(10) << elem_ref.size() << "\n";
 
         // Write element id
-        for (unsigned int i = 0; i < elem_ref.size(); i++)
+        for (std::size_t i = 0; i < elem_ref.size(); i++)
           mesh_stream << std::setw(10) << elem_ref[i]->id() << "\n";
 
         // Write connectivity
-        for (unsigned int i = 0; i < elem_ref.size(); i++)
+        for (std::size_t i = 0; i < elem_ref.size(); i++)
           {
             for (unsigned int j = 0; j < elem_ref[i]->n_nodes(); j++)
               {
@@ -312,7 +312,7 @@ void EnsightIO::write_case()
 
   for (; sys_it != sys_end; ++sys_it)
     {
-      for (unsigned int i=0; i < sys_it->second.EnsightScalars.size(); i++)
+      for (std::size_t i=0; i < sys_it->second.EnsightScalars.size(); i++)
         {
           Scalars scalar = sys_it->second.EnsightScalars[i];
           case_stream << "scalar per node:   1  "
@@ -320,7 +320,7 @@ void EnsightIO::write_case()
                       << _ensight_file_name << "_" << scalar.scalar_name << ".scl***\n";
         }
 
-      for (unsigned int i=0; i < sys_it->second.EnsightVectors.size(); i++)
+      for (std::size_t i=0; i < sys_it->second.EnsightVectors.size(); i++)
         {
           Vectors vec = sys_it->second.EnsightVectors[i];
           case_stream << "vector per node:      1    "
@@ -337,7 +337,7 @@ void EnsightIO::write_case()
           case_stream << "filename start number:   " << std::setw(10) << 0 << "\n";
           case_stream << "filename increment:  " << std::setw(10) << 1 << "\n";
           case_stream << "time values:\n";
-          for (unsigned int i = 0; i < _time_steps.size(); i++)
+          for (std::size_t i = 0; i < _time_steps.size(); i++)
             case_stream << std::setw(12) << std::setprecision(5) << std::scientific << _time_steps[i] << "\n";
         }
     }
@@ -352,11 +352,11 @@ void EnsightIO::write_solution_ascii()
 
   for (; sys_it != sys_end; ++sys_it)
     {
-      for (unsigned int i = 0; i < sys_it->second.EnsightScalars.size(); i++)
+      for (std::size_t i = 0; i < sys_it->second.EnsightScalars.size(); i++)
         this->write_scalar_ascii(sys_it->first,
                                  sys_it->second.EnsightScalars[i].scalar_name);
 
-      for (unsigned int i = 0; i < sys_it->second.EnsightVectors.size(); i++)
+      for (std::size_t i = 0; i < sys_it->second.EnsightVectors.size(); i++)
         this->write_vector_ascii(sys_it->first,
                                  sys_it->second.EnsightVectors[i].components,
                                  sys_it->second.EnsightVectors[i].description);
@@ -418,7 +418,7 @@ void EnsightIO::write_scalar_ascii(const std::string & sys,
 
       elem_soln.resize(dof_indices_scl.size());
 
-      for (unsigned int i = 0; i < dof_indices_scl.size(); i++)
+      for (std::size_t i = 0; i < dof_indices_scl.size(); i++)
         elem_soln[i] = system.current_solution(dof_indices_scl[i]);
 
       FEInterface::nodal_soln (dim, fe_type, elem, elem_soln, nodal_soln);
@@ -522,7 +522,7 @@ void EnsightIO::write_vector_ascii(const std::string & sys,
       if (dim == 3)
         elem_soln_w.resize(dof_indices_w.size());
 
-      for (unsigned int i = 0; i < dof_indices_u.size(); i++)
+      for (std::size_t i = 0; i < dof_indices_u.size(); i++)
         {
           elem_soln_u[i] = system.current_solution(dof_indices_u[i]);
           elem_soln_v[i] = system.current_solution(dof_indices_v[i]);

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -296,7 +296,7 @@ void ExodusII_IO::read (const std::string & fname)
             = sideset_name;
       }
 
-    for (unsigned int e=0; e<exio_helper->elem_list.size(); e++)
+    for (std::size_t e=0; e<exio_helper->elem_list.size(); e++)
       {
         // The numbers in the Exodus file sidesets should be thought
         // of as (1-based) indices into the elem_num_map array.  So,
@@ -369,7 +369,7 @@ void ExodusII_IO::read (const std::string & fname)
 
         exio_helper->read_nodeset(nodeset);
 
-        for (unsigned int node=0; node<exio_helper->node_list.size(); node++)
+        for (std::size_t node=0; node<exio_helper->node_list.size(); node++)
           {
             // As before, the entries in 'node_list' are 1-based
             // indcies into the node_num_map array, so we have to map
@@ -466,7 +466,7 @@ void ExodusII_IO::copy_nodal_solution(System & system,
 
   const unsigned int var_num = system.variable_number(system_var_name);
 
-  for (unsigned int i=0; i<exio_helper->nodal_var_values.size(); ++i)
+  for (std::size_t i=0; i<exio_helper->nodal_var_values.size(); ++i)
     {
       const Node & node = MeshInput<MeshBase>::mesh().node_ref(i);
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -840,7 +840,7 @@ void ExodusII_IO_Helper::read_nodal_var_values(std::string nodal_var_name, int t
   this->read_var_names(NODAL);
 
   // See if we can find the variable we are looking for
-  unsigned int var_index = 0;
+  std::size_t var_index = 0;
   bool found = false;
 
   // Do a linear search for nodal_var_name in nodal_var_names
@@ -854,7 +854,7 @@ void ExodusII_IO_Helper::read_nodal_var_values(std::string nodal_var_name, int t
   if (!found)
     {
       libMesh::err << "Available variables: " << std::endl;
-      for (unsigned int i=0; i<nodal_var_names.size(); ++i)
+      for (std::size_t i=0; i<nodal_var_names.size(); ++i)
         libMesh::err << nodal_var_names[i] << std::endl;
 
       libmesh_error_msg("Unable to locate variable named: " << nodal_var_name);
@@ -968,13 +968,13 @@ void ExodusII_IO_Helper::write_var_names_impl(const char * var_type, int & count
       NamesData names_table(names.size(), MAX_STR_LENGTH);
 
       // Store the input names in the format required by Exodus.
-      for (unsigned i=0; i<names.size(); ++i)
+      for (std::size_t i=0; i<names.size(); ++i)
         names_table.push_back_entry(names[i]);
 
       if (verbose)
         {
           libMesh::out << "Writing variable name(s) to file: " << std::endl;
-          for (unsigned i=0; i<names.size(); ++i)
+          for (std::size_t i=0; i<names.size(); ++i)
             libMesh::out << names_table.get_char_star(i) << std::endl;
         }
 
@@ -997,7 +997,7 @@ void ExodusII_IO_Helper::read_elemental_var_values(std::string elemental_var_nam
   this->read_var_names(ELEMENTAL);
 
   // See if we can find the variable we are looking for
-  unsigned var_index = 0;
+  std::size_t var_index = 0;
   bool found = false;
 
   // Do a linear search for nodal_var_name in nodal_var_names
@@ -1011,7 +1011,7 @@ void ExodusII_IO_Helper::read_elemental_var_values(std::string elemental_var_nam
   if (!found)
     {
       libMesh::err << "Available variables: " << std::endl;
-      for (unsigned i=0; i<elem_var_names.size(); ++i)
+      for (std::size_t i=0; i<elem_var_names.size(); ++i)
         libMesh::err << elem_var_names[i] << std::endl;
 
       libmesh_error_msg("Unable to locate variable named: " << elemental_var_name);
@@ -1139,10 +1139,8 @@ void ExodusII_IO_Helper::initialize(std::string str_title, const MeshBase & mesh
     // treats these the same way.
     std::vector<boundary_id_type> shellface_boundaries;
     mesh.get_boundary_info().build_shellface_boundary_ids(shellface_boundaries);
-    for(unsigned int i=0; i<shellface_boundaries.size(); i++)
-      {
-        unique_side_boundaries.push_back(shellface_boundaries[i]);
-      }
+    for (std::size_t i=0; i<shellface_boundaries.size(); i++)
+      unique_side_boundaries.push_back(shellface_boundaries[i]);
   }
   mesh.get_boundary_info().build_node_boundary_ids(unique_node_boundaries);
 
@@ -1388,7 +1386,7 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
 
       connect.resize(tmp_vec.size()*num_nodes_per_elem);
 
-      for (unsigned int i=0; i<tmp_vec.size(); i++)
+      for (std::size_t i=0; i<tmp_vec.size(); i++)
         {
           unsigned int elem_id = tmp_vec[i];
           libmesh_elem_num_to_exodus[elem_id] = ++libmesh_elem_num_to_exodus_counter; // 1-based indexing for Exodus
@@ -1510,7 +1508,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
     mesh.get_boundary_info().build_side_list(el, sl, il);
 
     // Accumulate the vectors to pass into ex_put_side_set
-    for (unsigned int i=0; i<el.size(); i++)
+    for (std::size_t i=0; i<el.size(); i++)
       {
         std::vector<const Elem *> family;
 #ifdef LIBMESH_ENABLE_AMR
@@ -1523,7 +1521,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
         family.push_back(mesh.elem_ptr(el[i]));
 #endif
 
-        for (unsigned int j=0; j<family.size(); ++j)
+        for (std::size_t j=0; j<family.size(); ++j)
           {
             const ExodusII_IO_Helper::Conversion conv =
               em.assign_conversion(mesh.elem_ptr(family[j]->id())->type());
@@ -1548,7 +1546,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
     mesh.get_boundary_info().build_shellface_list(el, sl, il);
 
     // Accumulate the vectors to pass into ex_put_side_set
-    for (unsigned int i=0; i<el.size(); i++)
+    for (std::size_t i=0; i<el.size(); i++)
       {
         std::vector<const Elem *> family;
 #ifdef LIBMESH_ENABLE_AMR
@@ -1561,7 +1559,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
         family.push_back(mesh.elem_ptr(el[i]));
 #endif
 
-        for (unsigned int j=0; j<family.size(); ++j)
+        for (std::size_t j=0; j<family.size(); ++j)
           {
             const ExodusII_IO_Helper::Conversion conv =
               em.assign_conversion(mesh.elem_ptr(family[j]->id())->type());
@@ -1575,10 +1573,8 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
 
     std::vector<boundary_id_type> shellface_boundary_ids;
     mesh.get_boundary_info().build_shellface_boundary_ids(shellface_boundary_ids);
-    for(unsigned int i=0; i<shellface_boundary_ids.size(); i++)
-      {
-        side_boundary_ids.push_back(shellface_boundary_ids[i]);
-      }
+    for (std::size_t i=0; i<shellface_boundary_ids.size(); i++)
+      side_boundary_ids.push_back(shellface_boundary_ids[i]);
   }
 
   // Write out the sideset names, but only if there is something to write
@@ -1586,7 +1582,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
     {
       NamesData names_table(side_boundary_ids.size(), MAX_STR_LENGTH);
 
-      for (unsigned int i=0; i<side_boundary_ids.size(); i++)
+      for (std::size_t i=0; i<side_boundary_ids.size(); i++)
         {
           boundary_id_type ss_id = side_boundary_ids[i];
           int actual_id = ss_id;
@@ -1621,7 +1617,7 @@ void ExodusII_IO_Helper::write_nodesets(const MeshBase & mesh)
   std::map<boundary_id_type, std::vector<int> > node;
 
   // Accumulate the vectors to pass into ex_put_node_set
-  for (unsigned int i=0; i<nl.size(); i++)
+  for (std::size_t i=0; i<nl.size(); i++)
     node[il[i]].push_back(nl[i]+1);
 
   std::vector<boundary_id_type> node_boundary_ids;
@@ -1632,7 +1628,7 @@ void ExodusII_IO_Helper::write_nodesets(const MeshBase & mesh)
     {
       NamesData names_table(node_boundary_ids.size(), MAX_STR_LENGTH);
 
-      for (unsigned int i=0; i<node_boundary_ids.size(); i++)
+      for (std::size_t i=0; i<node_boundary_ids.size(); i++)
         {
           boundary_id_type nodeset_id = node_boundary_ids[i];
 
@@ -1772,11 +1768,11 @@ void ExodusII_IO_Helper::check_existing_vars(ExodusVarType type,
   if (names_from_file != names)
     {
       libMesh::err << "Error! The Exodus file already contains the variables:" << std::endl;
-      for (unsigned i=0; i<names_from_file.size(); ++i)
+      for (std::size_t i=0; i<names_from_file.size(); ++i)
         libMesh::out << names_from_file[i] << std::endl;
 
       libMesh::err << "And you asked to write:" << std::endl;
-      for (unsigned i=0; i<names.size(); ++i)
+      for (std::size_t i=0; i<names.size(); ++i)
         libMesh::out << names[i] << std::endl;
 
       libmesh_error_msg("Cannot overwrite existing variables in Exodus II file.");
@@ -1922,7 +1918,7 @@ void ExodusII_IO_Helper::write_information_records(const std::vector<std::string
 
       // If an entry is longer than MAX_LINE_LENGTH characters it's not an error, we just
       // write the first MAX_LINE_LENGTH characters to the file.
-      for (unsigned i=0; i<records.size(); ++i)
+      for (std::size_t i=0; i<records.size(); ++i)
         info.push_back_entry(records[i]);
 
       ex_err = exII::ex_put_info(ex_id, num_records, info.get_char_star_star());

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -455,7 +455,7 @@ void GmshIO::read_mesh(std::istream & in)
                 max_elem_dimension_seen=1,
                 min_elem_dimension_seen=3;
 
-              for (unsigned char i=0; i<elem_dimensions_seen.size(); ++i)
+              for (std::size_t i=0; i<elem_dimensions_seen.size(); ++i)
                 if (elem_dimensions_seen[i])
                   {
                     // Debugging
@@ -783,7 +783,7 @@ void GmshIO::write_mesh (std::ostream & out_stream)
         mesh.boundary_info->build_side_list(element_id_list, side_list, bc_id_list);
 
         // Loop over these lists, writing data to the file.
-        for (unsigned idx=0; idx<element_id_list.size(); ++idx)
+        for (std::size_t idx=0; idx<element_id_list.size(); ++idx)
           {
             const Elem & elem = mesh.elem_ref(element_id_list[idx]);
 

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -378,7 +378,7 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
         libmesh_assert_less_equal (ele.node_map.size(), elem->n_nodes());
 
         out_stream << ele.label << "\n";
-        for (unsigned int i=0; i < ele.node_map.size(); i++)
+        for (std::size_t i=0; i < ele.node_map.size(); i++)
           out_stream << elem->node_id(ele.node_map[i])+1 << " ";
         out_stream << "\n";
       }
@@ -463,7 +463,7 @@ void GMVIO::write_ascii_new_impl (const std::string & fname,
           // than are present in the current element!
           libmesh_assert_less_equal (ele.node_map.size(), elem->n_nodes());
 
-          for (unsigned int i=0; i < ele.node_map.size(); i++)
+          for (std::size_t i=0; i < ele.node_map.size(); i++)
             out_stream << elem->p_level() << " ";
         }
       out_stream << "\n\n";
@@ -697,7 +697,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                   {
                     out_stream << "line 2\n";
                     (*it)->connectivity(se, TECPLOT, conn);
-                    for (unsigned int i=0; i<conn.size(); i++)
+                    for (std::size_t i=0; i<conn.size(); i++)
                       out_stream << conn[i] << " ";
 
                     out_stream << '\n';
@@ -714,7 +714,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                         lo_elem->set_node(i) = (*it)->node_ptr(i);
                       lo_elem->connectivity(0, TECPLOT, conn);
                     }
-                  for (unsigned int i=0; i<conn.size(); i++)
+                  for (std::size_t i=0; i<conn.size(); i++)
                     out_stream << conn[i] << " ";
 
                   out_stream << '\n';
@@ -742,7 +742,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                       {
                         out_stream << "quad 4\n";
                         (*it)->connectivity(se, TECPLOT, conn);
-                        for (unsigned int i=0; i<conn.size(); i++)
+                        for (std::size_t i=0; i<conn.size(); i++)
                           out_stream << conn[i] << " ";
                       }
 
@@ -769,7 +769,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                     {
                       (*it)->connectivity(0, TECPLOT, conn);
                       out_stream << "quad 4\n";
-                      for (unsigned int i=0; i<conn.size(); i++)
+                      for (std::size_t i=0; i<conn.size(); i++)
                         out_stream << conn[i] << " ";
                     }
                   else if (((*it)->type() == QUAD8) ||
@@ -784,7 +784,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                         lo_elem->set_node(i) = (*it)->node_ptr(i);
                       lo_elem->connectivity(0, TECPLOT, conn);
                       out_stream << "quad 4\n";
-                      for (unsigned int i=0; i<conn.size(); i++)
+                      for (std::size_t i=0; i<conn.size(); i++)
                         out_stream << conn[i] << " ";
                     }
                   else if ((*it)->type() == TRI3)
@@ -823,7 +823,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                       {
                         out_stream << "phex8 8\n";
                         (*it)->connectivity(se, TECPLOT, conn);
-                        for (unsigned int i=0; i<conn.size(); i++)
+                        for (std::size_t i=0; i<conn.size(); i++)
                           out_stream << conn[i] << " ";
                       }
 
@@ -918,7 +918,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                       {
                         out_stream << "phex8 8\n";
                         (*it)->connectivity(se, TECPLOT, conn);
-                        for (unsigned int i=0; i<conn.size(); i++)
+                        for (std::size_t i=0; i<conn.size(); i++)
                           out_stream << conn[i] << " ";
                       }
 #endif
@@ -955,7 +955,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                         // degenerated phex8's.
                         out_stream << "phex8 8\n";
                         (*it)->connectivity(se, TECPLOT, conn);
-                        for (unsigned int i=0; i<conn.size(); i++)
+                        for (std::size_t i=0; i<conn.size(); i++)
                           out_stream << conn[i] << " ";
                       }
 
@@ -980,7 +980,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                     {
                       out_stream << "phex8 8\n";
                       lo_elem->connectivity(0, TECPLOT, conn);
-                      for (unsigned int i=0; i<conn.size(); i++)
+                      for (std::size_t i=0; i<conn.size(); i++)
                         out_stream << conn[i] << " ";
                     }
 
@@ -1003,7 +1003,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                       // degenerated phex8's.
                       out_stream << "phex8 8\n";
                       lo_elem->connectivity(0, TECPLOT, conn);
-                      for (unsigned int i=0; i<conn.size(); i++)
+                      for (std::size_t i=0; i<conn.size(); i++)
                         out_stream << conn[i] << " ";
                     }
 
@@ -1067,7 +1067,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
                      << sbdid_map.size()
                      << " 0\n";
 
-          for (unsigned int sbdid=0; sbdid<sbdid_map.size(); sbdid++)
+          for (std::size_t sbdid=0; sbdid<sbdid_map.size(); sbdid++)
             out_stream << "proc_" << sbdid << "\n";
 
           MeshBase::const_element_iterator       it  = mesh.active_elements_begin();
@@ -1398,7 +1398,7 @@ void GMVIO::write_binary (const std::string & fname,
         out_stream.write(reinterpret_cast<char *>(&tempint), sizeof(unsigned int));
 
         // Write the element connectivity
-        for (unsigned int i=0; i<ed.node_map.size(); i++)
+        for (std::size_t i=0; i<ed.node_map.size(); i++)
           {
             dof_id_type id = elem->node_id(ed.node_map[i]) + 1;
             out_stream.write(reinterpret_cast<char *>(&id), sizeof(dof_id_type));
@@ -2390,14 +2390,14 @@ void GMVIO::copy_nodal_solution(EquationSystems & es)
       const std::map<std::string, std::vector<Number> >::iterator end = _nodal_data.end();
       for (; it != end; ++it)
         {
-          std::string var_name = (*it).first;
+          std::string var_name = it->first;
           // libMesh::out << "Searching for var " << var_name << " in system " << sys << std::endl;
 
           if (system.has_variable(var_name))
             {
               // Check if there are as many nodes in the mesh as there are entries
               // in the stored nodal data vector
-              libmesh_assert_equal_to ( (*it).second.size(), MeshInput<MeshBase>::mesh().n_nodes() );
+              libmesh_assert_equal_to ( it->second.size(), MeshInput<MeshBase>::mesh().n_nodes() );
 
               const unsigned int var_num = system.variable_number(var_name);
 
@@ -2420,7 +2420,7 @@ void GMVIO::copy_nodal_solution(EquationSystems & es)
 
               // Loop over the stored vector's entries, inserting them into
               // the System's solution if appropriate.
-              for (unsigned int i=0; i<(*it).second.size(); ++i)
+              for (std::size_t i=0; i<it->second.size(); ++i)
                 {
                   // Since this var came from a GMV file, the index i corresponds to
                   // the (single) DOF value of the current variable for node i.
@@ -2430,14 +2430,14 @@ void GMVIO::copy_nodal_solution(EquationSystems & es)
                                                                         0);       // component #, always zero for LAGRANGE
 
                   // libMesh::out << "Value " << i << ": "
-                  //     << (*it).second [i]
+                  //     << it->second [i]
                   //     << ", dof index="
                   //     << dof_index << std::endl;
 
                   // If the dof_index is local to this processor, set the value
                   if ((dof_index >= system.solution->first_local_index()) &&
                       (dof_index <  system.solution->last_local_index()))
-                    system.solution->set (dof_index, (*it).second [i]);
+                    system.solution->set (dof_index, it->second [i]);
                 } // end loop over my GMVIO's copy of the solution
 
               // Add the most recently copied var to the set of copied vars
@@ -2460,10 +2460,10 @@ void GMVIO::copy_nodal_solution(EquationSystems & es)
 
     for (; it != end; ++it)
       {
-        if (vars_copied.find( (*it).first ) == vars_copied.end())
+        if (vars_copied.find( it->first ) == vars_copied.end())
           {
             libMesh::err << "Warning: Variable "
-                         << (*it).first
+                         << it->first
                          << " was not copied to the EquationSystems object."
                          << std::endl;
           }

--- a/src/mesh/gnuplot_io.C
+++ b/src/mesh/gnuplot_io.C
@@ -212,10 +212,8 @@ void GnuPlotIO::write_solution(const std::string & fname,
 
           data << kvp.first << "\t";
 
-          for(unsigned int i=0; i<values.size(); i++)
-            {
-              data << values[i] << "\t";
-            }
+          for (std::size_t i=0; i<values.size(); i++)
+            data << values[i] << "\t";
 
           data << "\n";
         }

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -262,8 +262,7 @@ void connect_families
         {
           std::vector<const Elem *> subactive_family;
           elem->total_family_tree(subactive_family);
-          for (unsigned int i=0; i != subactive_family.size();
-               ++i)
+          for (std::size_t i=0; i != subactive_family.size(); ++i)
             {
               libmesh_assert(subactive_family[i] != remote_elem);
               connected_elements.insert(subactive_family[i]);
@@ -797,7 +796,7 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
 
           std::vector<const Elem *> family_tree;
 
-          for (dof_id_type e=0, n_shared_nodes=0; e<my_interface_elements.size(); e++, n_shared_nodes=0)
+          for (std::size_t e=0, n_shared_nodes=0; e<my_interface_elements.size(); e++, n_shared_nodes=0)
             {
               const Elem * elem = my_interface_elements[e];
 
@@ -828,7 +827,7 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
                       family_tree.clear();
                       family_tree.push_back(elem);
 #endif
-                      for (unsigned int leaf=0; leaf<family_tree.size(); leaf++)
+                      for (std::size_t leaf=0; leaf<family_tree.size(); leaf++)
                         {
                           elem = family_tree[leaf];
                           elements_to_send.insert (elem);
@@ -1273,7 +1272,7 @@ struct SyncIds
   void act_on_data (const std::vector<dof_id_type> & old_ids,
                     std::vector<datum> & new_ids) const
   {
-    for (unsigned int i=0; i != old_ids.size(); ++i)
+    for (std::size_t i=0; i != old_ids.size(); ++i)
       if (old_ids[i] != new_ids[i])
         (mesh.*renumber)(old_ids[i], new_ids[i]);
   }
@@ -1387,7 +1386,7 @@ struct SyncPLevels
   {
     ids_out.reserve(ids.size());
 
-    for (unsigned int i=0; i != ids.size(); ++i)
+    for (std::size_t i=0; i != ids.size(); ++i)
       {
         Elem & elem = mesh.elem_ref(ids[i]);
 
@@ -1398,7 +1397,7 @@ struct SyncPLevels
   void act_on_data (const std::vector<dof_id_type> & old_ids,
                     std::vector<datum> & new_p_levels) const
   {
-    for (unsigned int i=0; i != old_ids.size(); ++i)
+    for (std::size_t i=0; i != old_ids.size(); ++i)
       {
         Elem & elem = mesh.elem_ref(old_ids[i]);
 
@@ -1430,7 +1429,7 @@ struct SyncUniqueIds
   {
     ids_out.reserve(ids.size());
 
-    for (unsigned int i=0; i != ids.size(); ++i)
+    for (std::size_t i=0; i != ids.size(); ++i)
       {
         DofObjSubclass *d = (mesh.*query)(ids[i]);
         libmesh_assert(d);
@@ -1442,7 +1441,7 @@ struct SyncUniqueIds
   void act_on_data (const std::vector<dof_id_type>& ids,
                     std::vector<datum>& unique_ids) const
   {
-    for (unsigned int i=0; i != ids.size(); ++i)
+    for (std::size_t i=0; i != ids.size(); ++i)
       {
         DofObjSubclass *d = (mesh.*query)(ids[i]);
         libmesh_assert(d);

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -807,7 +807,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
 
         // Fill the requests
         global_ids.clear(); /**/ global_ids.reserve(request_to_fill.size());
-        for (unsigned int idx=0; idx<request_to_fill.size(); idx++)
+        for (std::size_t idx=0; idx<request_to_fill.size(); idx++)
           {
             const Parallel::DofObjectKey & hilbert_indices = request_to_fill[idx];
             libmesh_assert_less_equal (hilbert_indices, upper_bounds[communicator.rank()]);

--- a/src/mesh/mesh_data_unv_support.C
+++ b/src/mesh/mesh_data_unv_support.C
@@ -558,7 +558,7 @@ void MeshData::write_unv_implementation (std::ostream & out_file)
       // const reference to the nodal values
       const std::vector<Number> & values = this->get_data(node);
 
-      for (unsigned int v_cnt=0; v_cnt<values.size(); v_cnt++)
+      for (std::size_t v_cnt=0; v_cnt<values.size(); v_cnt++)
         {
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
           std::sprintf(buf, "%13.5E%13.5E", values[v_cnt].real(),

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -283,7 +283,7 @@ void MeshFunction::operator() (const Point & p,
 
 
         // loop over all vars
-        for (unsigned int index=0; index < this->_system_vars.size(); index++)
+        for (std::size_t index=0; index < this->_system_vars.size(); index++)
           {
             /*
              * the data for this variable
@@ -308,7 +308,7 @@ void MeshFunction::operator() (const Point & p,
               {
                 Number value = 0.;
 
-                for (unsigned int i=0; i<dof_indices.size(); i++)
+                for (std::size_t i=0; i<dof_indices.size(); i++)
                   value += this->_vector(dof_indices[i]) * data.shape[i];
 
                 output(index) = value;
@@ -368,7 +368,7 @@ void MeshFunction::discontinuous_value (const Point & p,
 
 
       // loop over all vars
-      for (unsigned int index=0; index < this->_system_vars.size(); index++)
+      for (std::size_t index=0; index < this->_system_vars.size(); index++)
         {
           /*
            * the data for this variable
@@ -393,7 +393,7 @@ void MeshFunction::discontinuous_value (const Point & p,
             {
               Number value = 0.;
 
-              for (unsigned int i=0; i<dof_indices.size(); i++)
+              for (std::size_t i=0; i<dof_indices.size(); i++)
                 value += this->_vector(dof_indices[i]) * data.shape[i];
 
               temp_output(index) = value;
@@ -448,7 +448,7 @@ void MeshFunction::gradient (const Point & p,
         std::vector<Point> point_list (1, mapped_point);
 
         // loop over all vars
-        for (unsigned int index=0; index < this->_system_vars.size(); index++)
+        for (std::size_t index=0; index < this->_system_vars.size(); index++)
           {
             /*
              * the data for this variable
@@ -467,7 +467,7 @@ void MeshFunction::gradient (const Point & p,
             // interpolate the solution
             Gradient grad(0.);
 
-            for (unsigned int i=0; i<dof_indices.size(); i++)
+            for (std::size_t i=0; i<dof_indices.size(); i++)
               grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
 
             output[index] = grad;
@@ -523,7 +523,7 @@ void MeshFunction::discontinuous_gradient (const Point & p,
 
       // loop over all vars
       std::vector<Point> point_list (1, mapped_point);
-      for (unsigned int index = 0 ; index < this->_system_vars.size(); ++index)
+      for (std::size_t index = 0 ; index < this->_system_vars.size(); ++index)
         {
           /*
            * the data for this variable
@@ -541,7 +541,7 @@ void MeshFunction::discontinuous_gradient (const Point & p,
 
           Gradient grad(0.);
 
-          for (unsigned int i = 0; i < dof_indices.size(); ++i)
+          for (std::size_t i = 0; i < dof_indices.size(); ++i)
             grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
 
           temp_output[index] = grad;
@@ -594,7 +594,7 @@ void MeshFunction::hessian (const Point & p,
         std::vector<Point> point_list (1, mapped_point);
 
         // loop over all vars
-        for (unsigned int index=0; index < this->_system_vars.size(); index++)
+        for (std::size_t index=0; index < this->_system_vars.size(); index++)
           {
             /*
              * the data for this variable
@@ -614,7 +614,7 @@ void MeshFunction::hessian (const Point & p,
             // interpolate the solution
             Tensor hess;
 
-            for (unsigned int i=0; i<dof_indices.size(); i++)
+            for (std::size_t i=0; i<dof_indices.size(); i++)
               hess.add_scaled(d2phi[i][0], this->_vector(dof_indices[i]));
 
             output[index] = hess;

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -177,7 +177,7 @@ public:
       if (_nelem[dir] != 0)
         {
           _cosines[dir].resize(_nelem[dir]+1);
-          for (unsigned i=0; i<_cosines[dir].size(); ++i)
+          for (std::size_t i=0; i<_cosines[dir].size(); ++i)
             _cosines[dir][i] = std::cos(libMesh::pi * i / _nelem[dir]);
         }
   }
@@ -1380,7 +1380,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
             }
 
             // Add the new elements
-            for (unsigned int i=0; i<new_elements.size(); ++i)
+            for (std::size_t i=0; i<new_elements.size(); ++i)
               mesh.add_elem(new_elements[i]);
 
           } // end if (type == TET4,TET10,PYRAMID5,PYRAMID13,PYRAMID14

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1449,7 +1449,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                     // Make a sorted list of node ids for elem->side(sn)
                     UniquePtr<Elem> elem_side = elem->build_side_ptr(sn);
                     std::vector<dof_id_type> elem_side_nodes(elem_side->n_nodes());
-                    for (unsigned int esn=0; esn<elem_side_nodes.size(); ++esn)
+                    for (std::size_t esn=0; esn<elem_side_nodes.size(); ++esn)
                       elem_side_nodes[esn] = elem_side->node_id(esn);
                     std::sort(elem_side_nodes.begin(), elem_side_nodes.end());
 
@@ -1467,7 +1467,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
                               // a Hex20 or Prism15's QUAD8 face may be split into two Tri6 faces, and the
                               // original face will not contain the mid-edge node.
                               std::vector<dof_id_type> subside_nodes(subside_elem->n_vertices());
-                              for (unsigned int ssn=0; ssn<subside_nodes.size(); ++ssn)
+                              for (std::size_t ssn=0; ssn<subside_nodes.size(); ++ssn)
                                 subside_nodes[ssn] = subside_elem->node_id(ssn);
                               std::sort(subside_nodes.begin(), subside_nodes.end());
 
@@ -1559,7 +1559,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
       libmesh_assert_equal_to (new_bndry_sides.size(), new_bndry_ids.size());
 
       // Add the new boundary info to the mesh
-      for (unsigned int s=0; s<new_bndry_elements.size(); ++s)
+      for (std::size_t s=0; s<new_bndry_elements.size(); ++s)
         mesh.get_boundary_info().add_side(new_bndry_elements[s],
                                           new_bndry_sides[s],
                                           new_bndry_ids[s]);
@@ -1894,7 +1894,7 @@ void MeshTools::Modification::flatten(MeshBase & mesh)
   }
 
   // Finally, also add back the saved boundary information
-  for (unsigned int e=0; e<saved_boundary_elements.size(); ++e)
+  for (std::size_t e=0; e<saved_boundary_elements.size(); ++e)
     mesh.get_boundary_info().add_side(saved_boundary_elements[e],
                                       saved_bc_sides[e],
                                       saved_bc_ids[e]);
@@ -1929,7 +1929,7 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
     std::vector<boundary_id_type> bndry_ids;
 
     // For each node with the old_id...
-    for (unsigned idx=0; idx<node_list.size(); ++idx)
+    for (std::size_t idx=0; idx<node_list.size(); ++idx)
       if (bc_id_list[idx] == old_id)
         {
           // Get the node in question
@@ -1960,7 +1960,7 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
     std::vector<boundary_id_type> bndry_ids;
 
     // For each edge with the old_id...
-    for (unsigned idx=0; idx<elem_list.size(); ++idx)
+    for (std::size_t idx=0; idx<elem_list.size(); ++idx)
       if (bc_id_list[idx] == old_id)
         {
           // Get the elem in question
@@ -1994,7 +1994,7 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
     std::vector<boundary_id_type> bndry_ids;
 
     // For each shellface with the old_id...
-    for (unsigned idx=0; idx<elem_list.size(); ++idx)
+    for (std::size_t idx=0; idx<elem_list.size(); ++idx)
       if (bc_id_list[idx] == old_id)
         {
           // Get the elem in question
@@ -2028,7 +2028,7 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
     std::vector<boundary_id_type> bndry_ids;
 
     // For each side with the old_id...
-    for (unsigned idx=0; idx<elem_list.size(); ++idx)
+    for (std::size_t idx=0; idx<elem_list.size(); ++idx)
       if (bc_id_list[idx] == old_id)
         {
           // Get the elem in question

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -323,7 +323,7 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector & error_pe
 
   // create_parent_error_vector sets values for non-parents and
   // non-coarsenable parents to -1.  Get rid of them.
-  for (dof_id_type i=0; i != error_per_parent.size(); ++i)
+  for (std::size_t i=0; i != error_per_parent.size(); ++i)
     if (error_per_parent[i] != -1)
       sorted_parent_error.push_back(std::make_pair(error_per_parent[i], i));
 
@@ -374,7 +374,7 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector & error_pe
   {
     std::vector<bool> is_refinable(max_elem_id, false);
 
-    for (dof_id_type i=0; i != sorted_error.size(); ++i)
+    for (std::size_t i=0; i != sorted_error.size(); ++i)
       {
         dof_id_type eid = sorted_error[i].second;
         Elem * elem = _mesh.query_elem_ptr(eid);
@@ -385,7 +385,7 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector & error_pe
 
     if (refine_count > max_elem_refine)
       refine_count = max_elem_refine;
-    for (dof_id_type i=0; i != sorted_error.size(); ++i)
+    for (std::size_t i=0; i != sorted_error.size(); ++i)
       {
         if (successful_refine_count >= refine_count)
           break;
@@ -414,7 +414,7 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector & error_pe
   dof_id_type successful_coarsen_count = 0;
   if (coarsen_count)
     {
-      for (dof_id_type i=0; i != sorted_parent_error.size(); ++i)
+      for (std::size_t i=0; i != sorted_parent_error.size(); ++i)
         {
           if (successful_coarsen_count >= coarsen_count * twotodim)
             break;

--- a/src/mesh/mesh_smoother_laplace.C
+++ b/src/mesh/mesh_smoother_laplace.C
@@ -82,7 +82,7 @@ void LaplaceMeshSmoother::smooth(unsigned int n_iterations)
               {
                 Point avg_position(0.,0.,0.);
 
-                for (unsigned j=0; j<_graph[node->id()].size(); ++j)
+                for (std::size_t j=0; j<_graph[node->id()].size(); ++j)
                   {
                     // Will these nodal positions always be available
                     // or will they refer to remote nodes?  This will
@@ -266,7 +266,7 @@ void LaplaceMeshSmoother::init()
   // now have duplicate entries and we need to remove them so
   // they don't foul up the averaging algorithm employed by the
   // Laplace smoother.
-  for (unsigned i=0; i<_graph.size(); ++i)
+  for (std::size_t i=0; i<_graph.size(); ++i)
     {
       // The std::unique algorithm removes duplicate *consecutive* elements from a range,
       // so it only makes sense to call it on a sorted range...
@@ -281,7 +281,7 @@ void LaplaceMeshSmoother::init()
 
 void LaplaceMeshSmoother::print_graph(std::ostream & out_stream) const
 {
-  for (unsigned int i=0; i<_graph.size(); ++i)
+  for (std::size_t i=0; i<_graph.size(); ++i)
     {
       out_stream << i << ": ";
       std::copy(_graph[i].begin(),

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -342,10 +342,10 @@ int VariationalMeshSmoother::readgr(Array2D<double> & R,
                 mask[i] = 1;
 
                 // Search through neighbor nodes looking for two that form a straight line with this node
-                for (unsigned int a=0; a<thetas.size()-1; a++)
+                for (std::size_t a=0; a<thetas.size()-1; a++)
                   {
                     // Only try each pairing once
-                    for (unsigned int b=a+1; b<thetas.size(); b++)
+                    for (std::size_t b=a+1; b<thetas.size(); b++)
                       {
                         // Find if the two neighbor nodes angles are 180 degrees (pi) off of eachother (withing a tolerance)
                         // In order to make this a true movable boundary node... the two that forma  straight line with
@@ -525,7 +525,7 @@ float VariationalMeshSmoother::adapt_minimum() const
 {
   float min = 1.e30;
 
-  for (unsigned int i=0; i<_adapt_data->size(); i++)
+  for (std::size_t i=0; i<_adapt_data->size(); i++)
     {
       // Only positive (or zero) values in the error vector
       libmesh_assert_greater_equal ((*_adapt_data)[i], 0.);

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -121,7 +121,7 @@ void MeshTools::Subdivision::all_subdivision(MeshBase & mesh)
             {
               mesh.get_boundary_info().boundary_ids(elem, side, ids);
 
-              for (unsigned id=0; id<ids.size(); ++id)
+              for (std::size_t id=0; id<ids.size(); ++id)
                 {
                   // add the boundary id to the list of new boundary ids
                   new_boundary_ids.push_back(ids[id]);
@@ -150,7 +150,7 @@ void MeshTools::Subdivision::all_subdivision(MeshBase & mesh)
       libmesh_assert_equal_to(new_boundary_sides.size(), new_boundary_ids.size());
 
       // Add the new boundary info to the mesh.
-      for (unsigned int s = 0; s < new_boundary_elements.size(); ++s)
+      for (std::size_t s = 0; s < new_boundary_elements.size(); ++s)
         mesh.get_boundary_info().add_side(new_boundary_elements[s],
                                           new_boundary_sides[s],
                                           new_boundary_ids[s]);
@@ -281,7 +281,7 @@ void MeshTools::Subdivision::add_boundary_ghosts(MeshBase & mesh)
                   // which would then lead to a zero size ghost
                   // element below.
                   Node * node = libmesh_nullptr;
-                  for (unsigned int j = 0; j < ghost_nodes.size(); ++j)
+                  for (std::size_t j = 0; j < ghost_nodes.size(); ++j)
                     {
                       if ((*ghost_nodes[j] - point).norm() < tol * (elem->point(k) - point).norm())
                         {
@@ -353,7 +353,7 @@ void MeshTools::Subdivision::add_boundary_ghosts(MeshBase & mesh)
               // two mirrored ghost vertices coincide, which would
               // then lead to a zero size ghost element below.
               Node * node = libmesh_nullptr;
-              for (unsigned int j = 0; j < ghost_nodes.size(); ++j)
+              for (std::size_t j = 0; j < ghost_nodes.size(); ++j)
                 {
                   if ((*ghost_nodes[j] - point).norm() < tol * (elem->point(i) - point).norm())
                     {
@@ -437,7 +437,7 @@ void MeshTools::Subdivision::add_boundary_ghosts(MeshBase & mesh)
                   // This is necessary because for some triangulations, it can happen that two mirrored
                   // ghost vertices coincide, which would then lead to a zero size ghost element below.
                   Node * node = libmesh_nullptr;
-                  for (unsigned int k = 0; k < ghost_nodes.size(); ++k)
+                  for (std::size_t k = 0; k < ghost_nodes.size(); ++k)
                     {
                       if ((*ghost_nodes[k] - point).norm() < tol * (nb2->point(j) - point).norm())
                         {

--- a/src/mesh/mesh_triangle_interface.C
+++ b/src/mesh/mesh_triangle_interface.C
@@ -90,7 +90,7 @@ void TriangleInterface::triangulate()
       // Insert a new point on each PSLG at some random location
       // np=index into new points vector
       // n =index into original points vector
-      for (unsigned int np=0, n=0; np<2*original_points.size(); ++np)
+      for (std::size_t np=0, n=0; np<2*original_points.size(); ++np)
         {
           // the even entries are the original points
           if (np%2==0)
@@ -111,7 +111,7 @@ void TriangleInterface::triangulate()
 
   if (have_holes)
     {
-      for (unsigned int i=0; i<_holes->size(); ++i)
+      for (std::size_t i=0; i<_holes->size(); ++i)
         n_hole_points += (*_holes)[i]->n_points();
     }
 
@@ -157,7 +157,7 @@ void TriangleInterface::triangulate()
   unsigned int hole_offset=0;
 
   if (have_holes)
-    for (unsigned int i=0; i<_holes->size(); ++i)
+    for (std::size_t i=0; i<_holes->size(); ++i)
       {
         for (unsigned int ctr=0, h=0; h<(*_holes)[i]->n_points(); ctr+=2, ++h)
           {
@@ -212,7 +212,7 @@ void TriangleInterface::triangulate()
 
 
   // If the user provided it, use his ordering to define the segments
-  for (unsigned int ctr=0, s=0; s<this->segments.size(); ctr+=2, ++s)
+  for (std::size_t ctr=0, s=0; s<this->segments.size(); ctr+=2, ++s)
     {
       const unsigned int index0 = 2*hole_offset+ctr;
       const unsigned int index1 = 2*hole_offset+ctr+1;
@@ -228,7 +228,7 @@ void TriangleInterface::triangulate()
     {
       initial.numberofholes = _holes->size();
       initial.holelist      = static_cast<REAL*>(std::malloc(initial.numberofholes * 2 * sizeof(REAL)));
-      for (unsigned int i=0, ctr=0; i<_holes->size(); ++i, ctr+=2)
+      for (std::size_t i=0, ctr=0; i<_holes->size(); ++i, ctr+=2)
         {
           Point inside_point = (*_holes)[i]->inside();
           initial.holelist[ctr]   = inside_point(0);

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -326,7 +326,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   // will be responsible for numbering.
   unsigned int num_nodes_i_must_number = 0;
 
-  for (unsigned int idx=0; idx<node_ownership.size(); idx++)
+  for (std::size_t idx=0; idx<node_ownership.size(); idx++)
     if (node_ownership[idx] == this->processor_id())
       num_nodes_i_must_number++;
 
@@ -571,7 +571,7 @@ void Nemesis_IO::read (const std::string & base_filename)
           this->comm().receive (requesting_pid_idx, xfer_buf, nodes_tag);
 
           // Fill the request
-          for (unsigned int i=0; i<xfer_buf.size(); i++)
+          for (std::size_t i=0; i<xfer_buf.size(); i++)
             {
               // the requested old global node index, *now 0-based*
               const unsigned int old_global_node_idx = xfer_buf[i];
@@ -623,7 +623,7 @@ void Nemesis_IO::read (const std::string & base_filename)
           libmesh_assert_less_equal (needed_node_idxs[cmap].size(),
                                      nemhelper->node_cmap_node_ids[cmap].size());
 
-          for (unsigned int i=0,j=0; i<nemhelper->node_cmap_node_ids[cmap].size(); i++)
+          for (std::size_t i=0, j=0; i<nemhelper->node_cmap_node_ids[cmap].size(); i++)
             {
               const unsigned int
                 local_node_idx  = nemhelper->node_cmap_node_ids[cmap][i]-1,
@@ -881,16 +881,16 @@ void Nemesis_IO::read (const std::string & base_filename)
   if (_verbose)
     {
       // Print local elems_of_dimension information
-      for (unsigned int i=1; i<elems_of_dimension.size(); ++i)
+      for (std::size_t i=1; i<elems_of_dimension.size(); ++i)
         libMesh::out << "[" << this->processor_id() << "] "
                      << "elems_of_dimension[" << i << "]=" << elems_of_dimension[i] << std::endl;
     }
 
   // Get the max dimension seen on the current processor
   unsigned char max_dim_seen = 0;
-  for (unsigned char i=1; i<elems_of_dimension.size(); ++i)
+  for (std::size_t i=1; i<elems_of_dimension.size(); ++i)
     if (elems_of_dimension[i])
-      max_dim_seen = i;
+      max_dim_seen = static_cast<unsigned char>(i);
 
   // Do a global max to determine the max dimension seen by all processors.
   // It should match -- I don't think we even support calculations on meshes
@@ -1001,7 +1001,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   // Print entries of elem_list
   // libMesh::out << "[" << this->processor_id() << "] "
   //        << "elem_list = ";
-  // for (unsigned int e=0; e<nemhelper->elem_list.size(); e++)
+  // for (std::size_t e=0; e<nemhelper->elem_list.size(); e++)
   //   {
   //     libMesh::out << nemhelper->elem_list[e] << ", ";
   //   }
@@ -1010,7 +1010,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   // Print entries of side_list
   // libMesh::out << "[" << this->processor_id() << "] "
   //        << "side_list = ";
-  // for (unsigned int e=0; e<nemhelper->side_list.size(); e++)
+  // for (std::size_t e=0; e<nemhelper->side_list.size(); e++)
   //   {
   //     libMesh::out << nemhelper->side_list[e] << ", ";
   //   }
@@ -1019,7 +1019,7 @@ void Nemesis_IO::read (const std::string & base_filename)
 
   // Loop over the entries of the elem_list, get their pointers from the
   // Mesh data structure, and assign the appropriate side to the BoundaryInfo object.
-  for (unsigned int e=0; e<nemhelper->elem_list.size(); e++)
+  for (std::size_t e=0; e<nemhelper->elem_list.size(); e++)
     {
       // Calling mesh.elem_ptr() is an error if no element with that
       // id exists on this processor...
@@ -1089,7 +1089,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   //  libMesh::out << "[" << this->processor_id() << "] "
   //       << "nemhelper->node_num_map = ";
   //
-  //  for (unsigned int i=0; i<nemhelper->node_num_map.size(); ++i)
+  //  for (std::size_t i=0; i<nemhelper->node_num_map.size(); ++i)
   //    libMesh::out << nemhelper->node_num_map[i] << ", ";
   //  libMesh::out << std::endl;
 
@@ -1109,7 +1109,7 @@ void Nemesis_IO::read (const std::string & base_filename)
       nemhelper->read_nodeset(nodeset);
 
       // Add nodes from the node_list to the BoundaryInfo object
-      for (unsigned int node=0; node<nemhelper->node_list.size(); node++)
+      for (std::size_t node=0; node<nemhelper->node_list.size(); node++)
         {
           // Don't run past the end of our node map!
           if (to_uint(nemhelper->node_list[node]-1) >= nemhelper->node_num_map.size())

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -125,7 +125,7 @@ void Nemesis_IO_Helper::get_ss_param_global()
       if (verbose)
         {
           libMesh::out << "[" << this->processor_id() << "] " << "Global Sideset IDs, Side Counts, and DF counts:" << std::endl;
-          for (unsigned int bn=0; bn<global_sideset_ids.size(); ++bn)
+          for (std::size_t bn=0; bn<global_sideset_ids.size(); ++bn)
             {
               libMesh::out << "  [" << this->processor_id() << "] "
                            << "global_sideset_ids["<<bn<<"]=" << global_sideset_ids[bn]
@@ -158,7 +158,7 @@ void Nemesis_IO_Helper::get_ns_param_global()
       if (verbose)
         {
           libMesh::out << "[" << this->processor_id() << "] " << "Global Nodeset IDs, Node Counts, and DF counts:" << std::endl;
-          for (unsigned int bn=0; bn<global_nodeset_ids.size(); ++bn)
+          for (std::size_t bn=0; bn<global_nodeset_ids.size(); ++bn)
             {
               libMesh::out << "  [" << this->processor_id() << "] "
                            << "global_nodeset_ids["<<bn<<"]=" << global_nodeset_ids[bn]
@@ -189,7 +189,7 @@ void Nemesis_IO_Helper::get_eb_info_global()
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] " << "Global Element Block IDs and Counts:" << std::endl;
-      for (unsigned int bn=0; bn<global_elem_blk_ids.size(); ++bn)
+      for (std::size_t bn=0; bn<global_elem_blk_ids.size(); ++bn)
         {
           libMesh::out << "  [" << this->processor_id() << "] "
                        << "global_elem_blk_ids["<<bn<<"]=" << global_elem_blk_ids[bn]
@@ -338,22 +338,22 @@ void Nemesis_IO_Helper::get_cmap_params()
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] ";
-      for (unsigned int i=0; i<node_cmap_ids.size(); ++i)
+      for (std::size_t i=0; i<node_cmap_ids.size(); ++i)
         libMesh::out << "node_cmap_ids["<<i<<"]=" << node_cmap_ids[i] << " ";
       libMesh::out << std::endl;
 
       libMesh::out << "[" << this->processor_id() << "] ";
-      for (unsigned int i=0; i<node_cmap_node_cnts.size(); ++i)
+      for (std::size_t i=0; i<node_cmap_node_cnts.size(); ++i)
         libMesh::out << "node_cmap_node_cnts["<<i<<"]=" << node_cmap_node_cnts[i] << " ";
       libMesh::out << std::endl;
 
       libMesh::out << "[" << this->processor_id() << "] ";
-      for (unsigned int i=0; i<elem_cmap_ids.size(); ++i)
+      for (std::size_t i=0; i<elem_cmap_ids.size(); ++i)
         libMesh::out << "elem_cmap_ids["<<i<<"]=" << elem_cmap_ids[i] << " ";
       libMesh::out << std::endl;
 
       libMesh::out << "[" << this->processor_id() << "] ";
-      for (unsigned int i=0; i<elem_cmap_elem_cnts.size(); ++i)
+      for (std::size_t i=0; i<elem_cmap_elem_cnts.size(); ++i)
         libMesh::out << "elem_cmap_elem_cnts["<<i<<"]=" << elem_cmap_elem_cnts[i] << " ";
       libMesh::out << std::endl;
     }
@@ -366,7 +366,7 @@ void Nemesis_IO_Helper::get_node_cmap()
   node_cmap_node_ids.resize(num_node_cmaps);
   node_cmap_proc_ids.resize(num_node_cmaps);
 
-  for (unsigned int i=0; i<node_cmap_node_ids.size(); ++i)
+  for (std::size_t i=0; i<node_cmap_node_ids.size(); ++i)
     {
       node_cmap_node_ids[i].resize(node_cmap_node_cnts[i]);
       node_cmap_proc_ids[i].resize(node_cmap_node_cnts[i]);
@@ -387,14 +387,14 @@ void Nemesis_IO_Helper::get_node_cmap()
       if (verbose)
         {
           libMesh::out << "[" << this->processor_id() << "] node_cmap_node_ids["<<i<<"]=";
-          for (unsigned int j=0; j<node_cmap_node_ids[i].size(); ++j)
+          for (std::size_t j=0; j<node_cmap_node_ids[i].size(); ++j)
             libMesh::out << node_cmap_node_ids[i][j] << " ";
           libMesh::out << std::endl;
 
           // This is basically a vector, all entries of which are = node_cmap_ids[i]
           // Not sure if it's always guaranteed to be that or what...
           libMesh::out << "[" << this->processor_id() << "] node_cmap_proc_ids["<<i<<"]=";
-          for (unsigned int j=0; j<node_cmap_proc_ids[i].size(); ++j)
+          for (std::size_t j=0; j<node_cmap_proc_ids[i].size(); ++j)
             libMesh::out << node_cmap_proc_ids[i][j] << " ";
           libMesh::out << std::endl;
         }
@@ -409,7 +409,7 @@ void Nemesis_IO_Helper::get_elem_cmap()
   elem_cmap_side_ids.resize(num_elem_cmaps);
   elem_cmap_proc_ids.resize(num_elem_cmaps);
 
-  for (unsigned int i=0; i<elem_cmap_elem_ids.size(); ++i)
+  for (std::size_t i=0; i<elem_cmap_elem_ids.size(); ++i)
     {
       elem_cmap_elem_ids[i].resize(elem_cmap_elem_cnts[i]);
       elem_cmap_side_ids[i].resize(elem_cmap_elem_cnts[i]);
@@ -430,21 +430,21 @@ void Nemesis_IO_Helper::get_elem_cmap()
       if (verbose)
         {
           libMesh::out << "[" << this->processor_id() << "] elem_cmap_elem_ids["<<i<<"]=";
-          for (unsigned int j=0; j<elem_cmap_elem_ids[i].size(); ++j)
+          for (std::size_t j=0; j<elem_cmap_elem_ids[i].size(); ++j)
             libMesh::out << elem_cmap_elem_ids[i][j] << " ";
           libMesh::out << std::endl;
 
           // These must be the (local) side IDs (in the ExodusII face numbering scheme)
           // of the sides shared across processors.
           libMesh::out << "[" << this->processor_id() << "] elem_cmap_side_ids["<<i<<"]=";
-          for (unsigned int j=0; j<elem_cmap_side_ids[i].size(); ++j)
+          for (std::size_t j=0; j<elem_cmap_side_ids[i].size(); ++j)
             libMesh::out << elem_cmap_side_ids[i][j] << " ";
           libMesh::out << std::endl;
 
           // This is basically a vector, all entries of which are = elem_cmap_ids[i]
           // Not sure if it's always guaranteed to be that or what...
           libMesh::out << "[" << this->processor_id() << "] elem_cmap_proc_ids["<<i<<"]=";
-          for (unsigned int j=0; j<elem_cmap_proc_ids[i].size(); ++j)
+          for (std::size_t j=0; j<elem_cmap_proc_ids[i].size(); ++j)
             libMesh::out << elem_cmap_proc_ids[i][j] << " ";
           libMesh::out << std::endl;
         }
@@ -600,26 +600,26 @@ void Nemesis_IO_Helper::put_node_cmap(std::vector<std::vector<int> > & node_cmap
   // Print to screen what we are about to print to Nemesis file
   if (verbose)
     {
-      for (unsigned i=0; i<node_cmap_node_ids_in.size(); ++i)
+      for (std::size_t i=0; i<node_cmap_node_ids_in.size(); ++i)
         {
           libMesh::out << "[" << this->processor_id() << "] put_node_cmap() : nodes communicated to proc "
                        << this->node_cmap_ids[i]
                        << " = ";
-          for (unsigned j=0; j<node_cmap_node_ids_in[i].size(); ++j)
+          for (std::size_t j=0; j<node_cmap_node_ids_in[i].size(); ++j)
             libMesh::out << node_cmap_node_ids_in[i][j] << " ";
           libMesh::out << std::endl;
         }
 
-      for (unsigned i=0; i<node_cmap_node_ids_in.size(); ++i)
+      for (std::size_t i=0; i<node_cmap_node_ids_in.size(); ++i)
         {
           libMesh::out << "[" << this->processor_id() << "] put_node_cmap() : processor IDs = ";
-          for (unsigned j=0; j<node_cmap_proc_ids_in[i].size(); ++j)
+          for (std::size_t j=0; j<node_cmap_proc_ids_in[i].size(); ++j)
             libMesh::out << node_cmap_proc_ids_in[i][j] << " ";
           libMesh::out << std::endl;
         }
     }
 
-  for (unsigned int i=0; i<node_cmap_node_ids_in.size(); ++i)
+  for (std::size_t i=0; i<node_cmap_node_ids_in.size(); ++i)
     {
       nemesis_err_flag =
         Nemesis::ne_put_node_cmap(ex_id,
@@ -656,7 +656,7 @@ void Nemesis_IO_Helper::put_elem_cmap(std::vector<std::vector<int> > & elem_cmap
                                       std::vector<std::vector<int> > & elem_cmap_side_ids_in,
                                       std::vector<std::vector<int> > & elem_cmap_proc_ids_in)
 {
-  for (unsigned int i=0; i<elem_cmap_ids.size(); ++i)
+  for (std::size_t i=0; i<elem_cmap_ids.size(); ++i)
     {
       nemesis_err_flag =
         Nemesis::ne_put_elem_cmap(ex_id,
@@ -1035,7 +1035,7 @@ void Nemesis_IO_Helper::compute_elem_communication_maps()
         std::set<std::pair<unsigned,unsigned> >::iterator elem_set_iter = elem_set.begin();
 
         // Pack the vectors with elem IDs, side IDs, and processor IDs.
-        for (unsigned j=0; j<this->elem_cmap_elem_ids[cnt].size(); ++j, ++elem_set_iter)
+        for (std::size_t j=0; j<this->elem_cmap_elem_ids[cnt].size(); ++j, ++elem_set_iter)
           {
             std::map<int, int>::iterator elem_it = libmesh_elem_num_to_exodus.find((*elem_set_iter).first);
 
@@ -1134,7 +1134,7 @@ void Nemesis_IO_Helper::compute_node_communication_maps()
         std::set<unsigned>::iterator node_set_iter = node_set.begin();
 
         // Pack the vectors with node IDs and processor IDs.
-        for (unsigned j=0; j<this->node_cmap_node_ids[cnt].size(); ++j, ++node_set_iter)
+        for (std::size_t j=0; j<this->node_cmap_node_ids[cnt].size(); ++j, ++node_set_iter)
           {
             std::map<int, int>::iterator node_it = libmesh_node_num_to_exodus.find(*node_set_iter);
             if (node_it == libmesh_node_num_to_exodus.end())
@@ -1152,20 +1152,20 @@ void Nemesis_IO_Helper::compute_node_communication_maps()
   // Print out the vectors we just packed
   if (verbose)
     {
-      for (unsigned i=0; i<this->node_cmap_node_ids.size(); ++i)
+      for (std::size_t i=0; i<this->node_cmap_node_ids.size(); ++i)
         {
           libMesh::out << "[" << this->processor_id() << "] nodes communicated to proc "
                        << this->node_cmap_ids[i]
                        << " = ";
-          for (unsigned j=0; j<this->node_cmap_node_ids[i].size(); ++j)
+          for (std::size_t j=0; j<this->node_cmap_node_ids[i].size(); ++j)
             libMesh::out << this->node_cmap_node_ids[i][j] << " ";
           libMesh::out << std::endl;
         }
 
-      for (unsigned i=0; i<this->node_cmap_node_ids.size(); ++i)
+      for (std::size_t i=0; i<this->node_cmap_node_ids.size(); ++i)
         {
           libMesh::out << "[" << this->processor_id() << "] processor ID node communicated to = ";
-          for (unsigned j=0; j<this->node_cmap_proc_ids[i].size(); ++j)
+          for (std::size_t j=0; j<this->node_cmap_proc_ids[i].size(); ++j)
             libMesh::out << this->node_cmap_proc_ids[i][j] << " ";
           libMesh::out << std::endl;
         }
@@ -1203,12 +1203,12 @@ void Nemesis_IO_Helper::compute_communication_map_parameters()
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] node_cmap_node_cnts = ";
-      for (unsigned i=0; i<node_cmap_node_cnts.size(); ++i)
+      for (std::size_t i=0; i<node_cmap_node_cnts.size(); ++i)
         libMesh::out << node_cmap_node_cnts[i] << ", ";
       libMesh::out << std::endl;
 
       libMesh::out << "[" << this->processor_id() << "] node_cmap_ids = ";
-      for (unsigned i=0; i<node_cmap_ids.size(); ++i)
+      for (std::size_t i=0; i<node_cmap_ids.size(); ++i)
         libMesh::out << node_cmap_ids[i] << ", ";
       libMesh::out << std::endl;
     }
@@ -1238,12 +1238,12 @@ void Nemesis_IO_Helper::compute_communication_map_parameters()
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] elem_cmap_elem_cnts = ";
-      for (unsigned i=0; i<elem_cmap_elem_cnts.size(); ++i)
+      for (std::size_t i=0; i<elem_cmap_elem_cnts.size(); ++i)
         libMesh::out << elem_cmap_elem_cnts[i] << ", ";
       libMesh::out << std::endl;
 
       libMesh::out << "[" << this->processor_id() << "] elem_cmap_ids = ";
-      for (unsigned i=0; i<elem_cmap_ids.size(); ++i)
+      for (std::size_t i=0; i<elem_cmap_ids.size(); ++i)
         libMesh::out << elem_cmap_ids[i] << ", ";
       libMesh::out << std::endl;
     }
@@ -1382,8 +1382,8 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
         {
           libMesh::out << "[" << this->processor_id() << "] "
                        << "Proc "
-                       << (*it).first << " communicates "
-                       << (*it).second.size() << " elements." << std::endl;
+                       << it->first << " communicates "
+                       << it->second.size() << " elements." << std::endl;
         }
     }
 
@@ -1430,7 +1430,7 @@ void Nemesis_IO_Helper::compute_num_global_sidesets(const MeshBase & pmesh)
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] global_sideset_ids = ";
-      for (unsigned i=0; i<this->global_sideset_ids.size(); ++i)
+      for (std::size_t i=0; i<this->global_sideset_ids.size(); ++i)
         libMesh::out << this->global_sideset_ids[i] << ", ";
       libMesh::out << std::endl;
     }
@@ -1483,7 +1483,7 @@ void Nemesis_IO_Helper::compute_num_global_sidesets(const MeshBase & pmesh)
   this->num_global_side_counts.resize(this->global_sideset_ids.size());
 
   // Get the count for each global sideset ID
-  for (unsigned i=0; i<global_sideset_ids.size(); ++i)
+  for (std::size_t i=0; i<global_sideset_ids.size(); ++i)
     {
       this->num_global_side_counts[i] = cast_int<int>
         (std::count(bndry_id_list.begin(),
@@ -1494,7 +1494,7 @@ void Nemesis_IO_Helper::compute_num_global_sidesets(const MeshBase & pmesh)
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] num_global_side_counts = ";
-      for (unsigned i=0; i<this->num_global_side_counts.size(); ++i)
+      for (std::size_t i=0; i<this->num_global_side_counts.size(); ++i)
         libMesh::out << this->num_global_side_counts[i] << ", ";
       libMesh::out << std::endl;
     }
@@ -1505,7 +1505,7 @@ void Nemesis_IO_Helper::compute_num_global_sidesets(const MeshBase & pmesh)
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] num_global_side_counts = ";
-      for (unsigned i=0; i<this->num_global_side_counts.size(); ++i)
+      for (std::size_t i=0; i<this->num_global_side_counts.size(); ++i)
         libMesh::out << this->num_global_side_counts[i] << ", ";
       libMesh::out << std::endl;
     }
@@ -1544,7 +1544,7 @@ void Nemesis_IO_Helper::compute_num_global_nodesets(const MeshBase & pmesh)
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] global_nodeset_ids = ";
-      for (unsigned i=0; i<global_nodeset_ids.size(); ++i)
+      for (std::size_t i=0; i<global_nodeset_ids.size(); ++i)
         libMesh::out << global_nodeset_ids[i] << ", ";
       libMesh::out << std::endl;
 
@@ -1568,7 +1568,7 @@ void Nemesis_IO_Helper::compute_num_global_nodesets(const MeshBase & pmesh)
       libMesh::out << "[" << this->processor_id() << "] boundary_node_list.size()="
                    << boundary_node_list.size() << std::endl;
       libMesh::out << "[" << this->processor_id() << "] (boundary_node_id, boundary_id) = ";
-      for (unsigned i=0; i<boundary_node_list.size(); ++i)
+      for (std::size_t i=0; i<boundary_node_list.size(); ++i)
         {
           libMesh::out << "(" << boundary_node_list[i] << ", " << boundary_node_boundary_id_list[i] << ") ";
         }
@@ -1616,7 +1616,7 @@ void Nemesis_IO_Helper::compute_num_global_nodesets(const MeshBase & pmesh)
   boundary_node_boundary_id_list.erase(new_boundary_id_list_end, boundary_node_boundary_id_list.end());
 
   // Now we can do the local count for each ID...
-  for (unsigned i=0; i<global_nodeset_ids.size(); ++i)
+  for (std::size_t i=0; i<global_nodeset_ids.size(); ++i)
     {
       this->num_global_node_counts[i] = cast_int<int>
         (std::count(boundary_node_boundary_id_list.begin(),
@@ -1630,7 +1630,7 @@ void Nemesis_IO_Helper::compute_num_global_nodesets(const MeshBase & pmesh)
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] num_global_node_counts = ";
-      for (unsigned i=0; i<num_global_node_counts.size(); ++i)
+      for (std::size_t i=0; i<num_global_node_counts.size(); ++i)
         libMesh::out << num_global_node_counts[i] << ", ";
       libMesh::out << std::endl;
     }
@@ -1698,8 +1698,8 @@ void Nemesis_IO_Helper::compute_num_global_elem_blocks(const MeshBase & pmesh)
            ++it)
         {
           libMesh::out << "ID: "
-                       << static_cast<unsigned>((*it).first)
-                       << ", Count: " << (*it).second << ", ";
+                       << static_cast<unsigned>(it->first)
+                       << ", Count: " << it->second << ", ";
         }
       libMesh::out << std::endl;
     }
@@ -1723,7 +1723,7 @@ void Nemesis_IO_Helper::compute_num_global_elem_blocks(const MeshBase & pmesh)
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] global_elem_blk_cnts = ";
-      for (unsigned i=0; i<this->global_elem_blk_cnts.size(); ++i)
+      for (std::size_t i=0; i<this->global_elem_blk_cnts.size(); ++i)
         libMesh::out << this->global_elem_blk_cnts[i] << ", ";
       libMesh::out << std::endl;
     }
@@ -1737,7 +1737,7 @@ void Nemesis_IO_Helper::compute_num_global_elem_blocks(const MeshBase & pmesh)
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] global_elem_blk_ids = ";
-      for (unsigned i=0; i<this->global_elem_blk_ids.size(); ++i)
+      for (std::size_t i=0; i<this->global_elem_blk_ids.size(); ++i)
         libMesh::out << this->global_elem_blk_ids[i] << ", ";
       libMesh::out << std::endl;
     }
@@ -1774,7 +1774,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
        it != this->local_subdomain_counts.end();
        ++it)
     {
-      subdomain_id_type cur_subdomain = (*it).first;
+      subdomain_id_type cur_subdomain = it->first;
 
       /*
       // We can't have a zero subdomain ID in Exodus (for some reason?)
@@ -1787,12 +1787,12 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
         {
           libMesh::out << "[" << this->processor_id() << "] "
                        << "local_subdomain_counts [" << static_cast<unsigned>(cur_subdomain) << "]= "
-                       << (*it).second
+                       << it->second
                        << std::endl;
         }
 
       // *it.first is the subodmain ID, *it.second is the number of elements it contains
-      this->subdomain_map[ cur_subdomain ].reserve( (*it).second );
+      this->subdomain_map[ cur_subdomain ].reserve( it->second );
     }
 
 
@@ -1857,14 +1857,14 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
        it != this->subdomain_map.end();
        ++it)
     {
-      block_ids.push_back((*it).first);
+      block_ids.push_back(it->first);
 
       // Vector of element IDs for this subdomain
-      std::vector<unsigned int> & elem_ids_this_subdomain = (*it).second;
+      std::vector<unsigned int> & elem_ids_this_subdomain = it->second;
 
       // The code below assumes this subdomain block is not empty, make sure that's the case!
       if (elem_ids_this_subdomain.size() == 0)
-        libmesh_error_msg("Error, no element IDs found in subdomain " << (*it).first);
+        libmesh_error_msg("Error, no element IDs found in subdomain " << it->first);
 
       ExodusII_IO_Helper::ElementMaps em;
 
@@ -1878,13 +1878,13 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
 
       // Get a reference to the connectivity vector for this subdomain.  This vector
       // is most likely empty, we are going to fill it up now.
-      std::vector<int> & current_block_connectivity = this->block_id_to_elem_connectivity[(*it).first];
+      std::vector<int> & current_block_connectivity = this->block_id_to_elem_connectivity[it->first];
 
       // Just in case it's not already empty...
       current_block_connectivity.clear();
       current_block_connectivity.resize(elem_ids_this_subdomain.size() * this->num_nodes_per_elem);
 
-      for (unsigned int i=0; i<elem_ids_this_subdomain.size(); i++)
+      for (std::size_t i=0; i<elem_ids_this_subdomain.size(); i++)
         {
           unsigned int elem_id = elem_ids_this_subdomain[i];
 
@@ -1988,8 +1988,8 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
              ++it)
           {
             libMesh::out << "[" << this->processor_id()
-                         << "] proc_nodes_touched[" << (*it).first << "] has "
-                         << (*it).second.size()
+                         << "] proc_nodes_touched[" << it->first << "] has "
+                         << it->second.size()
                          << " entries."
                          << std::endl;
           }
@@ -2003,13 +2003,13 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
          ++it)
       {
         // Don't compute intersections with ourself
-        if ((*it).first == this->processor_id())
+        if (it->first == this->processor_id())
           continue;
 
         // Otherwise, compute intersection with other processor and ourself
         std::set<unsigned> & my_set = proc_nodes_touched[this->processor_id()];
-        std::set<unsigned> & other_set = (*it).second;
-        std::set<unsigned> & result_set = this->proc_nodes_touched_intersections[ (*it).first ]; // created if does not exist
+        std::set<unsigned> & other_set = it->second;
+        std::set<unsigned> & result_set = this->proc_nodes_touched_intersections[ it->first ]; // created if does not exist
 
         std::set_intersection(my_set.begin(), my_set.end(),
                               other_set.begin(), other_set.end(),
@@ -2023,8 +2023,8 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
              ++it)
           {
             libMesh::out << "[" << this->processor_id()
-                         << "] this->proc_nodes_touched_intersections[" << (*it).first << "] has "
-                         << (*it).second.size()
+                         << "] this->proc_nodes_touched_intersections[" << it->first << "] has "
+                         << it->second.size()
                          << " entries."
                          << std::endl;
           }
@@ -2036,7 +2036,7 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
          it != this->proc_nodes_touched_intersections.end();
          ++it)
       {
-        std::set<unsigned> & other_set = (*it).second;
+        std::set<unsigned> & other_set = it->second;
         std::set<unsigned> intermediate_result; // Don't think we can insert into one of the sets we're unioning...
 
         std::set_union(this->border_node_ids.begin(), this->border_node_ids.end(),
@@ -2087,7 +2087,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
       libMesh::out << "[" << this->processor_id() << "] boundary_node_list.size()="
                    << boundary_node_list.size() << std::endl;
       libMesh::out << "[" << this->processor_id() << "] (boundary_node_id, boundary_id) = ";
-      for (unsigned i=0; i<boundary_node_list.size(); ++i)
+      for (std::size_t i=0; i<boundary_node_list.size(); ++i)
         {
           libMesh::out << "(" << boundary_node_list[i] << ", " << boundary_node_boundary_id_list[i] << ") ";
         }
@@ -2097,7 +2097,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
   // For each node in the node list, add it to the vector of node IDs for that
   // set for the local processor.  This will be used later when writing Exodus
   // nodesets.
-  for (unsigned i=0; i<boundary_node_list.size(); ++i)
+  for (std::size_t i=0; i<boundary_node_list.size(); ++i)
     {
       // Don't try to grab a reference to the vector unless the current node is attached
       // to a local element.  Otherwise, another processor will be responsible for writing it in its nodeset.
@@ -2111,7 +2111,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
 
           // Push back Exodus-mapped node ID for this set
           // TODO: reserve space in these vectors somehow.
-          current_id_set.push_back( (*it).second );
+          current_id_set.push_back( it->second );
         }
     }
 
@@ -2122,12 +2122,12 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
            it != local_node_boundary_id_lists.end();
            ++it)
         {
-          libMesh::out << "[" << this->processor_id() << "] ID: " << (*it).first << ", ";
+          libMesh::out << "[" << this->processor_id() << "] ID: " << it->first << ", ";
 
-          std::vector<int> & current_id_set = (*it).second;
+          std::vector<int> & current_id_set = it->second;
 
           // Libmesh node ID (Exodus Node ID)
-          for (unsigned j=0; j<current_id_set.size(); ++j)
+          for (std::size_t j=0; j<current_id_set.size(); ++j)
             libMesh::out << current_id_set[j]
                          << ", ";
 
@@ -2140,7 +2140,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
   if (global_nodeset_ids.size() > 0) {
   NamesData names_table(global_nodeset_ids.size(), MAX_STR_LENGTH);
 
-  for (unsigned i=0; i<this->global_nodeset_ids.size(); ++i)
+  for (std::size_t i=0; i<this->global_nodeset_ids.size(); ++i)
     {
       const std::string & current_ns_name =
         mesh.get_boundary_info().get_nodeset_name(global_nodeset_ids[i]);
@@ -2190,7 +2190,7 @@ void Nemesis_IO_Helper::write_nodesets(const MeshBase & mesh)
       else // Boundary ID *was* found in list
         {
           // Get reference to the vector of node IDs
-          std::vector<int> & current_nodeset_ids = (*it).second;
+          std::vector<int> & current_nodeset_ids = it->second;
 
           // Call the Exodus interface to write the parameters of this node set
           this->ex_err = exII::ex_put_node_set_param(this->ex_id,
@@ -2246,7 +2246,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
     (bndry_elem_list, bndry_side_list, bndry_id_list);
 
   // Integer looping, skipping non-local elements
-  for (unsigned i=0; i<bndry_elem_list.size(); ++i)
+  for (std::size_t i=0; i<bndry_elem_list.size(); ++i)
     {
       // Get pointer to current Elem
       const Elem * elem = mesh.elem_ptr(bndry_elem_list[i]);
@@ -2265,7 +2265,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
       // Loop over all the elements in the family tree, store their converted IDs
       // and side IDs to the map's vectors.  TODO: Somehow reserve enough space for these
       // push_back's...
-      for (unsigned int j=0; j<family.size(); ++j)
+      for (std::size_t j=0; j<family.size(); ++j)
         {
           const dof_id_type f_id = family[j]->id();
           const Elem & f = mesh.elem_ref(f_id);
@@ -2283,7 +2283,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
               std::map<int,int>::iterator it = this->libmesh_elem_num_to_exodus.find( f_id );
               if (it != this->libmesh_elem_num_to_exodus.end())
                 {
-                  local_elem_boundary_id_lists[ bndry_id_list[i] ].push_back( (*it).second );
+                  local_elem_boundary_id_lists[ bndry_id_list[i] ].push_back( it->second );
                   local_elem_boundary_id_side_lists[ bndry_id_list[i] ].push_back(conv.get_inverse_side_map( bndry_side_list[i] ));
                 }
               else
@@ -2301,7 +2301,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
   if (global_sideset_ids.size() > 0) {
   NamesData names_table(global_sideset_ids.size(), MAX_STR_LENGTH);
 
-  for (unsigned i=0; i<this->global_sideset_ids.size(); ++i)
+  for (std::size_t i=0; i<this->global_sideset_ids.size(); ++i)
     {
       const std::string & current_ss_name =
         mesh.get_boundary_info().get_sideset_name(global_sideset_ids[i]);
@@ -2357,7 +2357,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
           libmesh_assert (it_sides != local_elem_boundary_id_side_lists.end());
 
           // Get reference to the vector of elem IDs
-          std::vector<int> & current_sideset_elem_ids = (*it).second;
+          std::vector<int> & current_sideset_elem_ids = it->second;
 
           // Get reference to the vector of side IDs
           std::vector<int> & current_sideset_side_ids = (*it_sides).second;
@@ -2491,8 +2491,8 @@ void Nemesis_IO_Helper::write_elements(const MeshBase & mesh, bool /*use_discont
       else
         {
           subdomain_id_type block =
-            cast_int<subdomain_id_type>((*it).first);
-          std::vector<int> & this_block_connectivity = (*it).second;
+            cast_int<subdomain_id_type>(it->first);
+          std::vector<int> & this_block_connectivity = it->second;
           std::vector<unsigned int> & elements_in_this_block = subdomain_map[block];
 
           ExodusII_IO_Helper::ElementMaps em;

--- a/src/mesh/postscript_io.C
+++ b/src/mesh/postscript_io.C
@@ -257,7 +257,7 @@ void PostscriptIO::plot_quadratic_elem(const Elem * elem)
       this->_compute_edge_bezier_coeffs(side.get());
 
       // Print curveto path to file
-      for (unsigned int i=0; i<_bezier_coeffs.size(); ++i)
+      for (std::size_t i=0; i<_bezier_coeffs.size(); ++i)
         _out << _bezier_coeffs[i](0) << " " << _bezier_coeffs[i](1) << " ";
       _out << " cs\n";
     }

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -790,14 +790,14 @@ void ReplicatedMesh::renumber_nodes_and_elements ()
 void ReplicatedMesh::fix_broken_node_and_element_numbering ()
 {
   // Nodes first
-  for (dof_id_type n=0; n<this->_nodes.size(); n++)
+  for (std::size_t n=0; n<this->_nodes.size(); n++)
     if (this->_nodes[n] != libmesh_nullptr)
-      this->_nodes[n]->set_id() = n;
+      this->_nodes[n]->set_id() = cast_int<dof_id_type>(n);
 
   // Elements next
-  for (dof_id_type e=0; e<this->_elements.size(); e++)
+  for (std::size_t e=0; e<this->_elements.size(); e++)
     if (this->_elements[e] != libmesh_nullptr)
-      this->_elements[e]->set_id() = e;
+      this->_elements[e]->set_id() = cast_int<dof_id_type>(e);
 }
 
 
@@ -897,7 +897,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
                 // Get the list of nodes with associated boundary IDs
                 mesh_array[i]->get_boundary_info().build_node_list(node_id_list, bc_id_list);
 
-                for(unsigned int node_index=0; node_index<bc_id_list.size(); node_index++)
+                for (std::size_t node_index=0; node_index<bc_id_list.size(); node_index++)
                   {
                     boundary_id_type node_bc_id = bc_id_list[node_index];
                     if (node_bc_id == id_array[i])
@@ -1044,7 +1044,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
           }
 
           // Build up the node_to_node_map and node_to_elems_map using the sorted vectors of Points.
-          for (unsigned i=0; i<this_sorted_bndry_nodes.size(); ++i)
+          for (std::size_t i=0; i<this_sorted_bndry_nodes.size(); ++i)
             {
               // Current point we're working on
               Point this_point = this_sorted_bndry_nodes[i].first;

--- a/src/mesh/tecplot_io.C
+++ b/src/mesh/tecplot_io.C
@@ -258,7 +258,7 @@ void TecplotIO::write_ascii (const std::string & fname,
     out_stream << "Variables=x,y,z";
 
     if (solution_names != libmesh_nullptr)
-      for (unsigned int n=0; n<solution_names->size(); n++)
+      for (std::size_t n=0; n<solution_names->size(); n++)
         {
 #ifdef LIBMESH_USE_REAL_NUMBERS
 
@@ -419,7 +419,7 @@ void TecplotIO::write_binary (const std::string & fname,
 
     if (solution_names != libmesh_nullptr)
       {
-        for (unsigned int name=0; name<solution_names->size(); name++)
+        for (std::size_t name=0; name<solution_names->size(); name++)
           {
 #ifdef LIBMESH_USE_REAL_NUMBERS
 
@@ -529,7 +529,7 @@ void TecplotIO::write_binary (const std::string & fname,
               {
                 (*it)->connectivity(se, TECPLOT, conn);
 
-                for (unsigned int node=0; node<conn.size(); node++)
+                for (std::size_t node=0; node<conn.size(); node++)
                   tm.cd(node,te) = conn[node];
 
                 te++;
@@ -672,7 +672,7 @@ void TecplotIO::write_binary (const std::string & fname,
 
     if (solution_names != libmesh_nullptr)
       {
-        for (unsigned int name=0; name<solution_names->size(); name++)
+        for (std::size_t name=0; name<solution_names->size(); name++)
           {
 #ifdef LIBMESH_USE_REAL_NUMBERS
 
@@ -725,9 +725,9 @@ void TecplotIO::write_binary (const std::string & fname,
       if ((vec != libmesh_nullptr) &&
           (solution_names != libmesh_nullptr))
         {
-          const unsigned int n_vars = solution_names->size();
+          const std::size_t n_vars = solution_names->size();
 
-          for (unsigned int c=0; c<n_vars; c++)
+          for (std::size_t c=0; c<n_vars; c++)
             {
 #ifdef LIBMESH_USE_REAL_NUMBERS
 
@@ -756,7 +756,7 @@ void TecplotIO::write_binary (const std::string & fname,
           {
             (*it)->connectivity(se, TECPLOT, conn);
 
-            for (unsigned int node=0; node<conn.size(); node++)
+            for (std::size_t node=0; node<conn.size(); node++)
               tm.cd(node,te) = conn[node];
 
             te++;

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -368,7 +368,7 @@ void UCDIO::write_soln(std::ostream & out_stream,
 
   // First write out how many variables and how many components per variable
   out_stream << names.size();
-  for (unsigned int i = 0; i < names.size(); i++)
+  for (std::size_t i = 0; i < names.size(); i++)
     {
       libmesh_assert (out_stream.good());
       // Each named variable has only 1 component

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -225,7 +225,7 @@ void VTKIO::read (const std::string & name)
 
       // then reshuffle the nodes according to the connectivity, this
       // two-time-assign would evade the definition of the vtk_mapping
-      for (unsigned int j=0; j<conn.size(); ++j)
+      for (std::size_t j=0; j<conn.size(); ++j)
         elem->set_node(j) = mesh.node_ptr(conn[j]);
 
       elem->set_id(i);
@@ -447,7 +447,7 @@ void VTKIO::cells_to_vtk()
       std::vector<dof_id_type> conn;
       elem->connectivity(0, VTK, conn);
 
-      for (unsigned int i=0; i<conn.size(); ++i)
+      for (std::size_t i=0; i<conn.size(); ++i)
         {
           // If the node ID is not found in the _local_node_map, we'll
           // add it to the _vtk_grid.  NOTE[JWP]: none of the examples
@@ -531,7 +531,7 @@ void VTKIO::cells_to_vtk()
 //           libmesh_assert_equal_to (it->second.size(), es.get_mesh().n_nodes());
 //           data->SetNumberOfValues(it->second.size());
 //
-//           for (unsigned int i=0; i<it->second.size(); ++i)
+//           for (std::size_t i=0; i<it->second.size(); ++i)
 //             {
 // #ifdef LIBMESH_USE_COMPLEX_NUMBERS
 //               libmesh_do_once (libMesh::err << "Only writing the real part for complex numbers!\n"

--- a/src/numerics/dense_matrix_blas_lapack.C
+++ b/src/numerics/dense_matrix_blas_lapack.C
@@ -486,7 +486,7 @@ void DenseMatrix<T>::_svd_helper (char JOBU,
   // numbers to LAPACKgesvd_, but _val may contain Reals so we copy to Number below to
   // handle both the real-valued and complex-valued cases.
   std::vector<Number> val_copy(_val.size());
-  for (unsigned int i=0; i<_val.size(); i++)
+  for (std::size_t i=0; i<_val.size(); i++)
       val_copy[i] = _val[i];
 
   std::vector<Real> RWORK(5 * min_MN);
@@ -656,7 +656,7 @@ void DenseMatrix<T>::_svd_solve_lapack(const DenseVector<T> & rhs,
   // Debugging: print singular values and information about condition number:
   // libMesh::err << "RCOND=" << RCOND << std::endl;
   // libMesh::err << "Singular values: " << std::endl;
-  // for (unsigned i=0; i<S.size(); ++i)
+  // for (std::size_t i=0; i<S.size(); ++i)
   //   libMesh::err << S[i] << std::endl;
   // libMesh::err << "The condition number of A is approximately: " << S[0]/S.back() << std::endl;
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -75,7 +75,7 @@ void transform_preallocation_arrays (const PetscInt blocksize,
   b_n_nz.clear(); /**/ b_n_nz.reserve(n_nz.size()/blocksize);
   b_n_oz.clear(); /**/ b_n_oz.reserve(n_oz.size()/blocksize);
 
-  for (unsigned int nn=0; nn<n_nz.size(); nn += blocksize)
+  for (std::size_t nn=0; nn<n_nz.size(); nn += blocksize)
     {
       b_n_nz.push_back (n_nz[nn]/blocksize);
       b_n_oz.push_back (n_oz[nn]/blocksize);

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -75,7 +75,7 @@ void SparseMatrix<T>::add_block_matrix (const DenseMatrix<T> & dm,
   rows.reserve(blocksize*brows.size());
   cols.reserve(blocksize*bcols.size());
 
-  for (unsigned int ib=0; ib<brows.size(); ib++)
+  for (std::size_t ib=0; ib<brows.size(); ib++)
     {
       numeric_index_type i=brows[ib]*blocksize;
 
@@ -83,7 +83,7 @@ void SparseMatrix<T>::add_block_matrix (const DenseMatrix<T> & dm,
         rows.push_back(i++);
     }
 
-  for (unsigned int jb=0; jb<bcols.size(); jb++)
+  for (std::size_t jb=0; jb<bcols.size(); jb++)
     {
       numeric_index_type j=bcols[jb]*blocksize;
 

--- a/src/numerics/sum_shell_matrix.C
+++ b/src/numerics/sum_shell_matrix.C
@@ -28,14 +28,12 @@ template <typename T>
 numeric_index_type SumShellMatrix<T>::m () const
 {
   libmesh_assert(!matrices.empty());
-  const numeric_index_type result = matrices[0]->m();
+  const numeric_index_type n_rows = matrices[0]->m();
 #ifndef NDEBUG
-  for(std::size_t i=matrices.size(); i-->1; )
-    {
-      libmesh_assert_equal_to (matrices[i]->m(), result);
-    }
+  for (std::size_t i=1; i<matrices.size(); ++i)
+    libmesh_assert_equal_to (matrices[i]->m(), n_rows);
 #endif
-  return result;
+  return n_rows;
 }
 
 
@@ -44,14 +42,12 @@ template <typename T>
 numeric_index_type SumShellMatrix<T>::n () const
 {
   libmesh_assert(!matrices.empty());
-  const numeric_index_type result = matrices[0]->n();
+  const numeric_index_type n_cols = matrices[0]->n();
 #ifndef NDEBUG
-  for(std::size_t i=matrices.size(); i-->1; )
-    {
-      libmesh_assert_equal_to (matrices[i]->n(), result);
-    }
+  for (std::size_t i=1; i<matrices.size(); ++i)
+    libmesh_assert_equal_to (matrices[i]->n(), n_cols);
 #endif
-  return result;
+  return n_cols;
 }
 
 
@@ -70,10 +66,8 @@ template <typename T>
 void SumShellMatrix<T>::vector_mult_add (NumericVector<T> & dest,
                                          const NumericVector<T> & arg) const
 {
-  for(std::size_t i=matrices.size(); i-->0; )
-    {
-      matrices[i]->vector_mult_add(dest,arg);
-    }
+  for (std::size_t i=0; i<matrices.size(); ++i)
+    matrices[i]->vector_mult_add(dest, arg);
 }
 
 
@@ -81,9 +75,8 @@ void SumShellMatrix<T>::vector_mult_add (NumericVector<T> & dest,
 template <typename T>
 void SumShellMatrix<T>::get_diagonal (NumericVector<T> & dest) const
 {
-  UniquePtr<NumericVector<T> > a = dest.clone();
-  dest.zero();
-  for(std::size_t i=matrices.size(); i-->0; )
+  UniquePtr<NumericVector<T> > a = dest.zero_clone();
+  for (std::size_t i=0; i<matrices.size(); ++i)
     {
       matrices[i]->get_diagonal(*a);
       dest += *a;

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -274,7 +274,7 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
                         // Get all the neighbor's children that
                         // live on that side and are thus connected
                         // to us
-                        for (unsigned int nc=0; nc<neighbors_offspring.size(); nc++)
+                        for (std::size_t nc=0; nc<neighbors_offspring.size(); nc++)
                           {
                             const Elem * child =
                               neighbors_offspring[nc];
@@ -365,7 +365,7 @@ void MetisPartitioner::_do_partition (MeshBase & mesh,
                         // Get all the neighbor's children that
                         // live on that side and are thus connected
                         // to us
-                        for (unsigned int nc=0; nc<neighbors_offspring.size(); nc++)
+                        for (std::size_t nc=0; nc<neighbors_offspring.size(); nc++)
                           {
                             const Elem * child =
                               neighbors_offspring[nc];

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -131,7 +131,7 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
   // per partition.
   {
     bool all_have_enough_elements = true;
-    for (processor_id_type pid=0; pid<_n_active_elem_on_proc.size(); pid++)
+    for (std::size_t pid=0; pid<_n_active_elem_on_proc.size(); pid++)
       if (_n_active_elem_on_proc[pid] < MIN_ELEM_PER_PROC)
         all_have_enough_elements = false;
 
@@ -537,7 +537,7 @@ void ParmetisPartitioner::build_graph (const MeshBase & mesh)
                   // Get all the neighbor's children that
                   // live on that side and are thus connected
                   // to us
-                  for (unsigned int nc=0; nc<neighbors_offspring.size(); nc++)
+                  for (std::size_t nc=0; nc<neighbors_offspring.size(); nc++)
                     {
                       const Elem * child =
                         neighbors_offspring[nc];

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -281,7 +281,7 @@ void Partitioner::set_parent_processor_ids(MeshBase & mesh)
 
           std::vector<const Elem *> subactive_family;
           child->total_family_tree(subactive_family);
-          for (unsigned int i = 0; i != subactive_family.size(); ++i)
+          for (std::size_t i = 0; i != subactive_family.size(); ++i)
             const_cast<Elem *>(subactive_family[i])->processor_id() = child->processor_id();
 
           // Then set ancestors
@@ -326,7 +326,7 @@ void Partitioner::set_parent_processor_ids(MeshBase & mesh)
 
           std::vector<const Elem *> subactive_family;
           child->total_family_tree(subactive_family);
-          for (unsigned int i = 0; i != subactive_family.size(); ++i)
+          for (std::size_t i = 0; i != subactive_family.size(); ++i)
             const_cast<Elem *>(subactive_family[i])->processor_id() = child->processor_id();
         }
 
@@ -381,7 +381,7 @@ void Partitioner::set_parent_processor_ids(MeshBase & mesh)
 
                   std::vector<const Elem *> active_family;
                   parent->active_family_tree(active_family);
-                  for (unsigned int i = 0; i != active_family.size(); ++i)
+                  for (std::size_t i = 0; i != active_family.size(); ++i)
                     parent_pid = std::min (parent_pid, active_family[i]->processor_id());
 
                   const dof_id_type packed_idx = parent_idx - first_elem_id;

--- a/src/physics/diff_qoi.C
+++ b/src/physics/diff_qoi.C
@@ -32,10 +32,8 @@ void DifferentiableQoI::thread_join( std::vector<Number> & qoi,
                                      const std::vector<Number> & other_qoi,
                                      const QoISet &)
 {
-  for (unsigned int i=0; i != qoi.size(); ++i)
+  for (std::size_t i=0; i != qoi.size(); ++i)
     qoi[i] += other_qoi[i];
-
-  return;
 }
 
 void DifferentiableQoI::parallel_op(const Parallel::Communicator & communicator,
@@ -48,8 +46,6 @@ void DifferentiableQoI::parallel_op(const Parallel::Communicator & communicator,
 
   // Now put into system qoi
   sys_qoi = local_qoi;
-
-  return;
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -111,7 +111,7 @@ void QBase::scale(std::pair<Real, Real> old_range,
   Real scfact = h_new/h_old;
 
   // We're mapping from old_range -> new_range
-  for (unsigned int i=0; i<_points.size(); i++)
+  for (std::size_t i=0; i<_points.size(); i++)
     {
       _points[i](0) = new_range.first +
         (_points[i](0) - old_range.first) * scfact;

--- a/src/quadrature/quadrature_gm.C
+++ b/src/quadrature/quadrature_gm.C
@@ -93,7 +93,7 @@ void QGrundmann_Moller::gm_rule(unsigned int s, unsigned int dim)
       compose_all(s-i, dim+1, permutations);
       //libMesh::out << "n. permutations=" << permutations.size() << std::endl;
 
-      for (unsigned int p=0; p<permutations.size(); ++p)
+      for (std::size_t p=0; p<permutations.size(); ++p)
         {
           // We use the first dim entries of each permutation to
           // construct an integration point.
@@ -129,7 +129,7 @@ void QGrundmann_Moller::gm_rule(unsigned int s, unsigned int dim)
         }
 
       // This is the weight for each of the points computed previously
-      for (unsigned int j=0; j<permutations.size(); ++j)
+      for (std::size_t j=0; j<permutations.size(); ++j)
         _weights[offset+j] = weight;
 
       // Change sign for next iteration

--- a/src/reduced_basis/rb_assembly_expansion.C
+++ b/src/reduced_basis/rb_assembly_expansion.C
@@ -135,10 +135,8 @@ void RBAssemblyExpansion::attach_A_assembly(ElemAssembly * Aq_assembly)
 
 void RBAssemblyExpansion::attach_multiple_A_assembly(std::vector<ElemAssembly *> Aq_assembly)
 {
-  for(unsigned int i=0; i<Aq_assembly.size(); i++)
-    {
-      _A_assembly_vector.push_back(Aq_assembly[i]);
-    }
+  for (std::size_t i=0; i<Aq_assembly.size(); i++)
+    _A_assembly_vector.push_back(Aq_assembly[i]);
 }
 
 void RBAssemblyExpansion::attach_F_assembly(ElemAssembly * Fq_assembly)
@@ -148,10 +146,8 @@ void RBAssemblyExpansion::attach_F_assembly(ElemAssembly * Fq_assembly)
 
 void RBAssemblyExpansion::attach_multiple_F_assembly(std::vector<ElemAssembly *> Fq_assembly)
 {
-  for(unsigned int i=0; i<Fq_assembly.size(); i++)
-    {
-      _F_assembly_vector.push_back(Fq_assembly[i]);
-    }
+  for (std::size_t i=0; i<Fq_assembly.size(); i++)
+    _F_assembly_vector.push_back(Fq_assembly[i]);
 }
 
 void RBAssemblyExpansion::attach_output_assembly(std::vector<ElemAssembly *> output_assembly)

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -98,20 +98,20 @@ void RBConstruction::clear()
 
   Parent::clear();
 
-  for(unsigned int q=0; q<Aq_vector.size(); q++)
+  for (std::size_t q=0; q<Aq_vector.size(); q++)
     {
       delete Aq_vector[q];
       Aq_vector[q] = libmesh_nullptr;
     }
 
-  for(unsigned int q=0; q<Fq_vector.size(); q++)
+  for (std::size_t q=0; q<Fq_vector.size(); q++)
     {
       delete Fq_vector[q];
       Fq_vector[q] = libmesh_nullptr;
     }
 
-  for(unsigned int i=0; i<outputs_vector.size(); i++)
-    for(unsigned int q_l=0; q_l<outputs_vector[i].size(); q_l++)
+  for (std::size_t i=0; i<outputs_vector.size(); i++)
+    for (std::size_t q_l=0; q_l<outputs_vector[i].size(); q_l++)
       {
         delete outputs_vector[i][q_l];
         outputs_vector[i][q_l] = libmesh_nullptr;
@@ -119,20 +119,20 @@ void RBConstruction::clear()
 
   if(store_non_dirichlet_operators)
     {
-      for(unsigned int q=0; q<non_dirichlet_Aq_vector.size(); q++)
+      for (std::size_t q=0; q<non_dirichlet_Aq_vector.size(); q++)
         {
           delete non_dirichlet_Aq_vector[q];
           non_dirichlet_Aq_vector[q] = libmesh_nullptr;
         }
 
-      for(unsigned int q=0; q<non_dirichlet_Fq_vector.size(); q++)
+      for (std::size_t q=0; q<non_dirichlet_Fq_vector.size(); q++)
         {
           delete non_dirichlet_Fq_vector[q];
           non_dirichlet_Fq_vector[q] = libmesh_nullptr;
         }
 
-      for(unsigned int i=0; i<non_dirichlet_outputs_vector.size(); i++)
-        for(unsigned int q_l=0; q_l<non_dirichlet_outputs_vector[i].size(); q_l++)
+      for (std::size_t i=0; i<non_dirichlet_outputs_vector.size(); i++)
+        for (std::size_t q_l=0; q_l<non_dirichlet_outputs_vector[i].size(); q_l++)
           {
             delete non_dirichlet_outputs_vector[i][q_l];
             non_dirichlet_outputs_vector[i][q_l] = libmesh_nullptr;
@@ -140,7 +140,7 @@ void RBConstruction::clear()
     }
 
   // Also delete the Fq representors
-  for(unsigned int q_f=0; q_f<Fq_representor.size(); q_f++)
+  for (std::size_t q_f=0; q_f<Fq_representor.size(); q_f++)
     {
       delete Fq_representor[q_f];
       Fq_representor[q_f] = libmesh_nullptr;
@@ -268,10 +268,8 @@ void RBConstruction::process_parameters_file (const std::string & parameters_fil
 
       unsigned int n_vals_for_param = infile.vector_variable_size(param_name);
       std::vector<Real> vals_for_param(n_vals_for_param);
-      for(unsigned int j=0; j<vals_for_param.size(); j++)
-        {
-          vals_for_param[j] = infile(param_name, 0., j);
-        }
+      for (std::size_t j=0; j<vals_for_param.size(); j++)
+        vals_for_param[j] = infile(param_name, 0., j);
 
       discrete_parameter_values_in[param_name] = vals_for_param;
     }
@@ -631,7 +629,7 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
       // Get the list of nodes with boundary IDs
       mesh.get_boundary_info().build_node_list(node_id_list, bc_id_list);
 
-      for (unsigned int i=0; i<node_id_list.size(); i++)
+      for (std::size_t i=0; i<node_id_list.size(); i++)
         {
           const Node & node = mesh.node_ref(node_id_list[i]);
 
@@ -1013,10 +1011,9 @@ Real RBConstruction::train_reduced_basis(const bool resize_rb_eval_data)
     }
 
   // Clear the Greedy param list
-  for(unsigned int i=0; i<get_rb_evaluation().greedy_param_list.size(); i++)
-    {
-      get_rb_evaluation().greedy_param_list[i].clear();
-    }
+  for (std::size_t i=0; i<get_rb_evaluation().greedy_param_list.size(); i++)
+    get_rb_evaluation().greedy_param_list[i].clear();
+
   get_rb_evaluation().greedy_param_list.clear();
 
   Real training_greedy_error;
@@ -1116,7 +1113,7 @@ bool RBConstruction::greedy_termination_test(Real abs_greedy_error,
 
   if(exit_on_repeated_greedy_parameters)
     {
-      for(unsigned int i=0; i<get_rb_evaluation().greedy_param_list.size(); i++)
+      for (std::size_t i=0; i<get_rb_evaluation().greedy_param_list.size(); i++)
         {
           RBParameters & previous_parameters = get_rb_evaluation().greedy_param_list[i];
           if(previous_parameters == get_parameters())
@@ -1724,10 +1721,8 @@ void RBConstruction::load_rb_solution()
                       << " RB_solution vector constains " << get_rb_evaluation().RB_solution.size() << " entries." \
                       << " RB_solution in RBConstruction::load_rb_solution is too long!");
 
-  for(unsigned int i=0; i<get_rb_evaluation().RB_solution.size(); i++)
-    {
-      solution->add(get_rb_evaluation().RB_solution(i), get_rb_evaluation().get_basis_function(i));
-    }
+  for (std::size_t i=0; i<get_rb_evaluation().RB_solution.size(); i++)
+    solution->add(get_rb_evaluation().RB_solution(i), get_rb_evaluation().get_basis_function(i));
 
   update();
 }
@@ -1934,7 +1929,7 @@ void RBConstruction::write_riesz_representors_to_files(const std::string & riesz
     if ( mkdir(riesz_representors_dir.c_str(), 0755) != 0)
       libMesh::out << "Skipping creating residual_representors directory: " << strerror(errno) << std::endl;
 
-  for (unsigned int i=0; i<Fq_representor.size(); ++i)
+  for (std::size_t i=0; i<Fq_representor.size(); ++i)
     {
       if (Fq_representor[i] != libmesh_nullptr)
         {
@@ -1987,7 +1982,7 @@ void RBConstruction::write_riesz_representors_to_files(const std::string & riesz
 
   const unsigned int jstop  = get_rb_evaluation().get_n_basis_functions();
   const unsigned int jstart = jstop-get_delta_N();
-  for (unsigned int i=0; i<get_rb_evaluation().Aq_representor.size(); ++i)
+  for (std::size_t i=0; i<get_rb_evaluation().Aq_representor.size(); ++i)
     for (unsigned int j=jstart; j<jstop; ++j)
       {
         libMesh::out << "Writing out Aq_representor[" << i << "][" << j << "]..." << std::endl;
@@ -2034,13 +2029,13 @@ void RBConstruction::read_riesz_representors_from_files(const std::string & ries
 
   // Read in the Fq_representors.  There should be Q_f of these.  FIXME:
   // should we be worried about leaks here?
-  for (unsigned int i=0; i<Fq_representor.size(); ++i)
+  for (std::size_t i=0; i<Fq_representor.size(); ++i)
     {
       if (Fq_representor[i] != libmesh_nullptr)
         libmesh_error_msg("Error, must delete existing Fq_representor before reading in from file.");
     }
 
-  for (unsigned int i=0; i<Fq_representor.size(); i++)
+  for (std::size_t i=0; i<Fq_representor.size(); i++)
     {
       file_name.str(""); // reset filename
       file_name << riesz_representors_dir
@@ -2078,15 +2073,15 @@ void RBConstruction::read_riesz_representors_from_files(const std::string & ries
   // Read in the Aq representors.  The class makes room for [Q_a][Nmax] of these.  We are going to
   // read in [Q_a][get_rb_evaluation().get_n_basis_functions()].  FIXME:
   // should we be worried about leaks in the locations where we're about to fill entries?
-  for (unsigned int i=0; i<get_rb_evaluation().Aq_representor.size(); ++i)
-    for (unsigned int j=0; j<get_rb_evaluation().Aq_representor[i].size(); ++j)
+  for (std::size_t i=0; i<get_rb_evaluation().Aq_representor.size(); ++i)
+    for (std::size_t j=0; j<get_rb_evaluation().Aq_representor[i].size(); ++j)
       {
         if (get_rb_evaluation().Aq_representor[i][j] != libmesh_nullptr)
           libmesh_error_msg("Error, must delete existing Aq_representor before reading in from file.");
       }
 
   // Now ready to read them in from file!
-  for (unsigned int i=0; i<get_rb_evaluation().Aq_representor.size(); ++i)
+  for (std::size_t i=0; i<get_rb_evaluation().Aq_representor.size(); ++i)
     for (unsigned int j=0; j<get_rb_evaluation().get_n_basis_functions(); ++j)
       {
         file_name.str(""); // reset filename

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -677,10 +677,8 @@ void add_rb_scm_evaluation_data_to_builder(RBSCMEvaluation & rb_scm_eval,
     if (rb_scm_eval.B_min.size() != rb_scm_eval.get_rb_theta_expansion().get_n_A_terms())
       libmesh_error_msg("Size error while writing B_min");
     auto b_min_list = rb_scm_eval_builder.initBMin( rb_scm_eval.B_min.size() );
-    for(unsigned int i=0; i<rb_scm_eval.B_min.size(); i++)
-      {
-        b_min_list.set(i, rb_scm_eval.get_B_min(i));
-      }
+    for (std::size_t i=0; i<rb_scm_eval.B_min.size(); i++)
+      b_min_list.set(i, rb_scm_eval.get_B_min(i));
   }
 
   {
@@ -688,26 +686,22 @@ void add_rb_scm_evaluation_data_to_builder(RBSCMEvaluation & rb_scm_eval,
       libmesh_error_msg("Size error while writing B_max");
 
     auto b_max_list = rb_scm_eval_builder.initBMax( rb_scm_eval.B_max.size() );
-    for(unsigned int i=0; i<rb_scm_eval.B_max.size(); i++)
-      {
-        b_max_list.set(i, rb_scm_eval.get_B_max(i));
-      }
+    for (std::size_t i=0; i<rb_scm_eval.B_max.size(); i++)
+      b_max_list.set(i, rb_scm_eval.get_B_max(i));
   }
 
   {
     auto cj_stability_vector =
       rb_scm_eval_builder.initCJStabilityVector( rb_scm_eval.C_J_stability_vector.size() );
-    for(unsigned int i=0; i<rb_scm_eval.C_J_stability_vector.size(); i++)
-      {
-        cj_stability_vector.set(i, rb_scm_eval.get_C_J_stability_constraint(i));
-      }
+    for (std::size_t i=0; i<rb_scm_eval.C_J_stability_vector.size(); i++)
+      cj_stability_vector.set(i, rb_scm_eval.get_C_J_stability_constraint(i));
   }
 
   {
     auto cj_parameters_outer =
       rb_scm_eval_builder.initCJ( rb_scm_eval.C_J.size() );
 
-    for(unsigned int i=0; i<rb_scm_eval.C_J.size(); i++)
+    for (std::size_t i=0; i<rb_scm_eval.C_J.size(); i++)
       {
         auto cj_parameters_inner =
           cj_parameters_outer.init(i, rb_scm_eval.C_J[i].n_parameters());

--- a/src/reduced_basis/rb_eim_assembly.C
+++ b/src/reduced_basis/rb_eim_assembly.C
@@ -106,7 +106,7 @@ void RBEIMAssembly::evaluate_basis_function(unsigned int var,
   for(unsigned int qp=0; qp<n_qpoints; qp++)
     {
       values[qp] = 0.;
-      for (unsigned int i=0; i<dof_indices_var.size(); i++)
+      for (std::size_t i=0; i<dof_indices_var.size(); i++)
         values[qp] += (*_ghosted_basis_function)(dof_indices_var[i]) * phi[i][qp];
     }
 }

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -97,14 +97,12 @@ void RBEIMConstruction::clear()
   _mesh_function.reset();
 
   // clear the eim assembly vector
-  for(unsigned int i=0; i<_rb_eim_assembly_objects.size(); i++)
-    {
-      delete _rb_eim_assembly_objects[i];
-    }
+  for (std::size_t i=0; i<_rb_eim_assembly_objects.size(); i++)
+    delete _rb_eim_assembly_objects[i];
   _rb_eim_assembly_objects.clear();
 
   // clear the parametrized functions from the training set
-  for(unsigned int i=0; i<_parametrized_functions_in_training_set.size(); i++)
+  for (std::size_t i=0; i<_parametrized_functions_in_training_set.size(); i++)
     {
       if (_parametrized_functions_in_training_set[i])
         {
@@ -115,7 +113,7 @@ void RBEIMConstruction::clear()
     }
   _parametrized_functions_in_training_set_initialized = false;
 
-  for(unsigned int i=0; i<_matrix_times_bfs.size(); i++)
+  for (std::size_t i=0; i<_matrix_times_bfs.size(); i++)
     {
       if(_matrix_times_bfs[i])
         {
@@ -498,7 +496,7 @@ void RBEIMConstruction::plot_parametrized_functions_in_training_set(const std::s
 {
   libmesh_assert(_parametrized_functions_in_training_set_initialized);
 
-  for(unsigned int i=0; i<_parametrized_functions_in_training_set.size(); i++)
+  for (std::size_t i=0; i<_parametrized_functions_in_training_set.size(); i++)
     {
 #ifdef LIBMESH_HAVE_EXODUS_API
       *get_explicit_system().solution = *_parametrized_functions_in_training_set[i];
@@ -682,7 +680,7 @@ Real RBEIMConstruction::truth_solve(int plot_solution)
 
               // Loop over qp before var because parametrized functions often use
               // some caching based on qp.
-              for (unsigned int qp=0; qp<JxW_values[elem_id].size(); qp++)
+              for (std::size_t qp=0; qp<JxW_values[elem_id].size(); qp++)
                 {
                   unsigned int n_var_dofs = phi_values[elem_id][qp].size();
 
@@ -854,7 +852,7 @@ void RBEIMConstruction::set_explicit_sys_subvector(NumericVector<Number> & dest,
   localized_source->init(this->n_dofs(), false, SERIAL);
   source.localize(*localized_source);
 
-  for(unsigned int i=0; i<_dof_map_between_systems[var].size(); i++)
+  for (std::size_t i=0; i<_dof_map_between_systems[var].size(); i++)
     {
       dof_id_type implicit_sys_dof_index = i;
       dof_id_type explicit_sys_dof_index = _dof_map_between_systems[var][i];
@@ -874,7 +872,7 @@ void RBEIMConstruction::get_explicit_sys_subvector(NumericVector<Number> & dest,
 {
   LOG_SCOPE("get_explicit_sys_subvector()", "RBEIMConstruction");
 
-  for(unsigned int i=0; i<_dof_map_between_systems[var].size(); i++)
+  for (std::size_t i=0; i<_dof_map_between_systems[var].size(); i++)
     {
       dof_id_type implicit_sys_dof_index = i;
       dof_id_type explicit_sys_dof_index = _dof_map_between_systems[var][i];

--- a/src/reduced_basis/rb_eim_evaluation.C
+++ b/src/reduced_basis/rb_eim_evaluation.C
@@ -68,10 +68,8 @@ void RBEIMEvaluation::clear()
   _interpolation_points_mesh.clear();
 
   // Delete any RBTheta objects that were created
-  for(unsigned int i=0; i<_rb_eim_theta_objects.size(); i++)
-    {
-      delete _rb_eim_theta_objects[i];
-    }
+  for (std::size_t i=0; i<_rb_eim_theta_objects.size(); i++)
+    delete _rb_eim_theta_objects[i];
   _rb_eim_theta_objects.clear();
 }
 
@@ -305,7 +303,7 @@ void RBEIMEvaluation::legacy_write_out_interpolation_points_elem(const std::stri
   std::map<dof_id_type, dof_id_type> node_id_map;
 
   unsigned int new_node_id = 0;
-  for(unsigned int i=0; i<interpolation_points_elem.size(); i++)
+  for (std::size_t i=0; i<interpolation_points_elem.size(); i++)
     {
       Elem * old_elem = interpolation_points_elem[i];
 
@@ -333,7 +331,7 @@ void RBEIMEvaluation::legacy_write_out_interpolation_points_elem(const std::stri
   std::map<dof_id_type,dof_id_type> elem_id_map;
   std::vector<dof_id_type> interpolation_elem_ids(interpolation_points_elem.size());
   dof_id_type new_elem_id = 0;
-  for(unsigned int i=0; i<interpolation_elem_ids.size(); i++)
+  for (std::size_t i=0; i<interpolation_elem_ids.size(); i++)
     {
       Elem * old_elem = interpolation_points_elem[i];
 
@@ -387,10 +385,9 @@ void RBEIMEvaluation::legacy_write_out_interpolation_points_elem(const std::stri
       std::ofstream interpolation_elem_ids_out
         ((directory_name + "/interpolation_elem_ids.dat").c_str(), std::ofstream::out);
 
-      for(unsigned int i=0; i<interpolation_elem_ids.size(); i++)
-        {
-          interpolation_elem_ids_out << interpolation_elem_ids[i] << std::endl;
-        }
+      for (std::size_t i=0; i<interpolation_elem_ids.size(); i++)
+        interpolation_elem_ids_out << interpolation_elem_ids[i] << std::endl;
+
       interpolation_elem_ids_out.close();
     }
 }

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -61,7 +61,7 @@ void RBEvaluation::clear()
   LOG_SCOPE("clear()", "RBEvaluation");
 
   // Clear the basis functions
-  for(unsigned int i=0; i<basis_functions.size(); i++)
+  for (std::size_t i=0; i<basis_functions.size(); i++)
     {
       if (basis_functions[i])
         {
@@ -75,7 +75,7 @@ void RBEvaluation::clear()
   clear_riesz_representors();
 
   // Clear the Greedy param list
-  for(unsigned int i=0; i<greedy_param_list.size(); i++)
+  for (std::size_t i=0; i<greedy_param_list.size(); i++)
     greedy_param_list[i].clear();
   greedy_param_list.clear();
 }
@@ -412,15 +412,12 @@ void RBEvaluation::clear_riesz_representors()
 {
 
   // Clear the Aq_representors
-  for(unsigned int q_a=0; q_a<Aq_representor.size(); q_a++)
-    {
-      for(unsigned int i=0; i<Aq_representor[q_a].size(); i++)
-        {
-          delete Aq_representor[q_a][i];
-          Aq_representor[q_a][i] = libmesh_nullptr;
-        }
-    }
-
+  for (std::size_t q_a=0; q_a<Aq_representor.size(); q_a++)
+    for (std::size_t i=0; i<Aq_representor[q_a].size(); i++)
+      {
+        delete Aq_representor[q_a][i];
+        Aq_representor[q_a][i] = libmesh_nullptr;
+      }
 }
 
 void RBEvaluation::legacy_write_offline_data_to_files(const std::string & directory_name,
@@ -634,7 +631,7 @@ void RBEvaluation::legacy_write_offline_data_to_files(const std::string & direct
         file_name << directory_name << "/greedy_params" << suffix;
         Xdr greedy_params_out(file_name.str(), mode);
 
-        for(unsigned int i=0; i<greedy_param_list.size(); i++)
+        for (std::size_t i=0; i<greedy_param_list.size(); i++)
           {
             RBParameters::const_iterator it     = greedy_param_list[i].begin();
             RBParameters::const_iterator it_end = greedy_param_list[i].end();
@@ -882,7 +879,7 @@ void RBEvaluation::legacy_read_offline_data_from_files(const std::string & direc
   // get_n_bfs() returns the correct value. Initialize the pointers
   // to NULL
   set_n_basis_functions(n_bfs);
-  for(unsigned int i=0; i<basis_functions.size(); i++)
+  for (std::size_t i=0; i<basis_functions.size(); i++)
     {
       if(basis_functions[i])
         {
@@ -943,7 +940,7 @@ void RBEvaluation::write_out_vectors(System & sys,
 
   // // Use System::write_serialized_data to write out the basis functions
   // // by copying them into this->solution one at a time.
-  // for(unsigned int i=0; i<vectors.size(); i++)
+  // for (std::size_t i=0; i<vectors.size(); i++)
   // {
   //   // No need to copy, just swap
   //   // *solution = *vectors[i];
@@ -976,7 +973,7 @@ void RBEvaluation::write_out_vectors(System & sys,
     // Note the API wants pointers to constant vectors, hence this...
     std::vector<const NumericVector<Number> *> bf_out(vectors.begin(),
                                                       vectors.end());
-    // for(unsigned int i=0; i<vectors.size(); i++)
+    // for (std::size_t i=0; i<vectors.size(); i++)
     //   bf_out.push_back(vectors[i]);
     sys.write_serialized_vectors (bf_data, bf_out);
   }
@@ -1080,7 +1077,7 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
       std::vector<NumericVector<Number> *> & vectors = *multiple_vectors[data_index];
 
       // Allocate storage for each vector
-      for (unsigned int i=0; i<vectors.size(); i++)
+      for (std::size_t i=0; i<vectors.size(); i++)
         {
           // vectors should all be NULL, otherwise we get a memory leak when
           // we create the new vectors in RBEvaluation::read_in_vectors.

--- a/src/reduced_basis/rb_parametrized.C
+++ b/src/reduced_basis/rb_parametrized.C
@@ -379,7 +379,7 @@ void RBParametrized::read_discrete_parameter_values_from_file(const std::string 
           discrete_parameter_values_in >> n_discrete_values;
 
           std::vector<Real> discrete_values(n_discrete_values);
-          for(unsigned int j=0; j<discrete_values.size(); j++)
+          for (std::size_t j=0; j<discrete_values.size(); j++)
             {
               Real param_value;
               discrete_parameter_values_in >> param_value;
@@ -420,10 +420,8 @@ void RBParametrized::print_discrete_parameter_values() const
       libMesh::out << "Discrete parameter " << it->first << ", values: ";
 
       std::vector<Real> values = it->second;
-      for(unsigned int i=0; i<values.size(); i++)
-        {
-          libMesh::out << values[i] << " ";
-        }
+      for (std::size_t i=0; i<values.size(); i++)
+        libMesh::out << values[i] << " ";
       libMesh::out << std::endl;
     }
 }

--- a/src/reduced_basis/rb_scm_construction.C
+++ b/src/reduced_basis/rb_scm_construction.C
@@ -138,10 +138,8 @@ void RBSCMConstruction::process_parameters_file(const std::string & parameters_f
 
       unsigned int n_vals_for_param = infile.vector_variable_size(param_name);
       std::vector<Real> vals_for_param(n_vals_for_param);
-      for(unsigned int j=0; j<vals_for_param.size(); j++)
-        {
-          vals_for_param[j] = infile(param_name, 0., j);
-        }
+      for (std::size_t j=0; j<vals_for_param.size(); j++)
+        vals_for_param[j] = infile(param_name, 0., j);
 
       discrete_parameter_values_in[param_name] = vals_for_param;
     }
@@ -203,7 +201,7 @@ void RBSCMConstruction::resize_SCM_vectors()
   rb_scm_eval->B_max.clear();
   rb_scm_eval->C_J.clear();
   rb_scm_eval->C_J_stability_vector.clear();
-  for(unsigned int i=0; i<rb_scm_eval->SCM_UB_vectors.size(); i++)
+  for (std::size_t i=0; i<rb_scm_eval->SCM_UB_vectors.size(); i++)
     rb_scm_eval->SCM_UB_vectors[i].clear();
   rb_scm_eval->SCM_UB_vectors.clear();
 

--- a/src/reduced_basis/rb_scm_evaluation.C
+++ b/src/reduced_basis/rb_scm_evaluation.C
@@ -369,7 +369,7 @@ void RBSCMEvaluation::legacy_write_offline_data_to_files(const std::string & dir
       file_name << directory_name << "/B_min" << suffix;
       Xdr B_min_out(file_name.str(), mode);
 
-      for(unsigned int i=0; i<B_min.size(); i++)
+      for (std::size_t i=0; i<B_min.size(); i++)
         {
           Real B_min_i = get_B_min(i);
           B_min_out << B_min_i;
@@ -382,7 +382,7 @@ void RBSCMEvaluation::legacy_write_offline_data_to_files(const std::string & dir
       file_name << directory_name << "/B_max" << suffix;
       Xdr B_max_out(file_name.str(), mode);
 
-      for(unsigned int i=0; i<B_max.size(); i++)
+      for (std::size_t i=0; i<B_max.size(); i++)
         {
           Real B_max_i = get_B_max(i);
           B_max_out << B_max_i;
@@ -403,7 +403,7 @@ void RBSCMEvaluation::legacy_write_offline_data_to_files(const std::string & dir
       file_name << directory_name << "/C_J_stability_vector" << suffix;
       Xdr C_J_stability_vector_out(file_name.str(), mode);
 
-      for(unsigned int i=0; i<C_J_stability_vector.size(); i++)
+      for (std::size_t i=0; i<C_J_stability_vector.size(); i++)
         {
           Real C_J_stability_constraint_i = get_C_J_stability_constraint(i);
           C_J_stability_vector_out << C_J_stability_constraint_i;
@@ -415,7 +415,7 @@ void RBSCMEvaluation::legacy_write_offline_data_to_files(const std::string & dir
       file_name << directory_name << "/C_J" << suffix;
       Xdr C_J_out(file_name.str(), mode);
 
-      for(unsigned int i=0; i<C_J.size(); i++)
+      for (std::size_t i=0; i<C_J.size(); i++)
         {
           RBParameters::const_iterator it     = C_J[i].begin();
           RBParameters::const_iterator it_end = C_J[i].end();
@@ -434,14 +434,12 @@ void RBSCMEvaluation::legacy_write_offline_data_to_files(const std::string & dir
       file_name << directory_name << "/SCM_UB_vectors" << suffix;
       Xdr SCM_UB_vectors_out(file_name.str(), mode);
 
-      for(unsigned int i=0; i<SCM_UB_vectors.size(); i++)
-        {
-          for(unsigned int j=0; j<rb_theta_expansion->get_n_A_terms(); j++)
-            {
-              Real SCM_UB_vector_ij = get_SCM_UB_vector(i,j);
-              SCM_UB_vectors_out << SCM_UB_vector_ij;
-            }
-        }
+      for (std::size_t i=0; i<SCM_UB_vectors.size(); i++)
+        for (unsigned int j=0; j<rb_theta_expansion->get_n_A_terms(); j++)
+          {
+            Real SCM_UB_vector_ij = get_SCM_UB_vector(i,j);
+            SCM_UB_vectors_out << SCM_UB_vector_ij;
+          }
       SCM_UB_vectors_out.close();
     }
 }
@@ -534,7 +532,7 @@ void RBSCMEvaluation::legacy_read_offline_data_from_files(const std::string & di
 
   // Resize C_J based on C_J_stability_vector and Q_a
   C_J.resize( C_J_length );
-  for(unsigned int i=0; i<C_J.size(); i++)
+  for (std::size_t i=0; i<C_J.size(); i++)
     {
       RBParameters::const_iterator it     = get_parameters().begin();
       RBParameters::const_iterator it_end = get_parameters().end();
@@ -556,7 +554,7 @@ void RBSCMEvaluation::legacy_read_offline_data_from_files(const std::string & di
 
   // Resize SCM_UB_vectors based on C_J_stability_vector and Q_a
   SCM_UB_vectors.resize( C_J_stability_vector.size() );
-  for(unsigned int i=0; i<SCM_UB_vectors.size(); i++)
+  for (std::size_t i=0; i<SCM_UB_vectors.size(); i++)
     {
       SCM_UB_vectors[i].resize( rb_theta_expansion->get_n_A_terms() );
       for(unsigned int j=0; j<rb_theta_expansion->get_n_A_terms(); j++)

--- a/src/reduced_basis/rb_theta_expansion.C
+++ b/src/reduced_basis/rb_theta_expansion.C
@@ -68,7 +68,7 @@ void RBThetaExpansion::attach_A_theta(RBTheta * theta_q_a)
 
 void RBThetaExpansion::attach_multiple_A_theta(std::vector<RBTheta *> theta_q_a)
 {
-  for(std::size_t i=0; i<theta_q_a.size(); i++)
+  for (std::size_t i=0; i<theta_q_a.size(); i++)
     {
       libmesh_assert(theta_q_a[i]);
       _A_theta_vector.push_back(theta_q_a[i]);
@@ -84,7 +84,7 @@ void RBThetaExpansion::attach_F_theta(RBTheta * theta_q_f)
 
 void RBThetaExpansion::attach_multiple_F_theta(std::vector<RBTheta *> theta_q_f)
 {
-  for(unsigned int i=0; i<theta_q_f.size(); i++)
+  for (std::size_t i=0; i<theta_q_f.size(); i++)
     {
       libmesh_assert(theta_q_f[i]);
       _F_theta_vector.push_back(theta_q_f[i]);

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -91,7 +91,7 @@ void TransientRBConstruction::clear()
   Parent::clear();
 
   // clear the mass matrices
-  for(unsigned int q=0; q<M_q_vector.size(); q++)
+  for (std::size_t q=0; q<M_q_vector.size(); q++)
     {
       delete M_q_vector[q];
       M_q_vector[q] = libmesh_nullptr;
@@ -99,7 +99,7 @@ void TransientRBConstruction::clear()
 
   if(store_non_dirichlet_operators)
     {
-      for(unsigned int q=0; q<non_dirichlet_M_q_vector.size(); q++)
+      for (std::size_t q=0; q<non_dirichlet_M_q_vector.size(); q++)
         {
           delete non_dirichlet_M_q_vector[q];
           non_dirichlet_M_q_vector[q] = libmesh_nullptr;
@@ -107,7 +107,7 @@ void TransientRBConstruction::clear()
     }
 
   // clear the temporal_data
-  for(unsigned int i=0; i<temporal_data.size(); i++)
+  for (std::size_t i=0; i<temporal_data.size(); i++)
     {
       if(temporal_data[i])
         {
@@ -976,10 +976,8 @@ void TransientRBConstruction::load_rb_solution()
                       << RB_solution_vector_k.size() \
                       << " entries. RB_solution in TransientRBConstruction::load_rb_solution is too long!");
 
-  for(unsigned int i=0; i<RB_solution_vector_k.size(); i++)
-    {
-      solution->add(RB_solution_vector_k(i), get_rb_evaluation().get_basis_function(i));
-    }
+  for (unsigned int i=0; i<RB_solution_vector_k.size(); i++)
+    solution->add(RB_solution_vector_k(i), get_rb_evaluation().get_basis_function(i));
 
   update();
 }
@@ -1338,7 +1336,7 @@ void TransientRBConstruction::write_riesz_representors_to_files(const std::strin
   const unsigned int istop  = trans_rb_eval.get_n_basis_functions();
   const unsigned int istart = istop-get_delta_N();
 
-  for (unsigned int q=0; q<trans_rb_eval.M_q_representor.size(); ++q)
+  for (std::size_t q=0; q<trans_rb_eval.M_q_representor.size(); ++q)
     for (unsigned int i=istart; i<istop; ++i)
       {
         libMesh::out << "Writing out M_q_representor[" << q << "][" << i << "]..." << std::endl;
@@ -1387,16 +1385,16 @@ void TransientRBConstruction::read_riesz_representors_from_files(const std::stri
   // Read in the Aq representors.  The class makes room for [Q_m][Nmax] of these.  We are going to
   // read in [Q_m][this->rb_eval->get_n_basis_functions()].  FIXME:
   // should we be worried about leaks in the locations where we're about to fill entries?
-  for (unsigned int i=0; i<trans_rb_eval.M_q_representor.size(); ++i)
-    for (unsigned int j=0; j<trans_rb_eval.M_q_representor[i].size(); ++j)
+  for (std::size_t i=0; i<trans_rb_eval.M_q_representor.size(); ++i)
+    for (std::size_t j=0; j<trans_rb_eval.M_q_representor[i].size(); ++j)
       {
         if (trans_rb_eval.M_q_representor[i][j] != libmesh_nullptr)
           libmesh_error_msg("Error, must delete existing M_q_representor before reading in from file.");
       }
 
   // Now ready to read them in from file!
-  for (unsigned int i=0; i<trans_rb_eval.M_q_representor.size(); ++i)
-    for (unsigned int j=0; j<trans_rb_eval.get_n_basis_functions(); ++j)
+  for (std::size_t i=0; i<trans_rb_eval.M_q_representor.size(); ++i)
+    for (std::size_t j=0; j<trans_rb_eval.get_n_basis_functions(); ++j)
       {
         file_name.str(""); // reset filename
         file_name << riesz_representors_dir

--- a/src/reduced_basis/transient_rb_evaluation.C
+++ b/src/reduced_basis/transient_rb_evaluation.C
@@ -62,18 +62,16 @@ void TransientRBEvaluation::clear_riesz_representors()
   Parent::clear_riesz_representors();
 
   // Delete the M_q representors
-  for(unsigned int q_m=0; q_m<M_q_representor.size(); q_m++)
-    {
-      for(unsigned int i=0; i<M_q_representor[q_m].size(); i++)
-        {
-          if(M_q_representor[q_m][i])
-            {
-              M_q_representor[q_m][i]->clear();
-              delete M_q_representor[q_m][i];
-              M_q_representor[q_m][i] = libmesh_nullptr;
-            }
-        }
-    }
+  for (std::size_t q_m=0; q_m<M_q_representor.size(); q_m++)
+    for (std::size_t i=0; i<M_q_representor[q_m].size(); i++)
+      {
+        if (M_q_representor[q_m][i])
+          {
+            M_q_representor[q_m][i]->clear();
+            delete M_q_representor[q_m][i];
+            M_q_representor[q_m][i] = libmesh_nullptr;
+          }
+      }
 }
 
 void TransientRBEvaluation::resize_data_structures(const unsigned int Nmax,
@@ -104,7 +102,7 @@ void TransientRBEvaluation::resize_data_structures(const unsigned int Nmax,
 
   // Initialize the initial condition storage
   RB_initial_condition_all_N.resize(Nmax);
-  for(unsigned int i=0; i<RB_initial_condition_all_N.size(); i++)
+  for (std::size_t i=0; i<RB_initial_condition_all_N.size(); i++)
     {
       // The i^th row holds a vector of lenght i+1
       RB_initial_condition_all_N[i].resize(i+1);

--- a/src/solution_transfer/dtk_adapter.C
+++ b/src/solution_transfer/dtk_adapter.C
@@ -116,7 +116,7 @@ DTKAdapter::DTKAdapter(Teuchos::RCP<const Teuchos::Comm<int> > in_comm, Equation
     {
     libMesh::err<<this->processor_id()<<" Vertices: ";
 
-    for(unsigned int i=0; i<vertices.size(); i++)
+    for (std::size_t i=0; i<vertices.size(); i++)
     libMesh::err<<vertices[i]<<" ";
 
     libMesh::err<<std::endl;
@@ -126,7 +126,7 @@ DTKAdapter::DTKAdapter(Teuchos::RCP<const Teuchos::Comm<int> > in_comm, Equation
     {
     libMesh::err<<this->processor_id()<<" Coordinates: ";
 
-    for(unsigned int i=0; i<coordinates.size(); i++)
+    for (std::size_t i=0; i<coordinates.size(); i++)
     libMesh::err<<coordinates[i]<<" ";
 
     libMesh::err<<std::endl;
@@ -136,7 +136,7 @@ DTKAdapter::DTKAdapter(Teuchos::RCP<const Teuchos::Comm<int> > in_comm, Equation
     {
     libMesh::err<<this->processor_id()<<" Connectivity: ";
 
-    for(unsigned int i=0; i<connectivity.size(); i++)
+    for (std::size_t i=0; i<connectivity.size(); i++)
     libMesh::err<<connectivity[i]<<" ";
 
     libMesh::err<<std::endl;
@@ -146,7 +146,7 @@ DTKAdapter::DTKAdapter(Teuchos::RCP<const Teuchos::Comm<int> > in_comm, Equation
     {
     libMesh::err<<this->processor_id()<<" Permutation_List: ";
 
-    for(unsigned int i=0; i<permutation_list.size(); i++)
+    for (std::size_t i=0; i<permutation_list.size(); i++)
     libMesh::err<<permutation_list[i]<<" ";
 
     libMesh::err<<std::endl;

--- a/src/solution_transfer/dtk_evaluator.C
+++ b/src/solution_transfer/dtk_evaluator.C
@@ -71,7 +71,7 @@ DTKEvaluator::evaluate(const Teuchos::ArrayRCP<int> & elements,
 
       Number value = 0;
 
-      for (unsigned int j=0; j<dof_indices.size(); j++)
+      for (std::size_t j=0; j<dof_indices.size(); j++)
         value += current_local_solution(dof_indices[j]) * data.shape[j];
 
       values[i] = value;

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -83,7 +83,7 @@ void MeshfreeInterpolation::add_field_data (const std::vector<std::string> & fie
       if (_names.size() != field_names.size())
         libmesh_error_msg("ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 
-      for (unsigned int v=0; v<_names.size(); v++)
+      for (std::size_t v=0; v<_names.size(); v++)
         if (_names[v] != field_names[v])
           libmesh_error_msg("ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
     }
@@ -208,7 +208,7 @@ void InverseDistanceInterpolation<KDDim>::interpolate_field_data (const std::vec
   if (_names.size() != field_names.size())
     libmesh_error_msg("ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 
-  for (unsigned int v=0; v<_names.size(); v++)
+  for (std::size_t v=0; v<_names.size(); v++)
     if (_names[v] != field_names[v])
       libmesh_error_msg("ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 

--- a/src/solution_transfer/radial_basis_interpolation.C
+++ b/src/solution_transfer/radial_basis_interpolation.C
@@ -169,7 +169,7 @@ void RadialBasisInterpolation<KDDim,RBF>::interpolate_field_data (const std::vec
   if (this->_names.size() != field_names.size())
     libmesh_error_msg("ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 
-  for (unsigned int v=0; v<this->_names.size(); v++)
+  for (std::size_t v=0; v<this->_names.size(); v++)
     if (_names[v] != field_names[v])
       libmesh_error_msg("ERROR:  when adding field data to an existing list the \nvariable list must be the same!");
 

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -368,10 +368,8 @@ PetscLinearSolver<T>::restrict_solve_to (const std::vector<unsigned int> * const
       ierr = PetscMalloc(dofs->size()*sizeof(PetscInt), &petsc_dofs);
       LIBMESH_CHKERR(ierr);
 
-      for(size_t i=0; i<dofs->size(); i++)
-        {
-          petsc_dofs[i] = (*dofs)[i];
-        }
+      for (std::size_t i=0; i<dofs->size(); i++)
+        petsc_dofs[i] = (*dofs)[i];
 
       ierr = ISCreateLibMesh(this->comm().get(),dofs->size(),petsc_dofs,PETSC_OWN_POINTER,&_restrict_solve_to_is);
       LIBMESH_CHKERR(ierr);

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -201,7 +201,7 @@ std::pair<Real, Real> CondensedEigenSystem::get_eigenpair(dof_id_type i)
 
   // Now map temp to solution. Loop over local entries of local_non_condensed_dofs_vector
   this->solution->zero();
-  for (dof_id_type j=0; j<local_non_condensed_dofs_vector.size(); j++)
+  for (std::size_t j=0; j<local_non_condensed_dofs_vector.size(); j++)
     {
       dof_id_type index = local_non_condensed_dofs_vector[j];
       solution->set(index,(*temp)(temp->first_local_index()+j));

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -641,7 +641,7 @@ void EquationSystems::build_solution_vector (std::vector<Number> &,
 
   //       // Transfer the system solution to the element
   //       // solution by mapping it through the dof_indices vector.
-  //       for (unsigned int i=0; i<dof_indices.size(); i++)
+  //       for (std::size_t i=0; i<dof_indices.size(); i++)
   // elem_soln[i] = sys_soln[dof_indices[i]];
 
   //       // Using the FE interface, compute the nodal_soln
@@ -823,7 +823,7 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
 
                   elem_soln.resize(dof_indices.size());
 
-                  for (unsigned int i=0; i<dof_indices.size(); i++)
+                  for (std::size_t i=0; i<dof_indices.size(); i++)
                     elem_soln[i] = sys_soln(dof_indices[i]);
 
                   FEInterface::nodal_soln (dim,
@@ -1142,7 +1142,7 @@ void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> &
 
                     elem_soln.resize(dof_indices.size());
 
-                    for (unsigned int i=0; i<dof_indices.size(); i++)
+                    for (std::size_t i=0; i<dof_indices.size(); i++)
                       elem_soln[i] = sys_soln[dof_indices[i]];
 
                     FEInterface::nodal_soln (dim,

--- a/src/systems/explicit_system.C
+++ b/src/systems/explicit_system.C
@@ -90,7 +90,7 @@ void ExplicitSystem::assemble_qoi (const QoISet & qoi_indices)
 {
   // The user quantity of interest assembly gets to expect to
   // accumulate on initially zero values
-  for (unsigned int i=0; i != qoi.size(); ++i)
+  for (std::size_t i=0; i != qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       qoi[i] = 0;
 
@@ -105,7 +105,7 @@ void ExplicitSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
 {
   // The user quantity of interest derivative assembly gets to expect
   // to accumulate on initially zero vectors
-  for (unsigned int i=0; i != qoi.size(); ++i)
+  for (std::size_t i=0; i != qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       this->add_adjoint_rhs(i).zero();
 

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -335,7 +335,7 @@ void FEMContext::interior_values (unsigned int var,
   const std::vector<std::vector<OutputShape> > & phi = fe->get_phi();
 
   // Loop over all the q_points on this element
-  for (unsigned int qp=0; qp != u_vals.size(); qp++)
+  for (std::size_t qp=0; qp != u_vals.size(); qp++)
     {
       OutputType & u = u_vals[qp];
 
@@ -399,7 +399,7 @@ void FEMContext::interior_gradients(unsigned int var,
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputGradient> > & dphi = fe->get_dphi();
 
   // Loop over all the q_points in this finite element
-  for (unsigned int qp=0; qp != du_vals.size(); qp++)
+  for (std::size_t qp=0; qp != du_vals.size(); qp++)
     {
       OutputType & du = du_vals[qp];
 
@@ -463,7 +463,7 @@ void FEMContext::interior_hessians(unsigned int var,
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> > & d2phi = fe->get_d2phi();
 
   // Loop over all the q_points in this finite element
-  for (unsigned int qp=0; qp != d2u_vals.size(); qp++)
+  for (std::size_t qp=0; qp != d2u_vals.size(); qp++)
     {
       OutputType & d2u = d2u_vals[qp];
 
@@ -589,7 +589,7 @@ void FEMContext::side_values(unsigned int var,
   const std::vector<std::vector<OutputShape> > & phi = the_side_fe->get_phi();
 
   // Loop over all the q_points on this element
-  for (unsigned int qp=0; qp != u_vals.size(); qp++)
+  for (std::size_t qp=0; qp != u_vals.size(); qp++)
     {
       OutputType & u = u_vals[qp];
 
@@ -671,7 +671,7 @@ void FEMContext::side_gradients(unsigned int var,
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputGradient> > & dphi = the_side_fe->get_dphi();
 
   // Loop over all the q_points in this finite element
-  for (unsigned int qp=0; qp != du_vals.size(); qp++)
+  for (std::size_t qp=0; qp != du_vals.size(); qp++)
     {
       OutputType & du = du_vals[qp];
 
@@ -740,7 +740,7 @@ void FEMContext::side_hessians(unsigned int var,
   const std::vector<std::vector<typename FEGenericBase<OutputShape>::OutputTensor> > & d2phi = the_side_fe->get_d2phi();
 
   // Loop over all the q_points in this finite element
-  for (unsigned int qp=0; qp != d2u_vals.size(); qp++)
+  for (std::size_t qp=0; qp != d2u_vals.size(); qp++)
     {
       OutputType & d2u = d2u_vals[qp];
 

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -473,7 +473,7 @@ public:
     bool have_some_heterogenous_qoi_bc = false;
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
     std::vector<bool> have_heterogenous_qoi_bc(_sys.qoi.size(), false);
-    for (unsigned int q=0; q != _sys.qoi.size(); ++q)
+    for (std::size_t q=0; q != _sys.qoi.size(); ++q)
       if (_qoi_indices.has_index(q) &&
           _sys.get_dof_map().has_heterogenous_adjoint_constraints(q))
         {
@@ -499,12 +499,11 @@ public:
         std::vector<bool> elem_has_heterogenous_qoi_bc(_sys.qoi.size(), false);
         if (have_some_heterogenous_qoi_bc)
           {
-            for (unsigned int q=0; q != _sys.qoi.size(); ++q)
+            for (std::size_t q=0; q != _sys.qoi.size(); ++q)
               {
                 if (have_heterogenous_qoi_bc[q])
                   {
-                    for (unsigned int d=0;
-                         d != _femcontext.get_dof_indices().size(); ++d)
+                    for (std::size_t d=0; d != _femcontext.get_dof_indices().size(); ++d)
                       if (_sys.get_dof_map().has_heterogenous_adjoint_constraint
                           (q, _femcontext.get_dof_indices()[d]) != Number(0))
                         {
@@ -532,12 +531,11 @@ public:
           {
             _sys.time_solver->element_residual(false, _femcontext);
 
-            for (unsigned int q=0; q != _sys.qoi.size(); ++q)
+            for (std::size_t q=0; q != _sys.qoi.size(); ++q)
               {
                 if (elem_has_heterogenous_qoi_bc[q])
                   {
-                    for (unsigned int d=0;
-                         d != _femcontext.get_dof_indices().size(); ++d)
+                    for (std::size_t d=0; d != _femcontext.get_dof_indices().size(); ++d)
                       this->qoi[q] -= _femcontext.get_elem_residual()(d) *
                         _sys.get_dof_map().has_heterogenous_adjoint_constraint(q, _femcontext.get_dof_indices()[d]);
 
@@ -611,7 +609,7 @@ public:
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
     std::vector<bool> have_heterogenous_qoi_bc(_sys.qoi.size(), false);
     if (_include_liftfunc || _apply_constraints)
-      for (unsigned int q=0; q != _sys.qoi.size(); ++q)
+      for (std::size_t q=0; q != _sys.qoi.size(); ++q)
         if (_qoi_indices.has_index(q) &&
             _sys.get_dof_map().has_heterogenous_adjoint_constraints(q))
           {
@@ -637,12 +635,11 @@ public:
         std::vector<bool> elem_has_heterogenous_qoi_bc(_sys.qoi.size(), false);
         if (have_some_heterogenous_qoi_bc)
           {
-            for (unsigned int q=0; q != _sys.qoi.size(); ++q)
+            for (std::size_t q=0; q != _sys.qoi.size(); ++q)
               {
                 if (have_heterogenous_qoi_bc[q])
                   {
-                    for (unsigned int d=0;
-                         d != _femcontext.get_dof_indices().size(); ++d)
+                    for (std::size_t d=0; d != _femcontext.get_dof_indices().size(); ++d)
                       if (_sys.get_dof_map().has_heterogenous_adjoint_constraint
                           (q, _femcontext.get_dof_indices()[d]) != Number(0))
                         {
@@ -692,20 +689,18 @@ public:
         // may handle integrating
         if (_include_liftfunc && elem_has_some_heterogenous_qoi_bc)
           {
-            for (unsigned int q=0; q != _sys.qoi.size(); ++q)
+            for (std::size_t q=0; q != _sys.qoi.size(); ++q)
               {
                 if (elem_has_heterogenous_qoi_bc[q])
                   {
-                    for (unsigned int i=0;
-                         i != _femcontext.get_dof_indices().size(); ++i)
+                    for (std::size_t i=0; i != _femcontext.get_dof_indices().size(); ++i)
                       {
                         Number liftfunc_val =
                           _sys.get_dof_map().has_heterogenous_adjoint_constraint(q, _femcontext.get_dof_indices()[i]);
 
                         if (liftfunc_val != Number(0))
                           {
-                            for (unsigned int j=0;
-                                 j != _femcontext.get_dof_indices().size(); ++j)
+                            for (std::size_t j=0; j != _femcontext.get_dof_indices().size(); ++j)
                               _femcontext.get_qoi_derivatives()[q](j) -=
                                 _femcontext.get_elem_jacobian()(i,j) *
                                 liftfunc_val;
@@ -751,7 +746,7 @@ public:
             _sys.get_dof_map().constrain_nothing(_femcontext.get_dof_indices());
 #endif
 
-          for (unsigned int i=0; i != _sys.qoi.size(); ++i)
+          for (std::size_t i=0; i != _sys.qoi.size(); ++i)
             if (_qoi_indices.has_index(i))
               {
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
@@ -759,8 +754,7 @@ public:
                   {
 #ifndef NDEBUG
                     bool has_heterogenous_constraint = false;
-                    for (unsigned int d=0;
-                         d != _femcontext.get_dof_indices().size(); ++d)
+                    for (std::size_t d=0; d != _femcontext.get_dof_indices().size(); ++d)
                       if (_sys.get_dof_map().has_heterogenous_adjoint_constraint
                           (i, _femcontext.get_dof_indices()[d]) != Number(0))
                         {
@@ -1164,7 +1158,7 @@ void FEMSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
 
   // The quantity of interest derivative assembly accumulates on
   // initially zero vectors
-  for (unsigned int i=0; i != qoi.size(); ++i)
+  for (std::size_t i=0; i != qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       this->add_adjoint_rhs(i).zero();
 
@@ -1204,8 +1198,7 @@ void FEMSystem::numerical_jacobian (TimeSolverResPtr res,
 
       if (!context.get_dof_indices(v).empty())
         {
-          for (unsigned int i = 0;
-               i != context.get_dof_indices().size(); ++i)
+          for (std::size_t i = 0; i != context.get_dof_indices().size(); ++i)
             if (context.get_dof_indices()[i] ==
                 context.get_dof_indices(v)[0])
               j_offset = i;
@@ -1213,7 +1206,7 @@ void FEMSystem::numerical_jacobian (TimeSolverResPtr res,
           libmesh_assert_not_equal_to(j_offset, libMesh::invalid_uint);
         }
 
-      for (unsigned int j = 0; j != context.get_dof_indices(v).size(); ++j)
+      for (std::size_t j = 0; j != context.get_dof_indices(v).size(); ++j)
         {
           const unsigned int total_j = j + j_offset;
 
@@ -1264,7 +1257,7 @@ void FEMSystem::numerical_jacobian (TimeSolverResPtr res,
           if (coord)
             {
               *coord = libmesh_real(context.get_elem_solution(v)(j));
-              for (unsigned int i = 0; i != context.get_dof_indices().size(); ++i)
+              for (std::size_t i = 0; i != context.get_dof_indices().size(); ++i)
                 {
                   numeric_jacobian(i,total_j) =
                     (context.get_elem_residual()(i) - backwards_residual(i)) /
@@ -1273,7 +1266,7 @@ void FEMSystem::numerical_jacobian (TimeSolverResPtr res,
             }
           else
             {
-              for (unsigned int i = 0; i != context.get_dof_indices().size(); ++i)
+              for (std::size_t i = 0; i != context.get_dof_indices().size(); ++i)
                 {
                   numeric_jacobian(i,total_j) =
                     (context.get_elem_residual()(i) - backwards_residual(i)) /

--- a/src/systems/frequency_system.C
+++ b/src/systems/frequency_system.C
@@ -270,7 +270,7 @@ void FrequencySystem::set_frequencies (const std::vector<Real> & frequencies,
   es.parameters.set<unsigned int>("n_frequencies") = frequencies.size();
 
   // set frequencies, build solution storage
-  for (unsigned int n=0; n<frequencies.size(); n++)
+  for (std::size_t n=0; n<frequencies.size(); n++)
     {
       // remember frequencies as parameters
       es.parameters.set<Real>(this->form_freq_param_name(n)) = frequencies[n];

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -330,7 +330,7 @@ ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
 
   // Solve the linear system.
   SparseMatrix<Number> * pc = this->request_matrix("Preconditioner");
-  for (unsigned int p=0; p != parameters.size(); ++p)
+  for (std::size_t p=0; p != parameters.size(); ++p)
     {
       std::pair<unsigned int, Real> rval =
         linear_solver->solve (*matrix, pc,
@@ -345,7 +345,7 @@ ImplicitSystem::sensitivity_solve (const ParameterVector & parameters)
 
   // The linear solver may not have fit our constraints exactly
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  for (unsigned int p=0; p != parameters.size(); ++p)
+  for (std::size_t p=0; p != parameters.size(); ++p)
     this->get_dof_map().enforce_constraints_exactly
       (*this, &this->get_sensitivity_solution(p),
        /* homogeneous = */ true);
@@ -383,7 +383,7 @@ ImplicitSystem::adjoint_solve (const QoISet & qoi_indices)
     this->get_linear_solve_parameters();
   std::pair<unsigned int, Real> totalrval = std::make_pair(0,0.0);
 
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       {
         const std::pair<unsigned int, Real> rval =
@@ -400,7 +400,7 @@ ImplicitSystem::adjoint_solve (const QoISet & qoi_indices)
 
   // The linear solver may not have fit our constraints exactly
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       this->get_dof_map().enforce_adjoint_constraints_exactly
         (this->get_adjoint_solution(i), i);
@@ -433,7 +433,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
 
   // FIXME: The derivation here does not yet take adjoint boundary
   // conditions into account.
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       libmesh_assert(!this->get_dof_map().has_adjoint_dirichlet_boundaries(i));
 
@@ -444,7 +444,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   // any good reasons why users might want to save these:
 
   std::vector<NumericVector<Number> *> temprhs(this->qoi.size());
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       temprhs[i] = this->rhs->zero_clone().release();
 
@@ -475,7 +475,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   this->assemble_qoi_derivative(qoi_indices,
                                 /* include_liftfunc = */ false,
                                 /* apply_constraints = */ true);
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       {
         this->get_adjoint_rhs(i).close();
@@ -495,7 +495,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
   this->assemble_qoi_derivative(qoi_indices,
                                 /* include_liftfunc = */ false,
                                 /* apply_constraints = */ true);
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       {
         this->get_adjoint_rhs(i).close();
@@ -528,7 +528,7 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
     this->get_linear_solve_parameters();
   std::pair<unsigned int, Real> totalrval = std::make_pair(0,0.0);
 
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       {
         const std::pair<unsigned int, Real> rval =
@@ -543,13 +543,13 @@ ImplicitSystem::weighted_sensitivity_adjoint_solve (const ParameterVector & para
 
   this->release_linear_solver(linear_solver);
 
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       delete temprhs[i];
 
   // The linear solver may not have fit our constraints exactly
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       this->get_dof_map().enforce_constraints_exactly
         (*this, &this->get_weighted_sensitivity_adjoint_solution(i),
@@ -841,7 +841,7 @@ void ImplicitSystem::forward_qoi_parameter_sensitivity (const QoISet & qoi_indic
   // We don't need these to be closed() in this function, but libMesh
   // standard practice is to have them closed() by the time the
   // function exits
-  for (unsigned int i=0; i != this->qoi.size(); ++i)
+  for (std::size_t i=0; i != this->qoi.size(); ++i)
     if (qoi_indices.has_index(i))
       this->get_adjoint_rhs(i).close();
 

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -194,7 +194,7 @@ void LinearImplicitSystem::attach_shell_matrix (ShellMatrix<Number> * shell_matr
 
   // Solve the linear system.
   SparseMatrix<Number> * pc = this->request_matrix("Preconditioner");
-  for (unsigned int p=0; p != parameters.size(); ++p)
+  for (std::size_t p=0; p != parameters.size(); ++p)
   {
   rval = linear_solver->solve (*matrix, pc,
   this->get_sensitivity_solution(p),
@@ -205,7 +205,7 @@ void LinearImplicitSystem::attach_shell_matrix (ShellMatrix<Number> * shell_matr
 
   // Our matrix is the *negative* of the Jacobian for b-A*u, so our
   // solutions are all inverted
-  for (unsigned int p=0; p != parameters.size(); ++p)
+  for (std::size_t p=0; p != parameters.size(); ++p)
   {
   this->get_sensitivity_solution(p) *= -1.0;
   }

--- a/src/systems/parameter_vector.C
+++ b/src/systems/parameter_vector.C
@@ -29,7 +29,7 @@ ParameterVector::ParameterVector(const std::vector<Number *> &params)
 {
   _params.reserve(params.size());
 
-  for (unsigned int i=0; i != params.size(); ++i)
+  for (std::size_t i=0; i != params.size(); ++i)
     _params.push_back(new ParameterPointer<Number>(params[i]));
 }
 

--- a/src/systems/qoi_set.C
+++ b/src/systems/qoi_set.C
@@ -35,7 +35,7 @@ QoISet::QoISet(const System & sys) : _indices(sys.qoi.size(), true) {}
 unsigned int QoISet::size (const System & sys) const
 {
   unsigned int qoi_count = 0;
-  for (unsigned int i=0; i != sys.qoi.size(); ++i)
+  for (std::size_t i=0; i != sys.qoi.size(); ++i)
     if (this->has_index(i))
       qoi_count++;
   return qoi_count;

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1190,7 +1190,7 @@ unsigned int System::add_variables (const std::vector<std::string> & vars,
 
   // Make sure the variable isn't there already
   // or if it is, that it's the type we want
-  for (unsigned int ov=0; ov<vars.size(); ov++)
+  for (std::size_t ov=0; ov<vars.size(); ov++)
     for (unsigned int v=0; v<this->n_vars(); v++)
       if (this->variable_name(v) == vars[ov])
         {
@@ -1215,7 +1215,7 @@ unsigned int System::add_variables (const std::vector<std::string> & vars,
   const VariableGroup & vg (_variable_groups.back());
 
   // Add each component of the group individually
-  for (unsigned short v=0; v<vars.size(); v++)
+  for (std::size_t v=0; v<vars.size(); v++)
     {
       _variables.push_back (vg(v));
       _variable_numbers[vars[v]] = cast_int<unsigned short>
@@ -1311,7 +1311,7 @@ void System::local_dof_indices(const unsigned int var,
       const Elem * elem = *el;
       this->get_dof_map().dof_indices (elem, dof_indices, var);
 
-      for(unsigned int i=0; i<dof_indices.size(); i++)
+      for (std::size_t i=0; i<dof_indices.size(); i++)
         {
           dof_id_type dof = dof_indices[i];
 
@@ -1655,20 +1655,13 @@ Real System::calculate_norm(const NumericVector<Number> & v,
         }
 
       // Need to delete the FE and quadrature objects to prevent a memory leak
-      for(unsigned int i=0; i<fe_ptrs.size(); i++)
-        {
-          if(fe_ptrs[i])
-            {
-              delete fe_ptrs[i];
-            }
-        }
-      for(unsigned int i=0; i<q_rules.size(); i++)
-        {
-          if(q_rules[i])
-            {
-              delete q_rules[i];
-            }
-        }
+      for (std::size_t i=0; i<fe_ptrs.size(); i++)
+        if (fe_ptrs[i])
+          delete fe_ptrs[i];
+
+      for (std::size_t i=0; i<q_rules.size(); i++)
+        if (q_rules[i])
+          delete q_rules[i];
     }
 
   if (using_hilbert_norm)

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -629,10 +629,8 @@ void System::read_parallel_data (Xdr & io,
               std::vector<dof_id_type> SCALAR_dofs;
               dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-              for(unsigned int i=0; i<SCALAR_dofs.size(); i++)
-                {
-                  this->solution->set( SCALAR_dofs[i], io_buffer[cnt++] );
-                }
+              for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
+                this->solution->set(SCALAR_dofs[i], io_buffer[cnt++]);
             }
         }
     }
@@ -720,10 +718,8 @@ void System::read_parallel_data (Xdr & io,
                           std::vector<dof_id_type> SCALAR_dofs;
                           dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-                          for(unsigned int i=0; i<SCALAR_dofs.size(); i++)
-                            {
-                              pos->second->set( SCALAR_dofs[i], io_buffer[cnt++] );
-                            }
+                          for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
+                            pos->second->set(SCALAR_dofs[i], io_buffer[cnt++]);
                         }
                     }
                 }
@@ -1039,7 +1035,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
 
               // note its possible we didn't receive values for objects in
               // this block if they have no components allocated.
-              for (dof_id_type idx=0; idx<ids.size(); idx+=2)
+              for (std::size_t idx=0; idx<ids.size(); idx+=2)
                 {
                   const dof_id_type
                     local_idx          = ids[idx+0]-first_object,
@@ -1068,7 +1064,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
           // Wait for read completion
           async_io.join();
           // now copy the values back to the main vector for transfer
-          for (unsigned int i_val=0; i_val<input_vals.size(); i_val++)
+          for (std::size_t i_val=0; i_val<input_vals.size(); i_val++)
             input_vals[i_val] = input_vals_tmp[i_val];
 
           n_read_values += input_vals.size();
@@ -1192,7 +1188,7 @@ unsigned int System::read_SCALAR_dofs (const unsigned int var,
       std::vector<dof_id_type> SCALAR_dofs;
       dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-      for(unsigned int i=0; i<SCALAR_dofs.size(); i++)
+      for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
         {
           if (vec)
             vec->set (SCALAR_dofs[i], input_buffer[i]);
@@ -1645,10 +1641,8 @@ void System::write_parallel_data (Xdr & io,
             std::vector<dof_id_type> SCALAR_dofs;
             dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-            for(unsigned int i=0; i<SCALAR_dofs.size(); i++)
-              {
-                io_buffer.push_back( (*this->solution)(SCALAR_dofs[i]) );
-              }
+            for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
+              io_buffer.push_back((*this->solution)(SCALAR_dofs[i]));
           }
       }
 
@@ -1715,10 +1709,8 @@ void System::write_parallel_data (Xdr & io,
                     std::vector<dof_id_type> SCALAR_dofs;
                     dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-                    for(unsigned int i=0; i<SCALAR_dofs.size(); i++)
-                      {
-                        io_buffer.push_back( (*pos->second)(SCALAR_dofs[i]) );
-                      }
+                    for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
+                      io_buffer.push_back((*pos->second)(SCALAR_dofs[i]));
                   }
               }
 
@@ -2065,7 +2057,7 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
 
               // note its possible we didn't receive values for objects in
               // this block if they have no components allocated.
-              for (dof_id_type idx=0; idx<ids.size(); idx+=2)
+              for (std::size_t idx=0; idx<ids.size(); idx+=2)
                 {
                   const dof_id_type
                     local_idx          = ids[idx+0]-first_object,
@@ -2112,7 +2104,7 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
               const std::vector<Number>      & vals(recv_vals[proc]);
               std::vector<Number>::const_iterator proc_vals(vals.begin());
 
-              for (dof_id_type idx=0; idx<ids.size(); idx+=2)
+              for (std::size_t idx=0; idx<ids.size(); idx+=2)
                 {
                   const dof_id_type
                     local_idx          = ids[idx+0]-first_object,
@@ -2334,7 +2326,7 @@ std::size_t System::read_serialized_vectors (Xdr & io,
 
   //-------------------------------------------
   // Finally loop over all the SCALAR variables
-  for (unsigned int vec=0; vec<vectors.size(); vec++)
+  for (std::size_t vec=0; vec<vectors.size(); vec++)
     for (unsigned int var=0; var<this->n_vars(); var++)
       if(this->variable(var).type().family == SCALAR)
         {
@@ -2346,7 +2338,7 @@ std::size_t System::read_serialized_vectors (Xdr & io,
 
   //---------------------------------------
   // last step - must close all the vectors
-  for (unsigned int vec=0; vec<vectors.size(); vec++)
+  for (std::size_t vec=0; vec<vectors.size(); vec++)
     {
       libmesh_assert_not_equal_to (vectors[vec], 0);
       vectors[vec]->close();
@@ -2403,7 +2395,7 @@ std::size_t System::write_serialized_vectors (Xdr & io,
 
   //-------------------------------------------
   // Finally loop over all the SCALAR variables
-  for (unsigned int vec=0; vec<vectors.size(); vec++)
+  for (std::size_t vec=0; vec<vectors.size(); vec++)
     for (unsigned int var=0; var<this->n_vars(); var++)
       if(this->variable(var).type().family == SCALAR)
         {

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1101,7 +1101,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
 
   // Loop over all the variables we've been requested to project, to
   // pre-request
-  for (unsigned int v=0; v!=variables.size(); v++)
+  for (std::size_t v=0; v!=variables.size(); v++)
     {
       const unsigned int var = variables[v];
 
@@ -1182,7 +1182,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
 
       // Loop over all the variables we've been requested to project, to
       // do the projection
-      for (unsigned int v=0; v!=variables.size(); v++)
+      for (std::size_t v=0; v!=variables.size(); v++)
         {
           const unsigned int var = variables[v];
 
@@ -1597,7 +1597,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
                   // Some edge dofs are on nodes and already
                   // fixed, others are free to calculate
                   unsigned int free_dofs = 0;
-                  for (unsigned int i=0; i != side_dofs.size(); ++i)
+                  for (std::size_t i=0; i != side_dofs.size(); ++i)
                     if (!dof_is_fixed[side_dofs[i]])
                       free_dof[free_dofs++] = i;
 
@@ -1627,14 +1627,14 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
                                                     system.time);
 
                       // Form edge projection matrix
-                      for (unsigned int sidei=0, freei=0;
+                      for (std::size_t sidei=0, freei=0;
                            sidei != side_dofs.size(); ++sidei)
                         {
                           unsigned int i = side_dofs[sidei];
                           // fixed DoFs aren't test functions
                           if (dof_is_fixed[i])
                             continue;
-                          for (unsigned int sidej=0, freej=0;
+                          for (std::size_t sidej=0, freej=0;
                                sidej != side_dofs.size(); ++sidej)
                             {
                               unsigned int j = side_dofs[sidej];
@@ -1731,7 +1731,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
                   // Some side dofs are on nodes/edges and already
                   // fixed, others are free to calculate
                   unsigned int free_dofs = 0;
-                  for (unsigned int i=0; i != side_dofs.size(); ++i)
+                  for (std::size_t i=0; i != side_dofs.size(); ++i)
                     if (!dof_is_fixed[side_dofs[i]])
                       free_dof[free_dofs++] = i;
 
@@ -1802,14 +1802,14 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
                                                     system.time);
 
                       // Form side projection matrix
-                      for (unsigned int sidei=0, freei=0;
+                      for (std::size_t sidei=0, freei=0;
                            sidei != side_dofs.size(); ++sidei)
                         {
                           unsigned int i = side_dofs[sidei];
                           // fixed DoFs aren't test functions
                           if (dof_is_fixed[i])
                             continue;
-                          for (unsigned int sidej=0, freej=0;
+                          for (std::size_t sidej=0, freej=0;
                                sidej != side_dofs.size(); ++sidej)
                             {
                               unsigned int j = side_dofs[sidej];
@@ -2108,7 +2108,7 @@ void BuildProjectionList::operator()(const ConstElemRange & range)
       else
         dof_map.old_dof_indices (elem, di);
 
-      for (unsigned int i=0; i != di.size(); ++i)
+      for (std::size_t i=0; i != di.size(); ++i)
         if (di[i] < first_old_dof || di[i] >= end_old_dof)
           this->send_list.push_back(di[i]);
     }  // end elem loop
@@ -2160,7 +2160,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
 
 
   // Loop over all the variables we've been requested to project
-  for (unsigned int v=0; v!=variables.size(); v++)
+  for (std::size_t v=0; v!=variables.size(); v++)
     {
       const unsigned int var = variables[v];
 
@@ -2454,7 +2454,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                 // Some edge dofs are on nodes and already
                 // fixed, others are free to calculate
                 unsigned int free_dofs = 0;
-                for (unsigned int i=0; i != side_dofs.size(); ++i)
+                for (std::size_t i=0; i != side_dofs.size(); ++i)
                   if (!dof_is_fixed[side_dofs[i]])
                     free_dof[free_dofs++] = i;
 
@@ -2487,14 +2487,14 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                                               system.time);
 
                     // Form edge projection matrix
-                    for (unsigned int sidei=0, freei=0;
+                    for (std::size_t sidei=0, freei=0;
                          sidei != side_dofs.size(); ++sidei)
                       {
                         unsigned int i = side_dofs[sidei];
                         // fixed DoFs aren't test functions
                         if (dof_is_fixed[i])
                           continue;
-                        for (unsigned int sidej=0, freej=0;
+                        for (std::size_t sidej=0, freej=0;
                              sidej != side_dofs.size(); ++sidej)
                           {
                             unsigned int j = side_dofs[sidej];
@@ -2552,7 +2552,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                 // Some side dofs are on nodes/edges and already
                 // fixed, others are free to calculate
                 unsigned int free_dofs = 0;
-                for (unsigned int i=0; i != side_dofs.size(); ++i)
+                for (std::size_t i=0; i != side_dofs.size(); ++i)
                   if (!dof_is_fixed[side_dofs[i]])
                     free_dof[free_dofs++] = i;
 
@@ -2585,14 +2585,14 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                                               system.time);
 
                     // Form side projection matrix
-                    for (unsigned int sidei=0, freei=0;
+                    for (std::size_t sidei=0, freei=0;
                          sidei != side_dofs.size(); ++sidei)
                       {
                         unsigned int i = side_dofs[sidei];
                         // fixed DoFs aren't test functions
                         if (dof_is_fixed[i])
                           continue;
-                        for (unsigned int sidej=0, freej=0;
+                        for (std::size_t sidej=0, freej=0;
                              sidej != side_dofs.size(); ++sidej)
                           {
                             unsigned int j = side_dofs[sidej];

--- a/src/systems/system_subset_by_subdomain.C
+++ b/src/systems/system_subset_by_subdomain.C
@@ -134,7 +134,7 @@ init (const SubdomainSelection & subdomain_selection)
           for (; it!=itEnd; ++it)
             {
               dof_map.dof_indices (elem, dof_indices, *it);
-              for(size_t i=0; i<dof_indices.size(); i++)
+              for (std::size_t i=0; i<dof_indices.size(); i++)
                 {
                   const dof_id_type dof = dof_indices[i];
                   for(processor_id_type proc=0; proc<this->n_processors(); proc++)
@@ -169,10 +169,8 @@ init (const SubdomainSelection & subdomain_selection)
         {
           this->comm().receive(proc,received_dofs);
         }
-      for(unsigned int i=0; i<received_dofs.size(); i++)
-        {
-          _dof_ids.push_back(received_dofs[i]);
-        }
+      for (std::size_t i=0; i<received_dofs.size(); i++)
+        _dof_ids.push_back(received_dofs[i]);
     }
 
   /* Sort and unique the vector (using the same mechanism as in \p

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -174,13 +174,13 @@ std::string PerfLog::get_info_header() const
 
       // Find the longest string in all the streams
       unsigned int max_length = 0;
-      for (unsigned int i=0; i<v.size(); ++i)
+      for (std::size_t i=0; i<v.size(); ++i)
         if (v[i]->str().size() > max_length)
           max_length = cast_int<unsigned int>
             (v[i]->str().size());
 
       // Find the longest string in the parsed_libmesh_configure_info
-      for (unsigned i=0; i<parsed_libmesh_configure_info.size(); ++i)
+      for (std::size_t i=0; i<parsed_libmesh_configure_info.size(); ++i)
         if (parsed_libmesh_configure_info[i].size() > max_length)
           max_length = cast_int<unsigned int>
             (parsed_libmesh_configure_info[i].size());
@@ -191,7 +191,7 @@ std::string PerfLog::get_info_header() const
           << '\n';
 
       // Loop over all the strings and add end formatting
-      for (unsigned int i=0; i<v.size(); ++i)
+      for (std::size_t i=0; i<v.size(); ++i)
         {
           if (v[i]->str().size())
             oss << v[i]->str()
@@ -214,7 +214,7 @@ std::string PerfLog::get_info_header() const
 
       // Loop over the parsed_libmesh_configure_info and add end formatting.  The magic
       // number 3 below accounts for the leading 'pipe' character and indentation
-      for (unsigned i=1; i<parsed_libmesh_configure_info.size(); ++i)
+      for (std::size_t i=1; i<parsed_libmesh_configure_info.size(); ++i)
         {
           oss << "|  "
               << parsed_libmesh_configure_info[i]

--- a/src/utils/plt_loader_read.C
+++ b/src/utils/plt_loader_read.C
@@ -857,7 +857,7 @@ void PltLoader::read_block_data (std::istream & in, const unsigned int zone)
 
             in.read ((char *) &data[0], LIBMESH_SIZEOF_FLOAT*data.size());
 
-            for (unsigned int i=0; i<data.size(); i++)
+            for (std::size_t i=0; i<data.size(); i++)
               rb(data[i]);
 
             break;
@@ -880,7 +880,7 @@ void PltLoader::read_block_data (std::istream & in, const unsigned int zone)
 
             in.read ((char *) &ddata[0], LIBMESH_SIZEOF_DOUBLE*ddata.size());
 
-            for (unsigned int i=0; i<data.size(); i++)
+            for (std::size_t i=0; i<data.size(); i++)
               data[i] = rb(ddata[i]);
 
             break;
@@ -970,7 +970,7 @@ void PltLoader::read_feblock_data (std::istream & in, const unsigned int zone)
 
             in.read ((char *) &data[0], LIBMESH_SIZEOF_FLOAT*data.size());
 
-            for (unsigned int i=0; i<data.size(); i++)
+            for (std::size_t i=0; i<data.size(); i++)
               rb(data[i]);
 
             break;
@@ -988,7 +988,7 @@ void PltLoader::read_feblock_data (std::istream & in, const unsigned int zone)
 
             in.read ((char *) &ddata[0], LIBMESH_SIZEOF_DOUBLE*ddata.size());
 
-            for (unsigned int i=0; i<data.size(); i++)
+            for (std::size_t i=0; i<data.size(); i++)
               data[i] = rb(ddata[i]);
 
             break;
@@ -1019,7 +1019,7 @@ void PltLoader::read_feblock_data (std::istream & in, const unsigned int zone)
 
         in.read ((char *) &_conn[zone][0], LIBMESH_SIZEOF_INT*_conn[zone].size());
 
-        for (unsigned int i=0; i<_conn[zone].size(); i++)
+        for (std::size_t i=0; i<_conn[zone].size(); i++)
           rb(_conn[zone][i]);
       }
   }
@@ -1094,7 +1094,7 @@ void PltLoader::read_fepoint_data (std::istream & in, const unsigned int zone)
 
         in.read ((char *) &_conn[zone][0], LIBMESH_SIZEOF_INT*_conn[zone].size());
 
-        for (unsigned int i=0; i<_conn[zone].size(); i++)
+        for (std::size_t i=0; i<_conn[zone].size(); i++)
           rb(_conn[zone][i]);
       }
   }

--- a/src/utils/plt_loader_write.C
+++ b/src/utils/plt_loader_write.C
@@ -220,7 +220,7 @@ namespace libMesh
 //   if (zn == 0)
 //     libMesh::out << "  Writing ";
 
-//   for (unsigned int i=0; i<write_vars.size(); i++)
+//   for (std::size_t i=0; i<write_vars.size(); i++)
 //     {
 //       // Number of the variable to write
 //       const unsigned int v = write_vars[i];

--- a/src/utils/statistics.C
+++ b/src/utils/statistics.C
@@ -194,7 +194,7 @@ void StatisticsVector<T>::histogram(std::vector<dof_id_type> & bin_members,
   LOG_SCOPE ("histogram()", "StatisticsVector");
 
   std::vector<Real> bin_bounds(n_bins+1);
-  for (unsigned int i=0; i<bin_bounds.size(); i++)
+  for (std::size_t i=0; i<bin_bounds.size(); i++)
     bin_bounds[i] = min + i * bin_size;
 
   // Give the last bin boundary a little wiggle room: we don't want
@@ -206,7 +206,7 @@ void StatisticsVector<T>::histogram(std::vector<dof_id_type> & bin_members,
   bin_members.resize(n_bins);
 
   dof_id_type data_index = 0;
-  for (unsigned int j=0; j<bin_members.size(); j++) // bin vector indexing
+  for (std::size_t j=0; j<bin_members.size(); j++) // bin vector indexing
     {
       // libMesh::out << "(debug) Filling bin " << j << std::endl;
 
@@ -291,14 +291,14 @@ void StatisticsVector<T>::plot_histogram(const processor_id_type my_procid,
 
       // abscissa values are located at the center of each bin.
       out_stream << "x=[";
-      for (unsigned int i=0; i<bin_members.size(); ++i)
+      for (std::size_t i=0; i<bin_members.size(); ++i)
         {
           out_stream << min + (i+0.5)*bin_size << " ";
         }
       out_stream << "];\n";
 
       out_stream << "y=[";
-      for (unsigned int i=0; i<bin_members.size(); ++i)
+      for (std::size_t i=0; i<bin_members.size(); ++i)
         {
           out_stream << bin_members[i] << " ";
         }

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -55,7 +55,7 @@ void TopologyMap::add_node(const Node & mid_node,
 
   libmesh_assert_not_equal_to(mid_node_id, DofObject::invalid_id);
 
-  for (unsigned int i=0; i != bracketing_nodes.size(); ++i)
+  for (std::size_t i=0; i != bracketing_nodes.size(); ++i)
     {
       const dof_id_type id1 = bracketing_nodes[i].first;
       const dof_id_type id2 = bracketing_nodes[i].second;
@@ -82,7 +82,7 @@ dof_id_type TopologyMap::find(const std::vector<std::pair<dof_id_type, dof_id_ty
 {
   dof_id_type new_node_id = DofObject::invalid_id;
 
-  for (unsigned int i = 0; i != bracketing_nodes.size(); ++i)
+  for (std::size_t i = 0; i != bracketing_nodes.size(); ++i)
     {
       const dof_id_type lower_id = std::min(bracketing_nodes[i].first,
                                             bracketing_nodes[i].second);

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -126,7 +126,7 @@ bool TreeNode<N>::insert (const Elem * elem)
         {
           element_count = 0;
           unsigned char highest_dim_elem = *elem_dimensions.rbegin();
-          for(unsigned int i=0; i<elements.size(); i++)
+          for (std::size_t i=0; i<elements.size(); i++)
           {
             if(elements[i]->dim() == highest_dim_elem)
             {
@@ -181,11 +181,11 @@ void TreeNode<N>::refine ()
       children[c]->set_bounding_box(this->create_bounding_box(c));
 
       // Pass off our nodes to our children
-      for (unsigned int n=0; n<nodes.size(); n++)
+      for (std::size_t n=0; n<nodes.size(); n++)
         children[c]->insert(nodes[n]);
 
       // Pass off our elements to our children
-      for (unsigned int e=0; e<elements.size(); e++)
+      for (std::size_t e=0; e<elements.size(); e++)
         children[c]->insert(elements[e]);
     }
 
@@ -375,14 +375,14 @@ void TreeNode<N>::print_nodes(std::ostream & out_stream) const
     {
       out_stream << "TreeNode Level: " << this->level() << std::endl;
 
-      for (unsigned int n=0; n<nodes.size(); n++)
+      for (std::size_t n=0; n<nodes.size(); n++)
         out_stream << " " << nodes[n]->id();
 
       out_stream << std::endl << std::endl;
     }
   else
     {
-      for (unsigned int child=0; child<children.size(); child++)
+      for (std::size_t child=0; child<children.size(); child++)
         children[child]->print_nodes();
     }
 }
@@ -404,7 +404,7 @@ void TreeNode<N>::print_elements(std::ostream & out_stream) const
     }
   else
     {
-      for (unsigned int child=0; child<children.size(); child++)
+      for (std::size_t child=0; child<children.size(); child++)
         children[child]->print_elements();
     }
 }
@@ -423,7 +423,7 @@ void TreeNode<N>::transform_nodes_to_elements (std::vector<std::vector<const Ele
       // set to eliminate the duplication.
       std::set<const Elem *> elements_set;
 
-      for (unsigned int n=0; n<nodes.size(); n++)
+      for (std::size_t n=0; n<nodes.size(); n++)
         {
           // the actual global node number we are replacing
           // with the connected elements
@@ -432,7 +432,7 @@ void TreeNode<N>::transform_nodes_to_elements (std::vector<std::vector<const Ele
           libmesh_assert_less (node_number, mesh.n_nodes());
           libmesh_assert_less (node_number, nodes_to_elem.size());
 
-          for (unsigned int e=0; e<nodes_to_elem[node_number].size(); e++)
+          for (std::size_t e=0; e<nodes_to_elem[node_number].size(); e++)
             elements_set.insert(nodes_to_elem[node_number][e]);
         }
 
@@ -462,7 +462,7 @@ void TreeNode<N>::transform_nodes_to_elements (std::vector<std::vector<const Ele
     }
   else
     {
-      for (unsigned int child=0; child<children.size(); child++)
+      for (std::size_t child=0; child<children.size(); child++)
         children[child]->transform_nodes_to_elements (nodes_to_elem);
     }
 
@@ -480,7 +480,7 @@ unsigned int TreeNode<N>::n_active_bins() const
     {
       unsigned int sum=0;
 
-      for (unsigned int c=0; c<children.size(); c++)
+      for (std::size_t c=0; c<children.size(); c++)
         sum += children[c]->n_active_bins();
 
       return sum;
@@ -532,7 +532,7 @@ const Elem * TreeNode<N>::find_element_in_children (const Point & p,
 
   // First only look in the children whose bounding box
   // contain the point p.
-  for (unsigned int c=0; c<children.size(); c++)
+  for (std::size_t c=0; c<children.size(); c++)
     if (children[c]->bounds_point(p, relative_tol))
       {
         const Elem * e =
@@ -555,7 +555,7 @@ const Elem * TreeNode<N>::find_element_in_children (const Point & p,
   // was searched and did not find any elements containing
   // the point p.  So, let's look at the other children
   // but exclude the one we have already searched.
-  for (unsigned int c=0; c<children.size(); c++)
+  for (std::size_t c=0; c<children.size(); c++)
     if (!searched_child[c])
       {
         const Elem * e =

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -634,7 +634,7 @@ void Xdr::do_read(std::vector<T> & a)
   data(length, "# vector length");
   a.resize(length);
 
-  for (unsigned int i=0; i<a.size(); i++)
+  for (std::size_t i=0; i<a.size(); i++)
     {
       libmesh_assert(in.get());
       libmesh_assert (in->good());
@@ -650,7 +650,7 @@ void Xdr::do_read(std::vector<std::complex<T> > & a)
   data(length, "# vector length x 2 (complex)");
   a.resize(length);
 
-  for (unsigned int i=0; i<a.size(); i++)
+  for (std::size_t i=0; i<a.size(); i++)
     {
       T r, im;
       libmesh_assert(in.get());


### PR DESCRIPTION
We initially used `unsigned int` when looping to `std::vector::size()` but technically the type of `size()` is `std::size_t`.  Newer code seems to have used this convention in a few places already, this just gets most of the remaining places...