### PR TITLE
Added a API flush in sparse matrix

### DIFF
--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -150,6 +150,8 @@ public:
 
   virtual void close () libmesh_override;
 
+  virtual void flush () libmesh_override;
+
   virtual numeric_index_type m () const libmesh_override;
 
   virtual numeric_index_type n () const libmesh_override;

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -171,6 +171,13 @@ public:
   virtual void close () = 0;
 
   /**
+   *  For PETSc matrix , this function is similar to close but without shrinking memory.
+   *  This is useful when we want to switch between ADD_VALUES and INSERT_VALUES.
+   *  close should be called before using the matrix.
+   */
+  virtual void flush () { close(); }
+
+  /**
    * \returns The row-dimension of the matrix.
    */
   virtual numeric_index_type m () const = 0;

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -913,6 +913,19 @@ void PetscMatrix<T>::close ()
   LIBMESH_CHKERR(ierr);
 }
 
+template <typename T>
+void PetscMatrix<T>::flush ()
+{
+  semiparallel_only();
+
+  PetscErrorCode ierr=0;
+
+  ierr = MatAssemblyBegin (_mat, MAT_FLUSH_ASSEMBLY);
+  LIBMESH_CHKERR(ierr);
+  ierr = MatAssemblyEnd   (_mat, MAT_FLUSH_ASSEMBLY);
+  LIBMESH_CHKERR(ierr);
+}
+
 
 
 template <typename T>


### PR DESCRIPTION
It is useful when we switch between  `ADD_VALUES` and `INSERT_VALUES` for a petsc matrix.
`Flush` won't shrink the memory. Users still have to call `close` before doing any actual calculation.