### PR TITLE
DistributedMesh compatible tests

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -321,7 +321,9 @@ public:
   void remove_id (boundary_id_type id);
 
   /**
-   * Returns the number of user-specified boundary ids.
+   * Returns the number of user-specified boundary ids on the
+   * semilocal part of the mesh.  DistributedMesh users may need to
+   * compare boundary_ids sets via inter-processor communication.
    */
   std::size_t n_boundary_ids () const { return _boundary_ids.size(); }
 

--- a/tests/systems/equation_systems_test.C
+++ b/tests/systems/equation_systems_test.C
@@ -121,6 +121,7 @@ public:
   void testRefineThenReinitPreserveFlags()
   {
     Mesh mesh(*TestCommWorld);
+    mesh.allow_renumbering(false);
     EquationSystems es(mesh);
     System & sys = es.add_system<System> ("SimpleSystem");
     sys.add_variable("u", FIRST);


### PR DESCRIPTION
We had a couple unit tests that worked with --enable-parmesh on many processor counts but failed when the stars^H^H^H^H^Hpartitioning aligned.