### PR TITLE
Update DifferentiableQoI to handle more complex derivatives

### DIFF
--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -23,6 +23,7 @@
 // Local Includes
 #include "libmesh/auto_ptr.h"
 #include "libmesh/parallel.h"
+#include "libmesh/diff_context.h"
 
 // C++ includes
 
@@ -170,6 +171,12 @@ public:
                            std::vector<Number> & sys_qoi,
                            std::vector<Number> & local_qoi,
                            const QoISet & qoi_indices);
+
+  /**
+   * Method to finalize qoi derivatives which require more than just a simple
+   * sum of element contributions.
+   */
+  virtual void finalize_derivative(NumericVector<Number> & derivatives, std::size_t qoi_index);
 };
 
 } // namespace libMesh

--- a/src/physics/diff_qoi.C
+++ b/src/physics/diff_qoi.C
@@ -48,4 +48,9 @@ void DifferentiableQoI::parallel_op(const Parallel::Communicator & communicator,
   sys_qoi = local_qoi;
 }
 
+void DifferentiableQoI::finalize_derivative(NumericVector<Number> &, std::size_t)
+{
+  // by default, do nothing
+}
+
 } // namespace libMesh

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1178,6 +1178,10 @@ void FEMSystem::assemble_qoi_derivative (const QoISet & qoi_indices,
                                                     *(this->diff_qoi),
                                                     include_liftfunc,
                                                     apply_constraints));
+
+  for (std::size_t i=0; i != qoi.size(); ++i)
+    if (qoi_indices.has_index(i))
+      this->diff_qoi->finalize_derivative(this->get_adjoint_rhs(i),i);
 }
 
 


### PR DESCRIPTION
This adds `DifferentiableQoI::finalize_derivative()` which is analogous to `DifferentiableQoI::parallel_op()`. I'm working with an exponential QoI function in GRINS for AMR (see [here](https://github.com/grinsfem/grins/blob/master/src/qoi/include/grins/absorption_coeff.h#L51)). Because of the exponential, in addition to summing the `element_qoi_derivatives`, I also need to apply the chain rule to the derivative values before they are fed to the adjoint solver.

By default, this function does nothing so there are no backward compatibility issues. If you have a better name, I'd be happy to change it.