### PR TITLE
Fix for upcoming MatGetSubMatrix name change in PETSc 3.8.

### DIFF
--- a/include/numerics/petsc_macro.h
+++ b/include/numerics/petsc_macro.h
@@ -96,6 +96,13 @@ typedef enum { PETSC_COPY_VALUES, PETSC_OWN_POINTER, PETSC_USE_POINTER} PetscCop
 #  define ISCreateLibMesh(comm,n,idx,mode,is) ISCreateGeneral((comm),(n),(idx),(mode),(is))
 #endif
 
+// As of release 3.8.0, MatGetSubMatrix was renamed to MatCreateSubMatrix.
+#if PETSC_RELEASE_LESS_THAN(3,8,0)
+# define LibMeshCreateSubMatrix MatGetSubMatrix
+#else
+# define LibMeshCreateSubMatrix MatCreateSubMatrix
+#endif
+
 #else // LIBMESH_HAVE_PETSC
 
 #define PETSC_VERSION_LESS_THAN(major,minor,subminor) 1

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -808,7 +808,7 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
                          &iscol); LIBMESH_CHKERR(ierr);
 
   // Extract submatrix
-  ierr = MatGetSubMatrix(_mat,
+  ierr = LibMeshCreateSubMatrix(_mat,
                          isrow,
                          iscol,
 #if PETSC_RELEASE_LESS_THAN(3,0,1)

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -809,13 +809,13 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
 
   // Extract submatrix
   ierr = LibMeshCreateSubMatrix(_mat,
-                         isrow,
-                         iscol,
+                                isrow,
+                                iscol,
 #if PETSC_RELEASE_LESS_THAN(3,0,1)
-                         PETSC_DECIDE,
+                                PETSC_DECIDE,
 #endif
-                         (reuse_submatrix ? MAT_REUSE_MATRIX : MAT_INITIAL_MATRIX),
-                         &(petsc_submatrix->_mat));  LIBMESH_CHKERR(ierr);
+                                (reuse_submatrix ? MAT_REUSE_MATRIX : MAT_INITIAL_MATRIX),
+                                &(petsc_submatrix->_mat));  LIBMESH_CHKERR(ierr);
 
   // Specify that the new submatrix is initialized and close it.
   petsc_submatrix->_is_initialized = true;

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -455,35 +455,25 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
       ierr = VecScatterEnd(scatter,solution->vec(),subsolution,INSERT_VALUES,SCATTER_FORWARD);
       LIBMESH_CHKERR(ierr);
 
+      ierr = LibMeshCreateSubMatrix(matrix->mat(),
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-      ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                    _restrict_solve_to_is,
-                                    _restrict_solve_to_is,
                                     PETSC_DECIDE,
-                                    MAT_INITIAL_MATRIX,
-                                    &submat);
-      LIBMESH_CHKERR(ierr);
-      ierr = LibMeshCreateSubMatrix(precond->mat(),
-                                    _restrict_solve_to_is,
-                                    _restrict_solve_to_is,
-                                    PETSC_DECIDE,
-                                    MAT_INITIAL_MATRIX,
-                                    &subprecond);
-      LIBMESH_CHKERR(ierr);
-#else
-      ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                    _restrict_solve_to_is,
-                                    _restrict_solve_to_is,
-                                    MAT_INITIAL_MATRIX,
-                                    &submat);
-      LIBMESH_CHKERR(ierr);
-      ierr = LibMeshCreateSubMatrix(precond->mat(),
-                                    _restrict_solve_to_is,
-                                    _restrict_solve_to_is,
-                                    MAT_INITIAL_MATRIX,
-                                    &subprecond);
-      LIBMESH_CHKERR(ierr);
 #endif
