### PR TITLE
Remove nullptr checks from BoundaryInfo::sync().

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -121,6 +121,20 @@ public:
              UnstructuredMesh & boundary_mesh);
 
   /**
+   * Like the other sync() implementations, but specifically intended
+   * for building "boundary" meshes from internal sidesets. In the
+   * case of an internal sideset, each side may belong to 2
+   * higher-dimensional parent elements, and typically we do not want
+   * to add the same side to the boundary mesh twice. The
+   * std::set<subdomain_id_type> passed into this function specifies
+   * which subdomain the sides in question should relative to, so that
+   * they are only added once.
+   */
+  void sync (const std::set<boundary_id_type> & requested_boundary_ids,
+             UnstructuredMesh & boundary_mesh,
+             const std::set<subdomain_id_type> & subdomains_relative_to);
+
+  /**
    * Suppose we have used sync to create \p boundary_mesh. Then each
    * element in \p boundary_mesh will have interior_parent defined.
    * This method gets extra data for us:
@@ -148,6 +162,16 @@ public:
    */
   void add_elements (const std::set<boundary_id_type> & requested_boundary_ids,
                      UnstructuredMesh & boundary_mesh);
+
+  /**
+   * Same as the add_elements() function above, but takes a set of
+   * subdomains for which the sides must be relative to. This is
+   * necessary to avoid double-adding sides of internal sidesets to
+   * the BoundaryMesh.
+   */
+  void add_elements(const std::set<boundary_id_type> & requested_boundary_ids,
+                    UnstructuredMesh & boundary_mesh,
+                    const std::set<subdomain_id_type> & subdomains_relative_to);
 
   /**
    * Add \p Node \p node with boundary id \p id to the boundary
@@ -757,7 +781,8 @@ private:
                       dof_id_type first_free_node_id,
                       std::map<dof_id_type, dof_id_type> * node_id_map,
                       dof_id_type first_free_elem_id,
-                      std::map<std::pair<dof_id_type, unsigned char>, dof_id_type> * side_id_map);
+                      std::map<std::pair<dof_id_type, unsigned char>, dof_id_type> * side_id_map,
+                      const std::set<subdomain_id_type> & subdomains_relative_to);
 
   /**
    * The Mesh this boundary info pertains to.

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -432,14 +432,16 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
                 }
             }
 
-          // if side s wasn't found or doesn't have a boundary
-          // condition we may still want to add it
-          if (range.first == range.second)
-            {
-              this_bcid = invalid_id;
-              if (requested_boundary_ids.count(this_bcid))
-                add_this_side = true;
-            }
+          // We may still want to add this side if the user called
+          // sync() with no requested_boundary_ids. This corresponds
+          // to the "old" style of calling sync() in which the entire
+          // boundary was copied to the BoundaryMesh, and handles the
+          // case where elements on the geometric boundary are not in
+          // any sidesets.
+          if (range.first == range.second              &&
+              requested_boundary_ids.count(invalid_id) &&
+              elem->neighbor_ptr(s) == libmesh_nullptr)
+            add_this_side = true;
 
           if (add_this_side)
             sides_to_add.push_back(std::make_pair(elem->id(), s));
@@ -2515,14 +2517,16 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> & requested_bo
                 }
             }
 
-          // Even if nothing was found in the _boundary_side_id
-          // container, we may still want to add it.
-          if (range.first == range.second)
-            {
-              this_bcid = invalid_id;
-              if (requested_boundary_ids.count(this_bcid))
-                add_this_side = true;
-            }
+          // We may still want to add this side if the user called
+          // sync() with no requested_boundary_ids. This corresponds
+          // to the "old" style of calling sync() in which the entire
+          // boundary was copied to the BoundaryMesh, and handles the
+          // case where elements on the geometric boundary are not in
+          // any sidesets.
+          if (range.first == range.second              &&
+              requested_boundary_ids.count(invalid_id) &&
+              elem->neighbor_ptr(s) == libmesh_nullptr)
+            add_this_side = true;
 
           if (add_this_side)
             {

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -439,6 +439,16 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
     {
       const Elem * elem = *el;
 
+      // If the subdomains_relative_to container has the
+      // invalid_subdomain_id, we fall back on the "old" behavior of
+      // adding sides regardless of this Elem's subdomain. Otherwise,
+      // if the subdomains_relative_to container doesn't contain the
+      // current Elem's subdomain_id(), we won't add any sides from
+      // it.
+      if (!subdomains_relative_to.count(Elem::invalid_subdomain_id) &&
+          !subdomains_relative_to.count(elem->subdomain_id()))
+        continue;
+
       // Get the top-level parent for this element
       const Elem * top_parent = elem->top_parent();
 
@@ -2474,7 +2484,7 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> & requested_bo
                                  std::map<dof_id_type, dof_id_type> * node_id_map,
                                  dof_id_type first_free_elem_id,
                                  std::map<std::pair<dof_id_type, unsigned char>, dof_id_type> * side_id_map,
-                                 const std::set<subdomain_id_type> & /*subdomains_relative_to*/)
+                                 const std::set<subdomain_id_type> & subdomains_relative_to)
 {
   // We'll do the same modulus trick that DistributedMesh uses to avoid
   // id conflicts between different processors
@@ -2523,6 +2533,16 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> & requested_bo
         }
 
       const Elem * elem = *el;
