### PR TITLE
AdjointRefinementEstimator::_residual_evaluation_physics

### DIFF
--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -111,11 +111,6 @@ public:
     return computed_global_QoI_errors[qoi_index];
   }
 
-  /**
-   * Swap pointer of current physics object with that of another called swap_physics
-   */
-  void swap (FEMPhysics* swap_physics_1, FEMPhysics* swap_physics_2);
-
   virtual ErrorEstimatorType type() const
   { return ADJOINT_REFINEMENT;}
 
@@ -135,6 +130,12 @@ public:
    */
   FEMPhysics * get_residual_evaluation_physics()
   { return this->_residual_evaluation_physics; }
+
+  /**
+   * Set the _residual_evaluation_physics member to argument
+   */
+  void set_residual_evaluation_physics(FEMPhysics* set_physics)
+  { this->_residual_evaluation_physics = set_physics; }
 
 protected:
 

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -24,11 +24,13 @@
 #include "libmesh/error_estimator.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/qoi_set.h"
-#include "libmesh/diff_physics.h"
 
 // C++ includes
 #include <cstddef>
 #include <vector>
+
+// Forward declarations
+class DifferentiablePhysics;
 
 #ifdef LIBMESH_ENABLE_AMR
 

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -56,8 +56,8 @@ public:
     ErrorEstimator(),
     number_h_refinements(1),
     number_p_refinements(0),
