### PR TITLE
Cleaning up the VTK parts

### DIFF
--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -26,6 +26,7 @@
 
 #ifdef LIBMESH_HAVE_VTK
 #include "vtkType.h"
+#include "vtkSmartPointer.h"
 #endif
 
 // C++ includes
@@ -140,9 +141,11 @@ private:
   //                            vtkUnstructuredGrid * & grid);
 
   /**
-   * pointer to the VTK grid
+   * pointer to the VTK grid. the vtkSmartPointer will automatically
+   * initialize the value to null and keep track of reference
+   * counting.
    */
-  vtkUnstructuredGrid * _vtk_grid;
+  vtkSmartPointer<vtkUnstructuredGrid> _vtk_grid;
 
   /**
    * Flag to indicate whether the output should be compressed


### PR DESCRIPTION
There was a likely VTK memory leak and/or access to deleted
memory (the leak check can be done at run-time by enabling the
VTK_DEBUG_LEAKS CMake option in the build). Other changes were
replacing non-thread safe methods with thread safe methods.
These are the getter methods that pass in the data to fill
as opposed to returning a value to the data.