### PR TITLE
Deprecated code use can optionally be an error, not just a warning

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4639,6 +4639,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/configure
+++ b/configure
@@ -855,6 +855,7 @@ LIBMESH_ENABLE_INFINITE_ELEMENTS_FALSE
 LIBMESH_ENABLE_INFINITE_ELEMENTS_TRUE
 enablelegacyincludepaths
 enabledefaultcommworld
+enabledeprecated
 enablewarnings
 enableuniqueptr
 PWD
@@ -1155,6 +1156,7 @@ enable_unordered_containers
 with_gdb_command
 enable_unique_ptr
 enable_warnings
+enable_deprecated
 enable_blocked_storage
 enable_default_comm_world
 enable_legacy_include_paths
@@ -1949,6 +1951,8 @@ Optional Features:
   --disable-unique-ptr    Use libMesh's deprecated, less safe AutoPtr
   --disable-warnings      Do not warn about deprecated, experimental, or
                           questionable code
+  --disable-deprecated    Deprecated code use gives errors rather than
+                          warnings
   --enable-blocked-storage
                           Support for blocked matrix/vector storage
   --enable-default-comm-world
@@ -32460,6 +32464,33 @@ else
 $as_echo "<<< Configuring library with warnings >>>" >&6; }
 
 $as_echo "#define ENABLE_WARNINGS 1" >>confdefs.h
+
+fi
+# --------------------------------------------------------------
+
+
+# --------------------------------------------------------------
+# library deprecated code - enable by default
+# --------------------------------------------------------------
+# Check whether --enable-deprecated was given.
+if test "${enable_deprecated+set}" = set; then :
+  enableval=$enable_deprecated; enabledeprecated=$enableval
+else
+  enabledeprecated=yes
+fi
+
+
+
+if test "$enabledeprecated" != yes ; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> INFO: Disabling library deprecated code <<<" >&5
+$as_echo ">>> INFO: Disabling library deprecated code <<<" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Configuring library without deprecated code support <<<" >&5
+$as_echo ">>> Configuring library without deprecated code support <<<" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with deprecated code support >>>" >&5
+$as_echo "<<< Configuring library with deprecated code support >>>" >&6; }
+
+$as_echo "#define ENABLE_DEPRECATED 1" >>confdefs.h
 
 fi
 # --------------------------------------------------------------

--- a/configure
+++ b/configure
@@ -47241,6 +47241,7 @@ echo Git revision....................... : $BUILD_VERSION
 echo
 echo Library Features:
 echo '  library warnings................. :' $enablewarnings
+echo '  library deprecated code support.. :' $enabledeprecated
 echo '  adaptive mesh refinement......... :' $enableamr
 echo '  blocked matrix/vector storage.... :' $enableblockedstorage
 echo '  complex variables................ :' $enablecomplex

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -693,6 +693,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/boost/include/Makefile.in
+++ b/contrib/boost/include/Makefile.in
@@ -2071,6 +2071,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/capnproto/Makefile.in
+++ b/contrib/capnproto/Makefile.in
@@ -568,6 +568,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/eigen/3.2.9/Makefile.in
+++ b/contrib/eigen/3.2.9/Makefile.in
@@ -457,6 +457,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/exodusii/5.22b/exodus/Makefile.in
+++ b/contrib/exodusii/5.22b/exodus/Makefile.in
@@ -2345,6 +2345,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/exodusii/5.22b/nemesis/Makefile.in
+++ b/contrib/exodusii/5.22b/nemesis/Makefile.in
@@ -513,6 +513,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/exodusii/Lib/Makefile.in
+++ b/contrib/exodusii/Lib/Makefile.in
@@ -1200,6 +1200,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/fparser/Makefile.in
+++ b/contrib/fparser/Makefile.in
@@ -867,6 +867,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/fparser/extrasrc/Makefile.in
+++ b/contrib/fparser/extrasrc/Makefile.in
@@ -410,6 +410,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/gmv/Makefile.in
+++ b/contrib/gmv/Makefile.in
@@ -508,6 +508,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/gzstream/Makefile.in
+++ b/contrib/gzstream/Makefile.in
@@ -530,6 +530,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/laspack/Makefile.in
+++ b/contrib/laspack/Makefile.in
@@ -568,6 +568,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/libHilbert/Makefile.in
+++ b/contrib/libHilbert/Makefile.in
@@ -576,6 +576,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/metis/Makefile.in
+++ b/contrib/metis/Makefile.in
@@ -805,6 +805,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/nanoflann/Makefile.in
+++ b/contrib/nanoflann/Makefile.in
@@ -539,6 +539,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/nemesis/Lib/Makefile.in
+++ b/contrib/nemesis/Lib/Makefile.in
@@ -668,6 +668,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/netcdf/Lib/Makefile.in
+++ b/contrib/netcdf/Lib/Makefile.in
@@ -572,6 +572,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/parmetis/Makefile.in
+++ b/contrib/parmetis/Makefile.in
@@ -779,6 +779,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/qhull/2012.1/Makefile.in
+++ b/contrib/qhull/2012.1/Makefile.in
@@ -1024,6 +1024,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/sfcurves/Makefile.in
+++ b/contrib/sfcurves/Makefile.in
@@ -518,6 +518,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/tecplot/binary/Makefile.in
+++ b/contrib/tecplot/binary/Makefile.in
@@ -503,6 +503,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/tecplot/tecio/Makefile.in
+++ b/contrib/tecplot/tecio/Makefile.in
@@ -652,6 +652,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/tetgen/Makefile.in
+++ b/contrib/tetgen/Makefile.in
@@ -539,6 +539,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/triangle/Makefile.in
+++ b/contrib/triangle/Makefile.in
@@ -539,6 +539,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/unique_ptr/Makefile.in
+++ b/contrib/unique_ptr/Makefile.in
@@ -455,6 +455,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -466,6 +466,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/doc/html/Makefile.in
+++ b/doc/html/Makefile.in
@@ -426,6 +426,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -498,6 +498,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex1/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex1/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex2/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex2/Makefile.in
@@ -587,6 +587,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex3/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex3/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex4/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex4/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex5/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex5/Makefile.in
@@ -583,6 +583,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex1/L-shaped.C
+++ b/examples/adjoints/adjoints_ex1/L-shaped.C
@@ -16,8 +16,9 @@ using namespace libMesh;
 
 void LaplaceSystem::init_data ()
 {
-  this->add_variable ("T", static_cast<Order>(_fe_order),
-                      Utility::string_to_enum<FEFamily>(_fe_family));
+  unsigned int T_var =
+    this->add_variable ("T", static_cast<Order>(_fe_order),
+                        Utility::string_to_enum<FEFamily>(_fe_family));
 
   GetPot infile("l-shaped.in");
   exact_QoI[0] = infile("QoI_0", 0.0);
@@ -26,7 +27,8 @@ void LaplaceSystem::init_data ()
   // Do the parent's initialization after variables are defined
   FEMSystem::init_data();
 
-  this->time_evolving(0);
+  // The temperature is evolving, with a first order time derivative
+  this->time_evolving(T_var, 1);
 }
 
 void LaplaceSystem::init_context(DiffContext & context)

--- a/examples/adjoints/adjoints_ex1/Makefile.in
+++ b/examples/adjoints/adjoints_ex1/Makefile.in
@@ -637,6 +637,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex2/L-shaped.C
+++ b/examples/adjoints/adjoints_ex2/L-shaped.C
@@ -16,8 +16,9 @@ using namespace libMesh;
 
 void LaplaceSystem::init_data ()
 {
-  this->add_variable ("T", static_cast<Order>(_fe_order),
-                      Utility::string_to_enum<FEFamily>(_fe_family));
+  unsigned int T_var =
+    this->add_variable ("T", static_cast<Order>(_fe_order),
+                        Utility::string_to_enum<FEFamily>(_fe_family));
 
   GetPot infile("l-shaped.in");
   parameters.push_back(infile("alpha_1", 1.0));
@@ -26,7 +27,8 @@ void LaplaceSystem::init_data ()
   // Do the parent's initialization after variables are defined
   FEMSystem::init_data();
 
-  this->time_evolving(0);
+  // The temperature is evolving, with a first order time derivative
+  this->time_evolving(T_var, 1);
 }
 
 void LaplaceSystem::init_context(DiffContext & context)

--- a/examples/adjoints/adjoints_ex2/Makefile.in
+++ b/examples/adjoints/adjoints_ex2/Makefile.in
@@ -620,6 +620,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex3/Makefile.in
+++ b/examples/adjoints/adjoints_ex3/Makefile.in
@@ -640,6 +640,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex3/coupled_system.C
+++ b/examples/adjoints/adjoints_ex3/coupled_system.C
@@ -104,11 +104,12 @@ void CoupledSystem::init_data ()
   C_var = this->add_variable ("C", static_cast<Order>(pressure_p+1),
                               fefamily);
 
