### PR TITLE
Fix a few small issues with --disable-xdr builds

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -96,6 +96,12 @@ int main (int argc, char ** argv)
   libmesh_example_requires(false, "--enable-eigen");
 #endif
 
+  // This example converts between ExodusII and XDR files, therefore
+  // it requires XDR support in libmesh.
+#ifndef LIBMESH_HAVE_XDR
+  libmesh_example_requires (false, "XDR support");
+#endif
+
   // Read the "distributed_load" flag from the command line
   GetPot command_line (argc, argv);
   int distributed_load = 0;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -183,7 +183,7 @@ if LIBMESH_ENABLE_CPPUNIT
 TESTS = run_unit_tests.sh
 endif
 
-CLEANFILES = cube_mesh.xdr \
+CLEANFILES = cube_mesh.xda \
              checkpoint_splitter.cpr* checkpoint_splitter.cpa* \
              slit_mesh.xda slit_solution.xda
 

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -1132,7 +1132,7 @@ unit_tests_sources = driver.C test_comm.h stream_redirector.h \
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_CXXFLAGS = $(CXXFLAGS_OPROF)
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPROF_MODE_TRUE@unit_tests_oprof_LDADD = $(top_builddir)/libmesh_oprof.la
 @LIBMESH_ENABLE_CPPUNIT_TRUE@TESTS = run_unit_tests.sh
-CLEANFILES = cube_mesh.xdr checkpoint_splitter.cpr* \
+CLEANFILES = cube_mesh.xda checkpoint_splitter.cpr* \
 	checkpoint_splitter.cpa* slit_mesh.xda slit_solution.xda \
 	$(am__append_12)
 all: all-am

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -144,7 +144,7 @@ public:
   void testEdgeBoundaryConditions()
   {
     const unsigned int n_elem = 5;
-    const std::string mesh_filename = "cube_mesh.xdr";
+    const std::string mesh_filename = "cube_mesh.xda";
 
     {
       Mesh mesh(*TestCommWorld);

--- a/tests/mesh/checkpoint.C
+++ b/tests/mesh/checkpoint.C
@@ -57,6 +57,9 @@ public:
   template <typename MeshA, typename MeshB>
   void testSplitter(bool binary, bool using_distmesh)
   {
+    // The CheckpointIO-based spltter requires XDR.
+#ifdef LIBMESH_HAVE_XDR
+
     // In this test, we partition the mesh into n_procs parts.  Don't
     // try to partition a DistributedMesh into more parts than we have
     // processors, though.
@@ -122,6 +125,7 @@ public:
       // Verify that we read in exactly as many elements as we started with.
       CPPUNIT_ASSERT_EQUAL(static_cast<dof_id_type>(read_in_elements), original_n_elem);
     }
+#endif // LIBMESH_HAVE_XDR
   }
 
   void testAsciiDistRepSplitter()


### PR DESCRIPTION
I did not experience any of the XDR-related errors posted in #1392, but there were a few tests and examples that weren't correctly guarded when `!LIBMESH_HAVE_XDR`. Those should now should be fixed.
