### PR TITLE
Ignore deprecated strstream warnings in VTK

### DIFF
--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -25,8 +25,11 @@
 #include "libmesh/mesh_output.h"
 
 #ifdef LIBMESH_HAVE_VTK
+// Ignore "deprecated...header" warning from strstream
+#include "libmesh/ignore_warnings.h"
 #include "vtkType.h"
 #include "vtkSmartPointer.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 // C++ includes


### PR DESCRIPTION
Hopefully newer VTK versions have fixed this, but VTK 6.3.0 causes GCC
6.1 to spew deprecated header warnings, and we don't need to expose
our users to that.