### PR TITLE
Bounding box accuracy for curved elements

### DIFF
--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -152,6 +152,16 @@ bounding_sphere (const MeshBase & mesh);
 
 /**
  * @returns two points defining a cartesian box that bounds the
+ * nodes of the mesh.
+ *
+ * In the case of curved elements, this box might *not* bound the
+ * elements of the mesh.
+ */
+libMesh::BoundingBox
+create_nodal_bounding_box (const MeshBase & mesh);
+
+/**
+ * @returns two points defining a cartesian box that bounds the
  * elements belonging to the local processor.
  *
  * Unlike the other bounding box creation functions, this does *not*

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -152,6 +152,17 @@ bounding_sphere (const MeshBase & mesh);
 
 /**
  * @returns two points defining a cartesian box that bounds the
+ * elements belonging to the local processor.
+ *
+ * Unlike the other bounding box creation functions, this does *not*
+ * need to be run in parallel, because this is the only function we
+ * can guarantee can be resolved with only local information.
+ */
+libMesh::BoundingBox
+create_local_bounding_box (const MeshBase & mesh);
+
+/**
+ * @returns two points defining a cartesian box that bounds the
  * elements belonging to processor pid.
  *
  * This function is now deprecated, use create_processor_bounding_box() instead.

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -182,9 +182,11 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
 
   const Parallel::Communicator & communicator (mesh.comm());
 
-  // Global bounding box
+  // Global bounding box.  We choose the nodal bounding box for
+  // backwards compatibility; the element bounding box may be looser
+  // on curved elements.
   BoundingBox bbox =
-    MeshTools::create_bounding_box (mesh);
+    MeshTools::create_nodal_bounding_box (mesh);
 
   //-------------------------------------------------------------
   // (1) compute Hilbert keys
@@ -577,9 +579,12 @@ void MeshCommunication::check_for_duplicate_global_indices (MeshBase & mesh) con
 {
   LOG_SCOPE ("check_for_duplicate_global_indices()", "MeshCommunication");
 
-  // Global bounding box
+  // Global bounding box.  We choose the nodal bounding box for
+  // backwards compatibility; the element bounding box may be looser
+  // on curved elements.
   BoundingBox bbox =
-    MeshTools::create_bounding_box (mesh);
+    MeshTools::create_nodal_bounding_box (mesh);
+
 
   std::vector<Parallel::DofObjectKey>
     node_keys, elem_keys;

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -124,12 +124,7 @@ public:
         const Elem * elem = *it;
         libmesh_assert(elem);
 
-        for (unsigned int n=0; n<elem->n_nodes(); n++)
-          {
-            const Point & point = elem->point(n);
-
-            _bbox.union_with(point);
-          }
+        _bbox.union_with(elem->loose_bounding_box());
       }
   }
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -379,6 +379,20 @@ MeshTools::bounding_sphere(const MeshBase & mesh)
 
 
 
+libMesh::BoundingBox
+MeshTools::create_local_bounding_box (const MeshBase & mesh)
+{
+  FindBBox find_bbox;
+
+  Threads::parallel_reduce (ConstElemRange (mesh.local_elements_begin(),
+                                            mesh.local_elements_end()),
+                            find_bbox);
+
+  return find_bbox.bbox();
+}
+
+
+
 MeshTools::BoundingBox
 MeshTools::processor_bounding_box (const MeshBase & mesh,
                                    const processor_id_type pid)

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -150,10 +150,12 @@ public:
   }
 #endif
 
-  /**
-   * FindBBox::bbox() now returns a non-deprecated libMesh::BoundingBox object.
-   */
-  libMesh::BoundingBox bbox () const
+  const libMesh::BoundingBox & bbox () const
+  {
+    return _bbox;
+  }
+
+  libMesh::BoundingBox & bbox ()
   {
     return _bbox;
   }


### PR DESCRIPTION
This PR fixes the MeshTools::create*bounding_box behavior for problems with curved elements, and adds a new create_local_bounding_box() method that is useful for refactoring and to fix some MOOSE bugs.