### PR TITLE
Remove deprecated MeshData usage from examples

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex2/Makefile.am
+++ b/examples/miscellaneous/miscellaneous_ex2/Makefile.am
@@ -1,4 +1,4 @@
-CLEANFILES   = # start empty, append beloe
+CLEANFILES   = # start empty, append below
 
 example_name = miscellaneous_ex2
 install_dir  = $(examples_install_path)/miscellaneous/ex2

--- a/examples/miscellaneous/miscellaneous_ex2/Makefile.am
+++ b/examples/miscellaneous/miscellaneous_ex2/Makefile.am
@@ -18,7 +18,7 @@ if LIBMESH_VPATH_BUILD
 	-rm -f lshape_data.unv && $(LN_S) -f $(srcdir)/lshape_data.unv .
 	$(AM_V_GEN)touch .linkstamp
 
-  CLEANFILES += lshape.unv lshape_data.unv .linkstamp
+  CLEANFILES += lshape.unv lshape_data.unv out_*.e eqn_sys.dat .linkstamp
 endif
 
 

--- a/examples/miscellaneous/miscellaneous_ex2/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex2/Makefile.in
@@ -89,7 +89,7 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 target_triplet = @target@
-@LIBMESH_VPATH_BUILD_TRUE@am__append_1 = lshape.unv lshape_data.unv .linkstamp
+@LIBMESH_VPATH_BUILD_TRUE@am__append_1 = lshape.unv lshape_data.unv out_*.e eqn_sys.dat .linkstamp
 check_PROGRAMS = $(am__EXEEXT_1) $(am__EXEEXT_2) $(am__EXEEXT_3) \
 	$(am__EXEEXT_4) $(am__EXEEXT_5)
 @LIBMESH_DBG_MODE_TRUE@am__append_2 = example-dbg

--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -22,22 +22,19 @@
 // \author Steffen Petersen
 // \date 2003
 //
-// This is the seventh example program.  It builds on
-// the previous example programs, introduces complex
-// numbers and the FrequencySystem class to solve a
-// simple Helmholtz equation grad(p)*grad(p)+(omega/c)^2*p=0,
+// This example program introduces complex numbers and the
+// FrequencySystem class to solve a simple Helmholtz equation,
+// Laplacian(p) + (omega/c)^2*p = 0,
 // for multiple frequencies rather efficiently.
 //
-// The FrequencySystem class offers two solution styles,
-// namely to solve large systems, or to solve
-// moderately-sized systems fast, for multiple frequencies.
+// The FrequencySystem class offers two solution styles:
+// 1.) Solve large systems once, and
+// 2.) Solve moderately-sized systems for multiple frequencies.
 // The latter approach is implemented here.
 //
-// This example uses an L--shaped mesh and nodal boundary data
-// given in the files lshape.un and lshape_data.unv
-//
-// For this example the library has to be compiled with
-// complex numbers enabled.
+// This example uses an L-shaped domain and nodal boundary data given
+// in the files lshape.unv and lshape_data.unv.  For this example, the
+// library has to be compiled with complex numbers enabled.
 
 // C++ include files that we need
 #include <iostream>
@@ -53,34 +50,28 @@
 #include "libmesh/equation_systems.h"
 #include "libmesh/elem.h"
 
-// Include FrequencySystem.  Compared to GeneralSystem,
-// this class offers added functionality for the solution of
-// frequency-dependent systems.
+// Include FrequencySystem.  This class offers added functionality for
+// the solution of frequency-dependent systems.
 #include "libmesh/frequency_system.h"
 
-// Define the Finite Element object.
+// Define the FE object.
 #include "libmesh/fe.h"
 
-// Define Gauss quadrature rules.
+// Define the QGauss quadrature rule objects.
 #include "libmesh/quadrature_gauss.h"
 
-// Define useful datatypes for finite element
-// matrix and vector components.
+// Useful datatypes for finite element assembly.
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 
-// Define matrix and vector data types for the global
-// equation system.  These are base classes,
-// from which specific implementations, like
-// the PETSc and Eigen implementations, are derived.
+// Sparse matrix and vector data types for parallel linear algebra.
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/numeric_vector.h"
 
-// Define the DofMap, which handles degree of freedom
-// indexing.
+// Define the DofMap, which handles degree of freedom indexing.
 #include "libmesh/dof_map.h"
 
-// Defines the MeshData class, which allows you to store
+// Define the MeshData class, which allows you to store
 // data about the mesh when reading in files, etc.
 #include "libmesh/mesh_data.h"
 
@@ -88,11 +79,11 @@
 using namespace libMesh;
 
 // This problem is only defined on complex-valued fields, for
-// which libMesh must be configured with Number == complex.
-
+// which libMesh must be configured with Number == Complex.
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
+
 // Function prototype.  This is the function that will assemble