-      _qoi_set(QoISet()),
-      _residual_evaluation_physics(libmesh_nullptr)
+    _qoi_set(QoISet()),
+    _residual_evaluation_physics(libmesh_nullptr)
   {
     // We're not actually going to use error_norm; our norms are
     // absolute values of QoI error.
@@ -125,8 +125,8 @@ public:
   unsigned char number_p_refinements;
 
   /**
-   * Returns reference to DifferentiablePhysics object. Note that if
-   * no external Physics object is attached, the default is this.
+   * Returns reference to DifferentiablePhysics object. Will return NULL if
+   * no external Physics object is attached.
    */
   FEMPhysics * get_residual_evaluation_physics()
   { return this->_residual_evaluation_physics; }
@@ -141,8 +141,7 @@ protected:
 
   /**
    * Pointer to object to use for physics assembly evaluations.
-   * Defaults to \p this for backwards compatibility; in the future
-   * users should create separate physics objects.
+   * Defaults to libmesh_nullptr for backwards compatibility.
    */
   FEMPhysics * _residual_evaluation_physics;
 

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -58,8 +58,8 @@ public:
     ErrorEstimator(),
     number_h_refinements(1),
     number_p_refinements(0),
-    _qoi_set(QoISet()),
-    _residual_evaluation_physics(libmesh_nullptr)
+    _residual_evaluation_physics(libmesh_nullptr),
+    _qoi_set(QoISet())
   {
     // We're not actually going to use error_norm; our norms are
     // absolute values of QoI error.

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -24,6 +24,7 @@
 #include "libmesh/error_estimator.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/qoi_set.h"
+#include "libmesh/fem_physics.h"
 
 // C++ includes
 #include <cstddef>
@@ -55,7 +56,8 @@ public:
     ErrorEstimator(),
     number_h_refinements(1),
     number_p_refinements(0),
-    _qoi_set(QoISet())
+      _qoi_set(QoISet()),
+      _residual_evaluation_physics(libmesh_nullptr)
   {
     // We're not actually going to use error_norm; our norms are
     // absolute values of QoI error.
@@ -122,7 +124,21 @@ public:
    */
   unsigned char number_p_refinements;
 
+  /**
+   * Returns reference to DifferentiablePhysics object. Note that if
+   * no external Physics object is attached, the default is this.
+   */
+  FEMPhysics * get_residual_evaluation_physics()
+  { return this->_residual_evaluation_physics; }
+
 protected:
+
+  /**
+   * Pointer to object to use for physics assembly evaluations.
+   * Defaults to \p this for backwards compatibility; in the future
+   * users should create separate physics objects.
+   */
+  FEMPhysics * _residual_evaluation_physics;
 
   /* A vector to hold the computed global QoI error estimate */
   std::vector<Number> computed_global_QoI_errors;

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -24,7 +24,7 @@
 #include "libmesh/error_estimator.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/qoi_set.h"
-#include "libmesh/fem_physics.h"
+#include "libmesh/diff_physics.h"
 
 // C++ includes
 #include <cstddef>
@@ -128,13 +128,13 @@ public:
    * Returns reference to DifferentiablePhysics object. Will return NULL if
    * no external Physics object is attached.
    */
-  FEMPhysics * get_residual_evaluation_physics()
+  DifferentiablePhysics * get_residual_evaluation_physics()
   { return this->_residual_evaluation_physics; }
 
   /**
    * Set the _residual_evaluation_physics member to argument
    */
-  void set_residual_evaluation_physics(FEMPhysics* set_physics)
+  void set_residual_evaluation_physics(DifferentiablePhysics* set_physics)
   { this->_residual_evaluation_physics = set_physics; }
 
 protected:
@@ -143,7 +143,7 @@ protected:
    * Pointer to object to use for physics assembly evaluations.
    * Defaults to libmesh_nullptr for backwards compatibility.
    */
-  FEMPhysics * _residual_evaluation_physics;
+  DifferentiablePhysics * _residual_evaluation_physics;
 
   /* A vector to hold the computed global QoI error estimate */
   std::vector<Number> computed_global_QoI_errors;

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -111,6 +111,11 @@ public:
     return computed_global_QoI_errors[qoi_index];
   }
 
+  /**
+   * Swap pointer of current physics object with that of another called swap_physics
+   */
+  void swap (FEMPhysics* swap_physics_1, FEMPhysics* swap_physics_2);
+
   virtual ErrorEstimatorType type() const
   { return ADJOINT_REFINEMENT;}
 

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -183,6 +183,11 @@ public:
     this->_diff_physics->init_physics(*this);}
 
   /**
+   * Swap current physics object with external object
+   */
+  void swap_physics ( DifferentiablePhysics * & swap_physics );
+
+  /**
    * Returns const reference to DifferentiableQoI object. Note that if no external
    * QoI object is attached, the default is this.
    */

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -234,11 +234,6 @@ public:
    */
   void numerical_nonlocal_jacobian (FEMContext & context) const;
 
-  /**
-   * Swap pointer of physics object belonging to current FEMSystem object with another FEMPhysics called swap_physics
-   */
-  FEMPhysics* swap_with_diff_physics (FEMPhysics* swap_physics);
-
 protected:
   /**
    * Initializes the member data fields associated with

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -237,7 +237,7 @@ public:
   /**
    * Swap pointer of physics object belonging to current FEMSystem object with another FEMPhysics called swap_physics
    */
-  FEMPhysics* swap_with_system_physics (FEMPhysics* swap_physics);
+  FEMPhysics* swap_with_diff_physics (FEMPhysics* swap_physics);
 
 protected:
   /**

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -234,6 +234,11 @@ public:
    */
   void numerical_nonlocal_jacobian (FEMContext & context) const;
 
+  /**
+   * Swap pointer of physics object belonging to current FEMSystem object with another FEMPhysics called swap_physics
+   */
+  void swap (FEMPhysics* swap_physics);
+
 protected:
   /**
    * Initializes the member data fields associated with

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -237,7 +237,7 @@ public:
   /**
    * Swap pointer of physics object belonging to current FEMSystem object with another FEMPhysics called swap_physics
    */
-  void swap (FEMPhysics* swap_physics);
+  FEMPhysics* swap_with_system_physics (FEMPhysics* swap_physics);
 
 protected:
   /**

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -265,18 +265,18 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 	  // // values, then to get a proper error estimate here we need
 	  // // to subtract off a coarse grid lift function. For convenience, we simply
 	  // // subtract off the coarse grid adjoint, which has the necessary lift properties.
-	  if(system.get_dof_map().has_adjoint_dirichlet_boundaries(j))
-	  {
-	    system.get_adjoint_solution(j) -= *coarse_adjoints[j];
-	  }
+	  // if(system.get_dof_map().has_adjoint_dirichlet_boundaries(j))
+	  // {
+	  //   system.get_adjoint_solution(j) -= *coarse_adjoints[j];
+	  // }
 
           computed_global_QoI_errors[j] = projected_residual->dot(system.get_adjoint_solution(j));
 
 	  // // Add the lift back to get the original adjoint solution
-	  if(system.get_dof_map().has_adjoint_dirichlet_boundaries(j))
-	  {
-	    system.get_adjoint_solution(j) += *coarse_adjoints[j];
-	  }
+	  // if(system.get_dof_map().has_adjoint_dirichlet_boundaries(j))
+	  // {
+	  //   system.get_adjoint_solution(j) += *coarse_adjoints[j];
+	  // }
 
         }
     }

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -142,7 +142,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
           else // Else residual ptr is not null (i.e. user has set physics which they want to use for the QoI evaluation)
             {
               // Swap the system and residual evaluation physics with each other
-              _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_diff_physics(_residual_evaluation_physics);
+              dynamic_cast<DifferentiableSystem &>(system).swap_physics(_residual_evaluation_physics);
 
               // Assemble without applying constraints, to capture the solution values on the boundary
               // The fact that we are assembling with the user specified residual physics impacts the
@@ -167,7 +167,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
                 (system.get_vector(liftfunc_name.str()), static_cast<unsigned int>(j));
 
               // Swap back the residual evaluation and system physics
-              _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_diff_physics(_residual_evaluation_physics);
+              dynamic_cast<DifferentiableSystem &>(system).swap_physics(_residual_evaluation_physics);
 
               // Compute the flux R(u^h, L)
               std::cout<<"The flux QoI "<<static_cast<unsigned int>(j)<<" is: "<<coarse_residual->dot(system.get_vector(liftfunc_name.str()))<<std::endl<<std::endl;
@@ -283,7 +283,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   else // Else residual ptr is not null (i.e. user has set physics which they want to use for residual evaluation)
     {
       // Swap the residual evaluation physics with the system physics
-      _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_diff_physics(_residual_evaluation_physics);
+      dynamic_cast<DifferentiableSystem &>(system).swap_physics(_residual_evaluation_physics);
 
       // Rebuild the rhs with the projected primal solution (and user specified physics), constraints have to be applied to get the correct error estimate since error on the Dirichlet boundary is zero
       (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false);
@@ -291,7 +291,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
       projected_residual->close();
 
       // Swap back system and residual evaluation physics
-      _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_diff_physics(_residual_evaluation_physics);
+      dynamic_cast<DifferentiableSystem &>(system).swap_physics(_residual_evaluation_physics);
     }
 
   // Solve the adjoint problem(s) on the refined FE space

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -226,7 +226,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
     std::cout<<"Diff Physics after swapping: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
     std::cout<<"Residual Physics after swapping: "<<_residual_evaluation_physics<<std::endl;
     // Rebuild the rhs with the projected primal solution
-    (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false);
+    (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false, true, false);
     projected_residual = &(dynamic_cast<ExplicitSystem &>(system)).get_vector("RHS Vector");
     projected_residual->close();
 
@@ -265,18 +265,18 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 	  // // values, then to get a proper error estimate here we need
 	  // // to subtract off a coarse grid lift function. For convenience, we simply
 	  // // subtract off the coarse grid adjoint, which has the necessary lift properties.
-	  // if(system.get_dof_map().has_adjoint_dirichlet_boundaries(j))
-	  // {
-	  //   system.get_adjoint_solution(j) -= *coarse_adjoints[j];
-	  // }
+	  if(system.get_dof_map().has_adjoint_dirichlet_boundaries(j))
+	  {
+	    system.get_adjoint_solution(j) -= *coarse_adjoints[j];
+	  }
 
           computed_global_QoI_errors[j] = projected_residual->dot(system.get_adjoint_solution(j));
 
 	  // // Add the lift back to get the original adjoint solution
-	  // if(system.get_dof_map().has_adjoint_dirichlet_boundaries(j))
-	  // {
-	  //   system.get_adjoint_solution(j) += *coarse_adjoints[j];
-	  // }
+	  if(system.get_dof_map().has_adjoint_dirichlet_boundaries(j))
+	  {
+	    system.get_adjoint_solution(j) += *coarse_adjoints[j];
+	  }
 
         }
     }

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -36,6 +36,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/system.h"
+#include "libmesh/diff_physics.h"
 #include "libmesh/fem_system.h"
 #include "libmesh/implicit_system.h"
 #include "libmesh/partitioner.h"
@@ -219,7 +220,11 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   else // Else if residual ptr is not null (i.e. user has set physics which they want to use for residual evaluation)
   {
     // Swap the residual evaluation physics with the system physics
-    _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_system_physics(&*_residual_evaluation_physics);
+    std::cout<<"Diff Physics: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
+    std::cout<<"Residual Physics: "<<_residual_evaluation_physics<<std::endl;
+    _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_diff_physics(_residual_evaluation_physics);
+    std::cout<<"Diff Physics: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
+    std::cout<<"Residual Physics: "<<_residual_evaluation_physics<<std::endl;
     // Rebuild the rhs with the projected primal solution
     (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false);
     projected_residual = &(dynamic_cast<ExplicitSystem &>(system)).get_vector("RHS Vector");
@@ -233,7 +238,9 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
     // End Hack
 
     // Swap back
-    _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_system_physics(&*_residual_evaluation_physics);
+    _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_diff_physics(_residual_evaluation_physics);
+    std::cout<<"Diff Physics: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
+    std::cout<<"Residual Physics: "<<_residual_evaluation_physics<<std::endl;
   }
 
   // Solve the adjoint problem(s) on the refined FE space

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -226,7 +226,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
     std::cout<<"Diff Physics after swapping: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
     std::cout<<"Residual Physics after swapping: "<<_residual_evaluation_physics<<std::endl;
     // Rebuild the rhs with the projected primal solution
-    (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false, true, false);
+    (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false, false, true);
     projected_residual = &(dynamic_cast<ExplicitSystem &>(system)).get_vector("RHS Vector");
     projected_residual->close();
 

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -220,11 +220,11 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   else // Else if residual ptr is not null (i.e. user has set physics which they want to use for residual evaluation)
   {
     // Swap the residual evaluation physics with the system physics
-    std::cout<<"Diff Physics: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
-    std::cout<<"Residual Physics: "<<_residual_evaluation_physics<<std::endl;
+    std::cout<<"Diff Physics before swapping: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
+    std::cout<<"Residual Physics before swapping: "<<_residual_evaluation_physics<<std::endl;
     _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_diff_physics(_residual_evaluation_physics);
-    std::cout<<"Diff Physics: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
-    std::cout<<"Residual Physics: "<<_residual_evaluation_physics<<std::endl;
+    std::cout<<"Diff Physics after swapping: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
+    std::cout<<"Residual Physics after swapping: "<<_residual_evaluation_physics<<std::endl;
     // Rebuild the rhs with the projected primal solution
     (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false);
     projected_residual = &(dynamic_cast<ExplicitSystem &>(system)).get_vector("RHS Vector");
@@ -239,8 +239,8 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 
     // Swap back
     _residual_evaluation_physics = dynamic_cast<FEMSystem &>(system).swap_with_diff_physics(_residual_evaluation_physics);
-    std::cout<<"Diff Physics: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
-    std::cout<<"Residual Physics: "<<_residual_evaluation_physics<<std::endl;
+    std::cout<<"Diff Physics after swapping back: "<<dynamic_cast<FEMSystem &>(system).get_physics()<<std::endl;
+    std::cout<<"Residual Physics after swapping back: "<<_residual_evaluation_physics<<std::endl;
   }
 
   // Solve the adjoint problem(s) on the refined FE space

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -205,6 +205,11 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
         coarse_adjoints.push_back(static_cast<NumericVector<Number> *>(libmesh_nullptr));
     }
 
+  // Next, we are going to build up the residual for evaluating the error estimate
+  // // If the residual ptr is null, set it to be the physics held by the system
+
+  // // Else if residual ptr is not null (i.e. user has set physics which they want to use for residual evaluation)
+
   // Rebuild the rhs with the projected primal solution
   (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false);
   NumericVector<Number> & projected_residual = (dynamic_cast<ExplicitSystem &>(system)).get_vector("RHS Vector");

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -63,6 +63,14 @@ namespace libMesh
 // By richer FE space, we mean a grid that has been refined once and a polynomial order
 // that has been increased once, i.e. one h and one p refinement
 
+
+void AdjointRefinementEstimator::swap (FEMPhysics* swap_physics_1, FEMPhysics* swap_physics_2)
+{
+  FEMPhysics* temp = swap_physics_1;
+  swap_physics_1 = swap_physics_2;
+  swap_physics_2 = temp;
+}
+
 // Both a global QoI error estimate and element wise error indicators are included
 // Note that the element wise error indicators slightly over estimate the error in
 // each element
@@ -206,19 +214,30 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
         coarse_adjoints.push_back(static_cast<NumericVector<Number> *>(libmesh_nullptr));
     }
 
-  // Next, we are going to build up the residual for evaluating the error estimate
+  // Hack
+  //_residual_evaluation_physics = dynamic_cast<FEMPhysics *>((dynamic_cast<FEMSystem &>(system)).get_physics());
 
-  // If the residual ptr is null, set it to be the physics held by the system
+  // Next, we are going to build up the residual for evaluating the error estimate
+  NumericVector<Number> * projected_residual = libmesh_nullptr;
+  // If the residual ptr is null, use whatever the default physics built by the user is to build the residual vector
   if (!_residual_evaluation_physics)
   {
-    _residual_evaluation_physics = dynamic_cast<FEMPhysics *>((dynamic_cast<FEMSystem &>(system)).get_physics());
+    // Rebuild the rhs with the projected primal solution
+    (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false);
+    NumericVector<Number> & projected_residual = (dynamic_cast<ExplicitSystem &>(system)).get_vector("RHS Vector");
+    projected_residual.close();
   }
   // Else if residual ptr is not null (i.e. user has set physics which they want to use for residual evaluation)
-
-  // Rebuild the rhs with the projected primal solution
-  (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false);
-  NumericVector<Number> & projected_residual = (dynamic_cast<ExplicitSystem &>(system)).get_vector("RHS Vector");
-  projected_residual.close();
+  {
+    // Swap the residual evaluation physics with the system physics
+    swap(dynamic_cast<FEMPhysics *>((dynamic_cast<FEMSystem &>(system)).get_physics()), _residual_evaluation_physics);
+    // Rebuild the rhs with the projected primal solution
+    (dynamic_cast<ImplicitSystem &>(system)).assembly(true, false);
+    NumericVector<Number> & projected_residual = (dynamic_cast<ExplicitSystem &>(system)).get_vector("RHS Vector");
+    projected_residual.close();
+    // Swap back
+    swap(dynamic_cast<FEMPhysics *>((dynamic_cast<FEMSystem &>(system)).get_physics()), _residual_evaluation_physics);
+  }
 
   // Solve the adjoint problem(s) on the refined FE space
   system.adjoint_solve(_qoi_set);
@@ -245,7 +264,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
           // use that for our lift function.
           system.get_adjoint_solution(j) -= *coarse_adjoints[j];
 
-          computed_global_QoI_errors[j] = projected_residual.dot(system.get_adjoint_solution(j));
+          computed_global_QoI_errors[j] = projected_residual->dot(system.get_adjoint_solution(j));
         }
     }
 
@@ -368,7 +387,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // an element it owns
   UniquePtr<NumericVector<Number> > localized_projected_residual = NumericVector<Number>::build(system.comm());
   localized_projected_residual->init(system.n_dofs(), system.n_local_dofs(), system.get_dof_map().get_send_list(), false, GHOSTED);
-  projected_residual.localize(*localized_projected_residual, system.get_dof_map().get_send_list());
+  projected_residual->localize(*localized_projected_residual, system.get_dof_map().get_send_list());
 
   // Each adjoint solution will also require ghosting; for efficiency we'll reuse the same memory
   UniquePtr<NumericVector<Number> > localized_adjoint_solution = NumericVector<Number>::build(system.comm());

--- a/src/solvers/eigen_time_solver.C
+++ b/src/solvers/eigen_time_solver.C
@@ -137,13 +137,13 @@ bool EigenTimeSolver::element_residual(bool request_jacobian,
   if (now_assembling == Matrix_A)
     {
       bool jacobian_computed =
-        _system.element_time_derivative(request_jacobian, context);
+        _system.get_physics()->element_time_derivative(request_jacobian, context);
 
       // The user shouldn't compute a jacobian unless requested
       libmesh_assert(request_jacobian || !jacobian_computed);
 
       bool jacobian_computed2 =
-        _system.element_constraint(jacobian_computed, context);
+        _system.get_physics()->element_constraint(jacobian_computed, context);
 
       // The user shouldn't compute a jacobian unless requested
       libmesh_assert (jacobian_computed || !jacobian_computed2);
@@ -156,7 +156,7 @@ bool EigenTimeSolver::element_residual(bool request_jacobian,
   else if (now_assembling == Matrix_B)
     {
       bool mass_jacobian_computed =
-        _system.mass_residual(request_jacobian, context);
+        _system.get_physics()->mass_residual(request_jacobian, context);
 
       // Scale Jacobian by -1 to get positive matrix from new negative
       // mass_residual convention
@@ -184,13 +184,13 @@ bool EigenTimeSolver::side_residual(bool request_jacobian,
   if (now_assembling == Matrix_A)
     {
       bool jacobian_computed =
-        _system.side_time_derivative(request_jacobian, context);
+        _system.get_physics()->side_time_derivative(request_jacobian, context);
 
       // The user shouldn't compute a jacobian unless requested
       libmesh_assert (request_jacobian || !jacobian_computed);
 
       bool jacobian_computed2 =
-        _system.side_constraint(jacobian_computed, context);
+        _system.get_physics()->side_constraint(jacobian_computed, context);
 
       // The user shouldn't compute a jacobian unless requested
       libmesh_assert (jacobian_computed || !jacobian_computed2);
@@ -203,7 +203,7 @@ bool EigenTimeSolver::side_residual(bool request_jacobian,
   else if (now_assembling == Matrix_B)
     {
       bool mass_jacobian_computed =
-        _system.side_mass_residual(request_jacobian, context);
+        _system.get_physics()->side_mass_residual(request_jacobian, context);
 
       // Scale Jacobian by -1 to get positive matrix from new negative
       // mass_residual convention
@@ -228,13 +228,13 @@ bool EigenTimeSolver::nonlocal_residual(bool request_jacobian,
   if (now_assembling == Matrix_A)
     {
       bool jacobian_computed =
-        _system.nonlocal_time_derivative(request_jacobian, context);
+        _system.get_physics()->nonlocal_time_derivative(request_jacobian, context);
 
       // The user shouldn't compute a jacobian unless requested
       libmesh_assert (request_jacobian || !jacobian_computed);
 
       bool jacobian_computed2 =
-        _system.nonlocal_constraint(jacobian_computed, context);
+        _system.get_physics()->nonlocal_constraint(jacobian_computed, context);
 
       // The user shouldn't compute a jacobian unless requested
       libmesh_assert (jacobian_computed || !jacobian_computed2);
@@ -247,7 +247,7 @@ bool EigenTimeSolver::nonlocal_residual(bool request_jacobian,
   else if (now_assembling == Matrix_B)
     {
       bool mass_jacobian_computed =
-        _system.nonlocal_mass_residual(request_jacobian, context);
+        _system.get_physics()->nonlocal_mass_residual(request_jacobian, context);
 
       // Scale Jacobian by -1 to get positive matrix from new negative
       // mass_residual convention

--- a/src/solvers/euler2_solver.C
+++ b/src/solvers/euler2_solver.C
@@ -50,7 +50,7 @@ Real Euler2Solver::error_order() const
 bool Euler2Solver::element_residual (bool request_jacobian,
                                      DiffContext & context)
 {
-  bool compute_second_order_eqns = !this->_system.get_second_order_vars().empty();
+  bool compute_second_order_eqns = !this->_system.get_physics()->get_second_order_vars().empty();
 
   return this->_general_residual(request_jacobian,
                                  context,
@@ -158,18 +158,18 @@ bool Euler2Solver::_general_residual (bool request_jacobian,
   // The element should already be in the proper place
   // even for a moving mesh problem.
   bool jacobian_computed =
-    (_system.*time_deriv)(request_jacobian, context);
+    (_system.get_physics()->*time_deriv)(request_jacobian, context);
 
   // Next, evaluate the mass residual at the new timestep
 
-  jacobian_computed = (_system.*mass)(jacobian_computed, context) &&
+  jacobian_computed = (_system.get_physics()->*mass)(jacobian_computed, context) &&
     jacobian_computed;
 
   // If we have second-order variables, we need to get damping terms
   // and the velocity equations
   if (compute_second_order_eqns)
     {
-      jacobian_computed = (_system.*damping)(jacobian_computed, context) &&
+      jacobian_computed = (_system.get_physics()->*damping)(jacobian_computed, context) &&
         jacobian_computed;
 
       jacobian_computed = this->compute_second_order_eqns(jacobian_computed, context) &&
@@ -177,7 +177,7 @@ bool Euler2Solver::_general_residual (bool request_jacobian,
     }
 
   // Add the constraint term
-  jacobian_computed = (_system.*constraint)(jacobian_computed, context) &&
+  jacobian_computed = (_system.get_physics()->*constraint)(jacobian_computed, context) &&
     jacobian_computed;
 
   // The new solution's contribution is scaled by theta
@@ -202,7 +202,7 @@ bool Euler2Solver::_general_residual (bool request_jacobian,
   (context.*reinit_func)(0.);
 
   jacobian_computed =
-    (_system.*time_deriv)(jacobian_computed, context) &&
+    (_system.get_physics()->*time_deriv)(jacobian_computed, context) &&
     jacobian_computed;
 
   // Add the mass residual term for the old solution
@@ -213,14 +213,14 @@ bool Euler2Solver::_general_residual (bool request_jacobian,
   // mass_residual functions
 
   jacobian_computed =
-    (_system.*mass)(jacobian_computed, context) &&
+    (_system.get_physics()->*mass)(jacobian_computed, context) &&
     jacobian_computed;
 
   // If we have second-order variables, we need to get damping terms
   // and the velocity equations
   if (compute_second_order_eqns)
     {
-      jacobian_computed = (_system.*damping)(jacobian_computed, context) &&
+      jacobian_computed = (_system.get_physics()->*damping)(jacobian_computed, context) &&
         jacobian_computed;
 
       jacobian_computed = this->compute_second_order_eqns(jacobian_computed, context) &&

--- a/src/solvers/euler_solver.C
+++ b/src/solvers/euler_solver.C
@@ -50,7 +50,7 @@ Real EulerSolver::error_order() const
 bool EulerSolver::element_residual (bool request_jacobian,
                                     DiffContext & context)
 {
-  bool compute_second_order_eqns = this->_system.have_second_order_vars();
+  bool compute_second_order_eqns = this->_system.get_physics()->have_second_order_vars();
 
   return this->_general_residual(request_jacobian,
                                  context,
@@ -151,16 +151,16 @@ bool EulerSolver::_general_residual (bool request_jacobian,
 
   // Get the time derivative at t_theta
   bool jacobian_computed =
-    (_system.*time_deriv)(request_jacobian, context);
+    (_system.get_physics()->*time_deriv)(request_jacobian, context);
 
-  jacobian_computed = (_system.*mass)(jacobian_computed, context) &&
+  jacobian_computed = (_system.get_physics()->*mass)(jacobian_computed, context) &&
     jacobian_computed;
 
   // If we have second-order variables, we need to get damping terms
   // and the velocity equations
   if (compute_second_order_eqns)
     {
-      jacobian_computed = (_system.*damping)(jacobian_computed, context) &&
+      jacobian_computed = (_system.get_physics()->*damping)(jacobian_computed, context) &&
         jacobian_computed;
 
       jacobian_computed = this->compute_second_order_eqns(jacobian_computed, context) &&
@@ -175,7 +175,7 @@ bool EulerSolver::_general_residual (bool request_jacobian,
   context.elem_solution_derivative = 1;
 
   // Add the constraint term
-  jacobian_computed = (_system.*constraint)(jacobian_computed, context) &&
+  jacobian_computed = (_system.get_physics()->*constraint)(jacobian_computed, context) &&
     jacobian_computed;
 
   // Add back (or restore) the old jacobian

--- a/src/solvers/newmark_solver.C
+++ b/src/solvers/newmark_solver.C
@@ -317,18 +317,18 @@ bool NewmarkSolver::_general_residual (bool request_jacobian,
     context.get_elem_fixed_solution() = context.get_elem_solution();
 
   // Get the time derivative at t_{n+1}, F(u_{n+1})
-  bool jacobian_computed = (_system.*time_deriv)(request_jacobian, context);
+  bool jacobian_computed = (_system.get_physics()->*time_deriv)(request_jacobian, context);
 
   // Damping at t_{n+1}, C(u_{n+1})
-  jacobian_computed = (_system.*damping)(jacobian_computed, context) &&
+  jacobian_computed = (_system.get_physics()->*damping)(jacobian_computed, context) &&
     jacobian_computed;
 
   // Mass at t_{n+1}, M(u_{n+1})
-  jacobian_computed = (_system.*mass)(jacobian_computed, context) &&
+  jacobian_computed = (_system.get_physics()->*mass)(jacobian_computed, context) &&
     jacobian_computed;
 
   // Add the constraint term
-  jacobian_computed = (_system.*constraint)(jacobian_computed, context) &&
+  jacobian_computed = (_system.get_physics()->*constraint)(jacobian_computed, context) &&
     jacobian_computed;
 
   // Add back (or restore) the old jacobian

--- a/src/solvers/steady_solver.C
+++ b/src/solvers/steady_solver.C
@@ -78,13 +78,13 @@ bool SteadySolver::_general_residual(bool request_jacobian,
     }
 
   bool jacobian_computed =
-    (_system.*time_deriv)(request_jacobian, context);
+    (_system.get_physics()->*time_deriv)(request_jacobian, context);
 
   // The user shouldn't compute a jacobian unless requested
   libmesh_assert (request_jacobian || !jacobian_computed);
 
   bool jacobian_computed2 =
-    (_system.*constraint)(jacobian_computed, context);
+    (_system.get_physics()->*constraint)(jacobian_computed, context);
 
   // The user shouldn't compute a jacobian unless requested
   libmesh_assert (jacobian_computed || !jacobian_computed2);

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -24,6 +24,8 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/zero_function.h"
 
+#include <utility> // std::swap
+
 namespace libMesh
 {
 
@@ -360,5 +362,13 @@ bool DifferentiableSystem::have_second_order_scalar_vars() const
 
   return have_second_order_scalar_vars;
 }
+
+
+
+void DifferentiableSystem::swap_physics ( DifferentiablePhysics * & swap_physics )
+{
+  std::swap(this->_diff_physics, swap_physics);
+}
+
 
 } // namespace libMesh

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -276,11 +276,7 @@ void add_element_system(const FEMSystem & _sys,
           (_femcontext.get_elem_jacobian(),
            _femcontext.get_elem_residual(),
            _femcontext.get_dof_indices(), false);
-      else if (_no_constraints)
-        {
-          // Do noting
-        }
-      else
+      else if (!_no_constraints)
         _sys.get_dof_map().constrain_element_matrix_and_vector
           (_femcontext.get_elem_jacobian(),
            _femcontext.get_elem_residual(),
@@ -294,11 +290,7 @@ void add_element_system(const FEMSystem & _sys,
           (_femcontext.get_elem_jacobian(),
            _femcontext.get_elem_residual(),
            _femcontext.get_dof_indices(), false);
-      else if (_no_constraints)
-        {
-          // Do noting
-        }
-      else
+      else if (!_no_constraints)
         _sys.get_dof_map().constrain_element_vector
           (_femcontext.get_elem_residual(), _femcontext.get_dof_indices(), false);
       // Do nothing if (_no_constraints)

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1434,11 +1434,12 @@ void FEMSystem::mesh_position_get()
   this->System::update();
 }
 
-void FEMSystem::swap (FEMPhysics* swap_physics)
+FEMPhysics* FEMSystem::swap_with_system_physics (FEMPhysics* swap_physics)
 {
   FEMPhysics* temp = dynamic_cast<FEMPhysics *>(this->get_physics());
   this->_diff_physics = dynamic_cast<DifferentiablePhysics *>(swap_physics);
   swap_physics = temp;
+  return swap_physics;
 }
 
 

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -298,7 +298,7 @@ void add_element_system(const FEMSystem & _sys,
       else if (_no_constraints)
 	{
 	  // Do noting
-	}      
+	}
       else
         _sys.get_dof_map().constrain_element_vector
           (_femcontext.get_elem_residual(), _femcontext.get_dof_indices(), false);

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -49,6 +49,7 @@ femsystem_mutex assembly_mutex;
 void assemble_unconstrained_element_system(const FEMSystem & _sys,
                                            const bool _get_jacobian,
                                            const bool _constrain_heterogeneously,
+					   const bool _no_constraints,
                                            FEMContext & _femcontext)
 {
   if (_sys.print_element_solutions)
@@ -276,6 +277,10 @@ void add_element_system(const FEMSystem & _sys,
           (_femcontext.get_elem_jacobian(),
            _femcontext.get_elem_residual(),
            _femcontext.get_dof_indices(), false);
+      else if (_no_constraints)
+	{
+	  // Do noting
+	}
       else
         _sys.get_dof_map().constrain_element_matrix_and_vector
           (_femcontext.get_elem_jacobian(),
@@ -290,6 +295,10 @@ void add_element_system(const FEMSystem & _sys,
           (_femcontext.get_elem_jacobian(),
            _femcontext.get_elem_residual(),
            _femcontext.get_dof_indices(), false);
+      else if (_no_constraints)
+	{
+	  // Do noting
+	}      
       else
         _sys.get_dof_map().constrain_element_vector
           (_femcontext.get_elem_residual(), _femcontext.get_dof_indices(), false);
@@ -380,7 +389,7 @@ public:
         _femcontext.elem_fe_reinit();
 
         assemble_unconstrained_element_system
-          (_sys, _get_jacobian, _constrain_heterogeneously,
+          (_sys, _get_jacobian, _constrain_heterogeneously, _no_constraints,
            _femcontext);
 
         add_element_system

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1434,4 +1434,12 @@ void FEMSystem::mesh_position_get()
   this->System::update();
 }
 
+void FEMSystem::swap (FEMPhysics* swap_physics)
+{
+  FEMPhysics* temp = dynamic_cast<FEMPhysics *>(this->get_physics());
+  this->_diff_physics = dynamic_cast<DifferentiablePhysics *>(swap_physics);
+  swap_physics = temp;
+}
+
+
 } // namespace libMesh

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -49,7 +49,6 @@ femsystem_mutex assembly_mutex;
 void assemble_unconstrained_element_system(const FEMSystem & _sys,
                                            const bool _get_jacobian,
                                            const bool _constrain_heterogeneously,
-					   const bool _no_constraints,
                                            FEMContext & _femcontext)
 {
   if (_sys.print_element_solutions)
@@ -389,8 +388,7 @@ public:
         _femcontext.elem_fe_reinit();
 
         assemble_unconstrained_element_system
-          (_sys, _get_jacobian, _constrain_heterogeneously, _no_constraints,
-           _femcontext);
+          (_sys, _get_jacobian, _constrain_heterogeneously, _femcontext);
 
         add_element_system
           (_sys, _get_residual, _get_jacobian,

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1434,10 +1434,13 @@ void FEMSystem::mesh_position_get()
   this->System::update();
 }
 
-FEMPhysics* FEMSystem::swap_with_system_physics (FEMPhysics* swap_physics)
+FEMPhysics* FEMSystem::swap_with_diff_physics (FEMPhysics* swap_physics)
 {
   FEMPhysics* temp = dynamic_cast<FEMPhysics *>(this->get_physics());
+  std::cout<<"Swap Physics: "<<swap_physics<<std::endl;
+  std::cout<<"Diff Physics: "<<this->_diff_physics<<std::endl;
   this->_diff_physics = dynamic_cast<DifferentiablePhysics *>(swap_physics);
+  std::cout<<"Diff Physics: "<<this->_diff_physics<<std::endl;
   swap_physics = temp;
   return swap_physics;
 }

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1433,16 +1433,4 @@ void FEMSystem::mesh_position_get()
   this->System::update();
 }
 
-FEMPhysics* FEMSystem::swap_with_diff_physics (FEMPhysics* swap_physics)
-{
-  FEMPhysics* temp = dynamic_cast<FEMPhysics *>(this->get_physics());
-
-  this->_diff_physics = dynamic_cast<DifferentiablePhysics *>(swap_physics);
-
-  swap_physics = temp;
-
-  return swap_physics;
-}
-
-
 } // namespace libMesh

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -277,9 +277,9 @@ void add_element_system(const FEMSystem & _sys,
            _femcontext.get_elem_residual(),
            _femcontext.get_dof_indices(), false);
       else if (_no_constraints)
-	{
-	  // Do noting
-	}
+        {
+          // Do noting
+        }
       else
         _sys.get_dof_map().constrain_element_matrix_and_vector
           (_femcontext.get_elem_jacobian(),
@@ -295,9 +295,9 @@ void add_element_system(const FEMSystem & _sys,
            _femcontext.get_elem_residual(),
            _femcontext.get_dof_indices(), false);
       else if (_no_constraints)
-	{
-	  // Do noting
-	}
+        {
+          // Do noting
+        }
       else
         _sys.get_dof_map().constrain_element_vector
           (_femcontext.get_elem_residual(), _femcontext.get_dof_indices(), false);
@@ -1444,11 +1444,11 @@ void FEMSystem::mesh_position_get()
 FEMPhysics* FEMSystem::swap_with_diff_physics (FEMPhysics* swap_physics)
 {
   FEMPhysics* temp = dynamic_cast<FEMPhysics *>(this->get_physics());
-  std::cout<<"Swap Physics: "<<swap_physics<<std::endl;
-  std::cout<<"Diff Physics: "<<this->_diff_physics<<std::endl;
+
   this->_diff_physics = dynamic_cast<DifferentiablePhysics *>(swap_physics);
-  std::cout<<"Diff Physics: "<<this->_diff_physics<<std::endl;
+
   swap_physics = temp;
+
   return swap_physics;
 }
 


### PR DESCRIPTION
@vikramvgarg and I are getting much-improved error estimator results from stabilized formulations when we enable the user to supply an unstabilized residual to evaluate.

This PR includes fixes to a long-standing DiffSystem bug (incomplete feature?) where we weren't respecting attached physics pointers, a fix to the no_constraints option, and adds the user-residual option to ARefEE.