### PR TITLE
Add MPI-less allgather(vector<string>)

### DIFF
--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -4131,6 +4131,10 @@ inline void Communicator::allgather(std::vector<T> &,
                                     const bool) const {}
 
 template <typename T>
+inline void Communicator::allgather(std::vector<std::basic_string<T> > &,
+                                    const bool) const {}
+
+template <typename T>
 inline void Communicator::scatter(const std::vector<T> & data,
                                   T & recv,
                                   const unsigned int libmesh_dbg_var(root_id)) const


### PR DESCRIPTION
I forgot to add this as part of #1415

Without it we can't even compile our own unit tests unless MPI is
installed.