-// the mass, damping and stiffness matrices.  It will <i>not</i>
+// the mass, damping and stiffness matrices.  It will not
 // form an overall system matrix ready for solution.
 void assemble_helmholtz(EquationSystems & es,
                         const std::string & system_name);
@@ -104,22 +95,26 @@ void add_M_C_K_helmholtz(EquationSystems & es,
                          const std::string & system_name);
 #endif
 
-// Begin the main program.  Note that this example only
-// works correctly if complex numbers have been enabled
-// in the library.  In order to link against the complex
-// PETSc libraries, you must have built PETSc with the same
-// C++ compiler that you used to build libMesh.  This is
-// so that the name mangling will be the same for the
-// routines in both libraries.
+// This example only works correctly if libmesh has been configured
+// with --enable-complex.  If you wish to use PETSc, you must also
+// build PETSc with complex number support by configuring with
+// --with-scalar-type=complex --with-clanguage=cxx, and using the same
+// C++ compiler to build both PETSc and libmesh.  This example also
+// works with the Eigen sparse linear solvers which are provided in
+// libmesh's contrib directory.
 int main (int argc, char ** argv)
 {
-  // Initialize libraries, like in example 2.
+  // The libMeshInit object initializes MPI, PETSc, etc, and must be
+  // constructed before all other objects.
   LibMeshInit init (argc, argv);
 
   // This example is designed for complex numbers.
 #ifndef LIBMESH_USE_COMPLEX_NUMBERS
   libmesh_example_requires(false, "--enable-complex");
 #else
+
+  // This example requires at least 2D support.
+  libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 
   // Check for proper usage.
   if (argc < 3)
@@ -147,107 +142,97 @@ int main (int argc, char ** argv)
       libMesh::out << std::endl << std::endl;
     }
 
-  // Get the frequency from argv[2] as a <i>float</i>,
-  // currently, solve for 1/3rd, 2/3rd and 1/1th of the given frequency
+  // Get the frequency from argv[2] as a float, solve for 1/3rd, 2/3rd
+  // and 1/1th of the given frequency.
   const Real frequency_in = atof(argv[2]);
   const unsigned int n_frequencies = 3;
-
-  // Skip this 2D example if libMesh was compiled as 1D-only.
-  libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 
   // Create a mesh, with dimension to be overridden later, distributed
   // across the default MPI communicator.
   Mesh mesh(init.comm());
 
-  // Create a corresponding MeshData
-  // and activate it. For more information on this object
-  // cf. example 12.
+  // Create a corresponding MeshData and activate it.
   MeshData mesh_data(mesh);
   mesh_data.activate();
 
   // Read the mesh file. Here the file lshape.unv contains
-  // an L--shaped domain in .unv format.
+  // an L-shaped domain in .unv format.
   mesh.read("lshape.unv", &mesh_data);
 
   // Print information about the mesh to the screen.
   mesh.print_info();
 
-  // The load on the boundary of the domain is stored in
-  // the .unv formated mesh data file lshape_data.unv.
-  // At this, the data is given as complex valued normal
-  // velocities.
+  // The load on the boundary of the domain is stored in the .unv data
+  // file lshape_data.unv.  The data are given as complex-valued
+  // normal velocities.
   mesh_data.read("lshape_data.unv");
 
   // Print information about the mesh to the screen.
   mesh_data.print_info();
 
-  // Create an equation systems object, which now handles
-  // a frequency system, as opposed to previous examples.
-  // Also pass a MeshData pointer so the data can be
-  // accessed in the matrix and rhs assembly.
+  // Create an EquationSystems object, and pass a MeshData pointer so
+  // the data can be accessed in the matrix and rhs assembly.
   EquationSystems equation_systems (mesh, &mesh_data);
 
-  // Create a FrequencySystem named "Helmholtz" & store a
+  // Create a FrequencySystem named "Helmholtz" and store a
   // reference to it.
   FrequencySystem & f_system =
     equation_systems.add_system<FrequencySystem> ("Helmholtz");
 
-  // Add the variable "p" to "Helmholtz".  "p"
+  // Add the variable "p" to the "Helmholtz" system.  "p"
   // will be approximated using second-order approximation.
   f_system.add_variable("p", SECOND);
 
-  // Tell the frequency system about the two user-provided
-  // functions.  In other circumstances, at least the
-  // solve function has to be attached.
+  // The FrequencySystem requires two user-provided functions: one for
+  // assembling the different operators and another that specifies how
+  // to combine them before the solve.
   f_system.attach_assemble_function (assemble_helmholtz);
   f_system.attach_solve_function    (add_M_C_K_helmholtz);
 