+                                    MAT_INITIAL_MATRIX,
+                                    &submat);
+      LIBMESH_CHKERR(ierr);
+
+      ierr = LibMeshCreateSubMatrix(precond->mat(),
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+#if PETSC_VERSION_LESS_THAN(3,1,0)
+                                    PETSC_DECIDE,
+#endif
+                                    MAT_INITIAL_MATRIX,
+                                    &subprecond);
+      LIBMESH_CHKERR(ierr);
 
       /* Since removing columns of the matrix changes the equation
          system, we will now change the right hand side to compensate
@@ -517,22 +507,15 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
           ierr = VecScale(subvec1,-1.0);
           LIBMESH_CHKERR(ierr);
 
+          ierr = LibMeshCreateSubMatrix(matrix->mat(),
+                                        _restrict_solve_to_is,
+                                        _restrict_solve_to_is_complement,
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-          ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                        _restrict_solve_to_is,
-                                        _restrict_solve_to_is_complement,
                                         PETSC_DECIDE,
-                                        MAT_INITIAL_MATRIX,
-                                        &submat1);
-          LIBMESH_CHKERR(ierr);
-#else
-          ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                        _restrict_solve_to_is,
-                                        _restrict_solve_to_is_complement,
-                                        MAT_INITIAL_MATRIX,
-                                        &submat1);
-          LIBMESH_CHKERR(ierr);
 #endif
+                                        MAT_INITIAL_MATRIX,
+                                        &submat1);
+          LIBMESH_CHKERR(ierr);
 
           ierr = MatMultAdd(submat1,subvec1,subrhs,subrhs);
           LIBMESH_CHKERR(ierr);
@@ -739,35 +722,25 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
       ierr = VecScatterEnd(scatter,solution->vec(),subsolution,INSERT_VALUES,SCATTER_FORWARD);
       LIBMESH_CHKERR(ierr);
 
+      ierr = LibMeshCreateSubMatrix(matrix->mat(),
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-      ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                    _restrict_solve_to_is,
-                                    _restrict_solve_to_is,
                                     PETSC_DECIDE,
-                                    MAT_INITIAL_MATRIX,
-                                    &submat);
-      LIBMESH_CHKERR(ierr);
-      ierr = LibMeshCreateSubMatrix(precond->mat(),
-                                    _restrict_solve_to_is,
-                                    _restrict_solve_to_is,
-                                    PETSC_DECIDE,
-                                    MAT_INITIAL_MATRIX,
-                                    &subprecond);
-      LIBMESH_CHKERR(ierr);
-#else
-      ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                    _restrict_solve_to_is,
-                                    _restrict_solve_to_is,
-                                    MAT_INITIAL_MATRIX,
-                                    &submat);
-      LIBMESH_CHKERR(ierr);
-      ierr = LibMeshCreateSubMatrix(precond->mat(),
-                                    _restrict_solve_to_is,
-                                    _restrict_solve_to_is,
-                                    MAT_INITIAL_MATRIX,
-                                    &subprecond);
-      LIBMESH_CHKERR(ierr);
 #endif
+                                    MAT_INITIAL_MATRIX,
+                                    &submat);
+      LIBMESH_CHKERR(ierr);
+
+      ierr = LibMeshCreateSubMatrix(precond->mat(),
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+#if PETSC_VERSION_LESS_THAN(3,1,0)
+                                    PETSC_DECIDE,
+#endif
+                                    MAT_INITIAL_MATRIX,
+                                    &subprecond);
+      LIBMESH_CHKERR(ierr);
 
       /* Since removing columns of the matrix changes the equation
          system, we will now change the right hand side to compensate
@@ -801,22 +774,15 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
           ierr = VecScale(subvec1,-1.0);
           LIBMESH_CHKERR(ierr);
 
+          ierr = LibMeshCreateSubMatrix(matrix->mat(),
+                                        _restrict_solve_to_is,
+                                        _restrict_solve_to_is_complement,
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-          ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                        _restrict_solve_to_is,
-                                        _restrict_solve_to_is_complement,
                                         PETSC_DECIDE,
-                                        MAT_INITIAL_MATRIX,
-                                        &submat1);
-          LIBMESH_CHKERR(ierr);
-#else
-          ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                        _restrict_solve_to_is,
-                                        _restrict_solve_to_is_complement,
-                                        MAT_INITIAL_MATRIX,
-                                        &submat1);
-          LIBMESH_CHKERR(ierr);
 #endif
+                                        MAT_INITIAL_MATRIX,
+                                        &submat1);
+          LIBMESH_CHKERR(ierr);
 
           ierr = MatMultAdd(submat1,subvec1,subrhs,subrhs);
           LIBMESH_CHKERR(ierr);
@@ -1042,8 +1008,8 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       LIBMESH_CHKERR(ierr);
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-      /* This point can't be reached, see above.  */
-      libmesh_assert(false);
+      // This point can't be reached, see above.
+      libmesh_error_msg("We'll never get here!");
 #else
       ierr = LibMeshCreateSubMatrix(mat,
                                     _restrict_solve_to_is,
@@ -1086,8 +1052,8 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           LIBMESH_CHKERR(ierr);
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-          /* This point can't be reached, see above.  */
-          libmesh_assert(false);
+          // This point can't be reached, see above.
+          libmesh_error_msg("We'll never get here!");
 #else
           ierr = LibMeshCreateSubMatrix(mat,
                                         _restrict_solve_to_is,
@@ -1319,8 +1285,8 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       LIBMESH_CHKERR(ierr);
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-      /* This point can't be reached, see above.  */
-      libmesh_assert(false);
+      // This point can't be reached, see above.
+      libmesh_error_msg("We'll never get here!");
 #else
       ierr = LibMeshCreateSubMatrix(mat,
                                     _restrict_solve_to_is,
@@ -1328,6 +1294,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
                                     MAT_INITIAL_MATRIX,
                                     &submat);
       LIBMESH_CHKERR(ierr);
+
       ierr = LibMeshCreateSubMatrix(const_cast<PetscMatrix<T> *>(precond)->mat(),
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
@@ -1368,8 +1335,8 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           LIBMESH_CHKERR(ierr);
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-          /* This point can't be reached, see above.  */
-          libmesh_assert(false);
+          // This point can't be reached, see above.
+          libmesh_error_msg("We'll never get here!");
 #else
           ierr = LibMeshCreateSubMatrix(mat,
                                         _restrict_solve_to_is,

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -457,21 +457,31 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
       ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             PETSC_DECIDE,MAT_INITIAL_MATRIX,&submat);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    PETSC_DECIDE,
+                                    MAT_INITIAL_MATRIX,
+                                    &submat);
       LIBMESH_CHKERR(ierr);
       ierr = LibMeshCreateSubMatrix(precond->mat(),
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             PETSC_DECIDE,MAT_INITIAL_MATRIX,&subprecond);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    PETSC_DECIDE,
+                                    MAT_INITIAL_MATRIX,
+                                    &subprecond);
       LIBMESH_CHKERR(ierr);
 #else
       ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             MAT_INITIAL_MATRIX,&submat);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    MAT_INITIAL_MATRIX,
