### PR TITLE
Parallel::OpFunction, BoundingBox refactor

### DIFF
--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -109,6 +109,11 @@ public:
   void intersect_with (const BoundingBox &);
 
   /*
+   * Enlarges this bounding box to include the given point
+   */
+  void union_with (const Point & p);
+
+  /*
    * Sets this bounding box to be the union with the other
    * bounding box.
    */
@@ -116,6 +121,22 @@ public:
 
 private:
 };
+
+
+
+// ------------------------------------------------------------
+// BoundingBox class member functions
+
+inline
+void
+BoundingBox::union_with(const Point & p)
+{
+  for (unsigned int i=0; i<LIBMESH_DIM; i++)
+    {
+      min()(i) = std::min(min()(i), p(i));
+      max()(i) = std::max(max()(i), p(i));
+    }
+}
 
 } // namespace libMesh
 

--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -391,6 +391,48 @@ private:
   StandardType(const T * example = libmesh_nullptr);
 };
 
+/**
+ * Templated class to provide the appropriate MPI reduction operations
+ * for use with built-in C types or simple C++ constructions.
+ *
+ * More complicated data types may need to provide a pointer-to-T so
+ * that we can use MPI_Address without constructing a new T.
+ */
+template <typename T>
+class OpFunction
+{
+#ifdef LIBMESH_HAVE_CXX11
+  // Get a slightly better compiler diagnostic if we have C++11
+  static_assert(dependent_false<T>::value,
+                "Only specializations of OpFunction may be used, did you forget to include a header file (e.g. parallel_algebra.h)?");
+#endif
+
+  /*
+   * The unspecialized class defines none of these functions;
+   * specializations will need to define any functions that need to be
+   * usable.
+   *
+   * Most specializations will just return MPI_MIN, etc, but we'll use
+   * a whitelist rather than a default implementation, so that any
+   * attempt to perform a reduction on an unspecialized type will be a
+   * compile-time rather than a run-time failure.
+   */
+/*
+  static MPI_Op max();
+  static MPI_Op min();
+  static MPI_Op sum();
+  static MPI_Op product();
+  static MPI_Op logical_and();
+  static MPI_Op bitwise_and();
+  static MPI_Op logical_or();
+  static MPI_Op bitwise_or();
+  static MPI_Op logical_xor();
+  static MPI_Op bitwise_xor();
+  static MPI_Op max_loc();
+  static MPI_Op min_loc();
+ */
+};
+
 /*
  * The unspecialized class gives default, lowest-common-denominator
  * attributes, for values which can't be used with Parallel min/max.

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -309,6 +309,113 @@ public:
   }
 };
 
+// OpFunction<> specializations to return an MPI_Op version of the
+// reduction operations on LIBMESH_DIM-vectors.
+//
+// We use static variables to minimize the number of MPI datatype
+// construction calls executed over the course of the program.
+//
+// We use a singleton pattern because a global variable would
+// have tried to call MPI functions before MPI got initialized.
+//
+// min() and max() are applied component-wise; this makes them useful
+// for bounding box reduction operations.
+template <typename V>
+class TypeVectorOpFunction
+{
+public:
+#ifdef LIBMESH_HAVE_MPI
+  static void vector_max (void *invec, void *inoutvec, int *len, MPI_Datatype *datatype)
+  {
+    V *in = static_cast<V *>(invec);
+    V *inout = static_cast<V *>(inoutvec);
+    for (int i=0; i != *len; ++i)
+      for (int d=0; d != LIBMESH_DIM; ++d)
+        inout[i](d) = std::max(in[i](d), inout[i](d));
+  }
+
+  static void vector_min (void *invec, void *inoutvec, int *len, MPI_Datatype *datatype)
+  {
+    V *in = static_cast<V *>(invec);
+    V *inout = static_cast<V *>(inoutvec);
+    for (int i=0; i != *len; ++i)
+      for (int d=0; d != LIBMESH_DIM; ++d)
+        inout[i](d) = std::min(in[i](d), inout[i](d));
+  }
+
+  static void vector_sum (void *invec, void *inoutvec, int *len, MPI_Datatype *datatype)
+  {
+    V *in = static_cast<V *>(invec);
+    V *inout = static_cast<V *>(inoutvec);
+    for (int i=0; i != *len; ++i)
+      for (int d=0; d != LIBMESH_DIM; ++d)
+        inout[i](d) += in[i](d);
+  }
+
+  static MPI_Op max()
+  {
+    // _static_op never gets freed, but it only gets committed once
+    // per T, so it's not a *huge* memory leak...
+    static MPI_Op _static_op;
+    static bool _is_initialized = false;
+    if (!_is_initialized)
+      {
+        libmesh_call_mpi
+          (MPI_Op_create (vector_max, /*commute=*/ true,
+                          &_static_op));
+
+        _is_initialized = true;
+      }
+
+    return _static_op;
+  }
+  static MPI_Op min()
+  {
+    // _static_op never gets freed, but it only gets committed once
+    // per T, so it's not a *huge* memory leak...
+    static MPI_Op _static_op;
+    static bool _is_initialized = false;
+    if (!_is_initialized)
+      {
+        libmesh_call_mpi
+          (MPI_Op_create (vector_min, /*commute=*/ true,
+                          &_static_op));
+
+        _is_initialized = true;
+      }
+
+    return _static_op;
+  }
+  static MPI_Op sum()
+  {
+    // _static_op never gets freed, but it only gets committed once
+    // per T, so it's not a *huge* memory leak...
+    static MPI_Op _static_op;
+    static bool _is_initialized = false;
+    if (!_is_initialized)
+      {
+        libmesh_call_mpi
+          (MPI_Op_create (vector_sum, /*commute=*/ true,
+                          &_static_op));
+
+        _is_initialized = true;
+      }
+
+    return _static_op;
+  }
+
+#endif // LIBMESH_HAVE_MPI
+};
+
+template <typename T>
+class OpFunction<TypeVector<T> > : public TypeVectorOpFunction<TypeVector<T> > {};
+
+template <typename T>
+class OpFunction<VectorValue<T> > : public TypeVectorOpFunction<VectorValue<T> > {};
+
+template <>
+class OpFunction<Point> : public TypeVectorOpFunction<Point> {};
+
 // StandardType<> specializations to return a derived MPI datatype
 // to handle communication of LIBMESH_DIM*LIBMESH_DIM-tensors.
 //

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -325,7 +325,7 @@ class TypeVectorOpFunction
 {
 public:
 #ifdef LIBMESH_HAVE_MPI
-  static void vector_max (void *invec, void *inoutvec, int *len, MPI_Datatype *datatype)
+  static void vector_max (void *invec, void *inoutvec, int *len, MPI_Datatype *)
   {
     V *in = static_cast<V *>(invec);
     V *inout = static_cast<V *>(inoutvec);
@@ -334,7 +334,7 @@ public:
         inout[i](d) = std::max(in[i](d), inout[i](d));
   }
 
-  static void vector_min (void *invec, void *inoutvec, int *len, MPI_Datatype *datatype)
+  static void vector_min (void *invec, void *inoutvec, int *len, MPI_Datatype *)
   {
     V *in = static_cast<V *>(invec);
     V *inout = static_cast<V *>(inoutvec);
@@ -343,7 +343,7 @@ public:
         inout[i](d) = std::min(in[i](d), inout[i](d));
   }
 
-  static void vector_sum (void *invec, void *inoutvec, int *len, MPI_Datatype *datatype)
+  static void vector_sum (void *invec, void *inoutvec, int *len, MPI_Datatype *)
   {
     V *in = static_cast<V *>(invec);
     V *inout = static_cast<V *>(inoutvec);

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -1583,7 +1583,8 @@ inline void Communicator::min(T & r) const
 
       T temp = r;
       libmesh_call_mpi
-        (MPI_Allreduce (&temp, &r, 1, StandardType<T>(&temp), MPI_MIN,
+        (MPI_Allreduce (&temp, &r, 1, StandardType<T>(&temp),
+                        OpFunction<T>::min(),
                         this->get()));
     }
 }
@@ -1600,7 +1601,8 @@ inline void Communicator::min(bool & r) const
 
       libmesh_call_mpi
         (MPI_Allreduce (&tempsend, &temp, 1,
-                        StandardType<unsigned int>(), MPI_MIN,
+                        StandardType<unsigned int>(),
+                        OpFunction<unsigned int>::min(),
                         this->get()));
       r = temp;
     }
@@ -1619,7 +1621,8 @@ inline void Communicator::min(std::vector<T> & r) const
       std::vector<T> temp(r);
       libmesh_call_mpi
         (MPI_Allreduce (&temp[0], &r[0], cast_int<int>(r.size()),
-                        StandardType<T>(&temp[0]), MPI_MIN,
+                        StandardType<T>(&temp[0]),
+                        OpFunction<T>::min(),
                         this->get()));
     }
 }
