### PR TITLE
GmshIO: Allow multiple lower-dimensional elements for BCs.

### DIFF
--- a/include/geom/cell.h
+++ b/include/geom/cell.h
@@ -58,7 +58,7 @@ public:
    * @return a bounding box (not necessarily the minimal bounding box)
    * containing the geometric element.
    */
-  virtual BoundingBox loose_bounding_box () const;
+  virtual BoundingBox loose_bounding_box () const libmesh_override;
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -153,7 +153,7 @@ public:
    * @return a bounding box (not necessarily the minimal bounding box)
    * containing the edge.
    */
-  virtual BoundingBox loose_bounding_box () const;
+  virtual BoundingBox loose_bounding_box () const libmesh_override;
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -140,7 +140,7 @@ public:
    * @return a bounding box (not necessarily the minimal bounding box)
    * containing the edge.
    */
-  virtual BoundingBox loose_bounding_box () const;
+  virtual BoundingBox loose_bounding_box () const libmesh_override;
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -174,7 +174,7 @@ public:
    * @return a bounding box (not necessarily the minimal bounding box)
    * containing the geometric element.
    */
-  virtual BoundingBox loose_bounding_box () const;
+  virtual BoundingBox loose_bounding_box () const libmesh_override;
 
 protected:
 

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -181,7 +181,7 @@ public:
    * @return a bounding box (not necessarily the minimal bounding box)
    * containing the geometric element.
    */
-  virtual BoundingBox loose_bounding_box () const;
+  virtual BoundingBox loose_bounding_box () const libmesh_override;
 
 protected:
 

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -174,7 +174,7 @@ public:
    * @return a bounding box (not necessarily the minimal bounding box)
    * containing the geometric element.
    */
-  virtual BoundingBox loose_bounding_box () const;
+  virtual BoundingBox loose_bounding_box () const libmesh_override;
 
 protected:
 

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -188,7 +188,7 @@ void VTKIO::read (const std::string & name)
       // and add the actual point
       double * pnt = _vtk_grid->GetPoint(static_cast<vtkIdType>(i));
       Point xyz(pnt[0], pnt[1], pnt[2]);
-      Node * newnode = mesh.add_point(xyz, i);
+      mesh.add_point(xyz, i);
     }
 
   // Get the number of cells from the _vtk_grid object


### PR DESCRIPTION
This fixes the problem reported by @lindsayad in #1252.

This PR also fixes a few unrelated warnings that cropped up after the recent `MeshData` removal and `Elem::loose_bounding_box()` changes.
