### PR TITLE
Ignore Eigen warnings

### DIFF
--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -27,7 +27,9 @@
 #include "libmesh/tensor_tools.h"
 
 #ifdef LIBMESH_HAVE_EIGEN
+#include "libmesh/ignore_warnings.h"
 #include <Eigen/Dense>
+#include "libmesh/restore_warnings.h"
 #endif
 
 // C++ includes

--- a/include/numerics/eigen_core_support.h
+++ b/include/numerics/eigen_core_support.h
@@ -40,13 +40,15 @@
 // #endif
 
 // Eigen uses deprecated std::binder1st/2nd classes, which GCC warns about.
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// GCC 6.1 also warns about misleading indentation from if blocks in
+// Eigen.
+#include "libmesh/ignore_warnings.h"
 
 // Eigen includes
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
 
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
+#include "libmesh/restore_warnings.h"
 
 // #ifdef libMeshSaveMatType
 // #  define libMeshSaveMatType MatType

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -45,5 +45,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 // Ignore warnings from code that uses deprecated members of std, like std::auto_ptr.
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// Ignore warnings from code that does "if (foo) bar();"
+#pragma GCC diagnostic ignored "-Wmisleading-indentation"
 #endif // GCC > 4.1
 #endif // __GNUC__ && !__INTEL_COMPILER

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -29,9 +29,10 @@
 // GCC > 4.1 supports diagnostic pragmas
 #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 1)
 // TODO: use the gcc 4.6 push/pop when available
+#pragma GCC diagnostic warning "-Wmisleading-indentation"
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
 #pragma GCC diagnostic warning "-Wunused-parameter"
 #pragma GCC diagnostic warning "-Wdeprecated"
 #pragma GCC diagnostic warning "-Wpedantic"
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
 #endif // GCC > 4.1
 #endif // __GNUC__ && !__INTEL_COMPILER


### PR DESCRIPTION
There are multiple warning sources in our contrib Eigen headers with
gcc 6.1, and dense_vector.h now imports those headers practically
*everywhere*.