### PR TITLE
second order infinite elements

### DIFF
--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -157,6 +157,13 @@ public:
    */
   virtual std::pair<Real, Real> qual_bounds (const ElemQuality q) const libmesh_override;
 
+  /**
+   * \returns \p true when this element contains the point
+   * \p p.  Customized for infinite elements, since knowledge
+   * about the envelope can be helpful.
+   */
+  virtual bool contains_point (const Point & p, Real tol=TOLERANCE) const libmesh_override;
+
 protected:
 
   /**

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -138,13 +138,6 @@ public:
   { return 12; }
 
   /**
-   * \returns \p true when this element contains the point
-   * \p p.  Customized for infinite elements, since knowledge
-   * about the envelope can be helpful.
-   */
-  virtual bool contains_point (const Point & p, Real tol=TOLERANCE) const libmesh_override;
-
-  /**
    * This maps the \f$ j^{th} \f$ node of the \f$ i^{th} \f$ side to
    * element node numbers.
    */

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -139,6 +139,13 @@ public:
    */
   virtual UniquePtr<Elem> side_ptr (const unsigned int i) libmesh_override;
 
+   /**
+   * @returns \p true when this element contains the point
+   * \p p.  Customized for infinite elements, since knowledge
+   * about the envelope can be helpful.
+   */
+  virtual bool contains_point (const Point & p, Real tol=TOLERANCE) const libmesh_override;
+
 
 protected:
 

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -137,13 +137,6 @@ public:
                             std::vector<dof_id_type> & conn) const libmesh_override;
 
   /**
-   * \returns \p true when this element contains the point
-   * \p p.  Customized for infinite elements, since knowledge
-   * about the envelope can be helpful.
-   */
-  virtual bool contains_point (const Point & p, Real tol=TOLERANCE) const libmesh_override;
-
-  /**
    * This maps the \f$ j^{th} \f$ node of the \f$ i^{th} \f$ side to
    * element node numbers.
    */

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -708,6 +708,8 @@ bool FEAbstract::on_reference_element(const Point & p, const ElemType t, const R
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
     case INFHEX8:
+    case INFHEX16:
+    case INFHEX18:
       {
         // The reference infhex8 is a [-1,1]^3.
         if ((xi   >= -1.-eps) &&
@@ -723,6 +725,7 @@ bool FEAbstract::on_reference_element(const Point & p, const ElemType t, const R
       }
 
     case INFPRISM6:
+    case INFPRISM12:
       {
         // inside the reference triangle with zeta in [-1,1]
         if ((xi   >=  0.-eps) &&

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -101,11 +101,6 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
   // build a base element to do the map inversion in the base face
   UniquePtr<Elem> base_elem (Base::build_elem (inf_elem));
 
-  const ElemType inf_elem_type = inf_elem->type();
-  if (inf_elem_type != INFHEX8 &&
-      inf_elem_type != INFPRISM6)
-    libmesh_error_msg("ERROR: InfFE::inverse_map is currently implemented only for \ninfinite elements of type InfHex8 and InfPrism6.");
-
   // 2.)
   // just like in FE<Dim-1,LAGRANGE>::inverse_map(): compute
   // the local coordinates, but only in the base element.
@@ -382,6 +377,7 @@ Point InfFE<Dim,T_radial,T_map>::inverse_map (const Elem * inf_elem,
         {
           // in this case, physical_point is not in this element.
           // We therefore give back the best approximation:
+          // TODO: is there a strict argument for this?
           p(Dim-1) = -1;
           return p;
         }

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -17,6 +17,7 @@
 
 // Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
 
@@ -33,6 +34,7 @@
 
 namespace libMesh
 {
+
 
 
 // ------------------------------------------------------------
@@ -354,6 +356,9 @@ std::pair<Real, Real> InfHex::qual_bounds (const ElemQuality) const
 }
 
 
+
+
+
 const unsigned short int InfHex::_second_order_adjacent_vertices[8][2] =
   {
     { 0,  1}, // vertices adjacent to node 8
@@ -429,6 +434,36 @@ bool InfHex::contains_point (const Point & p, Real tol) const
 
 
   if (conservative_p_dist_sq < min_distance_sq)
+    {
+      /*
+       * the physical point is definitely not contained in the element
+       */
+      return false;
+    }
+  /*
+   * this captures the case that the point is not (almost) in the direction of the element.:
+   * first, project the problem onto the unit sphere:
+   */
+
+
+  Point p_o(p-my_origin);
+  pt0_o/=pt0_o.norm();
+  pt1_o/=pt1_o.norm();
+  pt2_o/=pt2_o.norm();
+  pt3_o/=pt3_o.norm();
+  p_o/=p_o.norm();
+
+
+  /*
+   * now, check if it is in the projected face; using that the diagonal contains
+   * the largest distance between points in it
+  */
+  Real max_h=std::max( (pt0_o-pt2_o).norm_sq(),(pt1_o-pt2_o).norm_sq())*1.01; 
+
+  if ((p_o-pt0_o).norm_sq() > max_h ||
+      (p_o-pt1_o).norm_sq() > max_h || 
+      (p_o-pt2_o).norm_sq() > max_h ||
+      (p_o-pt3_o).norm_sq() > max_h )
     {
       /*
        * the physical point is definitely not contained in the element

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -17,7 +17,6 @@
 
 // Local includes
 #include "libmesh/libmesh_config.h"
-
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
 
@@ -29,10 +28,11 @@
 #include "libmesh/cell_inf_hex8.h"
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_inf_quad4.h"
+#include "libmesh/fe_type.h"
+#include "libmesh/fe_interface.h"
 
 namespace libMesh
 {
-
 
 
 // ------------------------------------------------------------
@@ -354,9 +354,6 @@ std::pair<Real, Real> InfHex::qual_bounds (const ElemQuality) const
 }
 
 
-
-
-
 const unsigned short int InfHex::_second_order_adjacent_vertices[8][2] =
   {
     { 0,  1}, // vertices adjacent to node 8
@@ -389,6 +386,71 @@ const unsigned short int InfHex::_second_order_vertex_child_index[18] =
     5,6,7,7,2,               // Faces
     6                        // Interior
   };
+
+
+bool InfHex::contains_point (const Point & p, Real tol) const
+{
+  /*
+   * For infinite elements with linear base interpolation:
+   *
+   * make use of the fact that infinite elements do not
+   * live inside the envelope.  Use a fast scheme to
+   * check whether point \p p is inside or outside
+   * our relevant part of the envelope.  Note that
+   * this is not exclusive: only when the distance is less,
+   * we are safe.  Otherwise, we cannot say anything. The
+   * envelope may be non-spherical, the physical point may lie
+   * inside the envelope, outside the envelope, or even inside
+   * this infinite element.  Therefore if this fails,
+   * fall back to the FEInterface::inverse_map()
+   */
+  const Point my_origin (this->origin());
+
+  /*
+   * determine the minimal distance of the base from the origin
+   * Use norm_sq() instead of norm(), it is faster
+   */
+
+  Point pt0_o(this->point(0)-my_origin);
+  Point pt1_o(this->point(1)-my_origin);
+  Point pt2_o(this->point(2)-my_origin);
+  Point pt3_o(this->point(3)-my_origin);
+  const Real min_distance_sq = std::min(pt0_o.norm_sq(),
+                               std::min(pt1_o.norm_sq(),
+                               std::min(pt2_o.norm_sq(),
+                                        pt3_o.norm_sq())));
+
+  /*
+   * work with 1% allowable deviation.  We can still fall
+   * back to the InfFE::inverse_map()
+   */
+  const Real conservative_p_dist_sq = 1.01 * (Point(p-my_origin).norm_sq());
+
+
+
+  if (conservative_p_dist_sq < min_distance_sq)
+    {
+      /*
+       * the physical point is definitely not contained in the element
+       */
+      return false;
+    }
+
+  /*
+   * Declare a basic FEType.  Will use default in the base,
+   * and something else (not important) in radial direction.
+   */
+  FEType fe_type(default_order());
+
+  const Point mapped_point = FEInterface::inverse_map(dim(),
+                                                      fe_type,
+                                                      this,
+                                                      p,
+                                                      tol,
+                                                      false);
+
+  return FEInterface::on_reference_element(mapped_point, this->type(), tol);
+}
 
 } // namespace libMesh
 

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -28,8 +28,6 @@
 #include "libmesh/edge_inf_edge2.h"
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_inf_quad4.h"
-#include "libmesh/fe_interface.h"
-#include "libmesh/fe_type.h"
 #include "libmesh/side.h"
 
 namespace libMesh
@@ -177,67 +175,6 @@ UniquePtr<Elem> InfHex8::build_edge_ptr (const unsigned int i)
     return UniquePtr<Elem>(new SideEdge<Edge2,InfHex8>(this,i));
   // infinite edges
   return UniquePtr<Elem>(new SideEdge<InfEdge2,InfHex8>(this,i));
-}
-
-bool InfHex8::contains_point (const Point & p, Real tol) const
-{
-  /*
-   * For infinite elements with linear base interpolation:
-   *
-   * make use of the fact that infinite elements do not
-   * live inside the envelope.  Use a fast scheme to
-   * check whether point \p p is inside or outside
-   * our relevant part of the envelope.  Note that
-   * this is not exclusive: only when the distance is less,
-   * we are safe.  Otherwise, we cannot say anything. The
-   * envelope may be non-spherical, the physical point may lie
-   * inside the envelope, outside the envelope, or even inside
-   * this infinite element.  Therefore if this fails,
-   * fall back to the FEInterface::inverse_map()
-   */
-  const Point my_origin (this->origin());
-
-  /*
-   * determine the minimal distance of the base from the origin
-   * Use norm_sq() instead of norm(), it is faster
-   */
-  const Real min_distance_sq = std::min((Point(this->point(0)-my_origin)).norm_sq(),
-                                        std::min((Point(this->point(1)-my_origin)).norm_sq(),
-                                                 std::min((Point(this->point(2)-my_origin)).norm_sq(),
-                                                          (Point(this->point(3)-my_origin)).norm_sq())));
-
-  /*
-   * work with 1% allowable deviation.  We can still fall
-   * back to the InfFE::inverse_map()
-   */
-  const Real conservative_p_dist_sq = 1.01 * (Point(p-my_origin).norm_sq());
-
-
-
-  if (conservative_p_dist_sq < min_distance_sq)
-    {
-      /*
-       * the physical point is definitely not contained in the element
-       */
-      return false;
-    }
-  else
-    {
-      /*
-       * Declare a basic FEType.  Will use default in the base,
-       * and something else (not important) in radial direction.
-       */
-      FEType fe_type(default_order());
-
-      const Point mapped_point = FEInterface::inverse_map(dim(),
-                                                          fe_type,
-                                                          this,
-                                                          p,
-                                                          tol,
-                                                          false);
-
-      return FEInterface::on_reference_element(mapped_point, this->type(), tol);
-    }
 }
 
 

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -202,12 +202,39 @@ bool InfPrism::contains_point (const Point & p, Real tol) const
       /*
        * the physical point is definitely not contained in the element:
        */
+      return false;
+    }
 
+  /*
+   * this captures the case that the point is not (almost) in the direction of the element.:
+   * first, project the problem onto the unit sphere:
+   */
+  
+  Point p_o(p-my_origin);
+  pt0_o/=pt0_o.norm();
+  pt1_o/=pt1_o.norm();
+  pt2_o/=pt2_o.norm();
+  p_o/=p_o.norm();
+
+  /*
+   * now, check if it is in the projected face; by comparing the distance of
+   * any point in the element to \p p with the largest distance between this point
+   * to any other point in the element.
+  */
+  if ((p_o-pt0_o).norm_sq() > std::max((pt0_o-pt1_o).norm_sq(), (pt0_o-pt2_o).norm_sq()) ||
+      (p_o-pt1_o).norm_sq() > std::max((pt1_o-pt2_o).norm_sq(), (pt1_o-pt0_o).norm_sq()) || 
+      (p_o-pt2_o).norm_sq() > std::max((pt2_o-pt0_o).norm_sq(), (pt2_o-pt1_o).norm_sq()) )
+    {
+      /*
+       * the physical point is definitely not contained in the element
+       */
       return false;
     }
 
 
    /*
+    * It seems that \p p is at least close to this element.
+    *
     * Declare a basic FEType.  Will use default in the base,
     * and something else (not important) in radial direction.
     */

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -28,6 +28,8 @@
 #include "libmesh/cell_inf_prism6.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/face_inf_quad4.h"
+#include "libmesh/fe_type.h"
+#include "libmesh/fe_interface.h"
 
 namespace libMesh
 {
@@ -159,6 +161,67 @@ bool InfPrism::is_edge_on_side (const unsigned int e,
           is_node_on_side(InfPrism6::edge_nodes_map[e][1],s));
 }
 
+bool InfPrism::contains_point (const Point & p, Real tol) const
+{
+  /*
+   * For infinite elements with linear base interpolation:
+   *
+   * make use of the fact that infinite elements do not
+   * live inside the envelope.  Use a fast scheme to
+   * check whether point \p p is inside or outside
+   * our relevant part of the envelope.  Note that
+   * this is not exclusive: only when the distance is less,
+   * we are safe.  Otherwise, we cannot say anything. The
+   * envelope may be non-spherical, the physical point may lie
+   * inside the envelope, outside the envelope, or even inside
+   * this infinite element.  Therefore if this fails,
+   * fall back to the FEInterface::inverse_map()
+   */
+  const Point my_origin (this->origin());
+
+  /*
+   * determine the minimal distance of the base from the origin
+   * use norm_sq(), it is faster than norm() and produces
+   * the same behavior. Shift my_origin to center first:
+   */
+  Point pt0_o(this->point(0)-my_origin);
+  Point pt1_o(this->point(1)-my_origin);
+  Point pt2_o(this->point(2)-my_origin);
+  const Real min_distance_sq = std::min(pt0_o.norm_sq(),
+                               std::min(pt1_o.norm_sq(),
+                                        pt2_o.norm_sq()));
+
+  /*
+   * work with 1% allowable deviation.  We can still fall
+   * back to the InfFE::inverse_map()
+   */
+  const Real conservative_p_dist_sq = 1.01 * (Point(p-my_origin).norm_sq());
+
+  if (conservative_p_dist_sq < min_distance_sq)
+    {
+      /*
+       * the physical point is definitely not contained in the element:
+       */
+
+      return false;
+    }
+
+
+   /*
+    * Declare a basic FEType.  Will use default in the base,
+    * and something else (not important) in radial direction.
+    */
+  FEType fe_type(default_order());
+
+  const Point mapped_point = FEInterface::inverse_map(dim(),
+                                                      fe_type,
+                                                      this,
+                                                      p,
+                                                      tol,
+                                                      false);
+
+  return FEInterface::on_reference_element(mapped_point, this->type(), tol);
+}
 
 
 } // namespace libMesh


### PR DESCRIPTION
Hi,
I have realised that second order infinite elements seem to be disabled without a reason, so I enabled them.

Closely related to this, (therefore part of this PR) is the fact that the inverse_map() function works quite unstable if one inserts points that are far away from the element tested (which regularly occurs when the PointLocator is used).
Thus, I added in the second commit a further criterium to the contains_point() function.
In my tests it works quite well; I hope, I didn't miss some cases not covered therein.

I hope, it is ok to put both changes into one PR and that the changes are fine so far.