### PR TITLE
Add RAII-based StreamRedirector object for unit testing libmesh_asserts

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,6 +11,7 @@ LIBS         = $(libmesh_optional_LIBS) $(CPPUNIT_LIBS)
 unit_tests_sources = \
   driver.C \
   test_comm.h \
+  stream_redirector.h \
   base/dof_object_test.h \
   base/default_coupling_test.C \
   base/getpot_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -179,16 +179,16 @@ CONFIG_CLEAN_VPATH_FILES =
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__EXEEXT_7 = unit_tests-dbg$(EXEEXT)
 PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/default_coupling_test.C \
-	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/unique_ptr_test.C fe/fe_bernstein_test.C \
-	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h \
-	geom/which_node_am_i_test.C mesh/all_tri.C \
+	stream_redirector.h base/dof_object_test.h \
+	base/default_coupling_test.C base/getpot_test.C \
+	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
+	fe/fe_bernstein_test.C fe/fe_clough_test.C \
+	fe/fe_hermite_test.C fe/fe_hierarchic_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/elem_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -280,16 +280,16 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/default_coupling_test.C \
-	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/unique_ptr_test.C fe/fe_bernstein_test.C \
-	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h \
-	geom/which_node_am_i_test.C mesh/all_tri.C \
+	stream_redirector.h base/dof_object_test.h \
+	base/default_coupling_test.C base/getpot_test.C \
+	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
+	fe/fe_bernstein_test.C fe/fe_clough_test.C \
+	fe/fe_hermite_test.C fe/fe_hierarchic_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/elem_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -378,16 +378,16 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/default_coupling_test.C \
-	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/unique_ptr_test.C fe/fe_bernstein_test.C \
-	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h \
-	geom/which_node_am_i_test.C mesh/all_tri.C \
+	stream_redirector.h base/dof_object_test.h \
+	base/default_coupling_test.C base/getpot_test.C \
+	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
+	fe/fe_bernstein_test.C fe/fe_clough_test.C \
+	fe/fe_hermite_test.C fe/fe_hierarchic_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/elem_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -476,16 +476,16 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/default_coupling_test.C \
-	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/unique_ptr_test.C fe/fe_bernstein_test.C \
-	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h \
-	geom/which_node_am_i_test.C mesh/all_tri.C \
+	stream_redirector.h base/dof_object_test.h \
+	base/default_coupling_test.C base/getpot_test.C \
+	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
+	fe/fe_bernstein_test.C fe/fe_clough_test.C \
+	fe/fe_hermite_test.C fe/fe_hierarchic_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/elem_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -572,16 +572,16 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
-	base/dof_object_test.h base/default_coupling_test.C \
-	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/unique_ptr_test.C fe/fe_bernstein_test.C \
-	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h \
-	geom/which_node_am_i_test.C mesh/all_tri.C \
+	stream_redirector.h base/dof_object_test.h \
+	base/default_coupling_test.C base/getpot_test.C \
+	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
+	fe/fe_bernstein_test.C fe/fe_clough_test.C \
+	fe/fe_hermite_test.C fe/fe_hierarchic_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/elem_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -1085,16 +1085,17 @@ AM_CPPFLAGS = $(libmesh_optional_INCLUDES) -I$(top_builddir)/include \
 	       -DLIBMESH_IS_UNIT_TESTING
 
 AM_LDFLAGS = $(libmesh_LDFLAGS)
-unit_tests_sources = driver.C test_comm.h base/dof_object_test.h \
-	base/default_coupling_test.C base/getpot_test.C \
-	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
-	fe/fe_bernstein_test.C fe/fe_clough_test.C \
-	fe/fe_hermite_test.C fe/fe_hierarchic_test.C \
-	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
-	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
-	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
-	geom/elem_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
+unit_tests_sources = driver.C test_comm.h stream_redirector.h \
+	base/dof_object_test.h base/default_coupling_test.C \
+	base/getpot_test.C base/point_neighbor_coupling_test.C \
+	base/unique_ptr_test.C fe/fe_bernstein_test.C \
+	fe/fe_clough_test.C fe/fe_hermite_test.C \
+	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
+	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
+	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
+	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \

--- a/tests/geom/which_node_am_i_test.C
+++ b/tests/geom/which_node_am_i_test.C
@@ -7,6 +7,9 @@
 #include <libmesh/elem.h>
 #include <libmesh/reference_elem.h>
 
+// Unit test headers
+#include "stream_redirector.h"
+
 // THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
 // std::auto_ptr, which in turn produces -Wdeprecated-declarations
 // warnings.  These can be ignored in GCC as long as we wrap the
@@ -42,12 +45,11 @@ public:
     // are available. If exceptions aren't available, libmesh_assert
     // simply aborts, so we can't unit test in that case.
 #if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
-    // Save the original streambuf and redirect to NULL
-    std::streambuf * errbuf = libMesh::err.rdbuf();
-    libMesh::err.rdbuf(libmesh_nullptr);
-
     try
       {
+        // Avoid sending confusing error messages to the console.
+        StreamRedirector stream_redirector;
+
         // Asking for the 4th node on a triangular face should throw.
         unsigned int n = pyr5.which_node_am_i(1, 3);
 
@@ -56,9 +58,6 @@ public:
         CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(-1), n);
       }
     catch (...) {}
-
-    // Restore original stream
-    libMesh::err.rdbuf(errbuf);
 #endif
 
 #ifdef NDEBUG
@@ -88,12 +87,11 @@ public:
     // are available. If exceptions aren't available, libmesh_assert
     // simply aborts, so we can't unit test in that case.
 #if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