+
+      // If the subdomains_relative_to container has the
+      // invalid_subdomain_id, we fall back on the "old" behavior of
+      // adding sides regardless of this Elem's subdomain. Otherwise,
+      // if the subdomains_relative_to container doesn't contain the
+      // current Elem's subdomain_id(), we won't add any sides from
+      // it.
+      if (!subdomains_relative_to.count(Elem::invalid_subdomain_id) &&
+          !subdomains_relative_to.count(elem->subdomain_id()))
+        continue;
 
       // Get the top-level parent for this element. This is used for
       // searching for boundary sides on this element.

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -406,45 +406,44 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
     {
       const Elem * elem = *el;
 
+      // Get the top-level parent for this element
+      const Elem * top_parent = elem->top_parent();
+
+      // Find all the boundary side ids for this Elem.
+      const std::pair<boundary_side_iter, boundary_side_iter>
+        range = _boundary_side_id.equal_range(top_parent);
+
       for (unsigned int s=0; s<elem->n_sides(); s++)
-        if (elem->neighbor_ptr(s) == libmesh_nullptr) // on the boundary
-          {
-            // Get the top-level parent for this element
-            const Elem * top_parent = elem->top_parent();
+        {
+          bool add_this_side = false;
+          boundary_id_type this_bcid = invalid_id;
 
-            // Find the right id number for that side
-            std::pair<boundary_side_iter, boundary_side_iter> pos = _boundary_side_id.equal_range(top_parent);
+          for (boundary_side_iter bsi = range.first; bsi != range.second; ++bsi)
+            {
+              this_bcid = bsi->second.second;
 
-            bool add_this_side = false;
-            boundary_id_type this_bcid = invalid_id;
-
-            for (; pos.first != pos.second; ++pos.first)
-              {
-                this_bcid = pos.first->second.second;
-
-                // if this side is flagged with a boundary condition
-                // and the user wants this id
-                if ((pos.first->second.first == s) &&
-                    (requested_boundary_ids.count(this_bcid)))
-                  {
-                    add_this_side = true;
-                    break;
-                  }
-              }
-
-            // if side s wasn't found or doesn't have a boundary
-            // condition we may still want to add it
-            if (pos.first == pos.second)
-              {
-                this_bcid = invalid_id;
-                if (requested_boundary_ids.count(this_bcid))
+              // if this side is flagged with a boundary condition
+              // and the user wants this id
+              if ((bsi->second.first == s) &&
+                  (requested_boundary_ids.count(this_bcid)))
+                {
                   add_this_side = true;
-              }
+                  break;
+                }
+            }
 
-            if (add_this_side)
-              sides_to_add.push_back
-                (std::make_pair(elem->id(), s));
-          }
+          // if side s wasn't found or doesn't have a boundary
+          // condition we may still want to add it
+          if (range.first == range.second)
+            {
+              this_bcid = invalid_id;
+              if (requested_boundary_ids.count(this_bcid))
+                add_this_side = true;
+            }
+
+          if (add_this_side)
+            sides_to_add.push_back(std::make_pair(elem->id(), s));
+        }
     }
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
@@ -2489,77 +2488,78 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> & requested_bo
 
       const Elem * elem = *el;
 
