### PR TITLE
Fix PETSc lock error from #1294

### DIFF
--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -110,7 +110,7 @@ extern "C"
     R_input.swap(R_system);
 
     // We may need to correct a non-conforming solution
-    sys.get_dof_map().enforce_constraints_exactly(sys);
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     // We may need to localize a parallel solution
     sys.update();
@@ -177,7 +177,7 @@ extern "C"
     J_input.swap(J_system);
 
     // We may need to correct a non-conforming solution
-    sys.get_dof_map().enforce_constraints_exactly(sys);
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     // We may need to localize a parallel solution
     sys.update();


### PR DESCRIPTION
This just replace .enforce_constraints_exactly(sys) with .enforce_constraints_exactly(sys, sys.current_local_solution.get()) on the residual and Jacobian computations.

In the solve there is already a:
#ifdef LIBMESH_ENABLE_CONSTRAINTS
  _system.get_dof_map().enforce_constraints_exactly(_system);
#endif

I'm in doubt if this shouldn't be moved after SNESSolve and have the the ifdef removed, closes #1294 .