### PR TITLE
ReferenceCountedObject::operator=

### DIFF
--- a/include/base/reference_counted_object.h
+++ b/include/base/reference_counted_object.h
@@ -108,6 +108,15 @@ protected:
   }
 #endif
 
+  /**
+   * Copy assignment operator does nothing - we're copying an
+   * already-allocated object over an already-allocated object, so the
+   * counts for this class shouldn't change.
+   */
+  ReferenceCountedObject & operator= (const ReferenceCountedObject & other)
+  {}
+
+
 public:
 
   /**


### PR DESCRIPTION
This needs to be user-defined in cases where we've got a move
constructor and we've thereby disabled the default assignment
operator.

This fixes compilation with Trilinos for me, which was broken by #1319