### PR TITLE
Put sideset/nodeset names in CheckpointIO header

### DIFF
--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -124,6 +124,11 @@ void CheckpointIO::write (const std::string & name)
 
       // write subdomain names
       this->write_subdomain_names(io);
+
+      // write boundary id names
+      const BoundaryInfo & boundary_info = mesh.get_boundary_info();
+      write_bc_names(io, boundary_info, true);  // sideset names
+      write_bc_names(io, boundary_info, false); // nodeset names
     }
 
   // If this is a serial mesh written to a serial file then we're only
@@ -426,10 +431,6 @@ void CheckpointIO::write_bcs (Xdr & io,
   // and our boundary info object
   const BoundaryInfo & boundary_info = mesh.get_boundary_info();
 
-  // Version 0.9.2+ introduces entity names
-  write_bc_names(io, boundary_info, true);  // sideset names
-  write_bc_names(io, boundary_info, false); // nodeset names
-
   std::vector<dof_id_type> full_element_id_list;
   std::vector<unsigned short int> full_side_list;
   std::vector<boundary_id_type> full_bc_id_list;
@@ -592,6 +593,15 @@ void CheckpointIO::read (const std::string & name)
         mesh.set_subdomain_name_map();
 
       this->comm().broadcast(subdomain_map);
+
+      // read and broadcast boundary names
+      BoundaryInfo & boundary_info = mesh.get_boundary_info();
+
+      read_bc_names(io, boundary_info, true);  // sideset names
+      this->comm().broadcast(boundary_info.set_sideset_name_map());
+
+      read_bc_names(io, boundary_info, false); // nodeset names
+      this->comm().broadcast(boundary_info.set_nodeset_name_map());
     }
   // We'll receive the header broadcast everywhere else.
   else
@@ -608,6 +618,10 @@ void CheckpointIO::read (const std::string & name)
       std::map<subdomain_id_type, std::string> & subdomain_map =
         mesh.set_subdomain_name_map();
       this->comm().broadcast(subdomain_map);
+
+      BoundaryInfo & boundary_info = mesh.get_boundary_info();
+      this->comm().broadcast(boundary_info.set_sideset_name_map());
+      this->comm().broadcast(boundary_info.set_nodeset_name_map());
     }
 
 
@@ -965,10 +979,6 @@ void CheckpointIO::read_bcs (Xdr & io)
 
   // and our boundary info object
   BoundaryInfo & boundary_info = mesh.get_boundary_info();
-
-  // Version 0.9.2+ introduces entity names
-  read_bc_names(io, boundary_info, true);  // sideset names
-  read_bc_names(io, boundary_info, false); // nodeset names
 
   std::vector<dof_id_type> element_id_list;
   std::vector<unsigned short int> side_list;


### PR DESCRIPTION
At present we need these names to be present on all processors if we
want name maps to be replicated everywhere even in early phases of
N->M restarts where M > N.

At some point in the future we might want to distribute these maps,
but for the moment it's very very unlikely that users will have so
many boundary names that scaling will be a problem.

This breaks backwards compatibility with old cpr/cpa files, and I'm
*just* about to check some cpr/cpa files into MOOSE, so after this
passes testing I'd like to sit on it until MOOSE is ready for their
next libMesh update.