-  // Tell the system to march velocity forward in time, but
-  // leave p as a constraint only
-  this->time_evolving(u_var);
-  this->time_evolving(v_var);
-  this->time_evolving(C_var);
+  // Tell the system to march velocity and concentration forward in
+  // time, with first order time derivatives, but leave pressure as a
+  // constraint only
+  this->time_evolving(u_var, 1);
+  this->time_evolving(v_var, 1);
+  this->time_evolving(C_var, 1);
 
   // Useful debugging options
   this->verify_analytic_jacobians = infile("verify_analytic_jacobians", 0.);

--- a/examples/adjoints/adjoints_ex3/coupled_system.h
+++ b/examples/adjoints/adjoints_ex3/coupled_system.h
@@ -22,6 +22,7 @@
 #include "libmesh/fem_function_base.h"
 #include "libmesh/fem_system.h"
 #include "libmesh/libmesh_common.h"
+#include "libmesh/parameter_pointer.h"
 #include "libmesh/parameter_vector.h"
 
 using namespace libMesh;
@@ -52,9 +53,11 @@ public:
 
   ParameterVector & get_parameter_vector()
   {
-    parameter_vector.resize(parameters.size());
-    for (std::size_t i = 0; i != parameters.size(); ++i)
-      parameter_vector[i] = &parameters[i];
+    if (!parameter_vector.size())
+      for (std::size_t i = 0; i != parameters.size(); ++i)
+        parameter_vector.push_back
+          (UniquePtr<ParameterAccessor<Number> >
+            (new ParameterPointer<Number>(&parameters[i])));
 
     return parameter_vector;
   }

--- a/examples/adjoints/adjoints_ex4/L-shaped.C
+++ b/examples/adjoints/adjoints_ex4/L-shaped.C
@@ -16,8 +16,9 @@ using namespace libMesh;
 
 void LaplaceSystem::init_data ()
 {
-  this->add_variable ("T", static_cast<Order>(_fe_order),
-                      Utility::string_to_enum<FEFamily>(_fe_family));
+  unsigned int T_var =
+    this->add_variable ("T", static_cast<Order>(_fe_order),
+                        Utility::string_to_enum<FEFamily>(_fe_family));
 
   GetPot infile("l-shaped.in");
   exact_QoI[0] = infile("QoI_0", 0.0);
@@ -26,7 +27,8 @@ void LaplaceSystem::init_data ()
   // Do the parent's initialization after variables are defined
   FEMSystem::init_data();
 
-  this->time_evolving(0);
+  // The temperature is evolving, with a first order time derivative
+  this->time_evolving(T_var, 1);
 }
 
 void LaplaceSystem::init_context(DiffContext & context)

--- a/examples/adjoints/adjoints_ex4/Makefile.in
+++ b/examples/adjoints/adjoints_ex4/Makefile.in
@@ -640,6 +640,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex5/Makefile.in
+++ b/examples/adjoints/adjoints_ex5/Makefile.in
@@ -640,6 +640,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex5/heatsystem.C
+++ b/examples/adjoints/adjoints_ex5/heatsystem.C
@@ -53,7 +53,8 @@ void HeatSystem::init_data ()
   // Set equation system parameters _k and theta, so they can be read by the exact solution
   this->get_equation_systems().parameters.set<Real>("_k") = _k;
 
-  this->time_evolving(T_var);
+  // The temperature is evolving, with a first order time derivative
+  this->time_evolving(T_var, 1);
 
   const boundary_id_type all_ids[4] = {0, 1, 2, 3};
   std::set<boundary_id_type> all_bdys(all_ids, all_ids+(2*2));

--- a/examples/adjoints/adjoints_ex5/heatsystem.h
+++ b/examples/adjoints/adjoints_ex5/heatsystem.h
@@ -19,6 +19,7 @@
 
 #include "libmesh/enum_fe_family.h"
 #include "libmesh/fem_system.h"
+#include "libmesh/parameter_pointer.h"
 #include "libmesh/parameter_vector.h"
 
 using namespace libMesh;
@@ -65,9 +66,11 @@ public:
 
   ParameterVector & get_parameter_vector()
   {
-    parameter_vector.resize(parameters.size());
-    for (std::size_t i = 0; i != parameters.size(); ++i)
-      parameter_vector[i] = &parameters[i];
+    if (!parameter_vector.size())
+      for (std::size_t i = 0; i != parameters.size(); ++i)
+        parameter_vector.push_back
+          (UniquePtr<ParameterAccessor<Number> >
+            (new ParameterPointer<Number>(&parameters[i])));
 
     return parameter_vector;
   }

