### PR TITLE
Add new subdomain-based Partitioner

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -363,6 +363,7 @@ am__libmesh_dbg_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/parallel/parallel_sort.C src/parallel/threads.C \
 	src/partitioning/centroid_partitioner.C \
 	src/partitioning/linear_partitioner.C \
+	src/partitioning/mapped_subdomain_partitioner.C \
 	src/partitioning/metis_partitioner.C \
 	src/partitioning/parmetis_partitioner.C \
 	src/partitioning/partitioner.C \
@@ -760,6 +761,7 @@ am__objects_1 = src/base/libmesh_dbg_la-default_coupling.lo \
 	src/parallel/libmesh_dbg_la-threads.lo \
 	src/partitioning/libmesh_dbg_la-centroid_partitioner.lo \
 	src/partitioning/libmesh_dbg_la-linear_partitioner.lo \
+	src/partitioning/libmesh_dbg_la-mapped_subdomain_partitioner.lo \
 	src/partitioning/libmesh_dbg_la-metis_partitioner.lo \
 	src/partitioning/libmesh_dbg_la-parmetis_partitioner.lo \
 	src/partitioning/libmesh_dbg_la-partitioner.lo \
@@ -1085,6 +1087,7 @@ am__libmesh_devel_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/parallel/parallel_sort.C src/parallel/threads.C \
 	src/partitioning/centroid_partitioner.C \
 	src/partitioning/linear_partitioner.C \
+	src/partitioning/mapped_subdomain_partitioner.C \
 	src/partitioning/metis_partitioner.C \
 	src/partitioning/parmetis_partitioner.C \
 	src/partitioning/partitioner.C \
@@ -1481,6 +1484,7 @@ am__objects_2 = src/base/libmesh_devel_la-default_coupling.lo \
 	src/parallel/libmesh_devel_la-threads.lo \
 	src/partitioning/libmesh_devel_la-centroid_partitioner.lo \
 	src/partitioning/libmesh_devel_la-linear_partitioner.lo \
+	src/partitioning/libmesh_devel_la-mapped_subdomain_partitioner.lo \
 	src/partitioning/libmesh_devel_la-metis_partitioner.lo \
 	src/partitioning/libmesh_devel_la-parmetis_partitioner.lo \
 	src/partitioning/libmesh_devel_la-partitioner.lo \
@@ -1803,6 +1807,7 @@ am__libmesh_oprof_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/parallel/parallel_sort.C src/parallel/threads.C \
 	src/partitioning/centroid_partitioner.C \
 	src/partitioning/linear_partitioner.C \
+	src/partitioning/mapped_subdomain_partitioner.C \
 	src/partitioning/metis_partitioner.C \
 	src/partitioning/parmetis_partitioner.C \
 	src/partitioning/partitioner.C \
@@ -2199,6 +2204,7 @@ am__objects_3 = src/base/libmesh_oprof_la-default_coupling.lo \
 	src/parallel/libmesh_oprof_la-threads.lo \
 	src/partitioning/libmesh_oprof_la-centroid_partitioner.lo \
 	src/partitioning/libmesh_oprof_la-linear_partitioner.lo \
+	src/partitioning/libmesh_oprof_la-mapped_subdomain_partitioner.lo \
 	src/partitioning/libmesh_oprof_la-metis_partitioner.lo \
 	src/partitioning/libmesh_oprof_la-parmetis_partitioner.lo \
 	src/partitioning/libmesh_oprof_la-partitioner.lo \
@@ -2521,6 +2527,7 @@ am__libmesh_opt_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/parallel/parallel_sort.C src/parallel/threads.C \
 	src/partitioning/centroid_partitioner.C \
 	src/partitioning/linear_partitioner.C \
+	src/partitioning/mapped_subdomain_partitioner.C \
 	src/partitioning/metis_partitioner.C \
 	src/partitioning/parmetis_partitioner.C \
 	src/partitioning/partitioner.C \
@@ -2917,6 +2924,7 @@ am__objects_4 = src/base/libmesh_opt_la-default_coupling.lo \
 	src/parallel/libmesh_opt_la-threads.lo \
 	src/partitioning/libmesh_opt_la-centroid_partitioner.lo \
 	src/partitioning/libmesh_opt_la-linear_partitioner.lo \
+	src/partitioning/libmesh_opt_la-mapped_subdomain_partitioner.lo \
 	src/partitioning/libmesh_opt_la-metis_partitioner.lo \
 	src/partitioning/libmesh_opt_la-parmetis_partitioner.lo \
 	src/partitioning/libmesh_opt_la-partitioner.lo \
@@ -3238,6 +3246,7 @@ am__libmesh_prof_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/parallel/parallel_sort.C src/parallel/threads.C \
 	src/partitioning/centroid_partitioner.C \
 	src/partitioning/linear_partitioner.C \
+	src/partitioning/mapped_subdomain_partitioner.C \
 	src/partitioning/metis_partitioner.C \
 	src/partitioning/parmetis_partitioner.C \
 	src/partitioning/partitioner.C \
@@ -3634,6 +3643,7 @@ am__objects_5 = src/base/libmesh_prof_la-default_coupling.lo \
 	src/parallel/libmesh_prof_la-threads.lo \
 	src/partitioning/libmesh_prof_la-centroid_partitioner.lo \
 	src/partitioning/libmesh_prof_la-linear_partitioner.lo \
+	src/partitioning/libmesh_prof_la-mapped_subdomain_partitioner.lo \
 	src/partitioning/libmesh_prof_la-metis_partitioner.lo \
 	src/partitioning/libmesh_prof_la-parmetis_partitioner.lo \
 	src/partitioning/libmesh_prof_la-partitioner.lo \
@@ -5032,6 +5042,7 @@ libmesh_SOURCES = \
         src/parallel/threads.C \
         src/partitioning/centroid_partitioner.C \
         src/partitioning/linear_partitioner.C \
+        src/partitioning/mapped_subdomain_partitioner.C \
         src/partitioning/metis_partitioner.C \
         src/partitioning/parmetis_partitioner.C \
         src/partitioning/partitioner.C \
