### PR TITLE
Serialized DistributedMesh fixes

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -119,6 +119,13 @@ public:
   { return _is_serial; }
 
   /**
+   * @returns \p true if new elements and nodes can and should be
+   * created in synchronization on all processors, \p false otherwise
+   */
+  virtual bool is_replicated () const libmesh_override
+  { return false; }
+
+  /**
    * Verify id, processor_id, and if applicable unique_id consistency
    * of a parallel objects container.
    * Calls libmesh_assert() on each possible failure in that container.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -136,6 +136,13 @@ public:
   { return true; }
 
   /**
+   * @returns \p true if new elements and nodes can and should be
+   * created in synchronization on all processors, \p false otherwise
+   */
+  virtual bool is_replicated () const
+  { return true; }
+
+  /**
    * Gathers all elements and nodes of the mesh onto
    * every processor
    */

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -89,7 +89,7 @@ void CheckpointIO::write (const std::string & name)
   // Try to dynamic cast the mesh to see if it's a DistributedMesh object
   // Note: Just using is_serial() is not good enough because the Mesh won't
   // have been prepared yet when is when that flag gets set to false... sigh.
-  _parallel = _parallel || dynamic_cast<const DistributedMesh *>(&mesh);
+  _parallel = _parallel || !mesh.is_replicated();
 
   // If this is a serial mesh then we're only going to write it on processor 0
   if (_parallel || _my_processor_id == 0)
@@ -526,7 +526,7 @@ void CheckpointIO::read (const std::string & name)
   // Try to dynamic cast the mesh to see if it's a DistributedMesh object
   // Note: Just using is_serial() is not good enough because the Mesh won't
   // have been prepared yet when is when that flag gets set to false... sigh.
-  _parallel = _parallel || dynamic_cast<DistributedMesh *>(&mesh);
+  _parallel = _parallel || !mesh.is_replicated();
 
   // If this is a serial mesh then we're going to only read it on processor 0 and broadcast it
   if (_parallel || _my_processor_id == 0)

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -422,11 +422,10 @@ Elem * DistributedMesh::add_elem (Elem * e)
                                    _max_elem_id);
       libmesh_assert_greater_equal(_next_free_local_elem_id, _max_elem_id);
 
-      // Use the unpartitioned ids for unpartitioned elems,
-      // in serial, and temporarily for ghost elems
+      // Use the unpartitioned ids for unpartitioned elems, and
+      // temporarily for ghost elems
       dof_id_type * next_id = &_next_free_unpartitioned_elem_id;
-      if (elem_procid == this->processor_id() &&
-          !this->is_serial())
+      if (elem_procid == this->processor_id())
         next_id = &_next_free_local_elem_id;
       e->set_id (*next_id);
     }
@@ -621,10 +620,9 @@ Node * DistributedMesh::add_node (Node * n)
       libmesh_assert_greater_equal(_next_free_local_node_id, _max_node_id);
 
       // Use the unpartitioned ids for unpartitioned nodes,
-      // in serial, and temporarily for ghost nodes
+      // and temporarily for ghost nodes
       dof_id_type * next_id = &_next_free_unpartitioned_node_id;
-      if (node_procid == this->processor_id() &&
-          !this->is_serial())
+      if (node_procid == this->processor_id())
         next_id = &_next_free_local_node_id;
       n->set_id (*next_id);
     }


### PR DESCRIPTION
We now have the capability to keep a DistributedMesh serialized, and exercising that capability revealed a few bugs.

In particular, we can't use "is_serial()" to tell whether a Mesh is a DistributedMesh, and I don't like the RTTI solution, so I added an is_replicated() method.