### PR TITLE
AbaqusIO improvements/fixes

### DIFF
--- a/include/mesh/abaqus_io.h
+++ b/include/mesh/abaqus_io.h
@@ -57,9 +57,11 @@ public:
   virtual void read (const std::string & name) libmesh_override;
 
   /**
-   * Default false.  Abaqus files have only nodesets in them by
-   * default.  Set this flag to true if you want libmesh to automatically
-   * generate sidesets from Abaqus' nodesets.
+   * Default false. Set this flag to true if you want libmesh to
+   * automatically generate sidesets from Abaqus' nodesets. If the
+   * Abaqus file already contains some sidesets, we ignore this flag
+   * and don't generate sidesets, because the algorithm to do so
+   * currently does not take into account existing sidesets.
    */
   bool build_sidesets_from_nodesets;
 

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -390,11 +390,11 @@ void AbaqusIO::read (const std::string & fname)
   // Assign sideset values in the BoundaryInfo object
   this->assign_sideset_ids();
 
-  // Abaqus files only contain nodesets by default.  To be useful in
-  // applying most types of BCs in libmesh, we will definitely need
-  // sidesets.  So we can call the new BoundaryInfo function which
-  // generates sidesets from nodesets.
-  if (build_sidesets_from_nodesets)
+  // If the Abaqus file contains only nodesets, we can have libmesh
+  // generate sidesets from them. This BoundaryInfo function currently
+  // *overwrites* existing sidesets in surprising ways, so we don't
+  // call it if there are already sidesets present in the original file.
+  if (build_sidesets_from_nodesets && the_mesh.get_boundary_info().n_boundary_conds() == 0)
     the_mesh.get_boundary_info().build_side_list_from_node_list();
 
   // Delete lower-dimensional elements from the Mesh.  We assume these

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -513,14 +513,15 @@ void AbaqusIO::read_elements(std::string upper, std::string elset_name)
   unsigned n_nodes_per_elem = 0;
 
   // Within s, we should have "type=XXXX"
-  if (upper.find("T3D2") != std::string::npos)
+  if (upper.find("T3D2") != std::string::npos ||
+      upper.find("B31") != std::string::npos)
     {
       elem_type = EDGE2;
       n_nodes_per_elem = 2;
       elems_of_dimension[1] = true;
     }
   else if (upper.find("CPE4") != std::string::npos ||
-           upper.find("CPS4") != std::string::npos)
+           upper.find("S4") != std::string::npos)
     {
       elem_type = QUAD4;
       n_nodes_per_elem = 4;


### PR DESCRIPTION
* Support "S4" and "B31" element types (QUAD4 and EDGE2).
* Don't allow automatic sideset generation from nodesets when there are already sidesets present in the Mesh.  The current `BoundaryInfo::build_side_list_from_node_list()` implementation assumes that there are no existing sidesets and does unexpected things to them when there are...