### PR TITLE
More ranged-for loops, deprecate Node copy constructor

### DIFF
--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -304,7 +304,7 @@ void assemble_1D(EquationSystems & es,
       // Loop over the sides of this element. For a 1D element, the "sides"
       // are defined as the nodes on each edge of the element, i.e. 1D elements
       // have 2 sides.
-      for (unsigned int s=0; s<elem->n_sides(); s++)
+      for (auto s : elem->side_index_range())
         {
           // If this element has a NULL neighbor, then it is on the edge of the
           // mesh and we need to enforce a boundary condition using the penalty

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -667,7 +667,7 @@ void assemble_cd (EquationSystems & es,
         // The following loops over the sides of the element.
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
-        for (unsigned int s=0; s<elem->n_sides(); s++)
+        for (auto s : elem->side_index_range())
           if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               fe_face->reinit(elem, s);

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -796,7 +796,7 @@ void assemble_laplace(EquationSystems & es,
         // The following loops over the sides of the element.
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
-        for (unsigned int s=0; s<elem->n_sides(); s++)
+        for (auto s : elem->side_index_range())
           if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               fe_face->reinit(elem, s);

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -848,7 +848,7 @@ void assemble_biharmonic(EquationSystems & es,
         // The following loops over the sides of the element.
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
-        for (unsigned int s=0; s<elem->n_sides(); s++)
+        for (auto s : elem->side_index_range())
           if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               // The value of the shape functions at the quadrature

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -168,7 +168,7 @@ int main (int argc, char ** argv)
       {
         const Elem * elem = *el;
 
-        for (unsigned int side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if (elem->neighbor_ptr (side) == NULL)
             mesh.get_boundary_info().add_side(elem, side, BOUNDARY_ID);
       }

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -114,7 +114,7 @@ int main (int argc, char ** argv)
       bool
         found_side_max_x = false, found_side_max_y = false,
         found_side_min_y = false, found_side_max_z = false;
-      for (unsigned int side=0; side<elem->n_sides(); side++)
+      for (auto side : elem->side_index_range())
         {
           if (mesh.get_boundary_info().has_boundary_id(elem, side, BOUNDARY_ID_MAX_X))
             {
@@ -145,7 +145,7 @@ int main (int argc, char ** argv)
       // BOUNDARY_ID_MAX_X, BOUNDARY_ID_MAX_Y, BOUNDARY_ID_MAX_Z
       // then let's set a node boundary condition
       if (found_side_max_x && found_side_max_y && found_side_max_z)
-        for (unsigned int n=0; n<elem->n_nodes(); n++)
+        for (auto n : elem->node_index_range())
           if (elem->is_node_on_side(n, side_max_x) &&
               elem->is_node_on_side(n, side_max_y) &&
               elem->is_node_on_side(n, side_max_z))
@@ -155,7 +155,7 @@ int main (int argc, char ** argv)
       // BOUNDARY_ID_MAX_X and BOUNDARY_ID_MIN_Y
       // then let's set an edge boundary condition
       if (found_side_max_x && found_side_min_y)
-        for (unsigned int e=0; e<elem->n_edges(); e++)
+        for (auto e : elem->edge_index_range())
           if (elem->is_edge_on_side(e, side_max_x) &&
               elem->is_edge_on_side(e, side_min_y))
             mesh.get_boundary_info().add_edge(elem, e, EDGE_BOUNDARY_ID);

--- a/examples/introduction/introduction_ex3/introduction_ex3.C
+++ b/examples/introduction/introduction_ex3/introduction_ex3.C
@@ -395,7 +395,7 @@ void assemble_poisson(EquationSystems & es,
         // The following loop is over the sides of the element.
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
-        for (unsigned int side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               // The value of the shape functions at the quadrature

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -591,7 +591,7 @@ void assemble_shell (EquationSystems & es,
 
       // Find the side which is part of the physical plate boundary,
       // that is, the boundary of the original mesh without ghosts.
-      for (unsigned int s=0; s<elem->n_sides(); ++s)
+      for (auto s : elem->side_index_range())
         {
           const Tri3Subdivision * nb_elem = static_cast<const Tri3Subdivision *> (elem->neighbor_ptr(s));
           if (nb_elem == libmesh_nullptr || nb_elem->is_ghost())

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -445,7 +445,7 @@ void assemble_shell (EquationSystems & es,
 
       // First compute element data at the nodes
       std::vector<Point> nodes;
-      for (unsigned int i=0; i<elem->n_nodes(); ++i)
+      for (auto i : elem->node_index_range())
         nodes.push_back(elem->reference_elem()->node_ref(i));
       fe->reinit (elem, &nodes);
 
@@ -458,7 +458,7 @@ void assemble_shell (EquationSystems & es,
       //Store covariant basis and local orthonormal basis at the nodes
       std::vector<Eigen::Matrix3d> F0node;
       std::vector<Eigen::Matrix3d> Qnode;
-      for (unsigned int i=0; i<elem->n_nodes(); ++i)
+      for (auto i : elem->node_index_range())
         {
           Eigen::Vector3d a1;
           a1 << dxyzdxi[i](0), dxyzdxi[i](1), dxyzdxi[i](2);

--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -435,7 +435,7 @@ void assemble_helmholtz(EquationSystems & es,
       // The following loops over the sides of the element.
       // If the element has no neighbor on a side then that
       // side MUST live on a boundary of the domain.
-      for (unsigned int side=0; side<elem->n_sides(); side++)
+      for (auto side : elem->side_index_range())
         if (elem->neighbor(side) == libmesh_nullptr)
           {
             LOG_SCOPE("damping", "assemble_helmholtz");

--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -432,7 +432,7 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
       // The following loops over the sides of the element.
       // If the element has no neighbor on a side then that
       // side MUST live on a boundary of the domain.
-      for (unsigned int side=0; side<elem->n_sides(); side++)
+      for (auto side : elem->side_index_range())
         if (elem->neighbor_ptr(side) == libmesh_nullptr)
           {
             // The value of the shape functions at the quadrature

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -404,7 +404,7 @@ void assemble (EquationSystems & es,
         // The following loops over the sides of the element.
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
-        for (unsigned int s=0; s<elem->n_sides(); s++)
+        for (auto s : elem->side_index_range())
           if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               fe_face->reinit(elem, s);

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -276,7 +276,7 @@ void assemble_ellipticdg(EquationSystems & es,
       // The following loops over the sides of the element.
       // If the element has no neighbor on a side then that
       // side MUST live on a boundary of the domain.
-      for (unsigned int side=0; side<elem->n_sides(); side++)
+      for (auto side : elem->side_index_range())
         {
           if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {

--- a/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
+++ b/examples/miscellaneous/miscellaneous_ex6/miscellaneous_ex6.C
@@ -282,13 +282,13 @@ void add_cube_convex_hull_to_mesh(MeshBase & mesh,
       {
         Elem * elem = *it;
 
-        for (unsigned s=0; s<elem->n_sides(); ++s)
+        for (auto s : elem->side_index_range())
           if (elem->neighbor(s) == libmesh_nullptr)
             {
               // Add the node IDs of this side to the set
               UniquePtr<Elem> side = elem->side(s);
 
-              for (unsigned n=0; n<side->n_nodes(); ++n)
+              for (auto n : side->node_index_range())
                 node_id_map.insert(std::make_pair(side->node_id(n), /*dummy_value=*/0));
             }
       }
@@ -328,7 +328,7 @@ void add_cube_convex_hull_to_mesh(MeshBase & mesh,
 
             // Assign nodes in new elements.  Since this is an example,
             // we'll do it in several steps.
-            for (unsigned i=0; i<old_elem->n_nodes(); ++i)
+            for (auto i : old_elem->node_index_range())
               {
                 // Locate old node ID in the map
                 iterator it = node_id_map.find(old_elem->node_id(i));

--- a/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
+++ b/examples/miscellaneous/miscellaneous_ex9/augment_sparsity_on_interface.C
@@ -42,7 +42,7 @@ void AugmentSparsityOnInterface::mesh_reinit ()
       const Elem * elem = *el;
 
       {
-        for (unsigned char side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               if (_mesh.get_boundary_info().has_boundary_id(elem, side, _crack_boundary_lower))
@@ -51,13 +51,7 @@ void AugmentSparsityOnInterface::mesh_reinit ()
 
                   lower_centroids[std::make_pair(elem, side)] = side_elem->centroid();
                 }
-            }
-      }
 
-      {
-        for (unsigned char side=0; side<elem->n_sides(); side++)
-          if (elem->neighbor_ptr(side) == libmesh_nullptr)
-            {
               if (_mesh.get_boundary_info().has_boundary_id(elem, side, _crack_boundary_upper))
                 {
                   UniquePtr<const Elem> side_elem = elem->build_side_ptr(side);
@@ -163,7 +157,7 @@ void AugmentSparsityOnInterface::operator()
       if (elem->processor_id() != p)
         coupled_elements.insert (std::make_pair(elem, null_mat));
 
-      for (unsigned int side=0; side<elem->n_sides(); side++)
+      for (auto side : elem->side_index_range())
         if (elem->neighbor_ptr(side) == libmesh_nullptr)
           {
             ElementSideMap::const_iterator ltu_it =

--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -272,7 +272,7 @@ void assemble_poisson(EquationSystems & es,
 
       // Boundary flux provides forcing in this example
       {
-        for (unsigned int side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               if (mesh.get_boundary_info().has_boundary_id (elem, side, MIN_Z_BOUNDARY))
@@ -289,7 +289,7 @@ void assemble_poisson(EquationSystems & es,
 
       // Add boundary terms on the crack
       {
-        for (unsigned int side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               // Found the lower side of the crack. Assemble terms due to lower and upper in here.

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -152,7 +152,7 @@ int main(int argc, char ** argv)
 
       unsigned int side_max_x = 0, side_max_y = 0, side_max_z = 0;
       bool found_side_max_x = false, found_side_max_y = false, found_side_max_z = false;
-      for (unsigned int side=0; side<elem->n_sides(); side++)
+      for (auto side : elem->side_index_range())
         {
           if (mesh.get_boundary_info().has_boundary_id(elem, side, BOUNDARY_ID_MAX_X))
             {
@@ -178,7 +178,7 @@ int main(int argc, char ** argv)
       // then let's set a node boundary condition
       if (found_side_max_x && found_side_max_y && found_side_max_z)
         {
-          for (unsigned int n=0; n<elem->n_nodes(); n++)
+          for (auto n : elem->node_index_range())
             {
               if (elem->is_node_on_side(n, side_max_x) &&
                   elem->is_node_on_side(n, side_max_y) &&

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -227,9 +227,9 @@ int main (int argc, char ** argv)
             // node inside and one node outside the circle.
             bool node_in = false;
             bool node_out = false;
-            for (unsigned int i=0; i<elem->n_nodes(); i++)
+            for (auto & n : elem->node_ref_range())
               {
-                double d = elem->point(i).norm();
+                double d = n.norm();
                 if (d<0.8)
                   {
                     node_in = true;
@@ -592,7 +592,7 @@ void assemble_poisson(EquationSystems & es,
             // neighbor, check that neighbor's subdomain_id; if that
             // is different from 1, the side is also located on the
             // boundary.
-            for (unsigned int side=0; side<elem->n_sides(); side++)
+            for (auto side : elem->side_index_range())
               if ((elem->neighbor_ptr(side) == libmesh_nullptr) ||
                   (elem->neighbor_ptr(side)->subdomain_id()!=1))
                 {

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -541,7 +541,7 @@ void assemble_poisson(EquationSystems & es,
         // The following loops over the sides of the element.
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
-        for (unsigned int side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if ((elem->neighbor_ptr(side) == libmesh_nullptr) ||
               (elem->neighbor_ptr(side)->subdomain_id() != elem->subdomain_id()))
             {

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -361,13 +361,13 @@ void assemble_stokes (EquationSystems & es,
         // The following loops over the sides of the element.
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
-        for (unsigned int s=0; s<elem->n_sides(); s++)
+        for (auto s : elem->side_index_range())
           if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               UniquePtr<const Elem> side (elem->build_side_ptr(s));
 
               // Loop over the nodes on the side.
-              for (unsigned int ns=0; ns<side->n_nodes(); ns++)
+              for (auto ns : side->node_index_range())
                 {
                   // The location on the boundary of the current
                   // node.
@@ -389,7 +389,7 @@ void assemble_stokes (EquationSystems & es,
                   // Find the node on the element matching this node on
                   // the side.  That defined where in the element matrix
                   // the boundary condition will be applied.
-                  for (unsigned int n=0; n<elem->n_nodes(); n++)
+                  for (auto n : elem->node_index_range())
                     if (elem->node_id(n) == side->node_id(ns))
                       {
                         // Matrix contribution.

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -642,7 +642,7 @@ void assemble_stokes (EquationSystems & es,
           const Real penalty = 1.e10;
           const unsigned int pressure_node = 0;
           const Real p_value               = 0.0;
-          for (unsigned int c=0; c<elem->n_nodes(); c++)
+          for (auto c : elem->node_index_range())
             if (elem->node_id(c) == pressure_node)
               {
                 Kpp(c,c) += penalty;

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -309,7 +309,7 @@ void assemble_elasticity(EquationSystems & es,
         }
 
       {
-        for (unsigned int side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               const std::vector<std::vector<Real> > & phi_face = fe_face->get_phi();

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -329,7 +329,7 @@ void assemble_elasticity(EquationSystems & es,
 
       {
         std::vector<boundary_id_type> bc_ids;
-        for (unsigned int side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               mesh.get_boundary_info().boundary_ids (elem, side, bc_ids);

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -248,7 +248,7 @@ public:
         g_vec(1) = 0.;
         g_vec(2) = -1.;
         {
-          for (unsigned int side=0; side<elem->n_sides(); side++)
+          for (auto side : elem->side_index_range())
             if (elem->neighbor_ptr(side) == libmesh_nullptr)
               {
                 const std::vector<std::vector<Real> > & phi_face = fe_face->get_phi();
@@ -471,7 +471,7 @@ int main (int argc, char ** argv)
         found_side_max_x = false, found_side_max_y = false,
         found_side_min_y = false, found_side_max_z = false;
 
-      for (unsigned int side=0; side<elem->n_sides(); side++)
+      for (auto side : elem->side_index_range())
         {
           if (mesh.get_boundary_info().has_boundary_id(elem, side, BOUNDARY_ID_MAX_X))
             {
@@ -502,7 +502,7 @@ int main (int argc, char ** argv)
       // BOUNDARY_ID_MAX_X, BOUNDARY_ID_MAX_Y, BOUNDARY_ID_MAX_Z
       // then let's set a node boundary condition
       if (found_side_max_x && found_side_max_y && found_side_max_z)
-        for (unsigned int n=0; n<elem->n_nodes(); n++)
+        for (auto n : elem->node_index_range())
           if (elem->is_node_on_side(n, side_max_x) &&
               elem->is_node_on_side(n, side_max_y) &&
               elem->is_node_on_side(n, side_max_z))
@@ -513,7 +513,7 @@ int main (int argc, char ** argv)
       // BOUNDARY_ID_MAX_X and BOUNDARY_ID_MIN_Y
       // then let's set an edge boundary condition
       if (found_side_max_x && found_side_min_y)
-        for (unsigned int e=0; e<elem->n_edges(); e++)
+        for (auto e : elem->edge_index_range())
           if (elem->is_edge_on_side(e, side_max_x) &&
               elem->is_edge_on_side(e, side_min_y))
             mesh.get_boundary_info().add_edge(elem, e, EDGE_BOUNDARY_ID);

--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
@@ -90,7 +90,7 @@ void LinearElasticityWithContact::move_mesh (MeshBase & input_mesh,
       Elem * elem = *el;
       Elem * orig_elem = _sys.get_mesh().elem_ptr(elem->id());
 
-      for (unsigned int node_id=0; node_id<elem->n_nodes(); node_id++)
+      for (auto node_id : elem->node_index_range())
         {
           Node & node = elem->node_ref(node_id);
 
@@ -158,7 +158,7 @@ void LinearElasticityWithContact::initialize_contact_load_paths()
     {
       const Elem * elem = *el;
 
-      for (unsigned int side=0; side<elem->n_sides(); side++)
+      for (auto side : elem->side_index_range())
         {
           if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
@@ -173,7 +173,7 @@ void LinearElasticityWithContact::initialize_contact_load_paths()
 
               if (on_lower_contact_surface || on_upper_contact_surface)
                 {
-                  for (unsigned int node_index=0; node_index<elem->n_nodes(); node_index++)
+                  for (auto node_index : elem->node_index_range())
                     if (elem->is_node_on_side(node_index, side))
                       {
                         if (on_lower_contact_surface)

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -484,7 +484,7 @@ void assemble_cd (EquationSystems & es,
         // The following loops over the sides of the element.
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
-        for (unsigned int s=0; s<elem->n_sides(); s++)
+        for (auto s : elem->side_index_range())
           if (elem->neighbor_ptr(s) == libmesh_nullptr)
             {
               fe_face->reinit(elem, s);

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -466,7 +466,7 @@ void assemble_wave(EquationSystems & es,
         // be extended.
         //
         // don't do this for any side
-        for (unsigned int side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if (!true)
             // if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -393,7 +393,7 @@ void assemble_poisson(EquationSystems & es,
         // The following loop is over the sides of the element.
         // If the element has no neighbor on a side then that
         // side MUST live on a boundary of the domain.
-        for (unsigned int side=0; side<elem->n_sides(); side++)
+        for (auto side : elem->side_index_range())
           if (elem->neighbor_ptr(side) == libmesh_nullptr)
             {
               // The value of the shape functions at the quadrature

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -973,6 +973,7 @@ include_HEADERS = \
         utils/error_vector.h \
         utils/hashword.h \
         utils/ignore_warnings.h \
+        utils/int_range.h \
         utils/libmesh_nullptr.h \
         utils/location_maps.h \
         utils/mapvector.h \

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -68,16 +68,6 @@ protected:
    */
   ~DofObject ();
 
-  /**
-   * Copy-constructor.
-   */
-  DofObject (const DofObject &);
-
-  /**
-   * Deep-copying assignment operator
-   */
-  DofObject & operator= (const DofObject & dof_obj);
-
 public:
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -380,6 +370,24 @@ public:
    * Print out info for debugging.
    */
   void print_dof_info() const;
+
+  // Deep copy (or almost-copy) of DofObjects is now deprecated in
+  // derived classes; we keep these methods around solely for a couple
+  // tricky internal uses.
+#ifndef LIBMESH_ENABLE_DEPRECATED
+private:
+#endif
+
+  /**
+   * "Copy"-constructor.  Does not copy old_dof_object, but leaves it
+   * null in the new object.
+   */
+  DofObject (const DofObject &);
+
+  /**
+   * Deep-copying assignment operator
+   */
+  DofObject & operator= (const DofObject & dof_obj);
 
 private:
 

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -272,9 +272,8 @@ struct facelocal_pid : predicate<T>
   {
     if ((*it)->processor_id() == _pid)
       return true;
-    for (unsigned int n = 0; n != (*it)->n_neighbors(); ++n)
-      if ((*it)->neighbor_ptr(n) &&
-          (*it)->neighbor_ptr(n)->processor_id() == _pid)
+    for (auto n : (*it)->neighbor_ptr_range())
+      if (n && n->processor_id() == _pid)
         return true;
     return false;
   }

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2009,8 +2009,8 @@ void Elem::set_neighbor (const unsigned int i, Elem * n)
 inline
 bool Elem::has_neighbor (const Elem * elem) const
 {
-  for (unsigned int n=0; n<this->n_neighbors(); n++)
-    if (this->neighbor_ptr(n) == elem)
+  for (auto n : this->neighbor_ptr_range())
+    if (n == elem)
       return true;
 
   return false;
@@ -2021,10 +2021,9 @@ bool Elem::has_neighbor (const Elem * elem) const
 inline
 Elem * Elem::child_neighbor (Elem * elem)
 {
-  for (unsigned int n=0; n<elem->n_neighbors(); n++)
-    if (elem->neighbor_ptr(n) &&
-        elem->neighbor_ptr(n)->parent() == this)
-      return elem->neighbor_ptr(n);
+  for (auto n : elem->neighbor_ptr_range())
+    if (n && n->parent() == this)
+      return n;
 
   return libmesh_nullptr;
 }
@@ -2034,10 +2033,9 @@ Elem * Elem::child_neighbor (Elem * elem)
 inline
 const Elem * Elem::child_neighbor (const Elem * elem) const
 {
-  for (unsigned int n=0; n<elem->n_neighbors(); n++)
-    if (elem->neighbor_ptr(n) &&
-        elem->neighbor_ptr(n)->parent() == this)
-      return elem->neighbor_ptr(n);
+  for (auto n : elem->neighbor_ptr_range())
+    if (n && n->parent() == this)
+      return n;
 
   return libmesh_nullptr;
 }
@@ -2192,7 +2190,7 @@ unsigned int Elem::which_neighbor_am_i (const Elem * e) const
       libmesh_assert(eparent);
     }
 
-  for (unsigned int s=0; s<this->n_neighbors(); s++)
+  for (unsigned int s=0, n_s = this->n_sides(); s != n_s; ++s)
     if (this->neighbor_ptr(s) == eparent)
       return s;
 

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -605,11 +605,12 @@ public:
    * \returns The number of neighbors the element that has been derived
    * from this class has.
    *
-   * By default, only face (or edge in 2D) neighbors are stored, so
-   * this method returns n_sides(), however it may be overridden in a
-   * derived class.
+   * Only face (or edge in 2D) neighbors are stored, so this method
+   * returns n_sides().  At one point we intended to allow derived
+   * classes to override this, but too much current libMesh code
+   * assumes n_neighbors==n_sides.
    */
-  virtual unsigned int n_neighbors () const
+  unsigned int n_neighbors () const
   { return this->n_sides(); }
 
   /**

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -34,6 +34,7 @@
 #include "libmesh/auto_ptr.h"
 #include "libmesh/multi_predicates.h"
 #include "libmesh/pointer_to_pointer_iter.h"
+#include "libmesh/int_range.h"
 #include "libmesh/simple_range.h"
 #include "libmesh/variant_filter_iterator.h"
 #include "libmesh/hashword.h" // Used in compute_key() functions
@@ -190,6 +191,23 @@ public:
    * \returns The pointer to local \p Node \p i as a writable reference.
    */
   virtual Node * & set_node (const unsigned int i);
+
+  /**
+   * Nested classes for use iterating over all nodes of an element.
+   */
+  class NodeRefIter;
+  class ConstNodeRefIter;
+
+  /**
+   * Returns a range with all nodes of an element, usable in
+   * range-based for loops.  The exact type of the return value here
+   * may be subject to change in future libMesh releases, but the
+   * iterators will always dereference to produce a reference to a
+   * Node.
+   */
+  SimpleRange<NodeRefIter> node_ref_range();
+
+  SimpleRange<ConstNodeRefIter> node_ref_range() const;
 
   /**
    * \returns The subdomain that this element belongs to.
@@ -551,6 +569,12 @@ public:
   virtual unsigned int n_nodes () const = 0;
 
   /**
+   * \returns An integer range from 0 up to (but not including)
+   * the number of nodes this element contains.
+   */
+  IntRange<unsigned short> node_index_range () const;
+
+  /**
    * \returns The number of nodes the given child of this element
    * contains.  Except in odd cases like pyramid refinement this will
    * be the same as the number of nodes in the parent element.
@@ -570,6 +594,12 @@ public:
    * of edges, in 3D the number of sides is the number of faces.
    */
   virtual unsigned int n_sides () const = 0;
+
+  /**
+   * \returns An integer range from 0 up to (but not including)
+   * the number of sides this element has.
+   */
+  IntRange<unsigned short> side_index_range () const;
 
   /**
    * \returns The number of neighbors the element that has been derived
@@ -593,6 +623,12 @@ public:
    * from this class has.
    */
   virtual unsigned int n_edges () const = 0;
+
+  /**
+   * \returns An integer range from 0 up to (but not including)
+   * the number of edges this element has.
+   */
+  IntRange<unsigned short> edge_index_range () const;
 
   /**
    * This array maps the integer representation of the \p ElemType enum
@@ -1624,6 +1660,22 @@ protected:
 
 // ------------------------------------------------------------
 // Elem helper classes
+//
+class
+Elem::NodeRefIter : public PointerToPointerIter<Node>
+{
+public:
+  NodeRefIter (Node * const * nodepp) : PointerToPointerIter<Node>(nodepp) {}
+};
+
+
+class
+Elem::ConstNodeRefIter : public PointerToPointerIter<const Node>
+{
+public:
+  ConstNodeRefIter (const Node * const * nodepp) : PointerToPointerIter<const Node>(nodepp) {}
+};
+
 
 #ifdef LIBMESH_ENABLE_AMR
 class
@@ -1988,6 +2040,52 @@ const Elem * Elem::child_neighbor (const Elem * elem) const
 
   return libmesh_nullptr;
 }
+
+
+
+inline
+SimpleRange<Elem::NodeRefIter>
+Elem::node_ref_range()
+{
+  return {_nodes, _nodes+this->n_nodes()};
+}
+
+
+
+inline
+SimpleRange<Elem::ConstNodeRefIter>
+Elem::node_ref_range() const
+{
+  return {_nodes, _nodes+this->n_nodes()};
+}
+
+
+
+inline
+IntRange<unsigned short>
+Elem::node_index_range() const
+{
+  return {0, cast_int<unsigned short>(this->n_nodes())};
+}
+
+
+
+inline
+IntRange<unsigned short>
+Elem::edge_index_range() const
+{
+  return {0, cast_int<unsigned short>(this->n_edges())};
+}
+
+
+
+inline
+IntRange<unsigned short>
+Elem::side_index_range() const
+{
+  return {0, cast_int<unsigned short>(this->n_sides())};
+}
+
 
 
 

--- a/include/geom/node.h
+++ b/include/geom/node.h
@@ -68,8 +68,14 @@ public:
 
   /**
    * Copy-constructor.
+   *
+   * \deprecated - anyone copying a Node would almost certainly be
+   * better off copying the much cheaper Point or taking a reference
+   * to the Node.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   Node (const Node & n);
+#endif
 
   /**
    * Copy-constructor from a \p Point.  Optionally assigned the \p id.
@@ -89,8 +95,14 @@ public:
 
   /**
    * \returns A \p Node copied from \p n and wrapped in a smart pointer.
+   *
+   * \deprecated - anyone copying a Node would almost certainly be
+   * better off copying the much cheaper Point or taking a reference
+   * to the Node.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   static UniquePtr<Node> build (const Node & n);
+#endif
 
   /**
    * \returns A \p Node copied from \p p with id == \id and wrapped in a smart pointer.
@@ -222,6 +234,7 @@ Node::Node (const Real x,
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline
 Node::Node (const Node & n) :
   Point(n),
@@ -232,7 +245,9 @@ Node::Node (const Node & n) :
   _valence(n._valence)
 #endif
 {
+  libmesh_deprecated();
 }
+#endif
 
 
 
@@ -278,11 +293,14 @@ Node & Node::operator= (const Point & p)
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 inline
 UniquePtr<Node> Node::build(const Node & n)
 {
+  libmesh_deprecated();
   return UniquePtr<Node>(new Node(n));
 }
+#endif
 
 
 

--- a/include/geom/side.h
+++ b/include/geom/side.h
@@ -62,7 +62,7 @@ public:
     // libmesh_assert_less (_side_number, this->parent()->n_sides());
     libmesh_assert_equal_to ((this->dim()+1), this->parent()->dim());
 
-    for (unsigned int n=0; n != this->n_nodes(); ++n)
+    for (auto n : this->node_index_range())
       this->_nodes[n] = this->parent()->node_ptr
         (ParentType::side_nodes_map[_side_number][n]);
   }
@@ -124,7 +124,7 @@ public:
     libmesh_assert_less (_edge_number, this->parent()->n_edges());
     libmesh_assert_equal_to (this->dim(), 1);
 
-    for (unsigned int n=0; n != this->n_nodes(); ++n)
+    for (auto n : this->node_index_range())
       this->_nodes[n] = this->parent()->node_ptr
         (ParentType::edge_nodes_map[_edge_number][n]);
   }

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -404,6 +404,7 @@ include_HEADERS =  \
         utils/error_vector.h \
         utils/hashword.h \
         utils/ignore_warnings.h \
+        utils/int_range.h \
         utils/libmesh_nullptr.h \
         utils/location_maps.h \
         utils/mapvector.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -400,6 +400,7 @@ BUILT_SOURCES = \
         error_vector.h \
         hashword.h \
         ignore_warnings.h \
+        int_range.h \
         libmesh_nullptr.h \
         location_maps.h \
         mapvector.h \
@@ -1713,6 +1714,9 @@ hashword.h: $(top_srcdir)/include/utils/hashword.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 ignore_warnings.h: $(top_srcdir)/include/utils/ignore_warnings.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+int_range.h: $(top_srcdir)/include/utils/int_range.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 libmesh_nullptr.h: $(top_srcdir)/include/utils/libmesh_nullptr.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -624,7 +624,7 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	steady_system.h system.h system_norm.h system_subset.h \
 	system_subset_by_subdomain.h transient_system.h \
 	compare_types.h error_vector.h hashword.h ignore_warnings.h \
-	libmesh_nullptr.h location_maps.h mapvector.h \
+	int_range.h libmesh_nullptr.h location_maps.h mapvector.h \
 	null_output_iterator.h number_lookups.h ostream_proxy.h \
 	parameters.h perf_log.h perfmon.h plt_loader.h \
 	point_locator_base.h point_locator_tree.h \
@@ -2058,6 +2058,9 @@ hashword.h: $(top_srcdir)/include/utils/hashword.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 ignore_warnings.h: $(top_srcdir)/include/utils/ignore_warnings.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+int_range.h: $(top_srcdir)/include/utils/int_range.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 libmesh_nullptr.h: $(top_srcdir)/include/utils/libmesh_nullptr.h

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -572,7 +572,7 @@ void sync_node_data_by_element_id(MeshBase &       mesh,
               proc_id == DofObject::invalid_processor_id)
             continue;
 
-          for (unsigned int n=0; n != elem->n_nodes(); ++n)
+          for (auto n : elem->node_index_range())
             {
               if (!node_check(elem, n))
                 continue;
@@ -619,7 +619,7 @@ void sync_node_data_by_element_id(MeshBase &       mesh,
 
           const dof_id_type elem_id = elem->id();
 
-          for (unsigned int n=0; n != elem->n_nodes(); ++n)
+          for (auto n : elem->node_index_range())
             {
               if (!node_check(elem, n))
                 continue;

--- a/include/utils/int_range.h
+++ b/include/utils/int_range.h
@@ -1,0 +1,86 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2017 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_INT_RANGE_H
+#define LIBMESH_INT_RANGE_H
+
+// C++ Includes   -----------------------------------
+#include <map>
+
+namespace libMesh
+{
+
+/**
+ * The \p IntRange templated class is intended to make it easy to
+ * loop over integers which are indices of a container.
+ *
+ * In cases where such a range is defined by the result of a virtual
+ * function call, this allows range-based for loops to be easily
+ * written which make only a single such call, rather than a new call
+ * for each iteration.
+ *
+ * \author  Roy H. Stogner
+ */
+
+template <typename T>
+class IntRange
+{
+public:
+  class iterator {
+  public:
+    iterator (T i) : _i(i) {}
+
+    T operator* () const { return _i; }
+
+    const iterator & operator++ () {
+      ++_i;
+      return *this;
+    }
+
+    iterator operator++ (int) {
+      iterator returnval(*this);
+      ++_i;
+      return returnval;
+    }
+
+    bool operator== (const iterator & j) const {
+      return ( _i == j._i );
+    }
+
+    bool operator!= (const iterator & j) const {
+      return !(*this == j);
+    }
+
+  private:
+    T _i;
+  };
+
+  IntRange(T begin, T end) : _begin(begin), _end(end) {}
+
+  iterator begin() const { return _begin; }
+
+  iterator end () const { return _end; }
+
+private:
+  iterator _begin, _end;
+};
+
+} // namespace libMesh
+
+#endif // LIBMESH_INT_RANGE_H

--- a/src/apps/amr.C
+++ b/src/apps/amr.C
@@ -235,7 +235,7 @@ void assemble(EquationSystems & es,
       // You can't compute "area" (perimeter) if you are in 2D
       if (dim == 3)
         {
-          for (unsigned int side=0; side<elem->n_sides(); side++)
+          for (auto side : elem->side_index_range())
             if (elem->neighbor_ptr(side) == libmesh_nullptr)
               {
                 fe_face->reinit (elem, side);

--- a/src/base/default_coupling.C
+++ b/src/base/default_coupling.C
@@ -125,7 +125,7 @@ void DefaultCoupling::operator()
           if (elem->processor_id() != p)
             coupled_elements.insert (std::make_pair(elem,_dof_coupling));
 
-          for (unsigned int s=0; s<elem->n_sides(); s++)
+          for (auto s : elem->side_index_range())
             {
               const Elem * neigh = elem->neighbor_ptr(s);
 

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -51,6 +51,14 @@ DofObject::DofObject (const DofObject & dof_obj) :
   _processor_id  (dof_obj._processor_id),
   _idx_buf       (dof_obj._idx_buf)
 {
+  // DO NOT copy old_dof_object, because this isn't a *real* copy
+  // constructor, it's a "copy almost everything" constructor that
+  // is intended to be used solely for internal construction of
+  // old_dof_object, never for a true deep copy where the newly
+  // created object really matches the source object.
+  //
+  // if (dof_obj.old_dof_object)
+  //  this->old_dof_object = new DofObject(*(dof_obj.old_dof_object));
 
   // Check that everything worked
 #ifdef DEBUG

--- a/src/base/ghost_point_neighbors.C
+++ b/src/base/ghost_point_neighbors.C
@@ -67,9 +67,8 @@ void GhostPointNeighbors::operator()
       if (elem->processor_id() != p)
         coupled_elements.insert (std::make_pair(elem,nullcm));
 
-      for (unsigned int s=0; s != elem->n_sides(); ++s)
+      for (auto neigh : elem->neighbor_ptr_range())
         {
-          const Elem * neigh = elem->neighbor_ptr(s);
           if (neigh && neigh != remote_elem)
             {
 #ifdef LIBMESH_ENABLE_AMR
@@ -105,7 +104,7 @@ void GhostPointNeighbors::operator()
         interior_parents.insert (elem->interior_parent());
 
       // Add nodes connected to active local elements
-      for (unsigned int n=0; n<elem->n_nodes(); n++)
+      for (auto n : elem->node_index_range())
         connected_nodes.insert (elem->node_ptr(n));
     }
 
@@ -142,8 +141,8 @@ void GhostPointNeighbors::operator()
 
         // Add elements connected to nodes on active local elements
         if (elem->processor_id() != p)
-          for (unsigned int n=0; n<elem->n_nodes(); n++)
-            if (connected_nodes.count(elem->node_ptr(n)))
+          for (auto & n : elem->node_ref_range())
+            if (connected_nodes.count(&n))
               coupled_elements.insert
                 (std::make_pair(elem, nullcm));
       }

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -206,7 +206,7 @@ void JumpErrorEstimator::estimate_error (const System & system,
             (*(system.solution), dof_map, parent, Uparent, false);
 
           // Loop over the neighbors of the parent
-          for (unsigned int n_p=0; n_p<parent->n_neighbors(); n_p++)
+          for (auto n_p : parent->side_index_range())
             {
               if (parent->neighbor_ptr(n_p) != libmesh_nullptr) // parent has a neighbor here
                 {
@@ -295,7 +295,7 @@ void JumpErrorEstimator::estimate_error (const System & system,
       fine_context->pre_fe_reinit(system, e);
 
       // Loop over the neighbors of element e
-      for (unsigned int n_e=0; n_e<e->n_neighbors(); n_e++)
+      for (auto n_e : e->side_index_range())
         {
           if ((e->neighbor_ptr(n_e) != libmesh_nullptr) ||
               integrate_boundary_sides)

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -812,7 +812,7 @@ void FEAbstract::compute_node_constraints (NodeConstraints & constraints,
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
-  for (unsigned int s=0; s<elem->n_sides(); s++)
+  for (auto s : elem->side_index_range())
     if (elem->neighbor_ptr(s) != libmesh_nullptr &&
         elem->neighbor_ptr(s) != remote_elem)
       if (elem->neighbor_ptr(s)->level() < elem->level()) // constrain dofs shared between
@@ -959,7 +959,7 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
   // Look at the element faces.  Check to see if we need to
   // build constraints.
   std::vector<boundary_id_type> bc_ids;
-  for (unsigned short int s=0; s<elem->n_sides(); s++)
+  for (auto s : elem->side_index_range())
     {
       if (elem->neighbor_ptr(s))
         continue;

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -78,8 +78,8 @@ const Elem * primary_boundary_point_neighbor(const Elem * elem,
       // one of its sides is on a relevant boundary and that side
       // contains this vertex
       bool vertex_on_periodic_side = false;
-      for (unsigned short int ns = 0;
-           ns != pt_neighbor->n_sides(); ++ns)
+      for (unsigned short int ns = 0, max_ns = pt_neighbor->n_sides();
+           ns != max_ns; ++ns)
         {
           boundary_info.boundary_ids (pt_neighbor, ns, bc_ids);
 
@@ -142,8 +142,8 @@ const Elem * primary_boundary_edge_neighbor(const Elem * elem,
       // one of its sides is on this periodic boundary and that
       // side contains this edge
       bool vertex_on_periodic_side = false;
-      for (unsigned short int ns = 0;
-           ns != e_neighbor->n_sides(); ++ns)
+      for (unsigned short int ns = 0, max_ns = e_neighbor->n_sides();
+           ns != max_ns; ++ns)
         {
           boundary_info.boundary_ids (e_neighbor, ns, bc_ids);
 
@@ -1083,7 +1083,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
 
   // Project any side values (edges in 2D, faces in 3D)
   if (dim > 1 && cont != DISCONTINUOUS)
-    for (unsigned int s=0; s != elem->n_sides(); ++s)
+    for (unsigned int s=0, max_ns = elem->n_sides(); s != max_ns; ++s)
       {
         FEInterface::dofs_on_side(elem, dim, fe_type,
                                   s, new_side_dofs);
@@ -1437,7 +1437,7 @@ FEGenericBase<OutputType>::compute_proj_constraints (DofConstraints & constraint
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
-  for (unsigned int s=0; s<elem->n_sides(); s++)
+  for (unsigned int s = 0, max_ns = elem->n_sides(); s != max_ns; ++s)
     if (elem->neighbor_ptr(s) != libmesh_nullptr)
       {
         // Get pointers to the element's neighbor.
@@ -1733,7 +1733,8 @@ compute_periodic_constraints (DofConstraints & constraints,
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
-  for (unsigned short int s=0; s<elem->n_sides(); s++)
+  const unsigned short int max_ns = elem->n_sides();
+  for (unsigned short int s = 0; s != max_ns; ++s)
     {
       if (elem->neighbor_ptr(s))
         continue;
@@ -1948,8 +1949,8 @@ compute_periodic_constraints (DofConstraints & constraints,
                           // conditions for this variable
                           std::set<boundary_id_type> point_bcids;
 
-                          for (unsigned int new_s = 0; new_s !=
-                                 elem->n_sides(); ++new_s)
+                          for (unsigned int new_s = 0;
+                               new_s != max_ns; ++new_s)
                             {
                               if (!elem->is_node_on_side(n,new_s))
                                 continue;
@@ -2093,8 +2094,8 @@ compute_periodic_constraints (DofConstraints & constraints,
                           // conditions for this variable
                           std::set<boundary_id_type> edge_bcids;
 
-                          for (unsigned int new_s = 0; new_s !=
-                                 elem->n_sides(); ++new_s)
+                          for (unsigned int new_s = 0;
+                               new_s != max_ns; ++new_s)
                             {
                               if (!elem->is_node_on_side(n,new_s))
                                 continue;

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -78,8 +78,7 @@ const Elem * primary_boundary_point_neighbor(const Elem * elem,
       // one of its sides is on a relevant boundary and that side
       // contains this vertex
       bool vertex_on_periodic_side = false;
-      for (unsigned short int ns = 0, max_ns = pt_neighbor->n_sides();
-           ns != max_ns; ++ns)
+      for (auto ns : pt_neighbor->side_index_range())
         {
           boundary_info.boundary_ids (pt_neighbor, ns, bc_ids);
 
@@ -142,8 +141,7 @@ const Elem * primary_boundary_edge_neighbor(const Elem * elem,
       // one of its sides is on this periodic boundary and that
       // side contains this edge
       bool vertex_on_periodic_side = false;
-      for (unsigned short int ns = 0, max_ns = e_neighbor->n_sides();
-           ns != max_ns; ++ns)
+      for (auto ns : e_neighbor->side_index_range())
         {
           boundary_info.boundary_ids (e_neighbor, ns, bc_ids);
 
@@ -946,7 +944,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
 
   // In 3D, project any edge values next
   if (dim > 2 && cont != DISCONTINUOUS)
-    for (unsigned int e=0; e != elem->n_edges(); ++e)
+    for (auto e : elem->edge_index_range())
       {
         FEInterface::dofs_on_edge(elem, dim, fe_type,
                                   e, new_side_dofs);
@@ -1083,7 +1081,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
 
   // Project any side values (edges in 2D, faces in 3D)
   if (dim > 1 && cont != DISCONTINUOUS)
-    for (unsigned int s=0, max_ns = elem->n_sides(); s != max_ns; ++s)
+    for (auto s : elem->side_index_range())
       {
         FEInterface::dofs_on_side(elem, dim, fe_type,
                                   s, new_side_dofs);
@@ -1437,7 +1435,7 @@ FEGenericBase<OutputType>::compute_proj_constraints (DofConstraints & constraint
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
-  for (unsigned int s = 0, max_ns = elem->n_sides(); s != max_ns; ++s)
+  for (auto s : elem->side_index_range())
     if (elem->neighbor_ptr(s) != libmesh_nullptr)
       {
         // Get pointers to the element's neighbor.

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -696,7 +696,7 @@ void lagrange_compute_constraints (DofConstraints & constraints,
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
-  for (unsigned int s=0; s<elem->n_sides(); s++)
+  for (auto s : elem->side_index_range())
     if (elem->neighbor_ptr(s) != libmesh_nullptr &&
         elem->neighbor_ptr(s) != remote_elem)
       if (elem->neighbor_ptr(s)->level() < elem->level()) // constrain dofs shared between

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -625,9 +625,8 @@ void Elem::find_point_neighbors(const Point & p,
         {
           const Elem * elem = *it;
 
-          for (unsigned int s=0; s<elem->n_sides(); s++)
+          for (auto current_neighbor : elem->neighbor_ptr_range())
             {
-              const Elem * current_neighbor = elem->neighbor_ptr(s);
               if (current_neighbor &&
                   current_neighbor != remote_elem)    // we have a real neighbor on this side
                 {
@@ -712,9 +711,8 @@ void Elem::find_point_neighbors(std::set<const Elem *> & neighbor_set,
         {
           const Elem * elem = *it;
 
-          for (unsigned int s=0; s<elem->n_sides(); s++)
+          for (auto current_neighbor : elem->neighbor_ptr_range())
             {
-              const Elem * current_neighbor = elem->neighbor_ptr(s);
               if (current_neighbor &&
                   current_neighbor != remote_elem)    // we have a real neighbor on this side
                 {
@@ -816,9 +814,8 @@ void Elem::find_edge_neighbors(std::set<const Elem *> & neighbor_set) const
         {
           const Elem * elem = *it;
 
-          for (unsigned int s=0; s<elem->n_sides(); s++)
+          for (auto current_neighbor : elem->neighbor_ptr_range())
             {
-              const Elem * current_neighbor = elem->neighbor_ptr(s);
               if (current_neighbor &&
                   current_neighbor != remote_elem)    // we have a real neighbor on this side
                 {
@@ -1305,9 +1302,8 @@ void Elem::make_links_to_me_remote()
 #endif
 
   // Remotify any neighbor links
-  for (unsigned int s = 0; s != this->n_sides(); ++s)
+  for (auto neigh : this->neighbor_ptr_range())
     {
-      Elem * neigh = this->neighbor_ptr(s);
       if (neigh && neigh != remote_elem)
         {
           // My neighbor should never be more refined than me; my real
@@ -1415,9 +1411,8 @@ void Elem::remove_links_to_me()
 #endif
 
   // Nullify any neighbor links
-  for (unsigned int s = 0; s != this->n_sides(); ++s)
+  for (auto neigh : this->neighbor_ptr_range())
     {
-      Elem * neigh = this->neighbor_ptr(s);
       if (neigh && neigh != remote_elem)
         {
           // My neighbor should never be more refined than me; my real
@@ -1892,16 +1887,13 @@ void Elem::family_tree_by_subneighbor (std::vector<const Elem *> & family,
   if (!this->active())
     for (auto & c : this->child_ref_range())
       if (&c != remote_elem)
-        for (unsigned int s=0; s != c.n_sides(); ++s)
-          {
-            const Elem * child_neigh = c.neighbor_ptr(s);
-            if (child_neigh &&
-                (child_neigh == neighbor_in ||
-                 (child_neigh->parent() == neighbor_in &&
-                  child_neigh->is_ancestor_of(subneighbor))))
-              c.family_tree_by_subneighbor (family, child_neigh,
-                                            subneighbor, false);
-          }
+        for (auto child_neigh : c.neighbor_ptr_range())
+          if (child_neigh &&
+              (child_neigh == neighbor_in ||
+               (child_neigh->parent() == neighbor_in &&
+                child_neigh->is_ancestor_of(subneighbor))))
+            c.family_tree_by_subneighbor (family, child_neigh,
+                                          subneighbor, false);
 }
 
 
@@ -1934,16 +1926,13 @@ void Elem::total_family_tree_by_subneighbor (std::vector<const Elem *> & family,
   if (this->has_children())
     for (auto & c : this->child_ref_range())
       if (&c != remote_elem)
-        for (unsigned int s=0; s != c.n_sides(); ++s)
-          {
-            const Elem * child_neigh = c.neighbor_ptr(s);
-            if (child_neigh &&
-                (child_neigh == neighbor_in ||
-                 (child_neigh->parent() == neighbor_in &&
-                  child_neigh->is_ancestor_of(subneighbor))))
-              c.total_family_tree_by_subneighbor
-                (family, child_neigh, subneighbor, false);
-          }
+        for (auto child_neigh : c.neighbor_ptr_range())
+          if (child_neigh &&
+              (child_neigh == neighbor_in ||
+               (child_neigh->parent() == neighbor_in &&
+                child_neigh->is_ancestor_of(subneighbor))))
+            c.total_family_tree_by_subneighbor
+              (family, child_neigh, subneighbor, false);
 }
 
 

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1110,7 +1110,7 @@ bool Elem::has_topological_neighbor (const Elem * elem,
   if (has_neighbor(elem))
     return true;
 
-  for (unsigned int n=0; n<this->n_neighbors(); n++)
+  for (auto n : this->side_index_range())
     if (this->topological_neighbor(n, mesh, point_locator, pb))
       return true;
 
@@ -1136,9 +1136,9 @@ void Elem::libmesh_assert_valid_node_pointers() const
 
 void Elem::libmesh_assert_valid_neighbors() const
 {
-  for (unsigned int s=0; s<this->n_neighbors(); s++)
+  for (auto n : this->side_index_range())
     {
-      const Elem * neigh = this->neighbor_ptr(s);
+      const Elem * neigh = this->neighbor_ptr(n);
 
       // Any element might have a remote neighbor; checking
       // to make sure that's not inaccurate is tough.
@@ -1197,7 +1197,7 @@ void Elem::libmesh_assert_valid_neighbors() const
               // is an interior mesh element for which we're on a side.
               // Nothing to test for in that case.
               (my_parent->dim() == this->dim()))
-            libmesh_assert (!my_parent->neighbor_ptr(s));
+            libmesh_assert (!my_parent->neighbor_ptr(n));
         }
     }
 }
@@ -2673,7 +2673,7 @@ void Elem::nullify_neighbors ()
 {
   // Tell any of my neighbors about my death...
   // Looks strange, huh?
-  for (unsigned int n=0; n<this->n_neighbors(); n++)
+  for (auto n : this->side_index_range())
     {
       Elem * current_neighbor = this->neighbor_ptr(n);
       if (current_neighbor && current_neighbor != remote_elem)

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -1088,7 +1088,7 @@ void AbaqusIO::assign_sideset_ids()
               // information for it.  Note that we have not yet called
               // find_neighbors(), so we can't use elem->neighbor(sn) in
               // this algorithm...
-              for (unsigned short sn=0; sn<elem->n_sides(); sn++)
+              for (auto sn : elem->side_index_range())
                 {
                   std::pair<provide_bcs_t::const_iterator,
                             provide_bcs_t::const_iterator>

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -390,7 +390,7 @@ void CheckpointIO::write_remote_elem (Xdr & io,
     {
       const Elem & elem = **it;
 
-      for (unsigned int n=0; n != elem.n_neighbors(); ++n)
+      for (auto n : elem.side_index_range())
         {
           const Elem * neigh = elem.neighbor_ptr(n);
           if (neigh == remote_elem ||

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -548,7 +548,7 @@ void GmshIO::read_mesh(std::istream & in)
                             // the Mesh's BoundaryInfo object with the
                             // lower-dimensional element's subdomain
                             // ID.
-                            for (unsigned n=0; n<elem->n_nodes(); n++)
+                            for (auto n : elem->node_index_range())
                               mesh.get_boundary_info().add_node(elem->node_id(n),
                                                                 elem->subdomain_id());
 
@@ -579,7 +579,7 @@ void GmshIO::read_mesh(std::istream & in)
                             // Note that we have not yet called
                             // find_neighbors(), so we can't use
                             // elem->neighbor(sn) in this algorithm...
-                            for (unsigned short sn=0; sn<elem->n_sides(); sn++)
+                            for (auto sn : elem->side_index_range())
                               {
                                 // Look for the current side in the provide_bcs multimap.
                                 std::pair<provide_container_t::iterator,
@@ -754,11 +754,11 @@ void GmshIO::write_mesh (std::ostream & out_stream)
 
         // if there is a node translation table, use it
         if (eletype.nodes.size() > 0)
-          for (unsigned int i=0; i < elem->n_nodes(); i++)
+          for (auto i : elem->node_index_range())
             out_stream << elem->node_id(eletype.nodes[i])+1 << " "; // gmsh is 1-based
         // otherwise keep the same node order
         else
-          for (unsigned int i=0; i < elem->n_nodes(); i++)
+          for (auto i : elem->node_index_range())
             out_stream << elem->node_id(i)+1 << " ";                  // gmsh is 1-based
         out_stream << "\n";
       } // element loop
@@ -827,12 +827,12 @@ void GmshIO::write_mesh (std::ostream & out_stream)
 
             // if there is a node translation table, use it
             if (eletype.nodes.size() > 0)
-              for (unsigned int i=0; i < side->n_nodes(); i++)
+              for (auto i : side->node_index_range())
                 out_stream << side->node_id(eletype.nodes[i])+1 << " "; // gmsh is 1-based
 
             // otherwise keep the same node order
             else
-              for (unsigned int i=0; i < side->n_nodes(); i++)
+              for (auto i : side->node_index_range())
                 out_stream << side->node_id(i)+1 << " ";                // gmsh is 1-based
 
             // Go to the next line

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -334,7 +334,7 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
       {
         Elem * elem = *it;
 
-        for (unsigned int s=0; s<elem->n_neighbors(); s++)
+        for (auto s : elem->side_index_range())
           {
             // check if element e is on the boundary
             if (elem->neighbor_ptr(s) == libmesh_nullptr)

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -1601,9 +1601,8 @@ struct ElemNodesMaybeNew
     // If this element has remote_elem neighbors then there may have
     // been refinement of those neighbors that affect its nodes'
     // processor_id()
-    unsigned int n_neigh = elem->n_neighbors();
-    for (unsigned int s=0; s != n_neigh; ++s)
-      if (elem->neighbor_ptr(s) == remote_elem)
+    for (auto neigh : elem->neighbor_ptr_range())
+      if (neigh == remote_elem)
         return true;
     return false;
   }
@@ -1632,9 +1631,8 @@ struct NodeMaybeNew
     // If this node is on a side with a remote element then there may
     // have been refinement of that element which affects this node's
     // processor_id()
-    unsigned int n_neigh = elem->n_neighbors();
-    for (unsigned int s=0; s != n_neigh; ++s)
-      if (elem->neighbor_ptr(s) == remote_elem)
+    for (auto s : elem->side_index_range())
+      if (elem->neighbor(s) == remote_elem)
         if (elem->is_node_on_side(local_node_num, s))
           return true;
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -300,8 +300,8 @@ void reconnect_nodes (const std::set<const Elem *, CompareElemIdsByLevel> & conn
     {
       const Elem * elem = *elem_it;
 
-      for (unsigned int n=0; n<elem->n_nodes(); n++)
-        connected_nodes.insert(elem->node_ptr(n));
+      for (auto & n : elem->node_ref_range())
+        connected_nodes.insert(&n);
     }
 }
 
@@ -630,7 +630,7 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
           {
             my_interface_elements.push_back(elem); // add the element, but only once, even
             // if there are multiple NULL neighbors
-            for (unsigned int s=0; s<elem->n_sides(); s++)
+            for (auto s : elem->side_index_range())
               if (elem->neighbor_ptr(s) == libmesh_nullptr)
                 {
                   UniquePtr<const Elem> side(elem->build_side_ptr(s));
@@ -820,8 +820,8 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
                           elem = family_tree[leaf];
                           elements_to_send.insert (elem);
 
-                          for (unsigned int n=0; n<elem->n_nodes(); n++)
-                            connected_nodes.insert (elem->node_ptr(n));
+                          for (auto & n : elem->node_ref_range())
+                            connected_nodes.insert (&n);
                         }
                     }
                 }
@@ -1029,9 +1029,8 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
                     {
                       libmesh_assert(elem != remote_elem);
                       elements_to_send.insert(elem);
-                      for (unsigned int n=0, n_nodes = elem->n_nodes();
-                           n != n_nodes; ++n)
-                        nodes_to_send.insert(elem->node_ptr(n));
+                      for (auto & n : elem->node_ref_range())
+                        nodes_to_send.insert(&n);
                       elem = elem->parent();
                     }
                 }

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1332,7 +1332,7 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
                   // Container to catch ids handed back from BoundaryInfo
                   std::vector<boundary_id_type> ids;
 
-                  for (unsigned short s=0; s<base_hex->n_sides(); ++s)
+                  for (auto s : base_hex->side_index_range())
                     {
                       // Get the boundary ID(s) for this side
                       boundary_info.boundary_ids(*el, s, ids);
@@ -1919,13 +1919,13 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
         {
           Elem * elem = *it;
 
-          for (unsigned int s=0; s<elem->n_sides(); s++)
+          for (auto s : elem->side_index_range())
             if (elem->neighbor_ptr(s) == libmesh_nullptr || (mesh.mesh_dimension() == 2 && !flat))
               {
                 UniquePtr<Elem> side(elem->build_side_ptr(s));
 
                 // Pop each point to the sphere boundary
-                for (unsigned int n=0; n<side->n_nodes(); n++)
+                for (auto n : side->node_index_range())
                   side->point(n) =
                     sphere.closest_point(side->point(n));
               }
@@ -1966,13 +1966,13 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
         {
           Elem * elem = *it;
 
-          for (unsigned int s=0; s<elem->n_sides(); s++)
+          for (auto s : elem->side_index_range())
             if (elem->neighbor_ptr(s) == libmesh_nullptr)
               {
                 UniquePtr<Elem> side(elem->build_side_ptr(s));
 
                 // Pop each point to the sphere boundary
-                for (unsigned int n=0; n<side->n_nodes(); n++)
+                for (auto n : side->node_index_range())
                   side->point(n) =
                     sphere.closest_point(side->point(n));
               }
@@ -1992,7 +1992,7 @@ void MeshTools::Generation::build_sphere (UnstructuredMesh & mesh,
     for (; it != end; ++it)
       {
         Elem * elem = *it;
-        for (unsigned short s=0; s != elem->n_sides(); ++s)
+        for (auto s : elem->side_index_range())
           if (!elem->neighbor_ptr(s))
             boundary_info.add_side(elem, s, 0);
       }
@@ -2288,7 +2288,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
           new_elem = mesh.add_elem(new_elem);
 
           // Copy any old boundary ids on all sides
-          for (unsigned short s = 0; s != elem->n_sides(); ++s)
+          for (auto s : elem->side_index_range())
             {
               cross_section_boundary_info.boundary_ids(elem, s, ids_to_copy);
 
@@ -2411,7 +2411,7 @@ void MeshTools::Generation::build_delaunay_square(UnstructuredMesh & mesh,
     {
       const Elem * elem = *el;
 
-      for (unsigned int s=0; s<elem->n_sides(); s++)
+      for (auto s : elem->side_index_range())
         if (elem->neighbor_ptr(s) == libmesh_nullptr)
           {
             UniquePtr<const Elem> side (elem->build_side_ptr(s));

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1647,7 +1647,7 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
                  */
                 if (refinement_level == 0)
                   {
-                    for (unsigned int s=0; s<elem->n_neighbors(); s++)
+                    for (auto s : elem->side_index_range())
                       {
                         /*
                          * Only operate on sides which are on the

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -408,7 +408,7 @@ bool MeshRefinement::test_level_one (bool libmesh_dbg_var(libmesh_assert_pass))
       // Pointer to the element
       Elem * elem = *elem_it;
 
-      for (unsigned int n=0; n<elem->n_neighbors(); n++)
+      for (auto n : elem->side_index_range())
         {
           Elem * neighbor =
             topological_neighbor(elem, point_locator.get(), n);
@@ -938,7 +938,7 @@ bool MeshRefinement::make_coarsening_compatible()
                 {
                   const unsigned int my_level = elem->level();
 
-                  for (unsigned int n=0; n<elem->n_neighbors(); n++)
+                  for (auto n : elem->side_index_range())
                     {
                       const Elem * neighbor =
                         topological_neighbor(elem, point_locator.get(), n);
@@ -974,7 +974,7 @@ bool MeshRefinement::make_coarsening_compatible()
                 {
                   const unsigned int my_p_level = elem->p_level();
 
-                  for (unsigned int n=0; n<elem->n_neighbors(); n++)
+                  for (auto n : elem->side_index_range())
                     {
                       const Elem * neighbor =
                         topological_neighbor(elem, point_locator.get(), n);
@@ -1034,7 +1034,7 @@ bool MeshRefinement::make_coarsening_compatible()
               // our change has to propagate to neighboring
               // processors.
               if (my_flag_changed && !_mesh.is_serial())
-                for (unsigned int n=0; n != elem->n_neighbors(); ++n)
+                for (auto n : elem->side_index_range())
                   {
                     Elem * neigh =
                       topological_neighbor(elem, point_locator.get(), n);

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -175,7 +175,7 @@ Node * MeshRefinement::add_node(Elem & parent,
 
   Point p; // defaults to 0,0,0
 
-  for (unsigned int n=0; n != parent.n_nodes(); ++n)
+  for (auto n : parent.node_index_range())
     {
       // The value from the embedding matrix
       const float em_val = parent.embedding_matrix(child,node,n);
@@ -1282,12 +1282,16 @@ bool MeshRefinement::make_refinement_compatible()
           for (; el != end_el; ++el)
             {
               Elem * elem = *el;
+
+              const unsigned short n_sides = elem->n_sides();
+
               if (elem->refinement_flag() == Elem::REFINE)  // If the element is active and the
                 // h refinement flag is set
                 {
                   const unsigned int my_level = elem->level();
 
-                  for (unsigned int side=0; side != elem->n_sides(); side++)
+                  for (unsigned short side = 0; side != n_sides;
+                       ++side)
                     {
                       Elem * neighbor =
                         topological_neighbor(elem, point_locator.get(), side);
@@ -1345,7 +1349,7 @@ bool MeshRefinement::make_refinement_compatible()
                 {
                   const unsigned int my_p_level = elem->p_level();
 
-                  for (unsigned int side=0; side != elem->n_sides(); side++)
+                  for (unsigned int side=0; side != n_sides; side++)
                     {
                       Elem * neighbor =
                         topological_neighbor(elem, point_locator.get(), side);

--- a/src/mesh/mesh_refinement_smoothing.C
+++ b/src/mesh/mesh_refinement_smoothing.C
@@ -468,9 +468,8 @@ bool MeshRefinement::eliminate_unrefined_patches ()
         my_p_adjustment;
 
       // Check all the element neighbors
-      for (unsigned int n=0; n<elem->n_neighbors(); n++)
+      for (auto neighbor : elem->neighbor_ptr_range())
         {
-          const Elem * neighbor = elem->neighbor_ptr(n);
           // Quit if the element is on a local boundary
           if (neighbor == libmesh_nullptr || neighbor == remote_elem)
             {

--- a/src/mesh/mesh_smoother_laplace.C
+++ b/src/mesh/mesh_smoother_laplace.C
@@ -193,7 +193,7 @@ void LaplaceMeshSmoother::init()
             // Constant handle for the element
             const Elem * elem = *el;
 
-            for (unsigned int s=0; s<elem->n_neighbors(); s++)
+            for (auto s : elem->side_index_range())
               {
                 // Only operate on sides which are on the
                 // boundary or for which the current element's
@@ -225,7 +225,7 @@ void LaplaceMeshSmoother::init()
             // Shortcut notation for simplicity
             const Elem * elem = *el;
 
-            for (unsigned int f=0; f<elem->n_neighbors(); f++) // Loop over faces
+            for (auto f : elem->side_index_range()) // Loop over faces
               if ((elem->neighbor_ptr(f) == libmesh_nullptr) ||
                   (elem->id() > elem->neighbor_ptr(f)->id()))
                 {
@@ -233,7 +233,7 @@ void LaplaceMeshSmoother::init()
                   // be looking at its sides as well!
                   UniquePtr<const Elem> face = elem->build_side_ptr(f, /*proxy=*/false);
 
-                  for (unsigned int s=0; s<face->n_neighbors(); s++) // Loop over face's edges
+                  for (auto s : face->side_index_range()) // Loop over face's edges
                     {
                       // Here we can use a proxy
                       UniquePtr<const Elem> side = face->build_side_ptr(s);

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -117,7 +117,7 @@ void MeshTools::Subdivision::all_subdivision(MeshBase & mesh)
 
       if (mesh_has_boundary_data)
         {
-          for (unsigned short side = 0; side < elem->n_sides(); ++side)
+          for (auto side : elem->side_index_range())
             {
               mesh.get_boundary_info().boundary_ids(elem, side, ids);
 
@@ -219,7 +219,7 @@ void MeshTools::Subdivision::tag_boundary_ghosts(MeshBase & mesh)
       libmesh_assert_equal_to(elem->type(), TRI3SUBDIVISION);
 
       Tri3Subdivision * sd_elem = static_cast<Tri3Subdivision *>(elem);
-      for (unsigned int i = 0; i < elem->n_sides(); ++i)
+      for (auto i : elem->side_index_range())
         {
           if (elem->neighbor_ptr(i) == libmesh_nullptr)
             {
@@ -260,7 +260,7 @@ void MeshTools::Subdivision::add_boundary_ghosts(MeshBase & mesh)
       // triangle.  This prevents degenerated triangles in the mesh
       // corners and guarantees that the node in the middle of the
       // loop is of valence=6.
-      for (unsigned int i = 0; i < elem->n_sides(); ++i)
+      for (auto i : elem->side_index_range())
         {
           libmesh_assert_not_equal_to(elem->neighbor_ptr(i), elem);
 
@@ -339,7 +339,7 @@ void MeshTools::Subdivision::add_boundary_ghosts(MeshBase & mesh)
             }
         }
 
-      for (unsigned int i = 0; i < elem->n_sides(); ++i)
+      for (auto i : elem->side_index_range())
         {
           libmesh_assert_not_equal_to(elem->neighbor_ptr(i), elem);
           if (elem->neighbor_ptr(i) == libmesh_nullptr)
@@ -397,7 +397,7 @@ void MeshTools::Subdivision::add_boundary_ghosts(MeshBase & mesh)
       Tri3Subdivision * elem = *ghost_el;
       libmesh_assert(elem->is_ghost());
 
-      for (unsigned int i = 0; i < elem->n_sides(); ++i)
+      for (auto i : elem->side_index_range())
         {
           if (elem->neighbor_ptr(i) == libmesh_nullptr &&
               elem->neighbor_ptr(prev[i]) != libmesh_nullptr)

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -419,9 +419,9 @@ unsigned TetGenMeshInterface::check_hull_integrity()
           return 1;
         }
 
-      for (unsigned int i=0; i<elem->n_neighbors(); ++i)
+      for (auto neigh : elem->neighbor_ptr_range())
         {
-          if (elem->neighbor(i) == libmesh_nullptr)
+          if (neigh == libmesh_nullptr)
             {
               // libmesh_error_msg("ERROR: Non-convex hull, cannot be tetrahedralized.");
               return 2;

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -312,7 +312,7 @@ void MeshTools::find_boundary_nodes (const MeshBase & mesh,
     {
       const Elem * elem = *el;
 
-      for (unsigned int s=0; s<elem->n_neighbors(); s++)
+      for (auto s : elem->side_index_range())
         if (elem->neighbor_ptr(s) == libmesh_nullptr) // on the boundary
           {
             const UniquePtr<const Elem> side = elem->build_side_ptr(s);
@@ -1090,10 +1090,9 @@ void MeshTools::libmesh_assert_valid_node_pointers(const MeshBase & mesh)
       while (elem)
         {
           elem->libmesh_assert_valid_node_pointers();
-          for (unsigned int n=0; n != elem->n_neighbors(); ++n)
-            if (elem->neighbor_ptr(n) &&
-                elem->neighbor_ptr(n) != remote_elem)
-              elem->neighbor_ptr(n)->libmesh_assert_valid_node_pointers();
+          for (auto n : elem->neighbor_ptr_range())
+            if (n && n != remote_elem)
+              n->libmesh_assert_valid_node_pointers();
 
           libmesh_assert_not_equal_to (elem->parent(), remote_elem);
           elem = elem->parent();
@@ -1117,8 +1116,8 @@ void MeshTools::libmesh_assert_valid_remote_elems(const MeshBase & mesh)
       // We currently don't allow active_local_elements to have
       // remote_elem neighbors
       if (elem->active())
-        for (unsigned int n=0; n != elem->n_neighbors(); ++n)
-          libmesh_assert_not_equal_to (elem->neighbor_ptr(n), remote_elem);
+        for (auto n : elem->neighbor_ptr_range())
+          libmesh_assert_not_equal_to (n, remote_elem);
 
 #ifdef LIBMESH_ENABLE_AMR
       const Elem * parent = elem->parent();
@@ -1146,8 +1145,9 @@ void MeshTools::libmesh_assert_no_links_to_elem(const MeshBase & mesh,
       const Elem * elem = *el;
       libmesh_assert (elem);
       libmesh_assert_not_equal_to (elem->parent(), bad_elem);
-      for (unsigned int n=0; n != elem->n_neighbors(); ++n)
-        libmesh_assert_not_equal_to (elem->neighbor_ptr(n), bad_elem);
+      for (auto n : elem->neighbor_ptr_range())
+        libmesh_assert_not_equal_to (n, bad_elem);
+
 #ifdef LIBMESH_ENABLE_AMR
       if (elem->has_children())
         for (auto & child : elem->child_ref_range())

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1304,7 +1304,7 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
         } // end loop over element's nodes
 
       // Loop over element's neighbors, see if it has a neighbor which is off-processor
-      for (unsigned int n=0; n<elem->n_neighbors(); ++n)
+      for (auto n : elem->side_index_range())
         {
           if (elem->neighbor_ptr(n) != libmesh_nullptr)
             {

--- a/src/mesh/patch.C
+++ b/src/mesh/patch.C
@@ -43,11 +43,9 @@ void Patch::find_face_neighbors(std::set<const Elem *> & new_neighbors)
   for (; it != end_it; ++it)
     {
       const Elem * elem = *it;
-      for (unsigned int s=0; s<elem->n_sides(); s++)
-        if (elem->neighbor_ptr(s) != libmesh_nullptr)        // we have a neighbor on this side
+      for (auto neighbor : elem->neighbor_ptr_range())
+        if (neighbor != libmesh_nullptr)        // we have a neighbor on this side
           {
-            const Elem * neighbor = elem->neighbor_ptr(s);
-
 #ifdef LIBMESH_ENABLE_AMR
             if (!neighbor->active())          // the neighbor is *not* active,
               {                               // so add *all* neighboring

--- a/src/mesh/postscript_io.C
+++ b/src/mesh/postscript_io.C
@@ -236,7 +236,7 @@ void PostscriptIO::plot_linear_elem(const Elem * elem)
 
 void PostscriptIO::plot_quadratic_elem(const Elem * elem)
 {
-  for (unsigned int ns=0; ns<elem->n_sides(); ++ns)
+  for (auto ns : elem->side_index_range())
     {
       // Build the quadratic side
       UniquePtr<const Elem> side = elem->build_side_ptr(ns);

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1390,7 +1390,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
                 {
                   Elem * el = this->elem_ptr(elem_id);
                   fixed_elems.insert(elem_id);
-                  for (unsigned int s = 0; s < el->n_neighbors(); ++s)
+                  for (auto s : el->side_index_range())
                     {
                       if (el->neighbor_ptr(s) == libmesh_nullptr)
                         {

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -666,8 +666,8 @@ void ReplicatedMesh::renumber_nodes_and_elements ()
           if (_skip_renumber_nodes_and_elements)
             {
               // Add this elements nodes to the connected list
-              for (unsigned int n=0; n<el->n_nodes(); n++)
-                connected_nodes.insert(el->node_ptr(n));
+              for (auto & n : el->node_ref_range())
+                connected_nodes.insert(&n);
             }
           else  // We DO want node renumbering
             {
@@ -675,15 +675,15 @@ void ReplicatedMesh::renumber_nodes_and_elements ()
               // if they have not been numbered already.  Also,
               // position them in the _nodes vector so that they
               // are packed contiguously from the beginning.
-              for (unsigned int n=0; n<el->n_nodes(); n++)
-                if (el->node_id(n) == next_free_node)    // don't need to process
+              for (auto & n : el->node_ref_range())
+                if (n.id() == next_free_node)    // don't need to process
                   next_free_node++;                      // [(src == dst) below]
 
-                else if (el->node_id(n) > next_free_node) // need to process
+                else if (n.id() > next_free_node) // need to process
                   {
                     // The source and destination indices
                     // for this node
-                    const dof_id_type src_idx = el->node_id(n);
+                    const dof_id_type src_idx = n.id();
                     const dof_id_type dst_idx = next_free_node++;
 
                     // ensure we want to swap a valid nodes
@@ -931,7 +931,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
                 Elem * el = *elem_it;
 
                 // Now check whether elem has a face on the specified boundary
-                for (unsigned char side_id=0; side_id<el->n_sides(); ++side_id)
+                for (auto side_id : el->side_index_range())
                   if (el->neighbor_ptr(side_id) == libmesh_nullptr)
                     {
                       // Get *all* boundary IDs on this side, not just the first one!
@@ -940,8 +940,8 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
                       if (std::find(bc_ids.begin(), bc_ids.end(), id_array[i]) != bc_ids.end())
                         {
                           UniquePtr<Elem> side (el->build_side_ptr(side_id));
-                          for (unsigned int node_i=0; node_i<side->n_nodes(); ++node_i)
-                            set_array[i]->insert( side->node_id(node_i) );
+                          for (auto & n : side->node_ref_range())
+                            set_array[i]->insert(n.id());
 
                           h_min = std::min(h_min, side->hmin());
                           h_min_updated = true;
@@ -969,7 +969,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
                       // Also, check the edges on this side. We don't have to worry about
                       // updating neighbor info in this case since elements don't store
                       // neighbor info on edges.
-                      for (unsigned short edge_id=0; edge_id<el->n_edges(); ++edge_id)
+                      for (auto edge_id : el->edge_index_range())
                         {
                           if (el->is_edge_on_side(edge_id, side_id))
                             {
@@ -979,8 +979,8 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
                               if (std::find(bc_ids.begin(), bc_ids.end(), id_array[i]) != bc_ids.end())
                                 {
                                   UniquePtr<Elem> edge (el->build_edge_ptr(edge_id));
-                                  for (unsigned int node_i=0; node_i<edge->n_nodes(); ++node_i)
-                                    set_array[i]->insert( edge->node_id(node_i) );
+                                  for (auto & n : edge->node_ref_range())
+                                    set_array[i]->insert( n.id() );
 
                                   h_min = std::min(h_min, edge->hmin());
                                   h_min_updated = true;
@@ -1138,9 +1138,9 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
             // the current element ID back onto node_to_elems_map[this_node_id].
             // For that we will use the reverse mapping we created at
             // the same time as the forward mapping.
-            for (unsigned n=0; n<el->n_nodes(); ++n)
+            for (auto & n : el->node_ref_range())
               {
-                dof_id_type other_node_id = el->node_id(n);
+                dof_id_type other_node_id = n.id();
                 std::map<dof_id_type, dof_id_type>::iterator it =
                   other_to_this_node_map.find(other_node_id);
 
@@ -1481,7 +1481,7 @@ void ReplicatedMesh::stitching_helper (ReplicatedMesh * other_mesh,
         {
           Elem * el = *elem_it;
 
-          for (unsigned short side_id=0; side_id<el->n_sides(); side_id++)
+          for (auto side_id : el->side_index_range())
             {
               if (el->neighbor_ptr(side_id) != libmesh_nullptr)
                 {

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -199,7 +199,7 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
           {
             Elem * old_elem = *it;
             Elem * new_elem = old_elems_to_new_elems[old_elem];
-            for (unsigned int s=0; s != old_elem->n_neighbors(); ++s)
+            for (auto s : old_elem->side_index_range())
               {
                 const Elem * old_neighbor = old_elem->neighbor_ptr(s);
                 Elem * new_neighbor = old_elems_to_new_elems[old_neighbor];
@@ -257,7 +257,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
     for (element_iterator el = this->elements_begin(); el != el_end; ++el)
       {
         Elem * e = *el;
-        for (unsigned int s=0; s<e->n_neighbors(); s++)
+        for (auto s : e->side_index_range())
           if (e->neighbor_ptr(s) != remote_elem ||
               reset_remote_elements)
             e->set_neighbor(s, libmesh_nullptr);
@@ -283,7 +283,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
       {
         Elem * element = *el;
 
-        for (unsigned char ms=0; ms<element->n_neighbors(); ms++)
+        for (auto ms : element->side_index_range())
           {
           next_side:
             // If we haven't yet found a neighbor on this side, try.
@@ -424,7 +424,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
           libmesh_assert(parent);
           const unsigned int my_child_num = parent->which_child_am_i(current_elem);
 
-          for (unsigned int s=0; s < current_elem->n_neighbors(); s++)
+          for (auto s : current_elem->side_index_range())
             {
               if (current_elem->neighbor_ptr(s) == libmesh_nullptr ||
                   (current_elem->neighbor_ptr(s) == remote_elem &&
@@ -486,10 +486,8 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                               Elem * child = neigh->child_ptr(c);
                               if (child == remote_elem)
                                 continue;
-                              unsigned int n_neigh = child->n_neighbors();
-                              for (unsigned int n=0; n != n_neigh; ++n)
+                              for (auto ncn : child->neighbor_ptr_range())
                                 {
-                                  Elem * ncn = child->neighbor_ptr(n);
                                   if (ncn != remote_elem &&
                                       ncn->is_ancestor_of(current_elem))
                                     {

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -134,7 +134,7 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
 
         el->subdomain_id() = old->subdomain_id();
 
-        for (unsigned int s=0; s != old->n_sides(); ++s)
+        for (auto s : old->side_index_range())
           if (old->neighbor_ptr(s) == remote_elem)
             el->set_neighbor(s, const_cast<RemoteElem *>(remote_elem));
 
@@ -162,7 +162,7 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
 #endif // #ifdef LIBMESH_ENABLE_AMR
 
         //Assign all the nodes
-        for (unsigned int i=0;i<el->n_nodes();i++)
+        for (auto i : el->node_index_range())
           el->set_node(i) = this->node_ptr(old->node_id(i));
 
         // And start it off in the same subdomain
@@ -578,14 +578,12 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                 }
 
               bool child_contains_our_nodes = true;
-              for (unsigned int n=0; n != current_elem->n_nodes();
-                   ++n)
+              for (auto & n : current_elem->node_ref_range())
                 {
                   bool child_contains_this_node = false;
-                  for (unsigned int cn=0; cn != child.n_nodes();
-                       ++cn)
-                    if (child.point(cn).absolute_fuzzy_equals
-                        (current_elem->point(n), node_tolerance))
+                  for (auto & cn : child.node_ref_range())
+                    if (cn.absolute_fuzzy_equals
+                        (n, node_tolerance))
                       {
                         child_contains_this_node = true;
                         break;
@@ -756,7 +754,7 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh & new_mesh,
       libmesh_assert(new_elem);
 
       // Loop over the nodes on this element.
-      for (unsigned int n=0; n<old_elem->n_nodes(); n++)
+      for (auto n : old_elem->node_index_range())
         {
           const dof_id_type this_node_id = old_elem->node_id(n);
 
@@ -780,7 +778,7 @@ void UnstructuredMesh::create_submesh (UnstructuredMesh & new_mesh,
         }
 
       // Maybe add boundary conditions for this element
-      for (unsigned short s=0; s<old_elem->n_sides(); s++)
+      for (auto s : old_elem->side_index_range())
         {
           this->get_boundary_info().boundary_ids(old_elem, s, bc_ids);
           new_mesh.get_boundary_info().add_side (new_elem, s, bc_ids);

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -567,7 +567,7 @@ void UNVIO::groups_in (std::istream & in_file)
             // information for it.  Note that we have not yet called
             // find_neighbors(), so we can't use elem->neighbor(sn) in
             // this algorithm...
-            for (unsigned short sn=0; sn<elem->n_sides(); sn++)
+            for (auto sn : elem->side_index_range())
               {
                 // Look for this key in the provide_bcs map
                 std::pair<map_type::const_iterator,
@@ -1156,7 +1156,7 @@ void UNVIO::elements_out(std::ostream & out_file)
                << std::setw(10) << elem->n_nodes()     // No. of nodes per element
                << '\n';
 
-      for (unsigned int j=0; j<elem->n_nodes(); j++)
+      for (auto j : elem->node_index_range())
         {
           // assign_elem_nodes[j]-th node: i.e., j loops over the
           // libMesh numbering, and assign_elem_nodes[j] over the

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -997,8 +997,6 @@ void UNVIO::elements_out(std::ostream & out_file)
     {
       const Elem * elem = *it;
 
-      elem->n_nodes();
-
       switch (elem->type())
         {
 

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1088,7 +1088,7 @@ void XdrIO::write_serialized_bcs_helper (Xdr & io, const new_header_id_type n_bc
 
       if (bc_type == "side")
         {
-          for (unsigned short s=0; s<elem->n_sides(); s++)
+          for (auto s : elem->side_index_range())
             {
               boundary_info.boundary_ids (elem, s, bc_ids);
               for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
@@ -1105,7 +1105,7 @@ void XdrIO::write_serialized_bcs_helper (Xdr & io, const new_header_id_type n_bc
         }
       else if (bc_type == "edge")
         {
-          for (unsigned short e=0; e<elem->n_edges(); e++)
+          for (auto e : elem->edge_index_range())
             {
               boundary_info.edge_boundary_ids (elem, e, bc_ids);
               for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
@@ -1733,7 +1733,8 @@ void XdrIO::read_serialized_connectivity (Xdr & io, const dof_id_type n_elem, st
             }
 #endif
 
-          for (unsigned int n=0; n<elem->n_nodes(); n++, ++it)
+          for (unsigned int n=0, n_n = elem->n_nodes(); n != n_n;
+               n++, ++it)
             {
               const dof_id_type global_node_number =
                 cast_int<dof_id_type>(*it);
@@ -2221,7 +2222,7 @@ void XdrIO::pack_element (std::vector<xdr_id_type> & conn, const Elem * elem,
   conn.push_back (elem->p_level());
 #endif
 
-  for (unsigned int n=0; n<elem->n_nodes(); n++)
+  for (auto n : elem->node_index_range())
     conn.push_back (elem->node_id(n));
 }
 

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -148,13 +148,15 @@ Packing<const Elem *>::packable_size (const Elem * const & elem,
   unsigned int total_packed_bcs = 0;
   if (elem->level() == 0)
     {
-      total_packed_bcs += elem->n_sides();
-      for (unsigned short s = 0; s != elem->n_sides(); ++s)
+      const unsigned short n_sides = elem->n_sides();
+      total_packed_bcs += n_sides;
+      for (unsigned short s = 0; s != n_sides; ++s)
         total_packed_bcs +=
           mesh->get_boundary_info().n_boundary_ids(elem,s);
 
-      total_packed_bcs += elem->n_edges();
-      for (unsigned short e = 0; e != elem->n_edges(); ++e)
+      const unsigned short n_edges = elem->n_edges();
+      total_packed_bcs += n_edges;
+      for (unsigned short e = 0; e != n_edges; ++e)
         total_packed_bcs +=
           mesh->get_boundary_info().n_edge_boundary_ids(elem,e);
 
@@ -288,7 +290,7 @@ Packing<const Elem *>::pack (const Elem * const & elem,
   if (elem->level() == 0)
     {
       std::vector<boundary_id_type> bcs;
-      for (unsigned short s = 0; s != elem->n_sides(); ++s)
+      for (auto s : elem->side_index_range())
         {
           mesh->get_boundary_info().boundary_ids(elem, s, bcs);
 
@@ -299,7 +301,7 @@ Packing<const Elem *>::pack (const Elem * const & elem,
             *data_out++ =(*bc_it);
         }
 
-      for (unsigned short e = 0; e != elem->n_edges(); ++e)
+      for (auto e : elem->edge_index_range())
         {
           mesh->get_boundary_info().edge_boundary_ids(elem, e, bcs);
 
@@ -767,7 +769,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
   // add any element side or edge boundary condition ids
   if (level == 0)
     {
-      for (unsigned short s = 0; s != elem->n_sides(); ++s)
+      for (auto s : elem->side_index_range())
         {
           const boundary_id_type num_bcs =
             cast_int<boundary_id_type>(*in++);
@@ -777,7 +779,7 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
               (elem, s, cast_int<boundary_id_type>(*in++));
         }
 
-      for (unsigned short e = 0; e != elem->n_edges(); ++e)
+      for (auto e : elem->edge_index_range())
         {
           const boundary_id_type num_bcs =
             cast_int<boundary_id_type>(*in++);

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -222,10 +222,8 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
             // Loop over the element's neighbors.  An element
             // adjacency corresponds to a face neighbor
-            for (unsigned int ms=0; ms<elem->n_neighbors(); ms++)
+            for (auto neighbor : elem->neighbor_ptr_range())
               {
-                const Elem * neighbor = elem->neighbor_ptr(ms);
-
                 if (neighbor != libmesh_nullptr)
                   {
                     // If the neighbor is active, but is not in the
@@ -330,10 +328,8 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
             // Loop over the element's neighbors.  An element
             // adjacency corresponds to a face neighbor
-            for (unsigned int ms=0; ms<elem->n_neighbors(); ms++)
+            for (auto neighbor : elem->neighbor_ptr_range())
               {
-                const Elem * neighbor = elem->neighbor_ptr(ms);
-
                 if (neighbor != libmesh_nullptr)
                   {
                     // If the neighbor is active, but is not in the

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -493,10 +493,8 @@ void ParmetisPartitioner::build_graph (const MeshBase & mesh)
 
       // Loop over the element's neighbors.  An element
       // adjacency corresponds to a face neighbor
-      for (unsigned int ms=0; ms<elem->n_neighbors(); ms++)
+      for (auto neighbor : elem->neighbor_ptr_range())
         {
-          const Elem * neighbor = elem->neighbor_ptr(ms);
-
           if (neighbor != libmesh_nullptr)
             {
               // If the neighbor is active treat it

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,7 +30,6 @@ unit_tests_sources = \
   fe/fe_test.h \
   fe/fe_xyz_test.C \
   geom/elem_test.C \
-  geom/node_test.C \
   geom/point_test.C \
   geom/point_test.h \
   geom/which_node_am_i_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -187,8 +187,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
 	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
 	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
-	geom/elem_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
+	geom/elem_test.C geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -231,7 +231,6 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_xyz_test.$(OBJEXT) \
 	geom/unit_tests_dbg-elem_test.$(OBJEXT) \
-	geom/unit_tests_dbg-node_test.$(OBJEXT) \
 	geom/unit_tests_dbg-point_test.$(OBJEXT) \
 	geom/unit_tests_dbg-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-all_tri.$(OBJEXT) \
@@ -288,8 +287,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
 	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
 	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
-	geom/elem_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
+	geom/elem_test.C geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -331,7 +330,6 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	fe/unit_tests_devel-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_xyz_test.$(OBJEXT) \
 	geom/unit_tests_devel-elem_test.$(OBJEXT) \
-	geom/unit_tests_devel-node_test.$(OBJEXT) \
 	geom/unit_tests_devel-point_test.$(OBJEXT) \
 	geom/unit_tests_devel-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_devel-all_tri.$(OBJEXT) \
@@ -385,8 +383,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
 	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
 	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
-	geom/elem_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
+	geom/elem_test.C geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -428,7 +426,6 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_xyz_test.$(OBJEXT) \
 	geom/unit_tests_oprof-elem_test.$(OBJEXT) \
-	geom/unit_tests_oprof-node_test.$(OBJEXT) \
 	geom/unit_tests_oprof-point_test.$(OBJEXT) \
 	geom/unit_tests_oprof-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-all_tri.$(OBJEXT) \
@@ -482,8 +479,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
 	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
 	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
-	geom/elem_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
+	geom/elem_test.C geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -525,7 +522,6 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	fe/unit_tests_opt-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_xyz_test.$(OBJEXT) \
 	geom/unit_tests_opt-elem_test.$(OBJEXT) \
-	geom/unit_tests_opt-node_test.$(OBJEXT) \
 	geom/unit_tests_opt-point_test.$(OBJEXT) \
 	geom/unit_tests_opt-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_opt-all_tri.$(OBJEXT) \
@@ -578,8 +574,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
 	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
 	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
-	geom/elem_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
+	geom/elem_test.C geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -621,7 +617,6 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	fe/unit_tests_prof-fe_szabab_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_xyz_test.$(OBJEXT) \
 	geom/unit_tests_prof-elem_test.$(OBJEXT) \
-	geom/unit_tests_prof-node_test.$(OBJEXT) \
 	geom/unit_tests_prof-point_test.$(OBJEXT) \
 	geom/unit_tests_prof-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_prof-all_tri.$(OBJEXT) \
@@ -1092,8 +1087,8 @@ unit_tests_sources = driver.C test_comm.h stream_redirector.h \
 	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
 	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
 	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
-	geom/elem_test.C geom/node_test.C geom/point_test.C \
-	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
+	geom/elem_test.C geom/point_test.C geom/point_test.h \
+	geom/which_node_am_i_test.C mesh/all_tri.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/mixed_dim_mesh_test.C \
 	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
@@ -1243,8 +1238,6 @@ geom/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) geom/$(DEPDIR)
 	@: > geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_dbg-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
-	geom/$(DEPDIR)/$(am__dirstamp)
-geom/unit_tests_dbg-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_dbg-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
@@ -1405,8 +1398,6 @@ fe/unit_tests_devel-fe_xyz_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
-geom/unit_tests_devel-node_test.$(OBJEXT): geom/$(am__dirstamp) \
-	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_devel-which_node_am_i_test.$(OBJEXT):  \
@@ -1517,8 +1508,6 @@ fe/unit_tests_oprof-fe_szabab_test.$(OBJEXT): fe/$(am__dirstamp) \
 fe/unit_tests_oprof-fe_xyz_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_oprof-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
-	geom/$(DEPDIR)/$(am__dirstamp)
-geom/unit_tests_oprof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_oprof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
@@ -1631,8 +1620,6 @@ fe/unit_tests_opt-fe_xyz_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
-geom/unit_tests_opt-node_test.$(OBJEXT): geom/$(am__dirstamp) \
-	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_opt-which_node_am_i_test.$(OBJEXT):  \
@@ -1743,8 +1730,6 @@ fe/unit_tests_prof-fe_szabab_test.$(OBJEXT): fe/$(am__dirstamp) \
 fe/unit_tests_prof-fe_xyz_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_prof-elem_test.$(OBJEXT): geom/$(am__dirstamp) \
-	geom/$(DEPDIR)/$(am__dirstamp)
-geom/unit_tests_prof-node_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
 geom/unit_tests_prof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 	geom/$(DEPDIR)/$(am__dirstamp)
@@ -1929,23 +1914,18 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_opt-autodiff.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_prof-autodiff.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-elem_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_dbg-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-elem_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_devel-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-elem_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_oprof-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-elem_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_opt-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-elem_test.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-node_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@geom/$(DEPDIR)/unit_tests_prof-which_node_am_i_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-all_tri.Po@am__quote@
@@ -2380,20 +2360,6 @@ geom/unit_tests_dbg-elem_test.obj: geom/elem_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_dbg-elem_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
-
-geom/unit_tests_dbg-node_test.o: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_dbg-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_dbg-node_test.Tpo -c -o geom/unit_tests_dbg-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_dbg-node_test.Tpo geom/$(DEPDIR)/unit_tests_dbg-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_dbg-node_test.o' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-
-geom/unit_tests_dbg-node_test.obj: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_dbg-node_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_dbg-node_test.Tpo -c -o geom/unit_tests_dbg-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_dbg-node_test.Tpo geom/$(DEPDIR)/unit_tests_dbg-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_dbg-node_test.obj' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_dbg-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
 
 geom/unit_tests_dbg-point_test.o: geom/point_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_dbg-point_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_dbg-point_test.Tpo -c -o geom/unit_tests_dbg-point_test.o `test -f 'geom/point_test.C' || echo '$(srcdir)/'`geom/point_test.C
@@ -3151,20 +3117,6 @@ geom/unit_tests_devel-elem_test.obj: geom/elem_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
 
-geom/unit_tests_devel-node_test.o: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_devel-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_devel-node_test.Tpo -c -o geom/unit_tests_devel-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_devel-node_test.Tpo geom/$(DEPDIR)/unit_tests_devel-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_devel-node_test.o' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-
-geom/unit_tests_devel-node_test.obj: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_devel-node_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_devel-node_test.Tpo -c -o geom/unit_tests_devel-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_devel-node_test.Tpo geom/$(DEPDIR)/unit_tests_devel-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_devel-node_test.obj' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_devel-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
-
 geom/unit_tests_devel-point_test.o: geom/point_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_devel-point_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_devel-point_test.Tpo -c -o geom/unit_tests_devel-point_test.o `test -f 'geom/point_test.C' || echo '$(srcdir)/'`geom/point_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_devel-point_test.Tpo geom/$(DEPDIR)/unit_tests_devel-point_test.Po
@@ -3920,20 +3872,6 @@ geom/unit_tests_oprof-elem_test.obj: geom/elem_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_oprof-elem_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
-
-geom/unit_tests_oprof-node_test.o: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_oprof-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_oprof-node_test.Tpo -c -o geom/unit_tests_oprof-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_oprof-node_test.Tpo geom/$(DEPDIR)/unit_tests_oprof-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_oprof-node_test.o' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-
-geom/unit_tests_oprof-node_test.obj: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_oprof-node_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_oprof-node_test.Tpo -c -o geom/unit_tests_oprof-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_oprof-node_test.Tpo geom/$(DEPDIR)/unit_tests_oprof-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_oprof-node_test.obj' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_oprof-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
 
 geom/unit_tests_oprof-point_test.o: geom/point_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_oprof-point_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_oprof-point_test.Tpo -c -o geom/unit_tests_oprof-point_test.o `test -f 'geom/point_test.C' || echo '$(srcdir)/'`geom/point_test.C
@@ -4691,20 +4629,6 @@ geom/unit_tests_opt-elem_test.obj: geom/elem_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
 
-geom/unit_tests_opt-node_test.o: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_opt-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_opt-node_test.Tpo -c -o geom/unit_tests_opt-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_opt-node_test.Tpo geom/$(DEPDIR)/unit_tests_opt-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_opt-node_test.o' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-
-geom/unit_tests_opt-node_test.obj: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_opt-node_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_opt-node_test.Tpo -c -o geom/unit_tests_opt-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_opt-node_test.Tpo geom/$(DEPDIR)/unit_tests_opt-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_opt-node_test.obj' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_opt-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
-
 geom/unit_tests_opt-point_test.o: geom/point_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_opt-point_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_opt-point_test.Tpo -c -o geom/unit_tests_opt-point_test.o `test -f 'geom/point_test.C' || echo '$(srcdir)/'`geom/point_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_opt-point_test.Tpo geom/$(DEPDIR)/unit_tests_opt-point_test.Po
@@ -5460,20 +5384,6 @@ geom/unit_tests_prof-elem_test.obj: geom/elem_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/elem_test.C' object='geom/unit_tests_prof-elem_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-elem_test.obj `if test -f 'geom/elem_test.C'; then $(CYGPATH_W) 'geom/elem_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/elem_test.C'; fi`
-
-geom/unit_tests_prof-node_test.o: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_prof-node_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_prof-node_test.Tpo -c -o geom/unit_tests_prof-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_prof-node_test.Tpo geom/$(DEPDIR)/unit_tests_prof-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_prof-node_test.o' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-node_test.o `test -f 'geom/node_test.C' || echo '$(srcdir)/'`geom/node_test.C
-
-geom/unit_tests_prof-node_test.obj: geom/node_test.C
-@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_prof-node_test.obj -MD -MP -MF geom/$(DEPDIR)/unit_tests_prof-node_test.Tpo -c -o geom/unit_tests_prof-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
-@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) geom/$(DEPDIR)/unit_tests_prof-node_test.Tpo geom/$(DEPDIR)/unit_tests_prof-node_test.Po
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='geom/node_test.C' object='geom/unit_tests_prof-node_test.obj' libtool=no @AMDEPBACKSLASH@
-@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
-@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o geom/unit_tests_prof-node_test.obj `if test -f 'geom/node_test.C'; then $(CYGPATH_W) 'geom/node_test.C'; else $(CYGPATH_W) '$(srcdir)/geom/node_test.C'; fi`
 
 geom/unit_tests_prof-point_test.o: geom/point_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT geom/unit_tests_prof-point_test.o -MD -MP -MF geom/$(DEPDIR)/unit_tests_prof-point_test.Tpo -c -o geom/unit_tests_prof-point_test.o `test -f 'geom/point_test.C' || echo '$(srcdir)/'`geom/point_test.C


### PR DESCRIPTION
This PR adds Elem::side/edge/node_index_range() methods, which seem to be the most terse way to efficiently loop over ranges of indices from 0 to Elem::n_foo().  Using these ranges replaces a lot of one-virtual-call-per-iteration loops with one-virtual-call loops.  I think the new loops may be easier for compilers to unroll, too.

It also adds Elem::node_ref_range(), which iterates directly over element nodes the way child_ref_range() does over children, and which likewise is a little more terse (and a little more typo safe now, and possibly a little more efficient) than iterating over and evaluating indices.

Finally, we deprecate the Node copy constructor, which makes node_ref_range() (and plain Node referencing) safer to use by avoiding inadvertent copying, fixing #1451.

As with #1447, this is probably broken into far more commits than necessary, but unfortunately these aren't regexp-automated changes, I have made (and found and fixed and rebased) a couple typos, and in case there are still any subtle bugs left I'd like to be able to bisect them precisely.