### PR TITLE
Elem::loose_bounding_box() fixes

### DIFF
--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -91,7 +91,11 @@ public:
   BoundingBox & expand()
   { return *this; }
 
-  bool intersect (const BoundingBox &) const;
+  /*
+   * Returns true iff the other bounding box intersects this bounding
+   * box.
+   */
+  bool intersects (const BoundingBox &) const;
 
   /*
    * Returns true iff the bounding box contains the given point.

--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -98,6 +98,18 @@ public:
    */
   bool contains_point (const Point &) const;
 
+  /*
+   * Sets this bounding box to be the intersection with the other
+   * bounding box.
+   */
+  void intersect_with (const BoundingBox &);
+
+  /*
+   * Sets this bounding box to be the union with the other
+   * bounding box.
+   */
+  void union_with (const BoundingBox &);
+
 private:
 };
 

--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -58,6 +58,9 @@ public:
     this->invalidate();
   }
 
+  /*
+   * Sets the bounding box to encompass the universe.
+   */
   void invalidate ()
   {
     for (unsigned int i=0; i<LIBMESH_DIM; i++)
@@ -67,12 +70,18 @@ public:
       }
   }
 
+  /*
+   * Returns a point at the minimum x,y,z coordinates of the box.
+   */
   const Point & min() const
   { return this->first; }
 
   Point & min()
   { return this->first; }
 
+  /*
+   * Returns a point at the maximum x,y,z coordinates of the box.
+   */
   const Point & max() const
   { return this->second; }
 
@@ -84,6 +93,9 @@ public:
 
   bool intersect (const BoundingBox &) const;
 
+  /*
+   * Returns true iff the bounding box contains the given point.
+   */
   bool contains_point (const Point &) const;
 
 private:

--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -88,12 +88,9 @@ public:
   Point & max()
   { return this->second; }
 
-  BoundingBox & expand()
-  { return *this; }
-
   /*
-   * Returns true iff the other bounding box intersects this bounding
-   * box.
+   * Returns true iff the other bounding box has a non-empty
+   * intersection with this bounding box.
    */
   bool intersects (const BoundingBox &) const;
 

--- a/src/geom/cell.C
+++ b/src/geom/cell.C
@@ -32,7 +32,7 @@ BoundingBox Cell::loose_bounding_box () const
   BoundingBox bbox = this->build_side_ptr(0)->loose_bounding_box();
   unsigned int my_n_sides = this->n_sides();
   for (unsigned s=1; s < my_n_sides; ++s)
-    bbox.intersect(this->build_side_ptr(s)->loose_bounding_box());
+    bbox.union_with(this->build_side_ptr(s)->loose_bounding_box());
 
   return bbox;
 }

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -380,7 +380,7 @@ BoundingBox Quad8::loose_bounding_box () const
     {
       Real center = this->point(0)(d);
       for (unsigned int p=1; p != 8; ++p)
-        center += this->point(1)(d);
+        center += this->point(p)(d);
       center /= 8;
 
       Real hd = std::abs(center - this->point(0)(d));

--- a/src/mesh/bounding_box.C
+++ b/src/mesh/bounding_box.C
@@ -100,5 +100,39 @@ bool BoundingBox::contains_point (const Point & p) const
 }
 
 
+void BoundingBox::intersect_with (const BoundingBox & other_box)
+{
+  this->first(0)  = std::max(this->first(0),  other_box.first(0));
+  this->second(0) = std::min(this->second(0), other_box.second(0));
+
+#if LIBMESH_DIM > 1
+  this->first(1)  = std::max(this->first(1),  other_box.first(1));
+  this->second(1) = std::min(this->second(1), other_box.second(1));
+#endif
+
+#if LIBMESH_DIM > 2
+  this->first(2)  = std::max(this->first(2),  other_box.first(2));
+  this->second(2) = std::min(this->second(2), other_box.second(2));
+#endif
+}
+
+
+void BoundingBox::union_with (const BoundingBox & other_box)
+{
+  this->first(0)  = std::min(this->first(0),  other_box.first(0));
+  this->second(0) = std::max(this->second(0), other_box.second(0));
+
+#if LIBMESH_DIM > 1
+  this->first(1)  = std::min(this->first(1),  other_box.first(1));
+  this->second(1) = std::max(this->second(1), other_box.second(1));
+#endif
+
+#if LIBMESH_DIM > 2
+  this->first(2)  = std::min(this->first(2),  other_box.first(2));
+  this->second(2) = std::max(this->second(2), other_box.second(2));
+#endif
+}
+
+
 
 } // namespace libMesh

