### PR TITLE
Don't try to read into an existing mesh

### DIFF
--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -510,6 +510,8 @@ void CheckpointIO::read (const std::string & name)
 
   MeshBase & mesh = MeshInput<MeshBase>::mesh();
 
+  libmesh_assert(!mesh.n_elem());
+
   // Will this be a parallel input file?  With how many processors?  Stay tuned!
   unsigned int input_parallel;
   processor_id_type input_n_procs;


### PR DESCRIPTION
We don't come close to supporting that behavior, or even documenting
semantics under which it would make sense.  (Would it replace the
existing mesh?  Augment, but with different ids and unique_ids to
prevent overlap?  Stitch?)

This helped me figured out what was going wrong with restarts of MOOSE
StitchedMesh failures; it might catch other bugs too.