### PR TITLE
Update TetGenIO code for reading .ele files.

### DIFF
--- a/include/mesh/tetgen_io.h
+++ b/include/mesh/tetgen_io.h
@@ -83,7 +83,14 @@ public:
 
   /**
    * Data structure to hold element attributes read in from file.
-   * What you do with these is up to you!
+   *
+   * \note This vector is no longer filled or used for anything. If
+   * region attributes are present in the .ele file, they are used to
+   * set the subdomain ids of the elements as they are created.
+   *
+   * \depcreated This member, since it was originally a part of the
+   * public interface, remains for now, but will be removed some time
+   * in the near future.
    */
   std::vector<std::vector<Real> > element_attributes;
 


### PR DESCRIPTION
Previously we assumed that there could be multiple Real-valued
attributes for each tetrahedron, but according to the Tetgen docs
there can only be one integer-valued attribute. If present, we use
this attribute to specify the subodmain ids of each element.

Refs #1412.