--- a/src/mesh/bounding_box.C
+++ b/src/mesh/bounding_box.C
@@ -24,13 +24,13 @@
 
 namespace libMesh
 {
-// Small helper function to make intersect more readable.
+// Small helper function to make intersects() more readable.
 bool is_between(Real min, Real check, Real max)
 {
   return min <= check && check <= max;
 }
 
-bool BoundingBox::intersect (const BoundingBox & other_box) const
+bool BoundingBox::intersects (const BoundingBox & other_box) const
 {
   // Make local variables first to make thiings more clear in a moment
   const Real & my_min_x = this->first(0);

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -78,7 +78,7 @@ bool TreeNode<N>::insert (const Elem * elem)
   // with the bounding box of the current tree node.
   //
   // If not, we should not care about this element.
-  if (!this->bounding_box.intersect(bbox))
+  if (!this->bounding_box.intersects(bbox))
     return false;
 
   // Only add the element if we are active

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,6 +27,7 @@ unit_tests_sources = \
   fe/fe_szabab_test.C \
   fe/fe_test.h \
   fe/fe_xyz_test.C \
+  geom/elem_test.C \
   geom/node_test.C \
   geom/point_test.C \
   geom/point_test.h \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -110,6 +110,7 @@ endif
 
 if LIBMESH_DEVEL_MODE
   check_PROGRAMS           += unit_tests-devel
+  noinst_PROGRAMS          += unit_tests-devel
   unit_tests_devel_SOURCES  = $(unit_tests_sources)
   unit_tests_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
   unit_tests_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
@@ -118,6 +119,7 @@ endif
 
 if LIBMESH_PROF_MODE
   check_PROGRAMS          += unit_tests-prof
+  noinst_PROGRAMS         += unit_tests-prof
   unit_tests_prof_SOURCES  = $(unit_tests_sources)
   unit_tests_prof_CPPFLAGS = $(CPPFLAGS_PROF) $(AM_CPPFLAGS)
   unit_tests_prof_CXXFLAGS = $(CXXFLAGS_PROF)
@@ -126,6 +128,7 @@ endif
 
 if LIBMESH_OPROF_MODE
   check_PROGRAMS           += unit_tests-oprof
+  noinst_PROGRAMS          += unit_tests-oprof
   unit_tests_oprof_SOURCES  = $(unit_tests_sources)
   unit_tests_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
   unit_tests_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -96,7 +96,8 @@ target_triplet = @target@
 
 check_PROGRAMS = $(am__EXEEXT_1) $(am__EXEEXT_2) $(am__EXEEXT_3) \
 	$(am__EXEEXT_4) $(am__EXEEXT_5) $(am__EXEEXT_6)
-noinst_PROGRAMS = $(am__EXEEXT_7)
+noinst_PROGRAMS = $(am__EXEEXT_7) $(am__EXEEXT_4) $(am__EXEEXT_5) \
+	$(am__EXEEXT_6)
 @LIBMESH_OPT_MODE_TRUE@am__append_2 = unit_tests-opt
 
 # our GLIBC debugging preprocessor flags seem to potentially conflict
@@ -108,13 +109,16 @@ noinst_PROGRAMS = $(am__EXEEXT_7)
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__append_4 = unit_tests-dbg
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_FALSE@am__append_5 = unit_tests-dbg
 @LIBMESH_DEVEL_MODE_TRUE@am__append_6 = unit_tests-devel
-@LIBMESH_PROF_MODE_TRUE@am__append_7 = unit_tests-prof
-@LIBMESH_OPROF_MODE_TRUE@am__append_8 = unit_tests-oprof
+@LIBMESH_DEVEL_MODE_TRUE@am__append_7 = unit_tests-devel
+@LIBMESH_PROF_MODE_TRUE@am__append_8 = unit_tests-prof
+@LIBMESH_PROF_MODE_TRUE@am__append_9 = unit_tests-prof
+@LIBMESH_OPROF_MODE_TRUE@am__append_10 = unit_tests-oprof
+@LIBMESH_OPROF_MODE_TRUE@am__append_11 = unit_tests-oprof
 
 ######################################################################
 #
 # Don't leave code coverage outputs lying around
-@CODE_COVERAGE_ENABLED_TRUE@am__append_9 = */*.gcda */*.gcno
+@CODE_COVERAGE_ENABLED_TRUE@am__append_12 = */*.gcda */*.gcno
 subdir = tests
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ac_cxx_rtti.m4 \
@@ -182,12 +186,12 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/all_tri.C mesh/boundary_mesh.C \
-	mesh/boundary_info.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
+	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
 	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -224,6 +228,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_monomial_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_xyz_test.$(OBJEXT) \
+	geom/unit_tests_dbg-elem_test.$(OBJEXT) \
 	geom/unit_tests_dbg-node_test.$(OBJEXT) \
 	geom/unit_tests_dbg-point_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-all_tri.$(OBJEXT) \
@@ -280,12 +285,12 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/all_tri.C mesh/boundary_mesh.C \
-	mesh/boundary_info.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
+	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
 	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -321,6 +326,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	fe/unit_tests_devel-fe_monomial_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_xyz_test.$(OBJEXT) \
+	geom/unit_tests_devel-elem_test.$(OBJEXT) \
 	geom/unit_tests_devel-node_test.$(OBJEXT) \
 	geom/unit_tests_devel-point_test.$(OBJEXT) \
 	mesh/unit_tests_devel-all_tri.$(OBJEXT) \
@@ -375,12 +381,12 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/all_tri.C mesh/boundary_mesh.C \
-	mesh/boundary_info.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
+	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
 	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -416,6 +422,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_monomial_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_xyz_test.$(OBJEXT) \
+	geom/unit_tests_oprof-elem_test.$(OBJEXT) \
 	geom/unit_tests_oprof-node_test.$(OBJEXT) \
 	geom/unit_tests_oprof-point_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-all_tri.$(OBJEXT) \
@@ -470,12 +477,12 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/all_tri.C mesh/boundary_mesh.C \
-	mesh/boundary_info.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
+	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
 	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -511,6 +518,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	fe/unit_tests_opt-fe_monomial_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_xyz_test.$(OBJEXT) \
+	geom/unit_tests_opt-elem_test.$(OBJEXT) \
 	geom/unit_tests_opt-node_test.$(OBJEXT) \
 	geom/unit_tests_opt-point_test.$(OBJEXT) \
 	mesh/unit_tests_opt-all_tri.$(OBJEXT) \
@@ -563,12 +571,12 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/all_tri.C mesh/boundary_mesh.C \
-	mesh/boundary_info.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
+	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
 	numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -604,6 +612,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	fe/unit_tests_prof-fe_monomial_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_xyz_test.$(OBJEXT) \
+	geom/unit_tests_prof-elem_test.$(OBJEXT) \
 	geom/unit_tests_prof-node_test.$(OBJEXT) \
 	geom/unit_tests_prof-point_test.$(OBJEXT) \
 	mesh/unit_tests_prof-all_tri.$(OBJEXT) \
@@ -1074,9 +1083,9 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
 	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
 	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	mesh/all_tri.C mesh/boundary_mesh.C mesh/boundary_info.C \
-	mesh/checkpoint.C mesh/contains_point.C \
+	geom/elem_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h mesh/all_tri.C mesh/boundary_mesh.C \
+	mesh/boundary_info.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -1122,7 +1131,7 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 TESTS = run_unit_tests.sh
 CLEANFILES = cube_mesh.xdr checkpoint_splitter.cpr-2-0 \
 	checkpoint_splitter.cpr-2-1 slit_mesh.xda slit_solution.xda \
-	$(am__append_9)
+	$(am__append_12)
 all: all-am
 
 .SUFFIXES:
@@ -1222,6 +1231,8 @@ geom/$(am__dirstamp):
 geom/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) geom/$(DEPDIR)
 	@: > geom/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_dbg-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
+	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_dbg-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_dbg-point_test.$(OBJEXT): geom/$(am__dirstamp) \
@@ -1377,6 +1388,8 @@ fe/unit_tests_devel-fe_szabab_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_devel-fe_xyz_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_devel-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
+	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-point_test.$(OBJEXT): geom/$(am__dirstamp) \
@@ -1484,6 +1497,8 @@ fe/unit_tests_oprof-fe_szabab_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_oprof-fe_xyz_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_oprof-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
+	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_oprof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_oprof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
@@ -1591,6 +1606,8 @@ fe/unit_tests_opt-fe_szabab_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_opt-fe_xyz_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_opt-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
+	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-point_test.$(OBJEXT): geom/$(am__dirstamp) \
@@ -1698,6 +1715,8 @@ fe/unit_tests_prof-fe_szabab_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_prof-fe_xyz_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_prof-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
+	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_prof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_prof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
@@ -1875,14 +1894,19 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_oprof-autodiff.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_opt-autodiff.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_prof-autodiff.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Po@am__quote@
@@ -2289,6 +2313,20 @@ fe/unit_tests_dbg-fe_xyz_test.obj: fe/fe_xyz_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/fe_xyz_test.C' object='fe/unit_tests_dbg-fe_xyz_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_dbg-fe_xyz_test.obj `if test -f 'fe/fe_xyz_test.C'; then $(CYGPATH_W) 'fe/fe_xyz_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_xyz_test.C'; fi`
+
+geom/unit_tests_dbg-elem_test.o: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_dbg-elem_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_dbg-elem_test.Tpo -c -o geom/unit_tests_dbg-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_dbg-elem_test.Tpo geom/$(DEPDIR)/unit_tests_dbg-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_dbg-elem_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+
+geom/unit_tests_dbg-elem_test.obj: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_dbg-elem_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_dbg-elem_test.Tpo -c -o geom/unit_tests_dbg-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_dbg-elem_test.Tpo geom/$(DEPDIR)/unit_tests_dbg-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_dbg-elem_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
 
 geom/unit_tests_dbg-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_dbg-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_dbg-node_test.Tpo -c -o geom/unit_tests_dbg-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
@@ -3018,6 +3056,20 @@ fe/unit_tests_devel-fe_xyz_test.obj: fe/fe_xyz_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_devel-fe_xyz_test.obj `if test -f 'fe/fe_xyz_test.C'; then $(CYGPATH_W) 'fe/fe_xyz_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_xyz_test.C'; fi`
 
+geom/unit_tests_devel-elem_test.o: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_devel-elem_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_devel-elem_test.Tpo -c -o geom/unit_tests_devel-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_devel-elem_test.Tpo geom/$(DEPDIR)/unit_tests_devel-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_devel-elem_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+
+geom/unit_tests_devel-elem_test.obj: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_devel-elem_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_devel-elem_test.Tpo -c -o geom/unit_tests_devel-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_devel-elem_test.Tpo geom/$(DEPDIR)/unit_tests_devel-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_devel-elem_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
+
 geom/unit_tests_devel-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_devel-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_devel-node_test.Tpo -c -o geom/unit_tests_devel-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_devel-node_test.Tpo geom/$(DEPDIR)/unit_tests_devel-node_test.Po
@@ -3745,6 +3797,20 @@ fe/unit_tests_oprof-fe_xyz_test.obj: fe/fe_xyz_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/fe_xyz_test.C' object='fe/unit_tests_oprof-fe_xyz_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_oprof-fe_xyz_test.obj `if test -f 'fe/fe_xyz_test.C'; then $(CYGPATH_W) 'fe/fe_xyz_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_xyz_test.C'; fi`
+
+geom/unit_tests_oprof-elem_test.o: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_oprof-elem_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_oprof-elem_test.Tpo -c -o geom/unit_tests_oprof-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_oprof-elem_test.Tpo geom/$(DEPDIR)/unit_tests_oprof-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_oprof-elem_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+
+geom/unit_tests_oprof-elem_test.obj: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_oprof-elem_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_oprof-elem_test.Tpo -c -o geom/unit_tests_oprof-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_oprof-elem_test.Tpo geom/$(DEPDIR)/unit_tests_oprof-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_oprof-elem_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
 
 geom/unit_tests_oprof-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_oprof-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_oprof-node_test.Tpo -c -o geom/unit_tests_oprof-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
@@ -4474,6 +4540,20 @@ fe/unit_tests_opt-fe_xyz_test.obj: fe/fe_xyz_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_opt-fe_xyz_test.obj `if test -f 'fe/fe_xyz_test.C'; then $(CYGPATH_W) 'fe/fe_xyz_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_xyz_test.C'; fi`
 
+geom/unit_tests_opt-elem_test.o: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_opt-elem_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_opt-elem_test.Tpo -c -o geom/unit_tests_opt-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_opt-elem_test.Tpo geom/$(DEPDIR)/unit_tests_opt-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_opt-elem_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+
+geom/unit_tests_opt-elem_test.obj: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_opt-elem_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_opt-elem_test.Tpo -c -o geom/unit_tests_opt-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_opt-elem_test.Tpo geom/$(DEPDIR)/unit_tests_opt-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_opt-elem_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
+
 geom/unit_tests_opt-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_opt-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_opt-node_test.Tpo -c -o geom/unit_tests_opt-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_opt-node_test.Tpo geom/$(DEPDIR)/unit_tests_opt-node_test.Po
@@ -5201,6 +5281,20 @@ fe/unit_tests_prof-fe_xyz_test.obj: fe/fe_xyz_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/fe_xyz_test.C' object='fe/unit_tests_prof-fe_xyz_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_prof-fe_xyz_test.obj `if test -f 'fe/fe_xyz_test.C'; then $(CYGPATH_W) 'fe/fe_xyz_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_xyz_test.C'; fi`
+
+geom/unit_tests_prof-elem_test.o: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_prof-elem_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_prof-elem_test.Tpo -c -o geom/unit_tests_prof-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_prof-elem_test.Tpo geom/$(DEPDIR)/unit_tests_prof-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_prof-elem_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-elem_test.o `test -f 'geom/elem_test.C' || echo '$(srcdir)/'`geom/elem_test.C
+
+geom/unit_tests_prof-elem_test.obj: geom/elem_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_prof-elem_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_prof-elem_test.Tpo -c -o geom/unit_tests_prof-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_prof-elem_test.Tpo geom/$(DEPDIR)/unit_tests_prof-elem_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_prof-elem_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
 
 geom/unit_tests_prof-node_test.o: geom/node_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_prof-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_prof-node_test.Tpo -c -o geom/unit_tests_prof-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C

--- a/tests/geom/elem_test.C
+++ b/tests/geom/elem_test.C
@@ -1,0 +1,134 @@
+#include "test_comm.h"
+
+#include <libmesh/elem.h>
+#include <libmesh/enum_elem_type.h>
+#include <libmesh/mesh.h>
+#include <libmesh/mesh_generation.h>
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+using namespace libMesh;
+
+template <ElemType elem_type>
+class ElemTest : public CppUnit::TestCase {
+
+private:
+  Mesh * _mesh;
+
+public:
+  void setUp()
+  {
+    const Real minpos = 1.5, maxpos = 5.5;
+    const unsigned int N = 2;
+
+    _mesh = new Mesh(*TestCommWorld);
+    const UniquePtr<Elem> test_elem = Elem::build(elem_type);
+    const unsigned int dim = test_elem->dim();
+    const unsigned int use_y = dim > 1;
+    const unsigned int use_z = dim > 2;
+
+    MeshTools::Generation::build_cube (*_mesh,
+                                      N, N*use_y, N*use_z,
+                                      minpos, maxpos,
+                                      minpos, use_y*maxpos,
+                                      minpos, use_z*maxpos,
+                                      elem_type);
+  }
+
+  void tearDown()
+  {
+    delete _mesh;
+  }
+
+  void test_bounding_box()
+  {
+    MeshBase::const_element_iterator
+      elem_it  = _mesh->active_local_elements_begin(),
+      elem_end = _mesh->active_local_elements_end();
+    for (; elem_it != elem_end; ++elem_it)
+      {
+        const Elem & elem = **elem_it;
+
+        const BoundingBox bbox = elem.loose_bounding_box();
+
+        const Point centroid = elem.centroid();
+
+        // The "loose" bounding box should actually be pretty tight
+        // in most of these cases, but for weirdly aligned triangles
+        // (such as occur in pyramid elements) it won't be, so we'll
+        // just test against a widened bounding box.
+        BoundingBox wide_bbox(elem.point(0), elem.point(0));
+
+        for (unsigned int n = 0; n != elem.n_nodes(); ++n)
+          {
+            const Point & p = elem.point(n);
+
+            CPPUNIT_ASSERT(bbox.contains_point(p));
+
+            wide_bbox.union_with
+              (BoundingBox(elem.point(n), elem.point(n)));
+          }
+
+        for (unsigned int d=0; d != LIBMESH_DIM; ++d)
+          {
+            const Real widening =
+              (wide_bbox.max()(d) - wide_bbox.min()(d)) / 3;
+            wide_bbox.min()(d) -= widening;
+            wide_bbox.max()(d) += widening;
+          }
+
+        CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.min()));
+        CPPUNIT_ASSERT(!bbox.contains_point(wide_bbox.max()));
+    }
+  }
+};
+
+#define ELEMTEST                     \
+  CPPUNIT_TEST( test_bounding_box )
+
+#define INSTANTIATE_ELEMTEST(elemtype) \
+class ElemTest_##elemtype : public ElemTest<elemtype> { \
+public: \
+  CPPUNIT_TEST_SUITE( ElemTest_##elemtype ); \
+  ELEMTEST; \
+  CPPUNIT_TEST_SUITE_END(); \
+}; \
+ \
+CPPUNIT_TEST_SUITE_REGISTRATION( ElemTest_##elemtype )
+
+INSTANTIATE_ELEMTEST(EDGE2);
+INSTANTIATE_ELEMTEST(EDGE3);
+INSTANTIATE_ELEMTEST(EDGE4);
+
+INSTANTIATE_ELEMTEST(TRI3);
+INSTANTIATE_ELEMTEST(TRI6);
+
+INSTANTIATE_ELEMTEST(QUAD4);
+INSTANTIATE_ELEMTEST(QUAD8);
+INSTANTIATE_ELEMTEST(QUAD9);
+
+INSTANTIATE_ELEMTEST(TET4);
+INSTANTIATE_ELEMTEST(TET10);
+
+INSTANTIATE_ELEMTEST(HEX8);
+INSTANTIATE_ELEMTEST(HEX20);
+INSTANTIATE_ELEMTEST(HEX27);
+
+INSTANTIATE_ELEMTEST(PRISM6);
+INSTANTIATE_ELEMTEST(PRISM15);
+INSTANTIATE_ELEMTEST(PRISM18);
+
+INSTANTIATE_ELEMTEST(PYRAMID5);
+INSTANTIATE_ELEMTEST(PYRAMID13);
+INSTANTIATE_ELEMTEST(PYRAMID14);


### PR DESCRIPTION
I clearly should not be allowed to write code without writing unit tests along with it.

This adds Elem::loose_bounding_box() unit tests and adds two fixes to the flaws they made clear.

This should fix the PointLocatorTree (and hence PeriodicBoundary) regression caught by https://github.com/idaholab/moose/pull/8626