### PR TITLE
Assert fix for AdjointRefinementErrorEstimator

### DIFF
--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -160,7 +160,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 #ifndef NDEBUG
   // n_coarse_elem is only used in an assertion later so
   // avoid declaring it unless asserts are active.
-  const dof_id_type n_coarse_elem = mesh.n_elem();
+  const dof_id_type n_coarse_elem = mesh.n_active_elem();
 #endif
 
   // Uniformly refine the mesh
@@ -451,8 +451,10 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
       es.reinit();
     }
 
-  // We should be back where we started
-  libmesh_assert_equal_to (n_coarse_elem, mesh.n_elem());
+  // We should have the same number of active elements as when we started,
+  // but not necessarily the same number of elements since reinit() doesn't
+  // always call contract()
+  libmesh_assert_equal_to (n_coarse_elem, mesh.n_active_elem());
 
   // Restore old solutions and clean up the heap
   system.project_solution_on_reinit() = old_projection_setting;


### PR DESCRIPTION
Addresses the problem raised in #1301 by only checking for the same number of active elements in ARefEE.

Passes my `GRINS` test case, as well as the larger run that originally identified this issue.