### PR TITLE
Add Elem::which_node_am_i() interface and unit tests

### DIFF
--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -126,6 +126,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns Hex8::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * @returns a primitive (4-noded) quad for face i.
    */
   virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -131,6 +131,12 @@ public:
   virtual Order default_order() const libmesh_override { return SECOND; }
 
   /**
+   * Does some range checking and then returns Hex20::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Builds a \p QUAD8 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -147,6 +147,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns Hex27::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Builds a \p QUAD9 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -133,6 +133,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns InfHex8::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * @returns a primitive (4-noded) quad or infquad for
    * face i.
    */

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -129,6 +129,12 @@ public:
   virtual Order default_order() const libmesh_override { return SECOND; }
 
   /**
+   * Does some range checking and then returns InfHex16::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Returns a \p QUAD8 built coincident with face 0, an \p INFQUAD6
    * built coincident with faces 1 to 4. Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -159,6 +159,12 @@ public:
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
+  /**
+   * Does some range checking and then returns InfHex18::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const libmesh_override;

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -128,6 +128,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns InfPrism6::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * @returns a primitive (3-noded) tri or (4-noded) infquad for
    * face i.
    */

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -120,6 +120,12 @@ public:
   virtual Order default_order() const libmesh_override { return SECOND; }
 
   /**
+   * Does some range checking and then returns InfPrism12::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Returns a \p TRI6 built coincident with face 0, an \p INFQUAD6
    * built coincident with faces 1 to 3.  Note that the \p UniquePtr<Elem>
    * takes care of freeing memory.

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -117,6 +117,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns Prism6::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * @returns a primitive triangle or quad for
    * face i.
    */

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -132,6 +132,12 @@ public:
   virtual Order default_order() const libmesh_override { return SECOND; }
 
   /**
+   * Does some range checking and then returns Prism15::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Builds a \p QUAD8 or \p TRI6 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -148,6 +148,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns Prism18::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Builds a \p QUAD9 or \p TRI6 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -122,6 +122,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns Pyramid5::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * @returns a primitive triangle or quad for
    * face i.
    */

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -132,6 +132,12 @@ public:
   virtual Order default_order() const libmesh_override { return SECOND; }
 
   /**
+   * Does some range checking and then returns Pyramid13::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Builds a \p QUAD8 or \p TRI6 coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -151,6 +151,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns Pyramid14::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Builds a \p QUAD9 or \p TRI6 coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -106,6 +106,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns Tet4::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * @returns a primitive (3-noded) triangle for face i.
    */
   virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -130,6 +130,12 @@ public:
   virtual Order default_order() const libmesh_override { return SECOND; }
 
   /**
+   * Does some range checking and then returns Tet10::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Builds a \p TRI6 built coincident with face i.
    * The \p UniquePtr<Elem> handles the memory aspect.
    */

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -128,6 +128,12 @@ public:
   { return this->compute_key(this->node_id(s)); }
 
   /**
+   * Does some range checking and then returns side. side_node is ignored.
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int /*side_node*/) const libmesh_override;
+
+  /**
    * The \p Elem::side() member returns
    * an auto pointer to a NodeElem for the specified node.
    */

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -364,6 +364,19 @@ public:
   unsigned int which_side_am_i(const Elem * e) const;
 
   /**
+   * Returns the local node id for node "side_node" on side "side" of
+   * this Elem. Simply relies on the side_nodes_map for each of the
+   * derived types. For example,
+   * Tri3::which_node_am_i(0, 0) -> 0
+   * Tri3::which_node_am_i(0, 1) -> 1
+   * Tri3::which_node_am_i(1, 0) -> 1
+   * Tri3::which_node_am_i(1, 1) -> 2
+   * etc...
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const = 0;
+
+  /**
    * This function returns true if a vertex of \p e is contained
    * in this element.
    */

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -142,6 +142,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns InfQuad4::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * @returns a primitive (2-noded) edge or infedge for edge \p i.
    */
   virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -127,6 +127,12 @@ public:
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
   /**
+   * Does some range checking and then returns InfQuad6::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * Creates and returns an \p Edge3 for the base (0) side, and an \p InfEdge2 for
    * the sides 1, 2.
    */

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -140,6 +140,12 @@ public:
   virtual dof_id_type key () const libmesh_override;
 
   /**
+   * Does some range checking and then returns Quad4::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * @returns a primitive (2-noded) edge for edge i.
    */
   virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -129,6 +129,12 @@ public:
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
+  /**
+   * Does some range checking and then returns Quad8::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
   virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
                                           bool proxy) libmesh_override;
 

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -137,6 +137,12 @@ public:
    */
   virtual dof_id_type key () const libmesh_override;
 