-    // Save the original streambuf and redirect to NULL
-    std::streambuf * errbuf = libMesh::err.rdbuf();
-    libMesh::err.rdbuf(libmesh_nullptr);
-
     try
       {
+        // Avoid sending confusing error messages to the console.
+        StreamRedirector stream_redirector;
+
         // Asks for the 3rd node on a Tri face which only has
         // indices 0, 1, and 2. Should throw an exception
         // (libmesh_assert throws an exception) when NDEBUG is not
@@ -105,9 +103,6 @@ public:
         CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(-1), n);
       }
     catch (...) {}
-
-    // Restore original stream
-    libMesh::err.rdbuf(errbuf);
 #endif
 
 #ifdef NDEBUG

--- a/tests/geom/which_node_am_i_test.C
+++ b/tests/geom/which_node_am_i_test.C
@@ -32,37 +32,34 @@ public:
 
 public:
 
-  /**
-   * Note: the sections below marked
-   *
-   * #if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
-   *
-   * are currently commented out because (even though they work) they
-   * print a bunch of stuff to the screen (error message, stack trace,
-   * etc.) that makes it look like they failed. If we could silently
-   * avoid seeing all that in the output stream, it might be worth
-   * including this test. The Google Test suite may provide a better
-   * mechanism for doing this.
-   */
-
   void testPyramids()
   {
     // The last node on the right side (1) should be node 4 (apex node).
     const Elem & pyr5 = ReferenceElem::get(PYRAMID5);
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), pyr5.which_node_am_i(/*side=*/1, /*node=*/2));
 
-// #if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
-//     try
-//       {
-//         // Asking for the 4th node on a triangular face should throw.
-//         unsigned int n = pyr5.which_node_am_i(1, 3);
-//
-//         // We shouldn't get here if the line above throws. If we do
-//         // get here, there's no way this assert will pass.
-//         CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(-1), n);
-//       }
-//     catch (...) {}
-// #endif
+    // Test the libmesh_asserts when they are enabled and exceptions
+    // are available. If exceptions aren't available, libmesh_assert
+    // simply aborts, so we can't unit test in that case.
+#if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
+    // Save the original streambuf and redirect to NULL
+    std::streambuf * errbuf = libMesh::err.rdbuf();
+    libMesh::err.rdbuf(libmesh_nullptr);
+
+    try
+      {
+        // Asking for the 4th node on a triangular face should throw.
+        unsigned int n = pyr5.which_node_am_i(1, 3);
+
+        // We shouldn't get here if the line above throws. If we do
+        // get here, there's no way this assert will pass.
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(-1), n);
+      }
+    catch (...) {}
+
+    // Restore original stream
+    libMesh::err.rdbuf(errbuf);
+#endif
 
 #ifdef NDEBUG
     // In optimized mode, we expect to get the "dummy" value 99.
@@ -87,21 +84,31 @@ public:
     const Elem & prism6 = ReferenceElem::get(PRISM6);
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), prism6.which_node_am_i(/*side=*/4, /*node=*/1));
 
-// #if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
-//     try
-//       {
-//         // Asks for the 3rd node on a Tri face which only has
-//         // indices 0, 1, and 2. Should throw an exception
-//         // (libmesh_assert throws an exception) when NDEBUG is not
-//         // defined.
-//         unsigned int n = prism6.which_node_am_i(0, 3);
-//
-//         // We shouldn't get here if the line above throws. If we do
-//         // get here, there's no way this assert will pass.
-//         CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(-1), n);
-//       }
-//     catch (...) {}
-// #endif
+    // Test the libmesh_asserts when they are enabled and exceptions
+    // are available. If exceptions aren't available, libmesh_assert
+    // simply aborts, so we can't unit test in that case.
+#if !defined(NDEBUG) && defined(LIBMESH_ENABLE_EXCEPTIONS)
+    // Save the original streambuf and redirect to NULL
+    std::streambuf * errbuf = libMesh::err.rdbuf();
+    libMesh::err.rdbuf(libmesh_nullptr);
+
+    try
+      {
+        // Asks for the 3rd node on a Tri face which only has
+        // indices 0, 1, and 2. Should throw an exception
+        // (libmesh_assert throws an exception) when NDEBUG is not
+        // defined.
+        unsigned int n = prism6.which_node_am_i(0, 3);
+
+        // We shouldn't get here if the line above throws. If we do
+        // get here, there's no way this assert will pass.
+        CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(-1), n);
+      }
+    catch (...) {}
+
+    // Restore original stream
+    libMesh::err.rdbuf(errbuf);
+#endif
 
 #ifdef NDEBUG
     // In optimized mode, we expect to get the "dummy" value 99.

--- a/tests/stream_redirector.h
+++ b/tests/stream_redirector.h
@@ -1,0 +1,31 @@
+#include <libmesh/libmesh.h>
+
+/**
+ * This class uses RAII to control redirecting the libMesh::err stream
+ * to NULL and restoring it around some operation where we do not want
+ * to see output to the screen.
+ */
+class StreamRedirector
+{
+public:
+
+  /**
+   * Constructor; saves the original libMesh::err streambuf.
+   */
+  StreamRedirector()
+    : _errbuf(libMesh::err.rdbuf())
+  {
+    libMesh::err.rdbuf(libmesh_nullptr);
+  }
+
+  /**
+   * Destructor: restores the stream.
+   */
+  ~StreamRedirector()
+  {
+    libMesh::err.rdbuf(_errbuf);
+  }
+
+private:
+  std::streambuf * _errbuf;
+};


### PR DESCRIPTION
Follow-on to #1330, uncommenting the `libmesh_assert` tests that were added there. This also gives us a general tool to unit test other asserts without sending a bunch of stack traces and error messages to the screen.
