### PR TITLE
Don't delete_remote_elements() inappropriately

### DIFF
--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -98,10 +98,6 @@ void EquationSystems::init ()
 
   libmesh_assert_not_equal_to (n_sys, 0);
 
-  // Distribute the mesh if possible
-  if (this->n_processors() > 1)
-    _mesh.delete_remote_elements();
-
   // Tell all the \p DofObject entities how many systems
   // there are.
   {


### PR DESCRIPTION
When the user has a DistributedMesh that they're allowing to
distribute, then it will already be distributed by this point and
we're being redundant.

When the user has a DistributedMesh that they're not allowing to
distribute, distributing it anyway is a bug.