### PR TITLE
Disallow remote element removal during Mesh copy

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -209,9 +209,11 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
   //partitioning but also the same renumbering and partitioning
   //policies as our source mesh.
   this->allow_renumbering(false);
+  this->allow_remote_element_removal(false);
   this->skip_partitioning(true);
   this->prepare_for_use(false, skip_find_neighbors);
   this->allow_renumbering(other_mesh.allow_renumbering());
+  this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
   this->skip_partitioning(other_mesh.skip_partitioning());
 }
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -206,12 +206,15 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
   }
 
   //Finally prepare the new Mesh for use.  Keep the same numbering and
-  //partitioning but also the same renumbering and partitioning
-  //policies as our source mesh.
+  //partitioning for now.
   this->allow_renumbering(false);
   this->allow_remote_element_removal(false);
   this->skip_partitioning(true);
+
   this->prepare_for_use(false, skip_find_neighbors);
+
+  //But in the long term, use the same renumbering and partitioning
+  //policies as our source mesh.
   this->allow_renumbering(other_mesh.allow_renumbering());
   this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
   this->skip_partitioning(other_mesh.skip_partitioning());


### PR DESCRIPTION
Whether the copied mesh allows remote element removal or not, we
should make an exact copy first; we can then copy the copied mesh's
setting for later use.