### PR TITLE
DistributedMesh coarsening fix

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -772,6 +772,7 @@ include_HEADERS = \
         mesh/postscript_io.h \
         mesh/replicated_mesh.h \
         mesh/serial_mesh.h \
+        mesh/sync_refinement_flags.h \
         mesh/tecplot_io.h \
         mesh/tetgen_io.h \
         mesh/ucd_io.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -204,6 +204,7 @@ include_HEADERS =  \
         mesh/postscript_io.h \
         mesh/replicated_mesh.h \
         mesh/serial_mesh.h \
+        mesh/sync_refinement_flags.h \
         mesh/tecplot_io.h \
         mesh/tetgen_io.h \
         mesh/ucd_io.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -195,6 +195,7 @@ BUILT_SOURCES = \
         postscript_io.h \
         replicated_mesh.h \
         serial_mesh.h \
+        sync_refinement_flags.h \
         tecplot_io.h \
         tetgen_io.h \
         ucd_io.h \
@@ -1094,6 +1095,9 @@ replicated_mesh.h: $(top_srcdir)/include/mesh/replicated_mesh.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 serial_mesh.h: $(top_srcdir)/include/mesh/serial_mesh.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+sync_refinement_flags.h: $(top_srcdir)/include/mesh/sync_refinement_flags.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 tecplot_io.h: $(top_srcdir)/include/mesh/tecplot_io.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -544,9 +544,10 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	mesh_triangle_holes.h mesh_triangle_interface.h \
 	mesh_triangle_wrapper.h namebased_io.h nemesis_io.h \
 	nemesis_io_helper.h off_io.h parallel_mesh.h patch.h \
-	postscript_io.h replicated_mesh.h serial_mesh.h tecplot_io.h \
-	tetgen_io.h ucd_io.h unstructured_mesh.h unv_io.h vtk_io.h \
-	xdr_io.h analytic_function.h composite_fem_function.h \
+	postscript_io.h replicated_mesh.h serial_mesh.h \
+	sync_refinement_flags.h tecplot_io.h tetgen_io.h ucd_io.h \
+	unstructured_mesh.h unv_io.h vtk_io.h xdr_io.h \
+	analytic_function.h composite_fem_function.h \
 	composite_function.h const_fem_function.h const_function.h \
 	coupling_matrix.h dense_matrix.h dense_matrix_base.h \
 	dense_submatrix.h dense_subvector.h dense_vector.h \
@@ -1439,6 +1440,9 @@ replicated_mesh.h: $(top_srcdir)/include/mesh/replicated_mesh.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 serial_mesh.h: $(top_srcdir)/include/mesh/serial_mesh.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+sync_refinement_flags.h: $(top_srcdir)/include/mesh/sync_refinement_flags.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 tecplot_io.h: $(top_srcdir)/include/mesh/tecplot_io.h

