### PR TITLE
Distributed checkpoint fixes

### DIFF
--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -153,7 +153,7 @@ private:
                            const std::set<const Elem *, CompareElemIdsByLevel> & elements) const;
 
   /**
-   * Write the remote_elem neighbor links for part of a mesh
+   * Write the remote_elem neighbor and child links for part of a mesh
    */
   void write_remote_elem (Xdr & io,
                           const std::set<const Elem *, CompareElemIdsByLevel> & elements) const;
@@ -195,7 +195,7 @@ private:
   void read_connectivity (Xdr & io);
 
   /**
-   * Read the remote_elem neighbor links for a parallel, distributed mesh
+   * Read the remote_elem neighbor and child links for a parallel, distributed mesh
    */
   void read_remote_elem (Xdr & io);
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1820,10 +1820,11 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
 
       std::vector<const Elem *> active_family;
 #ifdef LIBMESH_ENABLE_AMR
-      elem->active_family_tree(active_family);
-#else
-      active_family.push_back(elem);
+      if (!elem->subactive())
+        elem->active_family_tree(active_family);
+      else
 #endif
+        active_family.push_back(elem);
 
       for (std::size_t i=0; i != active_family.size(); ++i)
         elements_to_keep.insert(active_family[i]);


### PR DESCRIPTION
This fixes --distributed-mesh recovery on https://github.com/idaholab/moose/issues/8890 for me.

It needs more testing (and possibly more test cases to be added) before we merge, to make sure I haven't regressed checkpoints elsewhere.

As is (currently) S.O.P. with CheckpointIO, this patch changes the file format without caring in the slightest about backwards compatibility with old files.  The ensuing mixed feelings of horror and liberation are hard to describe.