### PR TITLE
Keep is_serial* well-defined

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -126,7 +126,8 @@ public:
    * exist on the current processor.
    */
   virtual void set_distributed () libmesh_override
-  { _is_serial = false; }
+  { _is_serial = false;
+    _is_serial_on_proc_0 = false; }
 
   /**
    * \returns \p true if new elements and nodes can and should be


### PR DESCRIPTION
This fixes a MOOSE --distributed-mesh "regression" for me, where an
undefined is_serial_on_proc_0 value was lulling MeshSerializer into
doing nothing and thereby causing an ExodusII_IO output to miss other
processors' values.

I say "regression" with scare quotes because this was a long-standing
bug, and it was just vagaries of nasal demons that caused it to
trigger now and not earlier.  Hopefully we just fixed some other
exodiff regression test failures too.