### PR TITLE
EquationSystems::reinit preserve refinement flags

### DIFF
--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -454,6 +454,24 @@ public:
    **/
   void allgather ();
 
+  /**
+   * Calls to reinit() will also do two-step coarsen-then-refine
+   **/
+  void enable_refine_in_reinit()
+    { this->_refine_in_reinit = true; }
+
+  /**
+   * Calls to reinit() will not try to coarsen or refine the mesh
+   **/
+  void disable_refine_in_reinit()
+    { this->_refine_in_reinit = false; }
+
+  /**
+   * @returns whether or not calls to reinit() will try to coarsen/refine the mesh
+   **/
+  bool refine_in_reinit_flag()
+    { return this->_refine_in_reinit; }
+
 
   /**
    * Data structure holding arbitrary parameters.
@@ -489,6 +507,12 @@ protected:
    * Typedef for constatnt system iterators
    */
   typedef std::map<std::string, System *>::const_iterator const_system_iterator;
+
+  /**
+   * Flag for whether to call coarsen/refine in reinit().
+   * Default value: true
+   */
+  bool _refine_in_reinit;
 
 private:
 


### PR DESCRIPTION
I mentioned a few months ago on `libmesh-devel` that if an app (such as `GRINS`) calls `refine_and_coarsen_elements()` and then `es->reinit()`, the `JUST_REFINED` and `JUST_COARSENED` element flags get cleared out by the calls to `coarsen_elements()` and `refine_elements()` within `EquationSystems::reinit()`. My `GRINS::RayfireMesh` class requires that these flags be set properly post-reinit.

This PR adds a flag to `EquationSystems` that, when set to `false`, skips over these refine/coarsen calls, preserving the refinement flags. By default in the ES constructor, this flag is set to `true`, maintaining backward compatibility.

A `CPPUNIT` test is included to verify that the refinement flags for a simple 2-element mesh are correct post-reinit. Also tested this with a `GRINS` QoI AMR run that originally exposed this issue.

`make check` passes for both libMesh and `GRINS`. I welcome any comments on the variable/function naming or any other suggestions. In particular, I am unsure if the call to mesh `contract` (line 262) should be inside or outside the guarding `if` statement (line 234).