@@ -1660,7 +1663,7 @@ inline void Communicator::minloc(T & r,
       DataPlusInt<T> data_out;
       libmesh_call_mpi
         (MPI_Allreduce (&data_in, &data_out, 1, dataplusint_type<T>(),
-                        MPI_MINLOC, this->get()));
+                        OpFunction<T>::max_location(), this->get()));
       r = data_out.val;
       min_id = data_out.rank;
     }
@@ -1683,7 +1686,7 @@ inline void Communicator::minloc(bool & r,
       libmesh_call_mpi
         (MPI_Allreduce (&data_in, &data_out, 1,
                         dataplusint_type<int>(),
-                        MPI_MINLOC, this->get()));
+                        OpFunction<int>::min_location(), this->get()));
       r = data_out.val;
       min_id = data_out.rank;
     }
@@ -1712,8 +1715,8 @@ inline void Communicator::minloc(std::vector<T> & r,
       libmesh_call_mpi
         (MPI_Allreduce (&data_in[0], &data_out[0],
                         cast_int<int>(r.size()),
-                        dataplusint_type<T>(), MPI_MINLOC,
-                        this->get()));
+                        dataplusint_type<T>(),
+                        OpFunction<T>::min_location(), this->get()));
       for (std::size_t i=0; i != r.size(); ++i)
         {
           r[i]      = data_out[i].val;
@@ -1747,8 +1750,8 @@ inline void Communicator::minloc(std::vector<bool> & r,
       libmesh_call_mpi
         (MPI_Allreduce (&data_in[0], &data_out[0],
                         cast_int<int>(r.size()),
-                        StandardType<int>(), MPI_MINLOC,
-                        this->get()));
+                        StandardType<int>(),
+                        OpFunction<int>::min_location(), this->get()));
       for (std::size_t i=0; i != r.size(); ++i)
         {
           r[i]      = data_out[i].val;
@@ -1772,7 +1775,8 @@ inline void Communicator::max(T & r) const
 
       T temp;
       libmesh_call_mpi
-        (MPI_Allreduce (&r, &temp, 1, StandardType<T>(&r), MPI_MAX,
+        (MPI_Allreduce (&r, &temp, 1, StandardType<T>(&r),
+                        OpFunction<T>::max(),
                         this->get()));
       r = temp;
     }
@@ -1789,7 +1793,8 @@ inline void Communicator::max(bool & r) const
       unsigned int temp;
       libmesh_call_mpi
         (MPI_Allreduce (&tempsend, &temp, 1,
-                        StandardType<unsigned int>(), MPI_MAX,
+                        StandardType<unsigned int>(),
+                        OpFunction<unsigned int>::max(),
                         this->get()));
       r = temp;
     }
@@ -1808,7 +1813,8 @@ inline void Communicator::max(std::vector<T> & r) const
       std::vector<T> temp(r);
       libmesh_call_mpi
         (MPI_Allreduce (&temp[0], &r[0], cast_int<int>(r.size()),
-                        StandardType<T>(&temp[0]), MPI_MAX,
+                        StandardType<T>(&temp[0]),
+                        OpFunction<T>::max(),
                         this->get()));
     }
 }