@@ -6190,6 +6201,9 @@ src/partitioning/libmesh_dbg_la-centroid_partitioner.lo:  \
 src/partitioning/libmesh_dbg_la-linear_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
+src/partitioning/libmesh_dbg_la-mapped_subdomain_partitioner.lo:  \
+	src/partitioning/$(am__dirstamp) \
+	src/partitioning/$(DEPDIR)/$(am__dirstamp)
 src/partitioning/libmesh_dbg_la-metis_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
@@ -7263,6 +7277,9 @@ src/partitioning/libmesh_devel_la-centroid_partitioner.lo:  \
 src/partitioning/libmesh_devel_la-linear_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
+src/partitioning/libmesh_devel_la-mapped_subdomain_partitioner.lo:  \
+	src/partitioning/$(am__dirstamp) \
+	src/partitioning/$(DEPDIR)/$(am__dirstamp)
 src/partitioning/libmesh_devel_la-metis_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
@@ -8294,6 +8311,9 @@ src/partitioning/libmesh_oprof_la-centroid_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
 src/partitioning/libmesh_oprof_la-linear_partitioner.lo:  \
+	src/partitioning/$(am__dirstamp) \
+	src/partitioning/$(DEPDIR)/$(am__dirstamp)
+src/partitioning/libmesh_oprof_la-mapped_subdomain_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
 src/partitioning/libmesh_oprof_la-metis_partitioner.lo:  \
@@ -9328,6 +9348,9 @@ src/partitioning/libmesh_opt_la-centroid_partitioner.lo:  \
 src/partitioning/libmesh_opt_la-linear_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
+src/partitioning/libmesh_opt_la-mapped_subdomain_partitioner.lo:  \
+	src/partitioning/$(am__dirstamp) \
+	src/partitioning/$(DEPDIR)/$(am__dirstamp)
 src/partitioning/libmesh_opt_la-metis_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
@@ -10356,6 +10379,9 @@ src/partitioning/libmesh_prof_la-centroid_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
 src/partitioning/libmesh_prof_la-linear_partitioner.lo:  \
+	src/partitioning/$(am__dirstamp) \
+	src/partitioning/$(DEPDIR)/$(am__dirstamp)
+src/partitioning/libmesh_prof_la-mapped_subdomain_partitioner.lo:  \
 	src/partitioning/$(am__dirstamp) \
 	src/partitioning/$(DEPDIR)/$(am__dirstamp)
 src/partitioning/libmesh_prof_la-metis_partitioner.lo:  \
@@ -12650,6 +12676,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/parallel/$(DEPDIR)/libmesh_prof_la-threads.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_dbg_la-centroid_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_dbg_la-linear_partitioner.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_dbg_la-mapped_subdomain_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_dbg_la-metis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_dbg_la-parmetis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_dbg_la-partitioner.Plo@am__quote@
@@ -12658,6 +12685,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_dbg_la-subdomain_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_devel_la-centroid_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_devel_la-linear_partitioner.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_devel_la-mapped_subdomain_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_devel_la-metis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_devel_la-parmetis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_devel_la-partitioner.Plo@am__quote@
@@ -12666,6 +12694,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_devel_la-subdomain_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_oprof_la-centroid_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_oprof_la-linear_partitioner.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_oprof_la-mapped_subdomain_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_oprof_la-metis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_oprof_la-parmetis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_oprof_la-partitioner.Plo@am__quote@
@@ -12674,6 +12703,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_oprof_la-subdomain_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_opt_la-centroid_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_opt_la-linear_partitioner.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_opt_la-mapped_subdomain_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_opt_la-metis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_opt_la-parmetis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_opt_la-partitioner.Plo@am__quote@
@@ -12682,6 +12712,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_opt_la-subdomain_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_prof_la-centroid_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_prof_la-linear_partitioner.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_prof_la-mapped_subdomain_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_prof_la-metis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_prof_la-parmetis_partitioner.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/partitioning/$(DEPDIR)/libmesh_prof_la-partitioner.Plo@am__quote@
@@ -15314,6 +15345,13 @@ src/partitioning/libmesh_dbg_la-linear_partitioner.lo: src/partitioning/linear_p
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/partitioning/linear_partitioner.C' object='src/partitioning/libmesh_dbg_la-linear_partitioner.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_dbg_la-linear_partitioner.lo `test -f 'src/partitioning/linear_partitioner.C' || echo '$(srcdir)/'`src/partitioning/linear_partitioner.C
+
+src/partitioning/libmesh_dbg_la-mapped_subdomain_partitioner.lo: src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_dbg_la-mapped_subdomain_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_dbg_la-mapped_subdomain_partitioner.Tpo -c -o src/partitioning/libmesh_dbg_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/partitioning/$(DEPDIR)/libmesh_dbg_la-mapped_subdomain_partitioner.Tpo src/partitioning/$(DEPDIR)/libmesh_dbg_la-mapped_subdomain_partitioner.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/partitioning/mapped_subdomain_partitioner.C' object='src/partitioning/libmesh_dbg_la-mapped_subdomain_partitioner.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_dbg_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
 
 src/partitioning/libmesh_dbg_la-metis_partitioner.lo: src/partitioning/metis_partitioner.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_dbg_la-metis_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_dbg_la-metis_partitioner.Tpo -c -o src/partitioning/libmesh_dbg_la-metis_partitioner.lo `test -f 'src/partitioning/metis_partitioner.C' || echo '$(srcdir)/'`src/partitioning/metis_partitioner.C
@@ -18255,6 +18293,13 @@ src/partitioning/libmesh_devel_la-linear_partitioner.lo: src/partitioning/linear
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_devel_la-linear_partitioner.lo `test -f 'src/partitioning/linear_partitioner.C' || echo '$(srcdir)/'`src/partitioning/linear_partitioner.C
 
