### PR TITLE
Add Elem::remove_links_to_me()

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -431,8 +431,17 @@ public:
   /**
    * Resets this element's neighbors' appropriate neighbor pointers
    * and its parent's and children's appropriate pointers
+   * to point to null instead of to this.
+   *
+   * Used by the library before an element is deleted from a mesh.
+   */
+  void remove_links_to_me ();
+
+  /**
+   * Resets this element's neighbors' appropriate neighbor pointers
+   * and its parent's and children's appropriate pointers
    * to point to the global remote_elem instead of this.
-   * Used by the library before a remote element is deleted on the
+   * Used by the library before an element becomes remote on the
    * local processor.
    */
   void make_links_to_me_remote ();


### PR DESCRIPTION
This lets us delete elements (not just make remote, but delete) without leaving the mesh neighbor links in an unusable state.

I may need to use this later in MOOSE code for some https://github.com/idaholab/moose/issues/1500 fixes.