### PR TITLE
Add DofMap::dof_owner() search

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -578,6 +578,16 @@ public:
   dof_id_type end_dof() const
   { return this->end_dof(this->processor_id()); }
 
+  /**
+   * \returns The processor id that owns the dof index \p dof
+   */
+  processor_id_type dof_owner(const dof_id_type dof) const
+  { std::vector<dof_id_type>::const_iterator ub =
+      std::upper_bound(_end_df.begin(), _end_df.end(), dof);
+    libmesh_assert (ub != _end_df.end());
+    return (ub - _end_df.begin());
+  }
+
 #ifdef LIBMESH_ENABLE_AMR
   /**
    * \returns The first old dof index that is after all indices local

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,6 +13,7 @@ unit_tests_sources = \
   test_comm.h \
   stream_redirector.h \
   base/dof_object_test.h \
+  base/dof_map_test.h \
   base/default_coupling_test.C \
   base/getpot_test.C \
   base/point_neighbor_coupling_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -179,7 +179,7 @@ CONFIG_CLEAN_VPATH_FILES =
 @LIBMESH_DBG_MODE_TRUE@@LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@am__EXEEXT_7 = unit_tests-dbg$(EXEEXT)
 PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
-	stream_redirector.h base/dof_object_test.h \
+	stream_redirector.h base/dof_object_test.h base/dof_map_test.h \
 	base/default_coupling_test.C base/getpot_test.C \
 	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
 	fe/fe_bernstein_test.C fe/fe_clough_test.C \
@@ -279,7 +279,7 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
-	stream_redirector.h base/dof_object_test.h \
+	stream_redirector.h base/dof_object_test.h base/dof_map_test.h \
 	base/default_coupling_test.C base/getpot_test.C \
 	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
 	fe/fe_bernstein_test.C fe/fe_clough_test.C \
@@ -375,7 +375,7 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
-	stream_redirector.h base/dof_object_test.h \
+	stream_redirector.h base/dof_object_test.h base/dof_map_test.h \
 	base/default_coupling_test.C base/getpot_test.C \
 	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
 	fe/fe_bernstein_test.C fe/fe_clough_test.C \
@@ -471,7 +471,7 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
-	stream_redirector.h base/dof_object_test.h \
+	stream_redirector.h base/dof_object_test.h base/dof_map_test.h \
 	base/default_coupling_test.C base/getpot_test.C \
 	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
 	fe/fe_bernstein_test.C fe/fe_clough_test.C \
@@ -566,7 +566,7 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
-	stream_redirector.h base/dof_object_test.h \
+	stream_redirector.h base/dof_object_test.h base/dof_map_test.h \
 	base/default_coupling_test.C base/getpot_test.C \
 	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
 	fe/fe_bernstein_test.C fe/fe_clough_test.C \
@@ -1078,16 +1078,16 @@ AM_CPPFLAGS = $(libmesh_optional_INCLUDES) -I$(top_builddir)/include \
 
 AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h stream_redirector.h \
-	base/dof_object_test.h base/default_coupling_test.C \
-	base/getpot_test.C base/point_neighbor_coupling_test.C \
-	base/unique_ptr_test.C fe/fe_bernstein_test.C \
-	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/elem_test.C geom/node_test.C \
-	geom/point_test.C geom/point_test.h \
-	geom/which_node_am_i_test.C mesh/all_tri.C \
+	base/dof_object_test.h base/dof_map_test.h \
+	base/default_coupling_test.C base/getpot_test.C \
+	base/point_neighbor_coupling_test.C base/unique_ptr_test.C \
+	fe/fe_bernstein_test.C fe/fe_clough_test.C \
+	fe/fe_hermite_test.C fe/fe_hierarchic_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/elem_test.C geom/node_test.C geom/point_test.C \
+	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \

--- a/tests/base/dof_map_test.C
+++ b/tests/base/dof_map_test.C
@@ -1,0 +1,92 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/equation_systems.h>
+#include <libmesh/mesh.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/dof_map.h>
+
+#include "test_comm.h"
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+using namespace libMesh;
+
+
+
+class DofMapTest : public CppUnit::TestCase {
+public:
+  CPPUNIT_TEST_SUITE( DofMapTest );
+
+  CPPUNIT_TEST( testDofOwnerOnEdge3 );
+  CPPUNIT_TEST( testDofOwnerOnQuad9 );
+  CPPUNIT_TEST( testDofOwnerOnTri6 );
+  CPPUNIT_TEST( testDofOwnerOnHex27 );
+
+  CPPUNIT_TEST_SUITE_END();
+
+private:
+
+public:
+  void setUp()
+  {}
+
+  void tearDown()
+  {}
+
+  void testDofOwner(const ElemType elem_type)
+  {
+    Mesh mesh(*TestCommWorld);
+
+    EquationSystems es(mesh);
+    System &sys = es.add_system<System> ("SimpleSystem");
+    sys.add_variable("u", THIRD, HIERARCHIC);
+
+    const unsigned n_elem_per_side = 3;
+    const UniquePtr<Elem> test_elem = Elem::build(elem_type);
+    const Real ymax = test_elem->dim() > 1;
+    const Real zmax = test_elem->dim() > 2;
+    const unsigned int ny = ymax * n_elem_per_side;
+    const unsigned int nz = zmax * n_elem_per_side;
+
+    MeshTools::Generation::build_cube (mesh,
+                                       n_elem_per_side,
+                                       ny,
+                                       nz,
+                                       0., 1.,
+                                       0., ymax,
+                                       0., zmax,
+                                       elem_type);
+
+    es.init();
+
+    DofMap & dof_map = sys.get_dof_map();
+    for (dof_id_type id = 0; id != dof_map.n_dofs(); ++id)
+      {
+        const processor_id_type pid = dof_map.dof_owner(id);
+        CPPUNIT_ASSERT_LESS_EQUAL(dof_map.first_dof(pid), id);
+        CPPUNIT_ASSERT_LESS(id, dof_map.end_dof(pid));
+      }
+  }
+
+
+
+  void testDofOwnerOnEdge3() { testDofOwner(EDGE3); }
+  void testDofOwnerOnQuad9() { testDofOwner(QUAD9); }
+  void testDofOwnerOnTri6()  { testDofOwner(TRI6); }
+  void testDofOwnerOnHex27() { testDofOwner(HEX27); }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( DofMapTest );


### PR DESCRIPTION
This can be done without the current API, but I'd rather have a
short-to-invoke O(log N_procs) method available in libMesh, not force
users to write a longer O(N_procs) linear search or an even longer
(because we don't give raw access to the _end_dfs array) binary
search.

This is going to be necessary for MOOSE to use to fix one of the last bugs in https://github.com/idaholab/moose/issues/1500