### PR TITLE
Disallow ErrorVector::plot_error() mesh renumbering

### DIFF
--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -439,8 +439,8 @@ void UnstructuredMesh::all_first_order ()
   // might now have an invalid nodal processor_id()
   Partitioner::set_node_processor_ids(*this);
 
-  // delete or renumber nodes, etc
-  this->prepare_for_use(/*skip_renumber =*/ false);
+  // delete or renumber nodes if desired
+  this->prepare_for_use();
 }
 
 

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -210,8 +210,9 @@ void ErrorVector::plot_error(const std::string & filename,
   UniquePtr<MeshBase> meshptr = oldmesh.clone();
   MeshBase & mesh = *meshptr;
 
-  // The all_first_order routine requires that renumbering be allowed
-  mesh.allow_renumbering(true);
+  // The all_first_order routine will prepare_for_use(), which would
+  // break our ordering if elements get changed.
+  mesh.allow_renumbering(false);
   mesh.all_first_order();
 
 #ifdef LIBMESH_ENABLE_AMR


### PR DESCRIPTION
Our original reason for allowing renumbering was probably a workaround for when disabling renumbering was iffy; perhaps disallowing nodal renumbering in all_first_order() would leave a bunch of NULL Node* gaps in the SerialMesh data structures that the SerialMesh code wasn't prepared for?  @jwpeterson might remember better.

My reason for disabling renumbering is that in corner cases it can cause *element* renumbering in the mesh copy here, which trashes the plotting output of error vectors which we keep indexed by element id.  If there still is any remaining problem with disabling renumbering, this isn't the right workaround.