### PR TITLE
Avoid redundant init of old(er) Transient vectors

### DIFF
--- a/include/systems/transient_system.h
+++ b/include/systems/transient_system.h
@@ -141,6 +141,13 @@ protected:
    * makes it up-to-date on the current mesh.
    */
   virtual void re_update () libmesh_override;
+
+private:
+
+  /**
+   * Helper function for (re-)adding old and older solution vectors.
+   */
+  virtual void add_old_vectors ();
 };
 
 


### PR DESCRIPTION
That init seemed to be an atavism from when these vectors weren't
registered in the System container.

Also refactor the add_vector calls, to make it easy to ensure that
SERIAL-vs-GHOSTED is still correct for those vectors even after a
clear().

This should fix one of the concerns @YaqiWang had in #1376, avoid a
little redundant work, and make the code less confusing.