### PR TITLE
PerfLog speedup

### DIFF
--- a/include/base/libmesh_logging.h
+++ b/include/base/libmesh_logging.h
@@ -71,13 +71,13 @@ struct PerfItem
     _enabled(enabled)
   {
     if (_enabled)
-      libMesh::perflog.push(label, header);
+      libMesh::perflog.fast_push(label, header);
   }
 
   ~PerfItem()
   {
     if (_enabled)
-      libMesh::perflog.pop(_label, _header);
+      libMesh::perflog.fast_pop(_label, _header);
   }
 
 private:

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -2102,7 +2102,7 @@ inline Status Communicator::packed_range_probe (const unsigned int src_processor
                                                 const MessageTag & tag,
                                                 bool & flag) const
 {
-  START_LOG("packed_range_probe()", "Parallel");
+  LOG_SCOPE("packed_range_probe()", "Parallel");
 
   libmesh_experimental();
 
@@ -2117,8 +2117,6 @@ inline Status Communicator::packed_range_probe (const unsigned int src_processor
                               stat.get()));
 
   flag = int_flag;
-
-  STOP_LOG("packed_range_probe()", "Parallel");
 
   return stat;
 }

--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -327,6 +327,10 @@ private:
 
   /**
    * The actual log.
+   *
+   * An unsorted_map would work fine here and would be asymptotically
+   * faster, but in my tests for our log sizes there was no
+   * improvement.
    */
   std::map<std::pair<const char *,
                      const char *>,

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -854,7 +854,7 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
                           bool apply_no_constraints)
 {
   libmesh_assert(get_residual || get_jacobian);
-  std::string log_name;
+  const char * log_name;
   if (get_residual && get_jacobian)
     log_name = "assembly()";
   else if (get_residual)
@@ -862,7 +862,7 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
   else
     log_name = "assembly(get_jacobian)";
 
-  LOG_SCOPE(log_name.c_str(), "FEMSystem");
+  LOG_SCOPE(log_name, "FEMSystem");
 
   const MeshBase & mesh = this->get_mesh();
 

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -20,6 +20,7 @@
 // C++ includes
 #include <iostream>
 #include <iomanip>
+#include <cstring>
 #include <ctime>
 #include <unistd.h>
 #include <sys/types.h>
@@ -65,6 +66,9 @@ PerfLog::~PerfLog()
 {
   if (log_events)
     this->print_log();
+
+  for (const auto & pos : non_temporary_strings)
+    delete pos.second;
 }
 
 
@@ -74,13 +78,12 @@ void PerfLog::clear()
   if (log_events)
     {
       //  check that all events are closed
-      for (std::map<std::pair<std::string,std::string>, PerfData>::iterator
-             pos = log.begin(); pos != log.end(); ++pos)
-        if (pos->second.open)
+      for (auto pos : log)
+        if (pos.second.open)
           libmesh_error_msg("ERROR clearing performance log for class " \
                             << label_name                             \
                             << "\nevent "                             \
-                            << pos->first.second                      \
+                            << pos.first.second                      \
                             << " is still being monitored!");
 
       gettimeofday (&tstart, libmesh_nullptr);
@@ -91,6 +94,76 @@ void PerfLog::clear()
         log_stack.pop();
     }
 }
+
+
+
+void PerfLog::push (const std::string & label,
+                    const std::string & header)
+{
+  const char * label_c_str;
+  const char * header_c_str;
+  if (non_temporary_strings.count(label))
+    label_c_str = non_temporary_strings[label];
+  else
+    {
+      char * newcopy = new char [label.size()+1];
+      strcpy(newcopy, label.c_str());
+      label_c_str = newcopy;
+      non_temporary_strings[label] = label_c_str;
+    }
+
+  if (non_temporary_strings.count(header))
+    header_c_str = non_temporary_strings[header];
+  else
+    {
+      char * newcopy = new char [header.size()+1];
+      strcpy(newcopy, header.c_str());
+      header_c_str = newcopy;
+      non_temporary_strings[header] = header_c_str;
+    }
+
+  if (this->log_events)
+    this->fast_push(label_c_str, header_c_str);
+}
+
+
+
+void PerfLog::push (const char * label,
+                    const char * header)
+{
+  this->push(std::string(label), std::string(header));
+}
+
+
+
+
+
+void PerfLog::pop (const std::string & label,
+                   const std::string & header)
+{
+
+  const char * label_c_str = non_temporary_strings[label];
+  const char * header_c_str = non_temporary_strings[header];
+
+  // This could happen if users are *mixing* string and char* APIs for
+  // the same label/header combination.  For perfect backwards
+  // compatibility we should handle that, but there's just no fast way
+  // to do so.
+  libmesh_assert(label_c_str);
+  libmesh_assert(header_c_str);
+
+  if (this->log_events)
+    this->fast_pop(label_c_str, header_c_str);
+}
+
+
+
+void PerfLog::pop (const char * label,
+                   const char * header)
+{
+  this->pop(std::string(label), std::string(header));
+}
+
 
 
 std::string PerfLog::get_info_header() const