--- a/examples/adjoints/adjoints_ex6/Makefile.in
+++ b/examples/adjoints/adjoints_ex6/Makefile.in
@@ -620,6 +620,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex6/poisson.C
+++ b/examples/adjoints/adjoints_ex6/poisson.C
@@ -54,19 +54,18 @@ private:
 
 void PoissonSystem::init_data ()
 {
-  this->add_variable ("T", static_cast<Order>(_fe_order),
-                      Utility::string_to_enum<FEFamily>(_fe_family));
+  T_var =
+    this->add_variable ("T", static_cast<Order>(_fe_order),
+                        Utility::string_to_enum<FEFamily>(_fe_family));
 
   GetPot infile("poisson.in");
   exact_QoI[0] = infile("QoI_0", 0.0);
   alpha = infile("alpha", 100.0);
 
-  // Now we will set the Dirichlet boundary conditions
+  // The temperature is evolving, with a first order time derivative
+  this->time_evolving(T_var, 1);
 
-  // Get the variable number of the variable for which we will set
-  // the Dirichlet boundary conditions
-  T_var = this->variable_number ("T");
-  this->time_evolving(T_var);
+  // Now we will set the Dirichlet boundary conditions
 
   // Get boundary ids for all the boundaries
   const boundary_id_type all_bdry_id[4] = {0, 1, 2, 3};

--- a/examples/eigenproblems/eigenproblems_ex1/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex1/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/eigenproblems/eigenproblems_ex2/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex2/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/eigenproblems/eigenproblems_ex3/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex3/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/fem_system/fem_system_ex1/Makefile.in
+++ b/examples/fem_system/fem_system_ex1/Makefile.in
@@ -602,6 +602,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/fem_system/fem_system_ex2/Makefile.in
+++ b/examples/fem_system/fem_system_ex2/Makefile.in
@@ -612,6 +612,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/fem_system/fem_system_ex3/Makefile.in
+++ b/examples/fem_system/fem_system_ex3/Makefile.in
@@ -602,6 +602,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -195,14 +195,14 @@ int main (int argc, char ** argv)
   else if( time_solver == std::string("euler") )
     {
       system.time_solver.reset(new EulerSolver(system));
-      EulerSolver & euler_solver = libmesh_cast_ref<EulerSolver &>(*(system.time_solver.get()));
+      EulerSolver & euler_solver = cast_ref<EulerSolver &>(*(system.time_solver.get()));
       euler_solver.theta = infile("theta", 1.0);
     }
 
   else if( time_solver == std::string("euler2") )
     {
       system.time_solver.reset(new Euler2Solver(system));
-      Euler2Solver & euler_solver = libmesh_cast_ref<Euler2Solver &>(*(system.time_solver.get()));
+      Euler2Solver & euler_solver = cast_ref<Euler2Solver &>(*(system.time_solver.get()));
       euler_solver.theta = infile("theta", 1.0);
     }
 

--- a/examples/fem_system/fem_system_ex4/Makefile.in
+++ b/examples/fem_system/fem_system_ex4/Makefile.in
@@ -602,6 +602,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/fem_system/fem_system_ex4/heatsystem.C
+++ b/examples/fem_system/fem_system_ex4/heatsystem.C
@@ -46,7 +46,7 @@ void HeatSystem::init_data ()
 
 void HeatSystem::init_context(DiffContext & context)
 {
-  FEMContext & c = libmesh_cast_ref<FEMContext &>(context);
+  FEMContext & c = cast_ref<FEMContext &>(context);
 
   const std::set<unsigned char> & elem_dims =
     c.elem_dimensions();
@@ -73,7 +73,7 @@ void HeatSystem::init_context(DiffContext & context)
 bool HeatSystem::element_time_derivative (bool request_jacobian,
                                           DiffContext & context)
 {
-  FEMContext & c = libmesh_cast_ref<FEMContext &>(context);
+  FEMContext & c = cast_ref<FEMContext &>(context);
 
   const unsigned int mesh_dim =
     c.get_system().get_mesh().mesh_dimension();

--- a/examples/fem_system/fem_system_ex4/heatsystem.C
+++ b/examples/fem_system/fem_system_ex4/heatsystem.C
@@ -38,7 +38,8 @@ void HeatSystem::init_data ()
   // Do the parent's initialization after variables are defined
   FEMSystem::init_data();
 
-  this->time_evolving(0);
+  // The temperature is evolving, with a first-order time derivative
+  this->time_evolving(T_var, 1);
 }
 
 

--- a/examples/introduction/introduction_ex1/Makefile.in
+++ b/examples/introduction/introduction_ex1/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/introduction/introduction_ex2/Makefile.in
+++ b/examples/introduction/introduction_ex2/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/introduction/introduction_ex3/Makefile.in
+++ b/examples/introduction/introduction_ex3/Makefile.in
@@ -583,6 +583,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/introduction/introduction_ex4/Makefile.in
+++ b/examples/introduction/introduction_ex4/Makefile.in
@@ -583,6 +583,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/introduction/introduction_ex5/Makefile.in
+++ b/examples/introduction/introduction_ex5/Makefile.in
@@ -583,6 +583,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex1/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex1/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex10/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex10/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex11/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex11/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex12/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex12/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex2/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex2/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex3/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex3/Makefile.in
@@ -578,6 +578,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex4/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex4/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex5/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex5/Makefile.in
@@ -587,6 +587,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex6/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex6/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex7/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex7/Makefile.in
@@ -606,6 +606,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex8/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex8/Makefile.in
@@ -602,6 +602,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex9/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex9/Makefile.in
@@ -607,6 +607,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/optimization/optimization_ex1/Makefile.in
+++ b/examples/optimization/optimization_ex1/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/optimization/optimization_ex2/Makefile.in
+++ b/examples/optimization/optimization_ex2/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex1/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex1/Makefile.in
@@ -597,6 +597,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex2/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex2/Makefile.in
@@ -597,6 +597,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex3/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex3/Makefile.in
@@ -597,6 +597,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex4/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex4/Makefile.in
@@ -602,6 +602,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex5/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex5/Makefile.in
@@ -602,6 +602,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex6/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex6/Makefile.in
@@ -602,6 +602,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex7/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex7/Makefile.in
@@ -597,6 +597,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/solution_transfer/solution_transfer_ex1/Makefile.in
+++ b/examples/solution_transfer/solution_transfer_ex1/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/subdomains/subdomains_ex1/Makefile.in
+++ b/examples/subdomains/subdomains_ex1/Makefile.in
@@ -583,6 +583,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/subdomains/subdomains_ex2/Makefile.in
+++ b/examples/subdomains/subdomains_ex2/Makefile.in
@@ -583,6 +583,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/subdomains/subdomains_ex3/Makefile.in
+++ b/examples/subdomains/subdomains_ex3/Makefile.in
@@ -582,6 +582,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex1/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex1/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex2/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex2/Makefile.in
@@ -578,6 +578,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex3/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex3/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex4/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex4/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex5/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex5/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex6/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex6/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -530,7 +530,7 @@ int main (int argc, char ** argv)
 #ifdef LIBMESH_HAVE_PETSC
   // Attach a SolverConfiguration object to system.linear_solver
   PetscLinearSolver<Number> * petsc_linear_solver =
-    libmesh_cast_ptr<PetscLinearSolver<Number>*>(system.get_linear_solver());
+    cast_ptr<PetscLinearSolver<Number>*>(system.get_linear_solver());
   libmesh_assert(petsc_linear_solver);
   PetscSolverConfiguration petsc_solver_config(*petsc_linear_solver);
   petsc_linear_solver->set_solver_configuration(petsc_solver_config);

--- a/examples/systems_of_equations/systems_of_equations_ex7/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex7/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex8/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex8/Makefile.in
@@ -612,6 +612,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
@@ -229,8 +229,8 @@ void LinearElasticityWithContact::add_contact_edge_elements()
       dof_id_type master_node_id = it->first;
       dof_id_type slave_node_id = it->second;
 
-      Node & master_node = mesh.node(master_node_id);
-      Node & slave_node = mesh.node(slave_node_id);
+      Node & master_node = mesh.node_ref(master_node_id);
+      Node & slave_node = mesh.node_ref(slave_node_id);
 
       Elem * connector_elem = mesh.add_elem (new Edge2);
       connector_elem->set_node(0) = &master_node;

--- a/examples/transient/transient_ex1/Makefile.in
+++ b/examples/transient/transient_ex1/Makefile.in
@@ -583,6 +583,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/transient/transient_ex2/Makefile.in
+++ b/examples/transient/transient_ex2/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/vector_fe/vector_fe_ex1/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex1/Makefile.in
@@ -581,6 +581,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/vector_fe/vector_fe_ex2/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex2/Makefile.in
@@ -607,6 +607,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/vector_fe/vector_fe_ex2/laplace_system.C
+++ b/examples/vector_fe/vector_fe_ex2/laplace_system.C
@@ -46,7 +46,8 @@ void LaplaceSystem::init_data ()
   // Add the solution variable
   u_var = this->add_variable ("u", FIRST, LAGRANGE_VEC);
 
-  this->time_evolving(u_var);
+  // The solution is evolving, with a first order time derivative
+  this->time_evolving(u_var, 1);
 
   // Useful debugging options
   // Set verify_analytic_jacobians to 1e-6 to use

--- a/examples/vector_fe/vector_fe_ex3/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex3/Makefile.in
@@ -607,6 +607,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/vector_fe/vector_fe_ex3/curl_curl_system.C
+++ b/examples/vector_fe/vector_fe_ex3/curl_curl_system.C
@@ -46,7 +46,8 @@ void CurlCurlSystem::init_data ()
   // Add the solution variable
   u_var = this->add_variable ("u", FIRST, NEDELEC_ONE);
 
-  this->time_evolving(u_var);
+  // The solution is evolving, with a first order time derivative
+  this->time_evolving(u_var, 1);
 
   // Useful debugging options
   // Set verify_analytic_jacobians to 1e-6 to use

--- a/examples/vector_fe/vector_fe_ex4/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex4/Makefile.in
@@ -607,6 +607,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/vector_fe/vector_fe_ex4/curl_curl_system.C
+++ b/examples/vector_fe/vector_fe_ex4/curl_curl_system.C
@@ -46,7 +46,8 @@ void CurlCurlSystem::init_data ()
   // Add the solution variable
   u_var = this->add_variable ("u", FIRST, NEDELEC_ONE);
 
-  this->time_evolving(u_var);
+  // The solution is evolving, with a first order time derivative
+  this->time_evolving(u_var, 1);
 
   // Useful debugging options
   // Set verify_analytic_jacobians to 1e-6 to use

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -500,6 +500,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -556,6 +556,7 @@ public:
    * \deprecated This function returns nonsense in the rare case where
    * \p proc has no local dof indices.  Use end_dof() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   dof_id_type last_dof(const processor_id_type proc) const
   {
     libmesh_deprecated();
@@ -565,6 +566,7 @@ public:
 
   dof_id_type last_dof() const
   { return this->last_dof(this->processor_id()); }
+#endif
 
   /**
    * \returns The first dof index that is after all indices local to

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -505,6 +505,7 @@ inline Tnew cast_ref(Told & oldvar)
 #endif
 }
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 template <typename Tnew, typename Told>
 inline Tnew libmesh_cast_ref(Told & oldvar)
 {
@@ -512,6 +513,7 @@ inline Tnew libmesh_cast_ref(Told & oldvar)
   libmesh_deprecated();
   return cast_ref<Tnew>(oldvar);
 }
+#endif
 
 // We use two different function names to avoid an odd overloading
 // ambiguity bug with icc 10.1.008

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -460,8 +460,13 @@ extern bool warned_about_auto_ptr;
 
 // The libmesh_deprecated macro warns that you are using obsoleted code
 #undef libmesh_deprecated
+#ifndef LIBMESH_ENABLE_DEPRECATED
+#define libmesh_deprecated()                                            \
+  libmesh_error_msg("*** Error, This code is deprecated, and likely to be removed in future library versions! ");
+#else
 #define libmesh_deprecated()                                            \
   libmesh_warning("*** Warning, This code is deprecated, and likely to be removed in future library versions! ");
+#endif
 
 // A function template for ignoring unused variables.  This is a way
 // to shut up unused variable compiler warnings on a case by case

--- a/include/base/libmesh_logging.h
+++ b/include/base/libmesh_logging.h
@@ -100,8 +100,10 @@ private:
 
 #  define START_LOG(a,b)   { libMesh::perflog.push(a,b); }
 #  define STOP_LOG(a,b)    { libMesh::perflog.pop(a,b); }
+#ifdef LIBMESH_ENABLE_DEPRECATED
 #  define PALIBMESH_USE_LOG(a,b)   { libmesh_deprecated(); }
 #  define RESTART_LOG(a,b) { libmesh_deprecated(); }
+#endif
 #  define LOG_SCOPE(a,b)   libMesh::PerfItem TOKENPASTE2(perf_item_, __LINE__)(a,b);
 #  define LOG_SCOPE_IF(a,b,enabled)   libMesh::PerfItem TOKENPASTE2(perf_item_, __LINE__)(a,b,enabled);
 

--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -100,8 +100,10 @@ public:
    *
    * \deprecated Use the BoundingBox::intersects() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   bool intersect (const BoundingBox & b) const
   { libmesh_deprecated(); return this->intersects(b); }
+#endif
 
   /*
    * \returns \p true if the bounding box contains the given point.

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -136,7 +136,9 @@ public:
    *
    * \deprecated Use the less ambiguously named node_id() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   dof_id_type node (const unsigned int i) const;
+#endif
 
   /**
    * \returns The local id number of global \p Node id \p i,
@@ -180,7 +182,9 @@ public:
    *
    * \deprecated Use the less ambiguously named node_ptr() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   Node * get_node (const unsigned int i) const;
+#endif
 
   /**
    * \returns The pointer to local \p Node \p i as a writable reference.
@@ -266,7 +270,9 @@ public:
   /**
    * \deprecated Use the const-correct neighbor_ptr() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   Elem * neighbor (const unsigned int i) const;
+#endif
 
   /**
    * Nested "classes" for use iterating over all neighbors of an element.
@@ -704,7 +710,9 @@ public:
    * indirectly modify this.  Please use the the const-correct
    * side_ptr() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   UniquePtr<Elem> side (const unsigned int i) const;
+#endif
 
   /**
    * \returns An element coincident with side \p i wrapped in a smart pointer.
@@ -738,7 +746,9 @@ public:
    * indirectly modify this.  Please use the the const-correct
    * build_side_ptr() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   UniquePtr<Elem> build_side (const unsigned int i, bool proxy=true) const;
+#endif
 
   /**
    * \returns An element coincident with edge \p i wrapped in a smart pointer.
@@ -764,7 +774,9 @@ public:
    * indirectly modify this Elem.  Please use the the const-correct
    * build_edge_ptr() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   UniquePtr<Elem> build_edge (const unsigned int i) const;
+#endif
 
   /**
    * \returns The default approximation order for this element type.
@@ -1106,7 +1118,9 @@ public:
    * \deprecated Use the more accurately-named and const correct
    * child_ptr() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   Elem * child (const unsigned int i) const;
+#endif
 
   /**
    * Nested classes for use iterating over all children of a parent
@@ -1772,12 +1786,14 @@ dof_id_type Elem::node_id (const unsigned int i) const
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline
 dof_id_type Elem::node (const unsigned int i) const
 {
   libmesh_deprecated();
   return this->node_id(i);
 }
+#endif
 
 
 
@@ -1839,6 +1855,7 @@ Node & Elem::node_ref (const unsigned int i)
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline
 Node * Elem::get_node (const unsigned int i) const
 {
@@ -1851,6 +1868,7 @@ Node * Elem::get_node (const unsigned int i) const
   libmesh_deprecated();
   return const_cast<Node *>(this->node_ptr(i));
 }
+#endif
 
 
 
@@ -1912,6 +1930,7 @@ Elem * Elem::neighbor_ptr (unsigned int i)
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline
 Elem * Elem::neighbor (const unsigned int i) const
 {
@@ -1920,6 +1939,7 @@ Elem * Elem::neighbor (const unsigned int i) const
   libmesh_deprecated();
   return const_cast<Elem *>(this->neighbor_ptr(i));
 }
+#endif
 
 
 
@@ -1983,6 +2003,7 @@ UniquePtr<const Elem> Elem::side_ptr (unsigned int i) const
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline
 UniquePtr<Elem> Elem::side (const unsigned int i) const
 {
@@ -1991,6 +2012,7 @@ UniquePtr<Elem> Elem::side (const unsigned int i) const
   Elem * s = const_cast<Elem *>(this->side_ptr(i).release());
   return UniquePtr<Elem>(s);
 }
+#endif
 
 
 
@@ -2007,6 +2029,7 @@ Elem::build_side_ptr (const unsigned int i, bool proxy) const
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline
 UniquePtr<Elem>
 Elem::build_side (const unsigned int i, bool proxy) const
@@ -2016,6 +2039,7 @@ Elem::build_side (const unsigned int i, bool proxy) const
   Elem * s = const_cast<Elem *>(this->build_side_ptr(i, proxy).release());
   return UniquePtr<Elem>(s);
 }
+#endif
 
 
 
@@ -2032,6 +2056,7 @@ Elem::build_edge_ptr (const unsigned int i) const
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline
 UniquePtr<Elem>
 Elem::build_edge (const unsigned int i) const
@@ -2041,6 +2066,7 @@ Elem::build_edge (const unsigned int i) const
   Elem * e = const_cast<Elem *>(this->build_edge_ptr(i).release());
   return UniquePtr<Elem>(e);
 }
+#endif
 
 
 
@@ -2337,6 +2363,7 @@ Elem * Elem::child_ptr (unsigned int i)
 }
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline
 Elem * Elem::child (const unsigned int i) const
 {
@@ -2345,6 +2372,7 @@ Elem * Elem::child (const unsigned int i) const
   libmesh_deprecated();
   return const_cast<Elem *>(this->child_ptr(i));
 }
+#endif
 
 
 

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -426,6 +426,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -124,6 +124,9 @@
 /* Flag indicating if the library should use blocked matrix/vector storage */
 #undef ENABLE_BLOCKED_STORAGE
 
+/* Flag indicating if the library should support deprecated code */
+#undef ENABLE_DEPRECATED
+
 /* Flag indicating if the library should be built with Dirichlet boundary
    constraint support */
 #undef ENABLE_DIRICHLET

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -364,7 +364,9 @@ public:
    * \deprecated Instead, use the version of this function that fills
    * a std::vector.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   std::vector<boundary_id_type> boundary_ids (const Node * node) const;
+#endif
 
   /**
    * Fills a user-provided std::vector with the boundary ids associated
@@ -398,8 +400,10 @@ public:
    * \deprecated Instead, use the version of this function that fills
    * a std::vector.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   std::vector<boundary_id_type> edge_boundary_ids (const Elem * const elem,
                                                    const unsigned short int edge) const;
+#endif
 
   /**
    * \returns The list of boundary ids associated with the \p edge edge of
@@ -425,8 +429,10 @@ public:
    * \deprecated Instead, use the version of this function that fills
    * a std::vector.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   std::vector<boundary_id_type> raw_edge_boundary_ids (const Elem * const elem,
                                                        const unsigned short int edge) const;
+#endif
 
   /**
    * \returns The list of raw boundary ids associated with the \p edge
@@ -496,8 +502,10 @@ public:
    * BoundaryInfo::boundary_ids() or BoundaryInfo::has_boundary_id()
    * instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   boundary_id_type boundary_id (const Elem * const elem,
                                 const unsigned short int side) const;
+#endif
 
   /**
    * \returns The number of boundary ids associated with the \p side
@@ -513,8 +521,10 @@ public:
    * \deprecated Instead, use the version of this function that fills
    * a std::vector.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   std::vector<boundary_id_type> boundary_ids (const Elem * const elem,
                                               const unsigned short int side) const;
+#endif
 
   /**
    * \returns The list of boundary ids associated with the \p side side of
@@ -536,8 +546,10 @@ public:
    * \deprecated Instead, use the version of this function that fills
    * a std::vector.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   std::vector<boundary_id_type> raw_boundary_ids (const Elem * const elem,
                                                   const unsigned short int side) const;
+#endif
 
   /**
    * \returns The list of raw boundary ids associated with the \p side

--- a/include/mesh/boundary_mesh.h
+++ b/include/mesh/boundary_mesh.h
@@ -55,8 +55,10 @@ public:
    * \deprecated LIBMESH_DISABLE_COMMWORLD is now the default, use the
    * constructor that takes a Parallel::Communicator instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   explicit
   BoundaryMesh (unsigned char dim=1);
+#endif
 #endif
 
   /**

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -68,8 +68,10 @@ public:
    * \deprecated LIBMESH_DISABLE_COMMWORLD is now the default, use the
    * constructor that takes a Parallel::Communicator instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   explicit
   DistributedMesh (unsigned char dim=1);
+#endif
 #endif
 
 

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -108,9 +108,11 @@ public:
    *
    * \deprecated Use the version of copy_nodal_solution() that takes two names.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   void copy_nodal_solution(System & system,
                            std::string var_name,
                            unsigned int timestep=1);
+#endif
 
   /**
    * If we read in a nodal solution while reading in a mesh, we can attempt

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -85,7 +85,9 @@ public:
    * \deprecated LIBMESH_DISABLE_COMMWORLD is now the default, use the
    * constructor that takes a Parallel::Communicator instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   MeshBase (unsigned char dim=1);
+#endif
 #endif
 
   /**
@@ -433,11 +435,13 @@ public:
    *
    * \deprecated Use the less confusingly-named node_ref() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual const Node & node (const dof_id_type i) const
   {
     libmesh_deprecated();
     return *this->node_ptr(i);
   }
+#endif
 
   /**
    * \returns A reference to the \f$ i^{th} \f$ node, which should be
@@ -445,11 +449,13 @@ public:
    *
    * \deprecated Use the less confusingly-named node_ref() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual Node & node (const dof_id_type i)
   {
     libmesh_deprecated();
     return *this->node_ptr(i);
   }
+#endif
 
   /**
    * \returns A pointer to the \f$ i^{th} \f$ node, which should be
@@ -512,11 +518,13 @@ public:
    *
    * \deprecated Use the less confusingly-named elem_ptr() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual const Elem * elem (const dof_id_type i) const
   {
     libmesh_deprecated();
     return this->elem_ptr(i);
   }
+#endif
 
   /**
    * \returns A writable pointer to the \f$ i^{th} \f$ element, which
@@ -525,11 +533,13 @@ public:
    *
    * \deprecated Use the less confusingly-named elem_ptr() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual Elem * elem (const dof_id_type i)
   {
     libmesh_deprecated();
     return this->elem_ptr(i);
   }
+#endif
 
   /**
    * \returns A pointer to the \f$ i^{th} \f$ element, or NULL if no
@@ -549,11 +559,13 @@ public:
    *
    * \deprecated Use the less confusingly-named query_elem_ptr() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual const Elem * query_elem (const dof_id_type i) const
   {
     libmesh_deprecated();
     return this->query_elem_ptr(i);
   }
+#endif
 
   /**
    * \returns A writable pointer to the \f$ i^{th} \f$ element, or NULL
@@ -561,11 +573,13 @@ public:
    *
    * \deprecated Use the less confusingly-named query_elem_ptr() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual Elem * query_elem (const dof_id_type i)
   {
     libmesh_deprecated();
     return this->query_elem_ptr(i);
   }
+#endif
 
   /**
    * Add a new \p Node at \p Point \p p to the end of the vertex array,
@@ -910,7 +924,9 @@ public:
    *
    * \deprecated This should never be used in threaded or non-parallel_only code.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   const PointLocatorBase & point_locator () const;
+#endif
 
   /**
    * \returns A pointer to a subordinate \p PointLocatorBase object

--- a/include/mesh/mesh_refinement.h
+++ b/include/mesh/mesh_refinement.h
@@ -477,7 +477,9 @@ public:
    *
    * \deprecated Use enforce_mismatch_limit_prior_to_refinement() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   bool get_enforce_mismatch_limit_prior_to_refinement();
+#endif
 
   /**
    * Set _enforce_mismatch_limit_prior_to_refinement option.
@@ -485,7 +487,9 @@ public:
    *
    * \deprecated Use enforce_mismatch_limit_prior_to_refinement() instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   void set_enforce_mismatch_limit_prior_to_refinement(bool enforce);
+#endif
 
   /**
    * Get/set the _enforce_mismatch_limit_prior_to_refinement flag.
@@ -928,6 +932,7 @@ inline signed char & MeshRefinement::underrefined_boundary_limit()
   return _underrefined_boundary_limit;
 }
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline bool MeshRefinement::get_enforce_mismatch_limit_prior_to_refinement()
 {
   libmesh_deprecated();
@@ -939,6 +944,7 @@ inline void MeshRefinement::set_enforce_mismatch_limit_prior_to_refinement(bool 
   libmesh_deprecated();
   enforce_mismatch_limit_prior_to_refinement() = enforce;
 }
+#endif
 
 inline bool & MeshRefinement::enforce_mismatch_limit_prior_to_refinement()
 {

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -56,6 +56,7 @@ namespace MeshTools
  *
  * \deprecated Use libMesh::BoundingBox instead.
  */
+#ifdef LIBMESH_ENABLE_DEPRECATED
 class BoundingBox : public libMesh::BoundingBox
 {
 public:
@@ -74,6 +75,7 @@ public:
     libmesh_deprecated(); // Switch to libMesh::BoundingBox
   }
 };
+#endif
 
 
 /**
@@ -138,8 +140,10 @@ void find_boundary_nodes (const MeshBase & mesh,
  *
  * \deprecated Use create_bounding_box() instead.
  */
+#ifdef LIBMESH_ENABLE_DEPRECATED
 BoundingBox
 bounding_box (const MeshBase & mesh);
+#endif
 
 /**
  * The same functionality as the deprecated MeshTools::bounding_box().
@@ -182,9 +186,11 @@ create_local_bounding_box (const MeshBase & mesh);
  *
  * \deprecated Use create_processor_bounding_box() instead.
  */
+#ifdef LIBMESH_ENABLE_DEPRECATED
 BoundingBox
 processor_bounding_box (const MeshBase & mesh,
                         const processor_id_type pid);
+#endif
 
 /**
  * The same functionality as the deprecated MeshTools::processor_bounding_box().
@@ -208,9 +214,11 @@ processor_bounding_sphere (const MeshBase & mesh,
  *
  * \deprecated Use create_subdomain_bounding_box() instead.
  */
+#ifdef LIBMESH_ENABLE_DEPRECATED
 BoundingBox
 subdomain_bounding_box (const MeshBase & mesh,
                         const subdomain_id_type sid);
+#endif
 
 
 /**

--- a/include/mesh/parallel_mesh.h
+++ b/include/mesh/parallel_mesh.h
@@ -48,12 +48,14 @@ public:
    * \deprecated LIBMESH_DISABLE_COMMWORLD is now the default, use the
    * constructor that takes a Parallel::Communicator instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   explicit
   ParallelMesh (unsigned char dim=1)
     : DistributedMesh(dim)
   {
     libmesh_deprecated();
   }
+#endif
 #endif
 
   ParallelMesh (const UnstructuredMesh & other_mesh) : DistributedMesh(other_mesh) {}

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -57,12 +57,17 @@ public:
 
 #ifndef LIBMESH_DISABLE_COMMWORLD
   /**
-   * Deprecated constructor.  Takes \p dim, the dimension of the mesh.
-   * The mesh dimension can be changed (and may automatically be
-   * changed by mesh generation/loading) later.
+   * Constructor which takes \p dim, the dimension of the mesh.  The
+   * mesh dimension can be changed (and may automatically be changed
+   * by mesh generation/loading) later.
+   *
+   * \deprecated LIBMESH_DISABLE_COMMWORLD is now the default, use the
+   * constructor that takes a Parallel::Communicator instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   explicit
   ReplicatedMesh (unsigned char dim=1);
+#endif
 #endif
 
 

--- a/include/mesh/serial_mesh.h
+++ b/include/mesh/serial_mesh.h
@@ -48,12 +48,14 @@ public:
    * \deprecated LIBMESH_DISABLE_COMMWORLD is now the default, use the
    * constructor that takes a Parallel::Communicator instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   explicit
   SerialMesh (unsigned char dim=1)
     : ReplicatedMesh(dim)
   {
     libmesh_deprecated();
   }
+#endif
 #endif
 
   SerialMesh (const UnstructuredMesh & other_mesh) : ReplicatedMesh(other_mesh) {}

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -67,7 +67,9 @@ public:
    * \deprecated LIBMESH_DISABLE_COMMWORLD is now the default, use the
    * constructor that takes a Parallel::Communicator instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   UnstructuredMesh (unsigned char dim=1);
+#endif
 #endif
 
   /**

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -124,8 +124,10 @@ public:
    * \deprecated LIBMESH_DISABLE_COMMWORLD is now the default, use the
    * build() method that takes a Parallel::Communicator instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   static UniquePtr<NumericVector<T> >
   build(const SolverPackage solver_package = libMesh::default_solver_package());
+#endif
 #endif
 
   /**

--- a/include/numerics/type_n_tensor.h
+++ b/include/numerics/type_n_tensor.h
@@ -157,7 +157,9 @@ public:
    *
    * \deprecated Use the norm_sq() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   Real size_sq() const { libmesh_deprecated(); return 0.;}
+#endif
 
   /**
    * \returns The Frobenius norm of the tensor squared, i.e. the sum of the

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -325,7 +325,9 @@ public:
    *
    * \deprecated Use the norm() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   Real size() const;
+#endif
 
   /**
    * \returns The Frobenius norm of the tensor, i.e. the square-root of
@@ -339,7 +341,9 @@ public:
    *
    * \deprecated Use the norm_sq() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   Real size_sq() const;
+#endif
 
   /**
    * \returns The Frobenius norm of the tensor squared, i.e. sum of the
@@ -1178,6 +1182,7 @@ TypeTensor<T>::contract (const TypeTensor<T2> & t) const
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 template <typename T>
 inline
 Real TypeTensor<T>::size() const
@@ -1185,6 +1190,7 @@ Real TypeTensor<T>::size() const
   libmesh_deprecated();
   return this->norm();
 }
+#endif
 
 
 
@@ -1247,6 +1253,7 @@ void TypeTensor<T>::zero()
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 template <typename T>
 inline
 Real TypeTensor<T>::size_sq () const
@@ -1254,6 +1261,7 @@ Real TypeTensor<T>::size_sq () const
   libmesh_deprecated();
   return this->norm_sq();
 }
+#endif
 
 
 

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -280,7 +280,9 @@ public:
    *
    * \deprecated Use the norm() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   Real size() const;
+#endif
 
   /**
    * \returns The magnitude of the vector, i.e. the square-root of the
@@ -294,7 +296,9 @@ public:
    *
    * \deprecated Use the norm_sq() function instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   Real size_sq() const;
+#endif
 
   /**
    * \returns The magnitude of the vector squared, i.e. the sum of the
@@ -888,6 +892,7 @@ TypeVector<T>::cross(const TypeVector<T2> & p) const
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 template <typename T>
 inline
 Real TypeVector<T>::size() const
@@ -895,6 +900,7 @@ Real TypeVector<T>::size() const
   libmesh_deprecated();
   return this->norm();
 }
+#endif
 
 
 
@@ -917,6 +923,7 @@ void TypeVector<T>::zero()
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 template <typename T>
 inline
 Real TypeVector<T>::size_sq() const
@@ -924,6 +931,7 @@ Real TypeVector<T>::size_sq() const
   libmesh_deprecated();
   return this->norm_sq();
 }
+#endif
 
 
 

--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -41,6 +41,7 @@ namespace libMesh
 // Macro to identify and debug functions which should only be called in
 // parallel on every processor at once
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 #undef parallel_only
 #ifndef NDEBUG
 #define parallel_only() do {                                            \
@@ -50,6 +51,7 @@ namespace libMesh
     libmesh_assert(CommWorld.verify(__LINE__)); } while (0)
 #else
 #define parallel_only()  ((void) 0)
+#endif
 #endif
 
 #undef libmesh_parallel_only
@@ -65,6 +67,7 @@ namespace libMesh
 // Macro to identify and debug functions which should only be called in
 // parallel on every processor at once
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 #undef parallel_only_on
 #ifndef NDEBUG
 #define parallel_only_on(comm_arg) do {                                 \
@@ -74,6 +77,7 @@ namespace libMesh
     libmesh_assert(CommWorld.verify(__LINE__), comm_arg); } while (0)
 #else
 #define parallel_only_on(comm_arg)  ((void) 0)
+#endif
 #endif
 
 #undef libmesh_parallel_only_on

--- a/include/physics/diff_physics.h
+++ b/include/physics/diff_physics.h
@@ -244,11 +244,13 @@ public:
    * the order-in-time of the variable, either 1 or 2. This method
    * assumes the variable is first order for backward compatibility.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual void time_evolving (unsigned int var)
   {
     libmesh_deprecated();
     this->time_evolving(var,1);
   }
+#endif
 
   /**
    * Tells the DiffSystem that variable var is evolving with

--- a/include/systems/elem_assembly.h
+++ b/include/systems/elem_assembly.h
@@ -83,6 +83,7 @@ public:
    * Get values to add to the matrix or rhs vector based on \p node.
    * This allows one to impose point loads or springs, for example.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual void
   get_nodal_rhs_values(std::map<numeric_index_type, Number> & values,
                        const System &,
@@ -97,6 +98,7 @@ public:
     // Set flag so that we know this is the default implementation
     is_nodal_rhs_values_overriden = false;
   }
+#endif
 
   /**
    * Temporary flag to help us figure out if we should call the

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -206,7 +206,9 @@ public:
    * delete a System from an EquationSystems object, it could probably
    * be added.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   void delete_system (const std::string & name);
+#endif
 
   /**
    * \returns The total number of variables in all

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -91,7 +91,9 @@ public:
    * \deprecated Instead, use the version that takes a reference to a
    * std::set.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   std::vector<boundary_id_type> side_boundary_ids() const;
+#endif
 
   /**
    * As above, but fills in the std::set provided by the user.

--- a/include/systems/parameter_accessor.h
+++ b/include/systems/parameter_accessor.h
@@ -74,8 +74,10 @@ public:
    * This is included for backward compatibility, but will be
    * deprecated in some classes and not implemented in others.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual ParameterAccessor<T> &
   operator= (T * /* new_ptr */) { libmesh_error(); return *this; }
+#endif
 
   /**
    * Proxy: for backward compatibility, we allow codes to treat a

--- a/include/systems/parameter_multiaccessor.h
+++ b/include/systems/parameter_multiaccessor.h
@@ -69,12 +69,14 @@ public:
   /**
    * A simple reseater won't work with a multi-accessor
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual ParameterAccessor<T> &
   operator= (T * /* new_ptr */) libmesh_override
   {
     libmesh_error();
     return *this;
   }