@@ -1850,7 +1856,8 @@ inline void Communicator::maxloc(T & r,
       libmesh_call_mpi
         (MPI_Allreduce (&data_in, &data_out, 1,
                         dataplusint_type<T>(),
-                        MPI_MAXLOC, this->get()));
+                        OpFunction<T>::max_location(),
+                        this->get()));
       r = data_out.val;
       max_id = data_out.rank;
     }
@@ -1873,7 +1880,8 @@ inline void Communicator::maxloc(bool & r,
       libmesh_call_mpi
         (MPI_Allreduce (&data_in, &data_out, 1,
                         dataplusint_type<int>(),
-                        MPI_MAXLOC, this->get()));
+                        OpFunction<int>::max_location(),
+                        this->get()));
       r = data_out.val;
       max_id = data_out.rank;
     }
@@ -1902,7 +1910,8 @@ inline void Communicator::maxloc(std::vector<T> & r,
       libmesh_call_mpi
         (MPI_Allreduce (&data_in[0], &data_out[0],
                         cast_int<int>(r.size()),
-                        dataplusint_type<T>(), MPI_MAXLOC,
+                        dataplusint_type<T>(),
+                        OpFunction<T>::max_location(),
                         this->get()));
       for (std::size_t i=0; i != r.size(); ++i)
         {
@@ -1937,7 +1946,8 @@ inline void Communicator::maxloc(std::vector<bool> & r,
       libmesh_call_mpi
         (MPI_Allreduce (&data_in[0], &data_out[0],
                         cast_int<int>(r.size()),
-                        StandardType<int>(), MPI_MAXLOC,
+                        StandardType<int>(),
+                        OpFunction<int>::max_location(),
                         this->get()));
       for (std::size_t i=0; i != r.size(); ++i)
         {
@@ -1962,7 +1972,8 @@ inline void Communicator::sum(T & r) const
 
       T temp = r;
       libmesh_call_mpi
-        (MPI_Allreduce (&temp, &r, 1, StandardType<T>(&temp), MPI_SUM,
+        (MPI_Allreduce (&temp, &r, 1, StandardType<T>(&temp),
+                        OpFunction<T>::sum(),
                         this->get()));
     }
 }
@@ -1980,7 +1991,8 @@ inline void Communicator::sum(std::vector<T> & r) const
       std::vector<T> temp(r);
       libmesh_call_mpi
         (MPI_Allreduce (&temp[0], &r[0], cast_int<int>(r.size()),
-                        StandardType<T>(&temp[0]), MPI_SUM,
+                        StandardType<T>(&temp[0]),
+                        OpFunction<T>::sum(),
                         this->get()));
     }
 }
@@ -1997,7 +2009,8 @@ inline void Communicator::sum(std::complex<T> & r) const
 
       std::complex<T> temp(r);
       libmesh_call_mpi
-        (MPI_Allreduce (&temp, &r, 2, StandardType<T>(), MPI_SUM,
+        (MPI_Allreduce (&temp, &r, 2, StandardType<T>(),
+                        OpFunction<T>::sum(),
                         this->get()));
     }
 }
@@ -2015,7 +2028,8 @@ inline void Communicator::sum(std::vector<std::complex<T> > & r) const
       std::vector<std::complex<T> > temp(r);
       libmesh_call_mpi
         (MPI_Allreduce (&temp[0], &r[0], cast_int<int>(r.size() * 2),
-                        StandardType<T>(libmesh_nullptr), MPI_SUM, this->get()));
+                        StandardType<T>(libmesh_nullptr),
+                        OpFunction<T>::sum(), this->get()));
     }
 }
 

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -43,6 +43,38 @@ namespace Parallel {
       StandardType(const cxxtype * = libmesh_nullptr) : DataType(mpitype) {} \
   }
 
