### PR TITLE
BoundaryInfo::regenerate_id_sets()

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -88,6 +88,16 @@ public:
   void clear ();
 
   /**
+   * Clears and regenerates the cached sets of ids.
+   * This is necessary after use of remove_*() functions, which remove
+   * individual id associations (an O(1) process) without checking to
+   * see whether that is the last association with the id (an O(N)
+   * process.
+   */
+  void regenerate_id_sets ();
+
+
+  /**
    * Generates \p boundary_mesh data structures corresponding to the
    * \p mesh data structures.  Allows the \p boundary_mesh to be used
    * like any other mesh, except with interior_parent() values defined

--- a/src/apps/meshbcid.C
+++ b/src/apps/meshbcid.C
@@ -192,6 +192,11 @@ int main(int argc, char ** argv)
         }
     }
 
+  // We might have removed *every* instance of a given id, and if that
+  // happened then we should make sure that file formats which write
+  // out id sets do not write out the removed id.
+  mesh.get_boundary_info().regenerate_id_sets();
+
   std::string outputname;
   if(cl.search("--output"))
     {

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -151,6 +151,55 @@ void BoundaryInfo::clear()
 
 
 
+void BoundaryInfo::regenerate_id_sets()
+{
+  // Clear the old caches
+  _boundary_ids.clear();
+  _side_boundary_ids.clear();
+  _node_boundary_ids.clear();
+  _edge_boundary_ids.clear();
+  _shellface_boundary_ids.clear();
+
+  // Loop over id maps to regenerate each set.
+  for (boundary_node_iter it = _boundary_node_id.begin(),
+         end = _boundary_node_id.end();
+       it != end; ++it)
+    {
+      const boundary_id_type id = it->second;
+      _boundary_ids.insert(id);
+      _node_boundary_ids.insert(id);
+    }
+
+  for (boundary_edge_iter it = _boundary_edge_id.begin(),
+         end = _boundary_edge_id.end();
+       it != end; ++it)
+    {
+      const boundary_id_type id = it->second.second;
+      _boundary_ids.insert(id);
+      _edge_boundary_ids.insert(id);
+    }
+
+  for (boundary_side_iter it = _boundary_side_id.begin(),
+         end = _boundary_side_id.end();
+       it != end; ++it)
+    {
+      const boundary_id_type id = it->second.second;
+      _boundary_ids.insert(id);
+      _side_boundary_ids.insert(id);
+    }
+
+  for (boundary_shellface_iter it = _boundary_shellface_id.begin(),
+         end = _boundary_shellface_id.end();
+       it != end; ++it)
+    {
+      const boundary_id_type id = it->second.second;
+      _boundary_ids.insert(id);
+      _shellface_boundary_ids.insert(id);
+    }
+}
+
+
+
 void BoundaryInfo::sync (UnstructuredMesh & boundary_mesh)
 {
   std::set<boundary_id_type> request_boundary_ids(_boundary_ids);

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1891,6 +1891,10 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
   // elements it pointed to have been deleted.
   mesh.clear_point_locator();
 
+  // Much of our boundary info may have been for now-remote parts of
+  // the mesh, in which case we don't want to keep local copies.
+  mesh.get_boundary_info().regenerate_id_sets();
+
   // We now have all remote elements and nodes deleted; our ghosting
   // functors should be ready to delete any now-redundant cached data
   // they use too.

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -427,6 +427,11 @@ void UnstructuredMesh::all_first_order ()
         this->delete_node(the_node);
     }
 
+  // If crazy people applied boundary info to non-vertices and then
+  // deleted those non-vertices, we should make sure their boundary id
+  // caches are correct.
+  this->get_boundary_info().regenerate_id_sets();
+
   STOP_LOG("all_first_order()", "Mesh");
 
   // On hanging nodes that used to also be second order nodes, we

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -139,6 +139,9 @@ void TetGenMeshInterface::pointset_convexhull ()
       this->_mesh.delete_elem (*it);
   }
 
+  // We just removed any boundary info associated with element faces
+  // or edges, so let's update the boundary id caches.
+  this->_mesh.get_boundary_info().regenerate_id_sets();
 
   // Add the 2D elements which comprise the convex hull back to the mesh.
   // Vector that temporarily holds the node labels defining element.
@@ -468,6 +471,10 @@ void TetGenMeshInterface::delete_2D_hull_elements()
       if (elem->type() == TRI3)
         _mesh.delete_elem(elem);
     }
+
+  // We just removed any boundary info associated with hull element
+  // edges, so let's update the boundary id caches.
+  this->_mesh.get_boundary_info().regenerate_id_sets();
 }
 
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1457,6 +1457,11 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
                 }
             }
         }
+
+      // Removing stitched-away boundary ids might have removed an id
+      // *entirely*, so we need to recompute boundary id sets to check
+      // for that.
+      this->get_boundary_info().regenerate_id_sets();
     }
 }
 


### PR DESCRIPTION
This allows application code to fix issue #965 by regenerating cached sets of ids after performing operations which may remove all entries of a particular id.

This isn't as user friendly as the alternative (maintain maps with use counts for every id) but should be more efficient.

I've also added regenerate_id_sets() calls to everywhere in the library I can find that might invalidate the old cache.

This could potentially trigger errors in DistributedMesh-using application code, since it makes us much more strict about not storing id information for remote elements and nodes.