+                                    &submat);
       LIBMESH_CHKERR(ierr);
       ierr = LibMeshCreateSubMatrix(precond->mat(),
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             MAT_INITIAL_MATRIX,&subprecond);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    MAT_INITIAL_MATRIX,
+                                    &subprecond);
       LIBMESH_CHKERR(ierr);
 #endif
 
@@ -509,13 +519,18 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
           ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                 _restrict_solve_to_is,_restrict_solve_to_is_complement,
-                                 PETSC_DECIDE,MAT_INITIAL_MATRIX,&submat1);
+                                        _restrict_solve_to_is,
+                                        _restrict_solve_to_is_complement,
+                                        PETSC_DECIDE,
+                                        MAT_INITIAL_MATRIX,
+                                        &submat1);
           LIBMESH_CHKERR(ierr);
 #else
           ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                 _restrict_solve_to_is,_restrict_solve_to_is_complement,
-                                 MAT_INITIAL_MATRIX,&submat1);
+                                        _restrict_solve_to_is,
+                                        _restrict_solve_to_is_complement,
+                                        MAT_INITIAL_MATRIX,
+                                        &submat1);
           LIBMESH_CHKERR(ierr);
 #endif
 
@@ -726,21 +741,31 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
       ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             PETSC_DECIDE,MAT_INITIAL_MATRIX,&submat);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    PETSC_DECIDE,
+                                    MAT_INITIAL_MATRIX,
+                                    &submat);
       LIBMESH_CHKERR(ierr);
       ierr = LibMeshCreateSubMatrix(precond->mat(),
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             PETSC_DECIDE,MAT_INITIAL_MATRIX,&subprecond);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    PETSC_DECIDE,
+                                    MAT_INITIAL_MATRIX,
+                                    &subprecond);
       LIBMESH_CHKERR(ierr);
 #else
       ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             MAT_INITIAL_MATRIX,&submat);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    MAT_INITIAL_MATRIX,
+                                    &submat);
       LIBMESH_CHKERR(ierr);
       ierr = LibMeshCreateSubMatrix(precond->mat(),
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             MAT_INITIAL_MATRIX,&subprecond);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    MAT_INITIAL_MATRIX,
+                                    &subprecond);
       LIBMESH_CHKERR(ierr);
 #endif
 
@@ -778,13 +803,18 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
           ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                 _restrict_solve_to_is,_restrict_solve_to_is_complement,