+#define LIBMESH_PARALLEL_INTEGER_OPS(cxxtype)                           \
+  template<>                                                            \
+  class OpFunction<cxxtype>                                             \
+  {                                                                     \
+  public:                                                               \
+    static MPI_Op max()          { return MPI_MAX; }                    \
+    static MPI_Op min()          { return MPI_MIN; }                    \
+    static MPI_Op sum()          { return MPI_SUM; }                    \
+    static MPI_Op product()      { return MPI_PROD; }                   \
+    static MPI_Op logical_and()  { return MPI_LAND; }                   \
+    static MPI_Op bitwise_and()  { return MPI_BAND; }                   \
+    static MPI_Op logical_or()   { return MPI_LOR; }                    \
+    static MPI_Op bitwise_or()   { return MPI_BOR; }                    \
+    static MPI_Op logical_xor()  { return MPI_LXOR; }                   \
+    static MPI_Op bitwise_xor()  { return MPI_BXOR; }                   \
+    static MPI_Op max_location() { return MPI_MAXLOC; }                 \
+    static MPI_Op min_location() { return MPI_MINLOC; }                 \
+  }
+
+#define LIBMESH_PARALLEL_FLOAT_OPS(cxxtype)                             \
+  template<>                                                            \
+  class OpFunction<cxxtype>                                             \
+  {                                                                     \
+  public:                                                               \
+    static MPI_Op max()          { return MPI_MAX; }                    \
+    static MPI_Op min()          { return MPI_MIN; }                    \
+    static MPI_Op sum()          { return MPI_SUM; }                    \
+    static MPI_Op product()      { return MPI_PROD; }                   \
+    static MPI_Op max_location() { return MPI_MAXLOC; }                 \
+    static MPI_Op min_location() { return MPI_MINLOC; }                 \
+  }
+
 #else
 
 #define LIBMESH_STANDARD_TYPE(cxxtype,mpitype)                          \