+      // Get the top-level parent for this element. This is used for
+      // searching for boundary sides on this element.
+      const Elem * top_parent = elem->top_parent();
+
+      // Find all the boundary side ids for this Elem.
+      const std::pair<boundary_side_iter, boundary_side_iter>
+        range = _boundary_side_id.equal_range(top_parent);
+
       for (unsigned char s=0; s<elem->n_sides(); s++)
-        if (elem->neighbor_ptr(s) == libmesh_nullptr) // on the boundary
-          {
-            // Get the top-level parent for this element
-            const Elem * top_parent = elem->top_parent();
+        {
+          bool add_this_side = false;
+          boundary_id_type this_bcid = invalid_id;
 
-            // Find the right id number for that side
-            std::pair<boundary_side_iter, boundary_side_iter> pos = _boundary_side_id.equal_range(top_parent);
+          for (boundary_side_iter bsi = range.first; bsi != range.second; ++bsi)
+            {
+              this_bcid = bsi->second.second;
 
-            bool add_this_side = false;
-            boundary_id_type this_bcid = invalid_id;
-
-            for (; pos.first != pos.second; ++pos.first)
-              {
-                this_bcid = pos.first->second.second;
-
-                // if this side is flagged with a boundary condition
-                // and the user wants this id
-                if ((pos.first->second.first == s) &&
-                    (requested_boundary_ids.count(this_bcid)))
-                  {
-                    add_this_side = true;
-                    break;
-                  }
-              }
-
-            // if side s wasn't found or doesn't have a boundary
-            // condition we may still want to add it
-            if (pos.first == pos.second)
-              {
-                this_bcid = invalid_id;
-                if (requested_boundary_ids.count(this_bcid))
+              // if this side is flagged with a boundary condition
+              // and the user wants this id
+              if ((bsi->second.first == s) &&
+                  (requested_boundary_ids.count(this_bcid)))
+                {
                   add_this_side = true;
-              }
+                  break;
+                }
+            }
 
-            if (add_this_side)
-              {
-                // We only assign ids for our own and for
-                // unpartitioned elements
-                if (side_id_map &&
-                    ((elem->processor_id() == this->processor_id()) ||
-                     (elem->processor_id() ==
-                      DofObject::invalid_processor_id)))
-                  {
-                    std::pair<dof_id_type, unsigned char> side_pair(elem->id(), s);
-                    libmesh_assert (!side_id_map->count(side_pair));
-                    (*side_id_map)[side_pair] = next_elem_id;
-                    next_elem_id += this->n_processors() + 1;
-                  }
+          // Even if nothing was found in the _boundary_side_id
+          // container, we may still want to add it.
+          if (range.first == range.second)
+            {
+              this_bcid = invalid_id;
+              if (requested_boundary_ids.count(this_bcid))
+                add_this_side = true;
+            }
 
-                // Use a proxy element for the side to query nodes
-                UniquePtr<const Elem> side (elem->build_side_ptr(s));
-                for (unsigned int n = 0; n != side->n_nodes(); ++n)
-                  {
-                    const Node & node = side->node_ref(n);
+          if (add_this_side)
+            {
+              // We only assign ids for our own and for
+              // unpartitioned elements
+              if (side_id_map &&
+                  ((elem->processor_id() == this->processor_id()) ||
+                   (elem->processor_id() ==
+                    DofObject::invalid_processor_id)))
+                {
+                  std::pair<dof_id_type, unsigned char> side_pair(elem->id(), s);
+                  libmesh_assert (!side_id_map->count(side_pair));
+                  (*side_id_map)[side_pair] = next_elem_id;
+                  next_elem_id += this->n_processors() + 1;
+                }
 
-                    // In parallel we don't know enough to number
-                    // others' nodes ourselves.
-                    if (!hit_end_el &&
-                        (node.processor_id() != this->processor_id()))
-                      continue;
+              // Use a proxy element for the side to query nodes
+              UniquePtr<const Elem> side (elem->build_side_ptr(s));
+              for (unsigned int n = 0; n != side->n_nodes(); ++n)
+                {
+                  const Node & node = side->node_ref(n);
 
-                    dof_id_type node_id = node.id();
-                    if (node_id_map && !node_id_map->count(node_id))
-                      {
-                        (*node_id_map)[node_id] = next_node_id;
-                        next_node_id += this->n_processors() + 1;
-                      }
-                  }
-              }
-          }
+                  // In parallel we don't know enough to number
+                  // others' nodes ourselves.
+                  if (!hit_end_el &&
+                      (node.processor_id() != this->processor_id()))
+                    continue;
+
+                  dof_id_type node_id = node.id();
+                  if (node_id_map && !node_id_map->count(node_id))
+                    {
+                      (*node_id_map)[node_id] = next_node_id;
+                      next_node_id += this->n_processors() + 1;
+                    }
+                }
+            }
+        }
     }
 
   // FIXME: ought to renumber side/node_id_map image to be contiguous

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -38,17 +38,17 @@ public:
 
 protected:
 
