### PR TITLE
stitch_meshes() optimizing

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -172,6 +172,8 @@ void MeshBase::set_spatial_dimension(unsigned char d)
 
 void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, const bool skip_find_neighbors)
 {
+  LOG_SCOPE("prepare_for_use()", "MeshBase");
+
   parallel_object_only();
 
   libmesh_assert(this->comm().verify(this->is_serial()));

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1285,18 +1285,24 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
   for (dof_id_type i=0; i != pmax_elem_id; ++i)
     {
       const Elem * elem = mesh.query_elem_ptr(i);
-      unsigned int n_nodes = elem ? elem->n_nodes() : 0;
-      unsigned int n_edges = elem ? elem->n_edges() : 0;
-      unsigned int n_sides = elem ? elem->n_sides() : 0;
-      libmesh_assert(mesh.comm().semiverify
-                     (elem ? &n_nodes : libmesh_nullptr));
-      libmesh_assert(mesh.comm().semiverify
-                     (elem ? &n_edges : libmesh_nullptr));
-      libmesh_assert(mesh.comm().semiverify
-                     (elem ? &n_sides : libmesh_nullptr));
+      const unsigned int my_n_nodes = elem ? elem->n_nodes() : 0;
+      const unsigned int my_n_edges = elem ? elem->n_edges() : 0;
+      const unsigned int my_n_sides = elem ? elem->n_sides() : 0;
+      unsigned int n_nodes = my_n_nodes,
+                   n_edges = my_n_edges,
+                   n_sides = my_n_sides;
+
       mesh.comm().max(n_nodes);
       mesh.comm().max(n_edges);
       mesh.comm().max(n_sides);
+
+      if (elem)
+        {
+          libmesh_assert_equal_to(my_n_nodes, n_nodes);
+          libmesh_assert_equal_to(my_n_edges, n_edges);
+          libmesh_assert_equal_to(my_n_sides, n_sides);
+        }
+
       for (unsigned int n=0; n != n_nodes; ++n)
         {
           std::vector<boundary_id_type> bcids;

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -993,6 +993,8 @@ void MeshTools::find_hanging_nodes_and_parents(const MeshBase & mesh,
 #ifdef DEBUG
 void MeshTools::libmesh_assert_equal_n_systems (const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_equal_n_systems()", "MeshTools");
+
   MeshBase::const_element_iterator el =
     mesh.elements_begin();
   const MeshBase::const_element_iterator el_end =
@@ -1028,6 +1030,8 @@ void MeshTools::libmesh_assert_equal_n_systems (const MeshBase & mesh)
 #ifdef LIBMESH_ENABLE_AMR
 void MeshTools::libmesh_assert_old_dof_objects (const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_old_dof_objects()", "MeshTools");
+
   MeshBase::const_element_iterator el =
     mesh.elements_begin();
   const MeshBase::const_element_iterator el_end =
@@ -1060,6 +1064,8 @@ void MeshTools::libmesh_assert_old_dof_objects (const MeshBase &) {}
 
 void MeshTools::libmesh_assert_valid_node_pointers(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_valid_node_pointers()", "MeshTools");
+
   const MeshBase::const_element_iterator el_end =
     mesh.elements_end();
   for (MeshBase::const_element_iterator el =
@@ -1084,6 +1090,8 @@ void MeshTools::libmesh_assert_valid_node_pointers(const MeshBase & mesh)
 
 void MeshTools::libmesh_assert_valid_remote_elems(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_valid_remote_elems()", "MeshTools");
+
   const MeshBase::const_element_iterator el_end =
     mesh.local_elements_end();
   for (MeshBase::const_element_iterator el =
@@ -1138,6 +1146,8 @@ void MeshTools::libmesh_assert_no_links_to_elem(const MeshBase & mesh,
 
 void MeshTools::libmesh_assert_valid_elem_ids(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_valid_elem_ids()", "MeshTools");
+
   processor_id_type lastprocid = 0;
   dof_id_type lastelemid = 0;
 
@@ -1163,6 +1173,8 @@ void MeshTools::libmesh_assert_valid_elem_ids(const MeshBase & mesh)
 
 void MeshTools::libmesh_assert_valid_amr_elem_ids(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_valid_amr_elem_ids()", "MeshTools");
+
   const MeshBase::const_element_iterator el_end =
     mesh.elements_end();
   for (MeshBase::const_element_iterator el =
@@ -1185,6 +1197,8 @@ void MeshTools::libmesh_assert_valid_amr_elem_ids(const MeshBase & mesh)
 
 void MeshTools::libmesh_assert_valid_amr_interior_parents(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_valid_amr_interior_parents()", "MeshTools");
+
   const MeshBase::const_element_iterator el_end =
     mesh.elements_end();
   for (MeshBase::const_element_iterator el =
@@ -1223,6 +1237,8 @@ void MeshTools::libmesh_assert_valid_amr_interior_parents(const MeshBase & mesh)
 
 void MeshTools::libmesh_assert_connected_nodes (const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_connected_nodes()", "MeshTools");
+
   std::set<const Node *> used_nodes;
 
   const MeshBase::const_element_iterator el_end =
@@ -1254,6 +1270,8 @@ namespace MeshTools {
 
 void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_valid_boundary_ids()", "MeshTools");
+
   if (mesh.n_processors() == 1)
     return;
 
@@ -1378,6 +1396,8 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
 
 void libmesh_assert_valid_dof_ids(const MeshBase & mesh, unsigned int sysnum)
 {
+  LOG_SCOPE("libmesh_assert_valid_dof_ids()", "MeshTools");
+
   if (mesh.n_processors() == 1)
     return;
 
@@ -1404,6 +1424,8 @@ void libmesh_assert_valid_dof_ids(const MeshBase & mesh, unsigned int sysnum)
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
 void libmesh_assert_valid_unique_ids(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_valid_unique_ids()", "MeshTools");
+
   libmesh_parallel_only(mesh.comm());
 
   dof_id_type pmax_elem_id = mesh.max_elem_id();
@@ -1433,6 +1455,8 @@ void libmesh_assert_valid_unique_ids(const MeshBase & mesh)
 template <>
 void libmesh_assert_topology_consistent_procids<Elem>(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_topology_consistent_procids()", "MeshTools");
+
   // This parameter is not used when !LIBMESH_ENABLE_AMR
   libmesh_ignore(mesh);
 
@@ -1485,6 +1509,8 @@ void libmesh_assert_topology_consistent_procids<Elem>(const MeshBase & mesh)
 template <>
 void libmesh_assert_parallel_consistent_procids<Elem>(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_parallel_consistent_procids()", "MeshTools");
+
   if (mesh.n_processors() == 1)
     return;
 
@@ -1527,6 +1553,8 @@ void libmesh_assert_parallel_consistent_procids<Elem>(const MeshBase & mesh)
 template <>
 void libmesh_assert_topology_consistent_procids<Node>(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_topology_consistent_procids()", "MeshTools");
+
   if (mesh.n_processors() == 1)
     return;
 
@@ -1575,6 +1603,8 @@ void libmesh_assert_topology_consistent_procids<Node>(const MeshBase & mesh)
 template <>
 void libmesh_assert_parallel_consistent_procids<Node>(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_parallel_consistent_procids()", "MeshTools");
+
   if (mesh.n_processors() == 1)
     return;
 
@@ -1643,6 +1673,8 @@ void libmesh_assert_parallel_consistent_procids<Node>(const MeshBase & mesh)
 #ifdef LIBMESH_ENABLE_AMR
 void MeshTools::libmesh_assert_valid_refinement_flags(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_valid_refinement_flags()", "MeshTools");
+
   libmesh_parallel_only(mesh.comm());
   if (mesh.n_processors() == 1)
     return;
@@ -1693,6 +1725,8 @@ void MeshTools::libmesh_assert_valid_refinement_flags(const MeshBase &)
 #ifdef LIBMESH_ENABLE_AMR
 void MeshTools::libmesh_assert_valid_refinement_tree(const MeshBase & mesh)
 {
+  LOG_SCOPE("libmesh_assert_valid_refinement_tree()", "MeshTools");
+
   const MeshBase::const_element_iterator el_end =
     mesh.elements_end();
   for (MeshBase::const_element_iterator el =
@@ -1734,6 +1768,8 @@ void MeshTools::libmesh_assert_valid_refinement_tree(const MeshBase &)
 void MeshTools::libmesh_assert_valid_neighbors(const MeshBase & mesh,
                                                bool assert_valid_remote_elems)
 {
+  LOG_SCOPE("libmesh_assert_valid_neighbors()", "MeshTools");
+
   const MeshBase::const_element_iterator el_end = mesh.elements_end();
   for (MeshBase::const_element_iterator el = mesh.elements_begin();
        el != el_end; ++el)

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1303,6 +1303,11 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
           libmesh_assert_equal_to(my_n_sides, n_sides);
         }
 
+      // Let's test all IDs on the element with one communication
+      // rather than n_nodes + n_edges + n_sides communications, to
+      // cut down on latency in dbg modes.
+      std::vector<boundary_id_type> all_bcids;
+
       for (unsigned int n=0; n != n_nodes; ++n)
         {
           std::vector<boundary_id_type> bcids;
@@ -1313,8 +1318,13 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
               // Ordering of boundary ids shouldn't matter
               std::sort(bcids.begin(), bcids.end());
             }
-          libmesh_assert(mesh.comm().semiverify
-                         (elem ? &bcids : libmesh_nullptr));
+//          libmesh_assert(mesh.comm().semiverify
+//                         (elem ? &bcids : libmesh_nullptr));
+
+          all_bcids.insert(all_bcids.end(), bcids.begin(),
+                           bcids.end());
+          // Separator
+          all_bcids.push_back(BoundaryInfo::invalid_id);
         }
 
       for (unsigned short e=0; e != n_edges; ++e)
@@ -1329,8 +1339,13 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
               std::sort(bcids.begin(), bcids.end());
             }
 
-          libmesh_assert(mesh.comm().semiverify
-                         (elem ? &bcids : libmesh_nullptr));
+//          libmesh_assert(mesh.comm().semiverify
+//                         (elem ? &bcids : libmesh_nullptr));
+
+          all_bcids.insert(all_bcids.end(), bcids.begin(),
+                           bcids.end());
+          // Separator
+          all_bcids.push_back(BoundaryInfo::invalid_id);
 
           if (elem)
             {
@@ -1338,10 +1353,15 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
 
               // Ordering of boundary ids shouldn't matter
               std::sort(bcids.begin(), bcids.end());
+
+              all_bcids.insert(all_bcids.end(), bcids.begin(),
+                               bcids.end());
+              // Separator
+              all_bcids.push_back(BoundaryInfo::invalid_id);
             }
 
-          libmesh_assert(mesh.comm().semiverify
-                         (elem ? &bcids : libmesh_nullptr));
+//          libmesh_assert(mesh.comm().semiverify
+//                         (elem ? &bcids : libmesh_nullptr));
         }
 
       for (unsigned short s=0; s != n_sides; ++s)
@@ -1354,10 +1374,15 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
 
               // Ordering of boundary ids shouldn't matter
               std::sort(bcids.begin(), bcids.end());
+
+              all_bcids.insert(all_bcids.end(), bcids.begin(),
+                               bcids.end());
+              // Separator
+              all_bcids.push_back(BoundaryInfo::invalid_id);
             }
 
-          libmesh_assert(mesh.comm().semiverify
-                         (elem ? &bcids : libmesh_nullptr));
+//          libmesh_assert(mesh.comm().semiverify
+//                         (elem ? &bcids : libmesh_nullptr));
 
           if (elem)
             {
@@ -1365,10 +1390,15 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
 
               // Ordering of boundary ids shouldn't matter
               std::sort(bcids.begin(), bcids.end());
+
+              all_bcids.insert(all_bcids.end(), bcids.begin(),
+                               bcids.end());
+              // Separator
+              all_bcids.push_back(BoundaryInfo::invalid_id);
             }
 
-          libmesh_assert(mesh.comm().semiverify
-                         (elem ? &bcids : libmesh_nullptr));
+//          libmesh_assert(mesh.comm().semiverify
+//                         (elem ? &bcids : libmesh_nullptr));
         }
 
       for (unsigned short sf=0; sf != 2; ++sf)
@@ -1381,10 +1411,15 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
 
               // Ordering of boundary ids shouldn't matter
               std::sort(bcids.begin(), bcids.end());
+
+              all_bcids.insert(all_bcids.end(), bcids.begin(),
+                               bcids.end());
+              // Separator
+              all_bcids.push_back(BoundaryInfo::invalid_id);
             }
 
-          libmesh_assert(mesh.comm().semiverify
-                         (elem ? &bcids : libmesh_nullptr));
+//          libmesh_assert(mesh.comm().semiverify
+//                         (elem ? &bcids : libmesh_nullptr));
 
           if (elem)
             {
@@ -1392,11 +1427,19 @@ void libmesh_assert_valid_boundary_ids(const MeshBase & mesh)
 
               // Ordering of boundary ids shouldn't matter
               std::sort(bcids.begin(), bcids.end());
+
+              all_bcids.insert(all_bcids.end(), bcids.begin(),
+                               bcids.end());
+              // Separator
+              all_bcids.push_back(BoundaryInfo::invalid_id);
             }
 
-          libmesh_assert(mesh.comm().semiverify
-                         (elem ? &bcids : libmesh_nullptr));
+//          libmesh_assert(mesh.comm().semiverify
+//                         (elem ? &bcids : libmesh_nullptr));
         }
+
+      libmesh_assert(mesh.comm().semiverify
+                     (elem ? &all_bcids : libmesh_nullptr));
     }
 }
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -871,6 +871,8 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
   if ((this_mesh_boundary_id  != BoundaryInfo::invalid_id) &&
       (other_mesh_boundary_id != BoundaryInfo::invalid_id))
     {
+      LOG_SCOPE("stitch_meshes node merging", "ReplicatedMesh");
+
       // While finding nodes on the boundary, also find the minimum edge length
       // of all faces on both boundaries.  This will later be used in relative
       // distance checks when stitching nodes.
@@ -1183,6 +1185,8 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
   // in order to copy it to this mesh
   if (this!=other_mesh)
     {
+      LOG_SCOPE("stitch_meshes copying", "ReplicatedMesh");
+
       // need to increment node and element IDs of other_mesh before copying to this mesh
       MeshBase::node_iterator node_it  = other_mesh->nodes_begin();
       MeshBase::node_iterator node_end = other_mesh->nodes_end();
@@ -1295,6 +1299,9 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
 
   std::map<dof_id_type, std::vector<dof_id_type> >::iterator elem_map_it     = node_to_elems_map.begin();
   std::map<dof_id_type, std::vector<dof_id_type> >::iterator elem_map_it_end = node_to_elems_map.end();
+  {
+  LOG_SCOPE("stitch_meshes node updates", "ReplicatedMesh");
+
   for ( ; elem_map_it != elem_map_it_end; ++elem_map_it)
     {
       dof_id_type target_node_id = elem_map_it->first;
@@ -1317,9 +1324,12 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
           this->get_boundary_info().add_node(&target_node, bc_ids);
         }
     }
+  }
 
   std::map<dof_id_type, dof_id_type>::iterator node_map_it     = node_to_node_map.begin();
   std::map<dof_id_type, dof_id_type>::iterator node_map_it_end = node_to_node_map.end();
+  {
+  LOG_SCOPE("stitch_meshes node deletion", "ReplicatedMesh");
   for ( ; node_map_it != node_map_it_end; ++node_map_it)
     {
       // In the case that this==other_mesh, the two nodes might be the same (e.g. if
@@ -1330,6 +1340,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
       dof_id_type this_node_id = node_map_it->second;
       this->delete_node( this->node_ptr(this_node_id) );
     }
+  }
 
   // If find_neighbors() wasn't called in prepare_for_use(), we need to
   // manually loop once more over all elements adjacent to the stitched boundary
@@ -1340,6 +1351,8 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
   //   3. Update the corresponding side in side_to_elem_map as well
   if (skip_find_neighbors)
     {
+      LOG_SCOPE("stitch_meshes neighbor fixes", "ReplicatedMesh");
+
       elem_map_it     = node_to_elems_map.begin();
       elem_map_it_end = node_to_elems_map.end();
       std::set<dof_id_type> fixed_elems;
@@ -1433,6 +1446,8 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
   // faces that are now internal to the mesh
   if (clear_stitched_boundary_ids)
     {
+      LOG_SCOPE("stitch_meshes clear bcids", "ReplicatedMesh");
+
       // Container to catch boundary IDs passed back from BoundaryInfo.
       std::vector<boundary_id_type> bc_ids;
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1178,8 +1178,8 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
 
 
 
-  dof_id_type node_delta = this->n_nodes();
-  dof_id_type elem_delta = this->n_elem();
+  dof_id_type node_delta = this->max_node_id();
+  dof_id_type elem_delta = this->max_elem_id();
 
   // If other_mesh!=NULL, then we have to do a bunch of work
   // in order to copy it to this mesh

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -119,7 +119,6 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
     MeshBase::const_element_iterator it = other_mesh.elements_begin();
     const MeshBase::const_element_iterator end = other_mesh.elements_end();
 
-    // FIXME: Where do we set element IDs??
     for (; it != end; ++it)
       {
         //Look at the old element
@@ -166,7 +165,7 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
         // And start it off in the same subdomain
         el->processor_id() = old->processor_id();
 
-        // Give it the same ids
+        // Give it the same element and unique ids
         el->set_id(old->id());
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -113,7 +113,8 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
     this->reserve_elem(other_mesh.n_elem());
 
     // Declare a map linking old and new elements, needed to copy the neighbor lists
-    std::map<const Elem *, Elem *> old_elems_to_new_elems;
+    typedef LIBMESH_BEST_UNORDERED_MAP<const Elem *, Elem *> map_type;
+    map_type old_elems_to_new_elems;
 
     // Loop over the elements
     MeshBase::const_element_iterator it = other_mesh.elements_begin();

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -71,6 +71,8 @@ UnstructuredMesh::UnstructuredMesh (unsigned char d) :
 void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_mesh,
                                                const bool skip_find_neighbors)
 {
+  LOG_SCOPE("copy_nodes_and_elements()", "UnstructuredMesh");
+
   // We're assuming our subclass data needs no copy
   libmesh_assert_equal_to (_n_parts, other_mesh._n_parts);
   libmesh_assert_equal_to (_is_prepared, other_mesh._is_prepared);


### PR DESCRIPTION
I got tired of dbg-mode timeouts from the MOOSE mesh/patterned_mesh.patterned_generation test killing my test runs.

This PR:

Adds some logging in stitch_meshes(), in the MeshTools::libmesh_assert_foo() methods, and in a couple heavyweight libMesh methods.

Switches to unordered_map for a speedup in UnstructuredMesh::copy_nodes_and_elements()

Switches to more direct BoundaryInfo copying to speed up stitch_meshes()

Collects some MPI communications to *greatly* speed up parallel libmesh_assert_valid_boundary_ids() tests.  This actually might be a noticeable speedup for parallel dbg runs across the board.