### PR TITLE
Updating for VTK piece/parallel XML writers for changes in functionality

### DIFF
--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -34,6 +34,9 @@
 
 // Forward declarations
 class vtkUnstructuredGrid;
+#ifdef LIBMESH_HAVE_MPI
+class vtkMPIController;
+#endif
 
 namespace libMesh
 {
@@ -69,6 +72,11 @@ public:
    */
   explicit
   VTKIO (const MeshBase & mesh);
+
+  /**
+   * Destructor.
+   */
+  ~VTKIO ();
 
   /**
    * Bring in base class functionality for name resolution and to
@@ -145,6 +153,14 @@ private:
   vtkUnstructuredGrid * _vtk_grid;
 
   /**
+   * If libMesh is using MPI we need to use VTK's MPI controller
+   * when writing out data in the PXML format.
+   */
+#ifdef LIBMESH_HAVE_MPI
+  vtkMPIController* _vtk_mpicontroller;
+#endif
+
+  /**
    * Flag to indicate whether the output should be compressed
    */
   bool _compress;
@@ -153,7 +169,6 @@ private:
    * maps global node id to node id of partition
    */
   std::map<dof_id_type, dof_id_type> _local_node_map;
-
 
   /**
    * Helper object that holds a map from VTK to libMesh element types

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -32,7 +32,8 @@
 #ifdef LIBMESH_HAVE_VTK
 
 // I get a lot of "warning: extra ';' inside a class [-Wextra-semi]" from clang
-// on VTK header files.
+// on VTK header files. This is because VTK macros have ';' at the end of them
+// but some developers add in an extra ';' at the end of the macro use.
 #include "libmesh/ignore_warnings.h"
 
 #include "vtkXMLUnstructuredGridReader.h"
@@ -47,6 +48,9 @@
 #include "vtkPointData.h"
 #include "vtkPoints.h"
 #include "vtkSmartPointer.h"
+#ifdef LIBMESH_HAVE_MPI
+#include "vtkMPIController.h"
+#endif
 
 #include "libmesh/restore_warnings.h"
 
@@ -76,6 +80,9 @@ VTKIO::VTKIO (MeshBase & mesh) :
 #ifdef LIBMESH_HAVE_VTK
   ,_vtk_grid(libmesh_nullptr)
   ,_compress(false)
+#ifdef LIBMESH_HAVE_MPI
+  ,_vtk_mpicontroller(libmesh_nullptr)
+#endif
 #endif
 {
 }
@@ -90,6 +97,26 @@ VTKIO::VTKIO (const MeshBase & mesh) :
   ,_compress(false)
 #endif
 {
+#ifdef LIBMESH_HAVE_MPI
+  _vtk_mpicontroller = vtkMPIController::New();
+  // assume that MPI is already initialized
+  _vtk_mpicontroller->Initialize();
+  _vtk_mpicontroller->SetGlobalController(_vtk_mpicontroller);
+#endif
+}
+
+
+
+// Destructor
+VTKIO::~VTKIO ()
+{
+#if defined(LIBMESH_HAVE_VTK) && defined(LIBMESH_HAVE_MPI)
+  if (_vtk_mpicontroller)
+    {
+      _vtk_mpicontroller->Finalize(1);
+      _vtk_mpicontroller = libmesh_nullptr;
+    }
+#endif
 }
 
 


### PR DESCRIPTION
In parallel the vtkXMLPUnstructuredGridWriter needs to have the
vtkMPIController set so that it can communicate properly
between MPI processes to figure out the information in the .pvtu
meta-file.

This compiled on my machine but I did not run any tests on this change since I did not know how to do that. I am more than happy to run tests on the change if someone can tell me how to do that.