-  Mesh * _mesh;
-  Mesh * _all_boundary_mesh;
-  Mesh * _left_boundary_mesh;
-  Mesh * _internal_boundary_mesh;
+  UniquePtr<Mesh> _mesh;
+  UniquePtr<Mesh> _all_boundary_mesh;
+  UniquePtr<Mesh> _left_boundary_mesh;
+  UniquePtr<Mesh> _internal_boundary_mesh;
 
   void build_mesh()
   {
-    _mesh = new Mesh(*TestCommWorld);
-    _all_boundary_mesh = new Mesh(*TestCommWorld);
-    _left_boundary_mesh = new Mesh(*TestCommWorld);
-    _internal_boundary_mesh = new Mesh(*TestCommWorld);
+    _mesh.reset(new Mesh(*TestCommWorld));
+    _all_boundary_mesh.reset(new Mesh(*TestCommWorld));
+    _left_boundary_mesh.reset(new Mesh(*TestCommWorld));
+    _internal_boundary_mesh.reset(new Mesh(*TestCommWorld));
 
     MeshTools::Generation::build_square(*_mesh, 3, 5,
                                         0.1, 0.9, 0.1, 0.9, QUAD9);
@@ -152,14 +152,6 @@ public:
   void setUp()
   {
     this->build_mesh();
-  }
-
-  void tearDown()
-  {
-    delete _internal_boundary_mesh;
-    delete _all_boundary_mesh;
-    delete _left_boundary_mesh;
-    delete _mesh;
   }
 
   void testMesh()

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -166,28 +166,36 @@ public:
   {
     // There'd better be 3*5 + 5 elements in the interior plus right
     // boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)20, _mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(20),
+                         _mesh->n_elem());
 
     // There'd better be only 7*11 nodes in the interior
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)77, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(77),
+                         _mesh->n_nodes());
 
     // There'd better be only 2*(3+5) elements on the full boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)16, _all_boundary_mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(16),
+                         _all_boundary_mesh->n_elem());
 
     // There'd better be only 2*2*(3+5) nodes on the full boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)32, _all_boundary_mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(32),
+                         _all_boundary_mesh->n_nodes());
 
     // There'd better be only 5 elements on the left boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)5, _left_boundary_mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(5),
+                         _left_boundary_mesh->n_elem());
 
     // There'd better be only 2*5+1 nodes on the left boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)11, _left_boundary_mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(11),
+                         _left_boundary_mesh->n_nodes());
 
     // There are only four elements in the internal sideset mesh.
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)4, _internal_boundary_mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(4),
+                         _internal_boundary_mesh->n_elem());
 
     // There are 2*n_elem + 1 nodes in the internal sideset mesh.
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)9, _internal_boundary_mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(9),
+                         _internal_boundary_mesh->n_nodes());
 
     this->sanityCheck();
   }
@@ -303,7 +311,8 @@ public:
         // All of the elements in the internal sideset mesh should
         // have the same subdomain id as the parent Elems (i.e. 1)
         // they came from.
-        CPPUNIT_ASSERT_EQUAL(static_cast<subdomain_id_type>(1), elem->subdomain_id());
+        CPPUNIT_ASSERT_EQUAL(static_cast<subdomain_id_type>(1),
+                             elem->subdomain_id());
       }
   }
 