+src/partitioning/libmesh_devel_la-mapped_subdomain_partitioner.lo: src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_devel_la-mapped_subdomain_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_devel_la-mapped_subdomain_partitioner.Tpo -c -o src/partitioning/libmesh_devel_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/partitioning/$(DEPDIR)/libmesh_devel_la-mapped_subdomain_partitioner.Tpo src/partitioning/$(DEPDIR)/libmesh_devel_la-mapped_subdomain_partitioner.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/partitioning/mapped_subdomain_partitioner.C' object='src/partitioning/libmesh_devel_la-mapped_subdomain_partitioner.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_devel_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
+
 src/partitioning/libmesh_devel_la-metis_partitioner.lo: src/partitioning/metis_partitioner.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_devel_la-metis_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_devel_la-metis_partitioner.Tpo -c -o src/partitioning/libmesh_devel_la-metis_partitioner.lo `test -f 'src/partitioning/metis_partitioner.C' || echo '$(srcdir)/'`src/partitioning/metis_partitioner.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/partitioning/$(DEPDIR)/libmesh_devel_la-metis_partitioner.Tpo src/partitioning/$(DEPDIR)/libmesh_devel_la-metis_partitioner.Plo
@@ -21194,6 +21239,13 @@ src/partitioning/libmesh_oprof_la-linear_partitioner.lo: src/partitioning/linear
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/partitioning/linear_partitioner.C' object='src/partitioning/libmesh_oprof_la-linear_partitioner.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_oprof_la-linear_partitioner.lo `test -f 'src/partitioning/linear_partitioner.C' || echo '$(srcdir)/'`src/partitioning/linear_partitioner.C
+
+src/partitioning/libmesh_oprof_la-mapped_subdomain_partitioner.lo: src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_oprof_la-mapped_subdomain_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_oprof_la-mapped_subdomain_partitioner.Tpo -c -o src/partitioning/libmesh_oprof_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/partitioning/$(DEPDIR)/libmesh_oprof_la-mapped_subdomain_partitioner.Tpo src/partitioning/$(DEPDIR)/libmesh_oprof_la-mapped_subdomain_partitioner.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/partitioning/mapped_subdomain_partitioner.C' object='src/partitioning/libmesh_oprof_la-mapped_subdomain_partitioner.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_oprof_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
 
 src/partitioning/libmesh_oprof_la-metis_partitioner.lo: src/partitioning/metis_partitioner.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_oprof_la-metis_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_oprof_la-metis_partitioner.Tpo -c -o src/partitioning/libmesh_oprof_la-metis_partitioner.lo `test -f 'src/partitioning/metis_partitioner.C' || echo '$(srcdir)/'`src/partitioning/metis_partitioner.C
@@ -24135,6 +24187,13 @@ src/partitioning/libmesh_opt_la-linear_partitioner.lo: src/partitioning/linear_p
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_opt_la-linear_partitioner.lo `test -f 'src/partitioning/linear_partitioner.C' || echo '$(srcdir)/'`src/partitioning/linear_partitioner.C
 
+src/partitioning/libmesh_opt_la-mapped_subdomain_partitioner.lo: src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_opt_la-mapped_subdomain_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_opt_la-mapped_subdomain_partitioner.Tpo -c -o src/partitioning/libmesh_opt_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/partitioning/$(DEPDIR)/libmesh_opt_la-mapped_subdomain_partitioner.Tpo src/partitioning/$(DEPDIR)/libmesh_opt_la-mapped_subdomain_partitioner.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/partitioning/mapped_subdomain_partitioner.C' object='src/partitioning/libmesh_opt_la-mapped_subdomain_partitioner.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_opt_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
+
 src/partitioning/libmesh_opt_la-metis_partitioner.lo: src/partitioning/metis_partitioner.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_opt_la-metis_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_opt_la-metis_partitioner.Tpo -c -o src/partitioning/libmesh_opt_la-metis_partitioner.lo `test -f 'src/partitioning/metis_partitioner.C' || echo '$(srcdir)/'`src/partitioning/metis_partitioner.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/partitioning/$(DEPDIR)/libmesh_opt_la-metis_partitioner.Tpo src/partitioning/$(DEPDIR)/libmesh_opt_la-metis_partitioner.Plo
@@ -27074,6 +27133,13 @@ src/partitioning/libmesh_prof_la-linear_partitioner.lo: src/partitioning/linear_
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/partitioning/linear_partitioner.C' object='src/partitioning/libmesh_prof_la-linear_partitioner.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_prof_la-linear_partitioner.lo `test -f 'src/partitioning/linear_partitioner.C' || echo '$(srcdir)/'`src/partitioning/linear_partitioner.C
+
+src/partitioning/libmesh_prof_la-mapped_subdomain_partitioner.lo: src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_prof_la-mapped_subdomain_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_prof_la-mapped_subdomain_partitioner.Tpo -c -o src/partitioning/libmesh_prof_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/partitioning/$(DEPDIR)/libmesh_prof_la-mapped_subdomain_partitioner.Tpo src/partitioning/$(DEPDIR)/libmesh_prof_la-mapped_subdomain_partitioner.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/partitioning/mapped_subdomain_partitioner.C' object='src/partitioning/libmesh_prof_la-mapped_subdomain_partitioner.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/partitioning/libmesh_prof_la-mapped_subdomain_partitioner.lo `test -f 'src/partitioning/mapped_subdomain_partitioner.C' || echo '$(srcdir)/'`src/partitioning/mapped_subdomain_partitioner.C
 
 src/partitioning/libmesh_prof_la-metis_partitioner.lo: src/partitioning/metis_partitioner.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/partitioning/libmesh_prof_la-metis_partitioner.lo -MD -MP -MF src/partitioning/$(DEPDIR)/libmesh_prof_la-metis_partitioner.Tpo -c -o src/partitioning/libmesh_prof_la-metis_partitioner.lo `test -f 'src/partitioning/metis_partitioner.C' || echo '$(srcdir)/'`src/partitioning/metis_partitioner.C

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -846,6 +846,7 @@ include_HEADERS = \
         partitioning/centroid_partitioner.h \
         partitioning/hilbert_sfc_partitioner.h \
         partitioning/linear_partitioner.h \
+        partitioning/mapped_subdomain_partitioner.h \
         partitioning/metis_csr_graph.h \
         partitioning/metis_partitioner.h \
         partitioning/morton_sfc_partitioner.h \

