### PR TITLE
Only use out_of_mesh_value in out_of_mesh_mode

### DIFF
--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -257,6 +257,9 @@ void MeshFunction::operator() (const Point & p,
 
   if (!element)
     {
+      // We'd better be in out_of_mesh_mode if we couldn't find an
+      // element in the mesh
+      libmesh_assert (_out_of_mesh_mode);
       output = _out_of_mesh_value;
     }
   else

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -217,6 +217,12 @@ Real RBEIMConstruction::train_reduced_basis(const bool resize_rb_eval_data)
 Number RBEIMConstruction::evaluate_mesh_function(unsigned int var_number,
                                                  Point p)
 {
+  // Set default values to be an empty vector so that we can use it
+  // below
+  // to check if this processor returned valid data.
+  DenseVector<Number> default_values;
+  _mesh_function->enable_out_of_mesh_mode(default_values);
+
   _mesh_function->set_point_locator_tolerance( get_point_locator_tol() );
 
   DenseVector<Number> values;

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -233,11 +233,7 @@ const Elem * PointLocatorTree::operator() (const Point & p,
           // out-of-mesh mode this is sometimes expected, and we can
           // just return NULL without searching further.  Out of
           // out-of-mesh mode, something must have gone wrong.
-
-          // We'll avoid making this assertion just yet, though,
-          // because some users are leaving out_of_mesh_mode disabled
-          // as a workaround for old PointLocatorTree behavior.
-          // libmesh_assert_equal_to (_out_of_mesh_mode, true);
+          libmesh_assert_equal_to (_out_of_mesh_mode, true);
 
           return this->_element;
         }


### PR DESCRIPTION
If we weren't expecting to be searching outside the mesh then if we
can't find a mesh element it's an error.

This makes some errors in MeshFunction use much easier to debug.

However, this assert actually triggers for me in reduced_basis_ex4 for me when I run in parallel!  We've already manually set that example to use ReplicatedMesh, and it works on one processor, so I'm not sure what could be going wrong.