### PR TITLE
GCC 7 warning fixes

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -600,9 +600,9 @@ inline Tnew libmesh_cast_int (Told oldvar)
 // We should add support for standard C++17 [[fallthrough]]
 // Maybe [[clang::fallthrough]] or [[gcc::fallthough]] too?
 #if defined(__GNUC__) && (__GNUC__ > 6)
-#define libmesh_fallthrough __attribute__((fallthrough))
+#define libmesh_fallthrough() __attribute__((fallthrough))
 #else
-#define libmesh_fallthrough
+#define libmesh_fallthrough() ((void) 0)
 #endif
 
 } // namespace libMesh

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -596,6 +596,15 @@ inline Tnew libmesh_cast_int (Told oldvar)
 #define libmesh_final
 #endif
 
+// Define backwards-compatible fallthrough attribute.
+// We should add support for standard C++17 [[fallthrough]]
+// Maybe [[clang::fallthrough]] or [[gcc::fallthough]] too?
+#if defined(__GNUC__) && (__GNUC__ > 6)
+#define libmesh_fallthrough __attribute__((fallthrough))
+#else
+#define libmesh_fallthrough
+#endif
+
 } // namespace libMesh
 
 

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -28,7 +28,10 @@
 #if defined(LIBMESH_HAVE_LIBHILBERT)
 
 // Local includes
+// So many implicit-fallthrough warnings in crazy libHilbert macros...
+#include "libmesh/ignore_warnings.h"
 #include "hilbert.h"
+#include "libmesh/restore_warnings.h"
 #include "libmesh/parallel.h"
 
 // C++ includes

--- a/include/utils/hashword.h
+++ b/include/utils/hashword.h
@@ -172,12 +172,12 @@ uint32_t hashword(const uint32_t * k, size_t length, uint32_t initval=0)
   switch(length)                     // all the case statements fall through
     {
     case 3 : c+=k[2];
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case 2 : b+=k[1];
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case 1 : a+=k[0];
       final(a,b,c);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     default:     // case 0: nothing left to add
       break;
     }

--- a/include/utils/hashword.h
+++ b/include/utils/hashword.h
@@ -172,9 +172,12 @@ uint32_t hashword(const uint32_t * k, size_t length, uint32_t initval=0)
   switch(length)                     // all the case statements fall through
     {
     case 3 : c+=k[2];
+      /* FALLTHROUGH */
     case 2 : b+=k[1];
+      /* FALLTHROUGH */
     case 1 : a+=k[0];
       final(a,b,c);
+      /* FALLTHROUGH */
     default:     // case 0: nothing left to add
       break;
     }

--- a/include/utils/hashword.h
+++ b/include/utils/hashword.h
@@ -30,7 +30,7 @@
 #include <stdint.h> // uint32_t, uint64_t
 #include <vector>
 
-#include "libmesh_common.h" // libmesh_error_msg()
+#include "libmesh_common.h" // libmesh_error_msg(), libmesh_fallthrough
 
 // Anonymous namespace for utility functions used locally
 namespace
@@ -172,12 +172,12 @@ uint32_t hashword(const uint32_t * k, size_t length, uint32_t initval=0)
   switch(length)                     // all the case statements fall through
     {
     case 3 : c+=k[2];
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case 2 : b+=k[1];
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case 1 : a+=k[0];
       final(a,b,c);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     default:     // case 0: nothing left to add
       break;
     }

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -50,6 +50,9 @@
 #pragma GCC diagnostic ignored "-Wmisleading-indentation"
 // Ignore warnings from bad placement new use
 #pragma GCC diagnostic ignored "-Wplacement-new"
+#if (__GNUC__ > 6)
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#endif // GCC > 6
 #endif // GCC > 5
 #endif // GCC > 4.1
 #endif // __GNUC__ && !__INTEL_COMPILER

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -52,6 +52,7 @@
 #pragma GCC diagnostic ignored "-Wplacement-new"
 #if (__GNUC__ > 6)
 #pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif // GCC > 6
 #endif // GCC > 5
 #endif // GCC > 4.1

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -34,6 +34,7 @@
 #pragma GCC diagnostic warning "-Wmisleading-indentation"
 #if (__GNUC__ > 6)
 #pragma GCC diagnostic warning "-Wint-in-bool-context"
