### PR TITLE
More complete deprecation of MeshTools::BoundingBox

### DIFF
--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -172,7 +172,7 @@ public:
    */
   template <typename ForwardIterator>
   void find_global_indices (const Parallel::Communicator & communicator,
-                            const MeshTools::BoundingBox &,
+                            const libMesh::BoundingBox &,
                             const ForwardIterator &,
                             const ForwardIterator &,
                             std::vector<dof_id_type> &) const;

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -131,9 +131,18 @@ void find_boundary_nodes (const MeshBase & mesh,
  * @returns two points defining a cartesian box that bounds the
  * mesh.  The first entry in the pair is the mininum, the second
  * is the maximim.
+ *
+ * This function is now deprecated, use create_bounding_box() instead.
  */
 BoundingBox
 bounding_box (const MeshBase & mesh);
+
+/**
+ * The same functionality as the deprecated MeshTools::bounding_box()
+ * function, but returns the non-deprecated libMesh::BoundingBox type.
+ */
+libMesh::BoundingBox
+create_bounding_box (const MeshBase & mesh);
 
 /**
  * Same, but returns a sphere instead of a box.
@@ -144,10 +153,20 @@ bounding_sphere (const MeshBase & mesh);
 /**
  * @returns two points defining a cartesian box that bounds the
  * elements belonging to processor pid.
+ *
+ * This function is now deprecated, use create_processor_bounding_box() instead.
  */
 BoundingBox
 processor_bounding_box (const MeshBase & mesh,
                         const processor_id_type pid);
+
+/**
+ * The same functionality as the deprecated MeshTools::processor_bounding_box()
+ * function, but returns the non-deprecated libMesh::BoundingBox type.
+ */
+libMesh::BoundingBox
+create_processor_bounding_box (const MeshBase & mesh,
+                               const processor_id_type pid);
 
 /**
  * Same, but returns a sphere instead of a box.
@@ -159,10 +178,21 @@ processor_bounding_sphere (const MeshBase & mesh,
 /**
  * @returns two points defining a Cartesian box that bounds the
  * elements belonging to subdomain sid.
+ *
+ * This function is now deprecated, use create_subdomain_bounding_box() instead.
  */
 BoundingBox
 subdomain_bounding_box (const MeshBase & mesh,
                         const subdomain_id_type sid);
+
+
+/**
+ * The same functionality as the deprecated MeshTools::subdomain_bounding_box()
+ * function, but returns the non-deprecated libMesh::BoundingBox type.
+ */
+libMesh::BoundingBox
+create_subdomain_bounding_box (const MeshBase & mesh,
+                               const subdomain_id_type sid);
 
 /**
  * Same, but returns a sphere instead of a box.

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -41,7 +41,7 @@ const Point InfElemBuilder::build_inf_elem(bool be_verbose)
 {
   // determine origin automatically,
   // works only if the mesh has no symmetry planes.
-  const MeshTools::BoundingBox b_box = MeshTools::bounding_box(_mesh);
+  const BoundingBox b_box = MeshTools::create_bounding_box(_mesh);
   Point origin = (b_box.first + b_box.second) / 2;
 
   if (be_verbose && _mesh.processor_id() == 0)
@@ -101,7 +101,7 @@ const Point InfElemBuilder::build_inf_elem (const InfElemOriginValue & origin_x,
   if ( !origin_x.first || !origin_y.first || !origin_z.first)
     {
       // determine origin
-      const MeshTools::BoundingBox b_box = MeshTools::bounding_box(_mesh);
+      const BoundingBox b_box = MeshTools::create_bounding_box(_mesh);
       const Point auto_origin = (b_box.first+b_box.second)/2;
 
       // override default values, if necessary

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -42,7 +42,7 @@ using namespace libMesh;
 // Utility function to map (x,y,z) in [bbox.min, bbox.max]^3 into
 // [0,max_inttype]^3 for computing Hilbert keys
 void get_hilbert_coords (const Point & p,
-                         const MeshTools::BoundingBox & bbox,
+                         const libMesh::BoundingBox & bbox,
                          CFixBitVec icoords[3])
 {
   static const Hilbert::inttype max_inttype = static_cast<Hilbert::inttype>(-1);
@@ -75,7 +75,7 @@ void get_hilbert_coords (const Point & p,
 
 Parallel::DofObjectKey
 get_hilbert_index (const Elem * e,
-                   const MeshTools::BoundingBox & bbox)
+                   const libMesh::BoundingBox & bbox)
 {
   static const unsigned int sizeof_inttype = sizeof(Hilbert::inttype);
 
@@ -98,7 +98,7 @@ get_hilbert_index (const Elem * e,
 // Compute the hilbert index
 Parallel::DofObjectKey
 get_hilbert_index (const Node * n,
-                   const MeshTools::BoundingBox & bbox)
+                   const libMesh::BoundingBox & bbox)
 {
   static const unsigned int sizeof_inttype = sizeof(Hilbert::inttype);
 
@@ -120,7 +120,7 @@ get_hilbert_index (const Node * n,
 class ComputeHilbertKeys
 {
 public:
-  ComputeHilbertKeys (const MeshTools::BoundingBox & bbox,
+  ComputeHilbertKeys (const libMesh::BoundingBox & bbox,
                       std::vector<Parallel::DofObjectKey> & keys) :
     _bbox(bbox),
     _keys(keys)
@@ -153,7 +153,7 @@ public:
   }
 
 private:
-  const MeshTools::BoundingBox & _bbox;
+  const libMesh::BoundingBox & _bbox;
   std::vector<Parallel::DofObjectKey> & _keys;
 };
 }
@@ -184,7 +184,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
 
   // Global bounding box
   BoundingBox bbox =
-    MeshTools::bounding_box (mesh);
+    MeshTools::create_bounding_box (mesh);
 
   //-------------------------------------------------------------
   // (1) compute Hilbert keys
@@ -579,7 +579,7 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase & mesh) con
 
   // Global bounding box
   BoundingBox bbox =
-    MeshTools::bounding_box (mesh);
+    MeshTools::create_bounding_box (mesh);
 
   std::vector<Parallel::DofObjectKey>
     node_keys, elem_keys;
@@ -668,7 +668,7 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase &) const
 #if defined(LIBMESH_HAVE_LIBHILBERT) && defined(LIBMESH_HAVE_MPI)
 template <typename ForwardIterator>
 void MeshCommunication::find_global_indices (const Parallel::Communicator & communicator,
-                                             const MeshTools::BoundingBox & bbox,
+                                             const libMesh::BoundingBox & bbox,
                                              const ForwardIterator & begin,
                                              const ForwardIterator & end,
                                              std::vector<dof_id_type> & index_map) const
@@ -912,7 +912,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
 #else // LIBMESH_HAVE_LIBHILBERT, LIBMESH_HAVE_MPI
 template <typename ForwardIterator>
 void MeshCommunication::find_global_indices (const Parallel::Communicator &,
-                                             const MeshTools::BoundingBox &,
+                                             const libMesh::BoundingBox &,
                                              const ForwardIterator & begin,
                                              const ForwardIterator & end,
                                              std::vector<dof_id_type> & index_map) const
@@ -929,24 +929,24 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator &,
 
 //------------------------------------------------------------------
 template void MeshCommunication::find_global_indices<MeshBase::const_node_iterator> (const Parallel::Communicator &,
-                                                                                     const MeshTools::BoundingBox &,
+                                                                                     const libMesh::BoundingBox &,
                                                                                      const MeshBase::const_node_iterator &,
                                                                                      const MeshBase::const_node_iterator &,
                                                                                      std::vector<dof_id_type> &) const;
 
 template void MeshCommunication::find_global_indices<MeshBase::const_element_iterator> (const Parallel::Communicator &,
-                                                                                        const MeshTools::BoundingBox &,
+                                                                                        const libMesh::BoundingBox &,
                                                                                         const MeshBase::const_element_iterator &,
                                                                                         const MeshBase::const_element_iterator &,
                                                                                         std::vector<dof_id_type> &) const;
 template void MeshCommunication::find_global_indices<MeshBase::node_iterator> (const Parallel::Communicator &,
-                                                                               const MeshTools::BoundingBox &,
+                                                                               const libMesh::BoundingBox &,
                                                                                const MeshBase::node_iterator &,
                                                                                const MeshBase::node_iterator &,
                                                                                std::vector<dof_id_type> &) const;
 
 template void MeshCommunication::find_global_indices<MeshBase::element_iterator> (const Parallel::Communicator &,
-                                                                                  const MeshTools::BoundingBox &,
+                                                                                  const libMesh::BoundingBox &,
                                                                                   const MeshBase::element_iterator &,
                                                                                   const MeshBase::element_iterator &,
                                                                                   std::vector<dof_id_type> &) const;

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2085,9 +2085,9 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
                 new_elem->set_node(2) = mesh.node_ptr(elem->node_ptr(1)->id() + ((k+1) * orig_nodes));
                 new_elem->set_node(3) = mesh.node_ptr(elem->node_ptr(0)->id() + ((k+1) * orig_nodes));
 
-                if (elem->neighbor(0) == remote_elem)
+                if (elem->neighbor_ptr(0) == remote_elem)
                   new_elem->set_neighbor(3, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(1) == remote_elem)
+                if (elem->neighbor_ptr(1) == remote_elem)
                   new_elem->set_neighbor(1, const_cast<RemoteElem *>(remote_elem));
 
                 break;
@@ -2105,9 +2105,9 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
                 new_elem->set_node(7) = mesh.node_ptr(elem->node_ptr(0)->id() + ((2*k+1) * orig_nodes));
                 new_elem->set_node(8) = mesh.node_ptr(elem->node_ptr(2)->id() + ((2*k+1) * orig_nodes));
 
-                if (elem->neighbor(0) == remote_elem)
+                if (elem->neighbor_ptr(0) == remote_elem)
                   new_elem->set_neighbor(3, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(1) == remote_elem)
+                if (elem->neighbor_ptr(1) == remote_elem)
                   new_elem->set_neighbor(1, const_cast<RemoteElem *>(remote_elem));
 
                 break;
@@ -2122,11 +2122,11 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
                 new_elem->set_node(4) = mesh.node_ptr(elem->node_ptr(1)->id() + ((k+1) * orig_nodes));
                 new_elem->set_node(5) = mesh.node_ptr(elem->node_ptr(2)->id() + ((k+1) * orig_nodes));
 
-                if (elem->neighbor(0) == remote_elem)
+                if (elem->neighbor_ptr(0) == remote_elem)
                   new_elem->set_neighbor(1, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(1) == remote_elem)
+                if (elem->neighbor_ptr(1) == remote_elem)
                   new_elem->set_neighbor(2, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(2) == remote_elem)
+                if (elem->neighbor_ptr(2) == remote_elem)
                   new_elem->set_neighbor(3, const_cast<RemoteElem *>(remote_elem));
 
                 break;
@@ -2153,11 +2153,11 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
                 new_elem->set_node(16) = mesh.node_ptr(elem->node_ptr(4)->id() + ((2*k+1) * orig_nodes));
                 new_elem->set_node(17) = mesh.node_ptr(elem->node_ptr(5)->id() + ((2*k+1) * orig_nodes));
 
-                if (elem->neighbor(0) == remote_elem)
+                if (elem->neighbor_ptr(0) == remote_elem)
                   new_elem->set_neighbor(1, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(1) == remote_elem)
+                if (elem->neighbor_ptr(1) == remote_elem)
                   new_elem->set_neighbor(2, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(2) == remote_elem)
+                if (elem->neighbor_ptr(2) == remote_elem)
                   new_elem->set_neighbor(3, const_cast<RemoteElem *>(remote_elem));
 
                 break;
@@ -2174,13 +2174,13 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
                 new_elem->set_node(6) = mesh.node_ptr(elem->node_ptr(2)->id() + ((k+1) * orig_nodes));
                 new_elem->set_node(7) = mesh.node_ptr(elem->node_ptr(3)->id() + ((k+1) * orig_nodes));
 
-                if (elem->neighbor(0) == remote_elem)
+                if (elem->neighbor_ptr(0) == remote_elem)
                   new_elem->set_neighbor(1, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(1) == remote_elem)
+                if (elem->neighbor_ptr(1) == remote_elem)
                   new_elem->set_neighbor(2, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(2) == remote_elem)
+                if (elem->neighbor_ptr(2) == remote_elem)
                   new_elem->set_neighbor(3, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(3) == remote_elem)
+                if (elem->neighbor_ptr(3) == remote_elem)
                   new_elem->set_neighbor(4, const_cast<RemoteElem *>(remote_elem));
 
                 break;
@@ -2216,13 +2216,13 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
                 new_elem->set_node(25) = mesh.node_ptr(elem->node_ptr(8)->id() + ((2*k+2) * orig_nodes));
                 new_elem->set_node(26) = mesh.node_ptr(elem->node_ptr(8)->id() + ((2*k+1) * orig_nodes));
 
-                if (elem->neighbor(0) == remote_elem)
+                if (elem->neighbor_ptr(0) == remote_elem)
                   new_elem->set_neighbor(1, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(1) == remote_elem)
+                if (elem->neighbor_ptr(1) == remote_elem)
                   new_elem->set_neighbor(2, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(2) == remote_elem)
+                if (elem->neighbor_ptr(2) == remote_elem)
                   new_elem->set_neighbor(3, const_cast<RemoteElem *>(remote_elem));
-                if (elem->neighbor(3) == remote_elem)
+                if (elem->neighbor_ptr(3) == remote_elem)
                   new_elem->set_neighbor(4, const_cast<RemoteElem *>(remote_elem));
 
                 break;

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -159,7 +159,10 @@ public:
   }
 #endif
 
-  MeshTools::BoundingBox bbox () const
+  /**
+   * FindBBox::bbox() now returns a non-deprecated libMesh::BoundingBox object.
+   */
+  libMesh::BoundingBox bbox () const
   {
     Point pmin(_vmin[0]
 #if LIBMESH_DIM > 1
@@ -178,9 +181,7 @@ public:
 #endif
                );
 
-    const BoundingBox ret_val(pmin, pmax);
-
-    return ret_val;
+    return libMesh::BoundingBox(pmin, pmax);
   }
 
 private:
@@ -357,6 +358,18 @@ void MeshTools::find_boundary_nodes (const MeshBase & mesh,
 MeshTools::BoundingBox
 MeshTools::bounding_box(const MeshBase & mesh)
 {
+  // This function is deprecated.  It simply calls
+  // create_bounding_box() and converts the result to a
+  // MeshTools::BoundingBox.
+  libmesh_deprecated();
+  return MeshTools::create_bounding_box(mesh);
+}
+
+
+
+libMesh::BoundingBox
+MeshTools::create_bounding_box (const MeshBase & mesh)
+{
   // This function must be run on all processors at once
   libmesh_parallel_only(mesh.comm());
 
@@ -383,7 +396,7 @@ MeshTools::bounding_box(const MeshBase & mesh)
 Sphere
 MeshTools::bounding_sphere(const MeshBase & mesh)
 {
-  BoundingBox bbox = bounding_box(mesh);
+  libMesh::BoundingBox bbox = MeshTools::create_bounding_box(mesh);
 
   const Real  diag = (bbox.second - bbox.first).norm();
   const Point cent = (bbox.second + bbox.first)/2;
@@ -396,6 +409,16 @@ MeshTools::bounding_sphere(const MeshBase & mesh)
 MeshTools::BoundingBox
 MeshTools::processor_bounding_box (const MeshBase & mesh,
                                    const processor_id_type pid)
+{
+  libmesh_deprecated();
+  return MeshTools::create_processor_bounding_box(mesh, pid);
+}
+
+
+
+libMesh::BoundingBox
+MeshTools::create_processor_bounding_box (const MeshBase & mesh,
+                                          const processor_id_type pid)
 {
   libmesh_assert_less (pid, mesh.n_processors());
 
@@ -418,7 +441,8 @@ Sphere
 MeshTools::processor_bounding_sphere (const MeshBase & mesh,
                                       const processor_id_type pid)
 {
-  BoundingBox bbox = processor_bounding_box(mesh,pid);
+  libMesh::BoundingBox bbox =
+    MeshTools::create_processor_bounding_box(mesh, pid);
 
   const Real  diag = (bbox.second - bbox.first).norm();
   const Point cent = (bbox.second + bbox.first)/2;
@@ -431,6 +455,16 @@ MeshTools::processor_bounding_sphere (const MeshBase & mesh,
 MeshTools::BoundingBox
 MeshTools::subdomain_bounding_box (const MeshBase & mesh,
                                    const subdomain_id_type sid)
+{
+  libmesh_deprecated();
+  return MeshTools::create_subdomain_bounding_box(mesh, sid);
+}
+
+
+
+libMesh::BoundingBox
+MeshTools::create_subdomain_bounding_box (const MeshBase & mesh,
+                                          const subdomain_id_type sid)
 {
   FindBBox find_bbox;
 
@@ -452,7 +486,8 @@ Sphere
 MeshTools::subdomain_bounding_sphere (const MeshBase & mesh,
                                       const subdomain_id_type sid)
 {
-  BoundingBox bbox = subdomain_bounding_box(mesh,sid);
+  libMesh::BoundingBox bbox =
+    MeshTools::create_subdomain_bounding_box(mesh, sid);
 
   const Real  diag = (bbox.second - bbox.first).norm();
   const Point cent = (bbox.second + bbox.first)/2;

--- a/src/mesh/postscript_io.C
+++ b/src/mesh/postscript_io.C
@@ -92,7 +92,7 @@ void PostscriptIO::write (const std::string & fname)
 
       // The mesh bounding box gives us info about what the
       // Postscript bounding box should be.
-      BoundingBox bbox = MeshTools::bounding_box(the_mesh);
+      BoundingBox bbox = MeshTools::create_bounding_box(the_mesh);
 
       // Add a little extra padding to the "true" bounding box so
       // that we can still see the boundary

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -101,7 +101,7 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
     std::vector<dof_id_type> global_index;
 
     MeshCommunication().find_global_indices (mesh.comm(),
-                                             MeshTools::bounding_box(mesh),
+                                             MeshTools::create_bounding_box(mesh),
                                              beg, end, global_index);
 
     libmesh_assert_equal_to (global_index.size(), n_range_elem);

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -259,8 +259,8 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
   // This can be fed to ParMetis as the initial partitioning of the subdomains (decoupled
   // from the partitioning of the objects themselves).  This allows us to get the same
   // resultant partitioning independed of the input partitioning.
-  BoundingBox bbox =
-    MeshTools::bounding_box(mesh);
+  libMesh::BoundingBox bbox =
+    MeshTools::create_bounding_box(mesh);
 
   _global_index_by_pid_map.clear();
 

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -224,7 +224,7 @@ void Partitioner::partition_unpartitioned_elements (MeshBase & mesh,
   // Calling this on all processors a unique range in [0,n_unpartitioned_elements) is constructed.
   // Only the indices for the elements we pass in are returned in the array.
   MeshCommunication().find_global_indices (mesh.comm(),
-                                           MeshTools::bounding_box(mesh), it, end,
+                                           MeshTools::create_bounding_box(mesh), it, end,
                                            global_indices);
 
   for (dof_id_type cnt=0; it != end; ++it)

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -138,7 +138,7 @@ void PointLocatorTree::init (Trees::BuildType build_type)
               // Build the bounding box for the mesh.  If the delta-z bound is
               // negligibly small then we can use a quadtree.
               {
-                BoundingBox bbox = MeshTools::bounding_box(this->_mesh);
+                BoundingBox bbox = MeshTools::create_bounding_box(this->_mesh);
 
                 const Real
                   Dx = bbox.second(0) - bbox.first(0),

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -43,7 +43,7 @@ Tree<N>::Tree (const MeshBase & m,
 {
   // Set the root node bounding box equal to the bounding
   // box for the entire domain.
-  root.set_bounding_box (MeshTools::bounding_box(mesh));
+  root.set_bounding_box (MeshTools::create_bounding_box(mesh));
 
   if (build_type == Trees::NODES)
     {


### PR DESCRIPTION
MeshTools::BoundingBox is itself deprecated, so to be consistent we should also deprecate interfaces that return them.