### PR TITLE
allgather(vector<string>) overload

### DIFF
--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -1196,7 +1196,6 @@ public:
                         std::vector<std::basic_string<T> > & recv,
                         const bool identical_buffer_sizes=false) const;
 
-
   /**
    * Take a vector of local variables and expand it to include
    * values from all processors. By default, each processor is
@@ -1223,6 +1222,13 @@ public:
    */
   template <typename T>
   inline void allgather(std::vector<T> & r,
+                        const bool identical_buffer_sizes = false) const;
+
+  /**
+   * AllGather overload for vectors of string types
+   */
+  template <typename T>
+  inline void allgather(std::vector<std::basic_string<T> > & r,
                         const bool identical_buffer_sizes = false) const;
 
   //-------------------------------------------------------------------

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -28,6 +28,7 @@ public:
   CPPUNIT_TEST( testAllGather );
   CPPUNIT_TEST( testGatherString );
   CPPUNIT_TEST( testAllGatherString );
+  CPPUNIT_TEST( testAllGatherVectorString );
   CPPUNIT_TEST( testBroadcast );
   CPPUNIT_TEST( testScatter );
   CPPUNIT_TEST( testBarrier );
@@ -109,6 +110,22 @@ public:
 
     for (processor_id_type i=0; i<vals.size(); i++)
       CPPUNIT_ASSERT_EQUAL( "Processor" + _number[i % 10] , vals[i] );
+  }
+
+
+
+  void testAllGatherVectorString()
+  {
+    std::vector<std::string> vals;
+    vals.push_back("Processor" + _number[TestCommWorld->rank() % 10] + "A");
+    vals.push_back("Processor" + _number[TestCommWorld->rank() % 10] + "B");
+    TestCommWorld->allgather(vals);
+
+    for (processor_id_type i=0; i<(vals.size()/2); i++)
+      {
+        CPPUNIT_ASSERT_EQUAL( "Processor" + _number[i % 10] + "A" , vals[2*i] );
+        CPPUNIT_ASSERT_EQUAL( "Processor" + _number[i % 10] + "B" , vals[2*i+1] );
+      }
   }
 
 

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -29,6 +29,8 @@ public:
   CPPUNIT_TEST( testGatherString );
   CPPUNIT_TEST( testAllGatherString );
   CPPUNIT_TEST( testAllGatherVectorString );
+  CPPUNIT_TEST( testAllGatherEmptyVectorString );
+  CPPUNIT_TEST( testAllGatherHalfEmptyVectorString );
   CPPUNIT_TEST( testBroadcast );
   CPPUNIT_TEST( testScatter );
   CPPUNIT_TEST( testBarrier );
@@ -126,6 +128,30 @@ public:
         CPPUNIT_ASSERT_EQUAL( "Processor" + _number[i % 10] + "A" , vals[2*i] );
         CPPUNIT_ASSERT_EQUAL( "Processor" + _number[i % 10] + "B" , vals[2*i+1] );
       }
+  }
+
+
+
+  void testAllGatherEmptyVectorString()
+  {
+    std::vector<std::string> vals;
+    TestCommWorld->allgather(vals);
+
+    CPPUNIT_ASSERT( vals.empty() );
+  }
+
+
+
+  void testAllGatherHalfEmptyVectorString()
+  {
+    std::vector<std::string> vals;
+
+    if (!TestCommWorld->rank())
+      vals.push_back("Proc 0 only");
+
+    TestCommWorld->allgather(vals);
+
+    CPPUNIT_ASSERT_EQUAL( vals[0], std::string("Proc 0 only") );
   }
 
 


### PR DESCRIPTION
It looks like I need essentially this code in order to work on idaholab/moose#9700 and it's generic enough that it ought to be useful for other libMesh users as well; it's just a new overload on our existing allgather(vector).

There's unit test coverage, but I intend to wait to merge until after I'm confident that this is working correctly in its final use case too.  After that, if MOOSE really can [do another libMesh update sooner than later](https://github.com/libMesh/libmesh/pull/1413#issuecomment-326351328) then I'll follow it up with the MOOSE PR for that issue.