### PR TITLE
Ignore CppUnit warnings in Trilinos unit test

### DIFF
--- a/tests/numerics/trilinos_epetra_vector_test.C
+++ b/tests/numerics/trilinos_epetra_vector_test.C
@@ -7,6 +7,16 @@
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
 
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
 using namespace libMesh;
 
 class EpetraVectorTest : public NumericVectorTest<EpetraVector<Real> > {


### PR DESCRIPTION
We do this in all the other unit tests to prevent GCC from whining
about CppUnit's deprecated use of auto_ptr.  Not sure how we missed
one.