### PR TITLE
libmesh_assert_valid_dof_ids one System at a time.

### DIFF
--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -387,8 +387,12 @@ void libmesh_assert_valid_boundary_ids (const MeshBase & mesh);
 /**
  * A function for verifying that degree of freedom indexing matches
  * across processors.
+ *
+ * Verify a particular system by specifying that system's number, or
+ * verify all systems at once by leaving \p sysnum unspecified.
  */
-void libmesh_assert_valid_dof_ids (const MeshBase & mesh);
+void libmesh_assert_valid_dof_ids (const MeshBase & mesh,
+                                   unsigned int sysnum = libMesh::invalid_uint);
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
 /**

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1011,8 +1011,9 @@ void DofMap::distribute_dofs (MeshBase & mesh)
     const unsigned int
       sys_num = this->sys_number();
 
-    // Processors should all agree on DoF ids
-    MeshTools::libmesh_assert_valid_dof_ids(mesh);
+    // Processors should all agree on DoF ids for the newly numbered
+    // system.
+    MeshTools::libmesh_assert_valid_dof_ids(mesh, sys_num);
 
     // DoF processor ids should match DofObject processor ids
     MeshBase::const_node_iterator       node_it  = mesh.nodes_begin();


### PR DESCRIPTION
This fixes a idaholab/moose#1500 regression
for me on 10 processors.  All my own regression tests and use cases
for adaptivity on DistributedMesh were using a single System, so MOOSE
was the first to hit an overzealous assert that only affects corner
cases (it only hit one of their adaptivity regression tests, and only
hits it on 10 or more processors...) on multi-System problems.

I'm going to merge this as soon as Civet is happy; in theory all it affects is dbg mode and all it does is weaken an overzealous assertion.