+#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
 #endif // GCC > 6
 #endif // GCC > 5
 #pragma GCC diagnostic warning "-Wdeprecated-declarations"

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -32,6 +32,9 @@
 #if (__GNUC__ > 5)
 #pragma GCC diagnostic warning "-Wplacement-new"
 #pragma GCC diagnostic warning "-Wmisleading-indentation"
+#if (__GNUC__ > 6)
+#pragma GCC diagnostic warning "-Wint-in-bool-context"
+#endif // GCC > 6
 #endif // GCC > 5
 #pragma GCC diagnostic warning "-Wdeprecated-declarations"
 #pragma GCC diagnostic warning "-Wunused-parameter"

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -122,7 +122,7 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
       {
         if (o == 1)
@@ -136,7 +136,7 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
       return ((o+1)*(o+1));
     case HEX8:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX20:
       {
         if (o == 1)
@@ -151,12 +151,12 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
     case TRI3:
     case TRISHELL3:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TRI6:
       return ((o+1)*(o+2)/2);
     case TET4:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TET10:
       {
         libmesh_assert_less (o, 3);
@@ -200,7 +200,7 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case TRI3:
       libmesh_assert_less (n, 3);
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TRI6:
       switch (n)
         {
@@ -220,11 +220,11 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case QUAD4:
       libmesh_assert_less (n, 4);
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
       libmesh_assert_less (n, 8);
       libmesh_assert_less (o, 3);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD9:
       {
         switch (n)
@@ -252,11 +252,11 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case HEX8:
       libmesh_assert_less (n, 8);
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX20:
       libmesh_assert_less (n, 20);
       libmesh_assert_less (o, 3);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX27:
       switch (n)
         {
@@ -302,7 +302,7 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case TET4:
       libmesh_assert_less (n, 4);
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TET10:
       libmesh_assert_less (o, 3);
       libmesh_assert_less (n, 10);
@@ -356,12 +356,12 @@ unsigned int bernstein_n_dofs_per_elem(const ElemType t, const Order o)
     case QUAD8:
       if (o <= 2)
         return 0;
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD9:
       return ((o-1)*(o-1));
     case HEX8:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX20:
       libmesh_assert_less (o, 3);
       return 0;
@@ -369,7 +369,7 @@ unsigned int bernstein_n_dofs_per_elem(const ElemType t, const Order o)
       return ((o-1)*(o-1)*(o-1));
     case TET4:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TET10:
       libmesh_assert_less (o, 3);
       return 0;

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -122,6 +122,7 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case QUAD8:
       {
         if (o == 1)
@@ -135,6 +136,7 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
       return ((o+1)*(o+1));
     case HEX8:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case HEX20:
       {
         if (o == 1)
@@ -149,10 +151,12 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
     case TRI3:
     case TRISHELL3:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case TRI6:
       return ((o+1)*(o+2)/2);
     case TET4:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case TET10:
       {
         libmesh_assert_less (o, 3);
@@ -196,6 +200,7 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case TRI3:
       libmesh_assert_less (n, 3);
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case TRI6:
       switch (n)
         {
@@ -215,9 +220,11 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case QUAD4:
       libmesh_assert_less (n, 4);
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case QUAD8:
       libmesh_assert_less (n, 8);
       libmesh_assert_less (o, 3);
+      /* FALLTHROUGH */
     case QUAD9:
       {
         switch (n)
@@ -245,9 +252,11 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case HEX8:
       libmesh_assert_less (n, 8);
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case HEX20:
       libmesh_assert_less (n, 20);
       libmesh_assert_less (o, 3);
+      /* FALLTHROUGH */
     case HEX27:
       switch (n)
         {
@@ -293,6 +302,7 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case TET4:
       libmesh_assert_less (n, 4);
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case TET10:
       libmesh_assert_less (o, 3);
       libmesh_assert_less (n, 10);
@@ -350,6 +360,7 @@ unsigned int bernstein_n_dofs_per_elem(const ElemType t, const Order o)
       return ((o-1)*(o-1));
     case HEX8:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case HEX20:
       libmesh_assert_less (o, 3);
       return 0;
@@ -357,6 +368,7 @@ unsigned int bernstein_n_dofs_per_elem(const ElemType t, const Order o)
       return ((o-1)*(o-1)*(o-1));
     case TET4:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case TET10:
       libmesh_assert_less (o, 3);
       return 0;

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -356,6 +356,7 @@ unsigned int bernstein_n_dofs_per_elem(const ElemType t, const Order o)
     case QUAD8:
       if (o <= 2)
         return 0;
+      /* FALLTHROUGH */
     case QUAD9:
       return ((o-1)*(o-1));
     case HEX8:

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -122,7 +122,7 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
       {
         if (o == 1)
@@ -136,7 +136,7 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
       return ((o+1)*(o+1));
     case HEX8:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX20:
       {
         if (o == 1)
@@ -151,12 +151,12 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
     case TRI3:
     case TRISHELL3:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TRI6:
       return ((o+1)*(o+2)/2);
     case TET4:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TET10:
       {
         libmesh_assert_less (o, 3);
@@ -200,7 +200,7 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case TRI3:
       libmesh_assert_less (n, 3);
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TRI6:
       switch (n)
         {
@@ -220,11 +220,11 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case QUAD4:
       libmesh_assert_less (n, 4);
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
       libmesh_assert_less (n, 8);
       libmesh_assert_less (o, 3);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD9:
       {
         switch (n)
@@ -252,11 +252,11 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case HEX8:
       libmesh_assert_less (n, 8);
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX20:
       libmesh_assert_less (n, 20);
       libmesh_assert_less (o, 3);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX27:
       switch (n)
         {
@@ -302,7 +302,7 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     case TET4:
       libmesh_assert_less (n, 4);
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TET10:
       libmesh_assert_less (o, 3);
       libmesh_assert_less (n, 10);
@@ -356,12 +356,12 @@ unsigned int bernstein_n_dofs_per_elem(const ElemType t, const Order o)
     case QUAD8:
       if (o <= 2)
         return 0;
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD9:
       return ((o-1)*(o-1));
     case HEX8:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX20:
       libmesh_assert_less (o, 3);
       return 0;
@@ -369,7 +369,7 @@ unsigned int bernstein_n_dofs_per_elem(const ElemType t, const Order o)
       return ((o-1)*(o-1)*(o-1));
     case TET4:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TET10:
       libmesh_assert_less (o, 3);
       return 0;

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -145,7 +145,7 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
     case TRI3:
     case TRISHELL3:
       libmesh_assert_less (totalorder, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TRI6:
       switch (totalorder)
         {
@@ -518,7 +518,7 @@ Real FE<2,BERNSTEIN>::shape_deriv(const Elem * elem,
     case TRI3:
     case TRISHELL3:
       libmesh_assert_less (totalorder, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TRI6:
       {
         // I have been lazy here and am using finite differences

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -145,6 +145,7 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
     case TRI3:
     case TRISHELL3:
       libmesh_assert_less (totalorder, 2);
+      /* FALLTHROUGH */
     case TRI6:
       switch (totalorder)
         {
@@ -517,6 +518,7 @@ Real FE<2,BERNSTEIN>::shape_deriv(const Elem * elem,
     case TRI3:
     case TRISHELL3:
       libmesh_assert_less (totalorder, 2);
+      /* FALLTHROUGH */
     case TRI6:
       {
         // I have been lazy here and am using finite differences

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -145,7 +145,7 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
     case TRI3:
     case TRISHELL3:
       libmesh_assert_less (totalorder, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TRI6:
       switch (totalorder)
         {
@@ -518,7 +518,7 @@ Real FE<2,BERNSTEIN>::shape_deriv(const Elem * elem,
     case TRI3:
     case TRISHELL3:
       libmesh_assert_less (totalorder, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TRI6:
       {
         // I have been lazy here and am using finite differences

--- a/src/fe/fe_hermite.C
+++ b/src/fe/fe_hermite.C
@@ -88,6 +88,7 @@ unsigned int hermite_n_dofs(const ElemType t, const Order o)
       return 1;
     case EDGE2:
       libmesh_assert_less (o, 4);
+      /* FALLTHROUGH */
     case EDGE3:
       return (o+1);
 
@@ -95,12 +96,14 @@ unsigned int hermite_n_dofs(const ElemType t, const Order o)
     case QUADSHELL4:
     case QUAD8:
       libmesh_assert_less (o, 4);
+      /* FALLTHROUGH */
     case QUAD9:
       return ((o+1)*(o+1));
 
     case HEX8:
     case HEX20:
       libmesh_assert_less (o, 4);
+      /* FALLTHROUGH */
     case HEX27:
       return ((o+1)*(o+1)*(o+1));
 
@@ -149,6 +152,7 @@ unsigned int hermite_n_dofs_at_node(const ElemType t,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 4);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       {
@@ -179,6 +183,7 @@ unsigned int hermite_n_dofs_at_node(const ElemType t,
     case HEX8:
     case HEX20:
       libmesh_assert_less (o, 4);
+      /* FALLTHROUGH */
     case HEX27:
       {
         switch (n)
@@ -253,11 +258,13 @@ unsigned int hermite_n_dofs_per_elem(const ElemType t,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 4);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       return ((o-3)*(o-3));
     case HEX8:
       libmesh_assert_less (o, 4);
+      /* FALLTHROUGH */
     case HEX20:
     case HEX27:
       return ((o-3)*(o-3)*(o-3));

--- a/src/fe/fe_hermite.C
+++ b/src/fe/fe_hermite.C
@@ -88,7 +88,7 @@ unsigned int hermite_n_dofs(const ElemType t, const Order o)
       return 1;
     case EDGE2:
       libmesh_assert_less (o, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case EDGE3:
       return (o+1);
 
@@ -96,14 +96,14 @@ unsigned int hermite_n_dofs(const ElemType t, const Order o)
     case QUADSHELL4:
     case QUAD8:
       libmesh_assert_less (o, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD9:
       return ((o+1)*(o+1));
 
     case HEX8:
     case HEX20:
       libmesh_assert_less (o, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX27:
       return ((o+1)*(o+1)*(o+1));
 
@@ -152,7 +152,7 @@ unsigned int hermite_n_dofs_at_node(const ElemType t,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       {
@@ -183,7 +183,7 @@ unsigned int hermite_n_dofs_at_node(const ElemType t,
     case HEX8:
     case HEX20:
       libmesh_assert_less (o, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX27:
       {
         switch (n)
@@ -258,13 +258,13 @@ unsigned int hermite_n_dofs_per_elem(const ElemType t,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       return ((o-3)*(o-3));
     case HEX8:
       libmesh_assert_less (o, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX20:
     case HEX27:
       return ((o-3)*(o-3)*(o-3));

--- a/src/fe/fe_hermite.C
+++ b/src/fe/fe_hermite.C
@@ -88,7 +88,7 @@ unsigned int hermite_n_dofs(const ElemType t, const Order o)
       return 1;
     case EDGE2:
       libmesh_assert_less (o, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case EDGE3:
       return (o+1);
 
@@ -96,14 +96,14 @@ unsigned int hermite_n_dofs(const ElemType t, const Order o)
     case QUADSHELL4:
     case QUAD8:
       libmesh_assert_less (o, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD9:
       return ((o+1)*(o+1));
 
     case HEX8:
     case HEX20:
       libmesh_assert_less (o, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX27:
       return ((o+1)*(o+1)*(o+1));
 
@@ -152,7 +152,7 @@ unsigned int hermite_n_dofs_at_node(const ElemType t,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       {
@@ -183,7 +183,7 @@ unsigned int hermite_n_dofs_at_node(const ElemType t,
     case HEX8:
     case HEX20:
       libmesh_assert_less (o, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX27:
       {
         switch (n)
@@ -258,13 +258,13 @@ unsigned int hermite_n_dofs_per_elem(const ElemType t,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       return ((o-3)*(o-3));
     case HEX8:
       libmesh_assert_less (o, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX20:
     case HEX27:
       return ((o-3)*(o-3)*(o-3));

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -226,7 +226,7 @@ Real FE<2,HERMITE>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       {
@@ -293,7 +293,7 @@ Real FE<2,HERMITE>::shape_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       {
@@ -358,7 +358,7 @@ Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 4);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       {

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -226,6 +226,7 @@ Real FE<2,HERMITE>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 4);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       {
@@ -292,6 +293,7 @@ Real FE<2,HERMITE>::shape_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 4);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       {
@@ -356,6 +358,7 @@ Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 4);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       {

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -226,7 +226,7 @@ Real FE<2,HERMITE>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       {
@@ -293,7 +293,7 @@ Real FE<2,HERMITE>::shape_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       {
@@ -358,7 +358,7 @@ Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 4);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       {

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -113,17 +113,21 @@ unsigned int hierarchic_n_dofs(const ElemType t, const Order o)
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       return ((o+1)*(o+1));
     case HEX8:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case HEX20:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case HEX27:
       return ((o+1)*(o+1)*(o+1));
     case TRI3:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case TRI6:
       return ((o+1)*(o+2)/2);
     case INVALID_ELEM:
@@ -164,6 +168,7 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case TRI3:
       libmesh_assert_less (n, 3);
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case TRI6:
       switch (n)
         {
@@ -185,6 +190,7 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case QUADSHELL4:
       libmesh_assert_less (n, 4);
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       switch (n)
@@ -211,9 +217,11 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case HEX8:
       libmesh_assert_less (n, 8);
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case HEX20:
       libmesh_assert_less (n, 20);
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case HEX27:
       switch (n)
         {

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -113,21 +113,21 @@ unsigned int hierarchic_n_dofs(const ElemType t, const Order o)
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       return ((o+1)*(o+1));
     case HEX8:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX20:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX27:
       return ((o+1)*(o+1)*(o+1));
     case TRI3:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TRI6:
       return ((o+1)*(o+2)/2);
     case INVALID_ELEM:
@@ -168,7 +168,7 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case TRI3:
       libmesh_assert_less (n, 3);
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TRI6:
       switch (n)
         {
@@ -190,7 +190,7 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case QUADSHELL4:
       libmesh_assert_less (n, 4);
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       switch (n)
@@ -217,11 +217,11 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case HEX8:
       libmesh_assert_less (n, 8);
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX20:
       libmesh_assert_less (n, 20);
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX27:
       switch (n)
         {

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -113,21 +113,21 @@ unsigned int hierarchic_n_dofs(const ElemType t, const Order o)
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       return ((o+1)*(o+1));
     case HEX8:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX20:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX27:
       return ((o+1)*(o+1)*(o+1));
     case TRI3:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TRI6:
       return ((o+1)*(o+2)/2);
     case INVALID_ELEM:
@@ -168,7 +168,7 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case TRI3:
       libmesh_assert_less (n, 3);
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TRI6:
       switch (n)
         {
@@ -190,7 +190,7 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case QUADSHELL4:
       libmesh_assert_less (n, 4);
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       switch (n)
@@ -217,11 +217,11 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     case HEX8:
       libmesh_assert_less (n, 8);
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX20:
       libmesh_assert_less (n, 20);
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX27:
       switch (n)
         {

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -157,6 +157,7 @@ Real FE<2,HIERARCHIC>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       {
@@ -294,6 +295,7 @@ Real FE<2,HIERARCHIC>::shape_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       {

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -157,7 +157,7 @@ Real FE<2,HIERARCHIC>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       {
@@ -295,7 +295,7 @@ Real FE<2,HIERARCHIC>::shape_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       {

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -157,7 +157,7 @@ Real FE<2,HIERARCHIC>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       {
@@ -295,7 +295,7 @@ Real FE<2,HIERARCHIC>::shape_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       {

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -671,7 +671,7 @@ Real FE<3,HIERARCHIC>::shape(const Elem * elem,
     case HEX8:
     case HEX20:
       libmesh_assert_less (totalorder, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX27:
       {
         libmesh_assert_less (i, (totalorder+1u)*(totalorder+1u)*(totalorder+1u));

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -671,7 +671,7 @@ Real FE<3,HIERARCHIC>::shape(const Elem * elem,
     case HEX8:
     case HEX20:
       libmesh_assert_less (totalorder, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX27:
       {
         libmesh_assert_less (i, (totalorder+1u)*(totalorder+1u)*(totalorder+1u));

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -671,6 +671,7 @@ Real FE<3,HIERARCHIC>::shape(const Elem * elem,
     case HEX8:
     case HEX20:
       libmesh_assert_less (totalorder, 2);
+      /* FALLTHROUGH */
     case HEX27:
       {
         libmesh_assert_less (i, (totalorder+1u)*(totalorder+1u)*(totalorder+1u));

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -121,7 +121,7 @@ unsigned int l2_hierarchic_n_dofs(const ElemType t, const Order o)
       return ((o+1)*(o+1)*(o+1));
     case TRI3:
       libmesh_assert_less (o, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case TRI6:
       return ((o+1)*(o+2)/2);
     case INVALID_ELEM:

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -121,6 +121,7 @@ unsigned int l2_hierarchic_n_dofs(const ElemType t, const Order o)
       return ((o+1)*(o+1)*(o+1));
     case TRI3:
       libmesh_assert_less (o, 2);
+      /* FALLTHROUGH */
     case TRI6:
       return ((o+1)*(o+2)/2);
     case INVALID_ELEM:

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -121,7 +121,7 @@ unsigned int l2_hierarchic_n_dofs(const ElemType t, const Order o)
       return ((o+1)*(o+1)*(o+1));
     case TRI3:
       libmesh_assert_less (o, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case TRI6:
       return ((o+1)*(o+2)/2);
     case INVALID_ELEM:

--- a/src/fe/fe_l2_hierarchic_shape_2D.C
+++ b/src/fe/fe_l2_hierarchic_shape_2D.C
@@ -157,7 +157,7 @@ Real FE<2,L2_HIERARCHIC>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       {
@@ -296,7 +296,7 @@ Real FE<2,L2_HIERARCHIC>::shape_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case QUAD8:
     case QUAD9:
       {

--- a/src/fe/fe_l2_hierarchic_shape_2D.C
+++ b/src/fe/fe_l2_hierarchic_shape_2D.C
@@ -157,6 +157,7 @@ Real FE<2,L2_HIERARCHIC>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       {
@@ -295,6 +296,7 @@ Real FE<2,L2_HIERARCHIC>::shape_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
+      /* FALLTHROUGH */
     case QUAD8:
     case QUAD9:
       {

--- a/src/fe/fe_l2_hierarchic_shape_2D.C
+++ b/src/fe/fe_l2_hierarchic_shape_2D.C
@@ -157,7 +157,7 @@ Real FE<2,L2_HIERARCHIC>::shape(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       {
@@ -296,7 +296,7 @@ Real FE<2,L2_HIERARCHIC>::shape_deriv(const Elem * elem,
     case QUAD4:
     case QUADSHELL4:
       libmesh_assert_less (totalorder, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case QUAD8:
     case QUAD9:
       {

--- a/src/fe/fe_l2_hierarchic_shape_3D.C
+++ b/src/fe/fe_l2_hierarchic_shape_3D.C
@@ -671,7 +671,7 @@ Real FE<3,L2_HIERARCHIC>::shape(const Elem * elem,
     case HEX8:
     case HEX20:
       libmesh_assert_less (totalorder, 2);
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
     case HEX27:
       {
         libmesh_assert_less (i, (totalorder+1u)*(totalorder+1u)*(totalorder+1u));

--- a/src/fe/fe_l2_hierarchic_shape_3D.C
+++ b/src/fe/fe_l2_hierarchic_shape_3D.C
@@ -671,7 +671,7 @@ Real FE<3,L2_HIERARCHIC>::shape(const Elem * elem,
     case HEX8:
     case HEX20:
       libmesh_assert_less (totalorder, 2);
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case HEX27:
       {
         libmesh_assert_less (i, (totalorder+1u)*(totalorder+1u)*(totalorder+1u));

--- a/src/fe/fe_l2_hierarchic_shape_3D.C
+++ b/src/fe/fe_l2_hierarchic_shape_3D.C
@@ -671,6 +671,7 @@ Real FE<3,L2_HIERARCHIC>::shape(const Elem * elem,
     case HEX8:
     case HEX20:
       libmesh_assert_less (totalorder, 2);
+      /* FALLTHROUGH */
     case HEX27:
       {
         libmesh_assert_less (i, (totalorder+1u)*(totalorder+1u)*(totalorder+1u));

--- a/src/fe/fe_l2_lagrange_shape_3D.C
+++ b/src/fe/fe_l2_lagrange_shape_3D.C
@@ -1248,7 +1248,7 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const ElemType type,
                              << std::endl;
               warning_given_HEX20 = true;
             }
-            /* FALLTHROUGH */
+            libmesh_fallthrough;
 
           case HEX27:
             // triquadratic hexahedral shape functions

--- a/src/fe/fe_l2_lagrange_shape_3D.C
+++ b/src/fe/fe_l2_lagrange_shape_3D.C
@@ -1248,9 +1248,10 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const ElemType type,
                              << std::endl;
               warning_given_HEX20 = true;
             }
+            /* FALLTHROUGH */
 
-            // triquadraic hexahedral shape funcions
           case HEX27:
+            // triquadraic hexahedral shape funcions
             {
               libmesh_assert_less (i, 27);
 

--- a/src/fe/fe_l2_lagrange_shape_3D.C
+++ b/src/fe/fe_l2_lagrange_shape_3D.C
@@ -1248,7 +1248,7 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const ElemType type,
                              << std::endl;
               warning_given_HEX20 = true;
             }
-            libmesh_fallthrough;
+            libmesh_fallthrough();
 
           case HEX27:
             // triquadratic hexahedral shape functions

--- a/src/fe/fe_l2_lagrange_shape_3D.C
+++ b/src/fe/fe_l2_lagrange_shape_3D.C
@@ -1251,7 +1251,7 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const ElemType type,
             /* FALLTHROUGH */
 
           case HEX27:
-            // triquadraic hexahedral shape funcions
+            // triquadratic hexahedral shape functions
             {
               libmesh_assert_less (i, 27);
 

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1593,6 +1593,8 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
     case 1:
       {
         build_line (mesh, 3, -rad, rad, type);
+
+        break;
       }
 
 

--- a/src/numerics/dense_matrix.C
+++ b/src/numerics/dense_matrix.C
@@ -619,7 +619,7 @@ void DenseMatrix<T>::lu_solve (const DenseVector<T> & b,
         if (this->use_blas_lapack)
           break;
       }
-      libmesh_fallthrough;
+      libmesh_fallthrough();
 
     case LU:
       {
@@ -627,7 +627,7 @@ void DenseMatrix<T>::lu_solve (const DenseVector<T> & b,
         if (!(this->use_blas_lapack))
           break;
       }
-      libmesh_fallthrough;
+      libmesh_fallthrough();
 
     default:
       libmesh_error_msg("Error! This matrix already has a different decomposition...");

--- a/src/numerics/dense_matrix.C
+++ b/src/numerics/dense_matrix.C
@@ -619,7 +619,7 @@ void DenseMatrix<T>::lu_solve (const DenseVector<T> & b,
         if (this->use_blas_lapack)
           break;
       }
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
 
     case LU:
       {
@@ -627,7 +627,7 @@ void DenseMatrix<T>::lu_solve (const DenseVector<T> & b,
         if (!(this->use_blas_lapack))
           break;
       }
-      /* FALLTHROUGH */
+      libmesh_fallthrough;
 
     default:
       libmesh_error_msg("Error! This matrix already has a different decomposition...");

--- a/src/numerics/dense_matrix.C
+++ b/src/numerics/dense_matrix.C
@@ -619,6 +619,7 @@ void DenseMatrix<T>::lu_solve (const DenseVector<T> & b,
         if (this->use_blas_lapack)
           break;
       }
+      /* FALLTHROUGH */
 
     case LU:
       {
@@ -626,6 +627,7 @@ void DenseMatrix<T>::lu_solve (const DenseVector<T> & b,
         if (!(this->use_blas_lapack))
           break;
       }
+      /* FALLTHROUGH */
 
     default:
       libmesh_error_msg("Error! This matrix already has a different decomposition...");

--- a/src/numerics/dense_matrix_blas_lapack.C
+++ b/src/numerics/dense_matrix_blas_lapack.C
@@ -47,28 +47,28 @@ void DenseMatrix<T>::_multiply_blas(const DenseMatrixBase<T> & other,
         if (other.n() == this->m())
           break;
       }
-        /* FALLTHROUGH */
+      libmesh_fallthrough;
     case RIGHT_MULTIPLY:
       {
         result_size = other.n() * this->m();
         if (other.m() == this->n())
           break;
       }
-        /* FALLTHROUGH */
+      libmesh_fallthrough;
     case LEFT_MULTIPLY_TRANSPOSE:
       {
         result_size = other.n() * this->n();
         if (other.m() == this->m())
           break;
       }
-        /* FALLTHROUGH */
+      libmesh_fallthrough;
     case RIGHT_MULTIPLY_TRANSPOSE:
       {
         result_size = other.m() * this->m();
         if (other.n() == this->n())
           break;
       }
-        /* FALLTHROUGH */
+      libmesh_fallthrough;
     default:
       libmesh_error_msg("Unknown flag selected or matrices are incompatible for multiplication.");
     }

--- a/src/numerics/dense_matrix_blas_lapack.C
+++ b/src/numerics/dense_matrix_blas_lapack.C
@@ -47,24 +47,28 @@ void DenseMatrix<T>::_multiply_blas(const DenseMatrixBase<T> & other,
         if (other.n() == this->m())
           break;
       }
+        /* FALLTHROUGH */
     case RIGHT_MULTIPLY:
       {
         result_size = other.n() * this->m();
         if (other.m() == this->n())
           break;
       }
+        /* FALLTHROUGH */
     case LEFT_MULTIPLY_TRANSPOSE:
       {
         result_size = other.n() * this->n();
         if (other.m() == this->m())
           break;
       }
+        /* FALLTHROUGH */
     case RIGHT_MULTIPLY_TRANSPOSE:
       {
         result_size = other.m() * this->m();
         if (other.n() == this->n())
           break;
       }
+        /* FALLTHROUGH */
     default:
       libmesh_error_msg("Unknown flag selected or matrices are incompatible for multiplication.");
     }

--- a/src/numerics/dense_matrix_blas_lapack.C
+++ b/src/numerics/dense_matrix_blas_lapack.C
@@ -47,28 +47,28 @@ void DenseMatrix<T>::_multiply_blas(const DenseMatrixBase<T> & other,
         if (other.n() == this->m())
           break;
       }
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case RIGHT_MULTIPLY:
       {
         result_size = other.n() * this->m();
         if (other.m() == this->n())
           break;
       }
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case LEFT_MULTIPLY_TRANSPOSE:
       {
         result_size = other.n() * this->n();
         if (other.m() == this->m())
           break;
       }
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     case RIGHT_MULTIPLY_TRANSPOSE:
       {
         result_size = other.m() * this->m();
         if (other.n() == this->n())
           break;
       }
-      libmesh_fallthrough;
+      libmesh_fallthrough();
     default:
       libmesh_error_msg("Unknown flag selected or matrices are incompatible for multiplication.");
     }

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -217,7 +217,7 @@ void QGauss::init_3D(const ElemType type_in,
               // Note: if !allow_rules_with_negative_weights, fall through to next case.
             }
 
-
+            libmesh_fallthrough;
 
 
             // Walkington's fifth-order 14-point rule from
@@ -452,6 +452,9 @@ void QGauss::init_3D(const ElemType type_in,
                 } // end if (allow_rules_with_negative_weights)
               // Note: if !allow_rules_with_negative_weights, fall through to next case.
             }
+
+            libmesh_fallthrough;
+
 
             // Fall back on Grundmann-Moller or Conical Product rules at high orders.
           default:

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -217,7 +217,7 @@ void QGauss::init_3D(const ElemType type_in,
               // Note: if !allow_rules_with_negative_weights, fall through to next case.
             }
 
-            libmesh_fallthrough;
+            libmesh_fallthrough();
 
 
             // Walkington's fifth-order 14-point rule from
@@ -453,7 +453,7 @@ void QGauss::init_3D(const ElemType type_in,
               // Note: if !allow_rules_with_negative_weights, fall through to next case.
             }
 
-            libmesh_fallthrough;
+            libmesh_fallthrough();
 
 
             // Fall back on Grundmann-Moller or Conical Product rules at high orders.

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -523,7 +523,7 @@ void QMonomial::init_2D(const ElemType type_in,
           } // end switch(_order + 2*p)
       } // end case QUAD4/8/9
 
-      libmesh_fallthrough;
+      libmesh_fallthrough();
 
       // By default: construct and use a Gauss quadrature rule
     default:

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -523,6 +523,7 @@ void QMonomial::init_2D(const ElemType type_in,
           } // end switch(_order + 2*p)
       } // end case QUAD4/8/9
 
+      libmesh_fallthrough;
 
       // By default: construct and use a Gauss quadrature rule
     default:

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -317,6 +317,7 @@ void QMonomial::init_3D(const ElemType type_in,
           } // end switch(_order + 2*p)
       } // end case HEX8/20/27
 
+      libmesh_fallthrough;
 
       // By default: construct and use a Gauss quadrature rule
     default:

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -317,7 +317,7 @@ void QMonomial::init_3D(const ElemType type_in,
           } // end switch(_order + 2*p)
       } // end case HEX8/20/27
 
-      libmesh_fallthrough;
+      libmesh_fallthrough();
 
       // By default: construct and use a Gauss quadrature rule
     default:


### PR DESCRIPTION
There are still fallthrough warnings coming from quadrature .C files, but I can't seem to figure out how to get gcc to ignore those; it's as if the nested switch statements confuse the parser there.

Still, the output from this PR has *far* fewer false positives than it did before, thanks to the header fixes.