-                                 PETSC_DECIDE,MAT_INITIAL_MATRIX,&submat1);
+                                        _restrict_solve_to_is,
+                                        _restrict_solve_to_is_complement,
+                                        PETSC_DECIDE,
+                                        MAT_INITIAL_MATRIX,
+                                        &submat1);
           LIBMESH_CHKERR(ierr);
 #else
           ierr = LibMeshCreateSubMatrix(matrix->mat(),
-                                 _restrict_solve_to_is,_restrict_solve_to_is_complement,
-                                 MAT_INITIAL_MATRIX,&submat1);
+                                        _restrict_solve_to_is,
+                                        _restrict_solve_to_is_complement,
+                                        MAT_INITIAL_MATRIX,
+                                        &submat1);
           LIBMESH_CHKERR(ierr);
 #endif
 
@@ -1016,8 +1046,10 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       libmesh_assert(false);
 #else
       ierr = LibMeshCreateSubMatrix(mat,
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             MAT_INITIAL_MATRIX,&submat);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    MAT_INITIAL_MATRIX,
+                                    &submat);
       LIBMESH_CHKERR(ierr);
 #endif
 
@@ -1058,8 +1090,10 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           libmesh_assert(false);
 #else
           ierr = LibMeshCreateSubMatrix(mat,
-                                 _restrict_solve_to_is,_restrict_solve_to_is_complement,
-                                 MAT_INITIAL_MATRIX,&submat1);
+                                        _restrict_solve_to_is,
+                                        _restrict_solve_to_is_complement,
+                                        MAT_INITIAL_MATRIX,
+                                        &submat1);
           LIBMESH_CHKERR(ierr);
 #endif
 
@@ -1289,12 +1323,16 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       libmesh_assert(false);
 #else
       ierr = LibMeshCreateSubMatrix(mat,
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             MAT_INITIAL_MATRIX,&submat);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    MAT_INITIAL_MATRIX,
+                                    &submat);
       LIBMESH_CHKERR(ierr);
       ierr = LibMeshCreateSubMatrix(const_cast<PetscMatrix<T> *>(precond)->mat(),
-                             _restrict_solve_to_is,_restrict_solve_to_is,
-                             MAT_INITIAL_MATRIX,&subprecond);
+                                    _restrict_solve_to_is,
+                                    _restrict_solve_to_is,
+                                    MAT_INITIAL_MATRIX,
+                                    &subprecond);
       LIBMESH_CHKERR(ierr);
 #endif
 
