### PR TITLE
Fix move constructor test

### DIFF
--- a/configure
+++ b/configure
@@ -8651,13 +8651,13 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
     {
     public:
       move_constructable_base() {}
-      move_constructable_base(move_constructable_base && other) {}
+      move_constructable_base(move_constructable_base && other) noexcept {}
     };
     class move_constructable : public move_constructable_base
     {
     public:
       move_constructable() {}
-      move_constructable(move_constructable && other) : move_constructable_base(std::move(other)) {}
+      move_constructable(move_constructable && other) noexcept : move_constructable_base(std::move(other)) {}
     };
 
 int

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -70,13 +70,13 @@ AC_DEFUN([LIBMESH_TEST_CXX11_MOVE_CONSTRUCTORS],
     {
     public:
       move_constructable_base() {}
-      move_constructable_base(move_constructable_base && other) {}
+      move_constructable_base(move_constructable_base && other) noexcept {}
     };
     class move_constructable : public move_constructable_base
     {
     public:
       move_constructable() {}
-      move_constructable(move_constructable && other) : move_constructable_base(std::move(other)) {}
+      move_constructable(move_constructable && other) noexcept : move_constructable_base(std::move(other)) {}
     };
     ]], [[
         move_constructable m1;


### PR DESCRIPTION
We came across a version of the [Intel 2015 compiler](https://groups.google.com/d/msg/moose-users/MqjruY_SWs0/kwmdkbErBwAJ) that supported all parts of the C++11 move constructor syntax apart from the `noexcept` keyword, and then I noticed that I forgot to test for it in the configure test. This branch fixes the test.