-  // To enable the fast solution scheme, additional
-  // <i>global</i> matrices and one global vector, all appropriately sized,
-  // have to be added.  The system object takes care of the
-  // appropriate size, but the user should better fill explicitly
-  // the sparsity structure of the overall matrix, so that the
-  // fast matrix addition method can be used, as will be shown later.
+  // To enable the fast solution scheme, additional sparse matrices
+  // and one vector have to be added.  The FrequencySystem object
+  // takes care of sizing the additional objects.  The user should
+  // still set the sparsity structure of the f_system.matrix, so that
+  // the fast matrix addition method can be used.  The procedure for
+  // this is shown in detail in the assembly function.
   f_system.add_matrix ("stiffness");
   f_system.add_matrix ("damping");
   f_system.add_matrix ("mass");
   f_system.add_vector ("rhs");
 
-  // Communicates the frequencies to the system.  Note that
-  // the frequency system stores the frequencies as parameters
-  // in the equation systems object, so that our assemble and solve
-  // functions may directly access them.
-  // Will solve for 1/3rd, 2/3rd and 1/1th of the given frequency
+  // Communicate the frequencies to the system.  Note that the
+  // frequency system stores the frequencies as parameters in the
+  // EquationSystems object, so that our assemble and solve functions
+  // may directly access them. Must be called before the
+  // EquationSystems object is initialized.  Will solve for 1/3,
+  // 2/3, and 1 times the given frequency.
   f_system.set_frequencies_by_steps (frequency_in/n_frequencies,
                                      frequency_in,
                                      n_frequencies);
 
-  // Use the parameters of the equation systems object to
-  // tell the frequency system about the wave velocity and fluid
-  // density.  The frequency system provides default values, but
-  // these may be overridden, as shown here.
+  // Set the wave velocity and fluid density parameter values,
+  // otherwise default values will be used.
   equation_systems.parameters.set<Real> ("wave speed") = 1.;
   equation_systems.parameters.set<Real> ("rho")        = 1.;
 
-  // Initialize the data structures for the equation system.  <i>Always</i>
-  // prior to this, the frequencies have to be communicated to the system.
+  // Initialize the EquationSystems object.
   equation_systems.init ();
 
