### PR TITLE
Small optimization in TreeNode

### DIFF
--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -221,6 +221,11 @@ private:
    * Does this node contain any infinite elements.
    */
   bool contains_ifems;
+
+  /**
+   * Used in find_element_in_children
+   */
+  mutable std::vector<bool> searched_child;
 };
 
 

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -528,7 +528,10 @@ const Elem * TreeNode<N>::find_element_in_children (const Point & p,
 {
   libmesh_assert (!this->active());
 
-  std::vector<bool> searched_child(children.size(), false);
+  if (searched_child.size() != children.size())
+    searched_child.resize(children.size(), false);
+
+  std::fill(searched_child.begin(), searched_child.end(), false);
 
   // First only look in the children whose bounding box
   // contain the point p.


### PR DESCRIPTION
This little optimization gives ~10% speedup in heavy Tree searching activity.

And, yes, the `if` statement is actually necessary!  Without it... just the `resize()` call takes ~2% of runtime.  It really shouldn't since most of the time each TreeNode is going to have the same number of children so it should be a no-op.

My only guess is that once again `std::vector<bool>` is rearing its ugly head... maybe it doesn't have an optimized version of `resize()` for the case where the size is staying the same since it's an odd duck.  (pinging @permcody so he can weigh in on that 😎 )

This falls in the category of: Found while idly running Instruments while waiting on something to solve 😄 