### PR TITLE
Redo naming scheme for Checkpoint IO

### DIFF
--- a/src/apps/splitter.C
+++ b/src/apps/splitter.C
@@ -153,8 +153,7 @@ int main (int argc, char ** argv)
           cpr.parallel() = true;
           cpr.binary() = binary;
           std::ostringstream outputname;
-          outputname << remove_extension(filename) << '.' << n_procs
-            << (binary ? ".cpr" : ".cpa");
+          outputname << remove_extension(filename) << (binary ? ".cpr" : ".cpa");
           cpr.write(outputname.str());
         }
     }


### PR DESCRIPTION
Ok - the "new" naming scheme for parallel checkpoint IO wasn't working for me.  I'm putting this up as an idea (that I'm currently using) to start a discussion.

The thing is: I want to be able to say open `blah.cpr` and I want the framework to figure out that I'm running on `x` processors and automatically find the pre-split set of files that are right for that number of processors.

With the way it is currently implemented when you run `splitter` it generates files like this:

```
split.4.cpr
split.4.cpr-4-0
split.4.cpr-4-1
split.4.cpr-4-2
split.4.cpr-4-3
```

This means that if I want to now run on 6 processors I have to actually change my input file / code to read `split.6.cpr` instead of `split.4.cpr`.  Think of a scaling study where I want to run hundreds of different processor combinations.... So: I want to just be able to tell libMesh to open `split.cpr` and let it figure out the rest.

That's what's in this PR.  I change the naming to:

```
split.cpr-4
split.cpr-4-0
split.cpr-4-1
split.cpr-4-2
split.cpr-4-3
```

And I use the fact that you're trying to load into a replicated / distributed mesh to figure out whether or not to read a serial or distributed mesh.

It's not perfect however... because it does mean that you now can't read a serial cpr file into a distributed mesh (which I believe was supported before)... but that's an edge case I don't care much about and maybe we can make a hardcore parameter that would allow you to force that behavior.

Let me know what you think...