@@ -54,10 +86,17 @@ namespace Parallel {
       StandardType(const cxxtype * = libmesh_nullptr) : DataType() {}   \
   }
 
+#define LIBMESH_PARALLEL_INTEGER_OPS(cxxtype)                           \
+  template<>                                                            \
+  class OpFunction<cxxtype>                                             \
+  {                                                                     \
+  }
+
 #endif
 
 #define LIBMESH_INT_TYPE(cxxtype,mpitype)                               \
   LIBMESH_STANDARD_TYPE(cxxtype,mpitype);                               \
+  LIBMESH_PARALLEL_INTEGER_OPS(cxxtype);                                \
                                                                         \
   template<>                                                            \
   struct Attributes<cxxtype>                                            \
@@ -69,6 +108,7 @@ namespace Parallel {
 
 #define LIBMESH_FLOAT_TYPE(cxxtype,mpitype)                             \
   LIBMESH_STANDARD_TYPE(cxxtype,mpitype);                               \
+  LIBMESH_PARALLEL_FLOAT_OPS(cxxtype);                                  \
                                                                         \
   template<>                                                            \
   struct Attributes<cxxtype>                                            \
@@ -124,6 +164,8 @@ public:
                             sizeof(unsigned long));
   }
 };
+
+LIBMESH_PARALLEL_INTEGER_OPS(unsigned long long);                                \
 
 template<>
 struct Attributes<unsigned long long>


### PR DESCRIPTION
Actual bounding box bugfixes (for relatively little-used cases, I admit) will be coming shortly, but the first step here turned out to be a rabbit hole that needs testing.  We can now define OpFunction<T> specializations which wrap MPI_Op_create to perform default reductions for user-defined types.