### PR TITLE
libmesh-config: Move libmesh library PATH to beginning of --libs.

### DIFF
--- a/contrib/bin/libmesh-config.in
+++ b/contrib/bin/libmesh-config.in
@@ -132,9 +132,7 @@ while [ "x$1" != "x" ]; do
 	    ;;
 	
 	"--libs")
-	    return_val="@libmesh_optional_LIBS@ 
-                        -Wl,-rpath,${libdir} -L${libdir} -lmesh${libext} 
-                        $return_val"
+	    return_val="-Wl,-rpath,${libdir} -L${libdir} -lmesh${libext} @libmesh_optional_LIBS@ $return_val"
 	    ;;
 
 	"--ldflags")


### PR DESCRIPTION
This should hopefully fix the issue reported by @dknez in #1430 where
he was getting a libnetcdf.so from /usr/lib in his linker line before
the one in $LIBMESH_INSTALLED_DIR/lib.