### PR TITLE
Refinement early return

### DIFF
--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -31,6 +31,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/error_vector.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/mesh_refinement.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/system.h"
 #include "libmesh/tensor_value.h"
@@ -580,6 +581,13 @@ void HPCoarsenTest::select_refinement (System & system)
           elem->set_refinement_flag(Elem::DO_NOTHING);
         }
     }
+
+  // libMesh::MeshRefinement will now assume that users have set
+  // refinement flags consistently on all processors, but all we've
+  // done so far is set refinement flags on local elements.  Let's
+  // make sure that flags on geometrically ghosted elements are all
+  // set to whatever their owners decided.
+  MeshRefinement(mesh).make_flags_parallel_consistent();
 }
 
 } // namespace libMesh

--- a/src/error_estimation/hp_singular.C
+++ b/src/error_estimation/hp_singular.C
@@ -41,9 +41,9 @@ void HPSingularity::select_refinement (System & system)
   MeshBase & mesh = system.get_mesh();
 
   MeshBase::element_iterator       elem_it  =
-    mesh.active_local_elements_begin();
+    mesh.active_elements_begin();
   const MeshBase::element_iterator elem_end =
-    mesh.active_local_elements_end();
+    mesh.active_elements_end();
 
   for (; elem_it != elem_end; ++elem_it)
     {

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -573,19 +573,11 @@ bool MeshRefinement::refine_and_coarsen_elements ()
   // Parallel consistency has to come first, or coarsening
   // along processor boundaries might occasionally be falsely
   // prevented
+#ifdef DEBUG
   bool flags_were_consistent = this->make_flags_parallel_consistent();
 
-  // In theory, we should be able to remove the above call, which can
-  // be expensive and should be unnecessary.  In practice, doing
-  // consistent flagging in parallel is hard, it's impossible to
-  // verify at the library level if it's being done by user code, and
-  // we don't want to abort large parallel runs in opt mode... but we
-  // do want to warn that they should be fixed.
-  if (!flags_were_consistent)
-    {
-      libMesh::out << "Refinement flags were not consistent between processors!\n"
-                   << "Correcting and continuing.";
-    }
+  libmesh_assert (flags_were_consistent);
+#endif
 
   // Smooth refinement and coarsening flags
   _smooth_flags(true, true);


### PR DESCRIPTION
Add a test to MeshRefinement::refine_and_coarsen_elements() to make sure we actually have something to refine or coarsen; if not then we can return early without first testing for level mismatches and testing for unrefined islands and so forth.

Also remove the probably-redundant call to make_flags_parallel_compatible(), except as a dbg-mode test; if you need it then you can call it manually, and if you don't then we shouldn't be wasting your time with it.

See https://github.com/idaholab/moose/pull/10025 for discussion.