### PR TITLE
Fix warnings/errors in non-standard configurations

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,15 +1,14 @@
 Please use the following reference to cite libMesh:
 
 @Article{libMeshPaper,
-   author = {B.~S.~Kirk and J.~W.~Peterson and R.~H.~Stogner and G.~F.~Carey},
-    title = {{\texttt{libMesh}: A C++ Library for Parallel Adaptive Mesh
-              Refinement/Coarsening Simulations}},
+  author  = {B.~S.~Kirk and J.~W.~Peterson and R.~H.~Stogner and G.~F.~Carey},
+  title   = {{\texttt{libMesh}: A C++ library for parallel adaptive mesh refinement/coarsening simulations}},
   journal = {Engineering with Computers},
-   volume = {22},
-   number = {3--4},
-    pages = {237--254},
-     year = {2006},
-     note = {\url{http://dx.doi.org/10.1007/s00366-006-0049-3}}
+  volume  = 22,
+  number  = {3--4},
+  pages   = {237--254},
+  year    = 2006,
+  note    = {\url{http://dx.doi.org/10.1007/s00366-006-0049-3}}
 }
 
 B. S. Kirk, J. W. Peterson, R. H. Stogner, and G. F. Carey, "libMesh:

--- a/configure
+++ b/configure
@@ -42533,7 +42533,7 @@ if test "${enable_cppunit+set}" = set; then :
                 *)  as_fn_error $? "bad value ${enableval} for --enable-cppunit" "$LINENO" 5 ;;
               esac
 else
-  enablecppunit=$enableoptional
+  enablecppunit=yes
 fi
 
 if (test "$enablecppunit" = yes) ; then

--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -177,8 +177,11 @@ int main(int argc, char ** argv)
 
 // Define the matrix assembly function for the 1D PDE we are solving
 void assemble_1D(EquationSystems & es,
-                 const std::string & libmesh_dbg_var(system_name))
+                 const std::string & system_name)
 {
+  // Ignore unused parameter warnings when !LIBMESH_ENABLE_AMR.
+  libmesh_ignore(es);
+  libmesh_ignore(system_name);
 
 #ifdef LIBMESH_ENABLE_AMR
 

--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -65,6 +65,10 @@ int main(int argc, char ** argv)
   // finalized.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Skip adaptive examples on a non-adaptive libMesh build
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_example_requires(false, "--enable-amr");

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -119,6 +119,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_example_requires(false, "--enable-amr");
 #else

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -605,8 +605,12 @@ Gradient exact_derivative(const Point & p,
 // account the boundary conditions, which will be handled
 // via a penalty method.
 void assemble_laplace(EquationSystems & es,
-                      const std::string & libmesh_dbg_var(system_name))
+                      const std::string & system_name)
 {
+  // Ignore unused parameter warnings when !LIBMESH_ENABLE_AMR.
+  libmesh_ignore(es);
+  libmesh_ignore(system_name);
+
 #ifdef LIBMESH_ENABLE_AMR
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -118,6 +118,10 @@ int main(int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Single precision is inadequate for p refinement
   libmesh_example_requires(sizeof(Real) > 4, "--disable-singleprecision");
 

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -649,8 +649,12 @@ Number forcing_function_3D(const Point & p)
 // account the boundary conditions, which will be handled
 // via a penalty method.
 void assemble_biharmonic(EquationSystems & es,
-                         const std::string & libmesh_dbg_var(system_name))
+                         const std::string & system_name)
 {
+  // Ignore unused parameter warnings when libmesh is configured without certain options.
+  libmesh_ignore(es);
+  libmesh_ignore(system_name);
+
 #ifdef LIBMESH_ENABLE_AMR
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -152,6 +152,10 @@ int main(int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Adaptive constraint calculations for fine Hermite elements seems
   // to require half-decent precision
 #ifdef LIBMESH_DEFAULT_SINGLE_PRECISION

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -129,6 +129,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 

--- a/examples/adjoints/adjoints_ex1/adjoints_ex1.C
+++ b/examples/adjoints/adjoints_ex1/adjoints_ex1.C
@@ -99,6 +99,12 @@ void write_output(EquationSystems & es,
                   std::string solution_type,  // primal or adjoint solve
                   FEMParameters & param)
 {
+  // Ignore parameters when there are no output formats available.
+  libmesh_ignore(es);
+  libmesh_ignore(a_step);
+  libmesh_ignore(solution_type);
+  libmesh_ignore(param);
+
 #ifdef LIBMESH_HAVE_GMV
   if (param.output_gmv)
     {
@@ -272,6 +278,10 @@ int main (int argc, char ** argv)
 {
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
+
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
 
   // Skip adaptive examples on a non-adaptive libMesh build
 #ifndef LIBMESH_ENABLE_AMR

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -107,6 +107,12 @@ void write_output(EquationSystems & es,
                   std::string solution_type, // primal or adjoint solve
                   FEMParameters & param)
 {
+  // Ignore parameters when there are no output formats available.
+  libmesh_ignore(es);
+  libmesh_ignore(a_step);
+  libmesh_ignore(solution_type);
+  libmesh_ignore(param);
+
 #ifdef LIBMESH_HAVE_GMV
   if (param.output_gmv)
     {
@@ -271,6 +277,10 @@ int main (int argc, char ** argv)
 {
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
+
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
 
   // Skip adaptive examples on a non-adaptive libMesh build
 #ifndef LIBMESH_ENABLE_AMR

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -94,6 +94,12 @@ void write_output(EquationSystems & es,
                   std::string solution_type, // primal or adjoint solve
                   FEMParameters & param)
 {
+  // Ignore parameters when there are no output formats available.
+  libmesh_ignore(es);
+  libmesh_ignore(a_step);
+  libmesh_ignore(solution_type);
+  libmesh_ignore(param);
+
 #ifdef LIBMESH_HAVE_GMV
   if (param.output_gmv)
     {
@@ -240,6 +246,10 @@ int main (int argc, char** argv)
 {
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
+
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
 
   // Skip adaptive examples on a non-adaptive libMesh build
 #ifndef LIBMESH_ENABLE_AMR

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -113,6 +113,12 @@ void write_output(EquationSystems & es,
                   std::string solution_type, // primal or adjoint solve
                   FEMParameters & param)
 {
+  // Ignore parameters when there are no output formats available.
+  libmesh_ignore(es);
+  libmesh_ignore(t_step);
+  libmesh_ignore(solution_type);
+  libmesh_ignore(param);
+
 #ifdef LIBMESH_HAVE_GMV
   if (param.output_gmv)
     {

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -281,10 +281,12 @@ void set_system_parameters(HeatSystem & system,
 }
 
 // The main program.
-int main (int argc, char** argv)
+int main (int argc, char ** argv)
 {
   // Skip adaptive examples on a non-adaptive libMesh build
 #ifndef LIBMESH_ENABLE_AMR
+  libmesh_ignore(argc);
+  libmesh_ignore(argv);
   libmesh_example_requires(false, "--enable-amr");
 #else
   // Skip this 2D example if libMesh was compiled as 1D-only.

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -55,6 +55,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // This example fails without at least double precision FP
 #ifdef LIBMESH_DEFAULT_SINGLE_PRECISION
   libmesh_example_requires(false, "--disable-singleprecision");

--- a/examples/fem_system/fem_system_ex2/fem_system_ex2.C
+++ b/examples/fem_system/fem_system_ex2/fem_system_ex2.C
@@ -149,6 +149,10 @@ int main(int argc, char ** argv)
   // Initialize libMesh and any dependent libraries
   LibMeshInit init(argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Skip this example if we do not meet certain requirements
 #ifndef LIBMESH_HAVE_VTK
   libmesh_example_requires(false, "--enable-vtk");

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -60,6 +60,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Parse the input file
   GetPot infile("fem_system_ex3.in");
 

--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.C
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.C
@@ -59,6 +59,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_example_requires(false, "--enable-amr");
 #else

--- a/examples/introduction/introduction_ex2/introduction_ex2.C
+++ b/examples/introduction/introduction_ex2/introduction_ex2.C
@@ -71,6 +71,10 @@ int main (int argc, char ** argv)
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // A brief message to the user to inform her of the
   // exact name of the program being run, and its command line.
   libMesh::out << "Running " << argv[0];

--- a/examples/introduction/introduction_ex3/introduction_ex3.C
+++ b/examples/introduction/introduction_ex3/introduction_ex3.C
@@ -81,6 +81,10 @@ int main (int argc, char ** argv)
   // Initialize libraries, like in example 2.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Brief message to the user regarding the program name
   // and command line arguments.
   libMesh::out << "Running " << argv[0];

--- a/examples/introduction/introduction_ex4/introduction_ex4.C
+++ b/examples/introduction/introduction_ex4/introduction_ex4.C
@@ -118,6 +118,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh and any dependent libaries, like in example 2.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Declare a performance log for the main program
   // PerfLog perf_main("Main Program");
 

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -100,6 +100,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh and any dependent libaries, like in example 2.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Check for proper usage.  The quadrature rule
   // must be given at run time.
   if (argc < 3)

--- a/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
+++ b/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
@@ -73,6 +73,10 @@ int main (int argc, char ** argv)
   START_LOG("Initialize and create cubes", "main");
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Create a GetPot object to parse the command line
   GetPot command_line (argc, argv);
 

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -79,6 +79,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Skip this 3D example if libMesh was compiled as 1D/2D-only.
   libmesh_example_requires (3 == LIBMESH_DIM, "3D support");
 

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -239,8 +239,12 @@ int main (int argc, char ** argv)
 // computing the proper matrix entries for the element stiffness
 // matrices and right-hand sides.
 void assemble (EquationSystems & es,
-               const std::string & libmesh_dbg_var(system_name))
+               const std::string & system_name)
 {
+  // Ignore unused parameter warnings when !LIBMESH_ENABLE_AMR.
+  libmesh_ignore(es);
+  libmesh_ignore(system_name);
+
 #ifdef LIBMESH_ENABLE_AMR
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -500,6 +500,10 @@ int main (int argc, char** argv)
 {
   LibMeshInit init(argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Skip adaptive examples on a non-adaptive libMesh build
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_example_requires(false, "--enable-amr");

--- a/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
+++ b/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
@@ -78,6 +78,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
 #if !defined(LIBMESH_HAVE_XDR)
   // We need XDR support to write out reduced bases
   libmesh_example_requires(false, "--enable-xdr");

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -59,6 +59,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
 #if !defined(LIBMESH_HAVE_XDR)
   // We need XDR support to write out reduced bases
   libmesh_example_requires(false, "--enable-xdr");

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -84,6 +84,10 @@ int main(int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
 #if !defined(LIBMESH_HAVE_XDR)
   // We need XDR support to write out reduced bases
   libmesh_example_requires(false, "--enable-xdr");

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -112,6 +112,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
 #if !defined(LIBMESH_HAVE_XDR)
   // We need XDR support to write out reduced bases
   libmesh_example_requires(false, "--enable-xdr");

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -93,6 +93,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh and any dependent libaries, like in example 2.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Declare a performance log for the main program
   // PerfLog perf_main("Main Program");
 

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -69,6 +69,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -93,6 +93,10 @@ int main (int argc, char** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -81,6 +81,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
 

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -183,11 +183,13 @@ int main (int argc, char ** argv)
   UniquePtr<NumericVector<Number> >
     last_nonlinear_soln (navier_stokes_system.solution->clone());
 
+#ifdef LIBMESH_HAVE_EXODUS_API
   // Since we are not doing adaptivity, write all solutions to a single Exodus file.
   ExodusII_IO exo_io(mesh);
 
   // Write out the initial condition
   exo_io.write_equation_systems ("out.e", equation_systems);
+#endif
 
   for (unsigned int t_step=1; t_step<=n_timesteps; ++t_step)
     {

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -77,6 +77,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh and any dependent libaries
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Initialize the cantilever mesh
   const unsigned int dim = 2;
 

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -81,6 +81,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh and any dependent libaries
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // This example NaNs with the Eigen sparse linear solvers
   libmesh_example_requires(libMesh::default_solver_package() != EIGEN_SOLVERS, "--enable-petsc or --enable-laspack");
 

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -430,6 +430,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh and any dependent libraries
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Initialize the cantilever mesh
   const unsigned int dim = 3;
 

--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
@@ -231,8 +231,6 @@ int main (int argc, char ** argv)
                    << std::endl;
 
       current_max_gap_function = std::max(std::abs(least_gap_fn), std::abs(max_gap_fn));
-
-      outer_iteration++;
     }
 
   libMesh::out << "Computing stresses..." << std::endl;

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -286,8 +286,12 @@ void init_cd (EquationSystems & es,
 // by the EquationSystems object at each timestep to assemble
 // the linear system for solution.
 void assemble_cd (EquationSystems & es,
-                  const std::string & libmesh_dbg_var(system_name))
+                  const std::string & system_name)
 {
+  // Ignore unused parameter warnings when !LIBMESH_ENABLE_AMR.
+  libmesh_ignore(es);
+  libmesh_ignore(system_name);
+
 #ifdef LIBMESH_ENABLE_AMR
   // It is a good idea to make sure we are assembling
   // the proper system.

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -105,6 +105,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // This example requires Adaptive Mesh Refinement support - although
   // it only refines uniformly, the refinement code used is the same
   // underneath

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -101,6 +101,10 @@ int main (int argc, char** argv)
   // Initialize libraries, like in example 2.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Check for proper usage.
   if (argc < 2)
     libmesh_error_msg("Usage: " << argv[0] << " [meshfile]");

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -80,6 +80,10 @@ int main (int argc, char ** argv)
   // Initialize libraries.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Brief message to the user regarding the program name
   // and command line arguments.
   libMesh::out << "Running " << argv[0];

--- a/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
+++ b/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
@@ -49,6 +49,10 @@ int main (int argc, char** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Parse the input file
   GetPot infile("vector_fe_ex2.in");
 

--- a/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
+++ b/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
@@ -49,6 +49,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Parse the input file
   GetPot infile("vector_fe_ex3.in");
 

--- a/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
+++ b/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
@@ -49,6 +49,10 @@ int main (int argc, char ** argv)
   // Initialize libMesh.
   LibMeshInit init (argc, argv);
 
+  // This example requires a linear solver package.
+  libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
+                           "--enable-petsc, --enable-trilinos, or --enable-eigen");
+
   // Parse the input file
   GetPot infile("vector_fe_ex4.in");
 

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -247,7 +247,6 @@ private:
    */
 #ifdef LIBMESH_HAVE_EXODUS_API
   UniquePtr<ExodusII_IO_Helper> exio_helper;
-#endif
 
   /**
    * Stores the current value of the timestep when calling
@@ -261,16 +260,17 @@ private:
   bool _verbose;
 
   /**
-   * The names of the variables to be output.
-   * If this is empty then all variables are output.
-   */
-  std::vector<std::string> _output_variables;
-
-  /**
    * Default false.  If true, files will be opened with EX_WRITE
    * rather than created from scratch when writing.
    */
   bool _append;
+#endif
+
+  /**
+   * The names of the variables to be output.
+   * If this is empty then all variables are output.
+   */
+  std::vector<std::string> _output_variables;
 
   /**
    * This function factors out a bunch of code which is common to the

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -126,13 +126,13 @@ public:
 private:
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
   UniquePtr<Nemesis_IO_Helper> nemhelper;
-#endif
 
   /**
    * Keeps track of the current timestep index being written. Used
    * when calling write_nodal_data() and other functions.
    */
   int _timestep;
+#endif
 
   /**
    * Controls whether extra debugging information is printed to the screen or not.

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -451,7 +451,9 @@ typename CompareTypes<T, T2>::supertype DenseVector<T>::dot (const DenseVector<T
   const int N = cast_int<int>(_val.size());
   // The following pragma tells clang's vectorizer that it is safe to
   // reorder floating point operations for this loop.
+#ifdef __clang__
 #pragma clang loop vectorize(enable)
+#endif
   for (int i=0; i<N; i++)
     val += (*this)(i)*libmesh_conj(vec(i));
 
@@ -612,7 +614,9 @@ Real DenseVector<T>::l2_norm () const
   const int N = cast_int<int>(_val.size());
   // The following pragma tells clang's vectorizer that it is safe to
   // reorder floating point operations for this loop.
+#ifdef __clang__
 #pragma clang loop vectorize(enable)
+#endif
   for (int i=0; i!=N; i++)
     my_norm += TensorTools::norm_sq((*this)(i));
 

--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -857,9 +857,9 @@ ParsedFEMFunction<Output>::eval (FunctionParserBase<Output> & parser,
 template <typename Output>
 inline
 Output
-ParsedFEMFunction<Output>::eval (char & libmesh_dbg_var(parser),
-                                 const std::string & libmesh_dbg_var(function_name),
-                                 unsigned int libmesh_dbg_var(component_idx)) const
+ParsedFEMFunction<Output>::eval (char & /*parser*/,
+                                 const std::string & /*function_name*/,
+                                 unsigned int /*component_idx*/) const
 {
   libmesh_error_msg("ERROR: This functionality requires fparser!");
   return Output(0);

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -92,6 +92,12 @@ namespace Parallel {
   {                                                                     \
   }
 
+#define LIBMESH_PARALLEL_FLOAT_OPS(cxxtype)                             \
+  template<>                                                            \
+  class OpFunction<cxxtype>                                             \
+  {                                                                     \
+  }
+
 #endif
 
 #define LIBMESH_INT_TYPE(cxxtype,mpitype)                               \

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -615,7 +615,7 @@ AC_ARG_ENABLE(cppunit,
                 no)  enablecppunit=no ;;
                 *)  AC_MSG_ERROR(bad value ${enableval} for --enable-cppunit) ;;
               esac],
-              [enablecppunit=$enableoptional])
+              [enablecppunit=yes])
 if (test "$enablecppunit" = yes) ; then
   AM_PATH_CPPUNIT([1.10.0],[enablecppunit=yes],[enablecppunit=no])
 fi

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -93,6 +93,9 @@ void JumpErrorEstimator::estimate_error (const System & system,
    *  ----------------------
    */
 
+  // This parameter is not used when !LIBMESH_ENABLE_AMR.
+  libmesh_ignore(estimate_parent_error);
+
   // The current mesh
   const MeshBase & mesh = system.get_mesh();
 
@@ -100,7 +103,9 @@ void JumpErrorEstimator::estimate_error (const System & system,
   const unsigned int n_vars = system.n_vars();
 
   // The DofMap for this system
+#ifdef LIBMESH_ENABLE_AMR
   const DofMap & dof_map = system.get_dof_map();
+#endif
 
   // Resize the error_per_cell vector to be
   // the number of elements, initialize it to 0.

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -3043,6 +3043,8 @@ bool Elem::is_vertex_on_parent(unsigned int c,
 #else
 
   // No AMR?
+  libmesh_ignore(c);
+  libmesh_ignore(n);
   libmesh_error_msg("ERROR: AMR disabled, how did we get here?");
   return true;
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -56,10 +56,10 @@ ExodusII_IO::ExodusII_IO (MeshBase & mesh,
   ParallelObject(mesh),
 #ifdef LIBMESH_HAVE_EXODUS_API
   exio_helper(new ExodusII_IO_Helper(*this, false, true, single_precision)),
-#endif
   _timestep(1),
   _verbose(false),
   _append(false),
+#endif
   _allow_empty_variables(false)
 {
 }

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -138,6 +138,9 @@ void query_ghosting_functors(const MeshBase & mesh,
                              bool newly_coarsened_only,
                              std::set<const Elem *, CompareElemIdsByLevel> & connected_elements)
 {
+  // This parameter is not used when !LIBMESH_ENABLE_AMR.
+  libmesh_ignore(newly_coarsened_only);
+
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_assert(!newly_coarsened_only);
 #endif
@@ -187,6 +190,11 @@ void connect_children(const MeshBase & mesh,
                       processor_id_type pid,
                       std::set<const Elem *, CompareElemIdsByLevel> & connected_elements)
 {
+  // None of these parameters are used when !LIBMESH_ENABLE_AMR.
+  libmesh_ignore(mesh);
+  libmesh_ignore(pid);
+  libmesh_ignore(connected_elements);
+
 #ifdef LIBMESH_ENABLE_AMR
   // Our XdrIO output needs inactive local elements to not have any
   // remote_elem children.  Let's make sure that doesn't happen.
@@ -210,6 +218,9 @@ void connect_children(const MeshBase & mesh,
 
 void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_elements)
 {
+  // This parameter is not used when !LIBMESH_ENABLE_AMR.
+  libmesh_ignore(connected_elements);
+
 #ifdef LIBMESH_ENABLE_AMR
 
   // Because our set is sorted by ascending level, we can traverse it

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -928,6 +928,12 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
   if (mesh.is_serial())
     return;
 
+  // This algorithm uses the MeshBase::flagged_pid_elements_begin/end iterators
+  // which are only available when AMR is enabled.
+#ifndef LIBMESH_ENABLE_AMR
+  libmesh_error_msg("Calling MeshCommunication::send_coarse_ghosts() requires AMR to be enabled. "
+                    "Please configure libmesh with --enable-amr.");
+#else
   // When we coarsen elements on a DistributedMesh, we make their
   // parents active.  This may increase the ghosting requirements on
   // the processor which owns the newly-activated parent element.  To
@@ -1084,6 +1090,7 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
 
   // Wait for all sends to complete
   Parallel::wait (send_requests);
+#endif // LIBMESH_ENABLE_AMR
 }
 
 #endif // LIBMESH_HAVE_MPI

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1822,7 +1822,7 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
 #ifdef LIBMESH_ENABLE_AMR
       elem->active_family_tree(active_family);
 #else
-      active_family.insert(elem);
+      active_family.push_back(elem);
 #endif
 
       for (std::size_t i=0; i != active_family.size(); ++i)

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1433,6 +1433,9 @@ void libmesh_assert_valid_unique_ids(const MeshBase &mesh)
 template <>
 void libmesh_assert_topology_consistent_procids<Elem>(const MeshBase & mesh)
 {
+  // This parameter is not used when !LIBMESH_ENABLE_AMR
+  libmesh_ignore(mesh);
+
   // If we're adaptively refining, check processor ids for consistency
   // between parents and children.
 #ifdef LIBMESH_ENABLE_AMR

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1320,8 +1320,8 @@ void Nemesis_IO::prepare_to_write_nodal_data (const std::string & fname,
 
 #else
 
-void Nemesis_IO::prepare_to_write_nodal_data (const std::string & fname,
-                                              const std::vector<std::string> & names)
+void Nemesis_IO::prepare_to_write_nodal_data (const std::string &,
+                                              const std::vector<std::string> &)
 {
   libmesh_error_msg("ERROR, Nemesis API is not defined.");
 }

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -94,8 +94,8 @@ Nemesis_IO::Nemesis_IO (MeshBase & mesh,
   ParallelObject (mesh),
 #if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
   nemhelper(new Nemesis_IO_Helper(*this, false, single_precision)),
-#endif
   _timestep(1),
+#endif
   _verbose (false),
   _append(false)
 {

--- a/src/numerics/preconditioner.C
+++ b/src/numerics/preconditioner.C
@@ -38,6 +38,9 @@ Preconditioner<T> *
 Preconditioner<T>::build(const libMesh::Parallel::Communicator & comm,
                          const SolverPackage solver_package)
 {
+  // Avoid unused parameter warnings when no solver packages are enabled.
+  libmesh_ignore(comm);
+
   // Build the appropriate solver
   switch (solver_package)
     {

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -135,6 +135,9 @@ UniquePtr<SparseMatrix<T> >
 SparseMatrix<T>::build(const Parallel::Communicator & comm,
                        const SolverPackage solver_package)
 {
+  // Avoid unused parameter warnings when no solver packages are enabled.
+  libmesh_ignore(comm);
+
   // Build the appropriate vector
   switch (solver_package)
     {

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -498,8 +498,11 @@ void RBEIMConstruction::initialize_parametrized_functions_in_training_set()
   libMesh::out << "Parametrized functions in training set initialized" << std::endl << std::endl;
 }
 
-void RBEIMConstruction::plot_parametrized_functions_in_training_set(const std::string& pathname)
+void RBEIMConstruction::plot_parametrized_functions_in_training_set(const std::string & pathname)
 {
+  // Ignore unused parameter warnings when Exodus is not available.
+  libmesh_ignore(pathname);
+
   libmesh_assert(_parametrized_functions_in_training_set_initialized);
 
   for (std::size_t i=0; i<_parametrized_functions_in_training_set.size(); i++)

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -42,11 +42,12 @@ UniquePtr<LinearSolver<T> >
 LinearSolver<T>::build(const libMesh::Parallel::Communicator & comm,
                        const SolverPackage solver_package)
 {
+  // Avoid unused parameter warnings when no solver packages are enabled.
+  libmesh_ignore(comm);
+
   // Build the appropriate solver
   switch (solver_package)
     {
-
-
 #ifdef LIBMESH_HAVE_LASPACK
     case LASPACK_SOLVERS:
       return UniquePtr<LinearSolver<T> >(new LaspackLinearSolver<T>(comm));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -81,6 +81,7 @@ endif
 check_PROGRAMS = # empty, append below
 noinst_PROGRAMS = # empty, append below
 
+if LIBMESH_ENABLE_CPPUNIT
 if LIBMESH_OPT_MODE
   check_PROGRAMS         += unit_tests-opt
   unit_tests_opt_SOURCES  = $(unit_tests_sources)
@@ -88,12 +89,14 @@ if LIBMESH_OPT_MODE
   unit_tests_opt_CXXFLAGS = $(CXXFLAGS_OPT)
   unit_tests_opt_LDADD    = $(top_builddir)/libmesh_opt.la
 endif
+endif
 
 # our GLIBC debugging preprocessor flags seem to potentially conflict
 # with libcppunit binaries.  Some cppunit versions work fine for us,
 # others segfault and/or hang.  By default we will not run
 # GLIBCXX-debugging builds with cppunit unless specificallly
 # configured to.
+if LIBMESH_ENABLE_CPPUNIT
 if LIBMESH_DBG_MODE
 if LIBMESH_ENABLE_GLIBCXX_DEBUGGING
 if LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT
@@ -109,7 +112,9 @@ endif
   unit_tests_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
   unit_tests_dbg_LDADD    = $(top_builddir)/libmesh_dbg.la
 endif
+endif
 
+if LIBMESH_ENABLE_CPPUNIT
 if LIBMESH_DEVEL_MODE
   check_PROGRAMS           += unit_tests-devel
   noinst_PROGRAMS          += unit_tests-devel
@@ -118,7 +123,9 @@ if LIBMESH_DEVEL_MODE
   unit_tests_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
   unit_tests_devel_LDADD    = $(top_builddir)/libmesh_devel.la
 endif
+endif
 
+if LIBMESH_ENABLE_CPPUNIT
 if LIBMESH_PROF_MODE
   check_PROGRAMS          += unit_tests-prof
   noinst_PROGRAMS         += unit_tests-prof
@@ -127,7 +134,9 @@ if LIBMESH_PROF_MODE
   unit_tests_prof_CXXFLAGS = $(CXXFLAGS_PROF)
   unit_tests_prof_LDADD    = $(top_builddir)/libmesh_prof.la
 endif
+endif
 
+if LIBMESH_ENABLE_CPPUNIT
 if LIBMESH_OPROF_MODE
   check_PROGRAMS           += unit_tests-oprof
   noinst_PROGRAMS          += unit_tests-oprof
@@ -136,7 +145,7 @@ if LIBMESH_OPROF_MODE
   unit_tests_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
   unit_tests_oprof_LDADD    = $(top_builddir)/libmesh_oprof.la
 endif
-
+endif
 
 # Recursive automake builds subdirectories before parent directories.
 # But here we need the subdirectory to be able to link to

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -179,7 +179,9 @@ $(top_builddir)/libmesh_oprof.la: FORCE
 
 
 
+if LIBMESH_ENABLE_CPPUNIT
 TESTS = run_unit_tests.sh
+endif
 
 CLEANFILES = cube_mesh.xdr \
              checkpoint_splitter.cpr* checkpoint_splitter.cpa* \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -98,22 +98,22 @@ check_PROGRAMS = $(am__EXEEXT_1) $(am__EXEEXT_2) $(am__EXEEXT_3) \
 	$(am__EXEEXT_4) $(am__EXEEXT_5) $(am__EXEEXT_6)
 noinst_PROGRAMS = $(am__EXEEXT_7) $(am__EXEEXT_4) $(am__EXEEXT_5) \
 	$(am__EXEEXT_6)
-@LIBMESH_OPT_MODE_TRUE@am__append_2 = unit_tests-opt
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@am__append_2 = unit_tests-opt
 
 # our GLIBC debugging preprocessor flags seem to potentially conflict
 # with libcppunit binaries.  Some cppunit versions work fine for us,
 # others segfault and/or hang.  By default we will not run
 # GLIBCXX-debugging builds with cppunit unless specificallly
 # configured to.
-@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__append_3 = unit_tests-dbg
-@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__append_4 = unit_tests-dbg
-@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_FALSE@am__append_5 = unit_tests-dbg
-@LIBMESH_DEVEL_MODE_TRUE@am__append_6 = unit_tests-devel
-@LIBMESH_DEVEL_MODE_TRUE@am__append_7 = unit_tests-devel
-@LIBMESH_PROF_MODE_TRUE@am__append_8 = unit_tests-prof
-@LIBMESH_PROF_MODE_TRUE@am__append_9 = unit_tests-prof
-@LIBMESH_OPROF_MODE_TRUE@am__append_10 = unit_tests-oprof
-@LIBMESH_OPROF_MODE_TRUE@am__append_11 = unit_tests-oprof
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__append_3 = unit_tests-dbg
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__append_4 = unit_tests-dbg
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_FALSE@am__append_5 = unit_tests-dbg
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am__append_6 = unit_tests-devel
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am__append_7 = unit_tests-devel
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@am__append_8 = unit_tests-prof
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@am__append_9 = unit_tests-prof
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@am__append_10 = unit_tests-oprof
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@am__append_11 = unit_tests-oprof
 
 ######################################################################
 #
@@ -170,13 +170,13 @@ mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/include/libmesh_config.h.tmp
 CONFIG_CLEAN_FILES = run_unit_tests.sh
 CONFIG_CLEAN_VPATH_FILES =
-@LIBMESH_OPT_MODE_TRUE@am__EXEEXT_1 = unit_tests-opt$(EXEEXT)
-@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__EXEEXT_2 = unit_tests-dbg$(EXEEXT)
-@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_FALSE@am__EXEEXT_3 = unit_tests-dbg$(EXEEXT)
-@LIBMESH_DEVEL_MODE_TRUE@am__EXEEXT_4 = unit_tests-devel$(EXEEXT)
-@LIBMESH_PROF_MODE_TRUE@am__EXEEXT_5 = unit_tests-prof$(EXEEXT)
-@LIBMESH_OPROF_MODE_TRUE@am__EXEEXT_6 = unit_tests-oprof$(EXEEXT)
-@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__EXEEXT_7 = unit_tests-dbg$(EXEEXT)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@am__EXEEXT_1 = unit_tests-opt$(EXEEXT)
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__EXEEXT_2 = unit_tests-dbg$(EXEEXT)
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_FALSE@am__EXEEXT_3 = unit_tests-dbg$(EXEEXT)
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am__EXEEXT_4 = unit_tests-devel$(EXEEXT)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@am__EXEEXT_5 = unit_tests-prof$(EXEEXT)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@am__EXEEXT_6 = unit_tests-oprof$(EXEEXT)
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__EXEEXT_7 = unit_tests-dbg$(EXEEXT)
 PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	stream_redirector.h base/dof_object_test.h \
@@ -267,10 +267,9 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	systems/unit_tests_dbg-systems_test.$(OBJEXT) \
 	utils/unit_tests_dbg-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_dbg-vectormap_test.$(OBJEXT) $(am__objects_1)
-@LIBMESH_DBG_MODE_TRUE@am_unit_tests_dbg_OBJECTS = $(am__objects_2)
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am_unit_tests_dbg_OBJECTS = $(am__objects_2)
 unit_tests_dbg_OBJECTS = $(am_unit_tests_dbg_OBJECTS)
-@LIBMESH_DBG_MODE_TRUE@unit_tests_dbg_DEPENDENCIES =  \
-@LIBMESH_DBG_MODE_TRUE@	$(top_builddir)/libmesh_dbg.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_dbg_DEPENDENCIES = $(top_builddir)/libmesh_dbg.la
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
@@ -368,11 +367,9 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	utils/unit_tests_devel-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_devel-vectormap_test.$(OBJEXT) \
 	$(am__objects_3)
-@LIBMESH_DEVEL_MODE_TRUE@am_unit_tests_devel_OBJECTS =  \
-@LIBMESH_DEVEL_MODE_TRUE@	$(am__objects_4)
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@am_unit_tests_devel_OBJECTS = $(am__objects_4)
 unit_tests_devel_OBJECTS = $(am_unit_tests_devel_OBJECTS)
-@LIBMESH_DEVEL_MODE_TRUE@unit_tests_devel_DEPENDENCIES =  \
-@LIBMESH_DEVEL_MODE_TRUE@	$(top_builddir)/libmesh_devel.la
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_devel_DEPENDENCIES = $(top_builddir)/libmesh_devel.la
 unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
@@ -466,11 +463,9 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	utils/unit_tests_oprof-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_oprof-vectormap_test.$(OBJEXT) \
 	$(am__objects_5)
-@LIBMESH_OPROF_MODE_TRUE@am_unit_tests_oprof_OBJECTS =  \
-@LIBMESH_OPROF_MODE_TRUE@	$(am__objects_6)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@am_unit_tests_oprof_OBJECTS = $(am__objects_6)
 unit_tests_oprof_OBJECTS = $(am_unit_tests_oprof_OBJECTS)
-@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_DEPENDENCIES =  \
-@LIBMESH_OPROF_MODE_TRUE@	$(top_builddir)/libmesh_oprof.la
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_DEPENDENCIES = $(top_builddir)/libmesh_oprof.la
 unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
@@ -563,10 +558,9 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	systems/unit_tests_opt-systems_test.$(OBJEXT) \
 	utils/unit_tests_opt-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_opt-vectormap_test.$(OBJEXT) $(am__objects_7)
-@LIBMESH_OPT_MODE_TRUE@am_unit_tests_opt_OBJECTS = $(am__objects_8)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@am_unit_tests_opt_OBJECTS = $(am__objects_8)
 unit_tests_opt_OBJECTS = $(am_unit_tests_opt_OBJECTS)
-@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_DEPENDENCIES =  \
-@LIBMESH_OPT_MODE_TRUE@	$(top_builddir)/libmesh_opt.la
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_DEPENDENCIES = $(top_builddir)/libmesh_opt.la
 unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
@@ -660,11 +654,9 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	utils/unit_tests_prof-point_locator_test.$(OBJEXT) \
 	utils/unit_tests_prof-vectormap_test.$(OBJEXT) \
 	$(am__objects_9)
-@LIBMESH_PROF_MODE_TRUE@am_unit_tests_prof_OBJECTS =  \
-@LIBMESH_PROF_MODE_TRUE@	$(am__objects_10)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@am_unit_tests_prof_OBJECTS = $(am__objects_10)
 unit_tests_prof_OBJECTS = $(am_unit_tests_prof_OBJECTS)
-@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_DEPENDENCIES =  \
-@LIBMESH_PROF_MODE_TRUE@	$(top_builddir)/libmesh_prof.la
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_DEPENDENCIES = $(top_builddir)/libmesh_prof.la
 unit_tests_prof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CXXLD) \
 	$(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
@@ -1119,27 +1111,27 @@ unit_tests_sources = driver.C test_comm.h stream_redirector.h \
 	systems/equation_systems_test.C systems/systems_test.C \
 	utils/point_locator_test.C utils/vectormap_test.C \
 	$(am__append_1)
-@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_SOURCES = $(unit_tests_sources)
-@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
-@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_CXXFLAGS = $(CXXFLAGS_OPT)
-@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_LDADD = $(top_builddir)/libmesh_opt.la
-@LIBMESH_DBG_MODE_TRUE@unit_tests_dbg_SOURCES = $(unit_tests_sources)
-@LIBMESH_DBG_MODE_TRUE@unit_tests_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
-@LIBMESH_DBG_MODE_TRUE@unit_tests_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
-@LIBMESH_DBG_MODE_TRUE@unit_tests_dbg_LDADD = $(top_builddir)/libmesh_dbg.la
-@LIBMESH_DEVEL_MODE_TRUE@unit_tests_devel_SOURCES = $(unit_tests_sources)
-@LIBMESH_DEVEL_MODE_TRUE@unit_tests_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
-@LIBMESH_DEVEL_MODE_TRUE@unit_tests_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
-@LIBMESH_DEVEL_MODE_TRUE@unit_tests_devel_LDADD = $(top_builddir)/libmesh_devel.la
-@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_SOURCES = $(unit_tests_sources)
-@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_CPPFLAGS = $(CPPFLAGS_PROF) $(AM_CPPFLAGS)
-@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_CXXFLAGS = $(CXXFLAGS_PROF)
-@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_LDADD = $(top_builddir)/libmesh_prof.la
-@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_SOURCES = $(unit_tests_sources)
-@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
-@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
-@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
-TESTS = run_unit_tests.sh
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_SOURCES = $(unit_tests_sources)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_CPPFLAGS = $(CPPFLAGS_OPT) $(AM_CPPFLAGS)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_CXXFLAGS = $(CXXFLAGS_OPT)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_LDADD = $(top_builddir)/libmesh_opt.la
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_dbg_SOURCES = $(unit_tests_sources)
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_dbg_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_dbg_CXXFLAGS = $(CXXFLAGS_DBG)
+@LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_dbg_LDADD = $(top_builddir)/libmesh_dbg.la
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_devel_SOURCES = $(unit_tests_sources)
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_devel_CPPFLAGS = $(CPPFLAGS_DEVEL) $(AM_CPPFLAGS)
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_devel_CXXFLAGS = $(CXXFLAGS_DEVEL)
+@LIBMESH_DEVEL_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@unit_tests_devel_LDADD = $(top_builddir)/libmesh_devel.la
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_SOURCES = $(unit_tests_sources)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_CPPFLAGS = $(CPPFLAGS_PROF) $(AM_CPPFLAGS)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_CXXFLAGS = $(CXXFLAGS_PROF)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_PROF_MODE_TRUE@unit_tests_prof_LDADD = $(top_builddir)/libmesh_prof.la
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_SOURCES = $(unit_tests_sources)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_CPPFLAGS = $(CPPFLAGS_OPROF) $(AM_CPPFLAGS)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
+@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
+@LIBMESH_ENABLE_CPPUNIT_TRUE@TESTS = run_unit_tests.sh
 CLEANFILES = cube_mesh.xdr checkpoint_splitter.cpr* \
 	checkpoint_splitter.cpa* slit_mesh.xda slit_solution.xda \
 	$(am__append_12)

--- a/tests/fe/fe_test.h
+++ b/tests/fe/fe_test.h
@@ -130,6 +130,12 @@ public:
     if (!_elem)
       return;
 
+    // These tests require exceptions to be enabled because a
+    // TypeTensor::solve() call down in Elem::contains_point()
+    // actually throws a non-fatal exception for a certain Point which
+    // is not in the Elem. When exceptions are not enabled, this test
+    // simply aborts.
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
     for (unsigned int i=0; i != _nx; ++i)
       for (unsigned int j=0; j != _ny; ++j)
         for (unsigned int k=0; k != _nz; ++k)
@@ -157,6 +163,7 @@ public:
                libmesh_real(x + 0.25*y + 0.0625*z),
                TOLERANCE*TOLERANCE);
           }
+#endif
   }
 
   void testGradU()
@@ -165,6 +172,12 @@ public:
     if (!_elem)
       return;
 
+    // These tests require exceptions to be enabled because a
+    // TypeTensor::solve() call down in Elem::contains_point()
+    // actually throws a non-fatal exception for a certain Point which
+    // is not in the Elem. When exceptions are not enabled, this test
+    // simply aborts.
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
     for (unsigned int i=0; i != _nx; ++i)
       for (unsigned int j=0; j != _ny; ++j)
         for (unsigned int k=0; k != _nz; ++k)
@@ -195,6 +208,7 @@ public:
               CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(grad_u(2)), 0.0625,
                                            TOLERANCE*sqrt(TOLERANCE));
           }
+#endif
   }
 
   void testGradUComp()
@@ -203,6 +217,12 @@ public:
     if (!_elem)
       return;
 
+    // These tests require exceptions to be enabled because a
+    // TypeTensor::solve() call down in Elem::contains_point()
+    // actually throws a non-fatal exception for a certain Point which
+    // is not in the Elem. When exceptions are not enabled, this test
+    // simply aborts.
+#ifdef LIBMESH_ENABLE_EXCEPTIONS
     for (unsigned int i=0; i != _nx; ++i)
       for (unsigned int j=0; j != _ny; ++j)
         for (unsigned int k=0; k != _nz; ++k)
@@ -241,6 +261,7 @@ public:
               CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(grad_u_z), 0.0625,
                                            TOLERANCE*sqrt(TOLERANCE));
           }
+#endif
   }
 
 };

--- a/tests/systems/equation_systems_test.C
+++ b/tests/systems/equation_systems_test.C
@@ -120,6 +120,8 @@ public:
 
   void testRefineThenReinitPreserveFlags()
   {
+    // This test requires AMR support since it sets refinement flags.
+#ifdef LIBMESH_ENABLE_AMR
     Mesh mesh(*TestCommWorld);
     mesh.allow_renumbering(false);
     EquationSystems es(mesh);
@@ -150,6 +152,7 @@ public:
             CPPUNIT_ASSERT_EQUAL(Elem::JUST_REFINED,
                                  elem->child_ptr(c)->refinement_flag());
       }
+#endif
   }
 
 


### PR DESCRIPTION
I have now added optional "No AMR", "No Exceptions", "No Exodus", "Infinite Elements", "No MPI/No PETSc" and "No Optional" to CIVET and attached them to this PR.

~~It should still fail the No MPI test for the time being, since I haven't looked into fixing that yet.~~