### PR TITLE
64-bit build fix

### DIFF
--- a/src/apps/amr.C
+++ b/src/apps/amr.C
@@ -161,8 +161,8 @@ void assemble(EquationSystems & es,
   const std::vector<std::vector<Real> > & phi          = fe->get_phi();
   const std::vector<std::vector<RealGradient> > & dphi = fe->get_dphi();
 
-  std::vector<unsigned int> dof_indices_U;
-  std::vector<unsigned int> dof_indices_V;
+  std::vector<dof_id_type> dof_indices_U;
+  std::vector<dof_id_type> dof_indices_V;
   const DofMap & dof_map = system.get_dof_map();
 
   DenseMatrix<Number> Kuu;


### PR DESCRIPTION
closes #1361

@roystgnr - this needs to go into the current MOOSE update since we test against 64-bit builds on master. I tested this locally, it's the only regression so you can merge before testing completes.