### PR TITLE
added a flag to indicate whether or not to close the matrix before solve.

### DIFF
--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -82,13 +82,24 @@ public:
   bool initialized () const { return _is_initialized; }
 
   /**
-   * \returns \p true if we want to close the matrix before solve,
-   * false otherwise. It is true by default.
+   * \returns \p The value of the flag which controls whether libmesh
+   * closes the eigenproblem matrices before solving. \true by
+   * default.
    */
-  bool & close_matrix_before_solve()
+  bool get_close_matrix_before_solve() const
   {
     libmesh_experimental();
     return _close_matrix_before_solve;
+  }
+
+  /**
+   * Set the flag which controls whether libmesh closes the
+   * eigenproblem matrices before solving.
+   */
+  void set_close_matrix_before_solve(bool val)
+  {
+    libmesh_experimental();
+    _close_matrix_before_solve = val;
   }
 
   /**

--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -81,6 +81,16 @@ public:
    */
   bool initialized () const { return _is_initialized; }
 
+  /**
+  * \returns \p true if we want to close the matrix before solve,
+  * false otherwise. It is true by default.
+  */
+  bool close_matrix_before_solve() const { return _close_matrix_before_solve; }
+
+  /**
+  * Set if or not to close the matrix before solve
+  */
+  void close_matrix_before_solve(bool close_matrix) { _close_matrix_before_solve = close_matrix; }
 
   /**
    * Release all memory and clear data structures.
@@ -269,6 +279,8 @@ protected:
   SolverConfiguration * _solver_configuration;
 
   Real _target_val;
+
+  bool _close_matrix_before_solve;
 };
 
 
@@ -283,7 +295,8 @@ EigenSolver<T>::EigenSolver (const Parallel::Communicator & comm_in) :
   _eigen_problem_type   (NHEP),
   _position_of_spectrum (LARGEST_MAGNITUDE),
   _is_initialized       (false),
-  _solver_configuration(libmesh_nullptr)
+  _solver_configuration(libmesh_nullptr),
+  _close_matrix_before_solve(true)
 {
 }
 

--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -82,15 +82,14 @@ public:
   bool initialized () const { return _is_initialized; }
 
   /**
-  * \returns \p true if we want to close the matrix before solve,
-  * false otherwise. It is true by default.
-  */
-  bool close_matrix_before_solve() const { return _close_matrix_before_solve; }
-
-  /**
-  * Set if or not to close the matrix before solve
-  */
-  void close_matrix_before_solve(bool close_matrix) { _close_matrix_before_solve = close_matrix; }
+   * \returns \p true if we want to close the matrix before solve,
+   * false otherwise. It is true by default.
+   */
+  bool & close_matrix_before_solve()
+  {
+    libmesh_experimental();
+    return _close_matrix_before_solve;
+  }
 
   /**
    * Release all memory and clear data structures.

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -96,7 +96,8 @@ SlepcEigenSolver<T>::solve_standard (SparseMatrix<T> & matrix_A_in,
     libmesh_error_msg("Error: input matrix to solve_standard() must be a PetscMatrix.");
 
   // Close the matrix and vectors in case this wasn't already done.
-  matrix_A->close ();
+  if (this->_close_matrix_before_solve)
+    matrix_A->close ();
 
   return _solve_standard_helper(matrix_A->mat(), nev, ncv, tol, m_its);
 }
@@ -282,8 +283,11 @@ SlepcEigenSolver<T>::solve_generalized (SparseMatrix<T> & matrix_A_in,
     libmesh_error_msg("Error: inputs to solve_generalized() must be of type PetscMatrix.");
 
   // Close the matrix and vectors in case this wasn't already done.
-  matrix_A->close ();
-  matrix_B->close ();
+  if (this->_close_matrix_before_solve)
+  {
+    matrix_A->close ();
+    matrix_B->close ();
+  }
 
   return _solve_generalized_helper (matrix_A->mat(), matrix_B->mat(), nev, ncv, tol, m_its);
 }
@@ -321,7 +325,8 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
     libmesh_error_msg("Error: inputs to solve_generalized() must be of type PetscMatrix.");
 
   // Close the matrix and vectors in case this wasn't already done.
-  matrix_B->close ();
+  if (this->_close_matrix_before_solve)
+    matrix_B->close ();
 
   ierr = MatShellSetOperation(mat_A,MATOP_MULT,reinterpret_cast<void(*)(void)>(_petsc_shell_matrix_mult));
   LIBMESH_CHKERR(ierr);
@@ -350,7 +355,8 @@ SlepcEigenSolver<T>::solve_generalized (SparseMatrix<T> & matrix_A_in,
     libmesh_error_msg("Error: inputs to solve_generalized() must be of type PetscMatrix.");
 
   // Close the matrix and vectors in case this wasn't already done.
-  matrix_A->close ();
+  if (this->_close_matrix_before_solve)
+    matrix_A->close ();
 
   // Prepare the matrix.  Note that the const_cast is only necessary
   // because PETSc does not accept a const void *.  Inside the member


### PR DESCRIPTION
 It is useful for nonlinear eigenvalue solvers embedded in EPS recently. The nonlinear solvers have callbacks so that we do not need to close the matrix before solve. If we close the matrix before solve, the memory will be shrunk and the preallocation is not right any more. 