### PR TITLE
Make extra_ghost_elements save child elems

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -186,9 +186,11 @@ public:
   virtual void delete_remote_elements() libmesh_override;
 
   /**
-   * Inserts the element _and_ adds it to a list of elements not to
-   * get deleted by delete_remote_elements.  This is handy for inserting
-   * off-processor elements that you want to keep track of on this processor.
+   * Inserts the element _and_ adds it to a list of elements that
+   * should not get deleted or have their descendants deleted by
+   * delete_remote_elements.  This is handy for inserting otherwise
+   * off-processor elements that you want to keep track of on this
+   * processor.
    */
   virtual void add_extra_ghost_elem(Elem * e);
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1822,7 +1822,16 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
       it != extra_ghost_elem_ids.end(); ++it)
     {
       const Elem * elem = *it;
-      elements_to_keep.insert(elem);
+
+      std::vector<const Elem *> active_family;
+#ifdef LIBMESH_ENABLE_AMR
+      elem->active_family_tree(active_family);
+#else
+      active_family.insert(elem);
+#endif
+
+      for (std::size_t i=0; i != active_family.size(); ++i)
+        elements_to_keep.insert(active_family[i]);
     }
 
   // See which elements we still need to keep ghosted, given that


### PR DESCRIPTION
This allows us to define a region to be ghosted once on the coarse
mesh, then keep that region ghosted regardless of refinement.

This is not the best way to specify ghosting for most use cases, but
it turns out to be exactly what we'll need for MOOSE OversampleOutput.

With this alongside some forthcoming changes at the MOOSE level, I can get their OversampleOutput examples working with --distributed-mesh on up to 24 processors.