### PR TITLE
Uniform coarsening fix

### DIFF
--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1854,7 +1854,8 @@ void MeshRefinement::uniformly_coarsen (unsigned int n)
           for ( ; elem_it != elem_end; ++elem_it)
             {
               const Elem & elem = **elem_it;
-              if (elem.refinement_flag() == Elem::COARSEN_INACTIVE)
+              if (elem.processor_id() != my_proc_id &&
+                  elem.refinement_flag() == Elem::COARSEN_INACTIVE)
                 parents_to_coarsen[elem.processor_id()].push_back(elem.id());
             }
 

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1113,7 +1113,9 @@ bool MeshRefinement::make_coarsening_compatible()
   // then flag the parent so that they can kill their kids.
 
   // On a distributed mesh, we won't always be able to determine this
-  // on ghost elements without talking to neighboring processors.
+  // on parent elements with remote children, even if we own the
+  // parent, without communication.
+  //
   // We'll first communicate *to* parents' owners when we determine
   // they cannot be coarsened, then we'll sync the final refinement
   // flag *from* the parents.
@@ -1824,7 +1826,7 @@ void MeshRefinement::uniformly_coarsen (unsigned int n)
       // Clean up the refinement flags
       this->clean_refinement_flags();
 
-      // Flag all the active elements for coarsening
+      // Flag all the active elements for coarsening.
       MeshBase::element_iterator       elem_it  = _mesh.active_elements_begin();
       const MeshBase::element_iterator elem_end = _mesh.active_elements_end();
 
@@ -1833,6 +1835,73 @@ void MeshRefinement::uniformly_coarsen (unsigned int n)
           (*elem_it)->set_refinement_flag(Elem::COARSEN);
           if ((*elem_it)->parent())
             (*elem_it)->parent()->set_refinement_flag(Elem::COARSEN_INACTIVE);
+        }
+
+      // On a distributed mesh, we may have parent elements with
+      // remote active children.  To keep flags consistent, we'll need
+      // a communication step.
+      if (!_mesh.is_replicated())
+        {
+          const processor_id_type n_proc = _mesh.n_processors();
+          const processor_id_type my_proc_id = _mesh.processor_id();
+
+          std::vector<std::vector<dof_id_type> >
+            parents_to_coarsen(n_proc);
+
+          MeshBase::const_element_iterator       elem_it  = _mesh.ancestor_elements_begin();
+          const MeshBase::const_element_iterator elem_end = _mesh.ancestor_elements_end();
+
+          for ( ; elem_it != elem_end; ++elem_it)
+            {
+              const Elem & elem = **elem_it;
+              if (elem.refinement_flag() == Elem::COARSEN_INACTIVE)
+                parents_to_coarsen[elem.processor_id()].push_back(elem.id());
+            }
+
+          Parallel::MessageTag
+            coarsen_tag = this->comm().get_unique_tag(271);
+          std::vector<Parallel::Request> coarsen_push_requests(n_proc-1);
+
+          for (processor_id_type p = 0; p != n_proc; ++p)
+            {
+              if (p == my_proc_id)
+                continue;
+
+              Parallel::Request &request =
+                coarsen_push_requests[p - (p > my_proc_id)];
+
+              _mesh.comm().send
+                (p, parents_to_coarsen[p], request, coarsen_tag);
+            }
+
+          for (processor_id_type p = 1; p != n_proc; ++p)
+            {
+              std::vector<dof_id_type> my_parents_to_coarsen;
+              _mesh.comm().receive
+                (Parallel::any_source, my_parents_to_coarsen,
+                 coarsen_tag);
+
+              for (std::vector<dof_id_type>::const_iterator
+                   it = my_parents_to_coarsen.begin(),
+                   end = my_parents_to_coarsen.end(); it != end; ++it)
+                {
+                  Elem & elem = _mesh.elem_ref(*it);
+                  libmesh_assert(elem.refinement_flag() == Elem::INACTIVE ||
+                                 elem.refinement_flag() == Elem::COARSEN_INACTIVE);
+                  elem.set_refinement_flag(Elem::COARSEN_INACTIVE);
+                }
+            }
+
+          Parallel::wait(coarsen_push_requests);
+
+          SyncRefinementFlags hsync(_mesh, &Elem::refinement_flag,
+                                    &Elem::set_refinement_flag);
+          sync_dofobject_data_by_id
+            (this->comm(), _mesh.not_local_elements_begin(),
+             _mesh.not_local_elements_end(),
+             // We'd like a smaller sync, but this leads to bugs?
+             // SyncCoarsenInactive(),
+             hsync);
         }
 
       // Coarsen all the elements we just flagged.


### PR DESCRIPTION
This keeps our COARSEN_INACTIVE flags in sync when we coarsen uniformly, even in corner cases where parent elements have all their children remote, which fixes #1355 for me.  @borisboutkov, would you try it out too?