### PR TITLE
Add MeshBase::is_serial_on_zero()

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -122,6 +122,13 @@ public:
   { return _is_serial; }
 
   /**
+   * \returns \p true if all elements and nodes of the mesh
+   * exist on the processor 0, \p false otherwise
+   */
+  virtual bool is_serial_on_zero () const libmesh_override
+  { return _is_serial || _is_serial_on_proc_0; }
+
+  /**
    * Asserts that not all elements and nodes of the mesh necessarily
    * exist on the current processor.
    */

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -138,6 +138,13 @@ public:
   { return true; }
 
   /**
+   * \returns \p true if all elements and nodes of the mesh
+   * exist on the processor 0, \p false otherwise
+   */
+  virtual bool is_serial_on_zero () const
+  { return true; }
+
+  /**
    * Asserts that not all elements and nodes of the mesh necessarily
    * exist on the current processor.  Only valid to call on classes
    * which can be created in a distributed form.


### PR DESCRIPTION
I'm going to need this in MOOSE shortly, to help keep their reference
mesh and displaced mesh in sync.