### PR TITLE
Set an extra define if an external boost is found

### DIFF
--- a/configure
+++ b/configure
@@ -33604,6 +33604,18 @@ fi
 
 
 
+    # Set an extra define if an external boost installation (as opposed to
+    # libmesh's internal boost subset) was found. This will allow users to
+    # determine at compile time when they are safe to use boost features
+    # that are not available in the libmesh subset. Note: we currently don't
+    # distinguish which features are available in the external boost (we assume
+    # it is a full installation) but that could be added later.
+    if test "$external_boost_found" = "yes" ; then
+
+$as_echo "#define HAVE_EXTERNAL_BOOST 1" >>confdefs.h
+
+    fi
+
     # If that did not work, try using our builtin boost.
     if test "$external_boost_found" = "no" ; then
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< External boost installation *not* found... will try to configure for libmesh's internal boost >>>" >&5

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -435,6 +435,9 @@
 /* Flag indicating whether the library will be compiled with Exodus support */
 #undef HAVE_EXODUS_API
 
+/* Flag indicating whether an external Boost was found */
+#undef HAVE_EXTERNAL_BOOST
+
 /* define if the compiler supports __gnu_cxx::hash */
 #undef HAVE_EXT_HASH
 

--- a/m4/boost.m4
+++ b/m4/boost.m4
@@ -27,6 +27,16 @@ AC_DEFUN([CONFIGURE_BOOST],
                   [external_boost_found=no],
                   [])
 
+    # Set an extra define if an external boost installation (as opposed to
+    # libmesh's internal boost subset) was found. This will allow users to
+    # determine at compile time when they are safe to use boost features
+    # that are not available in the libmesh subset. Note: we currently don't
+    # distinguish which features are available in the external boost (we assume
+    # it is a full installation) but that could be added later.
+    if test "$external_boost_found" = "yes" ; then
+      AC_DEFINE(HAVE_EXTERNAL_BOOST, 1, [Flag indicating whether an external Boost was found])
+    fi
+
     # If that did not work, try using our builtin boost.
     if test "$external_boost_found" = "no" ; then
       AC_MSG_RESULT(<<< External boost installation *not* found... will try to configure for libmesh's internal boost >>>)


### PR DESCRIPTION
This only touches our local boost.m4, and thus should avoid rankling @roystgnr....