@@ -1334,8 +1372,10 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           libmesh_assert(false);
 #else
           ierr = LibMeshCreateSubMatrix(mat,
-                                 _restrict_solve_to_is,_restrict_solve_to_is_complement,
-                                 MAT_INITIAL_MATRIX,&submat1);
+                                        _restrict_solve_to_is,
+                                        _restrict_solve_to_is_complement,
+                                        MAT_INITIAL_MATRIX,
+                                        &submat1);
           LIBMESH_CHKERR(ierr);
 #endif
 

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -456,20 +456,20 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
       LIBMESH_CHKERR(ierr);
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-      ierr = MatGetSubMatrix(matrix->mat(),
+      ierr = LibMeshCreateSubMatrix(matrix->mat(),
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              PETSC_DECIDE,MAT_INITIAL_MATRIX,&submat);
       LIBMESH_CHKERR(ierr);
-      ierr = MatGetSubMatrix(precond->mat(),
+      ierr = LibMeshCreateSubMatrix(precond->mat(),
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              PETSC_DECIDE,MAT_INITIAL_MATRIX,&subprecond);
       LIBMESH_CHKERR(ierr);
 #else
-      ierr = MatGetSubMatrix(matrix->mat(),
+      ierr = LibMeshCreateSubMatrix(matrix->mat(),
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              MAT_INITIAL_MATRIX,&submat);
       LIBMESH_CHKERR(ierr);
-      ierr = MatGetSubMatrix(precond->mat(),
+      ierr = LibMeshCreateSubMatrix(precond->mat(),
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              MAT_INITIAL_MATRIX,&subprecond);
       LIBMESH_CHKERR(ierr);
@@ -508,12 +508,12 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
           LIBMESH_CHKERR(ierr);
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-          ierr = MatGetSubMatrix(matrix->mat(),
+          ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                  _restrict_solve_to_is,_restrict_solve_to_is_complement,
                                  PETSC_DECIDE,MAT_INITIAL_MATRIX,&submat1);
           LIBMESH_CHKERR(ierr);
 #else
-          ierr = MatGetSubMatrix(matrix->mat(),
+          ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                  _restrict_solve_to_is,_restrict_solve_to_is_complement,
                                  MAT_INITIAL_MATRIX,&submat1);
           LIBMESH_CHKERR(ierr);
@@ -725,20 +725,20 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
       LIBMESH_CHKERR(ierr);
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-      ierr = MatGetSubMatrix(matrix->mat(),
+      ierr = LibMeshCreateSubMatrix(matrix->mat(),
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              PETSC_DECIDE,MAT_INITIAL_MATRIX,&submat);
       LIBMESH_CHKERR(ierr);
-      ierr = MatGetSubMatrix(precond->mat(),
+      ierr = LibMeshCreateSubMatrix(precond->mat(),
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              PETSC_DECIDE,MAT_INITIAL_MATRIX,&subprecond);
       LIBMESH_CHKERR(ierr);
 #else
-      ierr = MatGetSubMatrix(matrix->mat(),
+      ierr = LibMeshCreateSubMatrix(matrix->mat(),
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              MAT_INITIAL_MATRIX,&submat);
       LIBMESH_CHKERR(ierr);
-      ierr = MatGetSubMatrix(precond->mat(),
+      ierr = LibMeshCreateSubMatrix(precond->mat(),
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              MAT_INITIAL_MATRIX,&subprecond);
       LIBMESH_CHKERR(ierr);
@@ -777,12 +777,12 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
           LIBMESH_CHKERR(ierr);
 
 #if PETSC_VERSION_LESS_THAN(3,1,0)
-          ierr = MatGetSubMatrix(matrix->mat(),
+          ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                  _restrict_solve_to_is,_restrict_solve_to_is_complement,
                                  PETSC_DECIDE,MAT_INITIAL_MATRIX,&submat1);
           LIBMESH_CHKERR(ierr);
 #else
-          ierr = MatGetSubMatrix(matrix->mat(),
+          ierr = LibMeshCreateSubMatrix(matrix->mat(),
                                  _restrict_solve_to_is,_restrict_solve_to_is_complement,
                                  MAT_INITIAL_MATRIX,&submat1);
           LIBMESH_CHKERR(ierr);
@@ -1015,7 +1015,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       /* This point can't be reached, see above.  */
       libmesh_assert(false);
 #else
-      ierr = MatGetSubMatrix(mat,
+      ierr = LibMeshCreateSubMatrix(mat,
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              MAT_INITIAL_MATRIX,&submat);
       LIBMESH_CHKERR(ierr);
@@ -1057,7 +1057,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           /* This point can't be reached, see above.  */
           libmesh_assert(false);
 #else
-          ierr = MatGetSubMatrix(mat,
+          ierr = LibMeshCreateSubMatrix(mat,
                                  _restrict_solve_to_is,_restrict_solve_to_is_complement,
                                  MAT_INITIAL_MATRIX,&submat1);
           LIBMESH_CHKERR(ierr);
@@ -1288,11 +1288,11 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       /* This point can't be reached, see above.  */
       libmesh_assert(false);
 #else
-      ierr = MatGetSubMatrix(mat,
+      ierr = LibMeshCreateSubMatrix(mat,
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              MAT_INITIAL_MATRIX,&submat);
       LIBMESH_CHKERR(ierr);
-      ierr = MatGetSubMatrix(const_cast<PetscMatrix<T> *>(precond)->mat(),
+      ierr = LibMeshCreateSubMatrix(const_cast<PetscMatrix<T> *>(precond)->mat(),
                              _restrict_solve_to_is,_restrict_solve_to_is,
                              MAT_INITIAL_MATRIX,&subprecond);
       LIBMESH_CHKERR(ierr);
@@ -1333,7 +1333,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           /* This point can't be reached, see above.  */
           libmesh_assert(false);
 #else
-          ierr = MatGetSubMatrix(mat,
+          ierr = LibMeshCreateSubMatrix(mat,
                                  _restrict_solve_to_is,_restrict_solve_to_is_complement,
                                  MAT_INITIAL_MATRIX,&submat1);
           LIBMESH_CHKERR(ierr);


### PR DESCRIPTION
The MatGetSubMatrix function was renamed to MatCreateSubMatrix in
petsc/petsc@7dae84e. Note: using the "RELEASE" version of this macro
supports people currently using petsc-dev since the change has already
been merged there.

@fdkong if you keep up with petsc-dev, would you mind pulling this branch and seeing if it works for you?