### PR TITLE
Further clean-up of vector writing/reading in RBEvaluation.

### DIFF
--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -929,51 +929,21 @@ void RBEvaluation::write_out_vectors(System & sys,
   std::ostringstream file_name;
   const std::string basis_function_suffix = (write_binary_vectors ? ".xdr" : ".dat");
 
-  file_name << directory_name << "/" << data_name << "_header" << basis_function_suffix;
-  Xdr header_data(file_name.str(),
-                  write_binary_vectors ? ENCODE : WRITE);
+  file_name << directory_name << "/" << data_name << "_data" << basis_function_suffix;
+  Xdr bf_data(file_name.str(),
+              write_binary_vectors ? ENCODE : WRITE);
 
   std::string version("libMesh-" + libMesh::get_io_compatibility_version());
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   version += " with infinite elements";
 #endif
-  header_data.data(version ,"# File Format Identifier");
+  bf_data.data(version ,"# File Format Identifier");
 
-  sys.write_header(header_data, /*(unused arg)*/ version, /*write_additional_data=*/false);
+  sys.write_header(bf_data, /*(unused arg)*/ version, /*write_additional_data=*/false);
 
   // Following EquationSystemsIO::write, we use a temporary numbering (node major)
   // before writing out the data
   MeshTools::Private::globally_renumber_nodes_and_elements(sys.get_mesh());
-
-  // // Use System::write_serialized_data to write out the basis functions
-  // // by copying them into this->solution one at a time.
-  // for (std::size_t i=0; i<vectors.size(); i++)
-  // {
-  //   // No need to copy, just swap
-  //   // *solution = *vectors[i];
-  //   vectors[i]->swap(*sys.solution);
-  //   file_name.str(""); // reset the string
-  //   file_name << directory_name << "/bf" << i << basis_function_suffix;
-  //   Xdr bf_data(file_name.str(),
-  //               write_binary_vectors ? ENCODE : WRITE);
-  //   // set the current version
-  //   bf_data.set_version(LIBMESH_VERSION_ID(LIBMESH_MAJOR_VERSION,
-  //    LIBMESH_MINOR_VERSION,
-  //    LIBMESH_MICRO_VERSION));
-
-  //   sys.write_serialized_data(bf_data, false);
-
-  //   // Synchronize before moving on
-  //   this->comm().barrier();
-  //   // Swap back
-  //   vectors[i]->swap(*sys.solution);
-  // }
-
-  file_name.str("");
-  file_name << directory_name << "/" << data_name << "_data" << basis_function_suffix;
-
-  Xdr bf_data(file_name.str(),
-              write_binary_vectors ? ENCODE : WRITE);
 
   // Write all vectors at once.
   {
@@ -1051,39 +1021,10 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
 
   std::ostringstream file_name;
   const std::string basis_function_suffix = (read_binary_vectors ? ".xdr" : ".dat");
-  struct stat stat_info;
-
-  // Assume that all the headers are the same, hence we can just use the first one.
-  file_name << multiple_directory_names[0] << "/"
-            << multiple_data_names[0] << "_header" << basis_function_suffix;
-  assert_file_exists(file_name.str());
-
-  Xdr header_data(file_name.str(),
-                  read_binary_vectors ? DECODE : READ);
-
-  // Set up the header info (based on EquationSystems::_read_impl).
-  std::string version;
-  header_data.data(version);
-
-  const std::string libMesh_label = "libMesh-";
-  std::string::size_type lm_pos = version.find(libMesh_label);
-  if (lm_pos==std::string::npos)
-  {
-    libmesh_error_msg("version info missing in Xdr header");
-  }
-
-  std::istringstream iss(version.substr(lm_pos + libMesh_label.size()));
-  int ver_major = 0, ver_minor = 0, ver_patch = 0;
-  char dot;
-  iss >> ver_major >> dot >> ver_minor >> dot >> ver_patch;
-  header_data.set_version(LIBMESH_VERSION_ID(ver_major, ver_minor, ver_patch));
-
-  // We need to call sys.read_header (e.g. to set _written_var_indices properly),
-  // but by setting the read_header argument to false, it doesn't reinitialize the system
-  sys.read_header(header_data, version, /*read_header=*/false, /*read_additional_data=*/false);
 
   // Following EquationSystemsIO::read, we use a temporary numbering (node major)
-  // before writing out the data
+  // before writing out the data. For the sake of efficiency, we do this once for
+  // all the vectors that we read in.
   MeshTools::Private::globally_renumber_nodes_and_elements(sys.get_mesh());
 
   for (unsigned int data_index=0; data_index<n_directories; data_index++)
@@ -1114,6 +1055,7 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
       // On processor zero check to be sure the file exists
       if (this->processor_id() == 0)
         {
+          struct stat stat_info;
           int stat_result = stat(file_name.str().c_str(), &stat_info);
 
           if (stat_result != 0)
@@ -1124,8 +1066,29 @@ void RBEvaluation::read_in_vectors_from_multiple_files(System & sys,
       Xdr vector_data(file_name.str(),
                       read_binary_vectors ? DECODE : READ);
 
-      // The vector_data needs to know which version to read.
-      vector_data.set_version(LIBMESH_VERSION_ID(ver_major, ver_minor, ver_patch));
+      // Read the header data. This block of code is based on EquationSystems::_read_impl.
+      {
+        std::string version;
+        vector_data.data(version);
+
+        const std::string libMesh_label = "libMesh-";
+        std::string::size_type lm_pos = version.find(libMesh_label);
+        if (lm_pos==std::string::npos)
+        {
+          libmesh_error_msg("version info missing in Xdr header");
+        }
+
+        std::istringstream iss(version.substr(lm_pos + libMesh_label.size()));
+        int ver_major = 0, ver_minor = 0, ver_patch = 0;
+        char dot;
+        iss >> ver_major >> dot >> ver_minor >> dot >> ver_patch;
+        vector_data.set_version(LIBMESH_VERSION_ID(ver_major, ver_minor, ver_patch));
+
+        // Actually read the header data. When we do this, set read_header=false
+        // so taht we do not reinit sys, since we assume that it has already been
+        // set up properly (e.g. the appropriate variables have already been added).
+        sys.read_header(vector_data, version, /*read_header=*/false, /*read_additional_data=*/false);
+      }
 
       sys.read_serialized_vectors (vector_data, vectors);
     }


### PR DESCRIPTION
Previously we separated the Xdr header and body into two files, which was unnecessary and ugly.
Since we cleaned up the header writing and reading in a recent change, now is also a good time
to fix this two-separate-files issue as well.