### PR TITLE
Check for exact file extensions in NameBasedIO::is_parallel_file_format()

### DIFF
--- a/include/mesh/namebased_io.h
+++ b/include/mesh/namebased_io.h
@@ -125,8 +125,8 @@ NameBasedIO::is_parallel_file_format (const std::string & name)
 {
   return ((name.rfind(".xda") < name.size()) ||
           (name.rfind(".xdr") < name.size()) ||
-          (name.rfind(".nem") < name.size()) ||
-          (name.rfind(".n") < name.size())   ||
+          (name.rfind(".nem") + 4 == name.size()) ||
+          (name.rfind(".n") + 2 == name.size()) ||
           (name.rfind(".cp") < name.size())
           );
 }


### PR DESCRIPTION
As pointed out by @YaqiWang in #1412, this function previously
returned true for ".node" files since they incorrectly matched the
".n" check, causing them to later be treated as Nemesis files. To be
consistent with a similar check in namebased_io.C, I also updated the
".nem" check.

There may be other places in the code where these rfind() checks could
be updated, but they can't all just be changed, because (I think) we
still want to support reading meshes from files with names like
out.xdr.0000, etc. where some number or other designation appears
after the "normal" file extension.

Nemesis (and parallel exodus) files are a special case in this regard,
since the user specifies a "base" filename while reading and then
libmesh automatically appends the number of processors and the
processor id (see Nemesis_IO_Helper::construct_nemesis_filename())
so those filenames cannot have extra characters after the file extension.