### PR TITLE
Make SparseMatrix::close() non-const.

### DIFF
--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -94,7 +94,7 @@ public:
 
   virtual void zero () libmesh_override;
 
-  virtual void close () const libmesh_override { const_cast<EigenSparseMatrix<T> *>(this)->_closed = true; }
+  virtual void close () libmesh_override { this->_closed = true; }
 
   virtual numeric_index_type m () const libmesh_override;
 

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -103,7 +103,7 @@ public:
 
   virtual void zero () libmesh_override;
 
-  virtual void close () const libmesh_override { const_cast<LaspackMatrix<T> *>(this)->_closed = true; }
+  virtual void close () libmesh_override { this->_closed = true; }
 
   virtual numeric_index_type m () const libmesh_override;
 

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -148,7 +148,7 @@ public:
 
   virtual void zero_rows (std::vector<numeric_index_type> & rows, T diag_value = 0.0) libmesh_override;
 
-  virtual void close () const libmesh_override;
+  virtual void close () libmesh_override;
 
   virtual numeric_index_type m () const libmesh_override;
 

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -168,7 +168,7 @@ public:
    * Calls the SparseMatrix's internal assembly routines, ensuring
    * that the values are consistent across processors.
    */
-  virtual void close () const = 0;
+  virtual void close () = 0;
 
   /**
    * \returns The row-dimension of the matrix.

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -121,7 +121,7 @@ public:
 
   virtual void zero () libmesh_override;
 
-  virtual void close () const libmesh_override;
+  virtual void close () libmesh_override;
 
   virtual numeric_index_type m () const libmesh_override;
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -878,7 +878,7 @@ void PetscMatrix<T>::get_transpose (SparseMatrix<T> & dest) const
 
 
 template <typename T>
-void PetscMatrix<T>::close () const
+void PetscMatrix<T>::close ()
 {
   semiparallel_only();
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -534,7 +534,12 @@ void PetscMatrix<T>::print_matlab (const std::string & name) const
   semiparallel_only();
 
   if (!this->closed())
-    libmesh_error_msg("The matrix must be assembled before calling PetscMatrix::print_matlab().");
+    {
+      libmesh_deprecated();
+      libmesh_warning("The matrix must be assembled before calling PetscMatrix::print_matlab().\n"
+                      "Please update your code, as this warning will become an error in a future release.");
+      const_cast<PetscMatrix<T> *>(this)->close();
+    }
 
   PetscErrorCode ierr=0;
   PetscViewer petsc_viewer;
@@ -616,7 +621,12 @@ void PetscMatrix<T>::print_personal(std::ostream & os) const
 
   // Matrix must be in an assembled state to be printed
   if (!this->closed())
-    libmesh_error_msg("The matrix must be assembled before calling PetscMatrix::print_personal().");
+    {
+      libmesh_deprecated();
+      libmesh_warning("The matrix must be assembled before calling PetscMatrix::print_personal().\n"
+                      "Please update your code, as this warning will become an error in a future release.");
+      const_cast<PetscMatrix<T> *>(this)->close();
+    }
 
   PetscErrorCode ierr=0;
 
@@ -782,7 +792,12 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
                                     const bool reuse_submatrix) const
 {
   if (!this->closed())
-    libmesh_error_msg("The matrix must be assembled before calling PetscMatrix::create_submatrix().");
+    {
+      libmesh_deprecated();
+      libmesh_warning("The matrix must be assembled before calling PetscMatrix::create_submatrix().\n"
+                      "Please update your code, as this warning will become an error in a future release.");
+      const_cast<PetscMatrix<T> *>(this)->close();
+    }
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
   PetscMatrix<T> * petsc_submatrix = cast_ptr<PetscMatrix<T> *>(&submatrix);

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -533,8 +533,8 @@ void PetscMatrix<T>::print_matlab (const std::string & name) const
 
   semiparallel_only();
 
-  // libmesh_assert (this->closed());
-  this->close();
+  if (!this->closed())
+    libmesh_error_msg("The matrix must be assembled before calling PetscMatrix::print_matlab().");
 
   PetscErrorCode ierr=0;
   PetscViewer petsc_viewer;
@@ -615,7 +615,8 @@ void PetscMatrix<T>::print_personal(std::ostream & os) const
   // #endif
 
   // Matrix must be in an assembled state to be printed
-  this->close();
+  if (!this->closed())
+    libmesh_error_msg("The matrix must be assembled before calling PetscMatrix::print_personal().");
 
   PetscErrorCode ierr=0;
 
@@ -780,8 +781,8 @@ void PetscMatrix<T>::_get_submatrix(SparseMatrix<T> & submatrix,
                                     const std::vector<numeric_index_type> & cols,
                                     const bool reuse_submatrix) const
 {
-  // Can only extract submatrices from closed matrices
-  this->close();
+  if (!this->closed())
+    libmesh_error_msg("The matrix must be assembled before calling PetscMatrix::create_submatrix().");
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
   PetscMatrix<T> * petsc_submatrix = cast_ptr<PetscMatrix<T> *>(&submatrix);

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -228,9 +228,14 @@ void PetscVector<T>::add_vector (const NumericVector<T> & V_in,
 
   PetscErrorCode ierr=0;
 
-  // We can't close() the matrix for you, as that would potentially modify the state of a const object.
+  // We shouldn't close() the matrix for you, as that would potentially modify the state of a const object.
   if (!A->closed())
-    libmesh_error_msg("Matrix A must be assembled before calling PetscVector::add_vector(v, A).");
+    {
+      libmesh_deprecated();
+      libmesh_warning("Matrix A must be assembled before calling PetscVector::add_vector(v, A).\n"
+                      "Please update your code, as this warning will become an error in a future release.");
+      const_cast<PetscMatrix<T> *>(A)->close();
+    }
 
   // The const_cast<> is not elegant, but it is required since PETSc
   // expects a non-const Mat.
@@ -251,9 +256,14 @@ void PetscVector<T>::add_vector_transpose (const NumericVector<T> & V_in,
 
   PetscErrorCode ierr=0;
 
-  // We can't close() the matrix for you, as that would potentially modify the state of a const object.
+  // We shouldn't close() the matrix for you, as that would potentially modify the state of a const object.
   if (!A->closed())
-    libmesh_error_msg("Matrix A must be assembled before calling PetscVector::add_vector_transpose(v, A).");
+    {
+      libmesh_deprecated();
+      libmesh_warning("Matrix A must be assembled before calling PetscVector::add_vector_transpose(v, A).\n"
+                      "Please update your code, as this warning will become an error in a future release.");
+      const_cast<PetscMatrix<T> *>(A)->close();
+    }
 
   // The const_cast<> is not elegant, but it is required since PETSc
   // expects a non-const Mat.
@@ -283,9 +293,14 @@ void PetscVector<T>::add_vector_conjugate_transpose (const NumericVector<T> & V_
   const PetscVector<T> * V = cast_ptr<const PetscVector<T> *>(&V_in);
   const PetscMatrix<T> * A = cast_ptr<const PetscMatrix<T> *>(&A_in);
 
-  // We can't close() the matrix for you, as that would potentially modify the state of a const object.
+  // We shouldn't close() the matrix for you, as that would potentially modify the state of a const object.
   if (!A->closed())
-    libmesh_error_msg("Matrix A must be assembled before calling PetscVector::add_vector_conjugate_transpose(v, A).");
+    {
+      libmesh_deprecated();
+      libmesh_warning("Matrix A must be assembled before calling PetscVector::add_vector_conjugate_transpose(v, A).\n"
+                      "Please update your code, as this warning will become an error in a future release.");
+      const_cast<PetscMatrix<T> *>(A)->close();
+    }
 
   // Store a temporary copy since MatMultHermitianTransposeAdd doesn't seem to work
   // TODO: Find out why MatMultHermitianTransposeAdd doesn't work, might be a PETSc bug?

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -228,10 +228,12 @@ void PetscVector<T>::add_vector (const NumericVector<T> & V_in,
 
   PetscErrorCode ierr=0;
 
-  A->close();
+  // We can't close() the matrix for you, as that would potentially modify the state of a const object.
+  if (!A->closed())
+    libmesh_error_msg("Matrix A must be assembled before calling PetscVector::add_vector(v, A).");
 
   // The const_cast<> is not elegant, but it is required since PETSc
-  // is not const-correct.
+  // expects a non-const Mat.
   ierr = MatMultAdd(const_cast<PetscMatrix<T> *>(A)->mat(), V->_vec, _vec, _vec);
   LIBMESH_CHKERR(ierr);
 }
@@ -249,10 +251,12 @@ void PetscVector<T>::add_vector_transpose (const NumericVector<T> & V_in,
 
   PetscErrorCode ierr=0;
 
-  A->close();
+  // We can't close() the matrix for you, as that would potentially modify the state of a const object.
+  if (!A->closed())
+    libmesh_error_msg("Matrix A must be assembled before calling PetscVector::add_vector_transpose(v, A).");
 
   // The const_cast<> is not elegant, but it is required since PETSc
-  // is not const-correct.
+  // expects a non-const Mat.
   ierr = MatMultTransposeAdd(const_cast<PetscMatrix<T> *>(A)->mat(), V->_vec, _vec, _vec);
   LIBMESH_CHKERR(ierr);
 }
@@ -279,14 +283,16 @@ void PetscVector<T>::add_vector_conjugate_transpose (const NumericVector<T> & V_
   const PetscVector<T> * V = cast_ptr<const PetscVector<T> *>(&V_in);
   const PetscMatrix<T> * A = cast_ptr<const PetscMatrix<T> *>(&A_in);
 
-  A->close();
+  // We can't close() the matrix for you, as that would potentially modify the state of a const object.
+  if (!A->closed())
+    libmesh_error_msg("Matrix A must be assembled before calling PetscVector::add_vector_conjugate_transpose(v, A).");
 
   // Store a temporary copy since MatMultHermitianTransposeAdd doesn't seem to work
   // TODO: Find out why MatMultHermitianTransposeAdd doesn't work, might be a PETSc bug?
   UniquePtr< NumericVector<Number> > this_clone = this->clone();
 
   // The const_cast<> is not elegant, but it is required since PETSc
-  // is not const-correct.
+  // expects a non-const Mat.
   PetscErrorCode ierr = MatMultHermitianTranspose(const_cast<PetscMatrix<T> *>(A)->mat(), V->_vec, _vec);
   LIBMESH_CHKERR(ierr);
 

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -319,7 +319,7 @@ EpetraMatrix<T>::~EpetraMatrix()
 
 
 template <typename T>
-void EpetraMatrix<T>::close () const
+void EpetraMatrix<T>::close ()
 {
   libmesh_assert(_mat);
 


### PR DESCRIPTION
This PR makes `SparseMatrix::close()` a non-const member function and deprecates/warns in a couple places in the library where we were calling `close()` on a `const SparseMatrix` object. It doesn't look like this change will have any effect on the libmesh examples or the MOOSE framework tests, I'm also attaching app tests to this PR to see if they are affected...

Refs #1371.