--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -662,6 +662,23 @@ struct ActiveSubdomain : abstract_multi_predicate<T>
 
 
 /**
+ * Used to iterate over non-NULL, active elements whose
+ * subdomains are in a user-specified set.
+ */
+template <typename T>
+struct ActiveSubdomainSet : abstract_multi_predicate<T>
+{
+  ActiveSubdomainSet(std::set<subdomain_id_type> sset)
+  {
+    this->_predicates.push_back(new not_null<T>);
+    this->_predicates.push_back(new active<T>);
+    this->_predicates.push_back(new subdomain_set<T>(sset));
+  }
+};
+
+
+
+/**
  * Used to iterate over non-NULL elements not owned by a given
  * processor but semi-local to that processor, i.e. ghost elements.
  */

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -26,6 +26,7 @@
 
 // C++ includes
 #include <vector>
+#include <set>
 
 namespace libMesh
 {
@@ -408,6 +409,24 @@ struct subdomain : predicate<T>
 protected:
   virtual predicate<T> * clone() const libmesh_override { return new subdomain<T>(*this); }
   const subdomain_id_type _subdomain;
+};
+
+
+// The subdomain_set predicate returns true if the pointer's
+// subdomain id is in the provided std::set<subdomain_id_type>.
+template <typename T>
+struct subdomain_set : predicate<T>
+{
+  // Constructor
+  subdomain_set(std::set<subdomain_id_type> sset) : _subdomain_set(sset) {}
+  virtual ~subdomain_set() {}
+
+  // op()
+  virtual bool operator()(const T & it) const libmesh_override { return _subdomain_set.count((*it)->subdomain_id()); }
+
+protected:
+  virtual predicate<T> * clone() const libmesh_override { return new subdomain_set<T>(*this); }
+  const std::set<subdomain_id_type> _subdomain_set;
 };
 
 

--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -95,7 +95,7 @@ public:
   bool intersects (const BoundingBox &) const;
 
   bool intersect (const BoundingBox & b) const
-    { libmesh_deprecated(); return this->intersect(b); }
+    { libmesh_deprecated(); return this->intersects(b); }
 
   /*
    * Returns true iff the bounding box contains the given point.

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -278,6 +278,7 @@ include_HEADERS =  \
         partitioning/centroid_partitioner.h \
         partitioning/hilbert_sfc_partitioner.h \
         partitioning/linear_partitioner.h \
+        partitioning/mapped_subdomain_partitioner.h \
         partitioning/metis_csr_graph.h \
         partitioning/metis_partitioner.h \
         partitioning/morton_sfc_partitioner.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -272,6 +272,7 @@ BUILT_SOURCES = \
         centroid_partitioner.h \
         hilbert_sfc_partitioner.h \
         linear_partitioner.h \
+        mapped_subdomain_partitioner.h \
         metis_csr_graph.h \
         metis_partitioner.h \
         morton_sfc_partitioner.h \
@@ -1323,6 +1324,9 @@ hilbert_sfc_partitioner.h: $(top_srcdir)/include/partitioning/hilbert_sfc_partit
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 linear_partitioner.h: $(top_srcdir)/include/partitioning/linear_partitioner.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+mapped_subdomain_partitioner.h: $(top_srcdir)/include/partitioning/mapped_subdomain_partitioner.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 metis_csr_graph.h: $(top_srcdir)/include/partitioning/metis_csr_graph.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -571,10 +571,11 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	parallel_sort.h threads.h threads_allocators.h threads_none.h \
 	threads_pthread.h threads_tbb.h centroid_partitioner.h \
 	hilbert_sfc_partitioner.h linear_partitioner.h \
-	metis_csr_graph.h metis_partitioner.h morton_sfc_partitioner.h \
-	parmetis_helper.h parmetis_partitioner.h partitioner.h \
-	sfc_partitioner.h subdomain_partitioner.h diff_physics.h \
-	diff_qoi.h fem_physics.h quadrature.h quadrature_clough.h \
+	mapped_subdomain_partitioner.h metis_csr_graph.h \
+	metis_partitioner.h morton_sfc_partitioner.h parmetis_helper.h \
+	parmetis_partitioner.h partitioner.h sfc_partitioner.h \
+	subdomain_partitioner.h diff_physics.h diff_qoi.h \
+	fem_physics.h quadrature.h quadrature_clough.h \
 	quadrature_composite.h quadrature_conical.h quadrature_gauss.h \
 	quadrature_gauss_lobatto.h quadrature_gm.h quadrature_grid.h \
 	quadrature_jacobi.h quadrature_monomial.h quadrature_simpson.h \
@@ -1669,6 +1670,9 @@ hilbert_sfc_partitioner.h: $(top_srcdir)/include/partitioning/hilbert_sfc_partit
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 linear_partitioner.h: $(top_srcdir)/include/partitioning/linear_partitioner.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+mapped_subdomain_partitioner.h: $(top_srcdir)/include/partitioning/mapped_subdomain_partitioner.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 metis_csr_graph.h: $(top_srcdir)/include/partitioning/metis_csr_graph.h

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -395,6 +395,11 @@ public:
   virtual const_element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) const libmesh_override;
   virtual const_element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) const libmesh_override;
 
+  virtual element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) libmesh_override;
+  virtual element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) libmesh_override;
+  virtual const_element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const libmesh_override;
+  virtual const_element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const libmesh_override;
+
   virtual element_iterator ghost_elements_begin () libmesh_override;
   virtual element_iterator ghost_elements_end () libmesh_override;
   virtual const_element_iterator ghost_elements_begin () const libmesh_override;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -27,7 +27,6 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/multi_predicates.h"
-#include "libmesh/partitioner.h" // UniquePtr needs a real declaration
 #include "libmesh/point_locator_base.h"
 #include "libmesh/variant_filter_iterator.h"
 #include "libmesh/parallel_object.h"
@@ -44,6 +43,7 @@ class Elem;
 class GhostingFunctor;
 class Node;
 class Point;
+class Partitioner;
 
 template <class MT>
 class MeshInput;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1097,6 +1097,11 @@ public:
   virtual const_element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) const = 0;
   virtual const_element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) const = 0;
 
+  virtual element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) = 0;
+  virtual element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) = 0;
+  virtual const_element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const = 0;
+  virtual const_element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const = 0;
+
   virtual element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) = 0;
   virtual element_iterator active_local_subdomain_elements_end (subdomain_id_type subdomain_id) = 0;
   virtual const_element_iterator active_local_subdomain_elements_begin (subdomain_id_type subdomain_id) const = 0;

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -353,6 +353,11 @@ public:
   virtual const_element_iterator active_subdomain_elements_begin (subdomain_id_type subdomain_id) const libmesh_override;
   virtual const_element_iterator active_subdomain_elements_end (subdomain_id_type subdomain_id) const libmesh_override;
 
+  virtual element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) libmesh_override;
+  virtual element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) libmesh_override;
+  virtual const_element_iterator active_subdomain_set_elements_begin (std::set<subdomain_id_type> ss) const libmesh_override;
+  virtual const_element_iterator active_subdomain_set_elements_end (std::set<subdomain_id_type> ss) const libmesh_override;
+
   virtual element_iterator ghost_elements_begin () libmesh_override;
   virtual element_iterator ghost_elements_end () libmesh_override;
   virtual const_element_iterator ghost_elements_begin () const libmesh_override;

--- a/include/partitioning/centroid_partitioner.h
+++ b/include/partitioning/centroid_partitioner.h
@@ -85,6 +85,13 @@ public:
    */
   void set_sort_method (const CentroidSortMethod sm) { _sort_method = sm; }
 
