### PR TITLE
Delete copy/pasted documentation of overridden virtual functions.

### DIFF
--- a/include/numerics/analytic_function.h
+++ b/include/numerics/analytic_function.h
@@ -34,9 +34,10 @@ template <typename T>
 class DenseVector;
 
 /**
- * This class provides function-like objects for which an
- * analytical expression can be provided.  The user may
- * either provide vector-return or number-return functions.
+ * This class provides function-like objects for which an analytical
+ * expression can be provided.  The user may either provide
+ * vector-return or number-return functions.  All overridden virtual
+ * functions are documented in function_base.h.
  *
  * \author Daniel Dreyer
  * \date 2003
@@ -81,31 +82,15 @@ public:
                          const Point & p,
                          const Real time);
 
-  /**
-   * The actual initialization process.
-   */
   virtual void init () libmesh_override;
 
-  /**
-   * Clears the function.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * \returns A new deep copy of the function.
-   */
   virtual UniquePtr<FunctionBase<Output> > clone () const libmesh_override;
 
-  /**
-   * \returns The value at point \p p and time
-   * \p time, which defaults to zero.
-   */
   virtual Output operator() (const Point & p,
                              const Real time=0.) libmesh_override;
 
-  /**
-   * Like before, but sets output values in the passed-in \p output DenseVector.
-   */
   virtual void operator() (const Point & p,
                            const Real time,
                            DenseVector<Output> & output) libmesh_override;

--- a/include/numerics/composite_fem_function.h
+++ b/include/numerics/composite_fem_function.h
@@ -52,9 +52,11 @@ public:
       delete subfunctions[i];
   }
 
-  // Attach a new subfunction, along with a map from the indices of
-  // that subfunction to the indices of the global function.
-  // (*this)(index_map[i]) will return f(i).
+  /**
+   * Attach a new subfunction, along with a map from the indices of
+   * that subfunction to the indices of the global function.
+   * (*this)(index_map[i]) will return f(i).
+   */
   void attach_subfunction (const FEMFunctionBase<Output> & f,
                            const std::vector<unsigned int> & index_map)
   {
@@ -113,10 +115,6 @@ public:
       }
   }
 
