### PR TITLE
Maintain subactive neighbor links

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1135,6 +1135,14 @@ public:
                                 const bool reset=true) const;
 
   /**
+   * Same as the \p family_tree_by_neighbor() member, but also adds
+   * any subactive descendants.
+   */
+  void total_family_tree_by_neighbor (std::vector<const Elem *> & family,
+                                      const Elem * neighbor,
+                                      const bool reset=true) const;
+
+  /**
    * Same as the \p family_tree() member, but only adds elements
    * which are next to \p subneighbor.  Only applicable when
    * \p this->has_neighbor(neighbor) and
@@ -1144,6 +1152,15 @@ public:
                                    const Elem * neighbor,
                                    const Elem * subneighbor,
                                    const bool reset=true) const;
+
+  /**
+   * Same as the \p family_tree_by_subneighbor() member, but also adds
+   * any subactive descendants.
+   */
+  void total_family_tree_by_subneighbor (std::vector<const Elem *> & family,
+                                         const Elem * neighbor,
+                                         const Elem * subneighbor,
+                                         const bool reset=true) const;
 
   /**
    * Same as the \p active_family_tree() member, but only adds elements

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1211,22 +1211,16 @@ void Elem::make_links_to_me_local(unsigned int n)
   libmesh_assert(!neigh->subactive() || this->subactive());
 
   // If we have a neighbor less refined than us then it must not
-  // have any more refined active descendants we could have
-  // pointed to instead.
-  libmesh_assert(neigh->level() == this->level() ||
-                 neigh->active());
+  // have any more refined descendants we could have pointed to
+  // instead.
+  libmesh_assert((neigh->level() == this->level()) ||
+                 (neigh->active() && !this->subactive()) ||
+                 (!neigh->has_children() && this->subactive()));
 
   // If neigh is at our level, then its family might have
   // remote_elem neighbor links which need to point to us
   // instead, but if not, then we're done.
   if (neigh->level() != this->level())
-    return;
-
-  // If neigh is subactive then we're not updating its neighbor links
-  // FIXME - this needs to change when we start using subactive
-  // elements for more than just the two-phase
-  // restriction/prolongation projections.
-  if (neigh->subactive())
     return;
 
   // What side of neigh are we on?  We can't use the usual Elem
@@ -1256,6 +1250,10 @@ void Elem::make_links_to_me_local(unsigned int n)
   for (std::size_t i = 0; i != neigh_family.size(); ++i)
     {
       Elem * neigh_family_member = const_cast<Elem *>(neigh_family[i]);
+
+      // Only subactive elements point to other subactive elements
+      if (this->subactive() && !neigh_family_member->subactive())
+        continue;
 
       // Ideally, the neighbor link ought to either be correct
       // already or ought to be to remote_elem.
@@ -1296,90 +1294,87 @@ void Elem::make_links_to_me_remote()
       }
 #endif
 
-  // Remotify any neighbor links to non-subactive elements
-  if (!this->subactive())
+  // Remotify any neighbor links
+  for (unsigned int s = 0; s != this->n_sides(); ++s)
     {
-      for (unsigned int s = 0; s != this->n_sides(); ++s)
+      Elem * neigh = this->neighbor_ptr(s);
+      if (neigh && neigh != remote_elem)
         {
-          Elem * neigh = this->neighbor_ptr(s);
-          if (neigh && neigh != remote_elem && !neigh->subactive())
+          // My neighbor should never be more refined than me; my real
+          // neighbor would have been its parent in that case.
+          libmesh_assert_greater_equal (this->level(), neigh->level());
+
+          if (this->level() == neigh->level() &&
+              neigh->has_neighbor(this))
             {
-              // My neighbor should never be more refined than me; my real
-              // neighbor would have been its parent in that case.
-              libmesh_assert_greater_equal (this->level(), neigh->level());
-
-              if (this->level() == neigh->level() &&
-                  neigh->has_neighbor(this))
-                {
 #ifdef LIBMESH_ENABLE_AMR
-                  // My neighbor may have descendants which also consider me a
-                  // neighbor
-                  std::vector<const Elem *> family;
-                  neigh->family_tree_by_neighbor (family, this);
+              // My neighbor may have descendants which also consider me a
+              // neighbor
+              std::vector<const Elem *> family;
+              neigh->total_family_tree_by_neighbor (family, this);
 
-                  // FIXME - There's a lot of ugly const_casts here; we
-                  // may want to make remote_elem non-const and create
-                  // non-const versions of the family_tree methods
-                  for (std::size_t i=0; i != family.size(); ++i)
-                    {
-                      Elem * n = const_cast<Elem *>(family[i]);
-                      libmesh_assert (n);
-                      if (n == remote_elem)
-                        continue;
-                      unsigned int my_s = n->which_neighbor_am_i(this);
-                      libmesh_assert_less (my_s, n->n_neighbors());
-                      libmesh_assert_equal_to (n->neighbor_ptr(my_s), this);
-                      n->set_neighbor(my_s, const_cast<RemoteElem *>(remote_elem));
-                    }
+              // FIXME - There's a lot of ugly const_casts here; we
+              // may want to make remote_elem non-const and create
+              // non-const versions of the family_tree methods
+              for (std::size_t i=0; i != family.size(); ++i)
+                {
+                  Elem * n = const_cast<Elem *>(family[i]);
+                  libmesh_assert (n);
+                  if (n == remote_elem)
+                    continue;
+                  unsigned int my_s = n->which_neighbor_am_i(this);
+                  libmesh_assert_less (my_s, n->n_neighbors());
+                  libmesh_assert_equal_to (n->neighbor_ptr(my_s), this);
+                  n->set_neighbor(my_s, const_cast<RemoteElem *>(remote_elem));
+                }
 #else
-                  unsigned int my_s = neigh->which_neighbor_am_i(this);
-                  libmesh_assert_less (my_s, neigh->n_neighbors());
-                  libmesh_assert_equal_to (neigh->neighbor(my_s), this);
-                  neigh->set_neighbor(my_s, const_cast<RemoteElem *>(remote_elem));
-#endif
-                }
-#ifdef LIBMESH_ENABLE_AMR
-              // Even if my neighbor doesn't link back to me, it might
-              // have subactive descendants which do
-              else if (neigh->has_children())
-                {
-                  // If my neighbor at the same level doesn't have me as a
-                  // neighbor, I must be subactive
-                  libmesh_assert(this->level() > neigh->level() ||
-                                 this->subactive());
-
-                  // My neighbor must have some ancestor of mine as a
-                  // neighbor
-                  Elem * my_ancestor = this->parent();
-                  libmesh_assert(my_ancestor);
-                  while (!neigh->has_neighbor(my_ancestor))
-                    {
-                      my_ancestor = my_ancestor->parent();
-                      libmesh_assert(my_ancestor);
-                    }
-
-                  // My neighbor may have descendants which consider me a
-                  // neighbor
-                  std::vector<const Elem *> family;
-                  neigh->family_tree_by_subneighbor (family, my_ancestor, this);
-
-                  // FIXME - There's a lot of ugly const_casts here; we
-                  // may want to make remote_elem non-const and create
-                  // non-const versions of the family_tree methods
-                  for (std::size_t i=0; i != family.size(); ++i)
-                    {
-                      Elem * n = const_cast<Elem *>(family[i]);
-                      libmesh_assert (n);
-                      if (n == remote_elem)
-                        continue;
-                      unsigned int my_s = n->which_neighbor_am_i(this);
-                      libmesh_assert_less (my_s, n->n_neighbors());
-                      libmesh_assert_equal_to (n->neighbor_ptr(my_s), this);
-                      n->set_neighbor(my_s, const_cast<RemoteElem *>(remote_elem));
-                    }
-                }
+              unsigned int my_s = neigh->which_neighbor_am_i(this);
+              libmesh_assert_less (my_s, neigh->n_neighbors());
+              libmesh_assert_equal_to (neigh->neighbor(my_s), this);
+              neigh->set_neighbor(my_s, const_cast<RemoteElem *>(remote_elem));
 #endif
             }
+#ifdef LIBMESH_ENABLE_AMR
+          // Even if my neighbor doesn't link back to me, it might
+          // have subactive descendants which do
+          else if (neigh->has_children())
+            {
+              // If my neighbor at the same level doesn't have me as a
+              // neighbor, I must be subactive
+              libmesh_assert(this->level() > neigh->level() ||
+                             this->subactive());
+
+              // My neighbor must have some ancestor of mine as a
+              // neighbor
+              Elem * my_ancestor = this->parent();
+              libmesh_assert(my_ancestor);
+              while (!neigh->has_neighbor(my_ancestor))
+                {
+                  my_ancestor = my_ancestor->parent();
+                  libmesh_assert(my_ancestor);
+                }
+
+              // My neighbor may have descendants which consider me a
+              // neighbor
+              std::vector<const Elem *> family;
+              neigh->total_family_tree_by_subneighbor (family, my_ancestor, this);
+
+              // FIXME - There's a lot of ugly const_casts here; we
+              // may want to make remote_elem non-const and create
+              // non-const versions of the family_tree methods
+              for (std::size_t i=0; i != family.size(); ++i)
+                {
+                  Elem * n = const_cast<Elem *>(family[i]);
+                  libmesh_assert (n);
+                  if (n == remote_elem)
+                    continue;
+                  unsigned int my_s = n->which_neighbor_am_i(this);
+                  libmesh_assert_less (my_s, n->n_neighbors());
+                  libmesh_assert_equal_to (n->neighbor_ptr(my_s), this);
+                  n->set_neighbor(my_s, const_cast<RemoteElem *>(remote_elem));
+                }
+            }
+#endif
         }
     }
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1868,11 +1868,6 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
           if (!keep_me)
             elem->make_links_to_me_remote();
 
-          // Subactive neighbor pointers aren't preservable here
-          if (elem->subactive())
-            for (unsigned int s=0; s != elem->n_sides(); ++s)
-              elem->set_neighbor(s, libmesh_nullptr);
-
           // delete_elem doesn't currently invalidate element
           // iterators... that had better not change
           if (!keep_me)

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -424,10 +424,12 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                   Elem * neigh = parent->neighbor_ptr(s);
 
                   // If neigh was refined and had non-subactive children
-                  // made remote earlier, then a non-subactive elem should
+                  // made remote earlier, then our current elem should
                   // actually have one of those remote children as a
                   // neighbor
-                  if (neigh && (neigh->ancestor()) && (!current_elem->subactive()))
+                  if (neigh &&
+                      (neigh->ancestor() ||
+                       current_elem->subactive() && neigh->has_children()))
                     {
 #ifdef DEBUG
                       // Let's make sure that "had children made remote"
@@ -450,8 +452,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                       neigh = const_cast<RemoteElem *>(remote_elem);
                     }
 
-                  if (!current_elem->subactive())
-                    current_elem->set_neighbor(s, neigh);
+                  current_elem->set_neighbor(s, neigh);
 #ifdef DEBUG
                   if (neigh != libmesh_nullptr && neigh != remote_elem)
                     // We ignore subactive elements here because

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -429,7 +429,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                   // neighbor
                   if (neigh &&
                       (neigh->ancestor() ||
-                       current_elem->subactive() && neigh->has_children()))
+                       (current_elem->subactive() && neigh->has_children())))
                     {
 #ifdef DEBUG
                       // Let's make sure that "had children made remote"


### PR DESCRIPTION
We've been mostly ignoring these in the past, but doing so has led to assertion failures in heavy adaptive coarsening with DistributedMesh.  (Thanks again to the MOOSE test suite and https://github.com/idaholab/moose/issues/1500)

Rather than weaken the assertions let's just maintain the neighbor links; the cost is trivial and it might prove useful if our geometric multigrid code ends up relying on subactive elements heavily.