### PR TITLE
Revert new METIS neighbor code until we can fix it

### DIFF
--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -228,6 +228,7 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
                 if (neighbor != libmesh_nullptr)
                   {
+/*
                     // If the neighbor is not in the range of elements
                     // being partitioned, treat it as a NULL neighbor.
                     //
@@ -237,6 +238,7 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                     // we vall vectormap::count() instead!
                     if (!global_index_map.count(neighbor->id()))
                       continue;
+*/
 
                     // If the neighbor is active treat it
                     // as a connection
@@ -276,9 +278,11 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                             const Elem * child =
                               neighbors_offspring[nc];
 
+/*
                             // Skip neighbor offspring which are not in the range of elements being partitioned.
                             if (!global_index_map.count(child->id()))
                               continue;
+*/
 
                             // This does not assume a level-1 mesh.
                             // Note that since children have sides numbered
@@ -340,6 +344,7 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
                 if (neighbor != libmesh_nullptr)
                   {
+/*
                     // If the neighbor is not in the range of elements
                     // being partitioned, treat it as a NULL neighbor.
                     //
@@ -349,6 +354,7 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                     // we vall vectormap::count() instead!
                     if (!global_index_map.count(neighbor->id()))
                       continue;
+*/
 
                     // If the neighbor is active treat it
                     // as a connection
@@ -380,9 +386,11 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                             const Elem * child =
                               neighbors_offspring[nc];
 
+/*
                             // Skip neighbor offspring which are not in the range of elements being partitioned.
                             if (!global_index_map.count(child->id()))
                               continue;
+*/
 
                             // This does not assume a level-1 mesh.
                             // Note that since children have sides numbered


### PR DESCRIPTION
I don't understand why this code could be leading to an occasional
segfault within METIS, but commenting it out fixes the problem for me
and so might be a useful temporary fix for others.

Refs https://github.com/idaholab/moose/issues/8759