### PR TITLE
add getter for underlying perf_log data structure

### DIFF
--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -249,6 +249,11 @@ public:
    */
   PerfData get_perf_data(const std::string & label, const std::string & header="");
 
+  /**
+   * \returns the raw underlying data structure for the entire performance log.
+   */
+  const std::map < std::pair<std::string, std::string>, PerfData > & get_log_raw() const { return log; }
+
 private:
 
 


### PR DESCRIPTION
This is needed to enable some continuous integration benchmarking we are
implementing for MOOSE. fixes #1367.