@@ -345,33 +354,40 @@ public:
   {
     // There'd better be 3*5*4 + 5*2 active elements in the interior
     // plus right boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)70, _mesh->n_active_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(70),
+                         _mesh->n_active_elem());
 
     // Plus the original 20 now-inactive elements
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)90, _mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(90),
+                         _mesh->n_elem());
 
     // There'd better be only 13*21 nodes in the interior
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)273, _mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(273),
+                         _mesh->n_nodes());
 
     // There'd better be only 2*2*(3+5) active elements on the full boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)32,
-                          _all_boundary_mesh->n_active_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(32),
+                         _all_boundary_mesh->n_active_elem());
 
     // Plus the original 16 now-inactive elements
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)48, _all_boundary_mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(48),
+                         _all_boundary_mesh->n_elem());
 
     // There'd better be only 2*2*2*(3+5) nodes on the full boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)64, _all_boundary_mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(64),
+                         _all_boundary_mesh->n_nodes());
 
     // There'd better be only 2*5 active elements on the left boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)10,
-                          _left_boundary_mesh->n_active_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(10),
+                         _left_boundary_mesh->n_active_elem());
 
     // Plus the original 5 now-inactive elements
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)15, _left_boundary_mesh->n_elem() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(15),
+                         _left_boundary_mesh->n_elem());
 
     // There'd better be only 2*2*5+1 nodes on the left boundary
-    CPPUNIT_ASSERT_EQUAL( (dof_id_type)21, _left_boundary_mesh->n_nodes() );
+    CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(21),
+                         _left_boundary_mesh->n_nodes());
 
     this->sanityCheck();
   }

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -38,9 +38,9 @@ public:
 
 protected:
 
-  Mesh* _mesh;
-  Mesh* _all_boundary_mesh;
-  Mesh* _left_boundary_mesh;
+  Mesh * _mesh;
+  Mesh * _all_boundary_mesh;
+  Mesh * _left_boundary_mesh;
 
   void build_mesh()
   {
@@ -123,9 +123,9 @@ public:
       _mesh->active_elements_end();
     for (; elem_it != elem_end; ++elem_it)
       {
-        const Elem *elem = *elem_it;
+        const Elem * elem = *elem_it;
 
-        const Elem *pip = elem->interior_parent();
+        const Elem * pip = elem->interior_parent();
 
         // On a DistributedMesh we might not be able to see the
         // interior_parent of a non-local element
@@ -159,11 +159,11 @@ public:
       _left_boundary_mesh->active_elements_end();
     for (; left_bdy_elem_it != left_bdy_elem_end; ++left_bdy_elem_it)
       {
-        const Elem *elem = *left_bdy_elem_it;
+        const Elem * elem = *left_bdy_elem_it;
 
         CPPUNIT_ASSERT_EQUAL(elem->type(), EDGE3);
 
-        const Elem *pip = elem->interior_parent();
+        const Elem * pip = elem->interior_parent();
 
         // On a DistributedMesh we might not be able to see the
         // interior_parent of a non-local element
@@ -190,11 +190,11 @@ public:
       _left_boundary_mesh->active_elements_end();
     for (; all_bdy_elem_it != all_bdy_elem_end; ++all_bdy_elem_it)
       {
-        const Elem *elem = *all_bdy_elem_it;
+        const Elem * elem = *all_bdy_elem_it;
 
         CPPUNIT_ASSERT_EQUAL(elem->type(), EDGE3);
 
-        const Elem *pip = elem->interior_parent();
+        const Elem * pip = elem->interior_parent();
 
         // On a DistributedMesh we might not be able to see the
         // interior_parent of a non-local element


### PR DESCRIPTION
This makes it possible to build BoundaryMeshes from internal sidesets,
a feature which did not work previously.  The decision of whether to
add a side to the BoundaryMesh should not be governed by whether an
Elem is on a *geometric* boundary, only by the information in the
_boundary_side_id container.

The relevant changes are in the helper functions:
* BoundaryInfo::_find_id_maps().
* BoundaryInfo::add_elements().

We are also able to hoist the multimap lookup outside of the loop over
sides, since we can get all the boundary information for a given
element's sides in a single call to equal_range(). Otherwise, the
majority of the diff is just the reindentation which accompanied the
removal of an outer if-statement.