-  // Prints information about the system to the screen.
+  // Print information about the system to the screen.
   equation_systems.print_info ();
 
   for (unsigned int n=0; n < n_frequencies; n++)
     {
-      // Solve the system "Helmholtz" for the n-th frequency.
+      // Solve the "Helmholtz" system for the n-th frequency.
       // Since we attached an assemble() function to the system,
-      // the mass, damping and stiffness contributions will only
+      // the mass, damping, and stiffness contributions will only
       // be assembled once.  Then, the system is solved for the
       // given frequencies.  Note that solve() may also solve
       // the system only for specific frequencies.
       f_system.solve (n, n);
 
-      // After solving the system, write the solution
-      // to an ExodusII-formatted plot file, for every frequency.
+      // After solving the system, write the solution to an ExodusII
+      // file for every frequency.
 #ifdef LIBMESH_HAVE_EXODUS_API
       std::ostringstream file_name;
 
@@ -266,7 +251,6 @@ int main (int argc, char ** argv)
   // Alternatively, the whole EquationSystems object can be
   // written to disk.  By default, the additional vectors are also
   // saved.
-
   equation_systems.write ("eqn_sys.dat", WRITE);
 
   // All done.
@@ -291,7 +275,7 @@ void assemble_helmholtz(EquationSystems & es,
   // Get a constant reference to the mesh object.
   const MeshBase & mesh = es.get_mesh();
 
-  // The dimension that we are in
+  // The maximum dimension of the elements stored in the mesh.
   const unsigned int dim = mesh.mesh_dimension();
 
   // Get a reference to our system, as before
@@ -303,49 +287,35 @@ void assemble_helmholtz(EquationSystems & es,
   // to degree of freedom numbers.
   const DofMap & dof_map = f_system.get_dof_map();
 
-  // Get a constant reference to the Finite Element type
+  // Get a constant reference to the finite element type
   // for the first (and only) variable in the system.
   const FEType & fe_type = dof_map.variable_type(0);
 
-  // For the admittance boundary condition,
-  // get the fluid density
+  // The fluid density is used by the admittance boundary condition.
   const Real rho = es.parameters.get<Real>("rho");
 
-  // In here, we will add the element matrices to the
-  // <i>additional</i> matrices "stiffness_mass", "damping",
-  // and the additional vector "rhs", not to the members
-  // "matrix" and "rhs".  Therefore, get writable
-  // references to them
+  // In this example, we assemble the element matrices into the
+  // additional matrices "stiffness_mass", "damping", and the element
+  // vectors into "rhs". We get writable references to these objects
+  // now.
   SparseMatrix<Number> & stiffness = f_system.get_matrix("stiffness");
   SparseMatrix<Number> & damping = f_system.get_matrix("damping");
   SparseMatrix<Number> & mass = f_system.get_matrix("mass");
   NumericVector<Number> & freq_indep_rhs = f_system.get_vector("rhs");
 
-  // Some solver packages (PETSc) are especially picky about
-  // allocating sparsity structure and truly assigning values
-  // to this structure.  Namely, matrix additions, as performed
-  // later, exhibit acceptable performance only for identical
-  // sparsity structures.  Therefore, explicitly zero the
-  // values in the collective matrix, so that matrix additions
-  // encounter identical sparsity structures.
-  SparseMatrix<Number> & matrix = *f_system.matrix;
-
-  // ------------------------------------------------------------------
-  // Finite Element related stuff
-  //
-  // Build a Finite Element object of the specified type.  Since the
+  // Build a finite element object of the specified type.  Since the
   // FEBase::build() member dynamically creates memory we will
   // store the object as a UniquePtr<FEBase>.  This can be thought
   // of as a pointer that will clean up after itself.
   UniquePtr<FEBase> fe (FEBase::build(dim, fe_type));
 
-  // A 5th order Gauss quadrature rule for numerical integration.
+  // A 5th-order Gauss quadrature rule for numerical integration.
   QGauss qrule (dim, FIFTH);
 
   // Tell the finite element object to use our quadrature rule.
   fe->attach_quadrature_rule (&qrule);
 
-  // The element Jacobian// quadrature weight at each integration point.
+  // The element Jacobian times the quadrature weight at each integration point.
   const std::vector<Real> & JxW = fe->get_JxW();
 
   // The element shape functions evaluated at the quadrature points.
@@ -355,16 +325,15 @@ void assemble_helmholtz(EquationSystems & es,
   // points.
   const std::vector<std::vector<RealGradient> > & dphi = fe->get_dphi();
 
-  // Now this is slightly different from example 4.
-  // We will not add directly to the global matrix,
-  // but to the additional matrices "stiffness_mass" and "damping".
-  // The same holds for the right-hand-side vector Fe, which we will
-  // later on store in the additional vector "rhs".
+  // Here we do not assemble directly in the System matrix, but to the
+  // additional matrices "stiffness_mass" and "damping".  The same
+  // approach is followed for the right-hand-side vector Fe, which we
+  // will later on store in the additional vector "rhs".
   // The zero_matrix is used to explicitly induce the same sparsity
-  // structure in the overall matrix.
-  // see later on. (At least) the mass, and stiffness matrices, however,
-  // are inherently real.  Therefore, store these as one complex
-  // matrix.  This will definitely save memory.
+  // structure in the overall matrix.  The mass and stiffness matrices
+  // are real-valued.  Therefore, it would be possible to store them
+  // as a single complex-valued matrix to save on memory, but we do
+  // not follow this approach here.
   DenseMatrix<Number> Ke, Ce, Me, zero_matrix;
   DenseVector<Number> Fe;
 
@@ -373,10 +342,8 @@ void assemble_helmholtz(EquationSystems & es,
   // the element degrees of freedom get mapped.
   std::vector<dof_id_type> dof_indices;
 
-  // Now we will loop over all the elements in the mesh.
-  // We will compute the element matrix and right-hand-side
-  // contribution.
-
+  // Now we will loop over all the elements in the mesh, and compute
+  // the element matrix and right-hand-side contributions.
   MeshBase::const_element_iterator           el = mesh.active_local_elements_begin();
   const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
 
@@ -425,9 +392,7 @@ void assemble_helmholtz(EquationSystems & es,
         {
           // Now we will build the element matrix.  This involves
           // a double loop to integrate the test funcions (i) against
-          // the trial functions (j).  Note the braces on the rhs
-          // of Ke(i,j): these are quite necessary to finally compute
-          // Real*(Point*Point) = Real, and not something else...
+          // the trial functions (j).
           for (std::size_t i=0; i<phi.size(); i++)
             for (std::size_t j=0; j<phi.size(); j++)
               {
@@ -445,7 +410,6 @@ void assemble_helmholtz(EquationSystems & es,
       // The following loops over the sides of the element.
       // If the element has no neighbor on a side then that
       // side MUST live on a boundary of the domain.
-
       for (unsigned int side=0; side<elem->n_sides(); side++)
         if (elem->neighbor(side) == libmesh_nullptr)
           {
@@ -469,7 +433,7 @@ void assemble_helmholtz(EquationSystems & es,
             const std::vector<std::vector<Real> > & phi_face =
               fe_face->get_phi();
 
-            // The Jacobian// Quadrature Weight at the quadrature
+            // The Jacobian times the quadrature weight at the quadrature
             // points on the face.
             const std::vector<Real> & JxW_face = fe_face->get_JxW();
 
@@ -477,19 +441,18 @@ void assemble_helmholtz(EquationSystems & es,
             // face.
             fe_face->reinit(elem, side);
 
-            // For the Robin BCs consider a normal admittance an=1
+            // For the Robin BCs, consider a normal admittance an=1
             // at some parts of the bounfdary
             const Real an_value = 1.;
 
             // Loop over the face quadrature points for integration.
             for (unsigned int qp=0; qp<qface.n_points(); qp++)
               {
-
-                // Element matrix contributrion due to precribed
+                // Element matrix contributrion due to prescribed
                 // admittance boundary conditions.
                 for (std::size_t i=0; i<phi_face.size(); i++)
                   for (std::size_t j=0; j<phi_face.size(); j++)
-                    Ce(i,j) += rho*an_value*JxW_face[qp]*phi_face[i][qp]*phi_face[j][qp];
+                    Ce(i,j) += rho * an_value * JxW_face[qp] * phi_face[i][qp] * phi_face[j][qp];
               }
           }
 
@@ -502,7 +465,6 @@ void assemble_helmholtz(EquationSystems & es,
       // dof_map.constrain_element_matrix (Ce, dof_indicesC);
       // dof_map.constrain_element_matrix (Me, dof_indicesM);
 
-
       // Finally, simply add the contributions to the additional
       // matrices and vector.
       stiffness.add_matrix (Ke, dof_indices);
@@ -512,25 +474,23 @@ void assemble_helmholtz(EquationSystems & es,
       // For the overall matrix, explicitly zero the entries where
       // we added values in the other ones, so that we have
       // identical sparsity footprints.
-      matrix.add_matrix(zero_matrix, dof_indices);
+      f_system.matrix->add_matrix(zero_matrix, dof_indices);
+    } // end loop over elements
 
-    } // loop el
 
-
-  // It now remains to compute the rhs. Here, we simply
-  // get the normal velocities values on the boundary from the
-  // mesh data.
+  // It now remains to compute the rhs. Here, we simply get the normal
+  // velocity values on the boundary from the mesh data.
   {
     LOG_SCOPE("rhs", "assemble_helmholtz");
 
-    // get a reference to the mesh data.
+    // Get a reference to the mesh data.
     const MeshData & mesh_data = es.get_mesh_data();
 
     // We will now loop over all nodes. In case nodal data
     // for a certain node is available in the MeshData, we simply
     // adopt the corresponding value for the rhs vector.
     // Note that normal data was given in the mesh data file,
-    // i.e. one value per node
+    // i.e. one value per node.
     libmesh_assert_equal_to (mesh_data.n_val_per_node(), 1);
 
     MeshBase::const_node_iterator       node_it  = mesh.nodes_begin();
@@ -541,10 +501,10 @@ void assemble_helmholtz(EquationSystems & es,
         // the current node pointer
         const Node * node = *node_it;
 
-        // check if the mesh data has data for the current node
-        // and do for all components
+        // Check if the MeshData object has data for the current node,
+        // and set the values for all the components.
         if (mesh_data.has_data(node))
-          for (unsigned int comp=0; comp<node->n_comp(0, 0); comp++)
+          for (unsigned int comp=0; comp<node->n_comp(/*system=*/0, /*variable=*/0); comp++)
             {
               // the dof number
               unsigned int dn = node->dof_number(0, 0, comp);
@@ -554,29 +514,24 @@ void assemble_helmholtz(EquationSystems & es,
             }
       }
   }
-
-  // All done!
 }
 
 
-// We now define the function which will combine
-// the previously-assembled mass, stiffness, and
-// damping matrices into a single system matrix.
+// We now define the function which will combine the previously-assembled
+// mass, stiffness, and damping matrices into a single system matrix.
 void add_M_C_K_helmholtz(EquationSystems & es,
                          const std::string & system_name)
 {
   START_LOG("init phase", "add_M_C_K_helmholtz");
 
-  // It is a good idea to make sure we are assembling
-  // the proper system.
+  // Verify that we are assembling the system we think we are.
   libmesh_assert_equal_to (system_name, "Helmholtz");
 
-  // Get a reference to our system, as before
+  // Get a reference to the FrequencySystem.
   FrequencySystem & f_system =
     es.get_system<FrequencySystem> (system_name);
 
-  // Get the frequency, fluid density, and speed of sound
-  // for which we should currently solve
+  // Get the frequency, fluid density, and sound speed of the current solve.
   const Real frequency = es.parameters.get<Real> ("current frequency");
   const Real rho       = es.parameters.get<Real> ("rho");
   const Real speed     = es.parameters.get<Real> ("wave speed");
@@ -585,8 +540,8 @@ void add_M_C_K_helmholtz(EquationSystems & es,
   const Real omega = 2.0*libMesh::pi*frequency;
   const Real k     = omega / speed;
 
-  // Get writable references to the overall matrix and vector, where the
-  // frequency-dependent system is to be collected
+  // Get writable references to the system matrix and vector, where the
+  // frequency-dependent system is to be collected.
   SparseMatrix<Number> & matrix = *f_system.matrix;
   NumericVector<Number> & rhs = *f_system.rhs;
 
@@ -599,7 +554,7 @@ void add_M_C_K_helmholtz(EquationSystems & es,
   SparseMatrix<Number> & mass = f_system.get_matrix("mass");
   NumericVector<Number> & freq_indep_rhs = f_system.get_vector("rhs");
 
-  // form the scaling values for the coming matrix and vector axpy's
+  // Compute the scale values for the different operators.
   const Number scale_stiffness (1., 0.);
   const Number scale_damping (0., omega);
   const Number scale_mass (-k*k, 0.);
@@ -623,15 +578,15 @@ void add_M_C_K_helmholtz(EquationSystems & es,
 
   START_LOG("global matrix & vector additions", "add_M_C_K_helmholtz");
 
-  // add the stiffness and mass with the proper frequency to the
-  // overall system.  For this to work properly, matrix has
+  // Add the stiffness and mass with the proper frequency to the
+  // overall system.  For this to work properly, the matrix has
   // to be not only initialized, but filled with the identical
   // sparsity structure as the matrix added to it, otherwise
   // solver packages like PETSc crash.
   //
-  // Note that we have to add the mass and stiffness contributions
-  // one at a time; otherwise, the real part of matrix would
-  // be fine, but the imaginary part cluttered with unwanted products.
+  // Note that we have to add the mass and stiffness contributions one
+  // at a time, otherwise the real part of matrix would be fine, but
+  // the imaginary part would be cluttered with unwanted products.
   matrix.add (scale_stiffness, stiffness);
   matrix.add (scale_mass,      mass);
   matrix.add (scale_damping,   damping);
@@ -639,7 +594,7 @@ void add_M_C_K_helmholtz(EquationSystems & es,
 
   STOP_LOG("global matrix & vector additions", "add_M_C_K_helmholtz");
 
-  // The "matrix" and "rhs" are now ready for solution
+  // The linear system involving "matrix" and "rhs" is now ready to be solved.
 }
 
 #endif // LIBMESH_USE_COMPLEX_NUMBERS

--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -249,10 +249,16 @@ int main (int argc, char ** argv)
       // After solving the system, write the solution
       // to an ExodusII-formatted plot file, for every frequency.
 #ifdef LIBMESH_HAVE_EXODUS_API
-      char buf[14];
-      sprintf (buf, "out%04u.exd", n);
+      std::ostringstream file_name;
 
-      ExodusII_IO(mesh).write_equation_systems (buf,
+      file_name << "out_"
+                << std::setw(4)
+                << std::setfill('0')
+                << std::right
+                << n
+                << ".e";
+
+      ExodusII_IO(mesh).write_equation_systems (file_name.str(),
                                                 equation_systems);
 #endif
     }

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -74,10 +74,6 @@
 // The definition of a geometric element
 #include "libmesh/elem.h"
 
-// Defines the MeshData class, which allows you to store
-// data about the mesh when reading in files, etc.
-#include "libmesh/mesh_data.h"
-
 // Bring in everything from the libMesh namespace
 using namespace libMesh;
 
@@ -141,18 +137,9 @@ int main (int argc, char** argv)
   // Create a ReplicatedMesh object, with dimension to be overridden
   // later, distributed across the default MPI communicator.
   ReplicatedMesh mesh(init.comm());
-  MeshData mesh_data(mesh);
 
-  // Read the meshfile specified in the command line or
-  // use the internal mesh generator to create a uniform
-  // grid on an elongated cube.
-  mesh.read(mesh_file, &mesh_data);
-
-  // mesh.build_cube (10, 10, 40,
-  //                       -1., 1.,
-  //                       -1., 1.,
-  //                        0., 4.,
-  //                        HEX8);
+  // Read the meshfile specified on the command line.
+  mesh.read(mesh_file);
 
   // Print information about the mesh to the screen.
   mesh.print_info();

--- a/include/mesh/unv_io.h
+++ b/include/mesh/unv_io.h
@@ -88,6 +88,19 @@ public:
    */
   bool & verbose ();
 
+  /**
+   * Read a UNV data file containing a dataset of type "2414".
+   * For more info, see http://tinyurl.com/htcf6zm
+   */
+  void read_dataset(std::string file_name);
+
+  /**
+   * @returns a pointer the values associated with the node \p node,
+   * as read in by the read_dataset() method.  If no values exist for
+   * the node in question, a libmesh_nullptr is returned instead.  It
+   * is up to the user to check the return value before using it.
+   */
+  const std::vector<Number> * get_data (Node * node) const;
 
 private:
 
@@ -155,6 +168,14 @@ private:
    */
   unsigned char max_elem_dimension_seen ();
 
+  /**
+   * Replaces "1.1111D+00" with "1.1111e+00" if necessary.  Returns
+   * true if the replacement occurs, false otherwise.  This function
+   * only needs to be called once per stream, one can assume that if
+   * one number needs rewriting, they all do.
+   */
+  bool need_D_to_e (std::string & number);
+
   //-------------------------------------------------------------
   // local data
 
@@ -164,9 +185,10 @@ private:
   bool _verbose;
 
   /**
-   * maps node IDs from UNV to internal.  Used when reading.
+   * Maps UNV node IDs to libMesh Node*s. Used when reading. Even if the
+   * libMesh Mesh is renumbered, this map should continue to be valid.
    */
-  std::map<unsigned, unsigned> _unv_node_id_to_libmesh_node_id;
+  std::map<dof_id_type, Node *> _unv_node_id_to_libmesh_node_ptr;
 
   /**
    * label for the node dataset
@@ -198,6 +220,12 @@ private:
    * Map UNV element IDs to libmesh element IDs.
    */
   std::map<unsigned, unsigned> _unv_elem_id_to_libmesh_elem_id;
+
+  /**
+   * Map from libMesh Node* to data at that node, as read in by the
+   * read_dataset() function.
+   */
+  std::map<Node *, std::vector<Number> > _node_data;
 };
 
 

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -387,11 +387,12 @@ void UNVIO::nodes_in (std::istream & in_file)
       coords_stream.clear(); // clear iostate bits!  Important!
       coords_stream >> xyz(0) >> xyz(1) >> xyz(2);
 
-      // set up the id map
-      _unv_node_id_to_libmesh_node_id[node_label] = ctr;
-
-      // add node to the Mesh
+      // Add node to the Mesh, bump the counter.
       Node * added_node = mesh.add_point(xyz, ctr++);
+
+      // Maintain the mapping between UNV node ids and libmesh Node
+      // pointers.
+      _unv_node_id_to_libmesh_node_ptr[node_label] = added_node;
 
       // tell the MeshData object the foreign node id
       if (_mesh_data)
@@ -413,6 +414,23 @@ unsigned char UNVIO::max_elem_dimension_seen ()
       max_dim = i;
 
   return max_dim;
+}
+
+
+
+bool UNVIO::need_D_to_e (std::string & number)
+{
+  // find "D" in string, start looking at 6th element since dont expect a "D" earlier.
+  std::string::size_type position = number.find("D", 6);
+
+  if (position != std::string::npos)
+    {
+      // replace "D" in string
+      number.replace(position, 1, "e");
+      return true;
+    }
+  else
+    return false;
 }
 
 
@@ -862,11 +880,11 @@ void UNVIO::elements_in (std::istream & in_file)
       for (dof_id_type j=1; j<=n_nodes; j++)
         {
           // Map the UNV node ID to the libmesh node ID
-          std::map<unsigned, unsigned>::iterator it =
-            _unv_node_id_to_libmesh_node_id.find(node_labels[j]);
+          std::map<unsigned, Node *>::iterator it =
+            _unv_node_id_to_libmesh_node_ptr.find(node_labels[j]);
 
-          if (it != _unv_node_id_to_libmesh_node_id.end())
-            elem->set_node(assign_elem_nodes[j]) = mesh.node_ptr(it->second);
+          if (it != _unv_node_id_to_libmesh_node_ptr.end())
+            elem->set_node(assign_elem_nodes[j]) = it->second;
           else
             libmesh_error_msg("ERROR: UNV node " << node_labels[j] << " not found!");
         }
@@ -1220,5 +1238,181 @@ void UNVIO::elements_out(std::ostream & out_file)
   // Write end of dataset
   out_file << "    -1\n";
 }
+
+
+
+void UNVIO::read_dataset(std::string file_name)
+{
+  std::ifstream in_stream(file_name.c_str());
+
+  if (!in_stream.good())
+    libmesh_error_msg("Error opening UNV data file.");
+
+  std::string olds, news, dummy;
+
+  while (true)
+    {
+      in_stream >> olds >> news;
+
+      // A "-1" followed by a number means the beginning of a dataset.
+      while (((olds != "-1") || (news == "-1")) && !in_stream.eof())
+        {
+          olds = news;
+          in_stream >> news;
+        }
+
+      if (in_stream.eof())
+        break;
+
+      // We only support reading datasets in the "2414" format.
+      if (news == "2414")
+        {
+          // Ignore the rest of the current line and the next two
+          // lines that contain analysis dataset label and name.
+          for (unsigned int i=0; i<3; i++)
+            std::getline(in_stream, dummy);
+
+          // Read the dataset location, where
+          // 1: Data at nodes
+          // 2: Data on elements
+          // Currently only data on nodes is supported.
+          unsigned int dataset_location;
+          in_stream >> dataset_location;
+
+          // Currently only nodal datasets are supported.
+          if (dataset_location != 1)
+            libmesh_error_msg("ERROR: Currently only Data at nodes is supported.");
+
+          // Ignore the rest of this line and the next five records.
+          for (unsigned int i=0; i<6; i++)
+            std::getline(in_stream, dummy);
+
+          // These data are all of no interest to us...
+          unsigned int
+            model_type,
+            analysis_type,
+            data_characteristic,
+            result_type;
+
+          // The type of data (complex, real, float, double etc, see
+          // below).
+          unsigned int data_type;
+
+          // The number of floating-point values per entity.
+          unsigned int num_vals_per_node;
+
+          in_stream >> model_type           // not used here
+                    >> analysis_type        // not used here
+                    >> data_characteristic  // not used here
+                    >> result_type          // not used here
+                    >> data_type
+                    >> num_vals_per_node;
+
+          // Ignore the rest of record 9, and records 10-13.
+          for (unsigned int i=0; i<5; i++)
+            std::getline(in_stream, dummy);
+
+          // Now get the foreign (aka UNV node) node number and
+          // the respective nodal data.
+          int f_n_id;
+          std::vector<Number> values;
+
+          while (true)
+            {
+              in_stream >> f_n_id;
+
+              // If -1 then we have reached the end of the dataset.
+              if (f_n_id == -1)
+                break;
+
+              // Resize the values vector (usually data in three
+              // principle directions, i.e. num_vals_per_node = 3).
+              values.resize(num_vals_per_node);
+
+              // Read the meshdata for the respective node.
+              for (unsigned int data_cnt=0; data_cnt<num_vals_per_node; data_cnt++)
+                {
+                  // Check what data type we are reading.
+                  // 2,4: Real
+                  // 5,6: Complex
+                  // other data types are not supported yet.
+                  // As again, these floats may also be written
+                  // using a 'D' instead of an 'e'.
+                  if (data_type == 2 || data_type == 4)
+                    {
+                      std::string buf;
+                      in_stream >> buf;
+                      this->need_D_to_e(buf);
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+                      values[data_cnt] = Complex(std::atof(buf.c_str()), 0.);
+#else
+                      values[data_cnt] = std::atof(buf.c_str());
+#endif
+                    }
+
+                  else if (data_type == 5 || data_type == 6)
+                    {
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+                      Real re_val, im_val;
+
+                      std::string buf;
+                      in_stream >> buf;
+
+                      if (this->need_D_to_e(buf))
+                        {
+                          re_val = std::atof(buf.c_str());
+                          in_stream >> buf;
+                          this->need_D_to_e(buf);
+                          im_val = std::atof(buf.c_str());
+                        }
+                      else
+                        {
+                          re_val = std::atof(buf.c_str());
+                          in_stream >> im_val;
+                        }
+
+                      values[data_cnt] = Complex(re_val,im_val);
+#else
+
+                      libmesh_error_msg("ERROR: Complex data only supported when libMesh is configured with --enable-complex!");
+#endif
+                    }
+
+                  else
+                    libmesh_error_msg("ERROR: Data type not supported.");
+
+                } // end loop data_cnt
+
+              // Get a pointer to the Node associated with the UNV node id.
+              std::map<unsigned, Node *>::const_iterator it =
+                _unv_node_id_to_libmesh_node_ptr.find(f_n_id);
+
+              if (it == _unv_node_id_to_libmesh_node_ptr.end())
+                libmesh_error_msg("UNV node id " << f_n_id << " was not found.");
+
+              // Store the nodal values in our map which uses the
+              // libMesh Node* as the key.  We use operator[] here
+              // because we want to create an empty vector if the
+              // entry does not already exist.
+              _node_data[it->second] = values;
+            } // end while (true)
+        } // end if (news == "2414")
+    } // end while (true)
+}
+
+
+
+const std::vector<Number> *
+UNVIO::get_data (Node * node) const
+{
+  std::map<Node *, std::vector<Number> >::const_iterator
+    it = _node_data.find(node);
+
+  if (it == _node_data.end())
+    return libmesh_nullptr;
+  else
+    return &(it->second);
+}
+
 
 } // namespace libMesh


### PR DESCRIPTION
We still support reading datasets from UNV files as is done in misc_ex2, that data is no longer stored in a MeshData object, however.  MeshData itself will actually be removed in a forthcoming PR.