+#endif
 
   /**
    * Setter: change the value of the parameter we access.

--- a/include/systems/parameter_multipointer.h
+++ b/include/systems/parameter_multipointer.h
@@ -60,12 +60,14 @@ public:
   /**
    * A simple reseater won't work with a multipointer
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual ParameterAccessor<T> &
   operator= (T * /* new_ptr */) libmesh_override
   {
     libmesh_error();
     return *this;
   }
+#endif
 
   /**
    * Setter: change the value of the parameter we access.

--- a/include/systems/parameter_pointer.h
+++ b/include/systems/parameter_pointer.h
@@ -66,6 +66,7 @@ public:
    * \deprecated This is included for backward compatibility, but
    * should no longer be used.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   virtual ParameterAccessor<T> &
   operator= (T * new_ptr) libmesh_override
   {
@@ -73,6 +74,7 @@ public:
     _ptr = new_ptr;
     return *this;
   }
+#endif
 
   /**
    * \returns A new copy of the accessor.

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1236,8 +1236,10 @@ public:
    * "legacy") XDR format has been deprecated for many years, this
    * capability may soon disappear altogether.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   void read_legacy_data (Xdr & io,
                          const bool read_additional_data=true);
+#endif
 
   /**
    * Reads additional data, namely vectors, for this System.

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -67,6 +67,7 @@ echo Git revision....................... : $BUILD_VERSION
 echo
 echo Library Features:
 echo '  library warnings................. :' $enablewarnings
+echo '  library deprecated code support.. :' $enabledeprecated
 echo '  adaptive mesh refinement......... :' $enableamr
 echo '  blocked matrix/vector storage.... :' $enableblockedstorage
 echo '  complex variables................ :' $enablecomplex

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -75,6 +75,26 @@ fi
 
 
 # --------------------------------------------------------------
+# library deprecated code - enable by default
+# --------------------------------------------------------------
+AC_ARG_ENABLE(deprecated,
+              [AS_HELP_STRING([--disable-deprecated],[Deprecated code use gives errors rather than warnings])],
+              enabledeprecated=$enableval,
+              enabledeprecated=yes)
+
+AC_SUBST(enabledeprecated)
+if test "$enabledeprecated" != yes ; then
+  AC_MSG_RESULT([>>> INFO: Disabling library deprecated code <<<])
+  AC_MSG_RESULT([>>> Configuring library without deprecated code support <<<])
+else
+  AC_MSG_RESULT([<<< Configuring library with deprecated code support >>>])
+  AC_DEFINE(ENABLE_DEPRECATED, 1,
+           [Flag indicating if the library should support deprecated code])
+fi
+# --------------------------------------------------------------
+
+
+# --------------------------------------------------------------
 # blocked matrix/vector storage - disabled by default.
 #   See http://sourceforge.net/mailarchive/forum.php?thread_name=B4613A7D-0033-43C7-A9DF-5A801217A097%40nasa.gov&forum_name=libmesh-devel
 # --------------------------------------------------------------

--- a/src/apps/L2system.C
+++ b/src/apps/L2system.C
@@ -51,7 +51,7 @@ void L2System::init_data ()
 
 void L2System::init_context(DiffContext & context)
 {
-  FEMContext & c = libmesh_cast_ref<FEMContext &>(context);
+  FEMContext & c = cast_ref<FEMContext &>(context);
 
   // Now make sure we have requested all the data
   // we need to build the L2 system.
@@ -78,7 +78,7 @@ void L2System::init_context(DiffContext & context)
 bool L2System::element_time_derivative (bool request_jacobian,
                                         DiffContext & context)
 {
-  FEMContext & c = libmesh_cast_ref<FEMContext &>(context);
+  FEMContext & c = cast_ref<FEMContext &>(context);
 
   // First we get some references to cell-specific data that
   // will be used to assemble the linear system.

--- a/src/apps/L2system.h
+++ b/src/apps/L2system.h
@@ -29,7 +29,7 @@ public:
   // reference to the system where it applies and a separate context
   // object (or multiple separate context objects, in the threaded
   // case) for that system.
-  libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> > goal_func;
+  libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> > goal_func;
 
   libMesh::System * input_system;
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1027,6 +1027,7 @@ bool BoundaryInfo::has_boundary_id(const Node * const node,
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 std::vector<boundary_id_type> BoundaryInfo::boundary_ids(const Node * node) const
 {
   libmesh_deprecated();
@@ -1035,6 +1036,7 @@ std::vector<boundary_id_type> BoundaryInfo::boundary_ids(const Node * node) cons
   this->boundary_ids(node, ids);
   return ids;
 }
+#endif
 
 
 
@@ -1062,6 +1064,7 @@ unsigned int BoundaryInfo::n_boundary_ids(const Node * node) const
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 std::vector<boundary_id_type> BoundaryInfo::edge_boundary_ids (const Elem * const elem,
                                                                const unsigned short int edge) const
 {
@@ -1071,6 +1074,7 @@ std::vector<boundary_id_type> BoundaryInfo::edge_boundary_ids (const Elem * cons
   this->edge_boundary_ids(elem, edge, ids);
   return ids;
 }
+#endif
 
 
 
@@ -1144,6 +1148,7 @@ unsigned int BoundaryInfo::n_edge_boundary_ids (const Elem * const elem,
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 std::vector<boundary_id_type> BoundaryInfo::raw_edge_boundary_ids (const Elem * const elem,
                                                                    const unsigned short int edge) const
 {
@@ -1153,6 +1158,7 @@ std::vector<boundary_id_type> BoundaryInfo::raw_edge_boundary_ids (const Elem * 
   this->raw_edge_boundary_ids(elem, edge, ids);
   return ids;
 }
+#endif
 
 
 
@@ -1253,6 +1259,7 @@ void BoundaryInfo::raw_shellface_boundary_ids (const Elem * const elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 boundary_id_type BoundaryInfo::boundary_id(const Elem * const elem,
                                            const unsigned short int side) const
 {
@@ -1269,6 +1276,7 @@ boundary_id_type BoundaryInfo::boundary_id(const Elem * const elem,
   // element on this side.
   return *(ids.begin());
 }
+#endif
 
 
 
@@ -1283,6 +1291,7 @@ bool BoundaryInfo::has_boundary_id(const Elem * const elem,
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 std::vector<boundary_id_type> BoundaryInfo::boundary_ids (const Elem * const elem,
                                                           const unsigned short int side) const
 {
@@ -1292,6 +1301,7 @@ std::vector<boundary_id_type> BoundaryInfo::boundary_ids (const Elem * const ele
   this->boundary_ids(elem, side, ids);
   return ids;
 }
+#endif
 
 
 
@@ -1345,6 +1355,7 @@ unsigned int BoundaryInfo::n_boundary_ids (const Elem * const elem,
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 std::vector<boundary_id_type> BoundaryInfo::raw_boundary_ids (const Elem * const elem,
                                                               const unsigned short int side) const
 {
@@ -1354,6 +1365,7 @@ std::vector<boundary_id_type> BoundaryInfo::raw_boundary_ids (const Elem * const
   this->raw_boundary_ids(elem, side, ids);
   return ids;
 }
+#endif
 
 
 

--- a/src/mesh/boundary_mesh.C
+++ b/src/mesh/boundary_mesh.C
@@ -34,11 +34,13 @@ BoundaryMesh::BoundaryMesh(const Parallel::Communicator & comm_in,
 
 
 #ifndef LIBMESH_DISABLE_COMMWORLD
+#ifdef LIBMESH_ENABLE_DEPRECATED
 BoundaryMesh::BoundaryMesh(unsigned char d) :
   Mesh(d)
 {
   libmesh_deprecated();
 }
+#endif
 #endif
 
 

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -1015,7 +1015,7 @@ void CheckpointIO::read_remote_elem (Xdr & io, bool libmesh_dbg_var(expect_all_r
   for (std::size_t i=0; i != elem_ids.size(); ++i)
     {
       Elem & elem = mesh.elem_ref(cast_int<dof_id_type>(elem_ids[i]));
-      if (!elem.neighbor(elem_sides[i]))
+      if (!elem.neighbor_ptr(elem_sides[i]))
         elem.set_neighbor(elem_sides[i],
                           const_cast<RemoteElem *>(remote_elem));
       else

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -54,6 +54,7 @@ DistributedMesh::DistributedMesh (const Parallel::Communicator & comm_in,
 
 
 #ifndef LIBMESH_DISABLE_COMMWORLD
+#ifdef LIBMESH_ENABLE_DEPRECATED
 DistributedMesh::DistributedMesh (unsigned char d) :
   UnstructuredMesh (d), _is_serial(true), _is_serial_on_proc_0(true),
   _n_nodes(0), _n_elem(0), _max_node_id(0), _max_elem_id(0),
@@ -74,6 +75,7 @@ DistributedMesh::DistributedMesh (unsigned char d) :
   // FIXME: give parmetis the communicator!
   _partitioner = UniquePtr<Partitioner>(new ParmetisPartitioner());
 }
+#endif
 #endif
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -74,6 +74,7 @@ void ExodusII_IO::set_output_variables(const std::vector<std::string> & output_v
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 void ExodusII_IO::copy_nodal_solution(System & system,
                                       std::string var_name,
                                       unsigned int timestep)
@@ -81,6 +82,7 @@ void ExodusII_IO::copy_nodal_solution(System & system,
   libmesh_deprecated();
   copy_nodal_solution(system, var_name, var_name, timestep);
 }
+#endif
 
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -419,7 +419,7 @@ void ExodusII_IO::write_as_dimension(unsigned dim)
 
 void ExodusII_IO::set_coordinate_offset(Point p)
 {
-  libmesh_deprecated();
+  libmesh_warning("This method may be deprecated in the future");
   exio_helper->set_coordinate_offset(p);
 }
 

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -337,7 +337,7 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
         for (unsigned int s=0; s<elem->n_neighbors(); s++)
           {
             // check if element e is on the boundary
-            if (elem->neighbor(s) == libmesh_nullptr)
+            if (elem->neighbor_ptr(s) == libmesh_nullptr)
               {
                 // note that it is safe to use the Elem::side() method,
                 // which gives a non-full-ordered element

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -74,6 +74,7 @@ MeshBase::MeshBase (const Parallel::Communicator & comm_in,
 
 
 #ifndef LIBMESH_DISABLE_COMMWORLD
+#ifdef LIBMESH_ENABLE_DEPRECATED
 MeshBase::MeshBase (unsigned char d) :
   ParallelObject (CommWorld),
   boundary_info  (new BoundaryInfo(*this)),
@@ -97,6 +98,7 @@ MeshBase::MeshBase (unsigned char d) :
   libmesh_assert_greater_equal (LIBMESH_DIM, d);
   libmesh_assert (libMesh::initialized());
 }
+#endif
 #endif // !LIBMESH_DISABLE_COMMWORLD
 
 
@@ -512,6 +514,7 @@ unsigned int MeshBase::recalculate_n_partitions()
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 const PointLocatorBase & MeshBase::point_locator () const
 {
   libmesh_deprecated();
@@ -526,6 +529,7 @@ const PointLocatorBase & MeshBase::point_locator () const
 
   return *_point_locator;
 }
+#endif
 
 
 UniquePtr<PointLocatorBase> MeshBase::sub_point_locator () const

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1604,7 +1604,7 @@ struct ElemNodesMaybeNew
     // processor_id()
     unsigned int n_neigh = elem->n_neighbors();
     for (unsigned int s=0; s != n_neigh; ++s)
-      if (elem->neighbor(s) == remote_elem)
+      if (elem->neighbor_ptr(s) == remote_elem)
         return true;
     return false;
   }
@@ -1635,7 +1635,7 @@ struct NodeMaybeNew
     // processor_id()
     unsigned int n_neigh = elem->n_neighbors();
     for (unsigned int s=0; s != n_neigh; ++s)
-      if (elem->neighbor(s) == remote_elem)
+      if (elem->neighbor_ptr(s) == remote_elem)
         if (elem->is_node_on_side(local_node_num, s))
           return true;
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -392,7 +392,7 @@ void UnstructuredMesh::all_first_order ()
        */
       for (unsigned short s=0; s<so_elem->n_sides(); s++)
         {
-          if (so_elem->neighbor(s) == remote_elem)
+          if (so_elem->neighbor_ptr(s) == remote_elem)
             lo_elem->set_neighbor(s, const_cast<RemoteElem*>(remote_elem));
         }
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -325,6 +325,7 @@ void MeshTools::find_boundary_nodes (const MeshBase & mesh,
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 MeshTools::BoundingBox
 MeshTools::bounding_box(const MeshBase & mesh)
 {
@@ -334,6 +335,7 @@ MeshTools::bounding_box(const MeshBase & mesh)
   libmesh_deprecated();
   return MeshTools::create_bounding_box(mesh);
 }
+#endif
 
 
 
@@ -416,6 +418,7 @@ MeshTools::create_local_bounding_box (const MeshBase & mesh)
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 MeshTools::BoundingBox
 MeshTools::processor_bounding_box (const MeshBase & mesh,
                                    const processor_id_type pid)
@@ -423,6 +426,7 @@ MeshTools::processor_bounding_box (const MeshBase & mesh,
   libmesh_deprecated();
   return MeshTools::create_processor_bounding_box(mesh, pid);
 }
+#endif
 
 
 
@@ -466,6 +470,7 @@ MeshTools::processor_bounding_sphere (const MeshBase & mesh,
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 MeshTools::BoundingBox
 MeshTools::subdomain_bounding_box (const MeshBase & mesh,
                                    const subdomain_id_type sid)
@@ -473,6 +478,7 @@ MeshTools::subdomain_bounding_box (const MeshBase & mesh,
   libmesh_deprecated();
   return MeshTools::create_subdomain_bounding_box(mesh, sid);
 }
+#endif
 
 
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -133,6 +133,7 @@ ReplicatedMesh::ReplicatedMesh (const Parallel::Communicator & comm_in,
 
 
 #ifndef LIBMESH_DISABLE_COMMWORLD
+#ifdef LIBMESH_ENABLE_DEPRECATED
 ReplicatedMesh::ReplicatedMesh (unsigned char d) :
   UnstructuredMesh (d)
 {
@@ -144,6 +145,7 @@ ReplicatedMesh::ReplicatedMesh (unsigned char d) :
 #endif
   _partitioner = UniquePtr<Partitioner>(new MetisPartitioner());
 }
+#endif
 #endif
 
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -58,12 +58,14 @@ UnstructuredMesh::UnstructuredMesh (const Parallel::Communicator & comm_in,
 
 
 #ifndef LIBMESH_DISABLE_COMMWORLD
+#ifdef LIBMESH_ENABLE_DEPRECATED
 UnstructuredMesh::UnstructuredMesh (unsigned char d) :
   MeshBase (d)
 {
   libmesh_deprecated();
   libmesh_assert (libMesh::initialized());
 }
+#endif
 #endif
 
 

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -487,7 +487,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                               unsigned int n_neigh = child->n_neighbors();
                               for (unsigned int n=0; n != n_neigh; ++n)
                                 {
-                                  Elem * ncn = child->neighbor(n);
+                                  Elem * ncn = child->neighbor_ptr(n);
                                   if (ncn != remote_elem &&
                                       ncn->is_ancestor_of(current_elem))
                                     {

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -79,6 +79,7 @@ NumericVector<T>::build(const Parallel::Communicator & comm, const SolverPackage
 
 
 #ifndef LIBMESH_DISABLE_COMMWORLD
+#ifdef LIBMESH_ENABLE_DEPRECATED
 template <typename T>
 UniquePtr<NumericVector<T> >
 NumericVector<T>::build(const SolverPackage solver_package)
@@ -86,6 +87,7 @@ NumericVector<T>::build(const SolverPackage solver_package)
   libmesh_deprecated();
   return NumericVector<T>::build(CommWorld, solver_package);
 }
+#endif
 #endif
 
 

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -231,9 +231,9 @@ void PetscVector<T>::add_vector (const NumericVector<T> & v_in,
   // We shouldn't close() the matrix for you, as that would potentially modify the state of a const object.
   if (!A->closed())
     {
-      libmesh_deprecated();
       libmesh_warning("Matrix A must be assembled before calling PetscVector::add_vector(v, A).\n"
                       "Please update your code, as this warning will become an error in a future release.");
+      libmesh_deprecated();
       const_cast<PetscMatrix<T> *>(A)->close();
     }
 
@@ -259,9 +259,9 @@ void PetscVector<T>::add_vector_transpose (const NumericVector<T> & v_in,
   // We shouldn't close() the matrix for you, as that would potentially modify the state of a const object.
   if (!A->closed())
     {
-      libmesh_deprecated();
       libmesh_warning("Matrix A must be assembled before calling PetscVector::add_vector_transpose(v, A).\n"
                       "Please update your code, as this warning will become an error in a future release.");
+      libmesh_deprecated();
       const_cast<PetscMatrix<T> *>(A)->close();
     }
 
@@ -296,9 +296,9 @@ void PetscVector<T>::add_vector_conjugate_transpose (const NumericVector<T> & v_
   // We shouldn't close() the matrix for you, as that would potentially modify the state of a const object.
   if (!A->closed())
     {
-      libmesh_deprecated();
       libmesh_warning("Matrix A must be assembled before calling PetscVector::add_vector_conjugate_transpose(v, A).\n"
                       "Please update your code, as this warning will become an error in a future release.");
+      libmesh_deprecated();
       const_cast<PetscMatrix<T> *>(A)->close();
     }
 

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -657,6 +657,7 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
                       input_matrix->add_matrix(nodal_matrix, nodal_dof_indices);
                     }
                 }
+#ifdef LIBMESH_ENABLE_DEPRECATED
               else if(elem_assembly->is_nodal_rhs_values_overriden)
                 {
                   // This is the "old" implementation, to be deprecated soon.
@@ -678,6 +679,7 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
                       input_vector->add( dof_index, value);
                     }
                 }
+#endif
             }
         }
     }

--- a/src/systems/condensed_eigen_system.C
+++ b/src/systems/condensed_eigen_system.C
@@ -118,8 +118,16 @@ void CondensedEigenSystem::solve()
   libmesh_assert (es.parameters.have_parameter<unsigned int>("basis vectors"));
 
   if (this->assemble_before_solve)
-    // Assemble the linear system
-    this->assemble ();
+    {
+      // Assemble the linear system
+      this->assemble ();
+
+      // And close the assembled matrices; using a non-closed matrix
+      // with create_submatrix() is deprecated.
+      matrix_A->close();
+      if (generalized())
+        matrix_B->close();
+    }
 
   // If we reach here, then there should be some non-condensed dofs
   libmesh_assert(!local_non_condensed_dofs_vector.empty());

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -431,6 +431,7 @@ System & EquationSystems::add_system (const std::string & sys_type,
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 void EquationSystems::delete_system (const std::string & name)
 {
   libmesh_deprecated();
@@ -442,6 +443,7 @@ void EquationSystems::delete_system (const std::string & name)
 
   _systems.erase (name);
 }
+#endif
 
 
 

--- a/src/systems/equation_systems_io.C
+++ b/src/systems/equation_systems_io.C
@@ -342,7 +342,9 @@ void EquationSystems::_read_impl (const std::string & name,
         if (read_legacy_format)
           {
             libmesh_deprecated();
+#ifdef LIBMESH_ENABLE_DEPRECATED
             pos->second->read_legacy_data (io, read_additional_data);
+#endif
           }
         else
           if (read_parallel_files)

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -212,11 +212,13 @@ bool FEMContext::has_side_boundary_id(boundary_id_type id) const
 }
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 std::vector<boundary_id_type> FEMContext::side_boundary_ids() const
 {
   libmesh_deprecated();
   return _boundary_info.boundary_ids(&(this->get_elem()), side);
 }
+#endif
 
 
 void FEMContext::side_boundary_ids(std::vector<boundary_id_type> & vec_to_fill) const

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -306,6 +306,7 @@ void System::read_header (Xdr & io,
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 void System::read_legacy_data (Xdr & io,
                                const bool read_additional_data)
 {
@@ -508,6 +509,7 @@ void System::read_legacy_data (Xdr & io,
         }
     } // end if (_additional_data_written)
 }
+#endif
 
 
 

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -1014,6 +1014,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledefaultcommworld = @enabledefaultcommworld@
+enabledeprecated = @enabledeprecated@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@


### PR DESCRIPTION
While working on other matters I noticed a long-deprecated function being called, and wondered just how many of those are still hiding somewhere in our codes.

This option makes it much easier to find out.

```configure --disable-deprecated``` turns off as much support for deprecated code as possible: completely deprecated APIs are ifdef'ed out in that case, and in deprecated code paths the ```libmesh_deprecated()``` calls turn from warnings into errors.

I've bundled in many fixes for just-discovered deprecated code usage within the library.