### PR TITLE
Ignore warnings from TBB

### DIFF
--- a/include/parallel/threads_allocators.h
+++ b/include/parallel/threads_allocators.h
@@ -25,7 +25,9 @@
 
 // Threading building blocks includes
 #ifdef LIBMESH_HAVE_TBB_API
+#  include "libmesh/ignore_warnings.h"
 #  include "tbb/scalable_allocator.h"
+#  include "libmesh/restore_warnings.h"
 #endif
 
 // C++ includes

--- a/include/parallel/threads_tbb.h
+++ b/include/parallel/threads_tbb.h
@@ -30,6 +30,8 @@
 // libMesh includes
 #include "libmesh/libmesh_logging.h"
 
+#include "libmesh/ignore_warnings.h"
+
 // Threading building blocks includes
 #include "tbb/tbb_stddef.h"
 #include "tbb/blocked_range.h"
@@ -42,6 +44,8 @@
 #include "tbb/atomic.h"
 #include "tbb/tbb_thread.h"
 #include "tbb/enumerable_thread_specific.h"
+
+#include "libmesh/restore_warnings.h"
 
 #define TBB_VERSION_LESS_THAN(major,minor)                              \
   ((LIBMESH_DETECTED_TBB_VERSION_MAJOR < (major) ||                     \

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -48,6 +48,8 @@
 #if (__GNUC__ > 5)
 // Ignore warnings from code that does "if (foo) bar();"
 #pragma GCC diagnostic ignored "-Wmisleading-indentation"
+// Ignore warnings from bad placement new use
+#pragma GCC diagnostic ignored "-Wplacement-new"
 #endif // GCC > 5
 #endif // GCC > 4.1
 #endif // __GNUC__ && !__INTEL_COMPILER

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -30,6 +30,7 @@
 #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 1)
 // TODO: use the gcc 4.6 push/pop when available
 #if (__GNUC__ > 5)
+#pragma GCC diagnostic warning "-Wplacement-new"
 #pragma GCC diagnostic warning "-Wmisleading-indentation"
 #endif // GCC > 5
 #pragma GCC diagnostic warning "-Wdeprecated-declarations"


### PR DESCRIPTION
Old versions of TBB spew placement-new warnings for me.  That's scary,
and I'm kind of tempted to refuse to configure against any version of
TBB that exhibits that warning, but if we *are* going to build against
TBB then we probably shouldn't hassle users about warnings they can't
fix.