+  /**
+   * Called by the SubdomainPartitioner to partition elements in the range (it, end).
+   */
+  virtual void partition_range(MeshBase & mesh,
+                               MeshBase::element_iterator it,
+                               MeshBase::element_iterator end,
+                               const unsigned int n) libmesh_override;
 
 protected:
 
@@ -97,10 +104,10 @@ protected:
 private:
 
   /**
-   * Computes a list of element centroids for the mesh.  This list
-   * will be kept around in case a repartition is desired.
+   * Computes a list of element centroids for the mesh.
    */
-  void compute_centroids (MeshBase & mesh);
+  void compute_centroids (MeshBase::element_iterator it,
+                          MeshBase::element_iterator end);
 
   /**
    * Helper function which sorts by the centroid's x-coordinate in the

--- a/include/partitioning/linear_partitioner.h
+++ b/include/partitioning/linear_partitioner.h
@@ -54,6 +54,13 @@ public:
     return UniquePtr<Partitioner>(new LinearPartitioner());
   }
 
+  /**
+   * Called by the SubdomainPartitioner to partition elements in the range (it, end).
+   */
+  virtual void partition_range(MeshBase & mesh,
+                               MeshBase::element_iterator it,
+                               MeshBase::element_iterator end,
+                               const unsigned int n) libmesh_override;
 protected:
 
   /**

--- a/include/partitioning/sfc_partitioner.h
+++ b/include/partitioning/sfc_partitioner.h
@@ -70,6 +70,13 @@ public:
     _sfc_type = sfc_type;
   }
 
+  /**
+   * Called by the SubdomainPartitioner to partition elements in the range (it, end).
+   */
+  virtual void partition_range(MeshBase & mesh,
+                               MeshBase::element_iterator it,
+                               MeshBase::element_iterator end,
+                               const unsigned int n) libmesh_override;
 
 protected:
 

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -268,6 +268,7 @@ libmesh_SOURCES =  \
         src/parallel/threads.C \
         src/partitioning/centroid_partitioner.C \
         src/partitioning/linear_partitioner.C \
+        src/partitioning/mapped_subdomain_partitioner.C \
         src/partitioning/metis_partitioner.C \
         src/partitioning/parmetis_partitioner.C \
         src/partitioning/partitioner.C \

