### PR TITLE
ASCII option, naming fixes for apps/splitter

### DIFF
--- a/src/apps/splitter.C
+++ b/src/apps/splitter.C
@@ -43,10 +43,11 @@ int main (int argc, char ** argv)
 
   if (libMesh::on_command_line("--help") || argc < 3)
     {
-      libMesh::out << "Example: ./splitter-opt --mesh=filename.e --n-procs='4 8 16' --dry-run\n\n"
+      libMesh::out << "Example: " << argv[0] << " --mesh=filename.e --n-procs='4 8 16' [--dry-run] [--ascii]\n\n"
                    << "--mesh             Full name of the mesh file to read in. \n"
                    << "--n-procs          Vector of number of processors.\n"
                    << "--dry-run          Only test the partitioning, don't write any files.\n"
+                   << "--ascii            Write ASCII cpa files rather than binary cpr files.\n"
                    << std::endl;
 
       return 0;
@@ -142,14 +143,19 @@ int main (int argc, char ** argv)
         {
           libMesh::out << "Writing " << my_num_chunks << " Files" << std::endl;
 
+          const bool binary = !libMesh::on_command_line("--ascii");
+
           CheckpointIO cpr(mesh);
           cpr.current_processor_ids().clear();
           for (unsigned int i = my_first_chunk; i < my_first_chunk + my_num_chunks; i++)
             cpr.current_processor_ids().push_back(i);
           cpr.current_n_processors() = n_procs;
-          cpr.binary() = true;
           cpr.parallel() = true;
-          cpr.write(remove_extension(filename) + ".cpr");
+          cpr.binary() = binary;
+          std::ostringstream outputname;
+          outputname << remove_extension(filename) << '.' << n_procs
+            << (binary ? ".cpr" : ".cpa");
+          cpr.write(outputname.str());
         }
     }
 


### PR DESCRIPTION
When doing multiple splittings in one run, we need to disambiguate the
primary (header) file name, so let's put n_procs into it.

ASCII is very useful for debugging, so let's make it a splitter option.

This is intended to support https://github.com/idaholab/moose/issues/7752