+  /**
+   * Does some range checking and then returns Quad9::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
   virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
                                           bool proxy) libmesh_override;
 

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -127,6 +127,12 @@ public:
   virtual dof_id_type key () const libmesh_override;
 
   /**
+   * Does some range checking and then returns Tri3::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
+  /**
    * @returns a primitive (2-noded) edge for edge i.
    */
   virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -129,6 +129,12 @@ public:
    */
   virtual dof_id_type key (const unsigned int s) const libmesh_override;
 
+  /**
+   * Does some range checking and then returns Tri6::side_nodes_map[side][side_node].
+   */
+  virtual unsigned int which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const libmesh_override;
+
   virtual UniquePtr<Elem> build_side_ptr (const unsigned int i,
                                           bool proxy) libmesh_override;
 

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -109,6 +109,13 @@ public:
   { return 0; }
 
   /**
+   * NodeElems don't have sides, so they can't have nodes on sides.
+   */
+  virtual unsigned int which_node_am_i(unsigned int /*side*/,
+                                       unsigned int /*side_node*/) const libmesh_override
+  { libmesh_error_msg("Calling NodeElem::which_node_am_i() does not make sense."); return 0; }
+
+  /**
    * The \p Elem::side() member makes no sense for nodes.
    */
   virtual UniquePtr<Elem> side_ptr (const unsigned int) libmesh_override

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -106,7 +106,7 @@ public:
    * This should never be important for NodeElems.
    */
   virtual dof_id_type key (const unsigned int) const libmesh_override
-  { return 0; }
+  { libmesh_error_msg("Calling NodeElem::key(side) does not make sense."); return 0; }
 
   /**
    * NodeElems don't have sides, so they can't have nodes on sides.

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -88,6 +88,10 @@ public:
   virtual dof_id_type key (const unsigned int) const libmesh_override
   { libmesh_not_implemented(); return 0; }
 
+  virtual unsigned int which_node_am_i(unsigned int /*side*/,
+                                       unsigned int /*side_node*/) const libmesh_override
+  { libmesh_not_implemented(); return 0; }
+
   virtual bool is_remote () const libmesh_override
   { return true; }
 

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -83,6 +83,17 @@ dof_id_type Hex::key (const unsigned int s) const
 
 
 