--- a/include/mesh/sync_refinement_flags.h
+++ b/include/mesh/sync_refinement_flags.h
@@ -1,0 +1,112 @@
+
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2017 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_SYNC_REFINEMENT_FLAGS_H
+#define LIBMESH_SYNC_REFINEMENT_FLAGS_H
+
+// Local includes
+#include "libmesh/libmesh_config.h"
+
+// Only compile these functions if the user requests AMR support
+#ifdef LIBMESH_ENABLE_AMR
+
+// libMesh includes
+#include "libmesh/elem.h"
+#include "libmesh/mesh_base.h"
+
+// C++ includes
+#include <vector>
+
+namespace libMesh {
+
+struct SyncRefinementFlags
+{
+  typedef unsigned char datum;
+  typedef Elem::RefinementState (Elem::*get_a_flag)() const;
+  typedef void (Elem::*set_a_flag)(const Elem::RefinementState);
+
+  SyncRefinementFlags(MeshBase & _mesh,
+                      get_a_flag _getter,
+                      set_a_flag _setter) :
+    mesh(_mesh), parallel_consistent(true),
+    get_flag(_getter), set_flag(_setter) {}
+
+  MeshBase & mesh;
+  bool parallel_consistent;
+  get_a_flag get_flag;
+  set_a_flag set_flag;
+  // References to pointers to member functions segfault?
+  // get_a_flag & get_flag;
+  // set_a_flag & set_flag;
+
+  // Find the refinement flag on each requested element
+  void gather_data (const std::vector<dof_id_type> & ids,
+                    std::vector<datum> & flags) const
+  {
+    flags.resize(ids.size());
+
+    for (std::size_t i=0; i != ids.size(); ++i)
+      {
+        // Look for this element in the mesh
+        // We'd better find every element we're asked for
+        Elem & elem = mesh.elem_ref(ids[i]);
+
+        // Return the element's refinement flag
+        flags[i] = (elem.*get_flag)();
+      }
+  }
+
+  void act_on_data (const std::vector<dof_id_type> & ids,
+                    std::vector<datum> & flags)
+  {
+    for (std::size_t i=0; i != ids.size(); ++i)
+      {
+        Elem & elem = mesh.elem_ref(ids[i]);
+
+        datum old_flag = (elem.*get_flag)();
+        datum & new_flag = flags[i];
+
+        if (old_flag != new_flag)
+          {
+            // It's possible for foreign flags to be (temporarily) more
+            // conservative than our own, such as when a refinement in
+            // one of the foreign processor's elements is mandated by a
+            // refinement in one of our neighboring elements it can see
+            // which was mandated by a refinement in one of our
+            // neighboring elements it can't see
+            // libmesh_assert (!(new_flag != Elem::REFINE &&
+            //                   old_flag == Elem::REFINE));
+            //
+            (elem.*set_flag)
+              (static_cast<Elem::RefinementState>(new_flag));
+            parallel_consistent = false;
+          }
+      }
+  }
+};
+
+
+
+} // namespace libMesh
+
+
+#endif // LIBMESH_ENABLE_AMR
+
+#endif // LIBMESH_SYNC_REFINEMENT_FLAGS_H

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1165,6 +1165,9 @@ bool MeshRefinement::make_coarsening_compatible()
   // INACTIVE vs. COARSEN_INACTIVE flags.
   if (distributed_mesh)
     {
+      // We'd better still be in sync here
+      parallel_object_only();
+
       Parallel::MessageTag
         uncoarsenable_tag = this->comm().get_unique_tag(2718);
       std::vector<Parallel::Request> uncoarsenable_push_requests(n_proc);

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -57,15 +57,18 @@ using namespace libMesh;
 struct SyncCoarsenInactive
 {
   bool operator() (const Elem * elem) const {
-    // If we're not an ancestor marked INACTIVE, there's no chance we
-    // need to be changed to COARSEN_INACTIVE
-    if (elem->refinement_flag() != Elem::INACTIVE ||
-        !elem->ancestor())
+    // If we're not an ancestor, there's no chance our coarsening
+    // settings need to be changed.
+    if (!elem->ancestor())
       return false;
 
-    // If we don't have any remote children, or if we know we have a
-    // child that isn't being coarsened, there's nothing we need to
-    // communicate.
+    // If we don't have any remote children, we already know enough to
+    // determine the correct refinement flag ourselves.
+    //
+    // If we know we have a child that isn't being coarsened, that
+    // also forces a specific flag.
+    //
+    // Either way there's nothing we need to communicate.
     bool found_remote_child = false;
     for (unsigned int c=0; c<elem->n_children(); c++)
       {

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1208,7 +1208,9 @@ bool MeshRefinement::make_coarsening_compatible()
                                 &Elem::set_refinement_flag);
       sync_dofobject_data_by_id
         (this->comm(), _mesh.not_local_elements_begin(),
-         _mesh.not_local_elements_end(), SyncCoarsenInactive(),
+         _mesh.not_local_elements_end(),
+         // We'd like a smaller sync, but this leads to bugs?
+         // SyncCoarsenInactive(),
          hsync);
     }
 

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1736,14 +1736,8 @@ void MeshRefinement::_smooth_flags(bool refining, bool coarsening)
           satisfied = (coarsening_satisfied &&
                        refinement_satisfied &&
                        smoothing_satisfied);
-#ifdef DEBUG
-          bool max_satisfied = satisfied,
-            min_satisfied = satisfied;
-          this->comm().max(max_satisfied);
-          this->comm().min(min_satisfied);
-          libmesh_assert_equal_to (satisfied, max_satisfied);
-          libmesh_assert_equal_to (satisfied, min_satisfied);
-#endif
+
+          libmesh_assert(this->comm().verify(satisfied));
         }
       while (!satisfied);
     }

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -880,8 +880,11 @@ bool MeshRefinement::make_coarsening_compatible()
       }
   }
 
-  // if there are no refined elements on this processor then
-  // there is no work for us to do
+  // Even if there are no refined elements on this processor then
+  // there may still be work for us to do on e.g. ancestor elements.
+  // At the very least we need to be in the loop if a distributed mesh
+  // needs to synchronize data.
+#if 0
   if (max_level == 0 && max_p_level == 0)
     {
       // But we still have to check with other processors
@@ -889,8 +892,7 @@ bool MeshRefinement::make_coarsening_compatible()
 
       return compatible_with_refinement;
     }
-
-
+#endif
 
   // Loop over all the active elements.  If an element is marked
   // for coarsening we better check its neighbors.  If ANY of these neighbors

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1170,7 +1170,7 @@ bool MeshRefinement::make_coarsening_compatible()
 
       Parallel::MessageTag
         uncoarsenable_tag = this->comm().get_unique_tag(2718);
-      std::vector<Parallel::Request> uncoarsenable_push_requests(n_proc);
+      std::vector<Parallel::Request> uncoarsenable_push_requests(n_proc-1);
 
       for (processor_id_type p = 0; p != n_proc; ++p)
         {
@@ -1201,6 +1201,8 @@ bool MeshRefinement::make_coarsening_compatible()
               elem.set_refinement_flag(Elem::INACTIVE);
             }
         }
+
+      Parallel::wait(uncoarsenable_push_requests);
 
       SyncRefinementFlags hsync(_mesh, &Elem::refinement_flag,
                                 &Elem::set_refinement_flag);


### PR DESCRIPTION
Ever since we got rid of the over-ghosting behavior, it's been possible to have an inactive parent element whose children are remote even on its own processor.  In such cases it's hard to correctly determine whether that element should be flagged COARSEN_INACTIVE, and we were not doing so correctly.
    
This fixes a nasty https://github.com/idaholab/moose/issues/1500 test failure for me, and I think it might also fix #1355 if I'm lucky.