### PR TITLE
Fix typos

### DIFF
--- a/configure
+++ b/configure
@@ -1955,14 +1955,13 @@ Optional Features:
   --enable-legacy-using-namespace
                           add "using namespace libMesh" to libMesh headers
   --enable-everything     enable all non-conflicting options
-  --enable-unique-id      build with unique id suppport
+  --enable-unique-id      build with unique id support
   --enable-tracefiles     write stack trace files on unexpected errors
-  --disable-amr           build without adaptive mesh refinement (AMR)
-                          suppport
-  --disable-vsmoother     build without variational smoother suppport
-  --disable-periodic      build without periodic boundary condition suppport
+  --disable-amr           build without adaptive mesh refinement (AMR) support
+  --disable-vsmoother     build without variational smoother support
+  --disable-periodic      build without periodic boundary condition support
   --disable-dirichlet     build without Dirichlet boundary constraint support
-  --enable-nodeconstraint build with node constraints suppport
+  --enable-nodeconstraint build with node constraints support
   --enable-parmesh        Use distributed ParallelMesh as Mesh
   --disable-ghosted       Use dense instead of sparse/ghosted local vectors
   --disable-node-valence  Do not compute and store node valence values
@@ -1986,7 +1985,7 @@ Optional Features:
   --disable-hinnant-unique-ptr
                           build without Howard Hinnant's unique_ptr
                           implementation
-  --disable-petsc         build without PETSc iterative solver suppport
+  --disable-petsc         build without PETSc iterative solver support
   --enable-petsc-required Error if PETSc is not detected by configure
   --disable-slepc         build without SLEPc eigen solver support
   --disable-trilinos      build without Trilinos support
@@ -1994,19 +1993,19 @@ Optional Features:
                           Building Blocks
   --disable-pthreads      build without POSIX threading (pthreads) support
   --disable-openmp        Build without OpenMP Support
-  --disable-laspack       build without LASPACK iterative solver suppport
-  --disable-sfc           build without space-filling curves suppport
-  --disable-gzstreams     build without gzstreams compressed I/O suppport
-  --disable-bzip2         build without bzip2 compressed I/O suppport
-  --disable-xz            build without xz compressed I/O suppport
+  --disable-laspack       build without LASPACK iterative solver support
+  --disable-sfc           build without space-filling curves support
+  --disable-gzstreams     build without gzstreams compressed I/O support
+  --disable-bzip2         build without bzip2 compressed I/O support
+  --disable-xz            build without xz compressed I/O support
   --disable-tecio         build without Tecplot TecIO API support (from
                           source)
   --enable-tecplot        build with Tecplot binary file I/O support (using
                           distributed libraries)
-  --disable-metis         build without Metis graph partitioning suppport
+  --disable-metis         build without Metis graph partitioning support
   --disable-parmetis      build without Parmetis parallel graph partitioning
-                          suppport
-  --disable-tetgen        build without TetGen tetrahedrization library
+                          support
+  --disable-tetgen        build without TetGen tetrahedralization library
                           support
   --disable-triangle      build without Triangle Delaunay triangulation
                           library support
@@ -2028,7 +2027,7 @@ Optional Features:
   --enable-fparser-debugging
                           Build fparser with bytecode debugging functions
   --disable-cppunit       Build without cppunit C++ unit testing support
-  --disable-nanoflann     build without nanoflann KD-tree suppport
+  --disable-nanoflann     build without nanoflann KD-tree support
   --enable-curl           link against libcurl, for using the cURL API
 
 Optional Packages:
@@ -2088,7 +2087,7 @@ Optional Packages:
                           Path to X11 header files. E.g. /usr/include but
                           _not_ /usr/include/X11
   --with-metis=<internal,PETSc>
-                          metis to use. interal: build from contrib, PETSc:
+                          metis to use. internal: build from contrib, PETSc:
                           rely on PETSc
   --with-vtk-include=PATH Specify the path for VTK header files
   --with-vtk-lib=PATH     Specify the path for VTK libs
@@ -2131,9 +2130,9 @@ Some influential environment variables:
   libmesh_CPPFLAGS
               User-specified C/C++ preprocessor flags
   libmesh_CXXFLAGS
-              User-specified C++ compliation flags
+              User-specified C++ compilation flags
   libmesh_CFLAGS
-              User-specified C compliation flags
+              User-specified C compilation flags
   LT_SYS_LIBRARY_PATH
               User-defined run-time library search path.
   CPP         C preprocessor
@@ -6505,7 +6504,7 @@ fi
   #
   # note though than on OSX for example the XCode tools provide
   # a 'mpif77' which will be detected below but is actually an
-  # emtpy shell script wrapper.  Then the compiler will fail to
+  # empty shell script wrapper.  Then the compiler will fail to
   # make executables and we will wind up with static libraries
   # due to a bizarre chain of events.  So, add support for
   # --disable-fortran
@@ -8062,8 +8061,8 @@ fi
               ;;
 
           *)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: Unknown Intel complier" >&5
-$as_echo "Unknown Intel complier" >&6; }
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: Unknown Intel compiler" >&5
+$as_echo "Unknown Intel compiler" >&6; }
               ;;
         esac
       ;;
@@ -9969,7 +9968,7 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
       template <typename T>
       T sum(T t) { return t; }
 
-      // Compute sum of arbitary number of passed parameters.
+      // Compute sum of arbitrary number of passed parameters.
       template <typename T, typename ...P>
       T sum(T t, P ...p)
       {
@@ -28980,9 +28979,9 @@ $as_echo "$ac_cv_path_SED" >&6; }
 
 
 # -------------------------------------------------------------
-# pkg-config - used to configure installed pakages.  We can
+# pkg-config - used to configure installed packages.  We can
 # use it to query our installed targets, if it exists.
-# Otherwise we caln fall back to libmesh-config.
+# Otherwise we can fall back to libmesh-config.
 #
 # Not required to build libmesh, but we can install a config
 # file so that users can use 'pkg-config libmesh ...'
@@ -39080,7 +39079,7 @@ if (test "$have_zlib_h" != yes -o "$have_libz" != yes) ; then
   enablegz=no
 fi
 
-# If both tests succeded, continue the configuration process.
+# If both tests succeeded, continue the configuration process.
 if (test "$enablegz" = yes) ; then
   GZSTREAM_INCLUDE="-I\$(top_srcdir)/contrib/gzstream"
   GZSTREAM_LIB="\$(EXTERNAL_LIBDIR)/libgzstream\$(libext) -lz"
@@ -42020,7 +42019,7 @@ $as_echo "#define HAVE_NETCDF 1" >>confdefs.h
 $as_echo "<<< Configuring library with NetCDF version 3 support >>>" >&6; }
 
         # pass --disable-netcdf-4 to the subpackage so that we do not require HDF-5
-        # note this is maddness - we will run configure in the subdirectory v4, but not use it,
+        # note this is madness - we will run configure in the subdirectory v4, but not use it,
         # so this is nothing more than a hedge against that failing.  we need it to work for
         # 'make dist' to work
         libmesh_subpackage_arguments="$libmesh_subpackage_arguments --disable-netcdf-4"
@@ -42033,7 +42032,7 @@ $as_echo "#define HAVE_NETCDF 1" >>confdefs.h
 
         # building netcdf-4 requires that we support nested subpackages
         if (test "x$enablenested" = "xno"); then
-          as_fn_error $? "NetCDF v4 requres nested subpackages, try --enable-nested" "$LINENO" 5
+          as_fn_error $? "NetCDF v4 requires nested subpackages, try --enable-nested" "$LINENO" 5
         fi
 
         if (test "x$enablehdf5" = "xno"); then

--- a/configure.ac
+++ b/configure.ac
@@ -247,7 +247,7 @@ AC_DEFINE_UNQUOTED(MICRO_VERSION,            [$AX_POINT_VERSION],  [libMesh micr
 AC_DEFINE_UNQUOTED(LIB_VERSION,              ["$VERSION"],         [libMesh version number])
 AC_DEFINE_UNQUOTED(LIB_RELEASE,              ["$BUILD_DEVSTATUS"], [libMesh source code version])
 AC_DEFINE_UNQUOTED(CXX,                      ["$CXX"],             [C++ compiler])
-AC_DEFINE_UNQUOTED(IO_COMPATIBILITY_VERSION, ["0.7.4"],            [libMesh I/O file format compatiblity string])
+AC_DEFINE_UNQUOTED(IO_COMPATIBILITY_VERSION, ["0.7.4"],            [libMesh I/O file format compatibility string])
 
 
 
@@ -279,9 +279,9 @@ AC_SUBST(SED)
 
 
 # -------------------------------------------------------------
-# pkg-config - used to configure installed pakages.  We can
+# pkg-config - used to configure installed packages.  We can
 # use it to query our installed targets, if it exists.
-# Otherwise we caln fall back to libmesh-config.
+# Otherwise we can fall back to libmesh-config.
 #
 # Not required to build libmesh, but we can install a config
 # file so that users can use 'pkg-config libmesh ...'

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -74,7 +74,7 @@ using namespace libMesh;
 // Function prototype.  This function will assemble the system
 // matrix and right-hand-side at each time step.  Note that
 // since the system is linear we technically do not need to
-// assmeble the matrix at each time step, but we will anyway.
+// assemble the matrix at each time step, but we will anyway.
 // In subsequent examples we will employ adaptive mesh refinement,
 // and with a changing mesh it will be necessary to rebuild the
 // system matrix.
@@ -709,6 +709,6 @@ void assemble_cd (EquationSystems & es,
       system.rhs->add_vector    (Fe, dof_indices);
 
     }
-  // Finished computing the sytem matrix and right-hand side.
+  // Finished computing the system matrix and right-hand side.
 }
 #endif // #ifdef LIBMESH_ENABLE_AMR

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -83,7 +83,7 @@ using namespace libMesh;
 // the linear system for our Laplace problem.  Note that the
 // function will take the EquationSystems object and the
 // name of the system we are assembling as input.  From the
-// EquationSystems object we have acess to the Mesh and
+// EquationSystems object we have access to the Mesh and
 // other objects we might need.
 void assemble_laplace(EquationSystems & es,
                       const std::string & system_name);
@@ -749,7 +749,7 @@ void assemble_laplace(EquationSystems & es,
       perf_log.pop("elem init");
 
       // Now we will build the element matrix.  This involves
-      // a double loop to integrate the test funcions (i) against
+      // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       //
       // Now start logging the element matrix computation

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -65,7 +65,7 @@ using namespace libMesh;
 // the linear system for our Biharmonic problem.  Note that the
 // function will take the EquationSystems object and the
 // name of the system we are assembling as input.  From the
-// EquationSystems object we have acess to the Mesh and
+// EquationSystems object we have access to the Mesh and
 // other objects we might need.
 void assemble_biharmonic(EquationSystems & es,
                          const std::string & system_name);
@@ -709,13 +709,13 @@ void assemble_biharmonic(EquationSystems & es,
   // boundary integration.
   UniquePtr<FEBase> fe_face (FEBase::build(dim, fe_type));
 
-  // Boundary integration requires another quadraure rule,
+  // Boundary integration requires another quadrature rule,
   // with dimensionality one less than the dimensionality
   // of the element.
   // In 1D, the Clough and Gauss quadrature rules are identical.
   UniquePtr<QBase> qface(fe_type.default_quadrature_rule(dim-1));
 
-  // Tell the finte element object to use our
+  // Tell the finite element object to use our
   // quadrature rule.
   fe_face->attach_quadrature_rule (qface.get());
 
@@ -800,7 +800,7 @@ void assemble_biharmonic(EquationSystems & es,
       perf_log.pop("elem init");
 
       // Now we will build the element matrix.  This involves
-      // a double loop to integrate laplacians of the test funcions
+      // a double loop to integrate laplacians of the test functions
       // (i) against laplacians of the trial functions (j).
       //
       // This step is why we need the Clough-Tocher elements -
@@ -875,7 +875,7 @@ void assemble_biharmonic(EquationSystems & es,
               // face.
               fe_face->reinit(elem, s);
 
-              // Loop over the face quagrature points for integration.
+              // Loop over the face quadrature points for integration.
               for (unsigned int qp=0; qp<qface->n_points(); qp++)
                 {
                   // The boundary value.

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -76,7 +76,7 @@ using namespace libMesh;
 // Function prototype.  This function will assemble the system
 // matrix and right-hand-side at each time step.  Note that
 // since the system is linear we technically do not need to
-// assmeble the matrix at each time step, but we will anyway.
+// assemble the matrix at each time step, but we will anyway.
 // In subsequent examples we will employ adaptive mesh refinement,
 // and with a changing mesh it will be necessary to rebuild the
 // system matrix.
@@ -753,7 +753,7 @@ void assemble_cd (EquationSystems & es,
       system.rhs->add_vector    (Fe, dof_indices);
 
     }
-  // Finished computing the sytem matrix and right-hand side.
+  // Finished computing the system matrix and right-hand side.
 }
 #endif // #ifdef LIBMESH_ENABLE_AMR
 

--- a/examples/adjoints/adjoints_ex1/adjoints_ex1.C
+++ b/examples/adjoints/adjoints_ex1/adjoints_ex1.C
@@ -396,7 +396,7 @@ int main (int argc, char ** argv)
         // solves the resulting system
         system.adjoint_solve();
 
-        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unneccesarily in the error estimator
+        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unnecessarily in the error estimator
         system.set_adjoint_already_solved(true);
 
         // Get a pointer to the solution vector of the adjoint problem for QoI 0
@@ -523,7 +523,7 @@ int main (int argc, char ** argv)
         linear_solver->reuse_preconditioner(param.reuse_preconditioner);
         system.adjoint_solve();
 
-        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unneccesarily in the error estimator
+        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unnecessarily in the error estimator
         system.set_adjoint_already_solved(true);
 
         NumericVector<Number> & dual_solution_0 = system.get_adjoint_solution(0);

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -394,7 +394,7 @@ int main (int argc, char ** argv)
         // Compute the sensitivities
         system.adjoint_qoi_parameter_sensitivity(qois, system.get_parameter_vector(), sensitivities);
 
-        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unneccesarily in the error estimator
+        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unnecessarily in the error estimator
         system.set_adjoint_already_solved(true);
 
         GetPot infile_l_shaped("l-shaped.in");
@@ -523,7 +523,7 @@ int main (int argc, char ** argv)
 
         system.adjoint_qoi_parameter_sensitivity(qois, system.get_parameter_vector(), sensitivities);
 
-        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unneccesarily in the error estimator
+        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unnecessarily in the error estimator
         system.set_adjoint_already_solved(true);
 
         GetPot infile_l_shaped("l-shaped.in");

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -613,7 +613,7 @@ UniquePtr<ErrorEstimator> build_error_estimator(FEMParameters & /* param */)
 }
 
 // Functions to build the adjoint based error indicators
-// The error_non_pressure and error_pressure constributions are estimated using
+// The error_non_pressure and error_pressure contributions are estimated using
 // the build_error_estimator_component_wise function below
 UniquePtr<ErrorEstimator>
 build_error_estimator_component_wise (FEMParameters & param,
@@ -866,7 +866,7 @@ int main (int argc, char ** argv)
           libMesh::out<< "Solving the adjoint problem" <<std::endl;
           system.adjoint_solve();
 
-          // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unneccesarily in the error estimator
+          // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unnecessarily in the error estimator
           system.set_adjoint_already_solved(true);
 
           // To plot the adjoint solution, we swap it with the primal solution
@@ -1069,7 +1069,7 @@ int main (int argc, char ** argv)
           coupled_system_weight_functions_y.push_back(&convdiffy3);
 
           // Build the error estimator to estimate the contributions
-          // to the QoI error from the convection diffsion y term
+          // to the QoI error from the convection diffusion y term
           UniquePtr<ErrorEstimator> error_estimator_convection_diffusion_y =
             build_weighted_error_estimator_component_wise (param,
                                                            weights_matrix_convection_diffusion_y,

--- a/examples/adjoints/adjoints_ex3/coupled_system.C
+++ b/examples/adjoints/adjoints_ex3/coupled_system.C
@@ -405,7 +405,7 @@ void CoupledSystem::postprocess()
 // ||e((u_2)_h C,2)||_{L2} ||e(C^*)||_{L2} + ||e(u2 C,2_h)||_{L2} ||e(C^*)||_{L2}
 // These functions compute (u_1)_h or C,1_h , and (u_2)_h or C,2_h , and supply it to the weighted patch recovery error estimator
 // In CoupledFEMFunctionsx, the object built with var = 0, returns the (u_1)_h weight, while
-// the object built with var = 1, returns the C,1_h weight. The switch statment
+// the object built with var = 1, returns the C,1_h weight. The switch statement
 // distinguishes the behavior of the two objects
 // Same thing for CoupledFEMFunctionsy
 Number CoupledFEMFunctionsx::operator()(const FEMContext & c,

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -367,7 +367,7 @@ int main (int argc, char** argv)
         // solves the resulting system
         system.adjoint_solve();
 
-        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unneccesarily in the error estimator
+        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unnecessarily in the error estimator
         system.set_adjoint_already_solved(true);
 
         // Get a pointer to the solution vector of the adjoint problem for QoI 0
@@ -442,7 +442,7 @@ int main (int argc, char** argv)
                      << std::endl
                      << std::endl;
 
-        // Also print out effecitivity indices (estimated error/true error)
+        // Also print out effectivity indices (estimated error/true error)
         libMesh::out << "The effectivity index for the computed error in QoI 0 is "
                      << std::setprecision(17)
                      << std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(0)) / std::abs(QoI_0_computed - QoI_0_exact)
@@ -526,7 +526,7 @@ int main (int argc, char** argv)
         linear_solver->reuse_preconditioner(param.reuse_preconditioner);
         system.adjoint_solve();
 
-        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unneccesarily in the error estimator
+        // Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unnecessarily in the error estimator
         system.set_adjoint_already_solved(true);
 
         NumericVector<Number> & dual_solution_0 = system.get_adjoint_solution(0);
@@ -597,7 +597,7 @@ int main (int argc, char** argv)
                      << std::endl
                      << std::endl;
 
-        // Also print out effecitivity indices (estimated error/true error)
+        // Also print out effectivity indices (estimated error/true error)
         libMesh::out << "The effectivity index for the computed error in QoI 0 is "
                      << std::setprecision(17)
                      << std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(0)) / std::abs(QoI_0_computed - QoI_0_exact)
@@ -611,7 +611,7 @@ int main (int argc, char** argv)
 
         // Hard coded assert to ensure that the actual numbers we are getting are what they should be
 
-        // The effectivity index isn't exactly reproduceable at single precision
+        // The effectivity index isn't exactly reproducible at single precision
         // libmesh_assert_less(std::abs(std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(0)) / std::abs(QoI_0_computed - QoI_0_exact) - 0.84010976704434637), 1.e-5);
         // libmesh_assert_less(std::abs(std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(1)) / std::abs(QoI_1_computed - QoI_1_exact) - 0.48294428289950514), 1.e-5);
 

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -483,7 +483,7 @@ int main (int argc, char ** argv)
 
       // Since we have specified an adjoint solution for the current
       // time (T), set the adjoint_already_solved boolean to true, so
-      // we dont solve unneccesarily in the adjoint sensitivity method
+      // we dont solve unnecessarily in the adjoint sensitivity method
       system.set_adjoint_already_solved(true);
 
       libMesh::out << "|Z("
@@ -536,7 +536,7 @@ int main (int argc, char ** argv)
 
           // Now that we have solved the adjoint, set the
           // adjoint_already_solved boolean to true, so we dont solve
-          // unneccesarily in the error estimator
+          // unnecessarily in the error estimator
           system.set_adjoint_already_solved(true);
 
           libMesh::out << "|Z("
@@ -562,7 +562,7 @@ int main (int argc, char ** argv)
         }
       // End adjoint timestep loop
 
-      // Now that we have computed both the primal and adjoint solutions, we compute the sensitivties to the parameter p
+      // Now that we have computed both the primal and adjoint solutions, we compute the sensitivities to the parameter p
       // dQ/dp = partialQ/partialp - partialR/partialp
       // partialQ/partialp = (Q(p+dp) - Q(p-dp))/(2*dp), this is not supported by the library yet
       // partialR/partialp = (R(u,z;p+dp) - R(u,z;p-dp))/(2*dp), where

--- a/examples/adjoints/adjoints_ex6/adjoints_ex6.C
+++ b/examples/adjoints/adjoints_ex6/adjoints_ex6.C
@@ -25,7 +25,7 @@
 // sharp layer, with QoI based adjoint error estimation and adaptive
 // mesh refinement. The exact QoI value is in poisson.in. This example
 // also illustrates the use of the adjoint Dirichlet boundary
-// condition capability, necesary for handling flux QoIs. We access
+// condition capability, necessary for handling flux QoIs. We access
 // the adjoint capabilities of libMesh via the DiffSystem
 // framework. This file (adjoints_ex6.C) contains the declaration of
 // mesh and equation system objects, poissonsystem.C contains the
@@ -331,7 +331,7 @@ int main (int argc, char ** argv)
         // solves the resulting system
         system.adjoint_solve();
 
-        //Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unneccesarily in the error estimator
+        //Now that we have solved the adjoint, set the adjoint_already_solved boolean to true, so we dont solve unnecessarily in the error estimator
         system.set_adjoint_already_solved(true);
 
         // Get a pointer to the primal solution vector
@@ -380,7 +380,7 @@ int main (int argc, char ** argv)
         libMesh::out << "The computed relative error in QoI 0 is " << std::setprecision(17)
                      << std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(0)) << std::endl; // / std::abs(QoI_0_exact)
 
-        // Also print out effecitivity indices (estimated error/true error)
+        // Also print out effectivity indices (estimated error/true error)
         libMesh::out << "The effectivity index for the computed error in QoI 0 is " << std::setprecision(17)
                      << std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(0)) /
           std::abs(QoI_0_computed - QoI_0_exact) << std::endl;
@@ -502,14 +502,14 @@ int main (int argc, char ** argv)
         libMesh::out << "The computed relative error in QoI 0 is " << std::setprecision(17)
                      << std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(0)) << std::endl; // / std::abs(QoI_0_exact)
 
-        // Also print out effecitivity indices (estimated error/true error)
+        // Also print out effectivity indices (estimated error/true error)
         libMesh::out << "The effectivity index for the computed error in QoI 0 is " << std::setprecision(17)
                      << std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(0)) /
           std::abs(QoI_0_computed - QoI_0_exact) << std::endl;
 
         // Hard coded assert to ensure that the actual numbers we are getting are what they should be
 
-        // The effectivity index isn't exactly reproduceable at single precision
+        // The effectivity index isn't exactly reproducible at single precision
         // libmesh_assert_less(std::abs(std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(0)) / std::abs(QoI_0_computed - QoI_0_exact) - 0.84010976704434637), 1.e-5);
         // libmesh_assert_less(std::abs(std::abs(adjoint_refinement_error_estimator->get_global_QoI_error_estimate(1)) / std::abs(QoI_1_computed - QoI_1_exact) - 0.48294428289950514), 1.e-5);
 

--- a/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
+++ b/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
@@ -122,7 +122,7 @@ int main (int argc, char ** argv)
   // function defined below.
   eigen_system.attach_assemble_function (assemble_mass);
 
-  // Set necessary parametrs used in EigenSystem::solve(),
+  // Set necessary parameters used in EigenSystem::solve(),
   // i.e. the number of requested eigenpairs nev and the number
   // of basis vectors ncv used in the solution algorithm. Note that
   // ncv >= nev must hold and ncv >= 2*nev is recommended.