+unsigned int Hex::which_node_am_i(unsigned int side,
+                                  unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 4);
+
+  return Hex8::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Hex::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -167,6 +167,17 @@ UniquePtr<Elem> Hex20::build_side_ptr (const unsigned int i,
 
 
 
+unsigned int Hex20::which_node_am_i(unsigned int side,
+                                    unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 8);
+
+  return Hex20::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Hex20::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -202,6 +202,17 @@ dof_id_type Hex27::key (const unsigned int s) const
 
 
 
+unsigned int Hex27::which_node_am_i(unsigned int side,
+                                    unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 9);
+
+  return Hex27::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Hex27::build_side_ptr (const unsigned int i,
                                        bool proxy)
 {

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -83,6 +83,17 @@ dof_id_type InfHex::key (const unsigned int s) const
 
 
 
+unsigned int InfHex::which_node_am_i(unsigned int side,
+                                     unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 4);
+
+  return InfHex8::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> InfHex::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -104,6 +104,24 @@ bool InfHex16::is_node_on_edge(const unsigned int n,
   return false;
 }
 
+
+
+unsigned int InfHex16::which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 8 nodes per side.
+  libmesh_assert_less (side_node, 8);
+
+  // Some sides have 6 nodes.
+  libmesh_assert(side == 0 || side_node < 6);
+
+  return InfHex16::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> InfHex16::build_side_ptr (const unsigned int i,
                                           bool proxy)
 {

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -131,6 +131,22 @@ dof_id_type InfHex18::key (const unsigned int s) const
 
 
 
+unsigned int InfHex18::which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 9 nodes per side.
+  libmesh_assert_less (side_node, 9);
+
+  // Some sides have 6 nodes.
+  libmesh_assert(side == 0 || side_node < 6);
+
+  return InfHex18::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> InfHex18::build_side_ptr (const unsigned int i,
                                           bool proxy)
 {

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -87,6 +87,22 @@ dof_id_type InfPrism::key (const unsigned int s) const
 
 
 
+unsigned int InfPrism::which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 4 nodes per side.
+  libmesh_assert_less(side_node, 4);
+
+  // Some sides have 3 nodes.
+  libmesh_assert(side != 0 || side_node < 3);
+
+  return InfPrism6::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> InfPrism::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -101,6 +101,21 @@ bool InfPrism12::is_node_on_edge(const unsigned int n,
   return false;
 }
 
+
+
+unsigned int InfPrism12::which_node_am_i(unsigned int side,
+                                         unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 6 nodes per side.
+  libmesh_assert_less(side_node, 6);
+
+  return InfPrism12::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
                                             bool proxy)
 {

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -90,6 +90,22 @@ dof_id_type Prism::key (const unsigned int s) const
 
 
 
+unsigned int Prism::which_node_am_i(unsigned int side,
+                                    unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 4 nodes per side.
+  libmesh_assert_less(side_node, 4);
+
+  // Some sides have 3 nodes.
+  libmesh_assert(!(side==0 || side==4) || side_node < 3);
+
+  return Prism6::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Prism::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -129,6 +129,22 @@ bool Prism15::has_affine_map() const
 
 
 
+unsigned int Prism15::which_node_am_i(unsigned int side,
+                                      unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 8 nodes per side.
+  libmesh_assert_less(side_node, 8);
+
+  // Some sides have 6 nodes.
+  libmesh_assert(!(side==0 || side==4) || side_node < 6);
+
+  return Prism15::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Prism15::build_side_ptr (const unsigned int i,
                                          bool proxy)
 {

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -172,6 +172,20 @@ dof_id_type Prism18::key (const unsigned int s) const
 
 
 
+unsigned int Prism18::which_node_am_i(unsigned int side,
+                                      unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 9 nodes per side.
+  libmesh_assert_less(side_node, 9);
+
+  // Some sides have 6 nodes.
+  libmesh_assert(!(side==0 || side==4) || side_node < 6);
+
+  return Prism18::side_nodes_map[side][side_node];
+}
+
 
 
 UniquePtr<Elem> Prism18::build_side_ptr (const unsigned int i,

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -84,6 +84,22 @@ dof_id_type Pyramid::key (const unsigned int s) const
 
 
 
+unsigned int Pyramid::which_node_am_i(unsigned int side,
+                                      unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 4 nodes per side.
+  libmesh_assert_less(side_node, 4);
+
+  // Some sides have 3 nodes.
+  libmesh_assert(side == 4 || side_node < 3);
+
+  return Pyramid5::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Pyramid::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -115,6 +115,22 @@ bool Pyramid13::has_affine_map() const
 
 
 
+unsigned int Pyramid13::which_node_am_i(unsigned int side,
+                                        unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 8 nodes per side.
+  libmesh_assert_less(side_node, 8);
+
+  // Some sides have 6 nodes.
+  libmesh_assert(side == 4 || side_node < 6);
+
+  return Pyramid13::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -144,6 +144,22 @@ dof_id_type Pyramid14::key (const unsigned int s) const
 
 
 
+unsigned int Pyramid14::which_node_am_i(unsigned int side,
+                                        unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+
+  // Never more than 9 nodes per side.
+  libmesh_assert_less(side_node, 9);
+
+  // Some sides have 6 nodes.
+  libmesh_assert(side == 4 || side_node < 6);
+
+  return Pyramid14::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool proxy)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -63,6 +63,17 @@ dof_id_type Tet::key (const unsigned int s) const
 
 
 
+unsigned int Tet::which_node_am_i(unsigned int side,
+                                  unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 3);
+
+  return Tet4::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Tet::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -153,6 +153,17 @@ bool Tet10::has_affine_map() const
 
 
 
+unsigned int Tet10::which_node_am_i(unsigned int side,
+                                    unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 6);
+
+  return Tet10::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Tet10::build_side_ptr (const unsigned int i,
                                        bool proxy)
 {

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -24,6 +24,14 @@
 namespace libMesh
 {
 
+unsigned int Edge::which_node_am_i(unsigned int side,
+                                   unsigned int /*side_node*/) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  return side;
+}
+
+
 
 UniquePtr<Elem> Edge::side_ptr (const unsigned int i)
 {

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -62,6 +62,17 @@ dof_id_type InfQuad::key (const unsigned int s) const
 
 
 
+unsigned int InfQuad::which_node_am_i(unsigned int side,
+                                      unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 2);
+
+  return InfQuad4::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> InfQuad::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -38,9 +38,9 @@ namespace libMesh
 // InfQuad6 class static member initializations
 const unsigned int InfQuad6::side_nodes_map[3][3] =
   {
-    {0, 1, 4}, // Side 0
-    {1, 3},    // Side 1
-    {0, 2}     // Side 2
+    {0, 1, 4},  // Side 0
+    {1, 3, 99}, // Side 1
+    {0, 2, 99}  // Side 2
   };
 
 

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -133,6 +133,17 @@ dof_id_type InfQuad6::key (const unsigned int s) const
 
 
 
+unsigned int InfQuad6::which_node_am_i(unsigned int side,
+                                       unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert ((side == 0 && side_node < 3) || (side_node < 2));
+
+  return InfQuad6::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
                                           bool proxy)
 {

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -60,6 +60,17 @@ dof_id_type Quad::key (const unsigned int s) const
 
 
 
+unsigned int Quad::which_node_am_i(unsigned int side,
+                                   unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 2);
+
+  return Quad4::side_nodes_map[side][side_node];
+}
+
+
+
 dof_id_type Quad::key () const
 {
   return this->compute_key(this->node_id(0),

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -190,6 +190,17 @@ dof_id_type Quad8::key (const unsigned int s) const
 
 
 
+unsigned int Quad8::which_node_am_i(unsigned int side,
+                                    unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 3);
+
+  return Quad8::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Quad8::build_side_ptr (const unsigned int i,
                                        bool proxy)
 {

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -208,6 +208,17 @@ dof_id_type Quad9::key () const
 
 
 
+unsigned int Quad9::which_node_am_i(unsigned int side,
+                                    unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 3);
+
+  return Quad9::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Quad9::build_side_ptr (const unsigned int i,
                                        bool proxy)
 {

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -59,6 +59,17 @@ dof_id_type Tri::key (const unsigned int s) const
 
 
 
+unsigned int Tri::which_node_am_i(unsigned int side,
+                                  unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 2);
+
+  return Tri3::side_nodes_map[side][side_node];
+}
+
+
+
 dof_id_type Tri::key () const
 {
   return this->compute_key(this->node_id(0),

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -174,6 +174,17 @@ dof_id_type Tri6::key (const unsigned int s) const
 
 
 
+unsigned int Tri6::which_node_am_i(unsigned int side,
+                                   unsigned int side_node) const
+{
+  libmesh_assert_less (side, this->n_sides());
+  libmesh_assert_less (side_node, 3);
+
+  return Tri6::side_nodes_map[side][side_node];
+}
+
+
+
 UniquePtr<Elem> Tri6::build_side_ptr (const unsigned int i,
                                       bool proxy)
 {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -31,6 +31,7 @@ unit_tests_sources = \
   geom/node_test.C \
   geom/point_test.C \
   geom/point_test.h \
+  geom/which_node_am_i_test.C \
   mesh/all_tri.C \
   mesh/boundary_mesh.C \
   mesh/boundary_info.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -187,7 +187,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -231,6 +232,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	geom/unit_tests_dbg-elem_test.$(OBJEXT) \
 	geom/unit_tests_dbg-node_test.$(OBJEXT) \
 	geom/unit_tests_dbg-point_test.$(OBJEXT) \
+	geom/unit_tests_dbg-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-all_tri.$(OBJEXT) \
 	mesh/unit_tests_dbg-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_dbg-boundary_info.$(OBJEXT) \
@@ -286,7 +288,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -329,6 +332,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	geom/unit_tests_devel-elem_test.$(OBJEXT) \
 	geom/unit_tests_devel-node_test.$(OBJEXT) \
 	geom/unit_tests_devel-point_test.$(OBJEXT) \
+	geom/unit_tests_devel-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_devel-all_tri.$(OBJEXT) \
 	mesh/unit_tests_devel-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_devel-boundary_info.$(OBJEXT) \
@@ -382,7 +386,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -425,6 +430,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	geom/unit_tests_oprof-elem_test.$(OBJEXT) \
 	geom/unit_tests_oprof-node_test.$(OBJEXT) \
 	geom/unit_tests_oprof-point_test.$(OBJEXT) \
+	geom/unit_tests_oprof-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-all_tri.$(OBJEXT) \
 	mesh/unit_tests_oprof-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_oprof-boundary_info.$(OBJEXT) \
@@ -478,7 +484,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -521,6 +528,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	geom/unit_tests_opt-elem_test.$(OBJEXT) \
 	geom/unit_tests_opt-node_test.$(OBJEXT) \
 	geom/unit_tests_opt-point_test.$(OBJEXT) \
+	geom/unit_tests_opt-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_opt-all_tri.$(OBJEXT) \
 	mesh/unit_tests_opt-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_opt-boundary_info.$(OBJEXT) \
@@ -572,7 +580,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h mesh/all_tri.C \
+	geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -615,6 +624,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	geom/unit_tests_prof-elem_test.$(OBJEXT) \
 	geom/unit_tests_prof-node_test.$(OBJEXT) \
 	geom/unit_tests_prof-point_test.$(OBJEXT) \
+	geom/unit_tests_prof-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_prof-all_tri.$(OBJEXT) \
 	mesh/unit_tests_prof-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_prof-boundary_info.$(OBJEXT) \
@@ -1084,11 +1094,11 @@ unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
 	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
 	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
 	geom/elem_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h mesh/all_tri.C mesh/boundary_mesh.C \
-	mesh/boundary_info.C mesh/checkpoint.C mesh/contains_point.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
+	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
@@ -1237,6 +1247,8 @@ geom/unit_tests_dbg-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_dbg-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_dbg-which_node_am_i_test.$(OBJEXT):  \
+	geom/$(am__dirstamp) geom/$(DEPDIR)/$(am__dirstamp)
 mesh/$(am__dirstamp):
 	@$(MKDIR_P) mesh
 	@: > mesh/$(am__dirstamp)
@@ -1394,6 +1406,8 @@ geom/unit_tests_devel-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_devel-which_node_am_i_test.$(OBJEXT):  \
+	geom/$(am__dirstamp) geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1503,6 +1517,8 @@ geom/unit_tests_oprof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_oprof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_oprof-which_node_am_i_test.$(OBJEXT):  \
+	geom/$(am__dirstamp) geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1612,6 +1628,8 @@ geom/unit_tests_opt-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_opt-which_node_am_i_test.$(OBJEXT):  \
+	geom/$(am__dirstamp) geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1721,6 +1739,8 @@ geom/unit_tests_prof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_prof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
+geom/unit_tests_prof-which_node_am_i_test.$(OBJEXT):  \
+	geom/$(am__dirstamp) geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1897,18 +1917,23 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-elem_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-point_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-boundary_info.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-boundary_mesh.Po@am__quote@
@@ -2355,6 +2380,20 @@ geom/unit_tests_dbg-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/point_test.C' object='geom/unit_tests_dbg-point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
+
+geom/unit_tests_dbg-which_node_am_i_test.o: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_dbg-which_node_am_i_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_dbg-which_node_am_i_test.Tpo -c -o geom/unit_tests_dbg-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_dbg-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_dbg-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_dbg-which_node_am_i_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+
+geom/unit_tests_dbg-which_node_am_i_test.obj: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_dbg-which_node_am_i_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_dbg-which_node_am_i_test.Tpo -c -o geom/unit_tests_dbg-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_dbg-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_dbg-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_dbg-which_node_am_i_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
 
 mesh/unit_tests_dbg-all_tri.o: mesh/all_tri.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Tpo -c -o mesh/unit_tests_dbg-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
@@ -3098,6 +3137,20 @@ geom/unit_tests_devel-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
 
+geom/unit_tests_devel-which_node_am_i_test.o: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_devel-which_node_am_i_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_devel-which_node_am_i_test.Tpo -c -o geom/unit_tests_devel-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_devel-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_devel-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_devel-which_node_am_i_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+
+geom/unit_tests_devel-which_node_am_i_test.obj: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_devel-which_node_am_i_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_devel-which_node_am_i_test.Tpo -c -o geom/unit_tests_devel-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_devel-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_devel-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_devel-which_node_am_i_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
+
 mesh/unit_tests_devel-all_tri.o: mesh/all_tri.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-all_tri.Tpo -c -o mesh/unit_tests_devel-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po
@@ -3839,6 +3892,20 @@ geom/unit_tests_oprof-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/point_test.C' object='geom/unit_tests_oprof-point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
+
+geom/unit_tests_oprof-which_node_am_i_test.o: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_oprof-which_node_am_i_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_oprof-which_node_am_i_test.Tpo -c -o geom/unit_tests_oprof-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_oprof-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_oprof-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_oprof-which_node_am_i_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+
+geom/unit_tests_oprof-which_node_am_i_test.obj: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_oprof-which_node_am_i_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_oprof-which_node_am_i_test.Tpo -c -o geom/unit_tests_oprof-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_oprof-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_oprof-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_oprof-which_node_am_i_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
 
 mesh/unit_tests_oprof-all_tri.o: mesh/all_tri.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Tpo -c -o mesh/unit_tests_oprof-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
@@ -4582,6 +4649,20 @@ geom/unit_tests_opt-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
 
+geom/unit_tests_opt-which_node_am_i_test.o: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_opt-which_node_am_i_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_opt-which_node_am_i_test.Tpo -c -o geom/unit_tests_opt-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_opt-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_opt-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_opt-which_node_am_i_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+
+geom/unit_tests_opt-which_node_am_i_test.obj: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_opt-which_node_am_i_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_opt-which_node_am_i_test.Tpo -c -o geom/unit_tests_opt-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_opt-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_opt-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_opt-which_node_am_i_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
+
 mesh/unit_tests_opt-all_tri.o: mesh/all_tri.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-all_tri.Tpo -c -o mesh/unit_tests_opt-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-all_tri.Tpo mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po
@@ -5323,6 +5404,20 @@ geom/unit_tests_prof-point_test.obj: geom/point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/point_test.C' object='geom/unit_tests_prof-point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-point_test.obj `if test -f 'geom/point_test.C'; then $(CYGPATH_W) 'geom/point_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/point_test.C'; fi`
+
+geom/unit_tests_prof-which_node_am_i_test.o: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_prof-which_node_am_i_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_prof-which_node_am_i_test.Tpo -c -o geom/unit_tests_prof-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_prof-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_prof-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_prof-which_node_am_i_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-which_node_am_i_test.o `test -f 'geom/which_node_am_i_test.C' || echo '$(srcdir)/'`geom/which_node_am_i_test.C
+
+geom/unit_tests_prof-which_node_am_i_test.obj: geom/which_node_am_i_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_prof-which_node_am_i_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_prof-which_node_am_i_test.Tpo -c -o geom/unit_tests_prof-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_prof-which_node_am_i_test.Tpo geom/$(DEPDIR)/unit_tests_prof-which_node_am_i_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/which_node_am_i_test.C' object='geom/unit_tests_prof-which_node_am_i_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-which_node_am_i_test.obj `if test -f 'geom/which_node_am_i_test.C'; then $(CYGPATH_W) 'geom/which_node_am_i_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/which_node_am_i_test.C'; fi`
 
 mesh/unit_tests_prof-all_tri.o: mesh/all_tri.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-all_tri.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-all_tri.Tpo -c -o mesh/unit_tests_prof-all_tri.o `test -f 'mesh/all_tri.C' || echo '$(srcdir)/'`mesh/all_tri.C

--- a/tests/geom/which_node_am_i_test.C
+++ b/tests/geom/which_node_am_i_test.C
@@ -1,0 +1,155 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/elem.h>
+#include <libmesh/reference_elem.h>
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+using namespace libMesh;
+
+class WhichNodeAmITest : public CppUnit::TestCase
+{
+
+public:
+  CPPUNIT_TEST_SUITE( WhichNodeAmITest );
+  CPPUNIT_TEST( testPyramids );
+  CPPUNIT_TEST( testPrisms );
+  CPPUNIT_TEST( testTets );
+  CPPUNIT_TEST( testHexes );
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  /**
+   * Note: the sections below marked
+   *
+   * #if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
+   *
+   * are currently commented out because (even though they work) they
+   * print a bunch of stuff to the screen (error message, stack trace,
+   * etc.) that makes it look like they failed. If we could silently
+   * avoid seeing all that in the output stream, it might be worth
+   * including this test. The Google Test suite may provide a better
+   * mechanism for doing this.
+   */
+
+  void testPyramids()
+  {
+    // The last node on the right side (1) should be node 4 (apex node).
+    const Elem & pyr5 = ReferenceElem::get(PYRAMID5);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), pyr5.which_node_am_i(/*side=*/1, /*node=*/2));
+
+// #if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
+//     try
+//       {
+//         // Asking for the 4th node on a triangular face should throw.
+//         unsigned int n = pyr5.which_node_am_i(1, 3);
+//
+//         // We shouldn't get here if the line above throws. If we do
+//         // get here, there's no way this assert will pass.
+//         CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(-1), n);
+//       }
+//     catch (...) {}
+// #endif
+
+#ifdef NDEBUG
+    // In optimized mode, we expect to get the "dummy" value 99.
+    unsigned int n = pyr5.which_node_am_i(1, 3);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(99), n);
+#endif
+
+    // The last node on the right side (1) should be node 10.
+    const Elem & pyr13 = ReferenceElem::get(PYRAMID13);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(10), pyr13.which_node_am_i(/*side=*/1, /*node=*/5));
+
+    // The central node of the base should be node 13
+    const Elem & pyr14 = ReferenceElem::get(PYRAMID14);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(13), pyr14.which_node_am_i(/*side=*/4, /*node=*/8));
+  }
+
+
+
+  void testPrisms()
+  {
+    // A PRISM6 has four nodes on some sides and three nodes on others
+    const Elem & prism6 = ReferenceElem::get(PRISM6);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), prism6.which_node_am_i(/*side=*/4, /*node=*/1));
+
+// #if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
+//     try
+//       {
+//         // Asks for the 3rd node on a Tri face which only has
+//         // indices 0, 1, and 2. Should throw an exception
+//         // (libmesh_assert throws an exception) when NDEBUG is not
+//         // defined.
+//         unsigned int n = prism6.which_node_am_i(0, 3);
+//
+//         // We shouldn't get here if the line above throws. If we do
+//         // get here, there's no way this assert will pass.
+//         CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(-1), n);
+//       }
+//     catch (...) {}
+// #endif
+
+#ifdef NDEBUG
+    // In optimized mode, we expect to get the "dummy" value 99.
+    unsigned int n = prism6.which_node_am_i(0, 3);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(99), n);
+#endif
+
+    // Test the Prism15.
+    const Elem & prism15 = ReferenceElem::get(PRISM15);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(3), prism15.which_node_am_i(/*side=*/1, /*node=*/3));
+  }
+
+
+
+  void testTets()
+  {
+    const Elem & tet4 = ReferenceElem::get(TET4);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(0), tet4.which_node_am_i(/*side=*/0, /*node=*/0));
+
+    // Node 4 is a mid-edge node on side 1.
+    const Elem & tet10 = ReferenceElem::get(TET10);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), tet10.which_node_am_i(/*side=*/1, /*node=*/3));
+  }
+
+
+
+  void testHexes()
+  {
+    // Top left node on back side.
+    const Elem & hex8 = ReferenceElem::get(HEX8);
+    CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(7), hex8.which_node_am_i(/*side=*/3, /*node=*/2));
+
+    const Elem & hex20 = ReferenceElem::get(HEX20);
+    const Elem & hex27 = ReferenceElem::get(HEX27);
+
+    // The vertices (i.e. the first 4 nodes on each side should match for all of the Hex types.
+    for (unsigned int side=0; side<hex8.n_sides(); ++side)
+      for (unsigned int node=0; node<4; ++node)
+        {
+          // Make sure the Hex8 and Hex20 implementations agree.
+          CPPUNIT_ASSERT_EQUAL(hex8.which_node_am_i(side, node),
+                               hex20.which_node_am_i(side, node));
+
+          // Make sure the Hex20 and Hex27 implementations agree.
+          CPPUNIT_ASSERT_EQUAL(hex20.which_node_am_i(side, node),
+                               hex27.which_node_am_i(side, node));
+        }
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( WhichNodeAmITest );


### PR DESCRIPTION
This function allows you to determine which (local) node number of Element `e` corresponds to (local) node number `n` on side `s`. This should be more efficient than calling `Elem::build_side()` in situations where you only need e.g. DOF values from the parent element and not the full side information.

