### PR TITLE
Allow users to control if the matrix and RHS should be zeroed out

### DIFF
--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -338,6 +338,12 @@ public:
    */
   SparseMatrix<Number> * matrix;
 
+  /**
+   * By default, the system will zero out the matrix and the right hand side.
+   * If this flag is false, it is the responsibility of the client code
+   * to take care of setting these to zero before assembly begins
+   */
+  bool zero_out_matrix_and_rhs;
 
 
 protected:

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -44,6 +44,7 @@ ImplicitSystem::ImplicitSystem (EquationSystems & es,
 
   Parent            (es, name_in, number_in),
   matrix            (libmesh_nullptr),
+  zero_out_matrix_and_rhs(true),
   _can_add_matrices (true)
 {
 }
@@ -193,10 +194,11 @@ void ImplicitSystem::assemble ()
   libmesh_assert(rhs);
   libmesh_assert (rhs->initialized());
 
-  // The user assembly gets to expect to accumulate on an initially
-  // empty system
-  matrix->zero ();
-  rhs->zero ();
+  if (zero_out_matrix_and_rhs)
+  {
+    matrix->zero ();
+    rhs->zero ();
+  }
 
   // Call the base class assemble function
   Parent::assemble ();


### PR DESCRIPTION
By default, ImplicitSystem::assemble() zeroes out the matrix and
right-hand side when the method is called.  In several cases, the matrix
can be constant and the user code can choose to not form it over and
over. For this purpose we are introducing a flag that will allow us to
do so.

Closes #1231