--- a/src/mesh/mesh_iterators.C
+++ b/src/mesh/mesh_iterators.C
@@ -154,6 +154,7 @@ INSTANTIATE_ELEM_ACCESSORS(type_elements,                   Type,               
 INSTANTIATE_ELEM_ACCESSORS(active_type_elements,            ActiveType,           ElemType type,                  type)
 INSTANTIATE_ELEM_ACCESSORS(active_pid_elements,             ActivePID,            processor_id_type proc_id,      proc_id)
 INSTANTIATE_ELEM_ACCESSORS(active_subdomain_elements,       ActiveSubdomain,      subdomain_id_type subdomain_id, subdomain_id)
+INSTANTIATE_ELEM_ACCESSORS(active_subdomain_set_elements,   ActiveSubdomainSet,   std::set<subdomain_id_type> ss, ss)
 INSTANTIATE_ELEM_ACCESSORS(ghost_elements,                  Ghost,                EMPTY,                          this->processor_id())
 INSTANTIATE_ELEM_ACCESSORS(evaluable_elements,              Evaluable,            const DofMap & dof_map LIBMESH_COMMA unsigned int var_num, this->processor_id(), dof_map, var_num)
 INSTANTIATE_ELEM_ACCESSORS(unpartitioned_elements,          PID,                  EMPTY,                          DofObject::invalid_processor_id)

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -39,6 +39,7 @@
 #include "libmesh/remote_elem.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/unstructured_mesh.h"
+#include "libmesh/partitioner.h"
 
 namespace
 {

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -226,6 +226,11 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
                 if (neighbor != libmesh_nullptr)
                   {
+                    // If the neighbor is not in the range of elements
+                    // being partitioned, treat it as a NULL neighbor.
+                    if (global_index_map.find(neighbor->id()) == global_index_map.end())
+                      continue;
+
                     // If the neighbor is active treat it
                     // as a connection
                     if (neighbor->active())
@@ -263,6 +268,10 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                           {
                             const Elem * child =
                               neighbors_offspring[nc];
+
+                            // Skip neighbor offspring which are not in the range of elements being partitioned.
+                            if (global_index_map.find(child->id()) == global_index_map.end())
+                              continue;
 
                             // This does not assume a level-1 mesh.
                             // Note that since children have sides numbered
@@ -324,6 +333,11 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
                 if (neighbor != libmesh_nullptr)
                   {
+                    // If the neighbor is not in the range of elements
+                    // being partitioned, treat it as a NULL neighbor.
+                    if (global_index_map.find(neighbor->id()) == global_index_map.end())
+                      continue;
+
                     // If the neighbor is active treat it
                     // as a connection
                     if (neighbor->active())
@@ -353,6 +367,10 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                           {
                             const Elem * child =
                               neighbors_offspring[nc];
+
+                            // Skip neighbor offspring which are not in the range of elements being partitioned.
+                            if (global_index_map.find(child->id()) == global_index_map.end())
+                              continue;
 
                             // This does not assume a level-1 mesh.
                             // Note that since children have sides numbered

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -88,21 +88,6 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
   const dof_id_type n_range_elem = std::distance(beg, end);
 
-  // build the graph
-  // std::vector<Metis::idx_t> options(5);
-  std::vector<Metis::idx_t> vwgt(n_range_elem);
-  std::vector<Metis::idx_t> part(n_range_elem);
-
-  Metis::idx_t
-    n = static_cast<Metis::idx_t>(n_range_elem),   // number of "nodes" (elements) in the graph
-    // wgtflag = 2,                                // weights on vertices only, none on edges
-    // numflag = 0,                                // C-style 0-based numbering
-    nparts  = static_cast<Metis::idx_t>(n_pieces), // number of subdomains to create
-    edgecut = 0;                                   // the numbers of edges cut by the resulting partition
-
-  // Set the options
-  // options[0] = 0; // use default options
-
   // Metis will only consider the elements in the range.
   // We need to map the range element ids into a
   // contiguous range.  Further, we want the unique range indexing to be
@@ -174,11 +159,28 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
       }
   }
 
+  // Data structure that Metis will fill up on processor 0 and broadcast.
+  std::vector<Metis::idx_t> part(n_range_elem);
 
   // Invoke METIS, but only on processor 0.
   // Then broadcast the resulting decomposition
   if (mesh.processor_id() == 0)
     {
+      // Data structures and parameters needed only on processor 0 by Metis.
+      // std::vector<Metis::idx_t> options(5);
+      std::vector<Metis::idx_t> vwgt(n_range_elem);
+
+      Metis::idx_t
+        n = static_cast<Metis::idx_t>(n_range_elem),   // number of "nodes" (elements) in the graph
+        // wgtflag = 2,                                // weights on vertices only, none on edges
+        // numflag = 0,                                // C-style 0-based numbering
+        nparts  = static_cast<Metis::idx_t>(n_pieces), // number of subdomains to create
+        edgecut = 0;                                   // the numbers of edges cut by the resulting partition
+
+      // Set the options
+      // options[0] = 0; // use default options
+
+      // build the graph
       METIS_CSR_Graph<Metis::idx_t> csr_graph;
 
       csr_graph.offsets.resize(n_range_elem + 1, 0);

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -230,7 +230,12 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                   {
                     // If the neighbor is not in the range of elements
                     // being partitioned, treat it as a NULL neighbor.
-                    if (global_index_map.find(neighbor->id()) == global_index_map.end())
+                    //
+                    // Note: vectormap::find() is a little weird, it
+                    // returns lower_bound, so checking its return
+                    // value against end() is not useful.  Therefore,
+                    // we vall vectormap::count() instead!
+                    if (!global_index_map.count(neighbor->id()))
                       continue;
 
                     // If the neighbor is active treat it
@@ -272,7 +277,7 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                               neighbors_offspring[nc];
 
                             // Skip neighbor offspring which are not in the range of elements being partitioned.
-                            if (global_index_map.find(child->id()) == global_index_map.end())
+                            if (!global_index_map.count(child->id()))
                               continue;
 
                             // This does not assume a level-1 mesh.
@@ -337,7 +342,12 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                   {
                     // If the neighbor is not in the range of elements
                     // being partitioned, treat it as a NULL neighbor.
-                    if (global_index_map.find(neighbor->id()) == global_index_map.end())
+                    //
+                    // Note: vectormap::find() is a little weird, it
+                    // returns lower_bound, so checking its return
+                    // value against end() is not useful.  Therefore,
+                    // we vall vectormap::count() instead!
+                    if (!global_index_map.count(neighbor->id()))
                       continue;
 
                     // If the neighbor is active treat it
@@ -371,7 +381,7 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                               neighbors_offspring[nc];
 
                             // Skip neighbor offspring which are not in the range of elements being partitioned.
-                            if (global_index_map.find(child->id()) == global_index_map.end())
+                            if (!global_index_map.count(child->id()))
                               continue;
 
                             // This does not assume a level-1 mesh.

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -150,24 +150,27 @@ void Partitioner::repartition (MeshBase & mesh,
 
 void Partitioner::single_partition (MeshBase & mesh)
 {
-  LOG_SCOPE("single_partition()","Partitioner");
-
-  // Loop over all the elements and assign them to processor 0.
-  MeshBase::element_iterator       elem_it  = mesh.elements_begin();
-  const MeshBase::element_iterator elem_end = mesh.elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
-    (*elem_it)->processor_id() = 0;
-
-  // For a single partition, all the nodes are on processor 0
-  MeshBase::node_iterator       node_it  = mesh.nodes_begin();
-  const MeshBase::node_iterator node_end = mesh.nodes_end();
-
-  for ( ; node_it != node_end; ++node_it)
-    (*node_it)->processor_id() = 0;
+  this->single_partition_range(mesh.elements_begin(),
+                               mesh.elements_end());
 }
 
 
+
+void Partitioner::single_partition_range (MeshBase::element_iterator it,
+                                          MeshBase::element_iterator end)
+{
+  LOG_SCOPE("single_partition_range()", "Partitioner");
+
+  for ( ; it != end; ++it)
+    {
+      Elem * elem = *it;
+      elem->processor_id() = 0;
+
+      // Assign all this element's nodes to processor 0 as well.
+      for (unsigned int n=0; n<elem->n_nodes(); ++n)
+        elem->node_ptr(n)->processor_id() = 0;
+    }
+}
 
 void Partitioner::partition_unpartitioned_elements (MeshBase & mesh)
 {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,7 +41,7 @@ unit_tests_sources = \
   mesh/mesh_extruder.C \
   mesh/slit_mesh_test.C \
   mesh/spatial_dimension_test.C \
-  mesh/subdomain_partitioner_test.C \
+  mesh/mapped_subdomain_partitioner_test.C \
   mesh/mesh_function_dfem.C \
   numerics/composite_function_test.C \
   numerics/coupling_matrix_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -192,8 +192,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
-	numerics/composite_function_test.C \
+	mesh/mapped_subdomain_partitioner_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -241,7 +241,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT) \
-	mesh/unit_tests_dbg-subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_dbg-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-coupling_matrix_test.$(OBJEXT) \
@@ -291,8 +291,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
-	numerics/composite_function_test.C \
+	mesh/mapped_subdomain_partitioner_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -339,7 +339,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_devel-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_devel-spatial_dimension_test.$(OBJEXT) \
-	mesh/unit_tests_devel-subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_devel-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_devel-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-coupling_matrix_test.$(OBJEXT) \
@@ -387,8 +387,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
-	numerics/composite_function_test.C \
+	mesh/mapped_subdomain_partitioner_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -435,7 +435,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT) \
-	mesh/unit_tests_oprof-subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_oprof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-coupling_matrix_test.$(OBJEXT) \
@@ -483,8 +483,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
-	numerics/composite_function_test.C \
+	mesh/mapped_subdomain_partitioner_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -531,7 +531,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_opt-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_opt-spatial_dimension_test.$(OBJEXT) \
-	mesh/unit_tests_opt-subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_opt-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_opt-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-coupling_matrix_test.$(OBJEXT) \
@@ -577,8 +577,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
 	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
-	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
-	numerics/composite_function_test.C \
+	mesh/mapped_subdomain_partitioner_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -625,7 +625,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_extruder.$(OBJEXT) \
 	mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT) \
-	mesh/unit_tests_prof-subdomain_partitioner_test.$(OBJEXT) \
+	mesh/unit_tests_prof-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_function_dfem.$(OBJEXT) \
 	numerics/unit_tests_prof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-coupling_matrix_test.$(OBJEXT) \
@@ -1089,8 +1089,8 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
-	mesh/subdomain_partitioner_test.C mesh/mesh_function_dfem.C \
-	numerics/composite_function_test.C \
+	mesh/mapped_subdomain_partitioner_test.C \
+	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -1263,7 +1263,7 @@ mesh/unit_tests_dbg-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
-mesh/unit_tests_dbg-subdomain_partitioner_test.$(OBJEXT):  \
+mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1414,7 +1414,7 @@ mesh/unit_tests_devel-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
-mesh/unit_tests_devel-subdomain_partitioner_test.$(OBJEXT):  \
+mesh/unit_tests_devel-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1523,7 +1523,7 @@ mesh/unit_tests_oprof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
-mesh/unit_tests_oprof-subdomain_partitioner_test.$(OBJEXT):  \
+mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1632,7 +1632,7 @@ mesh/unit_tests_opt-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
-mesh/unit_tests_opt-subdomain_partitioner_test.$(OBJEXT):  \
+mesh/unit_tests_opt-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1741,7 +1741,7 @@ mesh/unit_tests_prof-slit_mesh_test.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
-mesh/unit_tests_prof-subdomain_partitioner_test.$(OBJEXT):  \
+mesh/unit_tests_prof-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1914,61 +1914,61 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po@am__quote@
@@ -2496,19 +2496,19 @@ mesh/unit_tests_dbg-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
 
-mesh/unit_tests_dbg-subdomain_partitioner_test.o: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_dbg-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_dbg-subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.o: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
 
-mesh/unit_tests_dbg-subdomain_partitioner_test.obj: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_dbg-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_dbg-subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
 
 mesh/unit_tests_dbg-mesh_function_dfem.o: mesh/mesh_function_dfem.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Tpo -c -o mesh/unit_tests_dbg-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
@@ -3238,19 +3238,19 @@ mesh/unit_tests_devel-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
 
-mesh/unit_tests_devel-subdomain_partitioner_test.o: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_devel-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_devel-subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_devel-mapped_subdomain_partitioner_test.o: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mapped_subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_devel-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_devel-mapped_subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
 
-mesh/unit_tests_devel-subdomain_partitioner_test.obj: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_devel-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_devel-subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_devel-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mapped_subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_devel-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_devel-mapped_subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
 
 mesh/unit_tests_devel-mesh_function_dfem.o: mesh/mesh_function_dfem.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Tpo -c -o mesh/unit_tests_devel-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
@@ -3980,19 +3980,19 @@ mesh/unit_tests_oprof-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
 
-mesh/unit_tests_oprof-subdomain_partitioner_test.o: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_oprof-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_oprof-subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.o: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
 
-mesh/unit_tests_oprof-subdomain_partitioner_test.obj: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_oprof-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_oprof-subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
 
 mesh/unit_tests_oprof-mesh_function_dfem.o: mesh/mesh_function_dfem.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Tpo -c -o mesh/unit_tests_oprof-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
@@ -4722,19 +4722,19 @@ mesh/unit_tests_opt-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
 
-mesh/unit_tests_opt-subdomain_partitioner_test.o: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_opt-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_opt-subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_opt-mapped_subdomain_partitioner_test.o: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mapped_subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_opt-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_opt-mapped_subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
 
-mesh/unit_tests_opt-subdomain_partitioner_test.obj: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_opt-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_opt-subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_opt-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mapped_subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_opt-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_opt-mapped_subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
 
 mesh/unit_tests_opt-mesh_function_dfem.o: mesh/mesh_function_dfem.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Tpo -c -o mesh/unit_tests_opt-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C
@@ -5464,19 +5464,19 @@ mesh/unit_tests_prof-spatial_dimension_test.obj: mesh/spatial_dimension_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-spatial_dimension_test.obj `if test -f 'mesh/spatial_dimension_test.C'; then $(CYGPATH_W) 'mesh/spatial_dimension_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/spatial_dimension_test.C'; fi`
 
-mesh/unit_tests_prof-subdomain_partitioner_test.o: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_prof-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_prof-subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_prof-mapped_subdomain_partitioner_test.o: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mapped_subdomain_partitioner_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_prof-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_prof-mapped_subdomain_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-subdomain_partitioner_test.o `test -f 'mesh/subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/subdomain_partitioner_test.C
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mapped_subdomain_partitioner_test.o `test -f 'mesh/mapped_subdomain_partitioner_test.C' || echo '$(srcdir)/'`mesh/mapped_subdomain_partitioner_test.C
 
-mesh/unit_tests_prof-subdomain_partitioner_test.obj: mesh/subdomain_partitioner_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_prof-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-subdomain_partitioner_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/subdomain_partitioner_test.C' object='mesh/unit_tests_prof-subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+mesh/unit_tests_prof-mapped_subdomain_partitioner_test.obj: mesh/mapped_subdomain_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mapped_subdomain_partitioner_test.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Tpo -c -o mesh/unit_tests_prof-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mapped_subdomain_partitioner_test.C' object='mesh/unit_tests_prof-mapped_subdomain_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-subdomain_partitioner_test.obj `if test -f 'mesh/subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/subdomain_partitioner_test.C'; fi`
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mapped_subdomain_partitioner_test.obj `if test -f 'mesh/mapped_subdomain_partitioner_test.C'; then $(CYGPATH_W) 'mesh/mapped_subdomain_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mapped_subdomain_partitioner_test.C'; fi`
 
 mesh/unit_tests_prof-mesh_function_dfem.o: mesh/mesh_function_dfem.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_function_dfem.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Tpo -c -o mesh/unit_tests_prof-mesh_function_dfem.o `test -f 'mesh/mesh_function_dfem.C' || echo '$(srcdir)/'`mesh/mesh_function_dfem.C

--- a/tests/mesh/mapped_subdomain_partitioner_test.C
+++ b/tests/mesh/mapped_subdomain_partitioner_test.C
@@ -9,7 +9,7 @@
 #include <libmesh/elem.h>
 #include <libmesh/mesh_generation.h>
 #include <libmesh/mesh_modification.h>
-#include "libmesh/subdomain_partitioner.h"
+#include "libmesh/mapped_subdomain_partitioner.h"
 
 #include "test_comm.h"
 
@@ -25,16 +25,16 @@
 
 using namespace libMesh;
 
-class SubdomainPartitionerTest : public CppUnit::TestCase
+class MappedSubdomainPartitionerTest : public CppUnit::TestCase
 {
   /**
    * The goal of this test is to verify proper operation of the
-   * SubdomainPartitioner on different numbers of processors.
+   * MappedSubdomainPartitioner on different numbers of processors.
    */
 public:
-  CPPUNIT_TEST_SUITE( SubdomainPartitionerTest );
+  CPPUNIT_TEST_SUITE( MappedSubdomainPartitionerTest );
 
-  CPPUNIT_TEST( testSubdomainPartitionerTest );
+  CPPUNIT_TEST( testMappedSubdomainPartitioner );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -47,7 +47,7 @@ public:
 
   void tearDown() {}
 
-  void testSubdomainPartitionerTest()
+  void testMappedSubdomainPartitioner()
   {
     ReplicatedMesh mesh(*TestCommWorld, /*dim=*/2);
 
@@ -62,14 +62,14 @@ public:
                                          ymin, ymax,
                                          QUAD4);
 
-    // The SubdomainPartitioner partitions based on user-defined
+    // The MappedSubdomainPartitioner partitions based on user-defined
     // assignment of subdomains to processors.
-    mesh.partitioner() = UniquePtr<Partitioner>(new SubdomainPartitioner);
+    mesh.partitioner() = UniquePtr<Partitioner>(new MappedSubdomainPartitioner);
 
-    // Get a pointer to the SubdomainPartitioner so we can call its
+    // Get a pointer to the MappedSubdomainPartitioner so we can call its
     // API specifically.
-    SubdomainPartitioner * subdomain_partitioner =
-      dynamic_cast<SubdomainPartitioner *>(mesh.partitioner().get());
+    MappedSubdomainPartitioner * subdomain_partitioner =
+      dynamic_cast<MappedSubdomainPartitioner *>(mesh.partitioner().get());
 
     // Create 2x as many subdomains as processors, then assign them in
     // the following way:
@@ -103,7 +103,7 @@ public:
         }
     }
 
-    // Partition again, now that we have set up the SubdomainPartitioner.
+    // Partition again, now that we have set up the MappedSubdomainPartitioner.
     mesh.partition();
 
     // Assert that the partitioning worked as expected.
@@ -125,4 +125,4 @@ public:
 };
 
 
-CPPUNIT_TEST_SUITE_REGISTRATION( SubdomainPartitionerTest );
+CPPUNIT_TEST_SUITE_REGISTRATION( MappedSubdomainPartitionerTest );


### PR DESCRIPTION
The design/requirements for this new Partitioner are described in idaholab/moose#8672 by @YaqiWang.

In the first image below, the existing `MetisPartitioner` was used to partition the domain into 6 parts, while in the second image, the new `SubdomainPartitioner` was used to partition the central (Quads) and outer regions (Tris) separately using the `MetisPartitioner` internally. In the latter case, the elements in the central region are more evenly divided among the available processors, so the work load might be better distributed.  On the other hand, several of the partitions in the second case are non-contiguous, and the overall communication pattern is probably much worse.  Any of the other libmesh partitioners can be used as the "internal" partitioner within `SubdomainPartitioner`, so different results are of course possible.
 
No unit test added yet, however I am planning add one based on the Mesh in these images, as soon as I figure out how to add Mesh files to the unit test suite (discussed over on #1277).

![metis_only_6proc_viridis](https://cloud.githubusercontent.com/assets/1775907/23835916/3a91b220-0735-11e7-9797-b4116f9c088d.png)
![metis_6proc_2chunks_viridis_c](https://cloud.githubusercontent.com/assets/1775907/23835914/31d1672a-0735-11e7-95f3-034dc061a35b.png)