-  /**
-   * \returns The vector component \p i at coordinate
-   * \p p and time \p time.
-   */
   virtual Output component (const FEMContext & c,
                             unsigned int i,
                             const Point & p,

--- a/include/numerics/composite_function.h
+++ b/include/numerics/composite_function.h
@@ -1,4 +1,4 @@
-//-------------// The libMesh Finite Element Library.
+// The libMesh Finite Element Library.
 // Copyright (C) 2002-2017 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
 
 // This library is free software; you can redistribute it and/or
@@ -33,7 +33,8 @@ namespace libMesh
 {
 
 /**
- * Function which is a function of another function.
+ * Function which is a function of another function.  All overridden
+ * virtual functions are documented in function_base.h.
  *
  * \author Roy Stogner
  * \date 2012
@@ -52,9 +53,11 @@ public:
       delete subfunctions[i];
   }
 
-  // Attach a new subfunction, along with a map from the indices of
-  // that subfunction to the indices of the global function.
-  // (*this)(index_map[i]) will return f(i).
+  /**
+   * Attach a new subfunction, along with a map from the indices of
+   * that subfunction to the indices of the global function.
+   * (*this)(index_map[i]) will return f(i).
+   */
   void attach_subfunction (const FunctionBase<Output> & f,
                            const std::vector<unsigned int> & index_map)
   {
@@ -125,10 +128,6 @@ public:
       }
   }
 
-  /**
-   * \returns The vector component \p i at coordinate
-   * \p p and time \p time.
-   */
   virtual Output component (unsigned int i,
                             const Point & p,
                             Real time) libmesh_override

--- a/include/numerics/const_function.h
+++ b/include/numerics/const_function.h
@@ -31,7 +31,8 @@ namespace libMesh
 {
 
 /**
- * Function that returns a single value that never changes.
+ * Function that returns a single value that never changes. All
+ * overridden virtual functions are documented in function_base.h.
  *
  * \author Roy Stogner
  * \date 2012

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -42,8 +42,9 @@ template <typename T> class DenseVector;
 
 /**
  * Defines a dense matrix for use in Finite Element-type computations.
- * Useful for storing element stiffness matrices before summation
- * into a global matrix.
+ * Useful for storing element stiffness matrices before summation into
+ * a global matrix.  All overridden virtual functions are documented
+ * in dense_matrix_base.h.
  *
  * \author Benjamin S. Kirk
  * \date 2002
@@ -61,19 +62,11 @@ public:
               const unsigned int new_n=0);
 
   /**
-   * Copy-constructor.
-   */
-  //DenseMatrix (const DenseMatrix<T> & other_matrix);
-
-  /**
    * Destructor.  Empty.
    */
   virtual ~DenseMatrix() {}
 
 
-  /**
-   * Set every element in the matrix to 0.
-   */
   virtual void zero() libmesh_override;
 
   /**
@@ -88,23 +81,14 @@ public:
   T & operator() (const unsigned int i,
                   const unsigned int j);
 
-  /**
-   * \returns The \p (i,j) element of the matrix as a writable reference.
-   */
   virtual T el(const unsigned int i,
                const unsigned int j) const libmesh_override
   { return (*this)(i,j); }
 
-  /**
-   * \returns The \p (i,j) element of the matrix as a writable reference.
-   */
   virtual T & el(const unsigned int i,
                  const unsigned int j) libmesh_override
   { return (*this)(i,j); }
 
-  /**
-   * Left multiplies by the matrix \p M2.
-   */
   virtual void left_multiply (const DenseMatrixBase<T> & M2) libmesh_override;
 
   /**
@@ -113,9 +97,6 @@ public:
   template <typename T2>
   void left_multiply (const DenseMatrixBase<T2> & M2);
 
-  /**
-   * Right multiplies by the matrix \p M2.
-   */
   virtual void right_multiply (const DenseMatrixBase<T> & M2) libmesh_override;
 
   /**
@@ -755,19 +736,6 @@ DenseMatrix<T>::DenseMatrix(const unsigned int new_m,
 {
   this->resize(new_m,new_n);
 }
-
-
-
-// FIXME[JWP]: This copy ctor has not been maintained along with
-// the rest of the class...
-// Can we just use the compiler-generated copy ctor here?
-// template<typename T>
-// inline
-// DenseMatrix<T>::DenseMatrix (const DenseMatrix<T> & other_matrix)
-//   : DenseMatrixBase<T>(other_matrix._m, other_matrix._n)
-// {
-//   _val = other_matrix._val;
-// }
 
 
 

--- a/include/numerics/dense_submatrix.h
+++ b/include/numerics/dense_submatrix.h
@@ -31,9 +31,11 @@ namespace libMesh
 {
 
 /**
- * Defines a dense submatrix for use in Finite Element-type computations.
- * Useful for storing element stiffness matrices before summation
- * into a global matrix, particularly when you have systems of equations.
+ * Defines a dense submatrix for use in Finite Element-type
+ * computations.  Useful for storing element stiffness matrices before
+ * summation into a global matrix, particularly when you have systems
+ * of equations.  All overridden virtual functions are documented in
+ * dense_matrix_base.h.
  *
  * \author Benjamin S. Kirk
  * \date 2003
@@ -65,15 +67,11 @@ public:
    */
   virtual ~DenseSubMatrix() {}
 
-
   /**
    * \returns A reference to the parent matrix.
    */
   DenseMatrix<T> & parent () { return _parent_matrix; }
 
-  /**
-   * Set every element in the submatrix to 0.
-   */
   virtual void zero() libmesh_override;
 
   /**
@@ -88,28 +86,16 @@ public:
   T & operator() (const unsigned int i,
                   const unsigned int j);
 
-  /**
-   * \returns The \p (i,j) element of the matrix as a writable reference.
-   */
   virtual T el(const unsigned int i,
                const unsigned int j) const libmesh_override
   { return (*this)(i,j); }
 
-  /**
-   * \returns The \p (i,j) element of the matrix as a writable reference.
-   */
   virtual T & el(const unsigned int i,
                  const unsigned int j) libmesh_override
   { return (*this)(i,j); }
 
-  /**
-   * Performs the operation: (*this) <- M2 * (*this)
-   */
   virtual void left_multiply (const DenseMatrixBase<T> & M2) libmesh_override;
 
-  /**
-   * Performs the operation: (*this) <- (*this) * M3
-   */
   virtual void right_multiply (const DenseMatrixBase<T> & M3) libmesh_override;
 
   /**

--- a/include/numerics/dense_subvector.h
+++ b/include/numerics/dense_subvector.h
@@ -33,6 +33,7 @@ namespace libMesh
  * Defines a dense subvector for use in finite element computations.
  * Useful for storing element load vectors before summation into a
  * global vector, particularly when you have systems of equations.
+ * All overridden virtual functions are documented in dense_vector_base.h.
  *
  * \author Benjamin S. Kirk
  * \date 2003
@@ -61,9 +62,6 @@ public:
    */
   DenseVector<T> & parent () { return _parent_vector; }
 
-  /**
-   * Set every element in the subvector to 0.
-   */
   virtual void zero() libmesh_override;
 
   /**
@@ -77,27 +75,15 @@ public:
    */
   T & operator() (const unsigned int i);
 
-  /**
-   * \returns The \p (i) element of the vector.
-   */
   virtual T el(const unsigned int i) const libmesh_override
   { return (*this)(i); }
 
-  /**
-   * \returns The \p (i) element of the vector as a writable reference.
-   */
   virtual T & el(const unsigned int i) libmesh_override
   { return (*this)(i); }
 
-  /**
-   * \returns The size of the subvector.
-   */
   virtual unsigned int size() const libmesh_override
   { return _n; }
 
-  /**
-   * \returns \p true if size() is 0.
-   */
   virtual bool empty() const libmesh_override
   { return (_n == 0); }
 

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -43,6 +43,7 @@ namespace libMesh
  * This class is to basically compliment the \p DenseMatix class.  It
  * has additional capabilities over the \p std::vector that make it
  * useful for finite elements, particulary for systems of equations.
+ * All overridden virtual functions are documented in dense_vector_base.h.
  *
  * \author Benjamin S. Kirk
  * \date 2003
@@ -83,23 +84,14 @@ public:
    */
   ~DenseVector() {}
 
-  /**
-   * \returns The size of the vector.
-   */
   virtual unsigned int size() const libmesh_override
   {
     return cast_int<unsigned int>(_val.size());
   }
 
-  /**
-   * \returns \p true if size() is 0.
-   */
   virtual bool empty() const libmesh_override
   { return _val.empty(); }
 
-  /**
-   * Set every element in the vector to 0.
-   */
   virtual void zero() libmesh_override;
 
   /**
@@ -112,15 +104,9 @@ public:
    */
   T & operator() (const unsigned int i);
 
-  /**
-   * \returns A const reference to entry \p i of the vector via virtual function call.
-   */
   virtual T el(const unsigned int i) const libmesh_override
   { return (*this)(i); }
 
-  /**
-   * \returns A writable reference to entry \p i of the vector via virtual function call.
-   */
   virtual T & el(const unsigned int i) libmesh_override
   { return (*this)(i); }
 

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -37,11 +37,11 @@ namespace libMesh
 {
 
 /**
- * Distributed vector. Provides an interface for simple
- * parallel, distributed vectors. Offers some collective
- * communication capabilities.  Note that the class will
- * sill function without MPI, but only on one processor.
- * This lets us keep the parallel details behind the scenes.
+ * This class provides a simple parallel, distributed vector datatype
+ * which is specific to libmesh. Offers some collective communication
+ * capabilities.  Note that the class will sill function without MPI,
+ * but only on one processor. All overridden virtual functions are
+ * documented in numeric_vector.h.
  *
  * \author Benjamin S. Kirk
  * \date 2003
@@ -92,84 +92,36 @@ public:
    */
   ~DistributedVector ();
 
-  /**
-   * Call the assemble functions
-   */
   virtual void close () libmesh_override;
 
-  /**
-   * Restores the \p DistributedVector to a pristine state.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Set all entries to zero. Equivalent to \p v = 0, but more obvious and
-   * faster.
-   */
   virtual void zero () libmesh_override;
 
-  /**
-   * \returns A smart pointer to a copy of this vector with the same
-   * type, size, and partitioning, but with all zero entries.
-   */
   virtual UniquePtr<NumericVector<T> > zero_clone () const libmesh_override;
 
-  /**
-   * \returns A copy of this vector wrapped in a smart pointer.
-   */
   virtual UniquePtr<NumericVector<T> > clone () const libmesh_override;
 
-  /**
-   * Change the dimension of the vector to \p N. The reserved memory
-   * for this vector remains unchanged if possible.  If \p N==0, all
-   * memory is freed. Therefore, if you want to resize the vector and
-   * release the memory not needed, you have to first call \p init(0)
-   * and then \p init(N). This behaviour is analogous to that of the
-   * STL containers.
-   *
-   * On \p fast==false, the vector is filled by zeros.
-   */
   virtual void init (const numeric_index_type N,
                      const numeric_index_type n_local,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType ptype=AUTOMATIC) libmesh_override;
 
-  /**
-   * Call \p init() with n_local = N.
-   */
   virtual void init (const numeric_index_type N,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType ptype=AUTOMATIC) libmesh_override;
 
-  /**
-   * Create a vector that holds the local indices plus those specified
-   * in the \p ghost argument.
-   */
-  virtual void init (const numeric_index_type /*N*/,
-                     const numeric_index_type /*n_local*/,
-                     const std::vector<numeric_index_type> & /*ghost*/,
-                     const bool /*fast*/ = false,
+  virtual void init (const numeric_index_type N,
+                     const numeric_index_type n_local,
+                     const std::vector<numeric_index_type> & ghost,
+                     const bool fast = false,
                      const ParallelType = AUTOMATIC) libmesh_override;
 
-  /**
-   * Creates a vector that has the same dimension and storage type as
-   * \p other, including ghost dofs.
-   */
   virtual void init (const NumericVector<T> & other,
                      const bool fast = false) libmesh_override;
 
-  /**
-   * Sets all entries of the vector to the value \p s.
-   *
-   * \returns A reference to *this.
-   */
   virtual NumericVector<T> & operator= (const T s) libmesh_override;
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator= (const NumericVector<T> & v) libmesh_override;
 
   /**
@@ -179,133 +131,48 @@ public:
    */
   DistributedVector<T> & operator= (const DistributedVector<T> & v);
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator= (const std::vector<T> & v) libmesh_override;
 
-  /**
-   * \returns The minimum entry in the vector, or the minimum real
-   * part in the case of complex numbers.
-   */
   virtual Real min () const libmesh_override;
 
-  /**
-   * \returns The maximum entry in the vector, or the maximum real
-   * part in the case of complex numbers.
-   */
   virtual Real max () const libmesh_override;
 
-  /**
-   * \returns The sum of all values in the vector.
-   */
   virtual T sum() const libmesh_override;
 
-  /**
-   * \returns The \f$ l_1 \f$-norm of the vector, i.e. the sum of the
-   * absolute values of the entries.
-   */
   virtual Real l1_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_2\f$-norm of the vector, i.e. the square root
-   * of the sum of the squares of the entries.
-   */
   virtual Real l2_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_\infty\f$-norm of the vector, i.e. the maximum
-   * absolute value of the entries of the vector.
-   */
   virtual Real linfty_norm () const libmesh_override;
 
-  /**
-   * \returns The size of the vector.
-   */
   virtual numeric_index_type size () const libmesh_override;
 
-  /**
-   * \returns The local size of the vector, i.e. \p index_stop - \p index_start.
-   */
   virtual numeric_index_type local_size() const libmesh_override;
 
-  /**
-   * \returns The index of the first vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type first_local_index() const libmesh_override;
 
-  /**
-   * \returns The index of the last vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type last_local_index() const libmesh_override;
 
-  /**
-   * \returns A copy of the ith entry of the vector.
-   */
   virtual T operator() (const numeric_index_type i) const libmesh_override;
 
-  /**
-   * Add \p v to *this. Equivalent to \p U.add(1, V).
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator += (const NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Subtracts \p v from *this.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Pointwise division operator. Sets u(i) <- u(i)/v(i) for each
-   * entry in the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator /= (NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Sets u(i) <- 1/u(i) for each entry in the vector.
-   */
   virtual void reciprocal() libmesh_override;
 
-  /**
-   * Negates the imaginary component of each entry in the vector.
-   */
   virtual void conjugate() libmesh_override;
 
-  /**
-   * Sets v(i) = \p value.
-   */
   virtual void set (const numeric_index_type i, const T value) libmesh_override;
 
-  /**
-   * Adds \p value to each entry of the vector.
-   */
   virtual void add (const numeric_index_type i, const T value) libmesh_override;
 
-  /**
-   * Adds \p s to each entry of the vector.
-   */
   virtual void add (const T s) libmesh_override;
 
-  /**
-   * Vector addition. Sets u(i) <- u(i) + v(i) for each entry in the
-   * vector. Equivalent to calling \p operator+=().
-   */
   virtual void add (const NumericVector<T> & V) libmesh_override;
 
-  /**
-   * Vector addition with a scalar multiple. Sets u(i) <- u(i) + a *
-   * v(i) for each entry in the vector. Equivalent to calling \p
-   * operator+=().
-   */
   virtual void add (const T a, const NumericVector<T> & v) libmesh_override;
 
   /**
@@ -314,120 +181,66 @@ public:
    */
   using NumericVector<T>::add_vector;
 
-  /**
-   * Adds the product of a SparseMatrix \p A and a NumericVector \p
-   * v to this vector, i.e. \f$u += A v \f$.
-   *
-   * Not implemented.
-   */
   virtual void add_vector (const NumericVector<T> &,
                            const SparseMatrix<T> &) libmesh_override
   { libmesh_not_implemented(); }
 
-  /**
-   * Adds the product of a SparseMatrix \p A^T and a NumericVector \p
-   * v to this vector, i.e. \f$u += A^T v \f$.
-   *
-   * Not implemented.
-   */
   virtual void add_vector_transpose (const NumericVector<T> &,
                                      const SparseMatrix<T> &) libmesh_override
   { libmesh_not_implemented(); }
 
-  /**
-   * Scale each element of the vector by the given factor.
-   */
   virtual void scale (const T factor) libmesh_override;
 
-  /**
-   * Sets u(i) <- abs(u(i)) for each entry in the vector.
-   */
   virtual void abs() libmesh_override;
 
-  /**
-   * \returns The dot product of (*this) with the vector \p V.
-   */
   virtual T dot(const NumericVector<T> & V) const libmesh_override;
 
-  /**
-   * Creates a copy of the global vector in the local vector \p
-   * v_local.
-   */
   virtual void localize (std::vector<T> & v_local) const libmesh_override;
 
-  /**
-   * Same, but fills a \p NumericVector<T> instead of a \p
-   * std::vector.
-   */
   virtual void localize (NumericVector<T> & v_local) const libmesh_override;
 
-  /**
-   * Creates a local vector \p v_local containing only information
-   * relevant to this processor, as defined by the \p send_list.
-   */
   virtual void localize (NumericVector<T> & v_local,
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
-  /**
-   * Fill in the local std::vector "v_local" with the global indices
-   * given in "indices".  See numeric_vector.h for more details.
-   */
   virtual void localize (std::vector<T> & v_local,
                          const std::vector<numeric_index_type> & indices) const libmesh_override;
 
-  /**
-   * Updates a local vector with selected values from neighboring
-   * processors, as defined by \p send_list.
-   */
   virtual void localize (const numeric_index_type first_local_idx,
                          const numeric_index_type last_local_idx,
                          const std::vector<numeric_index_type> & send_list) libmesh_override;
 
-  /**
-   * Creates a local copy of the global vector in \p v_local only on
-   * processor \p proc_id. By default the data is sent to processor
-   * 0. This method is useful for outputting data from one processor.
-   */
   virtual void localize_to_one (std::vector<T> & v_local,
                                 const processor_id_type proc_id=0) const libmesh_override;
 
-  /**
-   * Computes the pointwise (i.e. component-wise) product of \p vec1
-   * and \p vec2 and stores the result in \p *this.
-   */
   virtual void pointwise_mult (const NumericVector<T> & vec1,
                                const NumericVector<T> & vec2) libmesh_override;
 
-  /**
-   * Swaps the vector data and metadata
-   */
   virtual void swap (NumericVector<T> & v) libmesh_override;
 
 private:
 
   /**
-   * Actual vector datatype
-   * to hold vector entries
+   * Actual vector datatype to hold vector entries.
    */
   std::vector<T> _values;
 
   /**
-   * The global vector size
+   * The global vector size.
    */
   numeric_index_type _global_size;
 
   /**
-   * The local vector size
+   * The local vector size.
    */
   numeric_index_type _local_size;
 
   /**
-   * The first component stored locally
+   * The first component stored locally.
    */
   numeric_index_type _first_local_index;
 
   /**
-   * The last component (+1) stored locally
+   * The last component (+1) stored locally.
    */
   numeric_index_type _last_local_index;
 };

--- a/include/numerics/eigen_preconditioner.h
+++ b/include/numerics/eigen_preconditioner.h
@@ -25,13 +25,7 @@
 #ifdef LIBMESH_HAVE_EIGEN
 
 // Local includes
-#include "libmesh/eigen_core_support.h"
 #include "libmesh/preconditioner.h"
-#include "libmesh/libmesh_common.h"
-#include "libmesh/enum_solver_package.h"
-#include "libmesh/enum_preconditioner_type.h"
-#include "libmesh/reference_counted_object.h"
-#include "libmesh/libmesh.h"
 
 namespace libMesh
 {
@@ -42,8 +36,9 @@ template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
 
 /**
- * This class provides an interface to the suite of preconditioners available
- * from Eigen.
+ * This class provides an interface to the suite of preconditioners
+ * available from Eigen. All overridden virtual functions are
+ * documented in preconditioner.h.
  *
  * \author Benjamin Kirk
  * \date 2013
@@ -63,20 +58,10 @@ public:
    */
   virtual ~EigenPreconditioner ();
 
-  /**
-   * Computes the preconditioned vector "y" based on input "x".
-   * Usually by solving Py=x to get the action of P^-1 x.
-   */
   virtual void apply(const NumericVector<T> & x, NumericVector<T> & y) libmesh_override;
 
-  /**
-   * Release all memory and clear data structures.
-   */
   virtual void clear () libmesh_override {}
 
-  /**
-   * Initialize data structures if not done so already.
-   */
   virtual void init () libmesh_override;
 };
 

--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -43,8 +43,9 @@ template <typename T> class EigenSparseVector;
 template <typename T> class EigenSparseLinearSolver;
 
 /**
- * The EigenSparseMatrix class wraps a sparse matrix object from the Eigen
- * library.
+ * The EigenSparseMatrix class wraps a sparse matrix object from the
+ * Eigen library. All overridden virtual functions are documented in
+ * sparse_matrix.h.
  *
  * \author Benjamin S. Kirk
  * \date 2013
@@ -55,27 +56,21 @@ class EigenSparseMatrix libmesh_final : public SparseMatrix<T>
 
 public:
   /**
-   * Constructor; initializes the matrix to
-   * be empty, without any structure, i.e.
-   * the matrix is not usable at all. This
-   * constructor is therefore only useful
-   * for matrices which are members of a
-   * class. All other matrices should be
-   * created at a point in the data flow
-   * where all necessary information is
+   * Constructor; initializes the matrix to be empty, without any
+   * structure, i.e.  the matrix is not usable at all. This
+   * constructor is therefore only useful for matrices which are
+   * members of a class. All other matrices should be created at a
+   * point in the data flow where all necessary information is
    * available.
    *
-   * You have to initialize
-   * the matrix before usage with
-   * \p init(...).
+   * You have to initialize the matrix before usage with \p init(...).
    */
   EigenSparseMatrix (const Parallel::Communicator & comm
                      LIBMESH_CAN_DEFAULT_TO_COMMWORLD);
 
   /**
-   * Destructor. Free all memory, but do not
-   * release the memory of the sparsity
-   * structure.
+   * Destructor. Free all memory, but do not release the memory of the
+   * sparsity structure.
    */
   ~EigenSparseMatrix ();
 
@@ -85,16 +80,6 @@ public:
   typedef EigenSM DataType;
   typedef Eigen::Triplet<T,eigen_idx_type> TripletType;
 
-  /**
-   * Initialize a Eigen matrix that is of global
-   * dimension \f$ m \times  n \f$ with local dimensions
-   * \f$ m_l \times n_l \f$.  \p nnz is the number of on-processor
-   * nonzeros per row (defaults to 30).
-   * \p noz is the number of on-processor
-   * nonzeros per row (defaults to 30).
-   * Optionally supports a block size, which indicates dense coupled blocks
-   * for systems with multiple variables all of the same type.
-   */
   virtual void init (const numeric_index_type m,
                      const numeric_index_type n,
                      const numeric_index_type m_l,
@@ -103,159 +88,52 @@ public:
                      const numeric_index_type noz=10,
                      const numeric_index_type blocksize=1) libmesh_override;
 
-  /**
-   * Initialize using sparsity structure computed by \p dof_map.
-   */
   virtual void init () libmesh_override;
 
-  /**
-   * Release all memory and return
-   * to a state just like after
-   * having called the default
-   * constructor.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Set all entries to 0.
-   */
   virtual void zero () libmesh_override;
 
-  /**
-   * Close the matrix.  Dummy routine.  After calling
-   * this method \p closed() is true and the matrix can
-   * be used in computations.
-   */
   virtual void close () const libmesh_override { const_cast<EigenSparseMatrix<T> *>(this)->_closed = true; }
 
-  /**
-   * \returns \p m, the row-dimension of
-   * the matrix where the marix is \f$ M \times N \f$.
-   */
   virtual numeric_index_type m () const libmesh_override;
 
-  /**
-   * \returns \p n, the column-dimension of
-   * the matrix where the marix is \f$ M \times N \f$.
-   */
   virtual numeric_index_type n () const libmesh_override;
 
-  /**
-   * return row_start, the index of the first
-   * matrix row stored on this processor
-   */
   virtual numeric_index_type row_start () const libmesh_override;
 
-  /**
-   * return row_stop, the index of the last
-   * matrix row (+1) stored on this processor
-   */
   virtual numeric_index_type row_stop () const libmesh_override;
 
-  /**
-   * Set the element \p (i,j) to \p value.
-   * Throws an error if the entry does
-   * not exist. Still, it is allowed to store
-   * zero values in non-existent fields.
-   */
   virtual void set (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) libmesh_override;
 
-  /**
-   * Add \p value to the element
-   * \p (i,j).  Throws an error if
-   * the entry does not
-   * exist. Still, it is allowed to
-   * store zero values in
-   * non-existent fields.
-   */
   virtual void add (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) libmesh_override;
 
-  /**
-   * Add the full matrix to the
-   * Eigen matrix.  This is useful
-   * for adding an element matrix
-   * at assembly time
-   */
   virtual void add_matrix (const DenseMatrix<T> & dm,
                            const std::vector<numeric_index_type> & rows,
                            const std::vector<numeric_index_type> & cols) libmesh_override;
 
-  /**
-   * Same, but assumes the row and column maps are the same.
-   * Thus the matrix \p dm must be square.
-   */
   virtual void add_matrix (const DenseMatrix<T> & dm,
                            const std::vector<numeric_index_type> & dof_indices) libmesh_override;
 
-  /**
-   * Add a Sparse matrix \p X, scaled with \p a, to \p this,
-   * stores the result in \p this: \f$\texttt{this} += a*X \f$.
-   * \p LASPACK does not provide a true \p axpy for matrices,
-   * so a hand-coded version with hopefully acceptable performance
-   * is provided.
-   */
   virtual void add (const T a, SparseMatrix<T> & X) libmesh_override;
 
-  /**
-   * Return the value of the entry
-   * \p (i,j).  This may be an
-   * expensive operation, and you
-   * should always be careful where
-   * you call this function.
-   */
   virtual T operator () (const numeric_index_type i,
                          const numeric_index_type j) const libmesh_override;
 
-  /**
-   * Return the l1-norm of the matrix, that is
-   * \f$|M|_1=max_{all columns j}\sum_{all
-   * rows i} |M_ij|\f$,
-   * (max. sum of columns).
-   * This is the
-   * natural matrix norm that is compatible
-   * to the l1-norm for vectors, i.e.
-   * \f$|Mv|_1\leq |M|_1 |v|_1\f$.
-   */
   virtual Real l1_norm () const libmesh_override;
 
-  /**
-   * Return the linfty-norm of the
-   * matrix, that is
-   * \f$|M|_\infty=max_{all rows i}\sum_{all
-   * columns j} |M_ij|\f$,
-   * (max. sum of rows).
-   * This is the
-   * natural matrix norm that is compatible
-   * to the linfty-norm of vectors, i.e.
-   * \f$|Mv|_\infty \leq |M|_\infty |v|_\infty\f$.
-   */
   virtual Real linfty_norm () const libmesh_override;
 
-  /**
-   * see if Eigen matrix has been closed
-   * and fully assembled yet
-   */
   virtual bool closed() const libmesh_override { return _closed; }
 
-  /**
-   * Print the contents of the matrix, by default to libMesh::out.
-   * Currently identical to \p print().
-   */
   virtual void print_personal(std::ostream & os=libMesh::out) const libmesh_override { this->print(os); }
 
-  /**
-   * Copies the diagonal part of the matrix into \p dest.
-   */
   virtual void get_diagonal (NumericVector<T> & dest) const libmesh_override;
 
-  /**
-   * Copies the transpose of the matrix into \p dest, which may be
-   * *this.
-   */
   virtual void get_transpose (SparseMatrix<T> & dest) const libmesh_override;
 
 private:

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -40,8 +40,9 @@ template <typename T> class EigenSparseLinearSolver;
 template <typename T> class SparseMatrix;
 
 /**
- * Eigen vector.  Provides a nice interface to the
- * Eigen C++-based data structures for serial vectors.
+ * This class provides a nice interface to the Eigen C++-based data
+ * structures for serial vectors. All overridden virtual functions are
+ * documented in numeric_vector.h.
  *
  * \author Benjamin S. Kirk
  * \date 2002
@@ -97,84 +98,36 @@ public:
    */
   typedef EigenSV DataType;
 
-  /**
-   * Call the assemble functions
-   */
   virtual void close () libmesh_override;
 
-  /**
-   * Restores the \p EigenSparseVector to a pristine state.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Set all entries to zero. Equivalent to \p v = 0, but more obvious and
-   * faster.
-   */
   virtual void zero () libmesh_override;
 
-  /**
-   * \returns A smart pointer to a copy of this vector with the same
-   * type, size, and partitioning, but with all zero entries.
-   */
   virtual UniquePtr<NumericVector<T> > zero_clone () const libmesh_override;
 
-  /**
-   * \returns A copy of this vector wrapped in a smart pointer.
-   */
   virtual UniquePtr<NumericVector<T> > clone () const libmesh_override;
 
-  /**
-   * Change the dimension of the vector to \p N. The reserved memory
-   * for this vector remains unchanged if possible.  If \p N==0, all
-   * memory is freed. Therefore, if you want to resize the vector and
-   * release the memory not needed, you have to first call \p init(0)
-   * and then \p init(N). This behaviour is analogous to that of the
-   * STL containers.
-   *
-   * On \p fast==false, the vector is filled by zeros.
-   */
   virtual void init (const numeric_index_type N,
                      const numeric_index_type n_local,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType ptype=AUTOMATIC) libmesh_override;
 
-  /**
-   * Call \p init() with n_local = N.
-   */
   virtual void init (const numeric_index_type N,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType ptype=AUTOMATIC) libmesh_override;
 
-  /**
-   * Create a vector that holds the local indices plus those specified
-   * in the \p ghost argument.
-   */
-  virtual void init (const numeric_index_type /*N*/,
-                     const numeric_index_type /*n_local*/,
-                     const std::vector<numeric_index_type> & /*ghost*/,
-                     const bool /*fast*/ = false,
+  virtual void init (const numeric_index_type N,
+                     const numeric_index_type n_local,
+                     const std::vector<numeric_index_type> & ghost,
+                     const bool fast = false,
                      const ParallelType = AUTOMATIC) libmesh_override;
 
-  /**
-   * Creates a vector that has the same dimension and storage type as
-   * \p other, including ghost dofs.
-   */
   virtual void init (const NumericVector<T> & other,
                      const bool fast = false) libmesh_override;
 
-  /**
-   * Sets all entries of the vector to the value \p s.
-   *
-   * \returns A reference to *this.
-   */
   virtual NumericVector<T> & operator= (const T s) libmesh_override;
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator= (const NumericVector<T> & v) libmesh_override;
 
   /**
@@ -184,133 +137,48 @@ public:
    */
   EigenSparseVector<T> & operator= (const EigenSparseVector<T> & v);
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator= (const std::vector<T> & v) libmesh_override;
 
-  /**
-   * \returns The minimum entry in the vector, or the minimum real
-   * part in the case of complex numbers.
-   */
   virtual Real min () const libmesh_override;
 
-  /**
-   * \returns The maximum entry in the vector, or the maximum real
-   * part in the case of complex numbers.
-   */
   virtual Real max () const libmesh_override;
 
-  /**
-   * \returns The sum of all values in the vector.
-   */
   virtual T sum () const libmesh_override;
 
-  /**
-   * \returns The \f$l_1\f$-norm of the vector, i.e. the sum of the
-   * absolute values.
-   */
   virtual Real l1_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_2\f$-norm of the vector, i.e. the square root
-   * of the sum of the squares of the entries.
-   */
   virtual Real l2_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_\infty\f$-norm of the vector, i.e. the maximum
-   * absolute value of the entries of the vector.
-   */
   virtual Real linfty_norm () const libmesh_override;
 
-  /**
-   * \returns The size of the vector.
-   */
   virtual numeric_index_type size () const libmesh_override;
 
-  /**
-   * \returns The local size of the vector, i.e. \p index_stop - \p index_start.
-   */
   virtual numeric_index_type local_size() const libmesh_override;
 
-  /**
-   * \returns The index of the first vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type first_local_index() const libmesh_override;
 
-  /**
-   * \returns The index of the last vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type last_local_index() const libmesh_override;
 
-  /**
-   * \returns A copy of the ith entry of the vector.
-   */
   virtual T operator() (const numeric_index_type i) const libmesh_override;
 
-  /**
-   * Add \p v to *this. Equivalent to \p U.add(1, V).
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator += (const NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Subtracts \p v from *this.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Pointwise division operator. Sets u(i) <- u(i)/v(i) for each
-   * entry in the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator /= (NumericVector<T> & v_in) libmesh_override;
 
-  /**
-   * Sets u(i) <- 1/u(i) for each entry in the vector.
-   */
   virtual void reciprocal() libmesh_override;
 
-  /**
-   * Negates the imaginary component of each entry in the vector.
-   */
   virtual void conjugate() libmesh_override;
 
-  /**
-   * Sets v(i) = \p value.
-   */
   virtual void set (const numeric_index_type i, const T value) libmesh_override;
 
-  /**
-   * Adds \p value to each entry of the vector.
-   */
   virtual void add (const numeric_index_type i, const T value) libmesh_override;
 
-  /**
-   * Adds \p s to each entry of the vector.
-   */
   virtual void add (const T s) libmesh_override;
 
-  /**
-   * Vector addition. Sets u(i) <- u(i) + v(i) for each entry in the
-   * vector. Equivalent to calling \p operator+=().
-   */
   virtual void add (const NumericVector<T> & V) libmesh_override;
 
-  /**
-   * Vector addition with a scalar multiple. Sets u(i) <- u(i) + a *
-   * v(i) for each entry in the vector. Equivalent to calling \p
-   * operator+=().
-   */
   virtual void add (const T a, const NumericVector<T> & v) libmesh_override;
 
   /**
@@ -319,87 +187,38 @@ public:
    */
   using NumericVector<T>::add_vector;
 
-  /**
-   * Adds the product of a SparseMatrix \p A and a NumericVector \p
-   * v to this vector, i.e. \f$ u += A v \f$.
-   */
   virtual void add_vector (const NumericVector<T> & v,
                            const SparseMatrix<T> & A) libmesh_override;
 
-  /**
-   * Adds the product of a SparseMatrix \p A^T and a NumericVector \p
-   * v to this vector, i.e. \f$ u += A^T v \f$.
-   */
   virtual void add_vector_transpose (const NumericVector<T> & v,
                                      const SparseMatrix<T> & A) libmesh_override;
 
-  /**
-   * Scale each element of the vector by the given factor.
-   */
   virtual void scale (const T factor) libmesh_override;
 
-  /**
-   * Sets u(i) <- abs(u(i)) for each entry in the vector.
-   */
   virtual void abs() libmesh_override;
 
-  /**
-   * \returns The dot product of (*this) with the vector \p V.
-   */
   virtual T dot(const NumericVector<T> & V) const libmesh_override;
 
-  /**
-   * Creates a copy of the global vector in the local vector \p
-   * v_local.
-   */
   virtual void localize (std::vector<T> & v_local) const libmesh_override;
 
-  /**
-   * Same, but fills a \p NumericVector<T> instead of a \p
-   * std::vector.
-   */
   virtual void localize (NumericVector<T> & v_local) const libmesh_override;
 
-  /**
-   * Creates a local vector \p v_local containing only information
-   * relevant to this processor, as defined by the \p send_list.
-   */
   virtual void localize (NumericVector<T> & v_local,
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
-  /**
-   * Fill in the local std::vector "v_local" with the global indices
-   * given in "indices".  See numeric_vector.h for more details.
-   */
   virtual void localize (std::vector<T> & v_local,
                          const std::vector<numeric_index_type> & indices) const libmesh_override;
 
-  /**
-   * Updates a local vector with selected values from neighboring
-   * processors, as defined by \p send_list.
-   */
   virtual void localize (const numeric_index_type first_local_idx,
                          const numeric_index_type last_local_idx,
                          const std::vector<numeric_index_type> & send_list) libmesh_override;
 
-  /**
-   * Creates a local copy of the global vector in \p v_local only on
-   * processor \p proc_id. By default the data is sent to processor
-   * 0. This method is useful for outputting data from one processor.
-   */
   virtual void localize_to_one (std::vector<T> & v_local,
                                 const processor_id_type proc_id=0) const libmesh_override;
 
-  /**
-   * Computes the pointwise (i.e. component-wise) product of \p vec1
-   * and \p vec2 and stores the result in \p *this.
-   */
   virtual void pointwise_mult (const NumericVector<T> & vec1,
                                const NumericVector<T> & vec2) libmesh_override;
 
-  /**
-   * Swaps the contents.
-   */
   virtual void swap (NumericVector<T> & v) libmesh_override;
 
   /**

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -46,7 +46,8 @@ template <typename T> class LaspackLinearSolver;
  * The LaspackMatrix class wraps a QMatrix object from the Laspack
  * library. Currently Laspack only supports real datatypes, so this
  * class is a full specialization of \p SparseMatrix<T> with \p T = \p
- * Real.
+ * Real. All overridden virtual functions are documented in
+ * sparse_matrix.h.
  *
  * \author Benjamin S. Kirk
  * \date 2003
@@ -57,27 +58,21 @@ class LaspackMatrix libmesh_final : public SparseMatrix<T>
 
 public:
   /**
-   * Constructor; initializes the matrix to
-   * be empty, without any structure, i.e.
-   * the matrix is not usable at all. This
-   * constructor is therefore only useful
-   * for matrices which are members of a
-   * class. All other matrices should be
-   * created at a point in the data flow
-   * where all necessary information is
+   * Constructor; initializes the matrix to be empty, without any
+   * structure, i.e.  the matrix is not usable at all. This
+   * constructor is therefore only useful for matrices which are
+   * members of a class. All other matrices should be created at a
+   * point in the data flow where all necessary information is
    * available.
    *
-   * You have to initialize
-   * the matrix before usage with
-   * \p init(...).
+   * You have to initialize the matrix before usage with \p init(...).
    */
   LaspackMatrix (const Parallel::Communicator & comm
                  LIBMESH_CAN_DEFAULT_TO_COMMWORLD);
 
   /**
-   * Destructor. Free all memory, but do not
-   * release the memory of the sparsity
-   * structure.
+   * Destructor. Free all memory, but do not release the memory of the
+   * sparsity structure.
    */
   ~LaspackMatrix ();
 
@@ -88,22 +83,12 @@ public:
   { return true; }
 
   /**
-   * Updates the matrix sparsity pattern.  This will
-   * tell the underlying matrix storage scheme how
-   * to map the \f$ (i,j) \f$ elements.
+   * Updates the matrix sparsity pattern.  This will tell the
+   * underlying matrix storage scheme how to map the \f$ (i,j) \f$
+   * elements.
    */
   virtual void update_sparsity_pattern (const SparsityPattern::Graph &) libmesh_override;
 
-  /**
-   * Initialize a Laspack matrix that is of global
-   * dimension \f$ m \times  n \f$ with local dimensions
-   * \f$ m_l \times n_l \f$.  \p nnz is the number of on-processor
-   * nonzeros per row (defaults to 30).
-   * \p noz is the number of on-processor
-   * nonzeros per row (defaults to 30).
-   * Optionally supports a block size, which indicates dense coupled blocks
-   * for systems with multiple variables all of the same type.
-   */
   virtual void init (const numeric_index_type m,
                      const numeric_index_type n,
                      const numeric_index_type m_l,
@@ -112,159 +97,59 @@ public:
                      const numeric_index_type noz=10,
                      const numeric_index_type blocksize=1) libmesh_override;
 
-  /**
-   * Initialize using sparsity structure computed by \p dof_map.
-   */
   virtual void init () libmesh_override;
 
-  /**
-   * Release all memory and return
-   * to a state just like after
-   * having called the default
-   * constructor.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Set all entries to 0.
-   */
   virtual void zero () libmesh_override;
 
-  /**
-   * Close the matrix.  Dummy routine.  After calling
-   * this method \p closed() is true and the matrix can
-   * be used in computations.
-   */
   virtual void close () const libmesh_override { const_cast<LaspackMatrix<T> *>(this)->_closed = true; }
 
-  /**
-   * \returns \p m, the row-dimension of
-   * the matrix where the marix is \f$ M \times N \f$.
-   */
   virtual numeric_index_type m () const libmesh_override;
 
-  /**
-   * \returns \p n, the column-dimension of
-   * the matrix where the marix is \f$ M \times N \f$.
-   */
   virtual numeric_index_type n () const libmesh_override;
 
-  /**
-   * return row_start, the index of the first
-   * matrix row stored on this processor
-   */
   virtual numeric_index_type row_start () const libmesh_override;
 
-  /**
-   * return row_stop, the index of the last
-   * matrix row (+1) stored on this processor
-   */
   virtual numeric_index_type row_stop () const libmesh_override;
 
-  /**
-   * Set the element \p (i,j) to \p value.
-   * Throws an error if the entry does
-   * not exist. Still, it is allowed to store
-   * zero values in non-existent fields.
-   */
   virtual void set (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) libmesh_override;
 
-  /**
-   * Add \p value to the element
-   * \p (i,j).  Throws an error if
-   * the entry does not
-   * exist. Still, it is allowed to
-   * store zero values in
-   * non-existent fields.
-   */
   virtual void add (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) libmesh_override;
 
-  /**
-   * Add the full matrix to the
-   * Laspack matrix.  This is useful
-   * for adding an element matrix
-   * at assembly time
-   */
   virtual void add_matrix (const DenseMatrix<T> & dm,
                            const std::vector<numeric_index_type> & rows,
                            const std::vector<numeric_index_type> & cols) libmesh_override;
 
-  /**
-   * Same, but assumes the row and column maps are the same.
-   * Thus the matrix \p dm must be square.
-   */
   virtual void add_matrix (const DenseMatrix<T> & dm,
                            const std::vector<numeric_index_type> & dof_indices) libmesh_override;
 
   /**
-   * Add a Sparse matrix \p X, scaled with \p a, to \p this,
-   * stores the result in \p this: \f$\texttt{this} += a*X \f$.
-   * \p LASPACK does not provide a true \p axpy for matrices,
+   * Compute A += a*X for scalar \p a, matrix \p X.
+   *
+   * \note LASPACK does not provide a true \p axpy for matrices,
    * so a hand-coded version with hopefully acceptable performance
    * is provided.
    */
   virtual void add (const T a, SparseMatrix<T> & X) libmesh_override;
 
-  /**
-   * Return the value of the entry
-   * \p (i,j).  This may be an
-   * expensive operation, and you
-   * should always be careful where
-   * you call this function.
-   */
   virtual T operator () (const numeric_index_type i,
                          const numeric_index_type j) const libmesh_override;
 
-  /**
-   * Return the l1-norm of the matrix, that is
-   * \f$|M|_1=max_{all columns j}\sum_{all
-   * rows i} |M_ij|\f$,
-   * (max. sum of columns).
-   * This is the
-   * natural matrix norm that is compatible
-   * to the l1-norm for vectors, i.e.
-   * \f$|Mv|_1\leq |M|_1 |v|_1\f$.
-   */
   virtual Real l1_norm () const libmesh_override { libmesh_not_implemented(); return 0.; }
 
-  /**
-   * Return the linfty-norm of the
-   * matrix, that is
-   * \f$|M|_\infty=max_{all rows i}\sum_{all
-   * columns j} |M_ij|\f$,
-   * (max. sum of rows).
-   * This is the
-   * natural matrix norm that is compatible
-   * to the linfty-norm of vectors, i.e.
-   * \f$|Mv|_\infty \leq |M|_\infty |v|_\infty\f$.
-   */
   virtual Real linfty_norm () const libmesh_override { libmesh_not_implemented(); return 0.; }
 
-  /**
-   * see if Laspack matrix has been closed
-   * and fully assembled yet
-   */
   virtual bool closed() const libmesh_override { return _closed; }
 
-  /**
-   * Print the contents of the matrix, by default to libMesh::out.
-   * Currently identical to \p print().
-   */
   virtual void print_personal(std::ostream & os=libMesh::out) const libmesh_override { this->print(os); }
 
-  /**
-   * Copies the diagonal part of the matrix into \p dest.
-   */
   virtual void get_diagonal (NumericVector<T> & dest) const libmesh_override;
 
-  /**
-   * Copies the transpose of the matrix into \p dest, which may be
-   * *this.
-   */
   virtual void get_transpose (SparseMatrix<T> & dest) const libmesh_override;
 
 private:

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -45,8 +45,9 @@ template <typename T> class LaspackLinearSolver;
 template <typename T> class SparseMatrix;
 
 /**
- * Laspack vector.  Provides a nice interface to the
- * Laspack C-based data structures for serial vectors.
+ * This class provides a nice interface to the Laspack C-based data
+ * structures for serial vectors.  All overridden virtual functions
+ * are documented in numeric_vector.h.
  *
  * \author Benjamin S. Kirk
  * \date 2002
@@ -97,84 +98,36 @@ public:
    */
   ~LaspackVector ();
 
-  /**
-   * Call the assemble functions
-   */
   virtual void close () libmesh_override;
 
-  /**
-   * Restores the \p LaspackVector to a pristine state.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Set all entries to zero. Equivalent to \p v = 0, but more obvious and
-   * faster.
-   */
   virtual void zero () libmesh_override;
 
-  /**
-   * \returns A smart pointer to a copy of this vector with the same
-   * type, size, and partitioning, but with all zero entries.
-   */
   virtual UniquePtr<NumericVector<T> > zero_clone () const libmesh_override;
 
-  /**
-   * \returns A smart pointer to a copy of this vector.
-   */
   virtual UniquePtr<NumericVector<T> > clone () const libmesh_override;
 
-  /**
-   * Change the dimension of the vector to \p N. The reserved memory
-   * for this vector remains unchanged if possible.  If \p N==0, all
-   * memory is freed. Therefore, if you want to resize the vector and
-   * release the memory not needed, you have to first call \p init(0)
-   * and then \p init(N). This behaviour is analogous to that of the
-   * STL containers.
-   *
-   * On \p fast==false, the vector is filled by zeros.
-   */
   virtual void init (const numeric_index_type N,
                      const numeric_index_type n_local,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType ptype=AUTOMATIC) libmesh_override;
 
-  /**
-   * Call \p init() with n_local = N.
-   */
   virtual void init (const numeric_index_type N,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType ptype=AUTOMATIC) libmesh_override;
 
-  /**
-   * Create a vector that holds tha local indices plus those specified
-   * in the \p ghost argument.
-   */
-  virtual void init (const numeric_index_type /*N*/,
-                     const numeric_index_type /*n_local*/,
-                     const std::vector<numeric_index_type> & /*ghost*/,
-                     const bool /*fast*/ = false,
+  virtual void init (const numeric_index_type N,
+                     const numeric_index_type n_local,
+                     const std::vector<numeric_index_type> & ghost,
+                     const bool fast = false,
                      const ParallelType = AUTOMATIC) libmesh_override;
 
-  /**
-   * Creates a vector that has the same dimension and storage type as
-   * \p other, including ghost dofs.
-   */
   virtual void init (const NumericVector<T> & other,
                      const bool fast = false) libmesh_override;
 
-  /**
-   * Sets all entries of the vector to the value \p s.
-   *
-   * \returns A reference to *this.
-   */
   virtual NumericVector<T> & operator= (const T s) libmesh_override;
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator= (const NumericVector<T> & v) libmesh_override;
 
   /**
@@ -184,133 +137,48 @@ public:
    */
   LaspackVector<T> & operator= (const LaspackVector<T> & v);
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator= (const std::vector<T> & v) libmesh_override;
 
-  /**
-   * \returns The minimum entry in the vector, or the minimum real
-   * part in the case of complex numbers.
-   */
   virtual Real min () const libmesh_override;
 
-  /**
-   * \returns The maximum entry in the vector, or the maximum real
-   * part in the case of complex numbers.
-   */
   virtual Real max () const libmesh_override;
 
-  /**
-   * \returns The sum of all values in the vector.
-   */
   virtual T sum () const libmesh_override;
 
-  /**
-   * \returns The \f$l_1\f$-norm of the vector, i.e. the sum of the
-   * absolute values.
-   */
   virtual Real l1_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_2\f$-norm of the vector, i.e. the square root
-   * of the sum of the squares of the entries.
-   */
   virtual Real l2_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_\infty\f$-norm of the vector, i.e. the maximum
-   * absolute value of the entries of the vector.
-   */
   virtual Real linfty_norm () const libmesh_override;
 
-  /**
-   * \returns The size of the vector.
-   */
   virtual numeric_index_type size () const libmesh_override;
 
-  /**
-   * \returns The local size of the vector, i.e. \p index_stop - \p index_start.
-   */
   virtual numeric_index_type local_size() const libmesh_override;
 
-  /**
-   * \returns The index of the first vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type first_local_index() const libmesh_override;
 
-  /**
-   * \returns The index of the last vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type last_local_index() const libmesh_override;
 
-  /**
-   * \returns A copy of the ith entry of the vector.
-   */
   virtual T operator() (const numeric_index_type i) const libmesh_override;
 
-  /**
-   * Add \p v to *this. Equivalent to \p U.add(1, V).
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator += (const NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Subtracts \p v from *this.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Pointwise division operator. Sets u(i) <- u(i)/v(i) for each
-   * entry in the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator /= (NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Sets u(i) <- 1/u(i) for each entry in the vector.
-   */
   virtual void reciprocal() libmesh_override;
 
-  /**
-   * Negates the imaginary component of each entry in the vector.
-   */
   virtual void conjugate() libmesh_override;
 
-  /**
-   * Sets v(i) = \p value.
-   */
   virtual void set (const numeric_index_type i, const T value) libmesh_override;
 
-  /**
-   * Adds \p value to each entry of the vector.
-   */
   virtual void add (const numeric_index_type i, const T value) libmesh_override;
 
-  /**
-   * Adds \p s to each entry of the vector.
-   */
   virtual void add (const T s) libmesh_override;
 
-  /**
-   * Vector addition. Sets u(i) <- u(i) + v(i) for each entry in the
-   * vector. Equivalent to calling \p operator+=().
-   */
   virtual void add (const NumericVector<T> & V) libmesh_override;
 
-  /**
-   * Vector addition with a scalar multiple. Sets u(i) <- u(i) + a *
-   * v(i) for each entry in the vector. Equivalent to calling \p
-   * operator+=().
-   */
   virtual void add (const T a, const NumericVector<T> & v) libmesh_override;
 
   /**
@@ -319,89 +187,38 @@ public:
    */
   using NumericVector<T>::add_vector;
 
-  /**
-   * Adds the product of a SparseMatrix \p A and a NumericVector \p
-   * v to this vector, i.e. \f$ u += A v \f$.
-   */
   virtual void add_vector (const NumericVector<T> & v,
                            const SparseMatrix<T> & A) libmesh_override;
 
-  /**
-   * Adds the product of a SparseMatrix \p A^T and a NumericVector \p
-   * v to this vector, i.e. \f$ u += A^T v \f$.
-   */
   virtual void add_vector_transpose (const NumericVector<T> & v,
                                      const SparseMatrix<T> & A) libmesh_override;
 
-  /**
-   * Scale each element of the vector by the given factor.
-   */
   virtual void scale (const T factor) libmesh_override;
 
-  /**
-   * Sets u(i) <- abs(u(i)) for each entry in the vector.
-   */
   virtual void abs() libmesh_override;
 
-  /**
-   * \returns The dot product of (*this) with the vector \p V.
-   */
   virtual T dot(const NumericVector<T> & V) const libmesh_override;
 
-  /**
-   * Creates a copy of the global vector in the local vector \p
-   * v_local.
-   */
   virtual void localize (std::vector<T> & v_local) const libmesh_override;
 
-  /**
-   * Same, but fills a \p NumericVector<T> instead of a \p
-   * std::vector.
-   */
   virtual void localize (NumericVector<T> & v_local) const libmesh_override;
 
-  /**
-   * Creates a local vector \p v_local containing only information
-   * relevant to this processor, as defined by the \p send_list.
-   */
   virtual void localize (NumericVector<T> & v_local,
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
-  /**
-   * Fill in the local std::vector "v_local" with the global indices
-   * given in "indices".  See numeric_vector.h for more details.
-   */
   virtual void localize (std::vector<T> & v_local,
                          const std::vector<numeric_index_type> & indices) const libmesh_override;
 
-  /**
-   * Updates a local vector with selected values from neighboring
-   * processors, as defined by \p send_list.
-   */
   virtual void localize (const numeric_index_type first_local_idx,
                          const numeric_index_type last_local_idx,
                          const std::vector<numeric_index_type> & send_list) libmesh_override;
 
-
-  /**
-   * Creates a local copy of the global vector in
-   * \p v_local only on processor \p proc_id.  By
-   * default the data is sent to processor 0.  This method
-   * is useful for outputting data from one processor.
-   */
   virtual void localize_to_one (std::vector<T> & v_local,
                                 const processor_id_type proc_id=0) const libmesh_override;
 
-  /**
-   * Computes the pointwise (i.e. component-wise) product of \p vec1
-   * and \p vec2 and stores the result in \p *this.
-   */
   virtual void pointwise_mult (const NumericVector<T> & vec1,
                                const NumericVector<T> & vec2) libmesh_override;
 
-  /**
-   * Swaps the raw QVector contents.
-   */
   virtual void swap (NumericVector<T> & v) libmesh_override;
 
 private:
@@ -420,7 +237,7 @@ private:
 
 
 
-//----------------------- ----------------------------------
+//----------------------------------------------------------
 // LaspackVector inline methods
 template <typename T>
 inline

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -476,7 +476,7 @@ public:
 
   /**
    * \f$U+=A^T*V\f$, add the product of the transpose of a \p
-   * SparseMatrix \p A_trans and a \p NumericVector \p V to \p this,
+   * SparseMatrix \p A and a \p NumericVector \p V to \p this,
    * where \p this=U.
    */
   virtual void add_vector_transpose (const NumericVector<T> & v,
@@ -651,7 +651,7 @@ public:
   }
 
   /**
-   * Print the contents of the matrix in Matlab's sparse matrix
+   * Print the contents of the vector in Matlab's sparse matrix
    * format. Optionally prints the vector to the file named \p name.
    * If \p name is not specified it is dumped to the screen.
    */
@@ -661,8 +661,8 @@ public:
   }
 
   /**
-   * Creates the subvector "subvector" from the indices in the "rows"
-   * array.  Similar to the \p create_submatrix() routine for the
+   * Fills in \p subvector from this vector using the indices in \p
+   * rows.  Similar to the \p create_submatrix() routine for the
    * SparseMatrix class, it is currently only implemented for
    * PetscVectors.
    */
@@ -673,8 +673,8 @@ public:
   }
 
   /**
-   * Exchanges the values/sizes of two vectors.  There should be
-   * enough indirection in subclasses to make this an O(1) header-swap
+   * Swaps the contents of this with \p v.  There should be enough
+   * indirection in subclasses to make this an O(1) header-swap
    * operation.
    */
   virtual void swap (NumericVector<T> & v);

--- a/include/numerics/parsed_fem_function.h
+++ b/include/numerics/parsed_fem_function.h
@@ -44,7 +44,8 @@ namespace libMesh
 
 /**
  * ParsedFEMFunction provides support for FParser-based parsed
- * functions in FEMSystem.
+ * functions in FEMSystem. All overridden virtual functions are
+ * documented in fem_function_base.h.
  *
  * \author Roy Stogner
  * \date 2014
@@ -69,44 +70,24 @@ public:
    */
   virtual ~ParsedFEMFunction () {}
 
-  // Re-parse with new expression
+  /**
+   * Re-parse with new expression.
+   */
   void reparse (const std::string & expression);
 
-  /**
-   * Prepares a context object for use.
-   */
   virtual void init_context (const FEMContext & c) libmesh_override;
 
-  /**
-   * \returns A new copy of the function.
-   *
-   * The new copy should be as "deep" as necessary to allow
-   * independent destruction and simultaneous evaluations of the
-   * copies in different threads.
-   */
   virtual UniquePtr<FEMFunctionBase<Output> > clone () const libmesh_override;
 
-  /**
-   * \returns The scalar function value at coordinate \p p and time \p
-   * time, which defaults to zero.
-   */
   virtual Output operator() (const FEMContext & c,
                              const Point & p,
                              const Real time = 0.) libmesh_override;
 
-  /**
-   * Evaluation function for time-dependent vector-valued functions.
-   * Sets output values in the passed-in \p output DenseVector.
-   */
   void operator() (const FEMContext & c,
                    const Point & p,
                    const Real time,
                    DenseVector<Output> & output) libmesh_override;
 
-  /**
-   * \returns The vector component \p i at coordinate \p p and time \p
-   * time.
-   */
   virtual Output component(const FEMContext & c,
                            unsigned int i,
                            const Point & p,

--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -46,11 +46,13 @@ namespace libMesh
 {
 
 /**
- * FEMFunction that returns a scalar value.
+ * A Function generated (via FParser) by parsing a mathematical
+ * expression. All overridden virtual functions are documented in
+ * function_base.h.
  *
  * \author Roy Stogner
  * \date 2012
- * \brief A Function generated (via FParser) by parsing a mathematical expression.
+ * \brief A Function defined by a std::string.
  */
 template <typename Output=Number, typename OutputGradient=Gradient>
 class ParsedFunction : public FunctionBase<Output>
@@ -67,7 +69,7 @@ public:
   void reparse (const std::string & expression);
 
   virtual Output operator() (const Point & p,
-                             const Real time = 0);
+                             const Real time = 0) libmesh_override;
 
   /**
    * Query if the automatic derivative generation was successful.
@@ -82,15 +84,11 @@ public:
 
   virtual void operator() (const Point & p,
                            const Real time,
-                           DenseVector<Output> & output);
+                           DenseVector<Output> & output) libmesh_override;
 
-  /**
-   * \returns The vector component \p i at coordinate \p p and time \p
-   * time.
-   */
   virtual Output component (unsigned int i,
                             const Point & p,
-                            Real time);
+                            Real time) libmesh_override;
 
   const std::string & expression() { return _expression; }
 
@@ -99,7 +97,7 @@ public:
    */
   virtual Output & getVarAddress(const std::string & variable_name);
 
-  virtual UniquePtr<FunctionBase<Output> > clone() const;
+  virtual UniquePtr<FunctionBase<Output> > clone() const libmesh_override;
 
   /**
    * \returns The value of an inline variable.

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -62,9 +62,9 @@ template <typename T> class DenseMatrix;
 
 
 /**
- * Petsc matrix. Provides a nice interface to the
- * Petsc C-based data structures for parallel,
- * sparse matrices.
+ * This class provides a nice interface to the PETSc C-based data
+ * structures for parallel, sparse matrices. All overridden virtual
+ * functions are documented in sparse_matrix.h.
  *
  * \author Benjamin S. Kirk
  * \date 2002
@@ -106,18 +106,6 @@ public:
    */
   ~PetscMatrix ();
 
-  /**
-   * Initialize a PetscMatrix with the specified sizes.
-   *
-   * \param m The global number of rows.
-   * \param n The global number of columns.
-   * \param m_l The local number of rows.
-   * \param n_l The local number of columns.
-   * \param nnz The number of on-diagonal nonzeros per row (defaults to 30).
-   * \param noz The number of off-diagonal nonzeros per row (defaults to 10).
-   * \param blocksize Optional value indicating dense coupled blocks
-   * for systems with multiple variables all of the same type.
-   */
   virtual void init (const numeric_index_type m,
                      const numeric_index_type n,
                      const numeric_index_type m_l,
@@ -127,15 +115,15 @@ public:
                      const numeric_index_type blocksize=1) libmesh_override;
 
   /**
-   * Initialize a Petsc matrix that is of global dimension \f$ m
-   * \times n \f$ with local dimensions \f$ m_l \times n_l \f$.
+   * Initialize a PETSc matrix.
    *
-   * \param n_nz array containing the number of nonzeros in each row
-   * of the DIAGONAL portion of the local submatrix.
-   * \param n_oz array containing the number of nonzeros in each row
-   * of the OFF-DIAGONAL portion of the local submatrix.
-   * \param blocksize Optional value indicating dense coupled blocks
-   * for systems with multiple variables all of the same type.
+   * \param m The global number of rows.
+   * \param n The global number of columns.
+   * \param m_l The local number of rows.
+   * \param n_l The local number of columns.
+   * \param n_nz array containing the number of nonzeros in each row of the DIAGONAL portion of the local submatrix.
+   * \param n_oz Array containing the number of nonzeros in each row of the OFF-DIAGONAL portion of the local submatrix.
+   * \param blocksize Optional value indicating dense coupled blocks for systems with multiple variables all of the same type.
    */
   void init (const numeric_index_type m,
              const numeric_index_type n,
@@ -145,9 +133,6 @@ public:
              const std::vector<numeric_index_type> & n_oz,
              const numeric_index_type blocksize=1);
 
-  /**
-   * Initialize using sparsity structure computed by \p dof_map.
-   */
   virtual void init () libmesh_override;
 
   /**
@@ -157,96 +142,41 @@ public:
    */
   void update_preallocation_and_zero();
 
-  /**
-   * Release all memory, and go back to the default-constructed state.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Set all entries to 0. This method retains sparsity structure.
-   */
   virtual void zero () libmesh_override;
 
-  /**
-   * Set all row entries to 0 then puts \p diag_value on the diagonal.
-   */
   virtual void zero_rows (std::vector<numeric_index_type> & rows, T diag_value = 0.0) libmesh_override;
 
-  /**
-   * Call the Petsc assemble routines. Sends/receives required values from
-   * other processors.
-   */
   virtual void close () const libmesh_override;
 
-  /**
-   * \returns The row-dimension of the matrix.
-   */
   virtual numeric_index_type m () const libmesh_override;
 
-  /**
-   * \returns The column-dimension of the matrix.
-   */
   virtual numeric_index_type n () const libmesh_override;
 
-  /**
-   * \returns The index of the first matrix row stored on this
-   * processor.
-   */
   virtual numeric_index_type row_start () const libmesh_override;
 
-  /**
-   * \returns The index of the last matrix row (+1) stored on this
-   * processor.
-   */
   virtual numeric_index_type row_stop () const libmesh_override;
 
-  /**
-   * Set the element \p (i,j) to \p value.  Throws an error if the
-   * entry does not exist. Zero values can be "stored" in non-existent
-   * fields.
-   */
   virtual void set (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) libmesh_override;
 
-  /**
-   * Add \p value to the element \p (i,j).  Throws an error if the
-   * entry does not exist. Zero values can be "added" to non-existent
-   * entries.
-   */
   virtual void add (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) libmesh_override;
 
-  /**
-   * Add the DenseMatrix to the Petsc matrix.  This is useful for
-   * adding an element matrix at assembly time.
-   */
   virtual void add_matrix (const DenseMatrix<T> & dm,
                            const std::vector<numeric_index_type> & rows,
                            const std::vector<numeric_index_type> & cols) libmesh_override;
 
-  /**
-   * Same, but assumes the row and column maps are the same.  Thus the
-   * matrix \p dm must be square.
-   */
   virtual void add_matrix (const DenseMatrix<T> & dm,
                            const std::vector<numeric_index_type> & dof_indices) libmesh_override;
 
-  /**
-   * Add the full matrix \p dm to the Sparse matrix.  This is useful
-   * for adding an element matrix at assembly time.  The matrix is
-   * assumed blocked, and \p brow, \p bcol correspond to the *block*
-   * row, columm indices.
-   */
   virtual void add_block_matrix (const DenseMatrix<T> & dm,
                                  const std::vector<numeric_index_type> & brows,
                                  const std::vector<numeric_index_type> & bcols) libmesh_override;
 
-  /**
-   * Same as \p add_block_matrix , but assumes the row and column maps are the same.
-   * Thus the matrix \p dm must be square.
-   */
   virtual void add_block_matrix (const DenseMatrix<T> & dm,
                                  const std::vector<numeric_index_type> & dof_indices) libmesh_override
   { this->add_block_matrix (dm, dof_indices, dof_indices); }
@@ -266,69 +196,32 @@ public:
    */
   virtual void add (const T a, SparseMatrix<T> & X) libmesh_override;
 
-  /**
-   * \returns A copy of matrix entry \p (i,j).
-   *
-   * \note This may be an expensive operation, and you should always
-   * be careful where you call this function.
-   */
   virtual T operator () (const numeric_index_type i,
                          const numeric_index_type j) const libmesh_override;
 
-  /**
-   * \returns The l1-norm of the matrix, that is the max column sum:
-   * \f$ |M|_1 = \max_{all columns j} \sum_{all rows i} |M_ij|\f$
-   *
-   * This is the natural matrix norm that is compatible with the
-   * l1-norm for vectors, i.e. \f$ |Mv|_1 \leq |M|_1 |v|_1 \f$.
-   * (cf. Haemmerlin-Hoffmann : Numerische Mathematik)
-   */
   virtual Real l1_norm () const libmesh_override;
 
-  /**
-   * Return the linfty-norm of the matrix, that is the max row sum:
-   *
-   * \f$ |M|_infty = \max_{all rows i} \sum_{all columns j} |M_ij| \f$
-   *
-   * This is the natural matrix norm that is compatible to the
-   * linfty-norm of vectors, i.e. \f$ |Mv|_infty \leq |M|_infty |v|_infty \f$.
-   * (cf. Haemmerlin-Hoffmann : Numerische Mathematik)
-   */
   virtual Real linfty_norm () const libmesh_override;
 
-  /**
-   * \returns \p true If the matrix's assembly routines have been called.
-   */
   virtual bool closed() const libmesh_override;
 
   /**
    * Print the contents of the matrix to the screen with the PETSc
-   * viewer. This function only allows printing to standard out, this
-   * is because we have limited ourselves to one PETSc implementation
-   * for writing.
+   * viewer. This function only allows printing to standard out since
+   * we have limited ourselves to one PETSc implementation for
+   * writing.
    */
   virtual void print_personal(std::ostream & os=libMesh::out) const libmesh_override;
 
-  /**
-   * Print the contents of the matrix in Matlab's sparse matrix
-   * format. Optionally prints the matrix to the file named \p name.
-   * If \p name is not specified it is dumped to the screen.
-   */
   virtual void print_matlab(const std::string & name = "") const libmesh_override;
 
-  /**
-   * Copies the diagonal part of the matrix into \p dest.
-   */
   virtual void get_diagonal (NumericVector<T> & dest) const libmesh_override;
 
-  /**
-   * Copies the transpose of the matrix into \p dest, which may be
-   * *this.
-   */
   virtual void get_transpose (SparseMatrix<T> & dest) const libmesh_override;
 
   /**
-   * Swaps the internal data pointers, no actual values are swapped.
+   * Swaps the internal data pointers of two PetscMatrices, no actual
+   * values are swapped.
    */
   void swap (PetscMatrix<T> &);
 
@@ -349,10 +242,10 @@ protected:
    * submatrix which is defined by the indices given in the \p rows
    * and \p cols vectors.
    *
-   * This function is implemented in terms of the MatGetSubMatrix()
-   * routine of PETSc.  The \p reuse_submatrix parameter determines
-   * whether or not PETSc will treat \p submatrix as one which has
-   * already been used (had memory allocated) or as a new matrix.
+   * This function is implemented in terms of MatGetSubMatrix().  The
+   * \p reuse_submatrix parameter determines whether or not PETSc will
+   * treat \p submatrix as one which has already been used (had memory
+   * allocated) or as a new matrix.
    */
   virtual void _get_submatrix(SparseMatrix<T> & submatrix,
                               const std::vector<numeric_index_type> & rows,
@@ -362,7 +255,7 @@ protected:
 private:
 
   /**
-   * Petsc matrix datatype to store values.
+   * PETSc matrix datatype to store values.
    */
   Mat _mat;
 

--- a/include/numerics/petsc_preconditioner.h
+++ b/include/numerics/petsc_preconditioner.h
@@ -45,8 +45,9 @@ template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
 
 /**
- * This class provides an interface to the suite of preconditioners available
- * from PETSc.
+ * This class provides an interface to the suite of preconditioners
+ * available from PETSc. All overridden virtual functions are
+ * documented in preconditioner.h.
  *
  * \author Derek Gaston
  * \date 2009
@@ -67,21 +68,10 @@ public:
    */
   virtual ~PetscPreconditioner ();
 
-  /**
-   * Computes the preconditioned vector \p y based on input vector \p
-   * x. This is usually done by solving \f$ Py=x \f$ to get the
-   * action of \f$ P^-1 x \f$.
-   */
   virtual void apply(const NumericVector<T> & x, NumericVector<T> & y) libmesh_override;
 
-  /**
-   * Release all memory and clear data structures.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Initialize data structures if not done so already.
-   */
   virtual void init () libmesh_override;
 
   /**

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -33,7 +33,7 @@
 #include "libmesh/petsc_solver_exception.h"
 #include LIBMESH_INCLUDE_UNORDERED_MAP
 
-// Petsc include files.
+// PETSc include files.
 #include <petscvec.h>
 
 // C++ includes
@@ -53,7 +53,8 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 
 /**
- * This class provides a nice interface to PETSc's Vec object.
+ * This class provides a nice interface to PETSc's Vec object.  All
+ * overridden virtual functions are documented in numeric_vector.h.
  *
  * \author Benjamin S. Kirk
  * \date 2002
@@ -116,85 +117,39 @@ public:
    */
   ~PetscVector ();
 
-  /**
-   * Call the assemble functions
-   */
   virtual void close () libmesh_override;
 
-  /**
-   * Restores the \p PetscVector<T> to a pristine state.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Set all entries to zero. Equivalent to \p v = 0, but more obvious and
-   * faster.
-   */
   virtual void zero () libmesh_override;
 
-  /**
-   * \returns A smart pointer to a copy of this vector with the same
-   * type, size, and partitioning, but with all zero entries.
-   */
   virtual UniquePtr<NumericVector<T> > zero_clone () const libmesh_override;
 
-  /**
-   * \returns A copy of this vector wrapped in a smart pointer.
-   */
   virtual UniquePtr<NumericVector<T> > clone () const libmesh_override;
 
-  /**
-   * Change the dimension of the vector to \p N. The reserved memory
-   * for this vector remains unchanged if possible.  If \p N==0, all
-   * memory is freed. Therefore, if you want to resize the vector and
-   * release the memory not needed, you have to first call \p init(0)
-   * and then \p init(N). This behaviour is analogous to that of the
-   * STL containers.
-   *
-   * On \p fast==false, the vector is filled by zeros.
-   */
   virtual void init (const numeric_index_type N,
                      const numeric_index_type n_local,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType type=AUTOMATIC) libmesh_override;
 
-  /**
-   * Call \p init() with n_local = N.
-   */
   virtual void init (const numeric_index_type N,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType type=AUTOMATIC) libmesh_override;
 
-  /**
-   * Create a vector that holds tha local indices plus those specified
-   * in the \p ghost argument.
-   */
-  virtual void init (const numeric_index_type /*N*/,
-                     const numeric_index_type /*n_local*/,
-                     const std::vector<numeric_index_type> & /*ghost*/,
-                     const bool /*fast*/ = false,
+  virtual void init (const numeric_index_type N,
+                     const numeric_index_type n_local,
+                     const std::vector<numeric_index_type> & ghost,
+                     const bool fast = false,
                      const ParallelType = AUTOMATIC) libmesh_override;
 
-  /**
-   * Creates a vector that has the same dimension and storage type as
-   * \p other, including ghost dofs.
-   */
   virtual void init (const NumericVector<T> & other,
                      const bool fast = false) libmesh_override;
 
-  /**
-   * Sets all entries of the vector to the value \p s.
-   *
-   * \returns A reference to *this.
-   */
   virtual NumericVector<T> & operator= (const T s) libmesh_override;
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator= (const NumericVector<T> & V) libmesh_override;
+
+  virtual NumericVector<T> & operator= (const std::vector<T> & v) libmesh_override;
 
   /**
    * Sets (*this)(i) = v(i) for each entry of the vector.
@@ -203,68 +158,24 @@ public:
    */
   PetscVector<T> & operator= (const PetscVector<T> & V);
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
-  virtual NumericVector<T> & operator= (const std::vector<T> & v) libmesh_override;
-
-  /**
-   * \returns The minimum entry in the vector, or the minimum real
-   * part in the case of complex numbers.
-   */
   virtual Real min () const libmesh_override;
 
-  /**
-   * \returns The maximum entry in the vector, or the maximum real
-   * part in the case of complex numbers.
-   */
   virtual Real max () const libmesh_override;
 
-  /**
-   * \returns The sum of all values in the vector.
-   */
   virtual T sum () const libmesh_override;
 
-  /**
-   * \returns The \f$ l_1 \f$-norm of the vector, i.e. the sum of the
-   * absolute values of the entries.
-   */
   virtual Real l1_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_2\f$-norm of the vector, i.e. the square root
-   * of the sum of the squares of the entries.
-   */
   virtual Real l2_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_\infty\f$-norm of the vector, i.e. the maximum
-   * absolute value of the entries of the vector.
-   */
   virtual Real linfty_norm () const libmesh_override;
 
-  /**
-   * \returns The size of the vector.
-   */
   virtual numeric_index_type size () const libmesh_override;
 
-  /**
-   * \returns The local size of the vector, i.e. \p index_stop - \p index_start.
-   */
   virtual numeric_index_type local_size() const libmesh_override;
 
-  /**
-   * \returns The index of the first vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type first_local_index() const libmesh_override;
 
-  /**
-   * \returns The index of the last vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type last_local_index() const libmesh_override;
 
   /**
@@ -276,17 +187,8 @@ public:
    */
   numeric_index_type map_global_to_local_index(const numeric_index_type i) const;
 
-  /**
-   * \returns A copy of the ith entry of the vector.
-   */
   virtual T operator() (const numeric_index_type i) const libmesh_override;
 
-  /**
-   * Access multiple components at once.  \p values will *not* be
-   * reallocated; it should already have enough space.  This method
-   * should be faster (probably much faster) than calling \p
-   * operator() individually for each index.
-   */
   virtual void get(const std::vector<numeric_index_type> & index,
                    T * values) const libmesh_override;
 
@@ -294,7 +196,7 @@ public:
    * Get read/write access to the raw PETSc Vector data array.
    *
    * \note This is an advanced interface. In general you should avoid
-   * using it!
+   * using it unless you know what you are doing!
    */
   PetscScalar * get_array();
 
@@ -302,7 +204,7 @@ public:
    * Get read only access to the raw PETSc Vector data array.
    *
    * \note This is an advanced interface. In general you should avoid
-   * using it!
+   * using it unless you know what you are doing!
    */
   const PetscScalar * get_array_read() const;
 
@@ -314,58 +216,24 @@ public:
    */
   void restore_array();
 
-  /**
-   * Add \p V to *this. Equivalent to \p U.add(1, V).
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator += (const NumericVector<T> & V) libmesh_override;
 
-  /**
-   * Subtracts \p V from *this.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator -= (const NumericVector<T> & V) libmesh_override;
 
-  /**
-   * Sets u(i) <- 1/u(i) for each entry in the vector.
-   */
   virtual void reciprocal() libmesh_override;
 
-  /**
-   * Negates the imaginary component of each entry in the vector.
-   */
   virtual void conjugate() libmesh_override;
 
-  /**
-   * Sets v(i) = \p value.
-   */
   virtual void set (const numeric_index_type i,
                     const T value) libmesh_override;
 
-  /**
-   * Adds \p value to each entry of the vector.
-   */
   virtual void add (const numeric_index_type i,
                     const T value) libmesh_override;
 
-  /**
-   * Adds \p s to each entry of the vector.
-   */
   virtual void add (const T s) libmesh_override;
 
-  /**
-   * Vector addition. Sets u(i) <- u(i) + v(i) for each entry in the
-   * vector. Equivalent to calling \p operator+=().
-   */
   virtual void add (const NumericVector<T> & V) libmesh_override;
 
-  /**
-   * Vector addition with a scalar multiple. Sets u(i) <- u(i) + a *
-   * v(i) for each entry in the vector. Equivalent to calling \p
-   * operator+=().
-   */
   virtual void add (const T a, const NumericVector<T> & v) libmesh_override;
 
   /**
@@ -374,25 +242,12 @@ public:
    */
   using NumericVector<T>::add_vector;
 
-  /**
-   * \f$ U+=v \f$ where v is a pointer and each \p dof_indices[i]
-   * specifies where to add value \p v[i]
-   */
   virtual void add_vector (const T * v,
                            const std::vector<numeric_index_type> & dof_indices) libmesh_override;
 
-  /**
-   * \f$U+=A*V\f$, add the product of a \p SparseMatrix \p A
-   * and a \p NumericVector \p V to \p this, where \p this=U.
-   */
   virtual void add_vector (const NumericVector<T> & V,
                            const SparseMatrix<T> & A) libmesh_override;
 
-  /**
-   * \f$ U \leftarrow U + A^T v \f$, add the product of the transpose
-   * of \p SparseMatrix \p A and a \p NumericVector \p v to
-   * \p this, where \p this=U.
-   */
   virtual void add_vector_transpose (const NumericVector<T> & v,
                                      const SparseMatrix<T> & A) libmesh_override;
 
@@ -411,36 +266,15 @@ public:
    */
   using NumericVector<T>::insert;
 
-  /**
-   * \f$ U=v \f$ where v is a \p T[] or T * and you want to specify
-   * WHERE to insert it.
-   */
   virtual void insert (const T * v,
                        const std::vector<numeric_index_type> & dof_indices) libmesh_override;
 
-  /**
-   * Scale each element of the vector by the given \p factor.
-   */
   virtual void scale (const T factor) libmesh_override;
 
-  /**
-   * Pointwise division operator. Sets u(i) <- u(i)/v(i) for each
-   * entry in the vector.
-   *
-   * \returns A reference to *this.
-   */
   virtual NumericVector<T> & operator /= (NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Sets u(i) <- abs(u(i)) for each entry in the vector.
-   */
   virtual void abs() libmesh_override;
 
-  /**
-   * \returns The dot product of (*this) with the vector \p v.
-   *
-   * \note Uses the complex-conjugate of v in the complex-valued case.
-   */
   virtual T dot(const NumericVector<T> & v) const libmesh_override;
 
   /**
@@ -450,71 +284,31 @@ public:
    */
   T indefinite_dot(const NumericVector<T> & v) const;
 
-  /**
-   * Creates a copy of the global vector in the local vector \p
-   * v_local.
-   */
   virtual void localize (std::vector<T> & v_local) const libmesh_override;
 
-  /**
-   * Same, but fills a \p NumericVector<T> instead of a \p
-   * std::vector.
-   */
   virtual void localize (NumericVector<T> & v_local) const libmesh_override;
 
-  /**
-   * Creates a local vector \p v_local containing only information
-   * relevant to this processor, as defined by the \p send_list.
-   */
   virtual void localize (NumericVector<T> & v_local,
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
-  /**
-   * Fill in the local std::vector "v_local" with the global indices
-   * given in "indices".  See numeric_vector.h for more details.
-   */
   virtual void localize (std::vector<T> & v_local,
                          const std::vector<numeric_index_type> & indices) const libmesh_override;
 
-  /**
-   * Updates a local vector with selected values from neighboring
-   * processors, as defined by \p send_list.
-   */
   virtual void localize (const numeric_index_type first_local_idx,
                          const numeric_index_type last_local_idx,
                          const std::vector<numeric_index_type> & send_list) libmesh_override;
 
-  /**
-   * Creates a local copy of the global vector in \p v_local only on
-   * processor \p proc_id.  By default the data is sent to processor
-   * 0.  This method is useful for outputting data from one processor.
-   */
   virtual void localize_to_one (std::vector<T> & v_local,
                                 const processor_id_type proc_id=0) const libmesh_override;
 
-  /**
-   * Computes the pointwise (i.e. component-wise) product of \p vec1
-   * and \p vec2 and stores the result in \p *this.
-   */
   virtual void pointwise_mult (const NumericVector<T> & vec1,
                                const NumericVector<T> & vec2) libmesh_override;
 
-  /**
-   * Print the contents of the vector in Matlab format. Optionally
-   * prints the matrix to the file named \p name.  If \p name is not
-   * specified it is dumped to the screen.
-   */
   virtual void print_matlab(const std::string & name = "") const libmesh_override;
 
-  /**
-   * Fills in \p subvector from this vector using the indices in \p rows.
-   */
   virtual void create_subvector(NumericVector<T> & subvector,
                                 const std::vector<numeric_index_type> & rows) const libmesh_override;
 
-  /**
-   * Swaps the raw PETSc vector context pointers.
-   */
   virtual void swap (NumericVector<T> & v) libmesh_override;
 
   /**
@@ -531,12 +325,12 @@ public:
 private:
 
   /**
-   * Actual Petsc vector datatype to hold vector entries.
+   * Actual PETSc vector datatype to hold vector entries.
    */
   Vec _vec;
 
   /**
-   * If \p true, the actual Petsc array of the values of the vector is
+   * If \p true, the actual PETSc array of the values of the vector is
    * currently accessible.  That means that the members \p _local_form
    * and \p _values are valid.
    */
@@ -567,16 +361,16 @@ private:
   mutable numeric_index_type _local_size;
 
   /**
-   * Petsc vector datatype to hold the local form of a ghosted vector.
+   * PETSc vector datatype to hold the local form of a ghosted vector.
    * The contents of this field are only valid if the vector is
    * ghosted and \p _array_is_present is \p true.
    */
   mutable Vec _local_form;
 
   /**
-   * Pointer to the actual Petsc array of the values of the vector.
+   * Pointer to the actual PETSc array of the values of the vector.
    * This pointer is only valid if \p _array_is_present is \p true.
-   * We're using Petsc's VecGetArrayRead() function, which requires a
+   * We're using PETSc's VecGetArrayRead() function, which requires a
    * constant PetscScalar *, but _get_array and _restore_array are
    * const member functions, so _values also needs to be mutable
    * (otherwise it is a "const PetscScalar * const" in that context).
@@ -584,9 +378,9 @@ private:
   mutable const PetscScalar * _read_only_values;
 
   /**
-   * Pointer to the actual Petsc array of the values of the vector.
+   * Pointer to the actual PETSc array of the values of the vector.
    * This pointer is only valid if \p _array_is_present is \p true.
-   * We're using Petsc's VecGetArrayRead() function, which requires a
+   * We're using PETSc's VecGetArrayRead() function, which requires a
    * constant PetscScalar *, but _get_array and _restore_array are
    * const member functions, so _values also needs to be mutable
    * (otherwise it is a "const PetscScalar * const" in that context).
@@ -606,7 +400,7 @@ private:
 
   /**
    * Queries the array (and the local form if the vector is ghosted)
-   * from Petsc.
+   * from PETSc.
    *
    * \param read_only Whether or not a read only copy of the raw data
    */
@@ -614,7 +408,7 @@ private:
 
   /**
    * Restores the array (and the local form if the vector is ghosted)
-   * to Petsc.
+   * to PETSc.
    */
   void _restore_array() const;
 
@@ -758,7 +552,7 @@ PetscVector<T>::PetscVector (Vec v,
   LIBMESH_CHKERR(ierr);
 
   // Get the vector type from PETSc.
-  // As of Petsc 3.0.0, the VecType #define lost its const-ness, so we
+  // As of PETSc 3.0.0, the VecType #define lost its const-ness, so we
   // need to have it in the code
 #if PETSC_VERSION_LESS_THAN(3,0,0) || !PETSC_VERSION_LESS_THAN(3,4,0)
   // Pre-3.0 and petsc-dev (as of October 2012) use non-const versions

--- a/include/numerics/sparse_shell_matrix.h
+++ b/include/numerics/sparse_shell_matrix.h
@@ -33,6 +33,8 @@ namespace libMesh
 
 /**
  * This class allows to use any SparseMatrix object as a shell matrix.
+ * All overridden virtual functions are documented in
+ * shell_matrix.h.
  *
  * \author Tim Kroeger
  * \date 2008
@@ -53,34 +55,16 @@ public:
    */
   virtual ~SparseShellMatrix ();
 
-  /**
-   * \returns \p m, the row-dimension of the matrix where the marix is
-   * \f$ M \times N \f$.
-   */
   virtual numeric_index_type m () const libmesh_override;
 
-  /**
-   * \returns \p n, the column-dimension of the matrix where the marix
-   * is \f$ M \times N \f$.
-   */
   virtual numeric_index_type n () const libmesh_override;
 
-  /**
-   * Multiplies the matrix with \p arg and stores the result in \p
-   * dest.
-   */
   virtual void vector_mult (NumericVector<T> & dest,
                             const NumericVector<T> & arg) const libmesh_override;
 
-  /**
-   * Multiplies the matrix with \p arg and adds the result to \p dest.
-   */
   virtual void vector_mult_add (NumericVector<T> & dest,
                                 const NumericVector<T> & arg) const libmesh_override;
 
-  /**
-   * Copies the diagonal part of the matrix into \p dest.
-   */
   virtual void get_diagonal (NumericVector<T> & dest) const libmesh_override;
 
 protected:

--- a/include/numerics/sum_shell_matrix.h
+++ b/include/numerics/sum_shell_matrix.h
@@ -34,7 +34,8 @@ namespace libMesh
 
 /**
  * This class combines any number of shell matrices to a single shell
- * matrix, acting as the sum of the matrices.
+ * matrix by summing them together. All overridden virtual functions
+ * are documented in shell_matrix.h.
  *
  * \author Tim Kroeger
  * \date 2008
@@ -65,38 +66,20 @@ public:
    */
   virtual ~SumShellMatrix ();
 
-  /**
-   * \returns \p m, the row-dimension of the matrix where the marix is
-   * \f$ M \times N \f$.
-   */
   virtual numeric_index_type m () const libmesh_override;
 
-  /**
-   * \returns \p n, the column-dimension of the matrix where the marix
-   * is \f$ M \times N \f$.
-   */
   virtual numeric_index_type n () const libmesh_override;
 
-  /**
-   * Multiplies the matrix with \p arg and stores the result in \p
-   * dest.
-   */
   virtual void vector_mult (NumericVector<T> & dest,
                             const NumericVector<T> & arg) const libmesh_override;
 
-  /**
-   * Multiplies the matrix with \p arg and adds the result to \p dest.
-   */
   virtual void vector_mult_add (NumericVector<T> & dest,
                                 const NumericVector<T> & arg) const libmesh_override;
 
-  /**
-   * Copies the diagonal part of the matrix into \p dest.
-   */
   virtual void get_diagonal (NumericVector<T> & dest) const libmesh_override;
 
   /**
-   * A vector of the summands.
+   * A vector of pointers to the summands.
    */
   std::vector<ShellMatrix<T> *> matrices;
 };

--- a/include/numerics/tensor_shell_matrix.h
+++ b/include/numerics/tensor_shell_matrix.h
@@ -32,8 +32,9 @@ namespace libMesh
 {
 
 /**
- * Shell matrix that is given by a tensor of two vectors, i.e. A =
- * v*w^T.
+ * Shell matrix that is given by a tensor product of two vectors,
+ * i.e. A = v*w^T. All overridden virtual functions are documented in
+ * shell_matrix.h.
  *
  * \author Tim Kroeger
  * \date 2008
@@ -54,34 +55,16 @@ public:
    */
   virtual ~TensorShellMatrix ();
 
-  /**
-   * \returns \p m, the row-dimension of the matrix where the marix is
-   * \f$ M \times N \f$.
-   */
   virtual numeric_index_type m () const libmesh_override;
 
-  /**
-   * \returns \p n, the column-dimension of the matrix where the marix
-   * is \f$ M \times N \f$.
-   */
   virtual numeric_index_type n () const libmesh_override;
 
-  /**
-   * Multiplies the matrix with \p arg and stores the result in \p
-   * dest.
-   */
   virtual void vector_mult (NumericVector<T> & dest,
                             const NumericVector<T> & arg) const libmesh_override;
 
-  /**
-   * Multiplies the matrix with \p arg and adds the result to \p dest.
-   */
   virtual void vector_mult_add (NumericVector<T> & dest,
                                 const NumericVector<T> & arg) const libmesh_override;
 
-  /**
-   * Copies the diagonal part of the matrix into \p dest.
-   */
   virtual void get_diagonal (NumericVector<T> & dest) const libmesh_override;
 
 protected:

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -53,7 +53,8 @@ template <typename T> class DenseMatrix;
 
 /**
  * This class provides a nice interface to the Epetra data structures
- * for parallel, sparse matrices.
+ * for parallel, sparse matrices. All overridden virtual functions are
+ * documented in sparse_matrix.h.
  *
  * \author Benjamin S. Kirk
  * \date 2008
@@ -106,18 +107,6 @@ public:
    */
   virtual void update_sparsity_pattern (const SparsityPattern::Graph &) libmesh_override;
 
-  /**
-   * Initialize an EpetraMatrix with the specified sizes.
-   *
-   * \param m The global number of rows.
-   * \param n The global number of columns.
-   * \param m_l The local number of rows.
-   * \param n_l The local number of columns.
-   * \param nnz The number of on-diagonal nonzeros per row (defaults to 30).
-   * \param noz The number of off-diagonal nonzeros per row (defaults to 10).
-   * \param blocksize Optional value indicating dense coupled blocks
-   * for systems with multiple variables all of the same type.
-   */
   virtual void init (const numeric_index_type m,
                      const numeric_index_type n,
                      const numeric_index_type m_l,
@@ -126,79 +115,34 @@ public:
                      const numeric_index_type noz=10,
                      const numeric_index_type blocksize=1) libmesh_override;
 
-  /**
-   * Initialize using sparsity structure computed by \p dof_map.
-   */
   virtual void init () libmesh_override;
 
-  /**
-   * Release all memory, and go back to the default-constructed state.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Set all entries to 0. This method retains sparsity structure.
-   */
   virtual void zero () libmesh_override;
 
-  /**
-   * Call the matrix's internal assembly routines. Sends/receives
-   * required values from other processors.
-   */
   virtual void close () const libmesh_override;
 
-  /**
-   * \returns The row-dimension of the matrix.
-   */
   virtual numeric_index_type m () const libmesh_override;
 
-  /**
-   * \returns The column-dimension of the matrix.
-   */
   virtual numeric_index_type n () const libmesh_override;
 
-  /**
-   * \returns The index of the first matrix row stored on this
-   * processor.
-   */
   virtual numeric_index_type row_start () const libmesh_override;
 
-  /**
-   * \returns The index of the last matrix row (+1) stored on this
-   * processor.
-   */
   virtual numeric_index_type row_stop () const libmesh_override;
 
-  /**
-   * Set the element \p (i,j) to \p value.  Throws an error if the
-   * entry does not exist. Zero values can be "stored" in non-existent
-   * fields.
-   */
   virtual void set (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) libmesh_override;
 
-  /**
-   * Add \p value to the element \p (i,j).  Throws an error if the
-   * entry does not exist. Zero values can be "added" to non-existent
-   * entries.
-   */
   virtual void add (const numeric_index_type i,
                     const numeric_index_type j,
                     const T value) libmesh_override;
 
-  /**
-   * Add the DenseMatrix to this SparseMatrix.  This is useful for
-   * adding an element matrix at assembly time.
-   */
   virtual void add_matrix (const DenseMatrix<T> & dm,
                            const std::vector<numeric_index_type> & rows,
                            const std::vector<numeric_index_type> & cols) libmesh_override;
 
-  /**
-   * Same, but assumes the row and column maps are the same.  Thus the
-   * matrix \p dm must be square.
-   */
   virtual void add_matrix (const DenseMatrix<T> & dm,
                            const std::vector<numeric_index_type> & dof_indices) libmesh_override;
 
@@ -214,55 +158,19 @@ public:
    */
   virtual void add (const T a, SparseMatrix<T> & X) libmesh_override;
 
-  /**
-   * \returns A copy of matrix entry \p (i,j).
-   *
-   * \note This may be an expensive operation, and you should always
-   * be careful where you call this function.
-   */
   virtual T operator () (const numeric_index_type i,
                          const numeric_index_type j) const libmesh_override;
 
-  /**
-   * \returns The l1-norm of the matrix, that is the max column sum:
-   * \f$ |M|_1 = \max_{all columns j} \sum_{all rows i} |M_ij|\f$
-   *
-   * This is the natural matrix norm that is compatible with the
-   * l1-norm for vectors, i.e. \f$ |Mv|_1 \leq |M|_1 |v|_1 \f$.
-   * (cf. Haemmerlin-Hoffmann : Numerische Mathematik)
-   */
   virtual Real l1_norm () const libmesh_override;
 
-  /**
-   * Return the linfty-norm of the matrix, that is the max row sum:
-   *
-   * \f$ |M|_infty = \max_{all rows i} \sum_{all columns j} |M_ij| \f$
-   *
-   * This is the natural matrix norm that is compatible to the
-   * linfty-norm of vectors, i.e. \f$ |Mv|_infty \leq |M|_infty |v|_infty \f$.
-   * (cf. Haemmerlin-Hoffmann : Numerische Mathematik)
-   */
   virtual Real linfty_norm () const libmesh_override;
 
-  /**
-   * \returns \p true If the matrix's assembly routines have been called.
-   */
   virtual bool closed() const libmesh_override;
 
-  /**
-   * Print the contents of the matrix, by default to libMesh::out.
-   */
   virtual void print_personal(std::ostream & os=libMesh::out) const libmesh_override;
 
-  /**
-   * Copies the diagonal part of the matrix into \p dest.
-   */
   virtual void get_diagonal (NumericVector<T> & dest) const libmesh_override;
 
-  /**
-   * Copies the transpose of the matrix into \p dest, which may be
-   * *this.
-   */
   virtual void get_transpose (SparseMatrix<T> & dest) const libmesh_override;
 
   /**

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -52,7 +52,8 @@ template <typename T> class SparseMatrix;
 
 /**
  * This class provides a nice interface to the Trilinos Epetra_Vector
- * object.
+ * object. All overridden virtual functions are documented in
+ * numeric_vector.h.
  *
  * \author Derek R. Gaston
  * \date 2008
@@ -114,84 +115,36 @@ public:
    */
   ~EpetraVector ();
 
-  /**
-   * Call the assemble functions
-   */
   virtual void close () libmesh_override;
 
-  /**
-   * Restores the \p EpetraVector<T> to a pristine state.
-   */
   virtual void clear () libmesh_override;
 
-  /**
-   * Set all entries to zero. Equivalent to \p v = 0, but more obvious and
-   * faster.
-   */
   virtual void zero () libmesh_override;
 
-  /**
-   * \returns A smart pointer to a copy of this vector with the same
-   * type, size, and partitioning, but with all zero entries.
-   */
   virtual UniquePtr<NumericVector<T> > zero_clone () const libmesh_override;
 
-  /**
-   * \returns A copy of this vector wrapped in a smart pointer.
-   */
   virtual UniquePtr<NumericVector<T> > clone () const libmesh_override;
 
-  /**
-   * Change the dimension of the vector to \p N. The reserved memory
-   * for this vector remains unchanged if possible.  If \p N==0, all
-   * memory is freed. Therefore, if you want to resize the vector and
-   * release the memory not needed, you have to first call \p init(0)
-   * and then \p init(N). This behaviour is analogous to that of the
-   * STL containers.
-   *
-   * On \p fast==false, the vector is filled by zeros.
-   */
   virtual void init (const numeric_index_type N,
                      const numeric_index_type n_local,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType type=AUTOMATIC) libmesh_override;
 
-  /**
-   * Call \p init() with n_local = N.
-   */
   virtual void init (const numeric_index_type N,
-                     const bool         fast=false,
+                     const bool fast=false,
                      const ParallelType type=AUTOMATIC) libmesh_override;
 
-  /**
-   * Create a vector that holds the local indices plus those specified
-   * in the \p ghost argument.
-   */
-  virtual void init (const numeric_index_type /*N*/,
-                     const numeric_index_type /*n_local*/,
-                     const std::vector<numeric_index_type> & /*ghost*/,
-                     const bool /*fast*/ = false,
+  virtual void init (const numeric_index_type N,
+                     const numeric_index_type n_local,
+                     const std::vector<numeric_index_type> & ghost,
+                     const bool fast = false,
                      const ParallelType = AUTOMATIC) libmesh_override;
 
-  /**
-   * Creates a vector that has the same dimension and storage type as
-   * \p other, including ghost dofs.
-   */
   virtual void init (const NumericVector<T> & other,
                      const bool fast = false) libmesh_override;
 
-  /**
-   * Sets all entries of the vector to the value \p s.
-   *
-   * \returns A reference to *this.
-   */
   virtual NumericVector<T> & operator= (const T s) libmesh_override;
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator= (const NumericVector<T> & v) libmesh_override;
 
   /**
@@ -201,133 +154,48 @@ public:
    */
   EpetraVector<T> & operator= (const EpetraVector<T> & v);
 
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator= (const std::vector<T> & v) libmesh_override;
 
-  /**
-   * \returns The minimum entry in the vector, or the minimum real
-   * part in the case of complex numbers.
-   */
   virtual Real min () const libmesh_override;
 
-  /**
-   * \returns The maximum entry in the vector, or the maximum real
-   * part in the case of complex numbers.
-   */
   virtual Real max () const libmesh_override;
 
-  /**
-   * \returns The sum of all values in the vector.
-   */
   virtual T sum () const libmesh_override;
 
-  /**
-   * \returns The \f$ l_1 \f$-norm of the vector, i.e. the sum of the
-   * absolute values of the entries.
-   */
   virtual Real l1_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_2\f$-norm of the vector, i.e. the square root
-   * of the sum of the squares of the entries.
-   */
   virtual Real l2_norm () const libmesh_override;
 
-  /**
-   * \returns The \f$l_\infty\f$-norm of the vector, i.e. the maximum
-   * absolute value of the entries of the vector.
-   */
   virtual Real linfty_norm () const libmesh_override;
 
-  /**
-   * \returns The size of the vector.
-   */
   virtual numeric_index_type size () const libmesh_override;
 
-  /**
-   * \returns The local size of the vector, i.e. \p index_stop - \p index_start.
-   */
   virtual numeric_index_type local_size() const libmesh_override;
 
-  /**
-   * \returns The index of the first vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type first_local_index() const libmesh_override;
 
-  /**
-   * \returns The index of the last vector element actually stored on
-   * this processor.
-   */
   virtual numeric_index_type last_local_index() const libmesh_override;
 
-  /**
-   * \returns A copy of the ith entry of the vector.
-   */
   virtual T operator() (const numeric_index_type i) const libmesh_override;
 
-  /**
-   * Add \p V to *this. Equivalent to \p U.add(1, V).
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator += (const NumericVector<T> & V) libmesh_override;
 
-  /**
-   * Subtracts \p V from *this.
-   *
-   * \returns A reference to *this as the base type.
-   */
   virtual NumericVector<T> & operator -= (const NumericVector<T> & V) libmesh_override;
 
-  /**
-   * Pointwise division operator. Sets u(i) <- u(i)/v(i) for each
-   * entry in the vector.
-   *
-   * \returns A reference to *this.
-   */
   virtual NumericVector<T> & operator /= (NumericVector<T> & v) libmesh_override;
 
-  /**
-   * Sets u(i) <- 1/u(i) for each entry in the vector.
-   */
   virtual void reciprocal() libmesh_override;
 
-  /**
-   * Negates the imaginary component of each entry in the vector.
-   */
   virtual void conjugate() libmesh_override;
 
-  /**
-   * Sets v(i) = \p value.
-   */
   virtual void set (const numeric_index_type i, const T value) libmesh_override;
 
-  /**
-   * Adds \p value to each entry of the vector.
-   */
   virtual void add (const numeric_index_type i, const T value) libmesh_override;
 
-  /**
-   * Adds \p s to each entry of the vector.
-   */
   virtual void add (const T s) libmesh_override;
 
-  /**
-   * Vector addition. Sets u(i) <- u(i) + v(i) for each entry in the
-   * vector. Equivalent to calling \p operator+=().
-   */
   virtual void add (const NumericVector<T> & V) libmesh_override;
 
-  /**
-   * Vector addition with a scalar multiple. Sets u(i) <- u(i) + a *
-   * v(i) for each entry in the vector. Equivalent to calling \p
-   * operator+=().
-   */
   virtual void add (const T a, const NumericVector<T> & v) libmesh_override;
 
   /**
@@ -336,28 +204,12 @@ public:
    */
   using NumericVector<T>::add_vector;
 
-  /**
-   * \f$ U+=v \f$ where v is a pointer and each \p dof_indices[i]
-   * specifies where to add value \p v[i].
-   */
   virtual void add_vector (const T * v,
                            const std::vector<numeric_index_type> & dof_indices) libmesh_override;
 
-  /**
-   * \f$ U \leftarrow U + A*v \f$.
-   *
-   * Adds the product of a \p SparseMatrix \p A and a \p NumericVector
-   * \p v to \p this.
-   */
   virtual void add_vector (const NumericVector<T> & v,
                            const SparseMatrix<T> & A) libmesh_override;
 
-  /**
-   * \f$ U \leftarrow U + A^T v \f$.
-   *
-   * Adds the product of the transpose of a \p SparseMatrix \p A and a
-   * \p NumericVector \p v to \p this.
-   */
   virtual void add_vector_transpose (const NumericVector<T> & v,
                                      const SparseMatrix<T> & A) libmesh_override;
 
@@ -367,89 +219,38 @@ public:
    */
   using NumericVector<T>::insert;
 
-  /**
-   * \f$ U=v \f$ where v is a \p T[] or T * and you want to specify
-   * WHERE to insert it.
-   */
   virtual void insert (const T * v,
                        const std::vector<numeric_index_type> & dof_indices) libmesh_override;
 
-  /**
-   * Scale each element of the vector by the given \p factor.
-   */
   virtual void scale (const T factor) libmesh_override;
 
-  /**
-   * Sets u(i) <- abs(u(i)) for each entry in the vector.
-   */
   virtual void abs() libmesh_override;
 
-  /**
-   * \returns The dot product of (*this) with the vector \p v.
-   *
-   * \note Uses the complex-conjugate of v in the complex-valued case.
-   */
   virtual T dot(const NumericVector<T> & V) const libmesh_override;
 
-  /**
-   * Creates a copy of the global vector in the local vector \p
-   * v_local.
-   */
   virtual void localize (std::vector<T> & v_local) const libmesh_override;
 
-  /**
-   * Same, but fills a \p NumericVector<T> instead of a \p
-   * std::vector.
-   */
   virtual void localize (NumericVector<T> & v_local) const libmesh_override;
 
-  /**
-   * Creates a local vector \p v_local containing only information
-   * relevant to this processor, as defined by the \p send_list.
-   */
   virtual void localize (NumericVector<T> & v_local,
                          const std::vector<numeric_index_type> & send_list) const libmesh_override;
 
-  /**
-   * Fill in the local std::vector "v_local" with the global indices
-   * given in "indices".  See numeric_vector.h for more details.
-   */
   virtual void localize (std::vector<T> & v_local,
                          const std::vector<numeric_index_type> & indices) const libmesh_override;
 
-
-  /**
-   * Updates a local vector with selected values from neighboring
-   * processors, as defined by \p send_list.
-   */
   virtual void localize (const numeric_index_type first_local_idx,
                          const numeric_index_type last_local_idx,
                          const std::vector<numeric_index_type> & send_list) libmesh_override;
 
-  /**
-   * Creates a local copy of the global vector in \p v_local only on
-   * processor \p proc_id.  By default the data is sent to processor
-   * 0.  This method is useful for outputting data from one processor.
-   */
   virtual void localize_to_one (std::vector<T> & v_local,
                                 const processor_id_type proc_id=0) const libmesh_override;
 
-  /**
-   * Computes the pointwise (i.e. component-wise) product of \p vec1
-   * and \p vec2 and stores the result in \p *this.
-   */
   virtual void pointwise_mult (const NumericVector<T> & vec1,
                                const NumericVector<T> & vec2) libmesh_override;
 
-  /**
-   * Fills in \p subvector from this vector using the indices in \p rows.
-   */
   virtual void create_subvector (NumericVector<T> & subvector,
                                  const std::vector<numeric_index_type> & rows) const libmesh_override;
 
-  /**
-   * Swaps the raw Epetra vector context pointers.
-   */
   virtual void swap (NumericVector<T> & v) libmesh_override;
 
   /**

--- a/include/numerics/trilinos_preconditioner.h
+++ b/include/numerics/trilinos_preconditioner.h
@@ -53,8 +53,9 @@ template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
 
 /**
- * This class provides an interface to the suite of preconditioners available
- * from Trilinos.
+ * This class provides an interface to the suite of preconditioners
+ * available from Trilinos. All overridden virtual functions are
+ * documented in preconditioner.h.
  *
  * \author David Andrs
  * \date 2011
@@ -77,22 +78,15 @@ public:
    */
   virtual ~TrilinosPreconditioner ();
 
-  /**
-   * Computes the preconditioned vector "y" based on input "x".
-   * Usually by solving Py=x to get the action of P^-1 x.
-   */
   virtual void apply(const NumericVector<T> & x, NumericVector<T> & y) libmesh_override;
 
-  /**
-   * Release all memory and clear data structures.
-   */
   virtual void clear () libmesh_override {}
 
-  /**
-   * Initialize data structures if not done so already.
-   */
   virtual void init () libmesh_override;
 
+  /**
+   * Stores a copy of the ParameterList \p list internally.
+   */
   void set_params(Teuchos::ParameterList & list);
 
   /**

--- a/include/numerics/wrapped_function.h
+++ b/include/numerics/wrapped_function.h
@@ -37,7 +37,8 @@ namespace libMesh
 /**
  * This class provides a wrapper with which to evaluate a
  * (libMesh-style) function pointer in a FunctionBase-compatible
- * interface.
+ * interface. All overridden virtual functions are documented in
+ * function_base.h.
  *
  * \author Roy Stogner
  * \date 2012
@@ -69,25 +70,13 @@ public:
 
   virtual UniquePtr<FunctionBase<Output> > clone () const libmesh_override;
 
-  /**
-   * \returns The scalar function value at coordinate \p p and time \p
-   * time, which defaults to zero.
-   */
   virtual Output operator() (const Point & p,
                              const Real time = 0.) libmesh_override;
 
-  /**
-   * Evaluation function for time-dependent vector-valued functions.
-   * Sets output values in the passed-in \p output DenseVector.
-   */
   virtual void operator() (const Point & p,
                            const Real time,
                            DenseVector<Output> & output) libmesh_override;
 
-  /**
-   * \returns The vector component \p i at coordinate \p p and time \p
-   * time.
-   */
   virtual Output component (unsigned int i,
                             const Point & p,
                             Real time=0.) libmesh_override;

--- a/include/numerics/wrapped_functor.h
+++ b/include/numerics/wrapped_functor.h
@@ -34,7 +34,8 @@ namespace libMesh
 /**
  * This class provides a wrapper with which to evaluate a
  * (libMesh-style) function pointer in a FunctionBase-compatible
- * interface.
+ * interface. All overridden virtual functions are documented in
+ * fem_function_base.h.
  *
  * \author Roy Stogner
  * \date 2015
@@ -58,29 +59,17 @@ public:
       (new WrappedFunctor<Output> (*_func));
   }
 
-  /**
-   * \returns The scalar function value at coordinate \p p and time \p
-   * time, which defaults to zero.
-   */
   virtual Output operator() (const FEMContext &,
                              const Point & p,
                              const Real time = 0.) libmesh_override
   { return _func->operator()(p, time); }
 
-  /**
-   * Evaluation function for time-dependent vector-valued functions.
-   * Sets output values in the passed-in \p output DenseVector.
-   */
   virtual void operator() (const FEMContext &,
                            const Point & p,
                            const Real time,
                            DenseVector<Output> & output) libmesh_override
   { _func->operator() (p, time, output); }
 
-  /**
-   * \returns The vector component \p i at coordinate \p p and time \p
-   * time.
-   */
   virtual Output component (const FEMContext &,
                             unsigned int i,
                             const Point & p,


### PR DESCRIPTION
Copy/pasted documentation is bad because it either requires extra
maintenance when the base class functionality changes, or it gets out
of date. This commit only touches classes in the numerics directory,
but the same concept could be applied across the entire library.

Refs #1364.