### PR TITLE
Checkpoint N->M restart fixes

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -1065,6 +1065,12 @@ public:
 
   /**
    * \returns A constant pointer to the \f$ i^{th} \f$ child for this element.
+   * For internal use only - skips assertions about null pointers.
+   */
+  const Elem * raw_child_ptr (unsigned int i) const;
+
+  /**
+   * \returns A constant pointer to the \f$ i^{th} \f$ child for this element.
    * Do not call if this element has no children, i.e. is active.
    */
   const Elem * child_ptr (unsigned int i) const;
@@ -2227,6 +2233,15 @@ unsigned int Elem::p_level() const
 
 
 #ifdef LIBMESH_ENABLE_AMR
+
+inline
+const Elem * Elem::raw_child_ptr (unsigned int i) const
+{
+  if (!_children)
+    return libmesh_nullptr;
+
+  return _children[i];
+}
 
 inline
 const Elem * Elem::child_ptr (unsigned int i) const

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -196,8 +196,12 @@ private:
 
   /**
    * Read the remote_elem neighbor and child links for a parallel, distributed mesh
+   *
+   * If we expect all these remote_elem links to truly be remote,
+   * because we aren't doing an N -> M restart with M < N, then we set
+   * \p expect_all_remote to true and test more assertions.
    */
-  void read_remote_elem (Xdr & io);
+  void read_remote_elem (Xdr & io, bool expect_all_remote);
 
   /**
    * Read the nodal locations for a parallel, distributed mesh

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -654,7 +654,8 @@ void CheckpointIO::read (const std::string & name)
           // be remote?  Only if we're not reading multiple input
           // files on the same processor.
           const bool expect_all_remote =
-            (input_n_procs <= mesh.n_processors());
+            (input_n_procs <= mesh.n_processors() &&
+             !mesh.is_replicated());
 
           // read remote_elem connectivity
           this->read_remote_elem (io, expect_all_remote);


### PR DESCRIPTION
Previously we could throw overzealous asserts in N->M restarts, or
even end up with corrupted child pointers in N->M AMR restarts.

This is an API and format backwards-compatible change.