### PR TITLE
Ignore -Wmisleading-indentation on GCC 6+ only

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -45,7 +45,9 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 // Ignore warnings from code that uses deprecated members of std, like std::auto_ptr.
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#if (__GNUC__ > 5)
 // Ignore warnings from code that does "if (foo) bar();"
 #pragma GCC diagnostic ignored "-Wmisleading-indentation"
+#endif // GCC > 5
 #endif // GCC > 4.1
 #endif // __GNUC__ && !__INTEL_COMPILER

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -29,7 +29,9 @@
 // GCC > 4.1 supports diagnostic pragmas
 #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 1)
 // TODO: use the gcc 4.6 push/pop when available
+#if (__GNUC__ > 5)
 #pragma GCC diagnostic warning "-Wmisleading-indentation"
+#endif // GCC > 5
 #pragma GCC diagnostic warning "-Wdeprecated-declarations"
 #pragma GCC diagnostic warning "-Wunused-parameter"
 #pragma GCC diagnostic warning "-Wdeprecated"


### PR DESCRIPTION
GCC 5 and below heard we like ignoring warnings so they warn us about
an unrecognized warning and we had to ignore a warning in the
ignore_warnings header.

Hopefully this PR fixes the gcc 4.9 spew @BalticPinguin discovered after #1235 