@@ -276,7 +276,7 @@ void assemble_mass(EquationSystems & es,
       // the numeric integration.
       //
       // We will build the element matrix.  This involves
-      // a double loop to integrate the test funcions (i) against
+      // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         for (std::size_t i=0; i<phi.size(); i++)

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -22,7 +22,7 @@
 // \date 2006
 //
 // This example shows how the previous EigenSolver example
-// can be adapted to solve generailzed eigenvalue problems.
+// can be adapted to solve generalized eigenvalue problems.
 //
 // For solving eigen problems, libMesh interfaces
 // SLEPc (www.grycap.upv.es/slepc/) which again is based on PETSc.
@@ -133,7 +133,7 @@ int main (int argc, char ** argv)
   // function defined below.
   eigen_system.attach_assemble_function (assemble_mass);
 
-  // Set necessary parametrs used in EigenSystem::solve(),
+  // Set necessary parameters used in EigenSystem::solve(),
   // i.e. the number of requested eigenpairs nev and the number
   // of basis vectors ncv used in the solution algorithm. Note that
   // ncv >= nev must hold and ncv >= 2*nev is recommended.
@@ -315,7 +315,7 @@ void assemble_mass(EquationSystems & es,
       // the numeric integration.
       //
       // We will build the element matrix.  This involves
-      // a double loop to integrate the test funcions (i) against
+      // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         for (std::size_t i=0; i<phi.size(); i++)

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -392,7 +392,7 @@ void assemble_matrices(EquationSystems & es,
       // the numeric integration.
       //
       // We will build the element matrix.  This involves
-      // a double loop to integrate the test funcions (i) against
+      // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         for (std::size_t i=0; i<phi.size(); i++)

--- a/examples/fem_system/fem_system_ex1/naviersystem.h
+++ b/examples/fem_system/fem_system_ex1/naviersystem.h
@@ -64,7 +64,7 @@ public:
 
   // The application number controls what boundary conditions and/or
   // forcing functions are applied.  Current options are:
-  // 0 - discontinuous lid velociy driven cavity
+  // 0 - discontinuous lid velocity driven cavity
   // 1 - homogeneous Dirichlet BC with smooth forcing
   unsigned int application;
 

--- a/examples/fem_system/fem_system_ex2/solid_system.C
+++ b/examples/fem_system/fem_system_ex2/solid_system.C
@@ -246,7 +246,7 @@ bool SolidSystem::element_time_derivative(bool request_jacobian,
       // gradient
       material.init_for_qp(grad_u, qp);
 
-      // Aquire, scale and assemble residual and stiffness
+      // Acquire, scale and assemble residual and stiffness
       for (unsigned int i = 0; i < n_u_dofs; i++)
         {
           res.resize(dim);

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -67,7 +67,7 @@ int main (int argc, char ** argv)
   // Parse the input file
   GetPot infile("fem_system_ex3.in");
 
-  // Override input file arguments from the commannd line
+  // Override input file arguments from the command line
   infile.parse_command_line(argc, argv);
 
   // Read in parameters from the input file
@@ -212,7 +212,7 @@ int main (int argc, char ** argv)
       libmesh_assert_equal_to (n_timesteps, 1);
     }
   else
-    libmesh_error_msg(std::string("ERROR: invalud time_solver ")+time_solver);
+    libmesh_error_msg(std::string("ERROR: invalid time_solver ")+time_solver);
 
   // Initialize the system
   equation_systems.init ();

--- a/examples/introduction/introduction_ex3/introduction_ex3.C
+++ b/examples/introduction/introduction_ex3/introduction_ex3.C
@@ -220,7 +220,7 @@ void assemble_poisson(EquationSystems & es,
   // boundary integration.
   UniquePtr<FEBase> fe_face (FEBase::build(dim, fe_type));
 
-  // Boundary integration requires one quadraure rule,
+  // Boundary integration requires one quadrature rule,
   // with dimensionality one less than the dimensionality
   // of the element.
   QGauss qface(dim-1, FIFTH);
@@ -317,7 +317,7 @@ void assemble_poisson(EquationSystems & es,
         {
 
           // Now we will build the element matrix.  This involves
-          // a double loop to integrate the test funcions (i) against
+          // a double loop to integrate the test functions (i) against
           // the trial functions (j).
           for (std::size_t i=0; i<phi.size(); i++)
             for (std::size_t j=0; j<phi.size(); j++)

--- a/examples/introduction/introduction_ex4/introduction_ex4.C
+++ b/examples/introduction/introduction_ex4/introduction_ex4.C
@@ -92,7 +92,7 @@ using namespace libMesh;
 // the linear system for our Poisson problem.  Note that the
 // function will take the EquationSystems object and the
 // name of the system we are assembling as input.  From the
-// EquationSystems object we have acess to the Mesh and
+// EquationSystems object we have access to the Mesh and
 // other objects we might need.
 void assemble_poisson(EquationSystems & es,
                       const std::string & system_name);
@@ -115,7 +115,7 @@ void exact_solution_wrapper (DenseVector<Number> & output,
 // Begin the main program.
 int main (int argc, char ** argv)
 {
-  // Initialize libMesh and any dependent libaries, like in example 2.
+  // Initialize libMesh and any dependent libraries, like in example 2.
   LibMeshInit init (argc, argv);
 
   // This example requires a linear solver package.
@@ -370,12 +370,12 @@ void assemble_poisson(EquationSystems & es,
   // boundary integration.
   UniquePtr<FEBase> fe_face (FEBase::build(dim, fe_type));
 
-  // Boundary integration requires one quadraure rule,
+  // Boundary integration requires one quadrature rule,
   // with dimensionality one less than the dimensionality
   // of the element.
   QGauss qface(dim-1, FIFTH);
 
-  // Tell the finte element object to use our
+  // Tell the finite element object to use our
   // quadrature rule.
   fe_face->attach_quadrature_rule (&qface);
 
@@ -456,12 +456,12 @@ void assemble_poisson(EquationSystems & es,
       perf_log.pop("elem init");
 
       // Now we will build the element matrix.  This involves
-      // a double loop to integrate the test funcions (i) against
+      // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       //
       // We have split the numeric integration into two loops
       // so that we can log the matrix and right-hand-side
-      // computation seperately.
+      // computation separately.
       //
       // Now start logging the element matrix computation
       perf_log.push ("Ke");

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -97,7 +97,7 @@ QuadratureType quad_type=INVALID_Q_RULE;
 // Begin the main program.
 int main (int argc, char ** argv)
 {
-  // Initialize libMesh and any dependent libaries, like in example 2.
+  // Initialize libMesh and any dependent libraries, like in example 2.
   LibMeshInit init (argc, argv);
 
   // This example requires a linear solver package.
@@ -242,7 +242,7 @@ void assemble_poisson(EquationSystems & es,
   // quadrature rules support this order.
   UniquePtr<QBase> qrule(QBase::build(quad_type, dim, THIRD));
 
-  // Tell the finte element object to use our
+  // Tell the finite element object to use our
   // quadrature rule.  Note that a UniquePtr<QBase> returns
   // a QBase* pointer to the object it handles with get().
   // However, using get(), the UniquePtr<QBase> qrule is
@@ -270,13 +270,13 @@ void assemble_poisson(EquationSystems & es,
   // THIRD));
   // \endverbatim
   // And again: using the UniquePtr<QBase> relaxes
-  // the need to delete the object afterwards,
+  // the need to delete the object afterward,
   // they clean up themselves.
   UniquePtr<QBase>  qface (QBase::build(quad_type,
                                         dim-1,
                                         THIRD));
 
-  // Tell the finte element object to use our
+  // Tell the finite element object to use our
   // quadrature rule.  Note that a UniquePtr<QBase> returns
   // a QBase* pointer to the object it handles with get().
   // However, using get(), the UniquePtr<QBase> qface is

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -114,7 +114,7 @@ int main (int argc, char ** argv)
 
   // Quadrisect the mesh triangles a few times to obtain a
   // finer mesh.  Subdivision surface elements require the
-  // refinement data to be removed afterwards.
+  // refinement data to be removed afterward.
   MeshRefinement mesh_refinement (mesh);
   mesh_refinement.uniformly_refine (3);
   MeshTools::Modification::flatten (mesh);
@@ -401,7 +401,7 @@ void assemble_shell (EquationSystems & es,
       //        | Kwu Kwv Kww |        | Fw |
       //         -           -          -  -
       //
-      // The DenseSubMatrix.repostition () member takes the
+      // The DenseSubMatrix.reposition () member takes the
       // (row_offset, column_offset, row_size, column_size).
       //
       // Similarly, the DenseSubVector.reposition () member
@@ -457,7 +457,7 @@ void assemble_shell (EquationSystems & es,
           // covariant components of the first fundamental form rather
           // than the contravariant components, exploiting that the
           // contravariant first fundamental form is the inverse of the
-          // covatiant first fundamental form (hence the determinant etc.).
+          // covariant first fundamental form (hence the determinant etc.).
           RealTensorValue H;
           H(0,0) = a(1) * a(1);
           H(0,1) = H(1,0) = nu * a(1) * a(0) + (1-nu) * a(2) * a(2);

--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -416,7 +416,7 @@ void assemble_helmholtz(EquationSystems & es,
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         {
           // Now we will build the element matrix.  This involves
-          // a double loop to integrate the test funcions (i) against
+          // a double loop to integrate the test functions (i) against
           // the trial functions (j).
           for (std::size_t i=0; i<phi.size(); i++)
             for (std::size_t j=0; j<phi.size(); j++)
@@ -444,12 +444,12 @@ void assemble_helmholtz(EquationSystems & es,
             // boundary integration.
             UniquePtr<FEBase> fe_face (FEBase::build(dim, fe_type));
 
-            // Boundary integration requires one quadraure rule,
+            // Boundary integration requires one quadrature rule,
             // with dimensionality one less than the dimensionality
             // of the element.
             QGauss qface(dim-1, SECOND);
 
-            // Tell the finte element object to use our
+            // Tell the finite element object to use our
             // quadrature rule.
             fe_face->attach_quadrature_rule (&qface);
 
@@ -467,13 +467,13 @@ void assemble_helmholtz(EquationSystems & es,
             fe_face->reinit(elem, side);
 
             // For the Robin BCs, consider a normal admittance an=1
-            // at some parts of the bounfdary
+            // at some parts of the boundary
             const Real an_value = 1.;
 
             // Loop over the face quadrature points for integration.
             for (unsigned int qp=0; qp<qface.n_points(); qp++)
               {
-                // Element matrix contributrion due to prescribed
+                // Element matrix contribution due to prescribed
                 // admittance boundary conditions.
                 for (std::size_t i=0; i<phi_face.size(); i++)
                   for (std::size_t j=0; j<phi_face.size(); j++)

--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -133,7 +133,7 @@ private:
 // Begin the main program.
 int main (int argc, char ** argv)
 {
-  // Initialize libMesh and any dependent libaries, like in example 2.
+  // Initialize libMesh and any dependent libraries, like in example 2.
   LibMeshInit init (argc, argv);
 
   // This example requires a NonlinearSolver.
@@ -192,7 +192,7 @@ int main (int argc, char ** argv)
   if (command_line.search(2, "-FEFamily", "-f"))
     family = command_line.next(family);
 
-  // Cannot use dicontinuous basis.
+  // Cannot use discontinuous basis.
   if ((family == "MONOMIAL") || (family == "XYZ"))
     libmesh_error_msg("This example requires a C^0 (or higher) FE basis.");
 
@@ -251,7 +251,7 @@ int main (int argc, char ** argv)
                       Utility::string_to_enum<Order>   (order),
                       Utility::string_to_enum<FEFamily>(family));
 
-  // Consruct object which provides the residual and jacobian
+  // Construct object which provides the residual and jacobian
   // computations and tell the solver to use it.
   LaplaceYoung laplace_young;
   system.nonlinear_solver->residual_object = &laplace_young;
@@ -334,12 +334,12 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
   // boundary integration.
   UniquePtr<FEBase> fe_face (FEBase::build(dim, fe_type));
 
-  // Boundary integration requires one quadraure rule,
+  // Boundary integration requires one quadrature rule,
   // with dimensionality one less than the dimensionality
   // of the element.
   QGauss qface(dim-1, FIFTH);
 
-  // Tell the finte element object to use our
+  // Tell the finite element object to use our
   // quadrature rule.
   fe_face->attach_quadrature_rule (&qface);
 
@@ -356,7 +356,7 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
   // points.
   const std::vector<std::vector<RealGradient> > & dphi = fe->get_dphi();
 
-  // Define data structures to contain the resdual contributions
+  // Define data structures to contain the residual contributions
   DenseVector<Number> Re;
 
   // This vector will hold the degree of freedom indices for
@@ -562,7 +562,7 @@ void LaplaceYoung::jacobian (const NumericVector<Number> & soln,
                  dof_indices.size());
 
       // Now we will build the element Jacobian.  This involves
-      // a double loop to integrate the test funcions (i) against
+      // a double loop to integrate the test functions (i) against
       // the trial functions (j). Note that the Jacobian depends
       // on the current solution x, which we access using the soln
       // vector.

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -186,7 +186,7 @@ int main (int argc, char ** argv)
   // Prints information about the system to the screen.
   equation_systems.print_info();
 
-  // Before the assemblation of the matrix, we have to clear the two
+  // Before assembling the matrix, we have to clear the two
   // vectors that form the tensor matrix (since this is not performed
   // automatically).
   system.get_vector("v").init(system.n_dofs(), system.n_local_dofs());
@@ -431,7 +431,7 @@ void assemble (EquationSystems & es,
 
       // However, constraining both the sparse matrix (and right hand
       // side) plus the rank 1 matrix is tricky.  The dof_indices
-      // vector has to be backuped for that because the constraining
+      // vector has to be backed up for that because the constraining
       // functions modify it.
 
       std::vector<dof_id_type> dof_indices_backup(dof_indices);
@@ -449,7 +449,7 @@ void assemble (EquationSystems & es,
       system.get_vector("v").add_vector(Ve, dof_indices);
       system.get_vector("w").add_vector(We, dof_indices);
     }
-  // Finished computing the sytem matrix and right-hand side.
+  // Finished computing the system matrix and right-hand side.
 
   // Matrices and vectors must be closed manually.  This is necessary
   // because the matrix is not directly used as the system matrix (in

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -218,7 +218,7 @@ void assemble_ellipticdg(EquationSystems & es,
   DenseVector<Number> Fe;
 
   // Data structures to contain the element and neighbor boundary matrix
-  // contribution. This matrices will do the coupling beetwen the dofs of
+  // contribution. This matrices will do the coupling between the dofs of
   // the element and those of his neighbors.
   // Ken: matrix coupling elem and neighbor dofs
   DenseMatrix<Number> Kne;
@@ -264,14 +264,14 @@ void assemble_ellipticdg(EquationSystems & es,
       Fe.resize (n_dofs);
 
       // Now we will build the element interior matrix.  This involves
-      // a double loop to integrate the test funcions (i) against
+      // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         for (unsigned int i=0; i<n_dofs; i++)
           for (unsigned int j=0; j<n_dofs; j++)
             Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);
 
-      // Now we adress boundary conditions.
+      // Now we address boundary conditions.
       // We consider Dirichlet bc imposed via the interior penalty method
       // The following loops over the sides of the element.
       // If the element has no neighbor on a side then that
@@ -284,7 +284,7 @@ void assemble_ellipticdg(EquationSystems & es,
               fe_elem_face->reinit(elem, side);
 
               UniquePtr<const Elem> elem_side (elem->build_side_ptr(side));
-              // h elemet dimension to compute the interior penalty penalty parameter
+              // h element dimension to compute the interior penalty penalty parameter
               const unsigned int elem_b_order = static_cast<unsigned int> (fe_elem_face->get_order());
               const double h_elem = elem->volume()/elem_side->volume() * 1./pow(elem_b_order, 2.);
 
@@ -399,7 +399,7 @@ void assemble_ellipticdg(EquationSystems & es,
 
                   // Now we will build the element and neighbor
                   // boundary matrices.  This involves
-                  // a double loop to integrate the test funcions
+                  // a double loop to integrate the test functions
                   // (i) against the trial functions (j).
                   for (unsigned int qp=0; qp<qface.n_points(); qp++)
                     {

--- a/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
+++ b/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
@@ -53,7 +53,7 @@ void add_cube_convex_hull_to_mesh(MeshBase & mesh, Point lower_limit, Point uppe
 // Begin the main program.
 int main (int argc, char ** argv)
 {
-  // Initialize libMesh and any dependent libaries, like in example 2.
+  // Initialize libMesh and any dependent libraries, like in example 2.
   LibMeshInit init (argc, argv);
 
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic.C
@@ -108,7 +108,7 @@ Biharmonic::Biharmonic(ReplicatedMesh & mesh) :
   else if (initialState == std::string("rod"))
     _initialState = ROD;
   else
-    libmesh_error_msg("Unknown initial state: neither ball nor rod nor srip");
+    libmesh_error_msg("Unknown initial state: neither ball nor rod nor strip");
 
   std::vector<Real> icenter;
   command_line_vector("initial_center", icenter);

--- a/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
+++ b/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
@@ -265,7 +265,7 @@ int main(int argc, char ** argv)
         rbi.get_source_vals()   = idi.get_source_vals();
       }
 
-      // We have only set local values - prepare for use by gathering remote gata
+      // We have only set local values - prepare for use by gathering remote data
       idi.prepare_for_use();
       rbi.prepare_for_use();
 

--- a/examples/optimization/optimization_ex1/optimization_ex1.C
+++ b/examples/optimization/optimization_ex1/optimization_ex1.C
@@ -222,7 +222,7 @@ void AssembleOptimization::gradient (const NumericVector<Number> & soln,
 {
   grad_f.zero();
 
-  // Since we've enforced constaints on soln, A and F,
+  // Since we've enforced constraints on soln, A and F,
   // this automatically sets grad_f to zero for constrained
   // dofs.
   A_matrix->vector_mult(grad_f, soln);

--- a/examples/reduced_basis/reduced_basis_ex1/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex1/rb_classes.h
@@ -106,7 +106,7 @@ public:
     // Generate a DirichletBoundary object
     dirichlet_bc = build_zero_dirichlet_boundary_object();
 
-    // Set the Dirichet boundary IDs
+    // Set the Dirichlet boundary IDs
     // and the Dirichlet boundary variable numbers
     dirichlet_bc->b.insert(0);
     dirichlet_bc->b.insert(1);

--- a/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
+++ b/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
@@ -33,7 +33,7 @@
 // dependent functions and a^q, f^q are parameter independent
 // operators (\mu denotes a parameter).
 //
-// We first attach the parameter dependent functions and paramater
+// We first attach the parameter dependent functions and parameter
 // independent operators to the RBSystem. Then in Offline mode, a
 // reduced basis space is generated and written out to the directory
 // "offline_data". In Online mode, the reduced basis data in

--- a/examples/reduced_basis/reduced_basis_ex2/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex2/rb_classes.h
@@ -123,7 +123,7 @@ public:
     // Generate a DirichletBoundary object
     dirichlet_bc = build_zero_dirichlet_boundary_object();
 
-    // Set the Dirichet boundary IDs
+    // Set the Dirichlet boundary IDs
     // and the Dirichlet boundary variable numbers
     dirichlet_bc->b.insert(3);
     dirichlet_bc->variables.push_back(u_var);

--- a/examples/reduced_basis/reduced_basis_ex3/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex3/rb_classes.h
@@ -106,7 +106,7 @@ public:
     // Generate a DirichletBoundary object
     dirichlet_bc = build_zero_dirichlet_boundary_object();
 
-    // Set the Dirichet boundary IDs
+    // Set the Dirichlet boundary IDs
     // and the Dirichlet boundary variable numbers
     dirichlet_bc->b.insert(0);
     dirichlet_bc->b.insert(1);

--- a/examples/reduced_basis/reduced_basis_ex4/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/rb_classes.h
@@ -87,7 +87,7 @@ public:
     // Generate a DirichletBoundary object
     dirichlet_bc = build_zero_dirichlet_boundary_object();
 
-    // Set the Dirichet boundary IDs
+    // Set the Dirichlet boundary IDs
     // and the Dirichlet boundary variable numbers
     dirichlet_bc->b.insert(0);
     dirichlet_bc->b.insert(1);

--- a/examples/reduced_basis/reduced_basis_ex5/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex5/rb_classes.h
@@ -81,7 +81,7 @@ public:
     // Generate a DirichletBoundary object
     dirichlet_bc = build_zero_dirichlet_boundary_object();
 
-    // Set the Dirichet boundary condition
+    // Set the Dirichlet boundary condition
     dirichlet_bc->b.insert(BOUNDARY_ID_MIN_X); // Dirichlet boundary at x=0
     dirichlet_bc->variables.push_back(u_var);
     dirichlet_bc->variables.push_back(v_var);

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -274,7 +274,7 @@ int main(int argc, char ** argv)
       rb_eval.legacy_read_offline_data_from_files();
 #endif
 
-      // Iinitialize online parameters
+      // Initialize online parameters
       Real online_x_scaling = infile("online_x_scaling", 0.);
       Real online_load_Fx   = infile("online_load_Fx",   0.);
       Real online_load_Fy   = infile("online_load_Fy",   0.);

--- a/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/rb_classes.h
@@ -108,7 +108,7 @@ public:
     // Generate a DirichletBoundary object
     dirichlet_bc = build_zero_dirichlet_boundary_object();
 
-    // Set the Dirichet boundary IDs
+    // Set the Dirichlet boundary IDs
     // and the Dirichlet boundary variable numbers
     dirichlet_bc->b.insert(0);
     dirichlet_bc->b.insert(5);

--- a/examples/reduced_basis/reduced_basis_ex7/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex7/assembly.h
@@ -106,7 +106,7 @@ struct AcousticsInnerProduct : ElemAssembly
     // Now we will build the affine operator
     unsigned int n_qpoints = c.get_element_qrule().n_points();
 
-    // We don't need to conjudate phi or dphi, since basis functions are real-valued
+    // We don't need to conjugate phi or dphi, since basis functions are real-valued
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       for (unsigned int i=0; i != n_p_dofs; i++)
         for (unsigned int j=0; j != n_p_dofs; j++)

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -82,7 +82,7 @@ using namespace libMesh;
 // the linear system for our Poisson problem.  Note that the
 // function will take the EquationSystems object and the
 // name of the system we are assembling as input.  From the
-// EquationSystems object we have acess to the Mesh and
+// EquationSystems object we have access to the Mesh and
 // other objects we might need.
 void assemble_poisson(EquationSystems & es,
                       const std::string & system_name);
@@ -95,7 +95,7 @@ Real exact_solution (const Real x,
 // Begin the main program.
 int main (int argc, char ** argv)
 {
-  // Initialize libMesh and any dependent libaries, like in example 2.
+  // Initialize libMesh and any dependent libraries, like in example 2.
   LibMeshInit init (argc, argv);
 
   // Only our PETSc interface currently supports solves restricted to
@@ -206,7 +206,7 @@ int main (int argc, char ** argv)
     }
 
 
-  // To demonstate solving on a subdomain, we will solve only on the
+  // To demonstrate solving on a subdomain, we will solve only on the
   // interior of a circle (ball in 3d) with radius 0.8.  So show that
   // this also works well on locally refined meshes, we refine once
   // all elements that are located on the boundary of this circle (or
@@ -397,12 +397,12 @@ void assemble_poisson(EquationSystems & es,
   // boundary integration.
   UniquePtr<FEBase> fe_face (FEBase::build(dim, fe_type));
 
-  // Boundary integration requires one quadraure rule,
+  // Boundary integration requires one quadrature rule,
   // with dimensionality one less than the dimensionality
   // of the element.
   QGauss qface(dim-1, FIFTH);
 
-  // Tell the finte element object to use our
+  // Tell the finite element object to use our
   // quadrature rule.
   fe_face->attach_quadrature_rule (&qface);
 
@@ -487,12 +487,12 @@ void assemble_poisson(EquationSystems & es,
           perf_log.pop("elem init");
 
           // Now we will build the element matrix.  This involves
-          // a double loop to integrate the test funcions (i) against
+          // a double loop to integrate the test functions (i) against
           // the trial functions (j).
           //
           // We have split the numeric integration into two loops
           // so that we can log the matrix and right-hand-side
-          // computation seperately.
+          // computation separately.
           //
           // Now start logging the element matrix computation
           perf_log.push ("Ke");

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -77,7 +77,7 @@ using namespace libMesh;
 // the linear system for our Poisson problem.  Note that the
 // function will take the EquationSystems object and the
 // name of the system we are assembling as input.  From the
-// EquationSystems object we have acess to the Mesh and
+// EquationSystems object we have access to the Mesh and
 // other objects we might need.
 void assemble_poisson(EquationSystems & es,
                       const std::string & system_name);
@@ -90,7 +90,7 @@ Real exact_solution (const Real x,
 // Begin the main program.
 int main (int argc, char ** argv)
 {
-  // Initialize libMesh and any dependent libaries, like in example 2.
+  // Initialize libMesh and any dependent libraries, like in example 2.
   LibMeshInit init (argc, argv);
 
   // This example requires a linear solver package.
@@ -341,12 +341,12 @@ void assemble_poisson(EquationSystems & es,
   // boundary integration.
   UniquePtr<FEBase> fe_face (FEBase::build(dim, fe_type));
 
-  // Boundary integration requires one quadraure rule,
+  // Boundary integration requires one quadrature rule,
   // with dimensionality one less than the dimensionality
   // of the element.
   QGauss qface(dim-1, FIFTH);
 
-  // Tell the finte element object to use our
+  // Tell the finite element object to use our
   // quadrature rule.
   fe_face->attach_quadrature_rule (&qface);
 
@@ -439,12 +439,12 @@ void assemble_poisson(EquationSystems & es,
       perf_log.pop("elem init");
 
       // Now we will build the element matrix.  This involves
-      // a double loop to integrate the test funcions (i) against
+      // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       //
       // We have split the numeric integration into two loops
       // so that we can log the matrix and right-hand-side
-      // computation seperately.
+      // computation separately.
       //
       // Now start logging the element matrix computation
       perf_log.push ("Ke");

--- a/examples/subdomains/subdomains_ex3/subdomains_ex3.C
+++ b/examples/subdomains/subdomains_ex3/subdomains_ex3.C
@@ -62,7 +62,7 @@ Real integrand (const Point & p)
 // Begin the main program.
 int main (int argc, char ** argv)
 {
-  // Initialize libMesh and any dependent libaries, like in example 2.
+  // Initialize libMesh and any dependent libraries, like in example 2.
   LibMeshInit init (argc, argv);
 
   // This example requires Adaptive Mesh Refinement support - although

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -288,7 +288,7 @@ void assemble_stokes (EquationSystems & es,
       //        | Kpu Kpv Kpp |        | Fp |
       //         -           -          -  -
       //
-      // The DenseSubMatrix.repostition () member takes the
+      // The DenseSubMatrix.reposition () member takes the
       // (row_offset, column_offset, row_size, column_size).
       //
       // Similarly, the DenseSubVector.reposition () member

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -176,7 +176,7 @@ int main (int argc, char** argv)
   const Real nonlinear_tolerance       = 1.e-5;
 
   // We also set a standard linear solver flag in the EquationSystems object
-  // which controls the maxiumum number of linear solver iterations allowed.
+  // which controls the maximum number of linear solver iterations allowed.
   equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = 250;
 
   // Tell the system of equations what the timestep is by using
@@ -198,7 +198,7 @@ int main (int argc, char** argv)
 
   for (unsigned int t_step=1; t_step<=n_timesteps; ++t_step)
     {
-      // Incremenet the time counter, set the time step size as
+      // Increment the time counter, set the time step size as
       // a parameter in the EquationSystem.
       navier_stokes_system.time += dt;
 
@@ -502,7 +502,7 @@ void assemble_stokes (EquationSystems & es,
       //        | Kpu Kpv Kpp |        | Fp |
       //         -           -          -  -
       //
-      // The DenseSubMatrix.repostition () member takes the
+      // The DenseSubMatrix.reposition () member takes the
       // (row_offset, column_offset, row_size, column_size).
       //
       // Similarly, the DenseSubVector.reposition () member

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -166,7 +166,7 @@ int main (int argc, char ** argv)
   const Real nonlinear_tolerance = TOLERANCE*10;
 
   // We also set a standard linear solver flag in the EquationSystems object
-  // which controls the maxiumum number of linear solver iterations allowed.
+  // which controls the maximum number of linear solver iterations allowed.
   equation_systems.parameters.set<unsigned int>("linear solver maximum iterations") = 250;
 
   // Tell the system of equations what the timestep is by using
@@ -193,7 +193,7 @@ int main (int argc, char ** argv)
 
   for (unsigned int t_step=1; t_step<=n_timesteps; ++t_step)
     {
-      // Incremenet the time counter, set the time and the
+      // Increment the time counter, set the time and the
       // time step size as parameters in the EquationSystem.
       navier_stokes_system.time += dt;
 
@@ -496,7 +496,7 @@ void assemble_stokes (EquationSystems & es,
       //        | Kpu Kpv Kpp |        | Fp |
       //         -           -          -  -
       //
-      // The DenseSubMatrix.repostition () member takes the
+      // The DenseSubMatrix.reposition () member takes the
       // (row_offset, column_offset, row_size, column_size).
       //
       // Similarly, the DenseSubVector.reposition () member

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -74,7 +74,7 @@ Real eval_elasticity_tensor(unsigned int i,
 // Begin the main program.
 int main (int argc, char ** argv)
 {
-  // Initialize libMesh and any dependent libaries
+  // Initialize libMesh and any dependent libraries
   LibMeshInit init (argc, argv);
 
   // This example requires a linear solver package.

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -78,7 +78,7 @@ Real eval_elasticity_tensor(unsigned int i,
 // Begin the main program.
 int main (int argc, char ** argv)
 {
-  // Initialize libMesh and any dependent libaries
+  // Initialize libMesh and any dependent libraries
   LibMeshInit init (argc, argv);
 
   // This example requires a linear solver package.

--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
@@ -186,7 +186,7 @@ void LinearElasticityWithContact::initialize_contact_load_paths()
                       }
                 }
 
-            } // end if nieghbor(side_) != libmesh_nullptr
+            } // end if neighbor(side_) != libmesh_nullptr
         } // end for side
     } // end for el
 

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -64,7 +64,7 @@ using namespace libMesh;
 // Function prototype.  This function will assemble the system
 // matrix and right-hand-side at each time step.  Note that
 // since the system is linear we technically do not need to
-// assmeble the matrix at each time step, but we will anyway.
+// assemble the matrix at each time step, but we will anyway.
 // In subsequent examples we will employ adaptive mesh refinement,
 // and with a changing mesh it will be necessary to rebuild the
 // system matrix.
@@ -191,7 +191,7 @@ int main (int argc, char ** argv)
 
   for (unsigned int t_step = 0; t_step < 50; t_step++)
     {
-      // Incremenet the time counter, set the time and the
+      // Increment the time counter, set the time and the
       // time step size as parameters in the EquationSystem.
       system.time += dt;
 
@@ -233,7 +233,7 @@ int main (int argc, char ** argv)
       // Assemble & solve the linear system
       equation_systems.get_system("Convection-Diffusion").solve();
 
-      // Output evey 10 timesteps to file.
+      // Output every 10 timesteps to file.
       if ((t_step+1)%10 == 0)
         {
 

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -446,7 +446,7 @@ void assemble_wave(EquationSystems & es,
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         {
           // Now we will build the element matrix.  This involves
-          // a double loop to integrate the test funcions (i) against
+          // a double loop to integrate the test functions (i) against
           // the trial functions (j).
           for (std::size_t i=0; i<phi.size(); i++)
             for (std::size_t j=0; j<phi.size(); j++)
@@ -474,12 +474,12 @@ void assemble_wave(EquationSystems & es,
               // boundary integration.
               UniquePtr<FEBase> fe_face (FEBase::build(dim, fe_type));
 
-              // Boundary integration requires one quadraure rule,
+              // Boundary integration requires one quadrature rule,
               // with dimensionality one less than the dimensionality
               // of the element.
               QGauss qface(dim-1, SECOND);
 
-              // Tell the finte element object to use our
+              // Tell the finite element object to use our
               // quadrature rule.
               fe_face->attach_quadrature_rule (&qface);
 
@@ -513,7 +513,7 @@ void assemble_wave(EquationSystems & es,
             } // end if (elem->neighbor_ptr(side) == libmesh_nullptr)
 
         // In this example the Dirichlet boundary conditions will be
-        // imposed via panalty method after the
+        // imposed via penalty method after the
         // system is assembled.
 
       } // end boundary condition section
@@ -558,7 +558,7 @@ void apply_initial(EquationSystems & es,
 
   // Assume our fluid to be at rest, which would
   // also be the default conditions in class NewmarkSystem,
-  // but let us do it explicetly here.
+  // but let us do it explicitly here.
   pres_vec.zero();
   vel_vec.zero();
   acc_vec.zero();
@@ -624,7 +624,7 @@ void fill_dirichlet_bc(EquationSystems & es,
           // Now add the contributions to the matrix and the rhs.
           rhs.add(dn, p_value*penalty);
 
-          // Add the panalty parameter to the global matrix
+          // Add the penalty parameter to the global matrix
           // if desired.
           if (do_for_matrix)
             matrix.add(dn, dn, penalty);

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -214,7 +214,7 @@ void assemble_poisson(EquationSystems & es,
   // boundary integration.
   UniquePtr<FEVectorBase> fe_face (FEVectorBase::build(dim, fe_type));
 
-  // Boundary integration requires one quadraure rule,
+  // Boundary integration requires one quadrature rule,
   // with dimensionality one less than the dimensionality
   // of the element.
   QGauss qface(dim-1, FIFTH);
@@ -311,7 +311,7 @@ void assemble_poisson(EquationSystems & es,
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         {
           // Now we will build the element matrix.  This involves
-          // a double loop to integrate the test funcions (i) against
+          // a double loop to integrate the test functions (i) against
           // the trial functions (j).
           for (std::size_t i=0; i<phi.size(); i++)
             for (std::size_t j=0; j<phi.size(); j++)

--- a/include/base/auto_ptr.h
+++ b/include/base/auto_ptr.h
@@ -243,7 +243,7 @@ public:
    * \param  a  Another AutoPtr of the same type.
    *
    * This object now owns the object previously owned by \p a, which has
-   * given up ownsership.
+   * given up ownership.
    */
   AutoPtr(AutoPtr & a)
     : _ptr(a.release())
@@ -257,7 +257,7 @@ public:
    * A pointer-to-Tp1 must be convertible to a pointer-to-Tp/element_type.
    *
    * This object now owns the object previously owned by \p a, which has
-   * given up ownsership.
+   * given up ownership.
    */
   template<typename Tp1>
   AutoPtr(AutoPtr<Tp1> & a)
@@ -270,7 +270,7 @@ public:
    * \param  a  Another AutoPtr of the same type.
    *
    * This object now owns the object previously owned by \p a, which has
-   * given up ownsership.  The object that this one used to own and
+   * given up ownership.  The object that this one used to own and
    * track has been deleted.
    */
   AutoPtr &
@@ -287,7 +287,7 @@ public:
    * A pointer-to-Tp1 must be convertible to a pointer-to-Tp/element_type.
    *
    * This object now owns the object previously owned by \p a, which has
-   * given up ownsership.  The object that this one used to own and
+   * given up ownership.  The object that this one used to own and
    * track has been deleted.
    */
   template <typename Tp1>

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -229,7 +229,7 @@ public:
   bool is_attached (SparseMatrix<Number> & matrix);
 
   /**
-   * Distrubute dofs on the current mesh.  Also builds the send list for
+   * Distribute dofs on the current mesh.  Also builds the send list for
    * processor \p proc_id, which defaults to 0 for ease of use in serial
    * applications.
    */
@@ -1194,7 +1194,7 @@ public:
 #endif // LIBMESH_ENABLE_AMR
 
   /**
-   * Reinitialize the underlying data strucures conformal to the current mesh.
+   * Reinitialize the underlying data structures conformal to the current mesh.
    */
   void reinit (MeshBase & mesh);
 
@@ -1361,7 +1361,7 @@ private:
    *
    * The forcing vector will depend on which solution's heterogenous
    * constraints are being applied.  For the default \p qoi_index this
-   * will be the primal solutoin; for \p qoi_index >= 0 the
+   * will be the primal solution; for \p qoi_index >= 0 the
    * corresponding adjoint solution's constraints will be used.
    */
   void build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
@@ -1441,7 +1441,7 @@ private:
   std::vector<dof_id_type> _send_list;
 
   /**
-   * Funtion object to call to add extra entries to the sparsity pattern
+   * Function object to call to add extra entries to the sparsity pattern
    */
   AugmentSparsityPattern * _augment_sparsity_pattern;
 
@@ -1453,7 +1453,7 @@ private:
                                    std::vector<dof_id_type> & n_oz,
                                    void *);
   /**
-   * A pointer associcated with the extra sparsity that can optionally be passed in
+   * A pointer associated with the extra sparsity that can optionally be passed in
    */
   void * _extra_sparsity_context;
 
@@ -1468,7 +1468,7 @@ private:
   void (*_extra_send_list_function)(std::vector<dof_id_type> &, void *);
 
   /**
-   * A pointer associcated with the extra send list that can optionally be passed in
+   * A pointer associated with the extra send list that can optionally be passed in
    */
   void * _extra_send_list_context;
 

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -236,7 +236,7 @@ public:
 
   /**
    * Sets number of variables in each group associated with system \p s for this
-   * \p DofObject. Implicit in this is salso setting the number of \p VariableGroup
+   * \p DofObject. Implicit in this is also setting the number of \p VariableGroup
    * variable groups for the system.
    * Has the effect of setting the number of components
    * to 0 even when called even with (nvg == this->n_var_groups(s)).
@@ -329,12 +329,12 @@ public:
                           const unsigned int vg) const;
 
   /**
-   * An invaild \p id to distinguish an uninitialized \p DofObject
+   * An invalid \p id to distinguish an uninitialized \p DofObject
    */
   static const dof_id_type invalid_id = static_cast<dof_id_type>(-1);
 
   /**
-   * An invaild \p unique_id to distinguish an uninitialized \p DofObject
+   * An invalid \p unique_id to distinguish an uninitialized \p DofObject
    */
   static const unique_id_type invalid_unique_id = static_cast<unique_id_type>(-1);
 
@@ -399,7 +399,7 @@ private:
                                      const unsigned int var) const;
 
   /**
-   * A globally unique id, guarenteed not to change as the mesh is repartioned or adapted
+   * A globally unique id, guaranteed not to change as the mesh is repartitioned or adapted
    */
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   unique_id_type _unique_id;
@@ -483,7 +483,7 @@ private:
    * and nc is the number of components for this set of variables.
    *
    * It is hoped that by setting this to a power of two, an optimizing compiler
-   * will recgnize later that  #/ncv_magic is simply a bitshift
+   * will recognize later that  #/ncv_magic is simply a bitshift
    */
   static const index_t ncv_magic = 256; // = 2^8, in case we want to manually bitshift
   static const index_t ncv_magic_exp = 8; // Let's manually bitshift
@@ -822,7 +822,7 @@ dof_id_type DofObject::dof_number(const unsigned int s,
     return invalid_id;
 
   // otherwise the index is the first component
-  // index augemented by the component number
+  // index augmented by the component number
   else
     {
       const unsigned int

--- a/include/base/factory.h
+++ b/include/base/factory.h
@@ -36,7 +36,7 @@ namespace libMesh
 
 
 /**
- * Factory class defintion.
+ * Factory class definition.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -144,7 +144,7 @@ namespace GETPOT_NAMESPACE {
 #endif
 
 /**
- * GetPot - A class for parsing comand line arguments and
+ * GetPot - A class for parsing command line arguments and
  * configuration files.
  *
  * \author Frank R. Schaefer
@@ -283,7 +283,7 @@ public:
   inline const char* operator()(const std::string& VarName, const char* Default, unsigned Idx) const;
 
   /**
-   * access varibles, but error out if not present
+   * access variables, but error out if not present
    * scalar values
    */
   template<typename T>
@@ -495,7 +495,7 @@ private:
     const std::string* get_element(unsigned Idx) const;
 
     /**
-     * data memebers
+     * data members
      */
     std::string name;      // identifier of variable
     STRING_VECTOR value;     // value of variable stored in vector
@@ -522,7 +522,7 @@ private:
    * nominus vector
    */
   int nominus_cursor;  // cursor for nominus_pointers
-  std::vector<unsigned> idx_nominus;     // indecies of 'no minus' arguments
+  std::vector<unsigned> idx_nominus;     // indices of 'no minus' arguments
 
   /**
    * variables (arguments of the form "variable=value")
@@ -822,7 +822,7 @@ GetPot::parse_command_line(const int argc_, const char * const * argv_,
   for (int i=1; i<argc_; i++)
     {
       std::string tmp(argv_[i]);   // recall the problem with temporaries,
-      _apriori_argv.push_back(tmp);       // reference counting in arguement lists ...
+      _apriori_argv.push_back(tmp);       // reference counting in argument lists ...
     }
   _parse_argument_vector(_apriori_argv);
 }
@@ -1207,7 +1207,7 @@ GetPot::_parse_argument_vector(const STRING_VECTOR& ARGV)
       if (equals_pos != std::string::npos)
         {
           // (*) record for later ufo detection
-          //     arguments carriying variables are always treated as 'requested' arguments.
+          //     arguments carrying variables are always treated as 'requested' arguments.
           //     unrequested variables have to be detected with the ufo-variable
           //     detection routine.
           if (request_recording_f)
@@ -2914,7 +2914,7 @@ GetPot::_DBE_get_variable(const std::string& VarName)
 
   prefix = secure_Prefix;
 
-  // error occured => variable name == ""
+  // error occurred => variable name == ""
   ev.original = "<<${ } variable '";
   ev.original += VarName + "' undefined>>";
   return &ev;
@@ -2929,7 +2929,7 @@ GetPot::_DBE_expand(const std::string& expr)
   if (expr[0] == ':')
     return expr.substr(1);
 
-  // ${& expr expr ... } text concatination
+  // ${& expr expr ... } text concatenation
   else if (expr[0] == '&')
     {
       const STRING_VECTOR A = _DBE_get_expr_list(expr.substr(1), 1);
@@ -3376,7 +3376,7 @@ GetPot::_DBE_expand(const std::string& expr)
       // error
       if (Var->name == "")
         {
-          // make a copy of the string if an error occured
+          // make a copy of the string if an error occurred
           // (since the error variable is a static variable inside get_variable())
           return std::string(Var->original);
         }
@@ -3411,7 +3411,7 @@ GetPot::_DBE_expand(const std::string& expr)
   const STRING_VECTOR    A = _DBE_get_expr_list(expr, 1);
   const GetPot::variable* B = _DBE_get_variable(A[0]);
 
-  // make a copy of the string if an error occured
+  // make a copy of the string if an error occurred
   // (since the error variable is a static variable inside get_variable())
   if (B->name == "")
     return std::string(B->original);

--- a/include/base/ghosting_functor.h
+++ b/include/base/ghosting_functor.h
@@ -142,7 +142,7 @@ public:
   /**
    * For the specified range of active elements, what other elements
    * currently living (whether local or ghosted) on this processor
-   * need to be coupled/ghosted to accomodate them?  Don't bother to
+   * need to be coupled/ghosted to accommodate them?  Don't bother to
    * return any results which already have processor_id p.
    *
    * This API is new, and we should replace "ignoring those on

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -70,7 +70,7 @@ extern "C" {
 // implementations, for example Sun Studio and PGI C++.  However,
 // this necessarily requires breaking the ISO-C++ standard, and is
 // really just a hack.  As such, only do it if we are building the
-// libmesh library itself.  Specifially, *DO NOT* export this to
+// libmesh library itself.  Specifically, *DO NOT* export this to
 // user code or install this header.
 #ifdef LIBMESH_IS_COMPILING_ITSELF
 #  include "libmesh/libmesh_augment_std_namespace.h"
@@ -255,9 +255,9 @@ extern bool warned_about_auto_ptr;
   } while (0)
 
 // the libmesh_stop() macro will stop the code until a SIGCONT signal
-// is recieved.  This is useful, for example, when determining the
+// is received.  This is useful, for example, when determining the
 // memory used by a given operation.  A libmesh_stop() could be
-// instered before and after a questionable operation and the delta
+// inserted before and after a questionable operation and the delta
 // memory can be obtained from a ps or top.  This macro only works for
 // serial cases.
 #define libmesh_stop()                                                  \

--- a/include/base/libmesh_documentation.h
+++ b/include/base/libmesh_documentation.h
@@ -28,11 +28,11 @@
  *    - 4 and 6 noded infinite quadrilaterals (\p InfQuad4, \p InfQuad6).
  *
  *  - Generic 3D Finite Elements
- *    - 4 and 10 noded tetrahedrals (\p Tet4, \p Tet10).
- *    - 8, 20, and 27 noded hexahedrals (\p Hex8, \p Hex20, \p Hex27).
+ *    - 4 and 10 noded tetrahedra (\p Tet4, \p Tet10).
+ *    - 8, 20, and 27 noded hexahedra (\p Hex8, \p Hex20, \p Hex27).
  *    - 6, 15, and 18 noded prisms (\p Prism6, \p Prism15, \p Prism18).
  *    - 5, 13, and 14 noded pyramids (\p Pyramid5, \p Pyramid13, \p Pyramid14).
- *    - 8, 16, and 18 noded infinite hexahedrals (\p InfHex8, \p InfHex16, \p InfHex18).
+ *    - 8, 16, and 18 noded infinite hexahedra (\p InfHex8, \p InfHex16, \p InfHex18).
  *    - 6 and 12 noded infinite prisms (\p InfPrism6, \p InfPrism12).
  *
  *  - Generic Finite Element Families

--- a/include/base/libmesh_logging.h
+++ b/include/base/libmesh_logging.h
@@ -36,7 +36,7 @@ namespace libMesh
 
 
 // Forward declaration, required when included
-// in perf_log.{C,h} because the preceeding
+// in perf_log.{C,h} because the preceding
 // #include "libmesh/perf_log.h" is ineffective.
 // Multiple inclusion avoidance problem...
 // LIBMESH_PERF_LOG_H already #define'd, but the

--- a/include/base/reference_counted_object.h
+++ b/include/base/reference_counted_object.h
@@ -67,7 +67,7 @@ class ReferenceCountedObject : public ReferenceCounter
 protected:
 
   /**
-   * Constructor. Protected so that you cannont
+   * Constructor. Protected so that you cannot
    * instantiate a \p ReferenceCountedObject, only derive
    * from it.
    */

--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -30,7 +30,7 @@
 namespace libMesh
 {
 
-// Forward declaractions
+// Forward declarations
 class MeshBase;
 class DofMap;
 class CouplingMatrix;

--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -129,7 +129,7 @@ public:
    * \returns \p true if this variable is active on subdomain \p sid,
    * \p false otherwise.
    *
-   * \note We interperet the special case of an empty \p
+   * \note We interpret the special case of an empty \p
    * _active_subdomains container as active everywhere, i.e. for all
    * subdomains.
    */

--- a/include/enums/enum_eigen_solver_type.h
+++ b/include/enums/enum_eigen_solver_type.h
@@ -71,8 +71,8 @@ enum PositionOfSpectrum {LARGEST_MAGNITUDE=0,
                          LARGEST_IMAGINARY,
                          SMALLEST_IMAGINARY,
                          TARGET_IMAGINARY,
-
-                         INVALID_Postion_of_Spectrum};
+                         INVALID_Postion_of_Spectrum,
+                         INVALID_POSITION_OF_SPECTRUM};
 }
 
 #endif // LIBMESH_ENUM_EIGENSOLVER_TYPE_H

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -69,7 +69,7 @@ struct FEOutputType<NEDELEC_ONE>
 
 
 /**
- * A specific instatiation of the \p FEBase class. This
+ * A specific instantiation of the \p FEBase class. This
  * class is templated, and specific template instantiations
  * will result in different Finite Element families. Full specialization
  * of the template for specific dimensions(\p Dim) and families
@@ -335,7 +335,7 @@ public:
 
   /**
    * Reinitializes all the physical element-dependent data based on
-   * the \p side of \p face.  The \p tolerance paremeter is passed to
+   * the \p side of \p face.  The \p tolerance parameter is passed to
    * the involved call to \p inverse_map().  By default the shape
    * functions and associated data are computed at the quadrature
    * points specified by the quadrature rule \p qrule, but may be any
@@ -350,7 +350,7 @@ public:
 
   /**
    * Reinitializes all the physical element-dependent data based on
-   * the \p edge.  The \p tolerance paremeter is passed to the
+   * the \p edge.  The \p tolerance parameter is passed to the
    * involved call to \p inverse_map().  By default the shape
    * functions and associated data are computed at the quadrature
    * points specified by the quadrature rule \p qrule, but may be any
@@ -792,7 +792,7 @@ public:
 
 
 /**
- * The FEScalar class is used for workign with SCALAR variables.
+ * The FEScalar class is used for working with SCALAR variables.
  */
 template <unsigned int Dim>
 class FEScalar : public FE<Dim,SCALAR>

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -138,7 +138,7 @@ public:
 
   /**
    * Reinitializes all the physical element-dependent data based on
-   * the \p side of the element \p elem.  The \p tolerance paremeter
+   * the \p side of the element \p elem.  The \p tolerance parameter
    * is passed to the involved call to \p inverse_map().  By default the
    * element data are computed at the quadrature points specified by the
    * quadrature rule \p qrule, but any set of points on the reference
@@ -152,7 +152,7 @@ public:
 
   /**
    * Reinitializes all the physical element-dependent data based on
-   * the \p edge of the element \p elem.  The \p tolerance paremeter
+   * the \p edge of the element \p elem.  The \p tolerance parameter
    * is passed to the involved call to \p inverse_map().  By default the
    * element data are computed at the quadrature points specified by the
    * quadrature rule \p qrule, but any set of points on the reference

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -116,7 +116,7 @@ public:
                         const Elem * side);
 
   /**
-   * Initalizes the reference to physical element map for a side.
+   * Initializes the reference to physical element map for a side.
    * This is used for boundary integration.
    */
   template< unsigned int Dim>
@@ -615,19 +615,19 @@ protected:
   std::vector<Point> xyz;
 
   /**
-   * Vector of parital derivatives:
+   * Vector of partial derivatives:
    * d(x)/d(xi), d(y)/d(xi), d(z)/d(xi)
    */
   std::vector<RealGradient> dxyzdxi_map;
 
   /**
-   * Vector of parital derivatives:
+   * Vector of partial derivatives:
    * d(x)/d(eta), d(y)/d(eta), d(z)/d(eta)
    */
   std::vector<RealGradient> dxyzdeta_map;
 
   /**
-   * Vector of parital derivatives:
+   * Vector of partial derivatives:
    * d(x)/d(zeta), d(y)/d(zeta), d(z)/d(zeta)
    */
   std::vector<RealGradient> dxyzdzeta_map;

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -72,7 +72,7 @@ public:
   }
 
   /**
-   * Explicity request the order as an int.
+   * Explicitly request the order as an int.
    */
   int get_order() const
   {

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -196,7 +196,7 @@ protected:
     /**
      * Build the base element of an infinite element.  Be careful,
      * this method allocates memory!  So be sure to delete the
-     * new element afterwards.
+     * new element afterward.
      */
     static Elem * build_elem (const Elem * inf_elem);
 
@@ -547,7 +547,7 @@ protected:
    * Combines the shape functions, which were formed in
    * \p init_shape_functions(Elem *), with geometric data.
    * Has to be called every time the geometric configuration
-   * changes.  Afterwards, the fields are ready to be used
+   * changes.  Afterward, the fields are ready to be used
    * to compute global derivatives, the jacobian etc, see
    * \p FEAbstract::compute_map().
    */
@@ -686,7 +686,7 @@ protected:
    * -- tensor product of base element times radial
    * nodes -- has to be determined from the node numbering
    * of the current infinite element.  This vector
-   * maps the infinte \p Elem node number to the
+   * maps the infinite \p Elem node number to the
    * radial node (either 0 or 1).
    */
   std::vector<unsigned int> _radial_node_index;
@@ -696,7 +696,7 @@ protected:
    * -- tensor product of base element times radial
    * nodes -- has to be determined from the node numbering
    * of the current element.  This vector
-   * maps the infinte \p Elem node number to the
+   * maps the infinite \p Elem node number to the
    * associated node in the base element.
    */
   std::vector<unsigned int> _base_node_index;

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -140,7 +140,7 @@ public:
    * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
-   * We reimplemenet this method here for the \p Hex27 since we can
+   * We reimplement this method here for the \p Hex27 since we can
    * use the center node of each face to provide a perfect (unique)
    * key.
    */

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -155,7 +155,7 @@ public:
    * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
-   * We reimplemenet this method here for the \p InfHex18 since we can
+   * We reimplement this method here for the \p InfHex18 since we can
    * use the center node of the bottom face to provide a perfect (unique)
    * key.
    */

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -81,7 +81,7 @@ public:
   virtual unsigned int n_vertices() const libmesh_override { return 6; }
 
   /**
-   * \returns 6.  All infinite prismahedrals have 6 edges,
+   * \returns 6.  All infinite prisms have 6 edges,
    * 3 lying in the base, and 3 perpendicular to the base.
    */
   virtual unsigned int n_edges() const libmesh_override { return 6; }

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -141,7 +141,7 @@ public:
    * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
-   * We reimplemenet this method here for the \p Prism18 since we can
+   * We reimplement this method here for the \p Prism18 since we can
    * use the center node of each quad face to provide a perfect (unique)
    * key.
    */

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -33,7 +33,7 @@ namespace libMesh
  * with linear pyramids, but as of version 14 will not export
  * quadratic pyramids.  Paraview may support 13-node pyramids, but
  * does not render 14-node pyramids correctly.  So even if this
- * element works in libmesh, we are curently limited in what we can do
+ * element works in libmesh, we are currently limited in what we can do
  * with it outside the library...
  *
  * The node numbering for the pyramid14 is given below:
@@ -144,7 +144,7 @@ public:
    * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
-   * We reimplemenet this method here for the \p Pyramid14 since we can
+   * We reimplement this method here for the \p Pyramid14 since we can
    * use the center node of the base face to provide a perfect (unique)
    * key.
    */

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -68,17 +68,17 @@ public:
   virtual unsigned int n_sides() const libmesh_override { return 4; }
 
   /**
-   * \returns 4.  All tetrahedrals have 4 vertices.
+   * \returns 4.  All tetrahedra have 4 vertices.
    */
   virtual unsigned int n_vertices() const libmesh_override { return 4; }
 
   /**
-   * \returns 6.  All tetrahedrals have 6 edges.
+   * \returns 6.  All tetrahedra have 6 edges.
    */
   virtual unsigned int n_edges() const libmesh_override { return 6; }
 
   /**
-   * \returns 4.  All tetrahedrals have 4 faces.
+   * \returns 4.  All tetrahedra have 4 faces.
    */
   virtual unsigned int n_faces() const libmesh_override { return 4; }
 

--- a/include/geom/edge_inf_edge2.h
+++ b/include/geom/edge_inf_edge2.h
@@ -31,7 +31,7 @@ namespace libMesh
 {
 
 /**
- * The \p InfEdge2 is an infinte element in 1D composed of 2 nodes.
+ * The \p InfEdge2 is an infinite element in 1D composed of 2 nodes.
  * It is numbered like this:
  *
  * \verbatim

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -755,7 +755,7 @@ public:
   virtual Order default_order () const = 0;
 
   /**
-   * \returns The centriod of the element. The centroid is
+   * \returns The centroid of the element. The centroid is
    * computed as the average of all the element vertices.
    *
    * This method is virtual since some derived elements
@@ -932,7 +932,7 @@ public:
   /**
    * \returns The higher-dimensional Elem for which this Elem is a face.
    *
-   * In some cases it is desireable to extract the boundary (or a subset thereof)
+   * In some cases it is desirable to extract the boundary (or a subset thereof)
    * of a D-dimensional mesh as a (D-1)-dimensional manifold.  In this case
    * we may want to know the 'parent' element from which the manifold elements
    * were extracted.  We can easily do that for the level-0 manifold elements
@@ -2570,7 +2570,7 @@ public:
 
   // Consults the parent Elem to determine if the side
   // is a boundary side.  Note: currently side N is a
-  // boundary side if nieghbor N is NULL.  Be careful,
+  // boundary side if neighbor N is NULL.  Be careful,
   // this could possibly change in the future?
   bool side_on_boundary() const
   {
@@ -2652,7 +2652,7 @@ Elem::side_iterator : variant_filter_iterator<Elem::Predicate, Elem *>
 } // namespace libMesh
 
 
-// Helper function for default caches in Elem subclases
+// Helper function for default caches in Elem subclasses
 
 #define LIBMESH_ENABLE_TOPOLOGY_CACHES                                  \
   virtual                                                               \

--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -133,19 +133,19 @@ protected:
                                 const std::vector<Real> & vertex_distance_func);
 
   /**
-   * cutting algoritm in 1D.
+   * cutting algorithm in 1D.
    */
   void cut_1D(const Elem & elem,
               const std::vector<Real> & vertex_distance_func);
 
   /**
-   * cutting algoritm in 2D.
+   * cutting algorithm in 2D.
    */
   void cut_2D(const Elem & elem,
               const std::vector<Real> & vertex_distance_func);
 
   /**
-   * cutting algoritm in 3D.
+   * cutting algorithm in 3D.
    */
   void cut_3D(const Elem & elem,
               const std::vector<Real> & vertex_distance_func);

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -123,7 +123,7 @@ public:
    * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
-   * We reimplemenet this method here for the \p Quad8 since we can
+   * We reimplement this method here for the \p Quad8 since we can
    * use the center node of each edge to provide a perfect (unique)
    * key.
    */

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -123,7 +123,7 @@ public:
    * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
-   * We reimplemenet this method here for the \p Quad9 since we can
+   * We reimplement this method here for the \p Quad9 since we can
    * use the center node of each edge to provide a perfect (unique)
    * key.
    */

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -123,7 +123,7 @@ public:
    * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    *
-   * We reimplemenet this method here for the \p Quad8 since we can
+   * We reimplement this method here for the \p Quad8 since we can
    * use the center node of each edge to provide a perfect (unique)
    * key.
    */

--- a/include/geom/reference_elem.h
+++ b/include/geom/reference_elem.h
@@ -36,7 +36,7 @@ class Elem;
  *
  * \author Benjamin S. Kirk
  * \date 2013
- * \brief Namespace providing access to reference geoemtric element types.
+ * \brief Namespace providing access to reference geometric element types.
  */
 namespace ReferenceElem
 {

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -70,7 +70,7 @@ public:
 
   /**
    * Return a reference to the global \p RemoteElem
-   * sigleton object.
+   * singleton object.
    */
   static const Elem & create ();
 

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -241,7 +241,7 @@
 /* Flag indicating whether compiler supports constexpr */
 #undef HAVE_CXX11_CONSTEXPR
 
-/* Compiler supports constexper, but it is disabled in libmesh */
+/* Compiler supports constexpr, but it is disabled in libmesh */
 #undef HAVE_CXX11_CONSTEXPR_BUT_DISABLED
 
 /* Flag indicating whether compiler supports decltype */
@@ -732,7 +732,7 @@
 /* header file for the final detected unordered_set type */
 #undef INCLUDE_UNORDERED_SET
 
-/* libMesh I/O file format compatiblity string */
+/* libMesh I/O file format compatibility string */
 #undef IO_COMPATIBILITY_VERSION
 
 /* libMesh source code version */
@@ -866,7 +866,7 @@
 /* size of unique_id */
 #undef UNIQUE_ID_BYTES
 
-/* Flag indicating if the library should be built using complxex numbers */
+/* Flag indicating if the library should be built using complex numbers */
 #undef USE_COMPLEX_NUMBERS
 
 /* Flag indicating if the library should be built using real numbers */

--- a/include/mesh/abaqus_io.h
+++ b/include/mesh/abaqus_io.h
@@ -160,7 +160,7 @@ private:
 
   /**
    * This function assigns boundary IDs to node sets based on the
-   * alphabetical order in which the sets are labelled in the Abaqus
+   * alphabetical order in which the sets are labeled in the Abaqus
    * file.  We choose the alphabetical ordering simply because
    * Abaqus does not provide a numerical one within the file.
    */

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -821,7 +821,7 @@ private:
                 boundary_id_type> _boundary_node_id;
 
   /**
-   * Typdef for iterators into the _boundary_node_id container.
+   * Typedef for iterators into the _boundary_node_id container.
    */
   typedef std::multimap<const Node *, boundary_id_type>::const_iterator boundary_node_iter;
 
@@ -841,7 +841,7 @@ private:
   _boundary_edge_id;
 
   /**
-   * Typdef for iterators into the _boundary_edge_id container.
+   * Typedef for iterators into the _boundary_edge_id container.
    */
   typedef std::multimap<const Elem *,
                         std::pair<unsigned short int, boundary_id_type> >::const_iterator boundary_edge_iter;
@@ -855,7 +855,7 @@ private:
   _boundary_shellface_id;
 
   /**
-   * Typdef for iterators into the _boundary_shellface_id container.
+   * Typedef for iterators into the _boundary_shellface_id container.
    */
   typedef std::multimap<const Elem *,
                         std::pair<unsigned short int, boundary_id_type> >::const_iterator boundary_shellface_iter;
@@ -870,7 +870,7 @@ private:
   _boundary_side_id;
 
   /**
-   * Typdef for iterators into the _boundary_side_id container.
+   * Typedef for iterators into the _boundary_side_id container.
    */
   typedef std::multimap<const Elem *,
                         std::pair<unsigned short int, boundary_id_type> >::const_iterator boundary_side_iter;

--- a/include/mesh/boundary_mesh.h
+++ b/include/mesh/boundary_mesh.h
@@ -40,7 +40,7 @@ class BoundaryMesh : public Mesh
 {
 public:
   /**
-   * Constructor. Initializes dimenstion and processor id.
+   * Constructor. Initializes dimension and processor id.
    */
   explicit
   BoundaryMesh (const Parallel::Communicator & comm_in,

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -507,7 +507,7 @@ public:
 protected:
 
   /**
-   * The verices (spatial coordinates) of the mesh.
+   * The vertices (spatial coordinates) of the mesh.
    */
   mapvector<Node *, dof_id_type> _nodes;
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -80,7 +80,7 @@ class MeshBase;
  * implementation details of interfacing with the Exodus binary
  * format.
  *
- * \author Johw W. Peterson
+ * \author John W. Peterson
  * \date 2002
  */
 class ExodusII_IO_Helper : public ParallelObject
@@ -1114,19 +1114,19 @@ public:
    */
 
   /**
-   * Maps the Exodus face numbering for general hexahedrals.
+   * Maps the Exodus face numbering for general hexahedra.
    * Useful for reading sideset information.
    */
   static const int hex_face_map[6];
 
   /**
-   * Maps the Exodus face numbering for 27-noded hexahedrals.
+   * Maps the Exodus face numbering for 27-noded hexahedra.
    * Useful for reading sideset information.
    */
   static const int hex27_face_map[6];
 
   /**
-   * Maps the Exodus face numbering for general tetrahedrals.
+   * Maps the Exodus face numbering for general tetrahedra.
    * Useful for reading sideset information.
    */
   static const int tet_face_map[4];
@@ -1144,19 +1144,19 @@ public:
   static const int pyramid_face_map[5];
 
   /**
-   * Maps the Exodus face numbering for general hexahedrals.
+   * Maps the Exodus face numbering for general hexahedra.
    * Useful for writing sideset information.
    */
   static const int hex_inverse_face_map[6];
 
   /**
-   * Maps the Exodus face numbering for 27-noded hexahedrals.
+   * Maps the Exodus face numbering for 27-noded hexahedra.
    * Useful for writing sideset information.
    */
   static const int hex27_inverse_face_map[6];
 
   /**
-   * Maps the Exodus face numbering for general tetrahedrals.
+   * Maps the Exodus face numbering for general tetrahedra.
    * Useful for writing sideset information.
    */
   static const int tet_inverse_face_map[4];

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -663,7 +663,7 @@ public:
                                const bool reset_current_list    = true) = 0;
 
   /**
-   * After partitoning a mesh it is useful to renumber the nodes and elements
+   * After partitioning a mesh it is useful to renumber the nodes and elements
    * so that they lie in contiguous blocks on the processors.  This method
    * does just that.
    */
@@ -728,7 +728,7 @@ public:
   /**
    * If false is passed in then this mesh will no longer be renumbered
    * when being prepared for use.  This may slightly adversely affect
-   * performance during subsequent element access, particulary when
+   * performance during subsequent element access, particularly when
    * using a distributed mesh.
    */
   void allow_renumbering(bool allow) { _skip_renumber_nodes_and_elements = !allow; }
@@ -1270,7 +1270,7 @@ public:
 
 
   /**
-   * Search the mesh and cache the different dimenions of the elements
+   * Search the mesh and cache the different dimensions of the elements
    * present in the mesh.  This is done in prepare_for_use(), but can
    * be done manually by other classes after major mesh modifications.
    */
@@ -1355,7 +1355,7 @@ protected:
   bool _skip_partitioning;
 
   /**
-   * If this is true then renumbering will be kept to a miniumum.
+   * If this is true then renumbering will be kept to a minimum.
    *
    * This is set when prepare_for_use() is called.
    */

--- a/include/mesh/mesh_modification.h
+++ b/include/mesh/mesh_modification.h
@@ -118,7 +118,7 @@ void all_tri (MeshBase & mesh);
 /**
  * Smooth the mesh with a simple Laplace smoothing algorithm.  The mesh is
  * smoothed \p n_iterations times.  If the parameter \p power is 0, each
- * node is moved to the average postition of the neighboring connected
+ * node is moved to the average position of the neighboring connected
  * nodes. If \p power > 0, the node positions are weighted by their
  * distance.  The positions of higher order nodes, and nodes living in
  * refined elements, are calculated from the vertex positions of their

--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -531,7 +531,7 @@ private:
   void _smooth_flags (bool refining, bool coarsening);
 
   //------------------------------------------------------
-  // "Smoothing" algorthms for refined meshes
+  // "Smoothing" algorithms for refined meshes
 
   /**
    * This algorithm restricts the maximum level mismatch

--- a/include/mesh/mesh_tetgen_interface.h
+++ b/include/mesh/mesh_tetgen_interface.h
@@ -42,7 +42,7 @@ class Elem;
 
 /**
  * Class \p TetGenMeshInterface provides an interface for
- * tetrahedrization of meshes using the TetGen library.  For
+ * tetrahedralization of meshes using the TetGen library.  For
  * information about TetGen cf.
  * <a href="http://tetgen.org/">TetGen home page</a>.
  *
@@ -67,24 +67,24 @@ public:
   ~TetGenMeshInterface() {}
 
   /**
-   * Method to set swithes to tetgen, allowing for different behaviours
+   * Method to set switches to tetgen, allowing for different behaviours
    */
   void set_switches(const std::string &);
 
   /**
-   * Method invokes TetGen library to compute a Delaunay tetrahedrization
+   * Method invokes TetGen library to compute a Delaunay tetrahedralization
    * from the nodes point set.
    */
   void triangulate_pointset ();
 
   /**
-   * Method invokes TetGen library to compute a Delaunay tetrahedrization
+   * Method invokes TetGen library to compute a Delaunay tetrahedralization
    * from the nodes point set. Stores only 2D hull surface elements.
    */
   void pointset_convexhull ();
 
   /**
-   * Method invokes TetGen library to compute a Delaunay tetrahedrization
+   * Method invokes TetGen library to compute a Delaunay tetrahedralization
    * from the nodes point set. Boundary constraints are taken from
    * elements array.
    */
@@ -92,7 +92,7 @@ public:
                                            double volume_constraint=0.);
 
   /**
-   * Method invokes TetGen library to compute a Delaunay tetrahedrization
+   * Method invokes TetGen library to compute a Delaunay tetrahedralization
    * from the nodes point set. Boundary constraints are taken from
    * elements array. Include carve-out functionality.
    */
@@ -165,7 +165,7 @@ protected:
   MeshSerializer _serializer;
 
   /**
-   * Parameter controling the behaviour of tetgen.
+   * Parameter controlling the behaviour of tetgen.
    * By default quiet.
    */
   std::string _switches;

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -77,7 +77,7 @@ public:
 
 
 /**
- * \returns The sum over all the elemenents of the number
+ * \returns The sum over all the elements of the number
  * of nodes per element.
  *
  * This can be useful for partitioning hybrid meshes.  A feasible load
@@ -87,7 +87,7 @@ public:
 dof_id_type total_weight (const MeshBase & mesh);
 
 /**
- * \returns The sum over all the elemenents on processor \p pid
+ * \returns The sum over all the elements on processor \p pid
  * of nodes per element.
  *
  * This can be useful for partitioning hybrid meshes.  A feasible load
@@ -133,8 +133,8 @@ void find_boundary_nodes (const MeshBase & mesh,
 
 /**
  * \returns Two points defining a cartesian box that bounds the
- * mesh.  The first entry in the pair is the mininum, the second
- * is the maximim.
+ * mesh.  The first entry in the pair is the minimum, the second
+ * is the maximum.
  *
  * \deprecated Use create_bounding_box() instead.
  */
@@ -286,7 +286,7 @@ unsigned int n_local_levels(const MeshBase & mesh);
  * \returns The number of levels of refinement in the active mesh.
  *
  * Implemented by looping over all the active local elements and finding
- * the maximum level, then maxxing in parallel.
+ * the maximum level, then taking the max in parallel.
  */
 unsigned int n_active_levels(const MeshBase & mesh);
 
@@ -343,7 +343,7 @@ dof_id_type n_nodes (const MeshBase::const_node_iterator & begin,
 
 
 /**
- * Find the maxium h-refinement level in a mesh.
+ * Find the maximum h-refinement level in a mesh.
  */
 unsigned int max_level (const MeshBase & mesh);
 

--- a/include/mesh/mesh_triangle_interface.h
+++ b/include/mesh/mesh_triangle_interface.h
@@ -66,7 +66,7 @@ public:
 
   /**
    * The TriangulationType is used with the general triangulate function
-   * defind below.
+   * defined below.
    */
   enum TriangulationType
     {

--- a/include/mesh/mesh_triangle_wrapper.h
+++ b/include/mesh/mesh_triangle_wrapper.h
@@ -80,7 +80,7 @@ void init(triangulateio & t);
 void destroy(triangulateio & t, IO_Type);
 
 /**
- * Copies triangulation data computed by triange from a triangulateio object
+ * Copies triangulation data computed by triangle from a triangulateio object
  * to a LibMesh mesh.   This routine is used internally by the
  * MeshTools::Generation::build_delaunay_square(...) and
  * MeshTools::Generation::build_delaunay_square_with_hole(...) routines.

--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -101,7 +101,7 @@ public:
                                  const std::vector<std::string> & names) libmesh_override;
 
   /**
-   * Set the flag indicationg if we should be verbose.
+   * Set the flag indicating if we should be verbose.
    */
   void verbose (bool set_verbosity);
 

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -193,7 +193,7 @@ public:
   /**
    * Outputs initial information for communication maps.
    *
-   * \note The order of the arguments specified in the Nemsis User's
+   * \note The order of the arguments specified in the Nemesis User's
    * Manual is \e wrong.  The correct order is (ids, counts, ids,
    * counts).  Must be called after put_loadbal_param().
    */
@@ -210,7 +210,7 @@ public:
    * .) node_cmap_node_ids = Nodal IDs of the FEM nodes in this communication map
    * .) node_cmap_proc_ids = processor IDs associated with each of the nodes in node_ids
    *
-   * In the Nemesis file, these all appeart to be written to the same chunks of data:
+   * In the Nemesis file, these all appear to be written to the same chunks of data:
    * n_comm_nids and n_comm_proc, but don't rely on these names...
    *
    * \note This class contains \p node_cmap_node_ids and \p
@@ -632,7 +632,7 @@ private:
   void compute_communication_map_parameters();
 
   /**
-   * Compute the node communcation maps (really just pack vectors)
+   * Compute the node communication maps (really just pack vectors)
    * in preparation for writing them to file.
    */
   void compute_node_communication_maps();

--- a/include/mesh/off_io.h
+++ b/include/mesh/off_io.h
@@ -29,7 +29,7 @@ namespace libMesh
 class MeshBase;
 
 /**
- * This class is repsonsible for reading an unstructured, triangulated
+ * This class is responsible for reading an unstructured, triangulated
  * surface in the standard OFF OOGL format.
  *
  * \author John W. Peterson

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -445,7 +445,7 @@ public:
 protected:
 
   /**
-   * The verices (spatial coordinates) of the mesh.
+   * The vertices (spatial coordinates) of the mesh.
    */
   std::vector<Node *> _nodes;
 

--- a/include/mesh/tetgen_io.h
+++ b/include/mesh/tetgen_io.h
@@ -88,7 +88,7 @@ public:
    * region attributes are present in the .ele file, they are used to
    * set the subdomain ids of the elements as they are created.
    *
-   * \depcreated This member, since it was originally a part of the
+   * \deprecated This member, since it was originally a part of the
    * public interface, remains for now, but will be removed some time
    * in the near future.
    */

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -34,7 +34,7 @@ namespace libMesh
  * user will typically want to instantiate and use the
  * Mesh class in her applications, which is currently a simple
  * derived class of UnstructuredMesh.
- * In order to use the adaptive mesh refinment capabilities
+ * In order to use the adaptive mesh refinement capabilities
  * of the library, first instantiate a MeshRefinement object
  * with a reference to this class.  Then call the appropriate
  * refinement functions from that object.  To interact with the

--- a/include/mesh/unv_io.h
+++ b/include/mesh/unv_io.h
@@ -25,7 +25,7 @@
 #include "libmesh/mesh_input.h"
 #include "libmesh/mesh_output.h"
 
-// C++ inludes
+// C++ includes
 #include <cstddef>
 #include <map>
 #include <string>
@@ -83,7 +83,7 @@ public:
   virtual void write (const std::string &) libmesh_override;
 
   /**
-   * Set the flag indicationg if we should be verbose.
+   * Set the flag indicating if we should be verbose.
    */
   bool & verbose ();
 

--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -119,7 +119,7 @@ public:
   void set_compression(bool b);
 
   /**
-   * Get a pointer to the VTK unstructed grid data structure.
+   * Get a pointer to the VTK unstructured grid data structure.
    */
   vtkUnstructuredGrid * get_vtk_grid();
 

--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -580,7 +580,7 @@ private:
    * The _multiply_blas function computes A <- op(A) * op(B) using
    * BLAS gemm function.  Used in the right_multiply(),
    * left_multiply(), right_multiply_transpose(), and
-   * left_multiply_tranpose() routines.
+   * left_multiply_transpose() routines.
    * [ Implementation in dense_matrix_blas_lapack.C ]
    */
   void _multiply_blas(const DenseMatrixBase<T> & other,

--- a/include/numerics/dense_matrix_base.h
+++ b/include/numerics/dense_matrix_base.h
@@ -29,7 +29,7 @@
 namespace libMesh
 {
 
-// Forward Delcarations
+// Forward declarations
 template <typename T> class DenseVectorBase;
 
 /**

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -40,9 +40,9 @@ namespace libMesh
 
 /**
  * Defines a dense vector for use in Finite Element-type computations.
- * This class is to basically compliment the \p DenseMatix class.  It
+ * This class is to basically compliment the \p DenseMatrix class.  It
  * has additional capabilities over the \p std::vector that make it
- * useful for finite elements, particulary for systems of equations.
+ * useful for finite elements, particularly for systems of equations.
  * All overridden virtual functions are documented in dense_vector_base.h.
  *
  * \author Benjamin S. Kirk

--- a/include/numerics/function_base.h
+++ b/include/numerics/function_base.h
@@ -43,7 +43,7 @@ class Point;
  * Use the constructors of the derived classes for creating new
  * objects. The required input of each derived class thwarts the
  * effective use of the commonly used \p build() member.  But
- * afterwards the virtual members allow the convenient and
+ * afterward the virtual members allow the convenient and
  * libMesh-common usage through a \p FunctionBase *.
  *
  * \note For functor objects for vector-valued variables, it is

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -784,7 +784,7 @@ void PetscVector<T>::init (const NumericVector<T> & other,
 
   this->_global_to_local_map = v._global_to_local_map;
 
-  // Even if we're initializeing sizes based on an uninitialized or
+  // Even if we're initializing sizes based on an uninitialized or
   // unclosed vector, *this* vector is being initialized now and is
   // initially closed.
   this->_is_closed      = true; // v._is_closed;

--- a/include/numerics/preconditioner.h
+++ b/include/numerics/preconditioner.h
@@ -128,12 +128,12 @@ protected:
 
   /**
    * The matrix P... ie the matrix to be preconditioned.
-   * This is often the actual system matrix of a linear sytem.
+   * This is often the actual system matrix of a linear system.
    */
   SparseMatrix<T> * _matrix;
 
   /**
-   * Enum statitng with type of preconditioner to use.
+   * Enum stating with type of preconditioner to use.
    */
   PreconditionerType _preconditioner_type;
 

--- a/include/numerics/shell_matrix.h
+++ b/include/numerics/shell_matrix.h
@@ -60,13 +60,13 @@ public:
   virtual ~ShellMatrix ();
 
   /**
-   * \returns \p m, the row-dimension of the matrix where the marix is
+   * \returns \p m, the row-dimension of the matrix where the matrix is
    * \f$ M \times N \f$.
    */
   virtual numeric_index_type m () const = 0;
 
   /**
-   * \returns \p n, the column-dimension of the matrix where the marix
+   * \returns \p n, the column-dimension of the matrix where the matrix
    * is \f$ M \times N \f$.
    */
   virtual numeric_index_type n () const = 0;

--- a/include/numerics/tensor_tools.h
+++ b/include/numerics/tensor_tools.h
@@ -276,7 +276,7 @@ VectorValue<Number> curl_from_grad( const TensorValue<Number> & grad );
   curl of a tensor given the gradient of that tensor. */
 TensorValue<Number> curl_from_grad( const TypeNTensor<3,Number> & grad );
 
-//! Dummy. Divgerence of a scalar not defined, but is needed for ExactSolution to compile
+//! Dummy. Divergence of a scalar not defined, but is needed for ExactSolution to compile
 Number div_from_grad( const VectorValue<Number> & grad );
 
 //! Computes the divergence of a vector given the gradient of that vector

--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -868,7 +868,7 @@ public:
    * Template type must match the object type that will be in
    * the packed range
    *
-   * \param src_processor_id The processor the mssage is expected from or Parallel::any_source
+   * \param src_processor_id The processor the message is expected from or Parallel::any_source
    * \param tag The message tag or Parallel::any_tag
    * \param flag Output.  True if a message exists.  False otherwise.
    */

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -193,7 +193,7 @@ void sync_dofobject_data_by_xyz(const Communicator & comm,
   libmesh_assert(!need_map_update);
 #endif
 
-  // Count the objectss to ask each processor about
+  // Count the objects to ask each processor about
   std::vector<dof_id_type>
     ghost_objects_from_proc(comm.size(), 0);
 
@@ -673,7 +673,7 @@ void sync_node_data_by_element_id(MeshBase &       mesh,
               const Node & node = elem.node_ref(n);
 
               // This isn't a safe assertion in the case where we're
-              // synching processor ids
+              // syncing processor ids
               // libmesh_assert_equal_to (node->processor_id(), comm.rank());
 
               request_to_fill_id[i] = node.id();

--- a/include/parallel/parallel_histogram.h
+++ b/include/parallel/parallel_histogram.h
@@ -39,7 +39,7 @@ namespace Parallel
 {
 
 /**
- * Defines a histogram to be used in parallel in conjuction with
+ * Defines a histogram to be used in parallel in conjunction with
  * a \p BinSorter.
  *
  * \author Benjamin S. Kirk

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -307,7 +307,7 @@ public:
 // Anonymous namespace for helper functions
 namespace {
 
-// Internal helper function to create vector<something_useable> from
+// Internal helper function to create vector<something_usable> from
 // vector<bool> for compatibility with MPI bitwise operations
 template <typename T>
 inline void pack_vector_bool(const std::vector<bool> & vec_in,
@@ -1018,7 +1018,7 @@ inline void Communicator::barrier () const {}
 #endif
 
 
-// legacy e.g. Paralell::send() methods, requires
+// legacy e.g. Parallel::send() methods, requires
 // Communicator_World
 #ifndef LIBMESH_DISABLE_COMMWORLD
 inline void barrier (const Communicator & comm = Communicator_World)
@@ -3730,7 +3730,7 @@ inline void Communicator::broadcast (std::vector<std::basic_string<T> > & data,
           for (std::size_t j=0; j != data[i].size(); ++j)
             /**
              * The strings will be packed in one long array with the size of each
-             * string preceeding the actual characters
+             * string preceding the actual characters
              */
             temp.push_back(data[i][j]);
         }

--- a/include/parallel/parallel_object.h
+++ b/include/parallel/parallel_object.h
@@ -38,8 +38,8 @@ namespace libMesh
 {
 /**
  * This class forms the base class for all other classes
- * that are expected to be implemented in paralel. Each
- * \p ParalelObject *requires* a \p Parallel::Communicator object
+ * that are expected to be implemented in parallel. Each
+ * \p ParallelObject *requires* a \p Parallel::Communicator object
  * for construction.
  *
  * \author Benjamin S. Kirk

--- a/include/parallel/parallel_sort.h
+++ b/include/parallel/parallel_sort.h
@@ -58,7 +58,7 @@ public:
    * the processor id, and a reference to a vector of data
    * to be sorted.  This vector is sorted by
    * the constructor, therefore, construction of
-   * a Sort object takes O(nlogn) time,
+   * a Sort object takes O(n log n) time,
    * where n is the length of the vector.
    */
   Sort (const Parallel::Communicator & comm,

--- a/include/parallel/threads_tbb.h
+++ b/include/parallel/threads_tbb.h
@@ -210,7 +210,7 @@ typedef tbb::spin_mutex spin_mutex;
 
 /**
  * Recursive mutex.  Implements mutual exclusion by busy-waiting in user
- * space for the lock to be acquired.  The same thread can aquire the
+ * space for the lock to be acquired.  The same thread can acquire the
  * same lock multiple times
  */
 typedef tbb::recursive_mutex recursive_mutex;

--- a/include/partitioning/partitioner.h
+++ b/include/partitioning/partitioner.h
@@ -124,7 +124,7 @@ public:
   { libmesh_not_implemented(); }
 
   /**
-   * Repartitions the \p MeshBase into \p n parts. (Some partitoning
+   * Repartitions the \p MeshBase into \p n parts. (Some partitioning
    * algorithms can repartition more efficiently than computing a new
    * partitioning from scratch.)  The default behavior is to simply
    * call this->partition(mesh,n).
@@ -134,7 +134,7 @@ public:
 
   /**
    * Repartitions the \p MeshBase into \p mesh.n_processors() parts.  This
-   * is required since some partitoning algorithms can repartition
+   * is required since some partitioning algorithms can repartition
    * more efficiently than computing a new partitioning from scratch.
    */
   void repartition (MeshBase & mesh);

--- a/include/partitioning/subdomain_partitioner.h
+++ b/include/partitioning/subdomain_partitioner.h
@@ -35,7 +35,7 @@ namespace libMesh
  * chunks[1] = {3, 7, 8}
  * chunks[2] = {5, 6}
  * then we will call the internal Partitioner three times, once for
- * subodmains 1, 2, and 4, once for subdomains 3, 7, and 8, and once
+ * subdomains 1, 2, and 4, once for subdomains 3, 7, and 8, and once
  * for subdomains 5 and 6.
  *
  * \note This Partitioner may produce highly non-optimal communication

--- a/include/physics/diff_physics.h
+++ b/include/physics/diff_physics.h
@@ -53,7 +53,7 @@ class DiffContext;
  * for unsteady TimeSolver and \f$ F(u) = 0\f$ for steady
  * TimeSolver. \f$F(u)\f$ is computed by element/side_time_derivative,
  * \f$G(u)\f$ is computed using element/side_constraint,
- * \f$C(u,\dot{u})\dot{u}\f$ is computed using the dampling_residual methods
+ * \f$C(u,\dot{u})\dot{u}\f$ is computed using the damping_residual methods
  * and \f$ -M(u,\ddot{u})\ddot{u}\f$ is computed using the mass_residual
  * methods. This is the sign convention used by the default implementation;
  * if the method is overridden, the user can choose any self-consistent sign
@@ -221,7 +221,7 @@ public:
    * should return false.
    *
    * Users may need to reimplement this for PDEs on systems to which
-   * SCALAR variables with non-tranient equations have been added.
+   * SCALAR variables with non-transient equations have been added.
    */
   virtual bool nonlocal_constraint (bool request_jacobian,
                                     DiffContext &) {
@@ -236,7 +236,7 @@ public:
    * behave like du/dt = F(u), and should not call time_evolving()
    * for any variables which behave like 0 = G(u).
    *
-   * Most derived systems will not have to reimplment this function; however
+   * Most derived systems will not have to reimplement this function; however
    * any system which reimplements mass_residual() may have to reimplement
    * time_evolving() to prepare data structures.
    *
@@ -258,7 +258,7 @@ public:
    * behave like d^2u/dt^2 = F(u), and should not call time_evolving()
    * for any variables which behave like 0 = G(u).
    *
-   * Most derived systems will not have to reimplment this function; however
+   * Most derived systems will not have to reimplement this function; however
    * any system which reimplements mass_residual() may have to reimplement
    * time_evolving() to prepare data structures.
    */

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -27,7 +27,7 @@ namespace libMesh
 {
 
 /**
- * This class implemenets specific orders of Gauss quadrature.  The
+ * This class implements specific orders of Gauss quadrature.  The
  * rules of Order \p p are capable of integrating polynomials of
  * degree \p p exactly.
  *

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -142,7 +142,7 @@ private:
    * The rules are obtained by considering the group G^{rot} of rotations of the reference
    * hex, and the invariant polynomials of this group.
    *
-   * In Kim and Song's rules, quadrauture points are described by the following points
+   * In Kim and Song's rules, quadrature points are described by the following points
    * and their unique permutations under the G^{rot} group:
    *
    * 0.) (0,0,0) ( 1 perm ) -> [0, 0, 0]

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -27,7 +27,7 @@ namespace libMesh
 {
 
 /**
- * This class implemenets Simpson quadrature.
+ * This class implements Simpson quadrature.
  * This is the same thing as Newton-Cotes quadrature with three points.
  * Simpson's rule can integrate polynomials of degree three exactly.
  *

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -27,7 +27,7 @@ namespace libMesh
 {
 
 /**
- * This class implemenets trapezoidal quadratue.  Sometimes also known
+ * This class implements trapezoidal quadrature.  Sometimes also known
  * as Newton-Cotes quadrature with two points.  These rules sample at
  * the corners and will integrate linears exactly.
  *

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -223,7 +223,7 @@ public:
 
   /**
    * Performs read_in_vectors for a list of directory names and data names.
-   * Reading in vectors requires us to renumber the dofs in a partition-indepdent
+   * Reading in vectors requires us to renumber the dofs in a partition-independent
    * way. This function only renumbers the dofs once at the start (and reverts
    * it at the end), which can save a lot of work compared to renumbering on every read.
    */

--- a/include/reduced_basis/rb_scm_evaluation.h
+++ b/include/reduced_basis/rb_scm_evaluation.h
@@ -150,7 +150,7 @@ public:
   virtual void save_current_parameters();
 
   /**
-   * Helper functiont to (re)load current_parameters
+   * Helper function to (re)load current_parameters
    * from saved_parameters.
    */
   virtual void reload_current_parameters();

--- a/include/solution_transfer/dtk_adapter.h
+++ b/include/solution_transfer/dtk_adapter.h
@@ -43,7 +43,7 @@ namespace libMesh
 {
 
 /**
- * The DTKAdapter is used with the DTKSolutionTranfer object to adapt
+ * The DTKAdapter is used with the DTKSolutionTransfer object to adapt
  * libmesh data to the DTK interface.
  *
  * \author Derek Gaston

--- a/include/solution_transfer/meshfree_interpolation.h
+++ b/include/solution_transfer/meshfree_interpolation.h
@@ -145,7 +145,7 @@ public:
 
   /**
    * Interpolate source data at target points.
-   * Pure virtual, must be overriden in derived classes.
+   * Pure virtual, must be overridden in derived classes.
    */
   virtual void interpolate_field_data (const std::vector<std::string> & field_names,
                                        const std::vector<Point>  & tgt_pts,
@@ -173,7 +173,7 @@ protected:
 
 
 /**
- * Inverse distance interplation.
+ * Inverse distance interpolation.
  */
 template <unsigned int KDDim>
 class InverseDistanceInterpolation : public MeshfreeInterpolation
@@ -347,7 +347,7 @@ public:
 
   /**
    * Interpolate source data at target points.
-   * Pure virtual, must be overriden in derived classes.
+   * Pure virtual, must be overridden in derived classes.
    */
   virtual void interpolate_field_data (const std::vector<std::string> & field_names,
                                        const std::vector<Point>  & tgt_pts,

--- a/include/solution_transfer/radial_basis_functions.h
+++ b/include/solution_transfer/radial_basis_functions.h
@@ -50,7 +50,7 @@ namespace libMesh
 //   {}
 
 //   /**
-//    * Evaluate the radial basis function at the reqested location.
+//    * Evaluate the radial basis function at the requested location.
 //    */
 //   Real operator()(Real rad) const
 //   {
@@ -87,7 +87,7 @@ public:
   { libmesh_experimental(); }
 
   /**
-   * Evaluate the radial basis function at the reqested location.
+   * Evaluate the radial basis function at the requested location.
    */
   Real operator()(Real /* rad */) const { libmesh_not_implemented(); return 0.; }
 };

--- a/include/solution_transfer/radial_basis_interpolation.h
+++ b/include/solution_transfer/radial_basis_interpolation.h
@@ -33,7 +33,7 @@ namespace libMesh
 {
 
 /**
- * Radial Basis Function interplation.
+ * Radial Basis Function interpolation.
  *
  * \author Benjamin S. Kirk
  * \date 2013
@@ -96,7 +96,7 @@ public:
 
   /**
    * Interpolate source data at target points.
-   * Pure virtual, must be overriden in derived classes.
+   * Pure virtual, must be overridden in derived classes.
    */
   virtual void interpolate_field_data (const std::vector<std::string> & field_names,
                                        const std::vector<Point> & tgt_pts,

--- a/include/solution_transfer/solution_transfer.h
+++ b/include/solution_transfer/solution_transfer.h
@@ -30,7 +30,7 @@
 namespace libMesh {
 
 /**
- * Base class for objects that allow transfering variable values
+ * Base class for objects that allow transferring variable values
  * between different systems with different meshes.
  *
  * \author Derek Gaston

--- a/include/solvers/eigen_sparse_linear_solver.h
+++ b/include/solvers/eigen_sparse_linear_solver.h
@@ -148,7 +148,7 @@ private:
   static std::map<Eigen::ComputationInfo, LinearConvergenceReason> _convergence_reasons;
 
   /**
-   * Static function used to initialize _covergence_reasons map
+   * Static function used to initialize _convergence_reasons map
    */
   static std::map<Eigen::ComputationInfo, LinearConvergenceReason> build_map()
   {

--- a/include/solvers/first_order_unsteady_solver.h
+++ b/include/solvers/first_order_unsteady_solver.h
@@ -39,7 +39,7 @@ namespace libMesh
  * of the variable \f$u\f$ is 2 when adding the variable using
  * FEMSystem::time_evolving. This class will then add the \f$v\f$ variables
  * to the FEMSystem (named "dot_u" if the second order variable name is "u").
- * Sublasses will then need to make sure to use the function
+ * Subclasses will then need to make sure to use the function
  * FirstOrderUnsteadySolver::prepare_accel() to prepare data structures for the
  * users to use from FEMContext. Furthermore, subclasses will need to appropriately
  * call damping_residual functions. Finally, subclasses will call

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -266,7 +266,7 @@ protected:
   SolverType _solver_type;
 
   /**
-   * Enum statitng with type of preconditioner to use.
+   * Enum stating with type of preconditioner to use.
    */
   PreconditionerType _preconditioner_type;
 

--- a/include/solvers/no_solution_history.h
+++ b/include/solvers/no_solution_history.h
@@ -29,7 +29,7 @@ namespace libMesh
  *
  * \author Vikram Garg
  * \date 2012
- * \brief For storing and retrieiving timestep data.
+ * \brief For storing and retrieving timestep data.
  */
 class NoSolutionHistory : public SolutionHistory
 {

--- a/include/solvers/optimization_solver.h
+++ b/include/solvers/optimization_solver.h
@@ -42,7 +42,7 @@ template <typename T> class Preconditioner;
 
 /**
  * This base class can be inherited from to provide interfaces to
- * optimziation solvers from different packages like PETSc/TAO and
+ * optimization solvers from different packages like PETSc/TAO and
  * nlopt.
  *
  * \author David Knezevic

--- a/include/solvers/petsc_linear_solver.h
+++ b/include/solvers/petsc_linear_solver.h
@@ -53,7 +53,7 @@ extern "C"
   PetscErrorCode __libmesh_petsc_preconditioner_setup (void * ctx);
 
   /**
-   * This function is called by PETSc to acctually apply the preconditioner.
+   * This function is called by PETSc to actually apply the preconditioner.
    * ctx will hold the Preconditioner.
    */
   PetscErrorCode __libmesh_petsc_preconditioner_apply(void * ctx, Vec x, Vec y);

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -149,7 +149,7 @@ public:
   void set_jacobian_zero_out(bool state) { _zero_out_jacobian = state; }
 
   /**
-   * Set to true to use the libMeash's default monitor, set to false to use your own
+   * Set to true to use the libMesh's default monitor, set to false to use your own
    */
   void use_default_monitor(bool state) { _default_monitor = state; }
 

--- a/include/solvers/second_order_unsteady_solver.h
+++ b/include/solvers/second_order_unsteady_solver.h
@@ -107,7 +107,7 @@ protected:
   UniquePtr<NumericVector<Number> > _old_local_solution_rate;
 
   /**
-   * Serial vector of previous time step accleration \f$ \ddot{u}_n \f$
+   * Serial vector of previous time step acceleration \f$ \ddot{u}_n \f$
    */
   UniquePtr<NumericVector<Number> > _old_local_solution_accel;
 };

--- a/include/solvers/solution_history.h
+++ b/include/solvers/solution_history.h
@@ -30,7 +30,7 @@ namespace libMesh
  *
  * \author Vikram Garg
  * \date 2012
- * \brief For storing and retrieiving timestep data.
+ * \brief For storing and retrieving timestep data.
  */
 class SolutionHistory
 {

--- a/include/solvers/solver_configuration.h
+++ b/include/solvers/solver_configuration.h
@@ -67,7 +67,7 @@ public:
    * This method can be called after the solver has failed (e.g. on
    * catching an exception thrown by a solver). It allows an appropriate
    * response to the failure, e.g. terminate the program, or change
-   * configuation options and try again.
+   * configuration options and try again.
    * \p solve_failure_count specifies the number of times we've tried to
    * recover from a failure.
    */

--- a/include/systems/continuation_system.h
+++ b/include/systems/continuation_system.h
@@ -148,7 +148,7 @@ public:
 
   /**
    * Stores the current solution and continuation parameter
-   * (as "previous_u" and "old_continuation_paramter") for later referral.
+   * (as "previous_u" and "old_continuation_parameter") for later referral.
    * You may need to call this e.g. after the first regular solve, in order
    * to store the first solution, before computing a second solution and
    * beginning arclength continuation.
@@ -175,7 +175,7 @@ public:
 
   /**
    * Arclength normalization parameter.  Defaults to 1.0 (no normalization).  Used to
-   * ensure that one term in the arclength contstraint equation does not wash out all
+   * ensure that one term in the arclength constraint equation does not wash out all
    * the others.
    */
   Real Theta;
@@ -404,7 +404,7 @@ private:
 
   /**
    * Value of stepsize currently in use.  Will not exceed user-provided maximum
-   * arclength stepize ds.
+   * arclength stepsize ds.
    */
   Real ds_current;
 

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -388,7 +388,7 @@ protected:
    * Helper function to and Dirichlet boundary conditions to "dot" variable
    * cousins of second order variables in the system. The function takes the
    * second order variable index, it's corresponding "dot" variable index and
-   * then searches for DirchletBoundary objects for var_idx and then adds a
+   * then searches for DirichletBoundary objects for var_idx and then adds a
    * DirichletBoundary object for dot_var_idx using the same boundary ids and
    * functors for the var_idx DirichletBoundary.
    */

--- a/include/systems/eigen_system.h
+++ b/include/systems/eigen_system.h
@@ -40,7 +40,7 @@ template <typename T> class SparseMatrix;
  * This class provides a specific system class.  It aims
  * at solving eigenvalue problems.  Currently, this class
  * is able  to handle standard eigenvalue problems
- * \p A*x=lambda*x  and generalited eigenvalue problems
+ * \p A*x=lambda*x  and generalized eigenvalue problems
  * \p A*x=lambda*B*x.
  *
  * \author Steffen Peterson
@@ -155,7 +155,7 @@ public:
   UniquePtr<SparseMatrix<Number> > matrix_B;
 
   /**
-   * The EigenSolver, definig which interface, i.e solver
+   * The EigenSolver, defining which interface, i.e solver
    * package to use.
    */
   UniquePtr<EigenSolver<Number> > eigen_solver;

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -139,7 +139,7 @@ public:
   const T_sys & get_system (const std::string & name) const;
 
   /**
-   * \returns A writable referene to the system named \p name.
+   * \returns A writable reference to the system named \p name.
    * The template argument defines the return type.  For example,
    * const SteadySystem & sys = eq.get_system<SteadySystem> ("sys");
    * is an example of how the method might be used
@@ -157,7 +157,7 @@ public:
   const T_sys & get_system (const unsigned int num) const;
 
   /**
-   * \returns A writable referene to the system number \p num.
+   * \returns A writable reference to the system number \p num.
    * The template argument defines the return type.  For example,
    * const SteadySystem & sys = eq.get_system<SteadySystem> (0);
    * is an example of how the method might be used
@@ -171,7 +171,7 @@ public:
   const System & get_system (const std::string & name) const;
 
   /**
-   * \returns A writable referene to the system named \p name.
+   * \returns A writable reference to the system named \p name.
    */
   System & get_system (const std::string & name);
 
@@ -181,7 +181,7 @@ public:
   const System & get_system (const unsigned int num) const;
 
   /**
-   * \returns A writable referene to the system number \p num.
+   * \returns A writable reference to the system number \p num.
    */
   System & get_system (const unsigned int num);
 
@@ -484,7 +484,7 @@ protected:
   typedef std::map<std::string, System *>::iterator       system_iterator;
 
   /**
-   * Typedef for constatnt system iterators
+   * Typedef for constant system iterators
    */
   typedef std::map<std::string, System *>::const_iterator const_system_iterator;
 

--- a/include/systems/frequency_system.h
+++ b/include/systems/frequency_system.h
@@ -211,7 +211,7 @@ protected:
   /**
    * Initializes the member data fields associated with
    * the system, so that, e.g., \p assemble() may be used.
-   * The frequenices have to be set prior to calling
+   * The frequencies have to be set prior to calling
    * \p init().
    */
   virtual void init_data () libmesh_override;

--- a/include/systems/newmark_system.h
+++ b/include/systems/newmark_system.h
@@ -35,7 +35,7 @@ namespace libMesh
  *
  * In the algorithm implemented here the system is solved for
  * displacements.
- * Curently the Newmark scheme is implemented for constant
+ * Currently the Newmark scheme is implemented for constant
  * time step sizes only. This time step is stored in the
  * \p EquationSystems parameter named \p "Newmark \p time \p step".
  * For the case of constant time steps the matrix only has to be

--- a/include/systems/parameter_accessor.h
+++ b/include/systems/parameter_accessor.h
@@ -47,7 +47,7 @@ class ConstParameterProxy;
  *
  * \author Roy Stogner
  * \date 2015
- * \brief Base class for reading/writing sensitivty parameters.
+ * \brief Base class for reading/writing sensitivity parameters.
  */
 template <typename T=Number>
 class ParameterAccessor

--- a/include/systems/sensitivity_data.h
+++ b/include/systems/sensitivity_data.h
@@ -32,7 +32,7 @@
 namespace libMesh
 {
 
-// Forward declaractions
+// Forward declarations
 class QoISet;
 
 /**

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -87,9 +87,9 @@ public:
           const unsigned int number);
 
   /**
-   * Abstract base class to be used for sysem initialization.
+   * Abstract base class to be used for system initialization.
    * A user class derived from this class may be used to
-   * intialize the system values by attaching an object
+   * initialize the system values by attaching an object
    * with the method \p attach_init_object.
    */
   class Initialization
@@ -111,7 +111,7 @@ public:
 
 
   /**
-   * Abstract base class to be used for sysem assembly.
+   * Abstract base class to be used for system assembly.
    * A user class derived from this class may be used to
    * assemble the system by attaching an object
    * with the method \p attach_assemble_object.
@@ -135,7 +135,7 @@ public:
 
 
   /**
-   * Abstract base class to be used for sysem constraints.
+   * Abstract base class to be used for system constraints.
    * A user class derived from this class may be used to
    * constrain the system by attaching an object
    * with the method \p attach_constraint_object.
@@ -173,7 +173,7 @@ public:
     virtual ~QOI () {}
 
     /**
-     * Quantitiy of interest function.  This function will be called
+     * Quantity of interest function.  This function will be called
      * to compute quantities of interest and must be provided by the
      * user in a derived class.
      */
@@ -197,8 +197,8 @@ public:
     virtual ~QOIDerivative () {}
 
     /**
-     * Quantitiy of interest derivative function. This function will
-     * be called to compute derivatived of quantities of interest and
+     * Quantity of interest derivative function. This function will
+     * be called to compute derivatives of quantities of interest and
      * must be provided by the user in a derived class.
      */
     virtual void qoi_derivative (const QoISet & qoi_indices,
@@ -771,7 +771,7 @@ public:
   /**
    * Adds the additional vector \p vec_name to this system.  All the
    * additional vectors are similarly distributed, like the \p
-   * solution, and inititialized to zero.
+   * solution, and initialized to zero.
    *
    * By default vectors added by add_vector are projected to changed grids by
    * reinit().  To zero them instead (more efficient), pass "false" as the
@@ -1033,7 +1033,7 @@ public:
    * \returns The number of matrices
    * handled by this system.
    *
-   * This will return 0 by default but can be overriden.
+   * This will return 0 by default but can be overridden.
    */
   virtual unsigned int n_matrices () const;
 
@@ -1144,7 +1144,7 @@ public:
   const std::string & variable_name(const unsigned int i) const;
 
   /**
-   * \returns The variable number assoicated with
+   * \returns The variable number associated with
    * the user-specified variable named \p var.
    */
   unsigned short int variable_number (const std::string & var) const;
@@ -1659,7 +1659,7 @@ protected:
   /**
    * Initializes the data for the system.
    *
-   * \note This is called before any user-supplied intitialization
+   * \note This is called before any user-supplied initialization
    * function so that all required storage will be available.
    */
   virtual void init_data ();

--- a/include/systems/system_norm.h
+++ b/include/systems/system_norm.h
@@ -112,7 +112,7 @@ public:
                       const std::vector<Real> & v2);
 
   /**
-   * \returns \p true if no weight matrix W is specified or an identiy matrix is specified, otherwise returns false
+   * \returns \p true if no weight matrix W is specified or an identity matrix is specified, otherwise returns false
    */
   bool is_identity();
 

--- a/include/systems/system_subset.h
+++ b/include/systems/system_subset.h
@@ -58,7 +58,7 @@ public:
    * \returns The actual set of dofs that the subset consists of.
    *
    * The result must contain local dofs on each processor only and
-   * must not contain duplictates.
+   * must not contain duplicates.
    */
   virtual const std::vector<unsigned int> & dof_ids () const = 0;
 

--- a/include/systems/system_subset_by_subdomain.h
+++ b/include/systems/system_subset_by_subdomain.h
@@ -150,7 +150,7 @@ public:
    * \returns The actual set of dofs that the subset consists of.
    *
    * The result will contain local dofs on each processor only and
-   * will not contain duplictates.
+   * will not contain duplicates.
    */
   virtual const std::vector<unsigned int> & dof_ids () const libmesh_override;
 

--- a/include/utils/error_vector.h
+++ b/include/utils/error_vector.h
@@ -96,7 +96,7 @@ public:
   virtual Real median() libmesh_override;
 
   /**
-   * A const version of the median funtion.
+   * A const version of the median function.
    * Requires twice the memory of original
    * data set but does not change the original.
    */

--- a/include/utils/parameters.h
+++ b/include/utils/parameters.h
@@ -394,7 +394,7 @@ void Parameters::print (std::ostream & os) const
 
 
 
-// Declare this now that Paramers::print() is defined.
+// Declare this now that Parameters::print() is defined.
 // By declaring this early we can use it in subsequent
 // methods.  Required for gcc-4.0.2 -- 11/30/2005, BSK
 inline

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -114,7 +114,7 @@ protected:
  * The \p PerfLog class allows monitoring of specific events.
  * An event is defined by a unique string that functions as
  * a label.  Each time the event is executed data are recorded.
- * This class is particulary useful for finding performance
+ * This class is particularly useful for finding performance
  * bottlenecks.
  *
  * \author Benjamin Kirk
@@ -307,7 +307,7 @@ private:
 
 
 // ------------------------------------------------------------
-// PerfData class member funcions
+// PerfData class member functions
 inline
 void PerfData::start ()
 {
@@ -376,7 +376,7 @@ double PerfData::stopit ()
 
 
 // ------------------------------------------------------------
-// PerfLog class inline member funcions
+// PerfLog class inline member functions
 inline
 void PerfLog::push (const std::string & label,
                     const std::string & header)

--- a/include/utils/plt_loader.h
+++ b/include/utils/plt_loader.h
@@ -81,7 +81,7 @@ public:
   void write_dat (const std::string & name,
                   const unsigned int version=10) const;
 
-  // BSK - this functionality requires FORTRAN subrouitine calls,
+  // BSK - this functionality requires FORTRAN subroutine calls,
   //       and there is no need to "dirty up" \p libMesh with FORTRAN
   //       just to enable these methods.
   //   /**

--- a/include/utils/statistics.h
+++ b/include/utils/statistics.h
@@ -37,7 +37,7 @@ namespace libMesh
  * therefore has all of its useful features.  It was designed to not
  * have any internal state, i.e. no public or private data members.
  * Also, it was only designed for classes and types for which the
- * operators +,*,/ have meaining, specifically floats, doubles, ints,
+ * operators +,*,/ have meaning, specifically floats, doubles, ints,
  * etc.  The main reason for this design decision was to allow a
  * std::vector<> to be successfully cast to a StatisticsVector,
  * thereby enabling its additional functionality.  We do not
@@ -117,7 +117,7 @@ public:
   virtual Real median();
 
   /**
-   * A const version of the median funtion.  Requires twice the memory
+   * A const version of the median function.  Requires twice the memory
    * of original data set but does not change the original.
    */
   virtual Real median() const;

--- a/include/utils/vectormap.h
+++ b/include/utils/vectormap.h
@@ -51,7 +51,7 @@ namespace libMesh
  * \note The two-phase usage.  It is not advised to do intermediate
  * insert/lookups, as each time an insertion is done the sort is
  * invalidated, and must be reperformed. Additionally, during the
- * insersion phase, there is no accounting for duplicate keys.  Each
+ * insertion phase, there is no accounting for duplicate keys.  Each
  * insertion is accepted regardless of key value, and then duplicate
  * keys are removed later.
  *

--- a/m4/ax_boost_base.m4
+++ b/m4/ax_boost_base.m4
@@ -10,7 +10,7 @@
 #
 #   Test for the Boost C++ libraries of a particular version (or newer)
 #
-#   If no path to the installed boost library is given the macro searchs
+#   If no path to the installed boost library is given the macro searches
 #   under /usr, /usr/local, /opt and /opt/local and evaluates the
 #   $BOOST_ROOT environment variable. Further documentation is available at
 #   <http://randspringer.de/boost/index.html>.

--- a/m4/capnproto.m4
+++ b/m4/capnproto.m4
@@ -2,7 +2,7 @@
 # The Reduced Basis code uses Cap'n Proto to write training data to
 # disk.  By default, we check for the Capn'n Proto installation files
 # in the directory provided to configure via --with-capnproto=xxx,
-# which is superceded by $CAPNPROTO_DIR if it is set.
+# which is superseded by $CAPNPROTO_DIR if it is set.
 # ----------------------------------------------------------------
 
 AC_DEFUN([CONFIGURE_CAPNPROTO],

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -75,7 +75,7 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
   #
   # note though than on OSX for example the XCode tools provide
   # a 'mpif77' which will be detected below but is actually an
-  # emtpy shell script wrapper.  Then the compiler will fail to
+  # empty shell script wrapper.  Then the compiler will fail to
   # make executables and we will wind up with static libraries
   # due to a bizarre chain of events.  So, add support for
   # --disable-fortran
@@ -1009,7 +1009,7 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
               ;;
 
           *)
-              AC_MSG_RESULT(Unknown Intel complier, "$GXX_VERSION")
+              AC_MSG_RESULT(Unknown Intel compiler, "$GXX_VERSION")
               ;;
         esac
       ;;

--- a/m4/curl.m4
+++ b/m4/curl.m4
@@ -1,4 +1,4 @@
-# The CURL API allows one to interact with URLs programatically.
+# The CURL API allows one to interact with URLs programmatically.
 AC_DEFUN([CONFIGURE_CURL],
 [
   AC_ARG_ENABLE(curl,

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -334,7 +334,7 @@ AC_DEFUN([LIBMESH_TEST_CXX11_CONSTEXPR],
         have_cxx11_constexpr=yes
       else
         AC_MSG_RESULT([yes, but disabled.])
-        AC_DEFINE(HAVE_CXX11_CONSTEXPR_BUT_DISABLED, 1, [Compiler supports constexper, but it is disabled in libmesh])
+        AC_DEFINE(HAVE_CXX11_CONSTEXPR_BUT_DISABLED, 1, [Compiler supports constexpr, but it is disabled in libmesh])
       fi
     ],[
         AC_MSG_RESULT(no)
@@ -773,7 +773,7 @@ AC_DEFUN([LIBMESH_TEST_CXX11_VARIADIC_TEMPLATES],
       template <typename T>
       T sum(T t) { return t; }
 
-      // Compute sum of arbitary number of passed parameters.
+      // Compute sum of arbitrary number of passed parameters.
       template <typename T, typename ...P>
       T sum(T t, P ...p)
       {

--- a/m4/gz.m4
+++ b/m4/gz.m4
@@ -5,7 +5,7 @@ AC_DEFUN([CONFIGURE_GZ],
 [
   AC_ARG_ENABLE(gzstreams,
                 AS_HELP_STRING([--disable-gzstreams],
-                               [build without gzstreams compressed I/O suppport]),
+                               [build without gzstreams compressed I/O support]),
                 [case "${enableval}" in
                   yes)  enablegz=yes ;;
                   no)  enablegz=no ;;
@@ -23,7 +23,7 @@ if (test "$have_zlib_h" != yes -o "$have_libz" != yes) ; then
   enablegz=no
 fi
 
-# If both tests succeded, continue the configuration process.
+# If both tests succeeded, continue the configuration process.
 if (test "$enablegz" = yes) ; then
   GZSTREAM_INCLUDE="-I\$(top_srcdir)/contrib/gzstream"
   GZSTREAM_LIB="\$(EXTERNAL_LIBDIR)/libgzstream\$(libext) -lz"

--- a/m4/laspack.m4
+++ b/m4/laspack.m4
@@ -5,7 +5,7 @@ AC_DEFUN([CONFIGURE_LASPACK],
 [
   AC_ARG_ENABLE(laspack,
                 AS_HELP_STRING([--disable-laspack],
-                               [build without LASPACK iterative solver suppport]),
+                               [build without LASPACK iterative solver support]),
                 [case "${enableval}" in
                   yes)  enablelaspack=yes ;;
                   no)  enablelaspack=no ;;

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -279,7 +279,7 @@ AC_ARG_ENABLE(everything,
 # -------------------------------------------------------------
 AC_ARG_ENABLE(unique-id,
               AS_HELP_STRING([--enable-unique-id],
-                             [build with unique id suppport]),
+                             [build with unique id support]),
               [case "${enableval}" in
                 yes)  enableuniqueid=yes ;;
                 no) enableuniqueid=no ;;
@@ -346,7 +346,7 @@ fi
 # -------------------------------------------------------------
 AC_ARG_ENABLE(amr,
               AS_HELP_STRING([--disable-amr],
-                             [build without adaptive mesh refinement (AMR) suppport]),
+                             [build without adaptive mesh refinement (AMR) support]),
               enableamr=$enableval,
               enableamr=yes)
 
@@ -364,7 +364,7 @@ fi
 # -------------------------------------------------------------
 AC_ARG_ENABLE(vsmoother,
               AS_HELP_STRING([--disable-vsmoother],
-                             [build without variational smoother suppport]),
+                             [build without variational smoother support]),
               enablevsmoother=$enableval,
               enablevsmoother=yes)
 
@@ -382,7 +382,7 @@ fi
 # -------------------------------------------------------------
 AC_ARG_ENABLE(periodic,
               AS_HELP_STRING([--disable-periodic],
-                             [build without periodic boundary condition suppport]),
+                             [build without periodic boundary condition support]),
               enableperiodic=$enableval,
               enableperiodic=yes)
 
@@ -418,7 +418,7 @@ fi
 # -------------------------------------------------------------
 AC_ARG_ENABLE(nodeconstraint,
               AS_HELP_STRING([--enable-nodeconstraint],
-                             [build with node constraints suppport]),
+                             [build with node constraints support]),
               enablenodeconstraint=$enableval,
               enablenodeconstraint=$enableeverything)
 
@@ -627,7 +627,7 @@ AC_ARG_ENABLE(complex,
 
 if test "$enablecomplex" != no ; then
   AC_DEFINE(USE_COMPLEX_NUMBERS, 1,
-     [Flag indicating if the library should be built using complxex numbers])
+     [Flag indicating if the library should be built using complex numbers])
   AC_MSG_RESULT(<<< Configuring library with complex number support >>>)
 
 else

--- a/m4/libmesh_method.m4
+++ b/m4/libmesh_method.m4
@@ -29,8 +29,8 @@
 #  AM_CONDITIONAL(LIBMESH_DEVEL_MODE, test x$METHOD = xdevel)
 
 #  AC_ARG_VAR([libmesh_CPPFLAGS], [User-specified C/C++ preprocessor flags])
-#  AC_ARG_VAR([libmesh_CXXFLAGS], [User-specified C++ compliation flags])
-#  AC_ARG_VAR([libmesh_CFLAGS],   [User-specified C compliation flags])
+#  AC_ARG_VAR([libmesh_CXXFLAGS], [User-specified C++ compilation flags])
+#  AC_ARG_VAR([libmesh_CFLAGS],   [User-specified C compilation flags])
 
 #  case "${METHOD}" in
 #     opt)
@@ -122,8 +122,8 @@ AC_DEFUN([LIBMESH_SET_METHODS],
  AC_MSG_RESULT([<<< Configuring libMesh with methods "$METHODS" >>>])
 
  AC_ARG_VAR([libmesh_CPPFLAGS], [User-specified C/C++ preprocessor flags])
- AC_ARG_VAR([libmesh_CXXFLAGS], [User-specified C++ compliation flags])
- AC_ARG_VAR([libmesh_CFLAGS],   [User-specified C compliation flags])
+ AC_ARG_VAR([libmesh_CXXFLAGS], [User-specified C++ compilation flags])
+ AC_ARG_VAR([libmesh_CFLAGS],   [User-specified C compilation flags])
 
  build_opt=no
  build_dbg=no

--- a/m4/libmesh_optional_packages.m4
+++ b/m4/libmesh_optional_packages.m4
@@ -258,7 +258,7 @@ AC_CONFIG_FILES([contrib/gzstream/Makefile])
 # -------------------------------------------------------------
 AC_ARG_ENABLE(bzip2,
               AS_HELP_STRING([--disable-bzip2],
-                             [build without bzip2 compressed I/O suppport]),
+                             [build without bzip2 compressed I/O support]),
               enablebz2=$enableval,
               enablebz2=$enableoptional)
 
@@ -282,7 +282,7 @@ fi
 # -------------------------------------------------------------
 AC_ARG_ENABLE(xz,
               AS_HELP_STRING([--disable-xz],
-                             [build without xz compressed I/O suppport]),
+                             [build without xz compressed I/O support]),
               enablexz=$enableval,
               enablexz=$enableoptional)
 

--- a/m4/metis.m4
+++ b/m4/metis.m4
@@ -5,7 +5,7 @@ AC_DEFUN([CONFIGURE_METIS],
 [
   AC_ARG_ENABLE(metis,
                 AS_HELP_STRING([--disable-metis],
-                               [build without Metis graph partitioning suppport]),
+                               [build without Metis graph partitioning support]),
                 [case "${enableval}" in
                   yes)  enablemetis=yes ;;
                   no)  enablemetis=no ;;
@@ -15,7 +15,7 @@ AC_DEFUN([CONFIGURE_METIS],
 
   AC_ARG_WITH(metis,
              AS_HELP_STRING([--with-metis=<internal,PETSc>],
-                            [metis to use. interal: build from contrib, PETSc: rely on PETSc]),
+                            [metis to use. internal: build from contrib, PETSc: rely on PETSc]),
              [case "${withval}" in
                internal)
                  build_metis=yes ;;

--- a/m4/nanoflann.m4
+++ b/m4/nanoflann.m4
@@ -5,7 +5,7 @@ AC_DEFUN([CONFIGURE_NANOFLANN],
 [
   AC_ARG_ENABLE(nanoflann,
                 AS_HELP_STRING([--disable-nanoflann],
-                               [build without nanoflann KD-tree suppport]),
+                               [build without nanoflann KD-tree support]),
                 [case "${enableval}" in
                   yes)  enablenanoflann=yes ;;
                   no)  enablenanoflann=no ;;

--- a/m4/netcdf.m4
+++ b/m4/netcdf.m4
@@ -28,7 +28,7 @@ AC_DEFUN([CONFIGURE_NETCDF],
         AC_MSG_RESULT(<<< Configuring library with NetCDF version 3 support >>>)
 
         # pass --disable-netcdf-4 to the subpackage so that we do not require HDF-5
-        # note this is maddness - we will run configure in the subdirectory v4, but not use it,
+        # note this is madness - we will run configure in the subdirectory v4, but not use it,
         # so this is nothing more than a hedge against that failing.  we need it to work for
         # 'make dist' to work
         libmesh_subpackage_arguments="$libmesh_subpackage_arguments --disable-netcdf-4"
@@ -39,7 +39,7 @@ AC_DEFUN([CONFIGURE_NETCDF],
         AC_DEFINE(HAVE_NETCDF, 1, [Flag indicating whether the library will be compiled with Netcdf support])
         # building netcdf-4 requires that we support nested subpackages
         if (test "x$enablenested" = "xno"); then
-          AC_MSG_ERROR([NetCDF v4 requres nested subpackages, try --enable-nested])
+          AC_MSG_ERROR([NetCDF v4 requires nested subpackages, try --enable-nested])
         fi
 
         if (test "x$enablehdf5" = "xno"); then

--- a/m4/parmetis.m4
+++ b/m4/parmetis.m4
@@ -5,7 +5,7 @@ AC_DEFUN([CONFIGURE_PARMETIS],
 [
   AC_ARG_ENABLE(parmetis,
                 AS_HELP_STRING([--disable-parmetis],
-                               [build without Parmetis parallel graph partitioning suppport]),
+                               [build without Parmetis parallel graph partitioning support]),
                 [case "${enableval}" in
                   yes)  enableparmetis=yes ;;
                   no)  enableparmetis=no ;;

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -5,7 +5,7 @@ AC_DEFUN([CONFIGURE_PETSC],
 [
   AC_ARG_ENABLE(petsc,
                 AS_HELP_STRING([--disable-petsc],
-                               [build without PETSc iterative solver suppport]),
+                               [build without PETSc iterative solver support]),
                 [case "${enableval}" in
                   yes)  enablepetsc=yes ;;
                    no)  enablepetsc=no ;;

--- a/m4/prefix_config.m4
+++ b/m4/prefix_config.m4
@@ -29,7 +29,7 @@
 #
 #   Your configure.ac script should contain both macros in this order, and
 #   unlike the earlier variations of this prefix-macro it is okay to place
-#   the AX_PREFIX_CONFIG_H call before the AC_OUTPUT invokation.
+#   the AX_PREFIX_CONFIG_H call before the AC_OUTPUT invocation.
 #
 #   Example:
 #

--- a/m4/sfc.m4
+++ b/m4/sfc.m4
@@ -5,7 +5,7 @@ AC_DEFUN([CONFIGURE_SFC],
 [
   AC_ARG_ENABLE(sfc,
                 AS_HELP_STRING([--disable-sfc],
-                               [build without space-filling curves suppport]),
+                               [build without space-filling curves support]),
                 [case "${enableval}" in
                   yes)  enablesfc=yes ;;
                   no)  enablesfc=no ;;

--- a/m4/tetgen.m4
+++ b/m4/tetgen.m4
@@ -1,11 +1,11 @@
 dnl -------------------------------------------------------------
-dnl TetGen tetrahedrization library
+dnl TetGen tetrahedralization library
 dnl -------------------------------------------------------------
 AC_DEFUN([CONFIGURE_TETGEN],
 [
   AC_ARG_ENABLE(tetgen,
                 AS_HELP_STRING([--disable-tetgen],
-                               [build without TetGen tetrahedrization library support]),
+                               [build without TetGen tetrahedralization library support]),
                 [case "${enableval}" in
                   yes)  enabletetgen=yes ;;
                   no)  enabletetgen=no ;;

--- a/src/apps/compare.C
+++ b/src/apps/compare.C
@@ -24,7 +24,7 @@
 #include <string>
 #ifdef LIBMESH_HAVE_GETOPT_H
 // GCC 2.95.3 (and maybe others) do not include
-// getopt.h in unistd.h...  Hower IBM xlC has no
+// getopt.h in unistd.h...  However IBM xlC has no
 // getopt.h!  This works around that.
 #include <getopt.h>
 #endif
@@ -119,7 +119,7 @@ void process_cmd_line(int argc,
             if (names.empty())
               names.push_back(optarg);
             else
-              libmesh_error_msg("ERROR: Mesh file name must preceed left file name!");
+              libmesh_error_msg("ERROR: Mesh file name must precede left file name!");
             break;
           }
 
@@ -143,7 +143,7 @@ void process_cmd_line(int argc,
                 left_name_set = true;
               }
             else
-              libmesh_error_msg("ERROR: Mesh file name must preceed right file name!");
+              libmesh_error_msg("ERROR: Mesh file name must precede right file name!");
             break;
           }
 
@@ -155,7 +155,7 @@ void process_cmd_line(int argc,
             if ((!names.empty()) && (left_name_set))
               names.push_back(optarg);
             else
-              libmesh_error_msg("ERROR: Mesh file name and left file name must preceed right file name!");
+              libmesh_error_msg("ERROR: Mesh file name and left file name must precede right file name!");
             break;
           }
 
@@ -323,7 +323,7 @@ int main (int argc, char ** argv)
 
 
   /**
-   * build the left and right mesh for left, inut them
+   * build the left and right mesh for left, init them
    */
   Mesh left_mesh  (init.comm(), dim);
   Mesh right_mesh (init.comm(), dim);
@@ -380,9 +380,9 @@ int main (int argc, char ** argv)
     {
       if (!quiet)
         libMesh::out << std::endl
-                     << " Oops, differences occured!"
+                     << " Oops, differences occurred!"
                      << std::endl
-                     << " Use -v to obtain more information where differences occured."
+                     << " Use -v to obtain more information where differences occurred."
                      << std::endl;
       our_result=1;
     }

--- a/src/apps/meshid.C
+++ b/src/apps/meshid.C
@@ -17,8 +17,8 @@
 
 
 // Open the mesh named in command line arguments,
-// update ids of one or more of the following enties
-// as perscribed on the command line:
+// update ids of one or more of the following entries
+// as prescribed on the command line:
 // blocks, sidesets and nodesets
 
 #include <iostream>
@@ -112,7 +112,7 @@ int main(int argc, char ** argv)
 
   for (unsigned char mask = 8; mask; mask/=2)
     {
-      // These are char *'s #defined in exodsuII_int.h
+      // These are char *'s #defined in exodusII_int.h
       switch (flags & mask)
         {
         case BLOCKS:
@@ -223,7 +223,7 @@ int main(int, char **)
 
 void handle_error(int error, std::string message)
 {
-  std::cout << "Error " << error << " occured while working with the netCDF API" << std::endl;
+  std::cout << "Error " << error << " occurred while working with the netCDF API" << std::endl;
   std::cout << message << std::endl;
 
   exit(1);

--- a/src/apps/meshtool.C
+++ b/src/apps/meshtool.C
@@ -22,7 +22,7 @@
 #include <fstream>
 #ifdef LIBMESH_HAVE_GETOPT_H
 // GCC 2.95.3 (and maybe others) do not include
-// getopt.h in unistd.h...  Hower IBM xlC has no
+// getopt.h in unistd.h...  However IBM xlC has no
 // getopt.h!  This works around that.
 #include <getopt.h>
 #endif
@@ -109,7 +109,7 @@ void usage(const std::string & progName)
     // <<   "    -L                            Build the script L connectivity matrix \n"
            << "\n"
            << "\n"
-           << " This program is used to convert and partions from/to a variety of\n"
+           << " This program is used to convert and partition from/to a variety of\n"
            << " formats.  File types are inferred from file extensions.  For example,\n"
            << " the command:\n"
            << "\n"
@@ -606,7 +606,7 @@ int main (int argc, char ** argv)
    */
   if (names.size() == 3)
     {
-      // TODO: Read XDR/A mesh file, contstruct an EquationSystems
+      // TODO: Read XDR/A mesh file, construct an EquationSystems
       // object, read XDR/A solution file by calling
       // es.read(file, READ_HEADER|READ_DATA|READ_ADDITIONAL_DATA);
       // then store a localized copy of the solution vector into 'soln'.
@@ -793,7 +793,7 @@ int main (int argc, char ** argv)
    */
   if (dist_fact > 0.)
     {
-      libMesh::out << "Distoring the mesh by a factor of "
+      libMesh::out << "Distorting the mesh by a factor of "
                    << dist_fact
                    << std::endl;
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -59,7 +59,7 @@ DofMap::build_sparsity (const MeshBase & mesh) const
   LOG_SCOPE("build_sparsity()", "DofMap");
 
   // Compute the sparsity structure of the global matrix.  This can be
-  // fed into a PetscMatrix to allocate exacly the number of nonzeros
+  // fed into a PetscMatrix to allocate exactly the number of nonzeros
   // necessary to store the matrix.  This algorithm should be linear
   // in the (# of elements)*(# nodes per element)
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3069,7 +3069,7 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
                         nodes_requested.insert(node);
 
                       // We can have 0 nodal constraint
-                      // coefficients, where no Lagrange constrant
+                      // coefficients, where no Lagrange constraint
                       // exists but non-Lagrange basis constraints
                       // might.
                       // libmesh_assert(j->second);
@@ -3860,7 +3860,7 @@ void DofMap::gather_constraints (MeshBase & /*mesh*/,
                   // from Number, which may be std::complex, in which
                   // case quiet_NaN() silently returns zero, rather
                   // than sanely returning NaN or throwing an
-                  // exception or sending Stroustrop hate mail.
+                  // exception or sending Stroustrup hate mail.
                   dof_row_rhss[i] =
                     std::numeric_limits<Real>::quiet_NaN();
 

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -204,7 +204,7 @@ void DofObject::add_system()
   // cache this value before we screw it up!
   const unsigned int ns_orig = this->n_systems();
 
-  // incriment the number of systems and the offsets for each of
+  // increment the number of systems and the offsets for each of
   // the systems including the new one we just added.
   for (unsigned int i=0; i<ns_orig+1; i++)
     _idx_buf[i]++;
@@ -222,13 +222,13 @@ void DofObject::set_n_vars_per_group(const unsigned int s,
 
   libmesh_assert_less (s, this->n_systems());
 
-  // number of varaible groups for this system - inferred
+  // number of variable groups for this system - inferred
   const unsigned int nvg = cast_int<unsigned int>(nvpg.size());
 
   // BSK - note that for compatibility with the previous implementation
   // calling this method when (nvars == this->n_vars()) requires that
   // we invalidate the DOF indices and set the number of components to 0.
-  // Note this was a bit of a suprise to me - there was no quick return in
+  // Note this was a bit of a surprise to me - there was no quick return in
   // the old method, which caused removal and readdition of the DOF indices
   // even in the case of (nvars == this->n_vars()), resulting in n_comp(s,v)
   // implicitly becoming 0 regardless of any previous value.
@@ -324,7 +324,7 @@ void DofObject::set_n_vars_per_group(const unsigned int s,
   for (unsigned int v=0; v<this->n_vars(s); v++)
     libmesh_assert_equal_to (this->n_comp(s,v), 0);
 
-  // again, all other system sizes shoudl be unchanged!
+  // again, all other system sizes should be unchanged!
   for (unsigned int s_ctr=0; s_ctr<this->n_systems(); s_ctr++)
     if (s_ctr != s)
       libmesh_assert_equal_to (this->n_var_groups(s_ctr), old_system_sizes[s_ctr]);

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -83,7 +83,7 @@
 #endif
 
 // --------------------------------------------------------
-// Local anonymous namespace to hold miscelaneous bits
+// Local anonymous namespace to hold miscellaneous bits
 namespace {
 
 libMesh::UniquePtr<GetPot> command_line;
@@ -564,7 +564,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
 #endif
 
 #if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
-  // Do MPI initializtion for VTK.
+  // Do MPI initialization for VTK.
   _vtk_mpi_controller = vtkMPIController::New();
   _vtk_mpi_controller->Initialize(&argc, const_cast<char ***>(&argv), /*initialized_externally=*/1);
   _vtk_mpi_controller->SetGlobalController(_vtk_mpi_controller);
@@ -585,7 +585,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
   // C and C++ style access to output streams is not required.
   // The amount of benefit which occurs is probably implementation
   // defined, and may be nothing.  On the other hand, I have seen
-  // some IO tests where IO peformance improves by a factor of two.
+  // some IO tests where IO performance improves by a factor of two.
   if (!libMesh::on_command_line ("--sync-with-stdio"))
     std::ios::sync_with_stdio(false);
 

--- a/src/base/libmesh_singleton.C
+++ b/src/base/libmesh_singleton.C
@@ -26,7 +26,7 @@
 
 
 // --------------------------------------------------------
-// Local anonymous namespace to hold miscelaneous bits
+// Local anonymous namespace to hold miscellaneous bits
 namespace
 {
 using namespace libMesh;
@@ -57,7 +57,7 @@ SetupList & get_setup_cache()
 
 
 // --------------------------------------------------------
-// Local anonymous namespace to hold miscelaneous bits
+// Local anonymous namespace to hold miscellaneous bits
 namespace libMesh
 {
 

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -202,7 +202,7 @@ void Build::handle_vi_vj(const Elem * partner,
 void Build::operator()(const ConstElemRange & range)
 {
   // Compute the sparsity structure of the global matrix.  This can be
-  // fed into a PetscMatrix to allocate exacly the number of nonzeros
+  // fed into a PetscMatrix to allocate exactly the number of nonzeros
   // necessary to store the matrix.  This algorithm should be linear
   // in the (# of elements)*(# nodes per element)
   const processor_id_type proc_id           = mesh.processor_id();
@@ -223,7 +223,7 @@ void Build::operator()(const ConstElemRange & range)
       {
         const Elem * const elem = *elem_it;
 
-        // Make some fakey element iterators defining a range
+        // Make some fake element iterators defining a range
         // pointing to only this element.
         Elem * const * elempp = const_cast<Elem * const *>(&elem);
         Elem * const * elemend = elempp+1;

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -55,7 +55,7 @@ namespace libMesh
 
 // As of 10/2/2012, this function implements a 'brute-force' adjoint based QoI
 // error estimator, using the following relationship:
-// Q(u) - Q(u_h) \aprrox - R( (u_h)_(h/2), z_(h/2) ) .
+// Q(u) - Q(u_h) \approx - R( (u_h)_(h/2), z_(h/2) ) .
 // where: Q(u) is the true QoI
 // u_h is the approximate primal solution on the current FE space
 // Q(u_h) is the approximate QoI
@@ -132,7 +132,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 
               system.add_vector(liftfunc_name.str());
 
-              // Intialize lift with coarse adjoint solve associate with this flux QoI to begin with
+              // Initialize lift with coarse adjoint solve associate with this flux QoI to begin with
               system.get_vector(liftfunc_name.str()).init(system.get_adjoint_solution(j), false);
 
               // Build the actual lift using adjoint dirichlet conditions
@@ -464,7 +464,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   // The global DOF indices, we will use these later on when we compute the element wise indicators
   std::vector<dof_id_type> dof_indices;
 
-  // Localize the global rhs and adjoint solution vectors (which might be shared on multiple processsors) onto a
+  // Localize the global rhs and adjoint solution vectors (which might be shared on multiple processors) onto a
   // local ghosted vector, this ensures each processor has all the dof_indices to compute an error indicator for
   // an element it owns
   UniquePtr<NumericVector<Number> > localized_projected_residual = NumericVector<Number>::build(system.comm());
@@ -600,7 +600,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
   mesh.partitioner().reset(old_partitioner.release());
   mesh.allow_renumbering(old_renumbering_setting);
 
-  // Fiinally sum the vector of estimated error values.
+  // Finally sum the vector of estimated error values.
   this->reduce_error(error_per_cell, system.comm());
 
   // We don't take a square root here; this is a goal-oriented

--- a/src/error_estimation/error_estimator.C
+++ b/src/error_estimation/error_estimator.C
@@ -36,7 +36,7 @@ void ErrorEstimator::reduce_error (std::vector<ErrorVectorReal> & error_per_cell
   // This function must be run on all processors at once
   // parallel_object_only();
 
-  // Each processor has now computed the error contribuions
+  // Each processor has now computed the error contributions
   // for its local elements.  We may need to sum the vector to
   // recover the error for each element.
 

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -382,7 +382,7 @@ void ExactErrorEstimator::estimate_error (const System & system,
 
 
 
-  // Each processor has now computed the error contribuions
+  // Each processor has now computed the error contributions
   // for its local elements.  We need to sum the vector
   // and then take the square-root of each component.  Note
   // that we only need to sum if we are running on multiple
@@ -473,7 +473,7 @@ Real ExactErrorEstimator::find_squared_element_error(const System & system,
 #endif
 
       // Compute solution values at the current
-      // quadrature point.  This reqiures a sum
+      // quadrature point.  This requires a sum
       // over all the shape functions evaluated
       // at the quadrature point.
       for (unsigned int i=0; i<n_sf; i++)

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -512,7 +512,7 @@ void ExactSolution::_compute_error(const std::string & sys_name,
   // Make sure we aren't "overconfigured"
   libmesh_assert (!(_exact_values.size() && _equation_systems_fine));
 
-  // We need a commmunicator.
+  // We need a communicator.
   const Parallel::Communicator & communicator(_equation_systems.comm());
 
   // This function must be run on all processors at once
@@ -724,7 +724,7 @@ void ExactSolution::_compute_error(const std::string & sys_name,
           typename FEGenericBase<OutputShape>::OutputNumberDivergence div_u_h = 0.0;
 
           // Compute solution values at the current
-          // quadrature point.  This reqiures a sum
+          // quadrature point.  This requires a sum
           // over all the shape functions evaluated
           // at the quadrature point.
           for (unsigned int i=0; i<n_sf; i++)

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -339,7 +339,7 @@ void JumpErrorEstimator::estimate_error (const System & system,
                         this->coarse_n_flux_faces_increment();
                     }
                 } // end if (case1 || case2)
-            } // if (e->neigbor(n_e) != libmesh_nullptr)
+            } // if (e->neighbor(n_e) != libmesh_nullptr)
 
           // Otherwise, e is on the boundary.  If it happens to
           // be on a Dirichlet boundary, we need not do anything.
@@ -369,7 +369,7 @@ void JumpErrorEstimator::estimate_error (const System & system,
     } // End loop over active local elements
 
 
-  // Each processor has now computed the error contribuions
+  // Each processor has now computed the error contributions
   // for its local elements.  We need to sum the vector
   // and then take the square-root of each component.  Note
   // that we only need to sum if we are running on multiple

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -83,7 +83,7 @@ std::vector<Real> PatchRecoveryErrorEstimator::specpoly(const unsigned int dim,
   // builds psi vector of form 1 x y z x^2 xy xz y^2 yz z^2 etc..
   // I haven't added 1D support here
   for (unsigned int poly_deg=0; poly_deg <= static_cast<unsigned int>(order) ; poly_deg++)
-    { // loop over all polynomials of total degreee = poly_deg
+    { // loop over all polynomials of total degree = poly_deg
 
       switch (dim)
         {
@@ -343,7 +343,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
           // global DOF indices
           std::vector<dof_id_type> dof_indices;
 
-          // Compute the approprite size for the patch projection matrices
+          // Compute the appropriate size for the patch projection matrices
           // and vectors;
           unsigned int matsize = element_order + 1;
           if (dim > 1)

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -561,7 +561,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
 #endif
 
                   // Compute solution values at the current
-                  // quadrature point.  This reqiures a sum
+                  // quadrature point.  This requires a sum
                   // over all the shape functions evaluated
                   // at the quadrature point.
                   for (unsigned int i=0; i<n_sf; i++)
@@ -666,7 +666,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
   // We should be back where we started
   libmesh_assert_equal_to (n_coarse_elem, mesh.n_elem());
 
-  // Each processor has now computed the error contribuions
+  // Each processor has now computed the error contributions
   // for its local elements.  We need to sum the vector
   // and then take the square-root of each component.  Note
   // that we only need to sum if we are running on multiple

--- a/src/error_estimation/weighted_patch_recovery_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_estimator.C
@@ -255,7 +255,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
           // global DOF indices
           std::vector<dof_id_type> dof_indices;
 
-          // Compute the approprite size for the patch projection matrices
+          // Compute the appropriate size for the patch projection matrices
           // and vectors;
           unsigned int matsize = element_order + 1;
           if (dim > 1)

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -592,7 +592,7 @@ bool FEAbstract::on_reference_element(const Point & p, const ElemType t, const R
     case TRISHELL3:
     case TRI6:
       {
-        // The reference triangle is isocoles
+        // The reference triangle is isosceles
         // and is bound by xi=0, eta=0, and xi+eta=1.
         if ((xi  >= 0.-eps) &&
             (eta >= 0.-eps) &&
@@ -622,7 +622,7 @@ bool FEAbstract::on_reference_element(const Point & p, const ElemType t, const R
     case TET4:
     case TET10:
       {
-        // The reference tetrahedral is isocoles
+        // The reference tetrahedral is isosceles
         // and is bound by xi=0, eta=0, zeta=0,
         // and xi+eta+zeta=1.
         if ((xi   >= 0.-eps) &&
@@ -670,7 +670,7 @@ bool FEAbstract::on_reference_element(const Point & p, const ElemType t, const R
     case PRISM18:
       {
         // Figure this one out...
-        // inside the reference triange with zeta in [-1,1]
+        // inside the reference triangle with zeta in [-1,1]
         if ((xi   >=  0.-eps) &&
             (eta  >=  0.-eps) &&
             (zeta >= -1.-eps) &&
@@ -722,7 +722,7 @@ bool FEAbstract::on_reference_element(const Point & p, const ElemType t, const R
 
     case INFPRISM6:
       {
-        // inside the reference triange with zeta in [-1,1]
+        // inside the reference triangle with zeta in [-1,1]
         if ((xi   >=  0.-eps) &&
             (eta  >=  0.-eps) &&
             (zeta >= -1.-eps) &&

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -2311,7 +2311,7 @@ compute_periodic_constraints (DofConstraints & constraints,
 
                       DofConstraintRow * constraint_row;
 
-                      // we may be running constraint methods concurretly
+                      // we may be running constraint methods concurrently
                       // on multiple threads, so we need a lock to
                       // ensure that this constraint is "ours"
                       {

--- a/src/fe/fe_clough_shape_1D.C
+++ b/src/fe/fe_clough_shape_1D.C
@@ -16,14 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
 
-// Anonymous namespace for persistant variables.
+// Anonymous namespace for persistent variables.
 // This allows us to cache the global-to-local mapping transformation
 // This should also screw up multithreading royally
 namespace

--- a/src/fe/fe_clough_shape_2D.C
+++ b/src/fe/fe_clough_shape_2D.C
@@ -16,14 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 
 
-// Anonymous namespace for persistant variables.
+// Anonymous namespace for persistent variables.
 // This allows us to cache the global-to-local mapping transformation
 // FIXME: This should also screw up multithreading royally
 namespace

--- a/src/fe/fe_hermite_shape_1D.C
+++ b/src/fe/fe_hermite_shape_1D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_hierarchic_shape_1D.C
+++ b/src/fe/fe_hierarchic_shape_1D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -190,7 +190,7 @@ void FEInterface::ifem_nodal_soln(const unsigned int dim,
         switch (fe_t.radial_family)
           {
           case INFINITE_MAP:
-            libmesh_error_msg("ERROR: INFINTE_MAP is not a valid shape family for radial approximation.");
+            libmesh_error_msg("ERROR: INFINITE_MAP is not a valid shape family for radial approximation.");
 
           case JACOBI_20_00:
             {
@@ -268,7 +268,7 @@ void FEInterface::ifem_nodal_soln(const unsigned int dim,
         switch (fe_t.radial_family)
           {
           case INFINITE_MAP:
-            libmesh_error_msg("ERROR: INFINTE_MAP is not a valid shape family for radial approximation.");
+            libmesh_error_msg("ERROR: INFINITE_MAP is not a valid shape family for radial approximation.");
 
           case JACOBI_20_00:
             {
@@ -346,7 +346,7 @@ void FEInterface::ifem_nodal_soln(const unsigned int dim,
         switch (fe_t.radial_family)
           {
           case INFINITE_MAP:
-            libmesh_error_msg("ERROR: INFINTE_MAP is not a valid shape family for radial approximation.");
+            libmesh_error_msg("ERROR: INFINITE_MAP is not a valid shape family for radial approximation.");
 
           case JACOBI_20_00:
             {

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -204,7 +204,7 @@ template <> bool FE<2,L2_HIERARCHIC>::is_hierarchic() const { return true; }
 template <> bool FE<3,L2_HIERARCHIC>::is_hierarchic() const { return true; }
 
 #ifdef LIBMESH_ENABLE_AMR
-// compute_constraints() is a NOOP for DISCONTINOUS FE's
+// compute_constraints() is a NOOP for DISCONTINUOUS FE's
 template <>
 void FE<2,L2_HIERARCHIC>::compute_constraints (DofConstraints &,
                                                DofMap &,

--- a/src/fe/fe_l2_hierarchic_shape_1D.C
+++ b/src/fe/fe_l2_hierarchic_shape_1D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_l2_lagrange_shape_1D.C
+++ b/src/fe/fe_l2_lagrange_shape_1D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_l2_lagrange_shape_2D.C
+++ b/src/fe/fe_l2_lagrange_shape_2D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_l2_lagrange_shape_3D.C
+++ b/src/fe/fe_l2_lagrange_shape_3D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"
@@ -245,7 +245,7 @@ Real FE<3,L2_LAGRANGE>::shape(const ElemType type,
                 }
             }
 
-            // triquadraic hexahedral shape funcions
+            // triquadratic hexahedral shape functions
           case HEX27:
             {
               libmesh_assert_less (i, 27);
@@ -316,7 +316,7 @@ Real FE<3,L2_LAGRANGE>::shape(const ElemType type,
                 }
             }
 
-            // quadradic prism shape functions
+            // quadratic prism shape functions
           case PRISM18:
             {
               libmesh_assert_less (i, 18);
@@ -945,7 +945,7 @@ Real FE<3,L2_LAGRANGE>::shape_deriv(const ElemType type,
                 }
             }
 
-            // triquadraic hexahedral shape funcions
+            // triquadratic hexahedral shape functions
           case HEX27:
             {
               libmesh_assert_less (i, 27);
@@ -1140,7 +1140,7 @@ Real FE<3,L2_LAGRANGE>::shape_deriv(const ElemType type,
 
 
 
-            // quadradic prism shape functions
+            // quadratic prism shape functions
           case PRISM18:
             {
               libmesh_assert_less (i, 18);
@@ -1380,7 +1380,7 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const ElemType type,
             }
 
 
-            // quadradic prism shape functions
+            // quadratic prism shape functions
           case PRISM18:
             {
               libmesh_assert_less (i, 18);

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -812,7 +812,7 @@ void lagrange_compute_constraints (DofConstraints & constraints,
                 }
             }
         }
-} // lagrange_compute_constrants()
+} // lagrange_compute_constraints()
 #endif // #ifdef LIBMESH_ENABLE_AMR
 
 } // anonymous namespace

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"
@@ -247,7 +247,7 @@ Real FE<3,LAGRANGE>::shape(const ElemType type,
                 }
             }
 
-            // triquadraic hexahedral shape funcions
+            // triquadratic hexahedral shape functions
           case HEX27:
             {
               libmesh_assert_less (i, 27);
@@ -379,7 +379,7 @@ Real FE<3,LAGRANGE>::shape(const ElemType type,
                 }
             }
 
-            // quadradic prism shape functions
+            // quadratic prism shape functions
           case PRISM18:
             {
               libmesh_assert_less (i, 18);
@@ -1122,7 +1122,7 @@ Real FE<3,LAGRANGE>::shape_deriv(const ElemType type,
                 }
             }
 
-            // triquadraic hexahedral shape funcions
+            // triquadratic hexahedral shape functions
           case HEX27:
             {
               libmesh_assert_less (i, 27);
@@ -1456,7 +1456,7 @@ Real FE<3,LAGRANGE>::shape_deriv(const ElemType type,
 
 
 
-            // quadradic prism shape functions
+            // quadratic prism shape functions
           case PRISM18:
             {
               libmesh_assert_less (i, 18);
@@ -2420,7 +2420,7 @@ Real FE<3,LAGRANGE>::shape_second_deriv(const ElemType type,
                 }
             }
 
-            // triquadraic hexahedral shape funcions
+            // triquadratic hexahedral shape functions
           case HEX27:
             {
               libmesh_assert_less (i, 27);
@@ -2767,7 +2767,7 @@ Real FE<3,LAGRANGE>::shape_second_deriv(const ElemType type,
 
 
 
-            // quadradic prism shape functions
+            // quadratic prism shape functions
           case PRISM18:
             {
               libmesh_assert_less (i, 18);

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -82,7 +82,7 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
   const Order    mapping_order     (elem->default_order());
   const ElemType mapping_elem_type (elem->type());
 
-  // Number of shape functions used to construt the map
+  // Number of shape functions used to construct the map
   // (Lagrange shape functions are used for mapping)
   const unsigned int n_mapping_shape_functions =
     FE<Dim,LAGRANGE>::n_shape_functions (mapping_elem_type,
@@ -452,7 +452,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         for (std::size_t i=0; i<elem_nodes.size(); i++) // sum over the nodes
           {
             // Reference to the point, helps eliminate
-            // exessive temporaries in the inner loop
+            // excessive temporaries in the inner loop
             libmesh_assert(elem_nodes[i]);
             const Point & elem_point = *elem_nodes[i];
 
@@ -691,7 +691,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         for (std::size_t i=0; i<elem_nodes.size(); i++) // sum over the nodes
           {
             // Reference to the point, helps eliminate
-            // exessive temporaries in the inner loop
+            // excessive temporaries in the inner loop
             libmesh_assert(elem_nodes[i]);
             const Point & elem_point = *elem_nodes[i];
 
@@ -1013,7 +1013,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         for (std::size_t i=0; i<elem_nodes.size(); i++) // sum over the nodes
           {
             // Reference to the point, helps eliminate
-            // exessive temporaries in the inner loop
+            // excessive temporaries in the inner loop
             libmesh_assert(elem_nodes[i]);
             const Point & elem_point = *elem_nodes[i];
 
@@ -1693,7 +1693,7 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
             //
             //  Where {X}, {X_n} are 3x1 vectors, [J] is a 3x2 matrix
             //  d(x,y,z)/d(xi,eta), and we seek {dp}, a 2x1 vector.  Since
-            //  the above system is either overdermined or rank-deficient,
+            //  the above system is either over-determined or rank-deficient,
             //  we will solve the normal equations for this system
             //
             //  [J]^T ({X} - {X_n}) = [J]^T [J] {dp}
@@ -1742,7 +1742,7 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
           //  Here we find the point in a 3D reference element that maps to
           //  the point \p physical_point in a 3D domain. Nothing special
           //  has to happen here, since (unless the map is singular because
-          //  you have a BAD element) the map will be invertable and we can
+          //  you have a BAD element) the map will be invertible and we can
           //  apply Newton's method directly.
         case 3:
           {
@@ -1756,7 +1756,7 @@ Point FE<Dim,T>::inverse_map (const Elem * elem,
             //
             //  Where {X}, {X_n} are 3x1 vectors, [J] is a 3x3 matrix
             //  d(x,y,z)/d(xi,eta,zeta), and we seek {dp}, a 3x1 vector.
-            //  Since the above system is nonsingular for invertable maps
+            //  Since the above system is nonsingular for invertible maps
             //  we will solve
             //
             //  {dp} = [J]^-1 ({X} - {X_n})

--- a/src/fe/fe_monomial_shape_1D.C
+++ b/src/fe/fe_monomial_shape_1D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_monomial_shape_2D.C
+++ b/src/fe/fe_monomial_shape_2D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_monomial_shape_3D.C
+++ b/src/fe/fe_monomial_shape_3D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -482,7 +482,7 @@ void nedelec_one_compute_constraints (DofConstraints & /*constraints*/,
   }
   }
   */
-} // nedelec_one_compute_constrants()
+} // nedelec_one_compute_constraints()
 #endif // #ifdef LIBMESH_ENABLE_AMR
 
 } // anonymous namespace

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_xyz_shape_1D.C
+++ b/src/fe/fe_xyz_shape_1D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ inlcludes
+// C++ includes
 
 // Local includes
 #include "libmesh/fe.h"

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -755,7 +755,7 @@ void H1FETransformation<RealGradient>::map_div(const unsigned int dim,
   return;
 }
 
-// Explicit Instantations
+// Explicit Instantiations
 template class H1FETransformation<Real>;
 template class H1FETransformation<RealGradient>;
 

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -104,7 +104,7 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
   const ElemType inf_elem_type = inf_elem->type();
   if (inf_elem_type != INFHEX8 &&
       inf_elem_type != INFPRISM6)
-    libmesh_error_msg("ERROR: InfFE::inverse_map is currently implemented only for \ninfinite elments of type InfHex8 and InfPrism6.");
+    libmesh_error_msg("ERROR: InfFE::inverse_map is currently implemented only for \ninfinite elements of type InfHex8 and InfPrism6.");
 
   // 2.)
   // just like in FE<Dim-1,LAGRANGE>::inverse_map(): compute
@@ -130,7 +130,7 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
   // element and the physical point.
   Point intersection;
 
-  // the origin of the infinite lement
+  // the origin of the infinite element
   const Point o = inf_elem->origin();
 
   switch (Dim)

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -192,7 +192,7 @@ Real Hex::quality (const ElemQuality q) const
     {
 
       /**
-       * Compue the min/max diagonal ratio.
+       * Compute the min/max diagonal ratio.
        * Source: CUBIT User's Manual.
        */
     case DIAGONAL:

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -174,7 +174,7 @@ Real InfHex::quality (const ElemQuality q) const
     {
 
       /**
-       * Compue the min/max diagonal ratio.
+       * Compute the min/max diagonal ratio.
        * Source: CUBIT User's Manual.
        *
        * For infinite elements, we just only compute

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -676,7 +676,7 @@ float Tet10::embedding_matrix (const unsigned int i,
   // libMesh::err << "jp=" << jp << std::endl;
   // libMesh::err << "kp=" << kp << std::endl;
 
-  // Call embedding matrx with permuted indices
+  // Call embedding matrix with permuted indices
   return this->_embedding_matrix[i][jp][kp];
 }
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -410,7 +410,7 @@ float Tet4::embedding_matrix (const unsigned int i,
   // libMesh::err << "jp=" << jp << std::endl;
   // libMesh::err << "kp=" << kp << std::endl;
 
-  // Call embedding matrx with permuted indices
+  // Call embedding matrix with permuted indices
   return this->_embedding_matrix[i][jp][kp];
 }
 
@@ -468,7 +468,7 @@ float Tet4::embedding_matrix (const unsigned int i,
 //  value.  */
 //       if (first_05_in_embedding_matrix==libMesh::invalid_uint)
 // {
-//   /* First time, so just remeber this position.  */
+//   /* First time, so just remember this position.  */
 //   first_05_in_embedding_matrix = n;
 // }
 //       else

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -230,7 +230,7 @@ const unsigned int Elem::type_to_n_edges_map [] =
   };
 
 // ------------------------------------------------------------
-// Elem class member funcions
+// Elem class member functions
 UniquePtr<Elem> Elem::build(const ElemType type,
                             Elem * p)
 {
@@ -1861,7 +1861,7 @@ void Elem::family_tree_by_subneighbor (std::vector<const Elem *> & family,
   if (reset)
     family.clear();
 
-  // To simplifly this function we need an existing neighbor
+  // To simplify this function we need an existing neighbor
   libmesh_assert (neighbor_in);
   libmesh_assert_not_equal_to (neighbor_in, remote_elem);
   libmesh_assert (this->has_neighbor(neighbor_in));
@@ -1906,7 +1906,7 @@ void Elem::total_family_tree_by_subneighbor (std::vector<const Elem *> & family,
   if (reset)
     family.clear();
 
-  // To simplifly this function we need an existing neighbor
+  // To simplify this function we need an existing neighbor
   libmesh_assert (neighbor_in);
   libmesh_assert_not_equal_to (neighbor_in, remote_elem);
   libmesh_assert (this->has_neighbor(neighbor_in));

--- a/src/geom/elem_quality.C
+++ b/src/geom/elem_quality.C
@@ -220,7 +220,7 @@ std::string Quality::describe (const ElemQuality q)
 
     case TAPER:
       desc << "Maximum ratio of lengths\n"
-           << "derived from opposited edges.\n"
+           << "derived from opposite edges.\n"
            << '\n'
            << "Suggested ranges:\n"
            << "Quads: (0.7 -> 1)\n"

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -154,7 +154,7 @@ Real Quad::quality (const ElemQuality q) const
     {
 
       /**
-       * Compue the min/max diagonal ratio.
+       * Compute the min/max diagonal ratio.
        * This is modeled after the Hex element
        */
     case DISTORTION:

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -145,7 +145,7 @@ Real Tri::quality (const ElemQuality q) const
   /**
    * I don't know what to do for this metric.
    * Maybe the base class knows.  We won't get
-   * here because of the defualt case above.
+   * here because of the default case above.
    */
   return Elem::quality(q);
 

--- a/src/geom/face_tri3_subdivision.C
+++ b/src/geom/face_tri3_subdivision.C
@@ -69,7 +69,7 @@ void Tri3Subdivision::prepare_subdivision_properties()
   /*
    * Rotate ordered vertices such that ordered_nodes[0] is the
    * irregular vertex. Doing this once in advance lets the evaluation
-   * of subdivision interpolation be much more efficient afterwards.
+   * of subdivision interpolation be much more efficient afterward.
    */
   switch (irregular_idx)
     {

--- a/src/geom/point.C
+++ b/src/geom/point.C
@@ -27,7 +27,7 @@
 
 
 // ------------------------------------------------------------
-// Point class member funcions
+// Point class member functions
 // unsigned int Point::key() const
 // {
 //   unsigned int tempx,tempy,tempz;

--- a/src/geom/reference_elem.C
+++ b/src/geom/reference_elem.C
@@ -117,7 +117,7 @@ void read_ref_elem (const ElemType type_in,
   // Construct elem of appropriate type
   UniquePtr<Elem> uelem = Elem::build(type_in);
 
-  // We are expecing an identity map, so assert it!
+  // We are expecting an identity map, so assert it!
   for (unsigned int n=0; n<n_nodes; n++)
     {
       in >> nn;
@@ -151,7 +151,7 @@ void read_ref_elem (const ElemType type_in,
 
 void init_ref_elem_table()
 {
-  // ouside mutex - if this pointer is set, we can trust it.
+  // outside mutex - if this pointer is set, we can trust it.
   if (singleton_cache != libmesh_nullptr)
     return;
 

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -85,7 +85,7 @@ void add_eletype_entry(ElemType libmesh_elem_type,
 void init_eletypes ()
 {
   // This should happen only once.  The first time this method is
-  // called the eletypes data struture will be empty, and we will
+  // called the eletypes data structure will be empty, and we will
   // fill it.  Any subsequent calls will find an initialized
   // eletypes map and will do nothing.
   if (eletypes.empty())

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -354,7 +354,7 @@ void BoundaryInfo::get_side_and_node_maps (UnstructuredMesh & boundary_mesh,
       const Elem * boundary_elem = *el;
       const Elem * interior_parent = boundary_elem->interior_parent();
 
-      // Find out which side of interior_parent boundary_elem correponds to.
+      // Find out which side of interior_parent boundary_elem corresponds to.
       // Use centroid comparison as a way to check.
       unsigned char interior_parent_side_index = 0;
       bool found_matching_sides = false;

--- a/src/mesh/bounding_box.C
+++ b/src/mesh/bounding_box.C
@@ -32,7 +32,7 @@ bool is_between(Real min, Real check, Real max)
 
 bool BoundingBox::intersects (const BoundingBox & other_box) const
 {
-  // Make local variables first to make thiings more clear in a moment
+  // Make local variables first to make things more clear in a moment
   const Real & my_min_x = this->first(0);
   const Real & my_max_x = this->second(0);
   const Real & other_min_x = other_box.first(0);
@@ -72,7 +72,7 @@ bool BoundingBox::intersects (const BoundingBox & other_box) const
 
 bool BoundingBox::contains_point (const Point & p) const
 {
-  // Make local variables first to make thiings more clear in a moment
+  // Make local variables first to make things more clear in a moment
   Real my_min_x = this->first(0);
   Real my_max_x = this->second(0);
   bool x_int = is_between(my_min_x, p(0), my_max_x);

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -749,7 +749,7 @@ void DistributedMesh::renumber_node(const dof_id_type old_id,
   // use, then those nodes will exist in _nodes, but may not be
   // locatable via a TopologyMap due to the insufficiency of elements
   // connecting to them.  If local refinement then wants to create a
-  // *new* node in the same location, it will initally get a temporary
+  // *new* node in the same location, it will initially get a temporary
   // id, and then make_node_ids_parallel_consistent() will try to move
   // it to the canonical id.  We need to account for this case to
   // avoid false positives and memory leaks.
@@ -1049,7 +1049,7 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
     requested_unique_ids(this->n_processors());
 #endif
 
-  // We know how many objects live on each processor, so reseve() space for
+  // We know how many objects live on each processor, so reserve() space for
   // each.
   for (processor_id_type p=0; p != this->n_processors(); ++p)
     if (p != this->processor_id())

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -372,7 +372,7 @@ void ExodusII_IO::read (const std::string & fname)
         for (std::size_t node=0; node<exio_helper->node_list.size(); node++)
           {
             // As before, the entries in 'node_list' are 1-based
-            // indcies into the node_num_map array, so we have to map
+            // indices into the node_num_map array, so we have to map
             // them.  See comment above.
             int libmesh_node_id = exio_helper->node_num_map[exio_helper->node_list[node] - 1] - 1;
             mesh.get_boundary_info().add_node(cast_int<dof_id_type>(libmesh_node_id),

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1357,9 +1357,9 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
   NamesData types_table(num_elem_blk, MAX_STR_LENGTH);
 
   // Note: It appears that there is a bug in exodusII::ex_put_name where
-  // the index returned from the ex_id_lkup is erronously used.  For now
+  // the index returned from the ex_id_lkup is erroneously used.  For now
   // the work around is to use the alternative function ex_put_names, but
-  // this function requires a char ** datastructure.
+  // this function requires a char ** data structure.
   NamesData names_table(num_elem_blk, MAX_STR_LENGTH);
 
   // counter indexes into the block_ids vector
@@ -1585,8 +1585,8 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
             const ExodusII_IO_Helper::Conversion conv =
               em.assign_conversion(mesh.elem_ptr(family[j]->id())->type());
 
-            // Use the libmesh to exodus datastructure map to get the proper sideset IDs
-            // The datastructure contains the "collapsed" contiguous ids
+            // Use the libmesh to exodus data structure map to get the proper sideset IDs
+            // The data structure contains the "collapsed" contiguous ids
             elem[il[i]].push_back(libmesh_elem_num_to_exodus[family[j]->id()]);
             side[il[i]].push_back(conv.get_inverse_side_map(sl[i]));
           }
@@ -1623,8 +1623,8 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
             const ExodusII_IO_Helper::Conversion conv =
               em.assign_conversion(mesh.elem_ptr(family[j]->id())->type());
 
-            // Use the libmesh to exodus datastructure map to get the proper sideset IDs
-            // The datastructure contains the "collapsed" contiguous ids
+            // Use the libmesh to exodus data structure map to get the proper sideset IDs
+            // The data structure contains the "collapsed" contiguous ids
             elem[il[i]].push_back(libmesh_elem_num_to_exodus[family[j]->id()]);
             side[il[i]].push_back(conv.get_inverse_shellface_map(sl[i]));
           }

--- a/src/mesh/fro_io.C
+++ b/src/mesh/fro_io.C
@@ -133,7 +133,7 @@ void FroIO::write (const std::string & fname)
                   // a---b b---c c---d d---e
                   // and piece them together.
                   //
-                  // so, for an arbitray edge n0---n1, we build the
+                  // so, for an arbitrary edge n0---n1, we build the
                   // "forward_edges"  map n0-->n1
                   // "backward_edges" map n1-->n0
                   // and then start with one chain link, and add on...

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -98,7 +98,7 @@ void init_eletypes ()
   if (eletypes.empty())
     {
       // This should happen only once.  The first time this method
-      // is called the eletypes data struture will be empty, and
+      // is called the eletypes data structure will be empty, and
       // we will fill it.  Any subsequent calls will find an initialized
       // eletypes map and will do nothing.
 
@@ -2039,7 +2039,7 @@ void GMVIO::read (const std::string & name)
   // from GMV to libmesh indices, so initialize that data now.
   init_eletypes();
 
-  // Clear the mesh so we are sure to start from a pristeen state.
+  // Clear the mesh so we are sure to start from a pristine state.
   MeshBase & mesh = MeshInput<MeshBase>::mesh();
   mesh.clear();
 
@@ -2345,7 +2345,7 @@ ElemType GMVIO::gmv_elem_to_libmesh_elem(std::string elemname)
   std::map<std::string, ElemType>::iterator it = _reading_element_map.find(elemname);
 
   if (it == _reading_element_map.end())
-    libmesh_error_msg("Uknown/unsupported element: " << elemname << " was read.");
+    libmesh_error_msg("Unknown/unsupported element: " << elemname << " was read.");
 
   return it->second;
 }
@@ -2378,7 +2378,7 @@ void GMVIO::copy_nodal_solution(EquationSystems & es)
   // that has the same variable key name.
   for (unsigned int sys=0; sys<es.n_systems(); ++sys)
     {
-      // Get a generic refernence to the current System
+      // Get a generic reference to the current System
       System & system = es.get_system(sys);
 
       // And a reference to that system's dof_map

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -181,7 +181,7 @@ const Point InfElemBuilder::build_inf_elem (const InfElemOriginValue & origin_x,
 
       // First use a std::vector<dof_id_type> that holds
       // the global node numbers.  Then sort this vector,
-      // so that it can be made unique (no multiple occurence
+      // so that it can be made unique (no multiple occurrence
       // of a node), and then finally insert the Node * in
       // the vector inner_boundary_nodes.
       //

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -685,7 +685,7 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
 
   std::vector<dof_id_type> common_interface_node_list;
 
-  // we expect two classess of messages -
+  // we expect two classes of messages -
   // (1) incoming interface node lists, to which we will reply with our elements
   //     touching nodes in the list, and
   // (2) replies from the requests we sent off previously.
@@ -1001,7 +1001,7 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
           const std::vector<Elem *> & elems = it->second;
           libmesh_assert(elems.size());
 
-          // Make some fakey element iterators defining this vector of
+          // Make some fake element iterators defining this vector of
           // elements
           Elem * const * elempp = const_cast<Elem * const *>(&elems[0]);
           Elem * const * elemend = elempp+elems.size();

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -309,7 +309,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
 
     communicator.allgather (my_max, /* identical_buffer_sizes = */ true);
 
-    // Be cereful here.  The *_upper_bounds will be used to find the processor
+    // Be careful here.  The *_upper_bounds will be used to find the processor
     // a given object belongs to.  So, if a processor contains no objects (possible!)
     // then copy the bound from the lower processor id.
     for (processor_id_type p=0; p<communicator.size(); p++)
@@ -748,7 +748,7 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
 
   communicator.allgather (upper_bounds, /* identical_buffer_sizes = */ true);
 
-  // Be cereful here.  The *_upper_bounds will be used to find the processor
+  // Be careful here.  The *_upper_bounds will be used to find the processor
   // a given object belongs to.  So, if a processor contains no objects (possible!)
   // then copy the bound from the lower processor id.
   for (unsigned int p=1; p<communicator.size(); p++)

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -397,7 +397,7 @@ void UnstructuredMesh::all_first_order ()
 
       /**
        * If the second order element had any boundary conditions they
-       * should be transfered to the first-order element.  The old
+       * should be transferred to the first-order element.  The old
        * boundary conditions will be removed from the BoundaryInfo
        * data structure by insert_elem.
        */
@@ -580,7 +580,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
        * the new_elements list.  Note that this here
        * is the only point where \p full_ordered
        * is necessary.  The remaining code works well
-       * for either type of seconrd-order equivalent, e.g.
+       * for either type of second-order equivalent, e.g.
        * Hex20 or Hex27, as equivalents for Hex8
        */
       Elem * so_elem =
@@ -706,7 +706,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
 
       /**
        * If the linear element had any boundary conditions they
-       * should be transfered to the second-order element.  The old
+       * should be transferred to the second-order element.  The old
        * boundary conditions will be removed from the BoundaryInfo
        * data structure by insert_elem.
        *
@@ -1737,7 +1737,7 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
           {
             /*
              * Now handle the additional second_order nodes by calculating
-             * their position based on the vertex postitions
+             * their position based on the vertex positions
              * we do a second loop over the level elements
              */
             MeshBase::element_iterator       el  = mesh.level_elements_begin(refinement_level);

--- a/src/mesh/mesh_refinement_smoothing.C
+++ b/src/mesh/mesh_refinement_smoothing.C
@@ -94,7 +94,7 @@ bool MeshRefinement::limit_level_mismatch_at_node (const unsigned int max_mismat
         const unsigned int elem_p_level = elem->p_level();
 
         // Skip the element if it is already fully flagged
-        // unless we are enforcing mismatch prior to refienemnt and may need to
+        // unless we are enforcing mismatch prior to refinement and may need to
         // remove the refinement flag(s)
         if (elem->refinement_flag() == Elem::REFINE &&
             elem->p_refinement_flag() == Elem::REFINE

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -274,7 +274,7 @@ int VariationalMeshSmoother::readgr(Array2D<double> & R,
                                     std::vector<int> & edges,
                                     std::vector<int> & hnodes)
 {
-  libMesh::out << "Sarting readgr" << std::endl;
+  libMesh::out << "Starting readgr" << std::endl;
   // add error messages where format can be inconsistent
 
   // Find the boundary nodes
@@ -347,7 +347,7 @@ int VariationalMeshSmoother::readgr(Array2D<double> & R,
                     // Only try each pairing once
                     for (std::size_t b=a+1; b<thetas.size(); b++)
                       {
-                        // Find if the two neighbor nodes angles are 180 degrees (pi) off of eachother (withing a tolerance)
+                        // Find if the two neighbor nodes angles are 180 degrees (pi) off of each other (withing a tolerance)
                         // In order to make this a true movable boundary node... the two that forma  straight line with
                         // it must also be on the boundary
                         if (on_boundary[neighbors[a]->id()] &&
@@ -898,7 +898,7 @@ void VariationalMeshSmoother::full_smooth(Array2D<double> & R,
                                           int adp,
                                           int gr)
 {
-  // Control the amount of print statements in this funcion
+  // Control the amount of print statements in this function
   int msglev = 1;
 
   dof_id_type afun_size = 0;
@@ -1050,7 +1050,7 @@ void VariationalMeshSmoother::full_smooth(Array2D<double> & R,
         // Outrageous Enm1 to make sure we hit this at least once
         Enm1 = 99999;
 
-        // Now that we've moved the boundary nodes (or not) we need to resmoooth
+        // Now that we've moved the boundary nodes (or not) we need to resmooth
         for (int j=0; j<iter[1]; j++)
           {
             if (std::abs(emax-Enm1) < 1e-2)
@@ -1958,7 +1958,7 @@ double VariationalMeshSmoother::minJ(Array2D<double> & R,
         }
       for (unsigned index=0; index<_dim; index++)
         {
-          // initialise local matrices
+          // initialize local matrices
           for (unsigned k=0; k<3*_dim + _dim%2; k++)
             {
               F[index][k] = 0;
@@ -3397,7 +3397,7 @@ double VariationalMeshSmoother::avertex(const std::vector<double> & afun,
 
 
 
-// Computes local matrics W and local rhs F on one basis
+// Computes local matrix W and local rhs F on one basis
 double VariationalMeshSmoother::vertex(Array3D<double> & W,
                                        Array2D<double> & F,
                                        const Array2D<double> & R,
@@ -3999,7 +3999,7 @@ void VariationalMeshSmoother::metr_data_gen(std::string grid,
 
   readgr(R, mask, cells, mcells, mcells, mcells);
 
-  // genetrate metric file
+  // generate metric file
   std::ofstream metric_file(metr.c_str());
   if (!metric_file.good())
     libmesh_error_msg("Error opening metric output file.");

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1566,7 +1566,7 @@ void libmesh_assert_parallel_consistent_procids<Elem>(const MeshBase & mesh)
   libmesh_parallel_only(mesh.comm());
 
   // We want this test to be valid even when called even after nodes
-  // have been added asynchonously but before they're renumbered
+  // have been added asynchronously but before they're renumbered
   dof_id_type parallel_max_elem_id = mesh.max_elem_id();
   mesh.comm().max(parallel_max_elem_id);
 
@@ -1610,7 +1610,7 @@ void libmesh_assert_topology_consistent_procids<Node>(const MeshBase & mesh)
   libmesh_parallel_only(mesh.comm());
 
   // We want this test to be valid even when called even after nodes
-  // have been added asynchonously but before they're renumbered
+  // have been added asynchronously but before they're renumbered
   dof_id_type parallel_max_node_id = mesh.max_node_id();
   mesh.comm().max(parallel_max_node_id);
 
@@ -1660,7 +1660,7 @@ void libmesh_assert_parallel_consistent_procids<Node>(const MeshBase & mesh)
   libmesh_parallel_only(mesh.comm());
 
   // We want this test to be valid even when called even after nodes
-  // have been added asynchonously but before they're renumbered
+  // have been added asynchronously but before they're renumbered
   dof_id_type parallel_max_node_id = mesh.max_node_id();
   mesh.comm().max(parallel_max_node_id);
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -659,7 +659,7 @@ void Nemesis_IO::read (const std::string & base_filename)
                   nemhelper->node_num_map[local_node_idx] = global_node_idx;
 
                   // we are not really going to use my_next_node again, but we can
-                  // keep incrimenting it to track how many nodes we have added
+                  // keep incrementing it to track how many nodes we have added
                   // to the mesh
                   my_next_node++;
                 }
@@ -1096,7 +1096,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   // For each nodeset,
   for (int nodeset=0; nodeset<nemhelper->num_node_sets; nodeset++)
     {
-      // Get the user-defined ID associcated with the nodeset
+      // Get the user-defined ID associated with the nodeset
       int nodeset_id = nemhelper->nodeset_ids[nodeset];
 
       if (_verbose)
@@ -1196,7 +1196,7 @@ void Nemesis_IO::write (const std::string & base_filename)
 
   nemhelper->create(nemesis_filename);
 
-  // Initialize data structures and write some global Nemesis-specifc data, such as
+  // Initialize data structures and write some global Nemesis-specific data, such as
   // communication maps, to file.
   nemhelper->initialize(nemesis_filename,mesh);
 

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -298,7 +298,7 @@ void Nemesis_IO_Helper::get_node_map()
 
   if (verbose)
     {
-      // Remark: The Exodus/Nemesis node numbring is always (?) 1-based!  This means the first interior node id will
+      // Remark: The Exodus/Nemesis node numbering is always (?) 1-based!  This means the first interior node id will
       // always be == 1.
       libMesh::out << "[" << this->processor_id() << "] " << "first interior node id=" << node_mapi[0] << std::endl;
       libMesh::out << "[" << this->processor_id() << "] " << "last interior node id=" << node_mapi.back() << std::endl;
@@ -766,7 +766,7 @@ void Nemesis_IO_Helper::initialize(std::string title_in, const MeshBase & mesh, 
 
 
   // Gather global "initial" information for Nemesis.  This consists of
-  // three parts labelled I, II, and III below...
+  // three parts labeled I, II, and III below...
 
   //
   // I.) Need to compute the number of global element blocks.  To be consistent with
@@ -876,7 +876,7 @@ void Nemesis_IO_Helper::initialize(std::string title_in, const MeshBase & mesh, 
                       this->node_cmap_proc_ids);
 
 
-  // Ready the node maps.  These have nothing to do with communiction, they map
+  // Ready the node maps.  These have nothing to do with communication, they map
   // the nodes to internal, border, and external nodes in the file.
   this->compute_node_maps();
 
@@ -1791,7 +1791,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
                        << std::endl;
         }
 
-      // *it.first is the subodmain ID, *it.second is the number of elements it contains
+      // *it.first is the subdomain ID, *it.second is the number of elements it contains
       this->subdomain_map[ cur_subdomain ].reserve( it->second );
     }
 
@@ -2276,8 +2276,8 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
             {
               const ExodusII_IO_Helper::Conversion conv = em.assign_conversion(f.type());
 
-              // Use the libmesh to exodus datastructure map to get the proper sideset IDs
-              // The datastructure contains the "collapsed" contiguous ids.
+              // Use the libmesh to exodus data structure map to get the proper sideset IDs
+              // The data structure contains the "collapsed" contiguous ids.
               //
               // We know the parent element is local, but let's be absolutely sure that all the children have been
               // actually mapped to Exodus IDs before we blindly try to add them...
@@ -2407,7 +2407,7 @@ void Nemesis_IO_Helper::write_nodal_coordinates(const MeshBase & mesh, bool /*us
   y.resize(local_num_nodes);
   z.resize(local_num_nodes);
 
-  // Just loop over our list outputing the nodes the way we built the map
+  // Just loop over our list outputting the nodes the way we built the map
   for (unsigned int i=0; i<local_num_nodes; ++i)
     {
       const Point & pt = mesh.point(this->exodus_node_num_to_libmesh[i]);

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -95,7 +95,7 @@ public:
     return (*this)(lhs.first, rhs.first);
   }
 
-  // Comparsion function where lhs is a Point and rhs is a pair<Point,dof_id_type>.
+  // comparison function where lhs is a Point and rhs is a pair<Point,dof_id_type>.
   // This is used in routines like lower_bound, where a specific value is being
   // searched for.
   bool operator()(const Point & lhs, std::pair<Point, dof_id_type> & rhs)

--- a/src/mesh/tecplot_io.C
+++ b/src/mesh/tecplot_io.C
@@ -516,7 +516,7 @@ void TecplotIO::write_binary (const std::string & fname,
         for (; it != end; ++it)
           n_subcells_in_subdomain += (*it)->n_sub_elem();
 
-        // update the connectivty array to include only the elements in this subdomain
+        // update the connectivity array to include only the elements in this subdomain
         tm.set_n_cells (n_subcells_in_subdomain);
 
         unsigned int te = 0;

--- a/src/mesh/tetgen_io.C
+++ b/src/mesh/tetgen_io.C
@@ -193,7 +193,7 @@ void TetGenIO::element_in (std::istream & ele_stream)
     libmesh_error_msg("Invalid region_attribute " << region_attribute << " specified in .ele file.");
 
   // Vector that assigns element nodes to their correct position.
-  // TetGen is normaly 0-based
+  // TetGen is normally 0-based
   // (right now this is strictly not necessary since it is the identity map,
   //  but in the future TetGen could change their numbering scheme.)
   static const unsigned int assign_elm_nodes[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -239,7 +239,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                                        const bool reset_current_list)
 {
   // We might actually want to run this on an empty mesh
-  // (e.g. the boundary mesh for a nonexistant bcid!)
+  // (e.g. the boundary mesh for a nonexistent bcid!)
   // libmesh_assert_not_equal_to (this->n_nodes(), 0);
   // libmesh_assert_not_equal_to (this->n_elem(), 0);
 
@@ -731,7 +731,7 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh & new_mesh,
     new_mesh.delete_remote_elements();
 
   // Fail if (*this == new_mesh), we cannot create a submesh inside ourself!
-  // This may happen if the user accidently passes the original mesh into
+  // This may happen if the user accidentally passes the original mesh into
   // this function!  We will check this by making sure we did not just
   // clear ourself.
   libmesh_assert_not_equal_to (this->n_nodes(), 0);

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -234,7 +234,7 @@ void UNVIO::read_implementation (std::istream & in_stream)
 #endif
 
     // Delete any lower-dimensional elements that might have been
-    // added to the mesh stricly for setting BCs.
+    // added to the mesh strictly for setting BCs.
     {
       // Grab reference to the Mesh
       MeshBase & mesh = MeshInput<MeshBase>::mesh();
@@ -905,7 +905,7 @@ void UNVIO::nodes_out (std::ostream & out_file)
   // A reference to the parent class's mesh
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
-  // Use scientific notation with captial E and 16 digits for printing out the coordinates
+  // Use scientific notation with capital E and 16 digits for printing out the coordinates
   out_file << std::scientific << std::setprecision(16) << std::uppercase;
 
   MeshBase::const_node_iterator       nd  = mesh.nodes_begin();

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -365,7 +365,7 @@ void VTKIO::nodes_to_vtk()
   // containers for points and coordinates of points
   vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
   vtkSmartPointer<vtkDoubleArray> pcoords = vtkSmartPointer<vtkDoubleArray>::New();
-  // if this grid is to be used in VTK then the dimesion of the points should be 3
+  // if this grid is to be used in VTK then the dimension of the points should be 3
   pcoords->SetNumberOfComponents(LIBMESH_DIM);
   pcoords->Allocate(3*mesh.n_local_nodes());
   points->SetNumberOfPoints(mesh.n_local_nodes()); // it seems that it needs this to prevent a segfault

--- a/src/numerics/dense_matrix_blas_lapack.C
+++ b/src/numerics/dense_matrix_blas_lapack.C
@@ -917,7 +917,7 @@ void DenseMatrix<T>::_lu_back_substitute_lapack (const DenseVector<T> & b,
   // dgetrs(TRANS, N, NRHS, A, LDA, IPIV, B, LDB, INFO)
 
   // trans (input)
-  //       'n' for no tranpose, 't' for transpose
+  //       'n' for no transpose, 't' for transpose
   char TRANS[] = "t";
 
   // N (input)

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -69,7 +69,7 @@ void EigenSparseMatrix<T>::init ()
   // We need the DofMap for this!
   libmesh_assert(this->_dof_map);
 
-  // Clear intialized matrices
+  // Clear initialized matrices
   if (this->initialized())
     this->clear();
 

--- a/src/numerics/laspack_matrix.C
+++ b/src/numerics/laspack_matrix.C
@@ -59,7 +59,7 @@ void LaspackMatrix<T>::update_sparsity_pattern (const SparsityPattern::Graph & s
   }
 
 
-  // Initize the _csr data structure.
+  // Initialize the _csr data structure.
   {
     std::vector<numeric_index_type>::iterator position = _csr.begin();
 
@@ -155,7 +155,7 @@ void LaspackMatrix<T>::init ()
   // We need the DofMap for this!
   libmesh_assert(this->_dof_map);
 
-  // Clear intialized matrices
+  // Clear initialized matrices
   if (this->initialized())
     this->clear();
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -30,7 +30,7 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/petsc_vector.h"
 
-// For some reason, the blocked matrix API calls below seem to break with PETSC 3.2 & presumably earier.
+// For some reason, the blocked matrix API calls below seem to break with PETSC 3.2 & presumably earlier.
 // For example:
 // [0]PETSC ERROR: --------------------- Error Message ------------------------------------
 // [0]PETSC ERROR: Nonconforming object sizes!

--- a/src/numerics/type_tensor.C
+++ b/src/numerics/type_tensor.C
@@ -32,7 +32,7 @@ namespace libMesh
 
 
 // ------------------------------------------------------------
-// TypeTensor<T> class member funcions
+// TypeTensor<T> class member functions
 
 
 template <typename T>

--- a/src/numerics/type_vector.C
+++ b/src/numerics/type_vector.C
@@ -32,7 +32,7 @@ namespace libMesh
 
 
 // ------------------------------------------------------------
-// TypeVector<T> class member funcions
+// TypeVector<T> class member functions
 template <typename T>
 TypeVector<T> TypeVector<T>::unit() const
 {

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -468,7 +468,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
       libmesh_assert_equal_to (elem->level(), level);
       libmesh_assert_equal_to (elem->id(), id);
       //#ifdef LIBMESH_ENABLE_UNIQUE_ID
-      // No check for unqiue id sanity
+      // No check for unique id sanity
       //#endif
       libmesh_assert_equal_to (elem->processor_id(), processor_id);
       libmesh_assert_equal_to (elem->subdomain_id(), subdomain_id);

--- a/src/parallel/parallel_sort.C
+++ b/src/parallel/parallel_sort.C
@@ -35,7 +35,7 @@ namespace Parallel {
 
 // The Constructor sorts the local data using
 // std::sort().  Therefore, the construction of
-// a Parallel::Sort object takes O(nlogn) time,
+// a Parallel::Sort object takes O(n log n) time,
 // where n is the length of _data.
 template <typename KeyType, typename IdxType>
 Sort<KeyType,IdxType>::Sort(const Parallel::Communicator & comm_in,

--- a/src/partitioning/centroid_partitioner.C
+++ b/src/partitioning/centroid_partitioner.C
@@ -40,7 +40,7 @@ void CentroidPartitioner::partition_range(MeshBase & /*mesh*/,
 
   // Compute the element centroids.  Note: we used to skip this step
   // if the number of elements was unchanged from the last call, but
-  // that doesn't account for elements that have moved alot since the
+  // that doesn't account for elements that have moved a lot since the
   // last time the Partitioner was called...
   this->compute_centroids (it, end);
 

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -488,7 +488,7 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
     } // end processor 0 part
 
-  // Broadcase the resutling partition
+  // Broadcast the resulting partition
   mesh.comm().broadcast(part);
 
   // Assign the returned processor ids.  The part array contains

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -234,7 +234,7 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
   // use mesh.n_active_elem() in general since this only returns the number
   // of active elements which are stored on the calling processor.
   // We should not use n_active_elem for any allocation because that will
-  // be inheritly unscalable, but it can be useful for libmesh_assertions.
+  // be inherently unscalable, but it can be useful for libmesh_assertions.
   dof_id_type n_active_elem=0;
 
   // Set up the vtxdist array.  This will be the same on each processor.
@@ -258,7 +258,7 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
   // unique range [0,n_active_elem) which is *independent* of the current partitioning.
   // This can be fed to ParMetis as the initial partitioning of the subdomains (decoupled
   // from the partitioning of the objects themselves).  This allows us to get the same
-  // resultant partitioning independed of the input partitioning.
+  // resultant partitioning independent of the input partitioning.
   libMesh::BoundingBox bbox =
     MeshTools::create_bounding_box(mesh);
 
@@ -615,7 +615,7 @@ void ParmetisPartitioner::build_graph (const MeshBase & mesh)
   for (std::size_t r=0; r<graph.size(); r++)
     {
       _pmetis->xadj.push_back(_pmetis->adjncy.size());
-      std::vector<dof_id_type> graph_row; // build this emtpy
+      std::vector<dof_id_type> graph_row; // build this empty
       graph_row.swap(graph[r]); // this will deallocate at the end of scope
       _pmetis->adjncy.insert(_pmetis->adjncy.end(),
                              graph_row.begin(),

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -218,7 +218,7 @@ void Partitioner::partition_unpartitioned_elements (MeshBase & mesh,
   libmesh_assert_equal_to (subdomain_bounds.back(), n_unpartitioned_elements);
 
   // create the unique mapping for all unpartitioned elements independent of partitioning
-  // determine the global indexing for all the unpartitoned elements
+  // determine the global indexing for all the unpartitioned elements
   std::vector<dof_id_type> global_indices;
 
   // Calling this on all processors a unique range in [0,n_unpartitioned_elements) is constructed.
@@ -264,7 +264,7 @@ void Partitioner::set_parent_processor_ids(MeshBase & mesh)
 
   // If the mesh is serial we have access to all the elements,
   // in particular all the active ones.  We can therefore set
-  // the parent processor ids indirecly through their children, and
+  // the parent processor ids indirectly through their children, and
   // set the subactive processor ids while examining their active
   // ancestors.
   // By convention a parent is assigned to the minimum processor
@@ -590,7 +590,7 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
           const processor_id_type new_pid = node.processor_id();
 
           // We may have an invalid processor_id() on nodes that have been
-          // "detatched" from coarsened-away elements but that have not yet
+          // "detached" from coarsened-away elements but that have not yet
           // themselves been removed.
           // libmesh_assert_not_equal_to (new_pid, DofObject::invalid_processor_id);
           // libmesh_assert_less (new_pid, mesh.n_partitions()); // this is the correct test --
@@ -612,7 +612,7 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
           // not equal the number of processors
 
           // But: we may have an invalid processor_id() on nodes that
-          // have been "detatched" from coarsened-away elements but
+          // have been "detached" from coarsened-away elements but
           // that have not yet themselves been removed.
           // libmesh_assert_less (filled_request[i], mesh.n_partitions());
 

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -1097,7 +1097,7 @@ void QGauss::init_2D(const ElemType type_in,
             // http://people.scs.fsu.edu/~burkardt/f_src/wandzura/wandzura.f90
           case TWENTIETH:
             {
-              // The equivalent concial product rule would have 121 points
+              // The equivalent conical product rule would have 121 points
               _points.resize (85);
               _weights.resize(85);
 
@@ -1151,7 +1151,7 @@ void QGauss::init_2D(const ElemType type_in,
           case TWENTYFOURTH:
           case TWENTYFIFTH:
             {
-              // The equivalent concial product rule would have 169 points
+              // The equivalent conical product rule would have 169 points
               _points.resize (126);
               _weights.resize(126);
 
@@ -1212,7 +1212,7 @@ void QGauss::init_2D(const ElemType type_in,
           case TWENTYNINTH:
           case THIRTIETH:
             {
-              // The equivalent concial product rule would have 256 points
+              // The equivalent conical product rule would have 256 points
               _points.resize (175);
               _weights.resize(175);
 

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -165,7 +165,7 @@ void QGauss::init_3D(const ElemType type_in,
                 } // end if (allow_rules_with_negative_weights)
               else
                 {
-                  // If a rule with postive weights is required, the 2x2x2 conical
+                  // If a rule with positive weights is required, the 2x2x2 conical
                   // product rule is third-order accurate and has less points than
                   // the next-available positive-weight rule at FIFTH order.
                   QConical conical_rule(3, _order);
@@ -462,7 +462,7 @@ void QGauss::init_3D(const ElemType type_in,
               if ((allow_rules_with_negative_weights) && (_order + 2*p < 34))
                 {
                   // The Grundmann-Moller rules are defined to arbitrary order and
-                  // can have significantly fewer evaluation points than concial product
+                  // can have significantly fewer evaluation points than conical product
                   // rules.  If you allow rules with negative weights, the GM rules
                   // will be more efficient for degree up to 33 (for degree 34 and
                   // higher, CP is more efficient!) but may be more susceptible

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -209,7 +209,7 @@ void QMonomial::init_3D(const ElemType type_in,
 
               // A degree 7, 34-point, "fully-symmetric" rule, first published in
               // P.C. Hammer and A.H. Stroud, "Numerical Evaluation of Multiple Integrals II",
-              // Mathmatical Tables and Other Aids to Computation, vol 12., no 64, 1958, pp. 272-280
+              // Mathematical Tables and Other Aids to Computation, vol 12., no 64, 1958, pp. 272-280
               //
               // This rule happens to fall under the same general
               // construction as the Kim rules, so we've re-used

--- a/src/solution_transfer/boundary_volume_solution_transfer.C
+++ b/src/solution_transfer/boundary_volume_solution_transfer.C
@@ -25,7 +25,7 @@ namespace libMesh {
 void BoundaryVolumeSolutionTransfer::transfer(const Variable & from_var,
                                               const Variable & to_var)
 {
-  // Determine which direction the tranfer is in
+  // Determine which direction the transfer is in
   System * from_sys = from_var.system();
   System * to_sys = to_var.system();
 

--- a/src/solution_transfer/meshfree_interpolation.C
+++ b/src/solution_transfer/meshfree_interpolation.C
@@ -259,7 +259,7 @@ void InverseDistanceInterpolation<KDDim>::interpolate (const Point              
                                                        std::vector<Number>::iterator & out_it) const
 {
   // We explicitly assume that the input source points are sorted from closest to
-  // farthests.  assert that assumption in DEBUG mode.
+  // farthest.  assert that assumption in DEBUG mode.
 #ifdef DEBUG
   if (!src_dist_sqr.empty())
     {

--- a/src/solution_transfer/meshfree_solution_transfer.C
+++ b/src/solution_transfer/meshfree_solution_transfer.C
@@ -123,7 +123,7 @@ MeshfreeSolutionTransfer::transfer(const Variable & from_var,
       }
   }
 
-  // We have only set local values - prepare for use by gathering remote gata
+  // We have only set local values - prepare for use by gathering remote data
   idi.prepare_for_use();
 
   // Create a MeshlessInterpolationFunction that uses our

--- a/src/solvers/newmark_solver.C
+++ b/src/solvers/newmark_solver.C
@@ -108,7 +108,7 @@ void NewmarkSolver::compute_initial_accel()
   // We need to compute the initial acceleration based off of
   // the initial position and velocity and, thus, acceleration
   // is the unknown in diff_solver and not the displacement. So,
-  // We swap solution and acceleration. NewarkSolver::_general_residual
+  // We swap solution and acceleration. NewmarkSolver::_general_residual
   // will check _is_accel_solve and provide the correct
   // values to the FEMContext assuming this swap was made.
   this->_is_accel_solve = true;
@@ -259,7 +259,7 @@ bool NewmarkSolver::_general_residual (bool request_jacobian,
       request_jacobian = false;
     }
   // Otherwise, the unknowns are the displacements and everything is straight
-  // foward and is what you think it is
+  // forward and is what you think it is
   else
     {
       if (request_jacobian)

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -423,7 +423,7 @@ PetscLinearSolver<T>::solve (SparseMatrix<T> &  matrix_in,
   UniquePtr<PetscMatrix<Number> > subprecond_matrix;
 
   // Set operators.  Also restrict rhs and solution vector to
-  // subdomain if neccessary.
+  // subdomain if necessary.
   if (_restrict_solve_to_is != libmesh_nullptr)
     {
       PetscInt is_local_size = this->_restrict_solve_to_is_local_size();
@@ -690,7 +690,7 @@ PetscLinearSolver<T>::adjoint_solve (SparseMatrix<T> &  matrix_in,
   UniquePtr<PetscMatrix<Number> > subprecond_matrix;
 
   // Set operators.  Also restrict rhs and solution vector to
-  // subdomain if neccessary.
+  // subdomain if necessary.
   if (_restrict_solve_to_is != libmesh_nullptr)
     {
       PetscInt is_local_size = this->_restrict_solve_to_is_local_size();

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -121,10 +121,10 @@ extern "C"
     // if the user has provided both function pointers and objects only the pointer
     // will be used, so catch that as an error
     if (solver->residual && solver->residual_object)
-      libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the Residual!");
+      libmesh_error_msg("ERROR: cannot specify both a function and object to compute the Residual!");
 
     if (solver->matvec && solver->residual_and_jacobian_object)
-      libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the combined Residual & Jacobian!");
+      libmesh_error_msg("ERROR: cannot specify both a function and object to compute the combined Residual & Jacobian!");
 
     if (solver->residual != libmesh_nullptr)
       solver->residual(*sys.current_local_solution.get(), R, sys);

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -95,7 +95,7 @@ PetscErrorCode DMlibMeshSetSystem_libMesh(DM dm, NonlinearImplicitSystem & sys)
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
   PetscBool islibmesh;
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
-  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
+  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
 
   if (dm->setupcalled) SETERRQ(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONGSTATE, "Cannot reset the libMesh system after DM has been set up.");
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
@@ -157,7 +157,7 @@ PetscErrorCode DMlibMeshGetSystem_libMesh(DM dm, NonlinearImplicitSystem *& sys)
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
   PetscBool islibmesh;
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);CHKERRQ(ierr);
-  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
+  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
   sys = dlm->sys;
   PetscFunctionReturn(0);
@@ -174,7 +174,7 @@ PetscErrorCode DMlibMeshGetBlocks(DM dm, PetscInt * n, char *** blocknames)
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
   PetscBool islibmesh;
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
-  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
+  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
   PetscValidPointer(n,2);
   *n = dlm->blockids->size();
@@ -198,7 +198,7 @@ PetscErrorCode DMlibMeshGetVariables(DM dm, PetscInt * n, char *** varnames)
   PetscBool islibmesh;
   PetscInt i;
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
-  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
+  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
   PetscValidPointer(n,2);
   *n = dlm->varids->size();
@@ -486,7 +486,7 @@ PetscErrorCode DMlibMeshCreateFieldDecompositionDM(DM dm, PetscInt dnumber, Pets
   PetscFunctionBegin;
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
-  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
+  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   if (dnumber < 0) SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Negative number %D of decomposition parts", dnumber);
   PetscValidPointer(ddm,5);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
@@ -539,7 +539,7 @@ PetscErrorCode DMlibMeshCreateDomainDecompositionDM(DM dm, PetscInt dnumber, Pet
   PetscFunctionBegin;
   PetscValidHeaderSpecific(dm,DM_CLASSID,1);
   ierr = PetscObjectTypeCompare((PetscObject)dm, DMLIBMESH,&islibmesh);
-  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM oftype %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
+  if (!islibmesh) SETERRQ2(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Got DM of type %s, not of type %s", ((PetscObject)dm)->type_name, DMLIBMESH);
   if (dnumber < 0) SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_ARG_WRONG, "Negative number %D of decomposition parts", dnumber);
   PetscValidPointer(ddm,5);
   DM_libMesh * dlm = (DM_libMesh *)(dm->data);
@@ -751,7 +751,7 @@ static PetscErrorCode  DMCreateFieldDecompositionDM_libMesh(DM dm, const char * 
   if (dtype == DMLIBMESH_FIELD_DECOMPOSITION){
     ierr = DMlibMeshCreateFieldDecompositionDM(dm,dcount,dsizes,dlists,ddm); CHKERRQ(ierr);
   }
-  else SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Uexpected unknown decomposition type for field decomposition descriptor %s", ddesc);
+  else SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Unexpected unknown decomposition type for field decomposition descriptor %s", ddesc);
   PetscFunctionReturn(0);
 }
 
@@ -770,7 +770,7 @@ static PetscErrorCode  DMCreateDomainDecompositionDM_libMesh(DM dm, const char *
   if (dtype == DMLIBMESH_DOMAIN_DECOMPOSITION) {
     ierr = DMlibMeshCreateDomainDecompositionDM(dm,dcount,dsizes,dlists,ddm); CHKERRQ(ierr);
   }
-  else SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Uexpected unknown decomposition type for domain decomposition descriptor %s", ddesc);
+  else SETERRQ1(((PetscObject)dm)->comm, PETSC_ERR_PLIB, "Unexpected unknown decomposition type for domain decomposition descriptor %s", ddesc);
   PetscFunctionReturn(0);
 }
 
@@ -808,10 +808,10 @@ static PetscErrorCode DMlibMeshFunction(DM dm, Vec x, Vec r)
   // if the user has provided both function pointers and objects only the pointer
   // will be used, so catch that as an error
   if (_sys->nonlinear_solver->residual && _sys->nonlinear_solver->residual_object)
-    libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the Residual!");
+    libmesh_error_msg("ERROR: cannot specify both a function and object to compute the Residual!");
 
   if (_sys->nonlinear_solver->matvec && _sys->nonlinear_solver->residual_and_jacobian_object)
-    libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the combined Residual & Jacobian!");
+    libmesh_error_msg("ERROR: cannot specify both a function and object to compute the combined Residual & Jacobian!");
 
   if (_sys->nonlinear_solver->residual != libmesh_nullptr)
     _sys->nonlinear_solver->residual(*(_sys->current_local_solution.get()), R, *_sys);
@@ -888,10 +888,10 @@ static PetscErrorCode DMlibMeshJacobian(
   // if the user has provided both function pointers and objects only the pointer
   // will be used, so catch that as an error
   if (sys.nonlinear_solver->jacobian && sys.nonlinear_solver->jacobian_object)
-    libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the Jacobian!");
+    libmesh_error_msg("ERROR: cannot specify both a function and object to compute the Jacobian!");
 
   if (sys.nonlinear_solver->matvec && sys.nonlinear_solver->residual_and_jacobian_object)
-    libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the combined Residual & Jacobian!");
+    libmesh_error_msg("ERROR: cannot specify both a function and object to compute the combined Residual & Jacobian!");
 
   if (sys.nonlinear_solver->jacobian != libmesh_nullptr)
     sys.nonlinear_solver->jacobian(*(sys.current_local_solution.get()), the_pc, sys);

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -473,7 +473,7 @@ void TaoOptimizationSolver<T>::solve ()
   // programmatically set tolerance and max. function evaluation
   // values when "-tao_type ipm" was specified on the command line: we
   // call TaoSetFromOptions twice (both before and after setting
-  // custom options programatically)
+  // custom options programmatically)
   ierr = TaoSetFromOptions(_tao);
   LIBMESH_CHKERR(ierr);
 

--- a/src/solvers/trilinos_nox_nonlinear_solver.C
+++ b/src/solvers/trilinos_nox_nonlinear_solver.C
@@ -122,10 +122,10 @@ bool Problem_Interface::computeF(const Epetra_Vector & x,
   // will be used, so catch that as an error
 
   if (_solver->residual && _solver->residual_object)
-    libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the Residual!");
+    libmesh_error_msg("ERROR: cannot specify both a function and object to compute the Residual!");
 
   if (_solver->matvec && _solver->residual_and_jacobian_object)
-    libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the combined Residual & Jacobian!");
+    libmesh_error_msg("ERROR: cannot specify both a function and object to compute the combined Residual & Jacobian!");
 
   if (_solver->residual != libmesh_nullptr)
     _solver->residual(*sys.current_local_solution.get(), R, sys);

--- a/src/systems/continuation_system.C
+++ b/src/systems/continuation_system.C
@@ -133,7 +133,7 @@ void ContinuationSystem::initialize_tangent()
   // Be sure the tangent was not already initialized.
   libmesh_assert (!tangent_initialized);
 
-  // Compute delta_s_zero, the initial arclength travelled during the
+  // Compute delta_s_zero, the initial arclength traveled during the
   // first step.  Here we assume that previous_u and lambda_old store
   // the previous solution and control parameter.  You may need to
   // read in an old solution (or solve the non-continuation system)
@@ -1224,7 +1224,7 @@ void ContinuationSystem::update_solution()
   previous_ds = ds_current;
 
   // // 1.) Cosine method (for some reason this always predicts the angle is ~0)
-  // // Don't try divinding by zero
+  // // Don't try dividing by zero
   // if ((yoldnorm > 1.e-12) && (ynorm > 1.e-12))
   //   tau = std::abs(yoldy) / yoldnorm  / ynorm;
   // else

--- a/src/systems/diff_system.C
+++ b/src/systems/diff_system.C
@@ -271,7 +271,7 @@ void DifferentiableSystem::add_dot_var_dirichlet_bcs( unsigned int var_idx,
               if (dbc.f)
                 is_time_evolving_bc = dbc.f->is_time_dependent();
               else if (dbc.f_fem)
-                // We it's a FEMFunctionBase object, it will be implictly
+                // We it's a FEMFunctionBase object, it will be implicitly
                 // time-dependent since it is assumed to depend on the solution.
                 is_time_evolving_bc = true;
               else

--- a/src/systems/eigen_system.C
+++ b/src/systems/eigen_system.C
@@ -94,7 +94,7 @@ void EigenSystem::set_eigenproblem_type (EigenProblemType ept)
       break;
 
     case GHEP:
-      // libMesh::out << "Gerneralized Hermitian" << std::endl;
+      // libMesh::out << "Generalized Hermitian" << std::endl;
       break;
 
     case GNHEP:

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -642,7 +642,7 @@ void EquationSystems::build_solution_vector (std::vector<Number> &,
   // elem_soln[i] = sys_soln[dof_indices[i]];
 
   //       // Using the FE interface, compute the nodal_soln
-  //       // for the current elemnt type given the elem_soln
+  //       // for the current element type given the elem_soln
   //       FEInterface::nodal_soln (dim,
   //        fe_type,
   //        elem,
@@ -850,7 +850,7 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
                 }
               else // If this variable doesn't exist on this subdomain we have to still increment repeat_count so that we won't divide by 0 later:
                 for (unsigned int n=0; n<elem->n_nodes(); n++)
-                  // Only do this if this variable has NO DoFs at this node... it might have some from an ajoining element...
+                  // Only do this if this variable has NO DoFs at this node... it might have some from an adjoining element...
                   if (!elem->node_ptr(n)->n_dofs(sys_num, var))
                     for (unsigned int d=0; d < n_vec_dim; d++)
                       repeat_count.add(nv*(elem->node_id(n)) + (var+d + var_num), 1);

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -79,7 +79,7 @@ FEMContext::FEMContext (const System & sys, int extra_quadrature_order)
 void FEMContext::init_internal_data(const System & sys)
 {
   // Reserve space for the FEAbstract and QBase objects for each
-  // element dimension possiblity (0,1,2,3)
+  // element dimension possibility (0,1,2,3)
   _element_fe.resize(4);
   _side_fe.resize(4);
   _element_fe_var.resize(4);

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -737,7 +737,7 @@ void ImplicitSystem::adjoint_qoi_parameter_sensitivity (const QoISet & qoi_indic
 
   this->assemble_residual_derivatives(parameters_in);
 
-  // Get ready to fill in senstivities:
+  // Get ready to fill in sensitivities:
   sensitivities.allocate_data(qoi_indices, *this, parameters);
 
   // We use the identities:
@@ -843,7 +843,7 @@ void ImplicitSystem::forward_qoi_parameter_sensitivity (const QoISet & qoi_indic
 
   this->sensitivity_solve(parameters);
 
-  // Get ready to fill in senstivities:
+  // Get ready to fill in sensitivities:
   sensitivities.allocate_data(qoi_indices, *this, parameters);
 
   // We use the identity:
@@ -950,7 +950,7 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
       this->adjoint_solve(qoi_indices);
     }
 
-  // Get ready to fill in senstivities:
+  // Get ready to fill in sensitivities:
   sensitivities.allocate_data(qoi_indices, *this, parameters);
 
   // We can't solve for all the solution sensitivities u'_l or for all
@@ -967,12 +967,12 @@ void ImplicitSystem::qoi_parameter_hessian_vector_product (const QoISet & qoi_in
   for (unsigned int k=0; k != Np; ++k)
     {
       // We approximate sum_l(w_l * Q''_{kl}) with a central
-      // differencing pertubation:
+      // differencing perturbation:
       // sum_l(w_l * Q''_{kl}) ~=
       // (Q(p + dp*w_l*e_l + dp*e_k) - Q(p - dp*w_l*e_l + dp*e_k) -
       // Q(p + dp*w_l*e_l - dp*e_k) + Q(p - dp*w_l*e_l - dp*e_k))/(4*dp^2)
 
-      // The sum(w_l*R''_kl) term requires the same sort of pertubation,
+      // The sum(w_l*R''_kl) term requires the same sort of perturbation,
       // and so we subtract it in at the same time:
       // sum_l(w_l * R''_{kl}) ~=
       // (R(p + dp*w_l*e_l + dp*e_k) - R(p - dp*w_l*e_l + dp*e_k) -

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -121,7 +121,7 @@ void LinearImplicitSystem::solve ()
   else
     linear_solver->init();
 
-  // Get the user-specifiied linear solver tolerance
+  // Get the user-specified linear solver tolerance
   const Real tol            =
     es.parameters.get<Real>("linear solver tolerance");
 
@@ -178,7 +178,7 @@ void LinearImplicitSystem::attach_shell_matrix (ShellMatrix<Number> * shell_matr
   const EquationSystems & es =
   this->get_equation_systems();
 
-  // Get the user-specifiied linear solver tolerance
+  // Get the user-specified linear solver tolerance
   const Real tol            =
   es.parameters.get<Real>("sensitivity solver tolerance");
 
@@ -245,7 +245,7 @@ void LinearImplicitSystem::attach_shell_matrix (ShellMatrix<Number> * shell_matr
   const EquationSystems & es =
   this->get_equation_systems();
 
-  // Get the user-specifiied linear solver tolerance
+  // Get the user-specified linear solver tolerance
   const Real tol            =
   es.parameters.get<Real>("adjoint solver tolerance");
 
@@ -301,7 +301,7 @@ void LinearImplicitSystem::attach_shell_matrix (ShellMatrix<Number> * shell_matr
 
   this->sensitivity_solve(parameters);
 
-  // Get ready to fill in senstivities:
+  // Get ready to fill in sensitivities:
   sensitivities.allocate_data(qoi_indices, *this, parameters);
 
   // We use the identity:

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -98,7 +98,7 @@ void NonlinearImplicitSystem::set_solver_parameters ()
   const EquationSystems & es =
     this->get_equation_systems();
 
-  // Get the user-specifiied nonlinear solver tolerances
+  // Get the user-specified nonlinear solver tolerances
   const unsigned int maxits =
     es.parameters.get<unsigned int>("nonlinear solver maximum iterations");
 
@@ -117,7 +117,7 @@ void NonlinearImplicitSystem::set_solver_parameters ()
   const Real rel_step_tol =
     es.parameters.get<Real>("nonlinear solver relative step tolerance");
 
-  // Get the user-specified linear solver toleranaces
+  // Get the user-specified linear solver tolerances
   const unsigned int maxlinearits =
     es.parameters.get<unsigned int>("linear solver maximum iterations");
 
@@ -220,13 +220,13 @@ void NonlinearImplicitSystem::assembly(bool get_residual,
   // if the user has provided both function pointers and objects only the pointer
   // will be used, so catch that as an error
   if (nonlinear_solver->jacobian && nonlinear_solver->jacobian_object)
-    libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the Jacobian!");
+    libmesh_error_msg("ERROR: cannot specify both a function and object to compute the Jacobian!");
 
   if (nonlinear_solver->residual && nonlinear_solver->residual_object)
-    libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the Residual!");
+    libmesh_error_msg("ERROR: cannot specify both a function and object to compute the Residual!");
 
   if (nonlinear_solver->matvec && nonlinear_solver->residual_and_jacobian_object)
-    libmesh_error_msg("ERROR: cannot specifiy both a function and object to compute the combined Residual & Jacobian!");
+    libmesh_error_msg("ERROR: cannot specify both a function and object to compute the combined Residual & Jacobian!");
 
 
   if (get_jacobian)

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -249,7 +249,7 @@ void System::init ()
   if (!this->n_vars())
     return;
 
-  // Then call the user-provided intialization function
+  // Then call the user-provided initialization function
   this->user_initialization();
 }
 
@@ -562,7 +562,7 @@ bool System::compare (const System & other_system,
       if (solu_result == -1)
         libMesh::out << " identical up to threshold." << std::endl;
       else
-        libMesh::out << "  first difference occured at index = "
+        libMesh::out << "  first difference occurred at index = "
                      << solu_result << "." << std::endl;
     }
 
@@ -611,7 +611,7 @@ bool System::compare (const System & other_system,
               if (ov_result[ov_result.size()-1] == -1)
                 libMesh::out << " identical up to threshold." << std::endl;
               else
-                libMesh::out << " first difference occured at" << std::endl
+                libMesh::out << " first difference occurred at" << std::endl
                              << "   index = " << ov_result[ov_result.size()-1] << "." << std::endl;
             }
 
@@ -1142,7 +1142,7 @@ unsigned int System::add_variable (const std::string & var,
       if (their_active_subdomains && !active_subdomains)
         should_be_in_vg = false;
 
-      // they aren't restriced, we are?
+      // they aren't restricted, we are?
       if (!their_active_subdomains && active_subdomains)
         should_be_in_vg = false;
 
@@ -1945,7 +1945,7 @@ void System::attach_QOI_derivative_object (QOIDerivative & qoi_derivative)
 
 void System::user_initialization ()
 {
-  // Call the user-provided intialization function,
+  // Call the user-provided initialization function,
   // if it was provided
   if (_init_system_function != libmesh_nullptr)
     this->_init_system_function (_equation_systems, this->name());
@@ -2090,7 +2090,7 @@ Number System::point_value(unsigned int var, const Point & p, const Elem & e) co
   // Fill in the dof_indices for our element
   dof_map.dof_indices (&e, dof_indices, var);
 
-  // Get the no of dofs assciated with this point
+  // Get the no of dofs associated with this point
   const unsigned int num_dofs = cast_int<unsigned int>
     (dof_indices.size());
 
@@ -2203,7 +2203,7 @@ Gradient System::point_gradient(unsigned int var, const Point & p, const Elem & 
   // Fill in the dof_indices for our element
   dof_map.dof_indices (&e, dof_indices, var);
 
-  // Get the no of dofs assciated with this point
+  // Get the no of dofs associated with this point
   const unsigned int num_dofs = cast_int<unsigned int>
     (dof_indices.size());
 
@@ -2317,7 +2317,7 @@ Tensor System::point_hessian(unsigned int var, const Point & p, const Elem & e) 
   // Fill in the dof_indices for our element
   dof_map.dof_indices (&e, dof_indices, var);
 
-  // Get the no of dofs assciated with this point
+  // Get the no of dofs associated with this point
   const unsigned int num_dofs = cast_int<unsigned int>
     (dof_indices.size());
 

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -132,7 +132,7 @@ void System::read_header (Xdr & io,
   //
   //     6.) The name of the variable (string)
   //
-  //     6.1.) Variable subdmains
+  //     6.1.) Variable subdomains
   //
   //     7.) Combined in an FEType:
   //         - The approximation order(s) of the variable
@@ -224,7 +224,7 @@ void System::read_header (Xdr & io,
         // changed for the monomial and xyz finite element families to
         // simplify extension to arbitrary p.  The consequence is that
         // old restart files will not be read correctly.  This is expected
-        // to be an unlikely occurance, but catch it anyway.
+        // to be an unlikely occurence, but catch it anyway.
         if (read_legacy_format)
           if ((type.family == MONOMIAL || type.family == XYZ) &&
               ((type.order.get_order() > 2 && this->get_mesh().mesh_dimension() == 2) ||
@@ -888,7 +888,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
   // ------------------------------------------------------
   // First pass - count the number of objects in each block
   // traverse all the objects and figure out which block they
-  // will utlimately live in.
+  // will ultimately live in.
   std::vector<std::size_t>
     xfer_ids_size  (num_blks,0),
     recv_vals_size (num_blks,0);
@@ -998,7 +998,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
           input_vals.resize(tot_vals_size[blk]);
           input_vals_tmp.resize(tot_vals_size[blk]);
 
-          // a ThreadedIO object to perform asychronous file IO
+          // a ThreadedIO object to perform asynchronous file IO
           ThreadedIO<InValType> threaded_io(io, input_vals_tmp);
           Threads::Thread async_io(threaded_io);
 
@@ -1052,7 +1052,7 @@ std::size_t System::read_serialized_blocked_dof_objects (const dof_id_type n_obj
 #endif
             }
 
-          // We need the offests into the input_vals vector for each object.
+          // We need the offsets into the input_vals vector for each object.
           // fortunately, this is simply the partial sum of the total number
           // of components for each object
           std::partial_sum(obj_val_offsets.begin(), obj_val_offsets.end(),
@@ -1915,7 +1915,7 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
   // ------------------------------------------------------
   // First pass - count the number of objects in each block
   // traverse all the objects and figure out which block they
-  // will utlimately live in.
+  // will ultimately live in.
   std::vector<unsigned int>
     xfer_ids_size  (num_blks,0),
     send_vals_size (num_blks,0);
@@ -2018,7 +2018,7 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
       std::vector<unsigned int> obj_val_offsets;          // map to traverse entry-wise rather than processor-wise
       std::vector<Number>       output_vals;              // The output buffer for the current block
 
-      // a ThreadedIO object to perform asychronous file IO
+      // a ThreadedIO object to perform asynchronous file IO
       ThreadedIO<Number> threaded_io(io, output_vals);
       UniquePtr<Threads::Thread> async_io;
 
@@ -2083,7 +2083,7 @@ std::size_t System::write_serialized_blocked_dof_objects (const std::vector<cons
               n_val_recvd_blk += vals.size();
             }
 
-          // We need the offests into the output_vals vector for each object.
+          // We need the offsets into the output_vals vector for each object.
           // fortunately, this is simply the partial sum of the total number
           // of components for each object
           std::partial_sum(obj_val_offsets.begin(), obj_val_offsets.end(),

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -516,7 +516,7 @@ public:
 /**
  * This class implements projecting an arbitrary
  * boundary function to the current mesh.  This
- * may be exectued in parallel on multiple threads.
+ * may be executed in parallel on multiple threads.
  */
 class BoundaryProjectSolution
 {
@@ -992,7 +992,7 @@ void System::boundary_project_solution (const std::set<boundary_id_type> & b,
 
 
 /**
- * This method projects an arbitary boundary function onto the
+ * This method projects an arbitrary boundary function onto the
  * solution via L2 projections and nodal interpolations on each
  * element.
  */

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -42,7 +42,7 @@ namespace libMesh
 
 
 // ------------------------------------------------------------
-// PerfLog class member funcions
+// PerfLog class member functions
 
 bool PerfLog::called = false;
 
@@ -77,7 +77,7 @@ void PerfLog::clear()
       for (std::map<std::pair<std::string,std::string>, PerfData>::iterator
              pos = log.begin(); pos != log.end(); ++pos)
         if (pos->second.open)
-          libmesh_error_msg("ERROR clearning performance log for class " \
+          libmesh_error_msg("ERROR clearing performance log for class " \
                             << label_name                             \
                             << "\nevent "                             \
                             << pos->first.second                      \

--- a/src/utils/plt_loader_read.C
+++ b/src/utils/plt_loader_read.C
@@ -198,7 +198,7 @@ void PltLoader::read_header (std::istream & in)
             // Found a Zone marker
             else if (f == 299.)
               {
-                // Incriment the Zone counter
+                // Increment the Zone counter
                 nz++;
 
                 // Read the zone name
@@ -400,7 +400,7 @@ void PltLoader::read_header (std::istream & in)
             // Found a Zone marker
             else if (f == 299.)
               {
-                // Incriment the Zone counter
+                // Increment the Zone counter
                 nz++;
 
                 // Read the zone name
@@ -515,7 +515,7 @@ void PltLoader::read_header (std::istream & in)
                   std::memcpy  (&k_max, buf, LIBMESH_SIZEOF_INT);
                   rb(k_max);
 
-                  // These are only useful for orderd data.  Otherwise
+                  // These are only useful for ordered data.  Otherwise
                   // we grabbed the relevant values above.
                   if (ztype.back() != ORDERED)
                     {

--- a/src/utils/statistics.C
+++ b/src/utils/statistics.C
@@ -366,7 +366,7 @@ std::vector<dof_id_type> StatisticsVector<T>::cut_above(Real cut) const
 
 
 //------------------------------------------------------------
-// Explicit Instantions
+// Explicit Instantiations
 template class StatisticsVector<float>;
 template class StatisticsVector<double>;
 #ifdef LIBMESH_DEFAULT_TRIPLE_PRECISION

--- a/src/utils/timestamp.C
+++ b/src/utils/timestamp.C
@@ -67,7 +67,7 @@ std::string get_timestamp()
 
   return date_stream.str();
 #else
-  // C-stye code originally found here:
+  // C-style code originally found here:
   // http://people.sc.fsu.edu/~burkardt/cpp_src/timestamp/timestamp.C
   // Author: John Burkardt, 24 September 2003
   const unsigned int time_size = 40;

--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -64,7 +64,7 @@ protected:
         _internal_boundary_mesh->skip_partitioning(true);
       }
 
-    // Set subdomain ids for specfic elements. This allows us to later
+    // Set subdomain ids for specific elements. This allows us to later
     // build an internal sideset with respect to a given
     // subdomain. The element subdomains look like:
     // ___________________

--- a/tests/mesh/checkpoint.C
+++ b/tests/mesh/checkpoint.C
@@ -57,7 +57,7 @@ public:
   template <typename MeshA, typename MeshB>
   void testSplitter(bool binary, bool using_distmesh)
   {
-    // The CheckpointIO-based spltter requires XDR.
+    // The CheckpointIO-based splitter requires XDR.
 #ifdef LIBMESH_HAVE_XDR
 
     // In this test, we partition the mesh into n_procs parts.  Don't

--- a/tests/mesh/contains_point.C
+++ b/tests/mesh/contains_point.C
@@ -25,8 +25,8 @@ class ContainsPointTest : public CppUnit::TestCase
 {
   /**
    * The goal of this test is to verify proper operation of the contains_point
-   * method that is used extensively in the point locator. This test focusses on
-   * the specializes contains_point implementaion in TRI3.
+   * method that is used extensively in the point locator. This test focuses on
+   * the specializes contains_point implementation in TRI3.
    */
 public:
   CPPUNIT_TEST_SUITE( ContainsPointTest );

--- a/tests/mesh/mesh_function_dfem.C
+++ b/tests/mesh/mesh_function_dfem.C
@@ -118,7 +118,7 @@ protected:
     }
 
     // libMesh will renumber, but we numbered according to its scheme
-    // anyway. We do this because when we call uniformly_refine subsequenly,
+    // anyway. We do this because when we call uniformly_refine subsequently,
     // it's going use skip_renumber=false.
     _mesh->prepare_for_use(false /*skip_renumber*/);
 

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -99,7 +99,7 @@ protected:
     }
 
     // libMesh will renumber, but we numbered according to its scheme
-    // anyway. We do this because when we call uniformly_refine subsequenly,
+    // anyway. We do this because when we call uniformly_refine subsequently,
     // it's going use skip_renumber=false.
     _mesh->prepare_for_use(false /*skip_renumber*/);
   }
@@ -475,7 +475,7 @@ protected:
     }
 
     // libMesh will renumber, but we numbered according to its scheme
-    // anyway. We do this because when we call uniformly_refine subsequenly,
+    // anyway. We do this because when we call uniformly_refine subsequently,
     // it's going use skip_renumber=false.
     _mesh->prepare_for_use(false /*skip_renumber*/);
 

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -75,7 +75,7 @@ public:
 class SlitMeshTest : public CppUnit::TestCase {
   /**
    * The goal of this test is to ensure that a 2D mesh with nodes overlapping
-   * on opposite sides of an internal, "slit" edge is useable.
+   * on opposite sides of an internal, "slit" edge is usable.
    */
 public:
   CPPUNIT_TEST_SUITE( SlitMeshTest );

--- a/tests/numerics/petsc_vector_test.C
+++ b/tests/numerics/petsc_vector_test.C
@@ -65,7 +65,7 @@ public:
 
     v.restore_array();
 
-    // Test getting a read only array after getting a writeable array
+    // Test getting a read only array after getting a writable array
     values = v.get_array();
     read_only_values = v.get_array_read();
     CPPUNIT_ASSERT_EQUAL((intptr_t)read_only_values, (intptr_t)values);


### PR DESCRIPTION
Inspired by adfd541b9, I found [scspell](https://github.com/myint/scspell) and used it to fix a bunch of typos in our documentation.