@@ -286,15 +359,12 @@ std::string PerfLog::get_perf_info() const
       const unsigned int pct_active_col_width = 9;
       const unsigned int pct_active_incl_sub_col_width = 9;
 
-      // Iterator to be used to loop over the map of timed events
-      std::map<std::pair<std::string,std::string>, PerfData>::const_iterator pos;
-
       // Reset the event column width based on the longest event name plus
       // a possible 2-character indentation, plus a space.
-      for (pos = log.begin(); pos != log.end(); ++pos)
-        if (pos->first.second.size()+3 > event_col_width)
+      for (auto pos : log)
+        if (std::strlen(pos.first.second)+3 > event_col_width)
           event_col_width = cast_int<unsigned int>
-            (pos->first.second.size()+3);
+            (std::strlen(pos.first.second)+3);
 
       // Set the total width of the column
       const unsigned int total_col_width =
@@ -404,9 +474,17 @@ std::string PerfLog::get_perf_info() const
 
       std::string last_header("");
 
-      for (pos = log.begin(); pos != log.end(); ++pos)
+      // Make a new log to sort entries alphabetically
+      std::map<std::pair<std::string, std::string>, PerfData> string_log;
+
+      for (auto char_data : log)
+        string_log[std::make_pair(char_data.first.first,
+                                  char_data.first.second)] =
+          char_data.second;
+
+      for (auto pos : string_log)
         {
-          const PerfData & perf_data = pos->second;
+          const PerfData & perf_data = pos.second;
 
           // Only print the event if the count is non-zero.
           if (perf_data.count != 0)
@@ -424,17 +502,17 @@ std::string PerfLog::get_perf_info() const
               summed_percentage     += perf_percent;
 
               // Print the event name
-              if (pos->first.first == "")
+              if (pos.first.first == "")
                 oss << "| "
                     << std::setw(event_col_width)
                     << std::left
-                    << pos->first.second;
+                    << pos.first.second;
 
               else
                 {
-                  if (last_header != pos->first.first)
+                  if (last_header != pos.first.first)
                     {
-                      last_header = pos->first.first;
+                      last_header = pos.first.first;
 
                       // print blank line followed by header name
                       // (account for additional space before the
@@ -444,14 +522,14 @@ std::string PerfLog::get_perf_info() const
                           << "|\n| "
                           << std::setw(total_col_width-1)
                           << std::left
-                          << pos->first.first
+                          << pos.first.first
                           << "|\n";
                     }
 
                   oss << "|   "
                       << std::setw(event_col_width-2)
                       << std::left
-                      << pos->first.second;
+                      << pos.first.second;
                 }
 
 
@@ -616,7 +694,7 @@ void PerfLog::print_log() const
 
 PerfData PerfLog::get_perf_data(const std::string & label, const std::string & header)
 {
-  return log[std::make_pair(header, label)];
+  return log[std::make_pair(header.c_str(), label.c_str())];
 }
 
 void PerfLog::start_event(const std::string & label,


### PR DESCRIPTION
Avoiding std::string allocation and deallocation speeds up PerfLog by a factor of 3 or 4 for me, and merging adjacent gettimeofday() calls speeds it up by about another factor of 2.

PerfLog is still not efficient enough to do very-fine-grained profiling, and if the remaining gettimeofday() calls are all that's left to blame then I may have to just remove the worst Heisen-profiling instances eventually, but at least now the worst-case scenario looks like 15% overhead rather than 115%.