### PR TITLE
Fix --enable-sanitize builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ AM_LDFLAGS       = $(libmesh_LDFLAGS)
 # with libtool, because Windows requires all shared
 # libraries to include all used symbols. This flag
 # should do no harm on other platforms.
-AM_LDFLAGS +="-no-undefined"
+AM_LDFLAGS += -no-undefined
 
 
 # AM_CPPFLAGS are method-independent cppflags that

--- a/Makefile.in
+++ b/Makefile.in
@@ -4719,7 +4719,7 @@ AM_CFLAGS = $(libmesh_CFLAGS)
 # with libtool, because Windows requires all shared
 # libraries to include all used symbols. This flag
 # should do no harm on other platforms.
-AM_LDFLAGS = $(libmesh_LDFLAGS) "-no-undefined"
+AM_LDFLAGS = $(libmesh_LDFLAGS) -no-undefined
 
 # AM_CPPFLAGS are method-independent cppflags that
 # we use when compiling libmesh proper, or its utility

--- a/configure
+++ b/configure
@@ -7649,6 +7649,11 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
     # Enable the address sanitizer stuff if the test code compiled
     if test "x$have_address_sanitizer" = xyes; then
+      # As of clang 3.9.0 or so, we also need to pass the sanitize flag to the linker
+      # if it's being used during compiling. It seems that we do not need to pass all
+      # the flags above, just the sanitize flag itself.
+      libmesh_LDFLAGS="$libmesh_LDFLAGS -Wc,-fsanitize=address"
+
       for method in ${SANITIZE_METHODS}; do
           case "${method}" in
               optimized|opt)

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -615,6 +615,11 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
 
     # Enable the address sanitizer stuff if the test code compiled
     if test "x$have_address_sanitizer" = xyes; then
+      # As of clang 3.9.0 or so, we also need to pass the sanitize flag to the linker
+      # if it's being used during compiling. It seems that we do not need to pass all
+      # the flags above, just the sanitize flag itself.
+      libmesh_LDFLAGS="$libmesh_LDFLAGS -Wc,-fsanitize=address"
+
       for method in ${SANITIZE_METHODS}; do
           case "${method}" in
               optimized|opt)


### PR DESCRIPTION
We were not passing the `-fsanitize=address` flag to the compiler doing the linking since it was (apparently) never required before. This fixes that issue by using the libtool `-Wc,` [syntax](https://www.gnu.org/software/libtool/manual/html_node/Link-mode.html#Link-mode) for passing flags to the compiler during linking. (I checked, and simply adding the flag to libmesh_LDFLAGS did not work).

Refs #1396.
