### PR TITLE
 Add MeshBase::elements_range() and many range-based for loops

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -291,6 +291,10 @@ public:
   virtual element_iterator elements_end () libmesh_override;
   virtual const_element_iterator elements_begin() const libmesh_override;
   virtual const_element_iterator elements_end() const libmesh_override;
+  virtual SimpleRange<element_iterator> elements_range() libmesh_override
+  {
+    return {elements_begin(), elements_end()};
+  }
 
   virtual element_iterator active_elements_begin () libmesh_override;
   virtual element_iterator active_elements_end () libmesh_override;

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -295,6 +295,10 @@ public:
   {
     return {elements_begin(), elements_end()};
   }
+  virtual SimpleRange<const_element_iterator> elements_range() const libmesh_override
+  {
+    return {elements_begin(), elements_end()};
+  }
 
   virtual element_iterator active_elements_begin () libmesh_override;
   virtual element_iterator active_elements_end () libmesh_override;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -30,6 +30,7 @@
 #include "libmesh/point_locator_base.h"
 #include "libmesh/variant_filter_iterator.h"
 #include "libmesh/parallel_object.h"
+#include "libmesh/simple_range.h"
 
 // C++ Includes
 #include <cstddef>
@@ -987,6 +988,7 @@ public:
   virtual element_iterator elements_end () = 0;
   virtual const_element_iterator elements_begin () const = 0;
   virtual const_element_iterator elements_end () const = 0;
+  virtual SimpleRange<element_iterator> elements_range() = 0;
 
   /**
    * Iterate over elements for which elem->ancestor() is true.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -989,6 +989,7 @@ public:
   virtual const_element_iterator elements_begin () const = 0;
   virtual const_element_iterator elements_end () const = 0;
   virtual SimpleRange<element_iterator> elements_range() = 0;
+  virtual SimpleRange<const_element_iterator> elements_range() const = 0;
 
   /**
    * Iterate over elements for which elem->ancestor() is true.

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -232,6 +232,10 @@ public:
   virtual element_iterator elements_end () libmesh_override;
   virtual const_element_iterator elements_begin() const libmesh_override;
   virtual const_element_iterator elements_end() const libmesh_override;
+  virtual SimpleRange<element_iterator> elements_range() libmesh_override
+  {
+    return {elements_begin(), elements_end()};
+  }
 
   virtual element_iterator active_elements_begin () libmesh_override;
   virtual element_iterator active_elements_end () libmesh_override;

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -236,6 +236,10 @@ public:
   {
     return {elements_begin(), elements_end()};
   }
+  virtual SimpleRange<const_element_iterator> elements_range() const libmesh_override
+  {
+    return {elements_begin(), elements_end()};
+  }
 
   virtual element_iterator active_elements_begin () libmesh_override;
   virtual element_iterator active_elements_end () libmesh_override;

--- a/src/apps/meshbcid.C
+++ b/src/apps/meshbcid.C
@@ -140,11 +140,8 @@ int main(int argc, char ** argv)
   const std::vector<Point> & face_points = fe->get_xyz();
   const std::vector<Point> & face_normals = fe->get_normals();
 
-  MeshBase::element_iterator           el = mesh.elements_begin();
-  const MeshBase::element_iterator end_el = mesh.elements_end();
-  for (; el != end_el; ++el)
+  for (auto & elem : mesh.elements_range())
     {
-      Elem * elem = *el;
       unsigned int n_sides = elem->n_sides();
 
       // Container to catch ids handed back from BoundaryInfo

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -501,13 +501,10 @@ void DofMap::reinit(MeshBase & mesh)
         libmesh_assert (!(*node_it)->old_dof_object);
       }
 
-    MeshBase::element_iterator       elem_it  = mesh.elements_begin();
-    const MeshBase::element_iterator elem_end = mesh.elements_end();
-
-    for ( ; elem_it != elem_end; ++elem_it)
+    for (auto & elem : mesh.elements_range())
       {
-        (*elem_it)->clear_old_dof_object();
-        libmesh_assert (!(*elem_it)->old_dof_object);
+        elem->clear_old_dof_object();
+        libmesh_assert (!elem->old_dof_object);
       }
   }
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1016,11 +1016,9 @@ void DofMap::distribute_dofs (MeshBase & mesh)
             }
       }
 
-    MeshBase::const_element_iterator       elem_it  = mesh.elements_begin();
-    const MeshBase::const_element_iterator elem_end = mesh.elements_end();
-    for ( ; elem_it != elem_end; ++elem_it)
+    for (auto & elem : mesh.elements_range())
       {
-        DofObject const * const dofobj = *elem_it;
+        DofObject const * const dofobj = elem;
         const processor_id_type obj_proc_id = dofobj->processor_id();
 
         for (unsigned int v=0; v != dofobj->n_vars(sys_num); ++v)

--- a/src/base/ghost_point_neighbors.C
+++ b/src/base/ghost_point_neighbors.C
@@ -109,25 +109,20 @@ void GhostPointNeighbors::operator()
     }
 
   // Connect any interior_parents who are really in our mesh
-  {
-    MeshBase::const_element_iterator       elem_it  = _mesh.elements_begin();
-    const MeshBase::const_element_iterator elem_end = _mesh.elements_end();
-    for (; elem_it != elem_end; ++elem_it)
-      {
-        const Elem * elem = *elem_it;
-        std::set<const Elem *>::iterator ip_it =
-          interior_parents.find(elem);
+  for (const auto & elem : _mesh.elements_range())
+    {
+      std::set<const Elem *>::iterator ip_it =
+        interior_parents.find(elem);
 
-        if (ip_it != interior_parents.end())
-          {
-            coupled_elements.insert
-              (std::make_pair(elem, nullcm));
+      if (ip_it != interior_parents.end())
+        {
+          coupled_elements.insert
+            (std::make_pair(elem, nullcm));
 
-            // Shrink the set ASAP to speed up subsequent searches
-            interior_parents.erase(ip_it);
-          }
-      }
-  }
+          // Shrink the set ASAP to speed up subsequent searches
+          interior_parents.erase(ip_it);
+        }
+    }
 
   // Connect any active elements which are connected to our range's
   // elements' nodes

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -403,16 +403,9 @@ void AbaqusIO::read (const std::string & fname)
   {
     unsigned char max_dim = this->max_elem_dimension_seen();
 
-    MeshBase::element_iterator       el     = the_mesh.elements_begin();
-    const MeshBase::element_iterator end_el = the_mesh.elements_end();
-
-    for (; el != end_el; ++el)
-      {
-        Elem * elem = *el;
-
-        if (elem->dim() < max_dim)
-          the_mesh.delete_elem(elem);
-      }
+    for (auto & elem : the_mesh.elements_range())
+      if (elem->dim() < max_dim)
+        the_mesh.delete_elem(elem);
   }
 }
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -426,12 +426,8 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
     side_container;
   side_container sides_to_add;
 
-  const MeshBase::const_element_iterator end_el = _mesh.elements_end();
-  for (MeshBase::const_element_iterator el = _mesh.elements_begin();
-       el != end_el; ++el)
+  for (const auto & elem : _mesh.elements_range())
     {
-      const Elem * elem = *el;
-
       // If the subdomains_relative_to container has the
       // invalid_subdomain_id, we fall back on the "old" behavior of
       // adding sides regardless of this Elem's subdomain. Otherwise,

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -296,15 +296,8 @@ void BoundaryInfo::sync (const std::set<boundary_id_type> & requested_boundary_i
   // This side's Node pointers still point to the nodes of the original mesh.
   // We need to re-point them to the boundary mesh's nodes!  Since we copied *ALL* of
   // the original mesh's nodes over, we should be guaranteed to have the same ordering.
-
-  const MeshBase::element_iterator end_bdy_el =
-    boundary_mesh.elements_end();
-
-  for (MeshBase::element_iterator el = boundary_mesh.elements_begin();
-       el != end_bdy_el; ++el)
+  for (auto & new_elem : boundary_mesh.elements_range())
     {
-      Elem * new_elem = *el;
-
       for (auto nn : new_elem->node_index_range())
         {
           // Get the correct node pointer, based on the id()

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -1317,93 +1317,80 @@ void MeshTools::Generation::build_cube(UnstructuredMesh & mesh,
               new_elements.reserve(6*mesh.n_elem());
 
             // Create tetrahedra or pyramids
-            {
-              MeshBase::element_iterator       el     = mesh.elements_begin();
-              const MeshBase::element_iterator end_el = mesh.elements_end();
+            for (auto & base_hex : mesh.elements_range())
+              {
+                // Get a pointer to the node located at the HEX27 centroid
+                Node * apex_node = base_hex->node_ptr(26);
 
-              for ( ; el != end_el;  ++el)
-                {
-                  // Get a pointer to the HEX27 element.
-                  Elem * base_hex = *el;
+                // Container to catch ids handed back from BoundaryInfo
+                std::vector<boundary_id_type> ids;
 
-                  // Get a pointer to the node located at the HEX27 centroid
-                  Node * apex_node = base_hex->node_ptr(26);
+                for (auto s : base_hex->side_index_range())
+                  {
+                    // Get the boundary ID(s) for this side
+                    boundary_info.boundary_ids(base_hex, s, ids);
 
-                  // Container to catch ids handed back from BoundaryInfo
-                  std::vector<boundary_id_type> ids;
+                    // We're creating this Mesh, so there should be 0 or 1 boundary IDs.
+                    libmesh_assert(ids.size() <= 1);
 
-                  for (auto s : base_hex->side_index_range())
-                    {
-                      // Get the boundary ID(s) for this side
-                      boundary_info.boundary_ids(*el, s, ids);
+                    // A convenient name for the side's ID.
+                    boundary_id_type b_id = ids.empty() ? BoundaryInfo::invalid_id : ids[0];
 
-                      // We're creating this Mesh, so there should be 0 or 1 boundary IDs.
-                      libmesh_assert(ids.size() <= 1);
+                    // Need to build the full-ordered side!
+                    UniquePtr<Elem> side = base_hex->build_side_ptr(s);
 
-                      // A convenient name for the side's ID.
-                      boundary_id_type b_id = ids.empty() ? BoundaryInfo::invalid_id : ids[0];
+                    if ((type == TET4) || (type == TET10))
+                      {
+                        // Build 4 sub-tets per side
+                        for (unsigned int sub_tet=0; sub_tet<4; ++sub_tet)
+                          {
+                            new_elements.push_back( new Tet4 );
+                            Elem * sub_elem = new_elements.back();
+                            sub_elem->set_node(0) = side->node_ptr(sub_tet);
+                            sub_elem->set_node(1) = side->node_ptr(8);                           // centroid of the face
+                            sub_elem->set_node(2) = side->node_ptr(sub_tet==3 ? 0 : sub_tet+1 ); // wrap-around
+                            sub_elem->set_node(3) = apex_node;                                   // apex node always used!
 
-                      // Need to build the full-ordered side!
-                      UniquePtr<Elem> side = base_hex->build_side_ptr(s);
+                            // If the original hex was a boundary hex, add the new sub_tet's side
+                            // 0 with the same b_id.  Note: the tets are all aligned so that their
+                            // side 0 is on the boundary.
+                            if (b_id != BoundaryInfo::invalid_id)
+                              boundary_info.add_side(sub_elem, 0, b_id);
+                          }
+                      } // end if ((type == TET4) || (type == TET10))
 
-                      if ((type == TET4) || (type == TET10))
-                        {
-                          // Build 4 sub-tets per side
-                          for (unsigned int sub_tet=0; sub_tet<4; ++sub_tet)
-                            {
-                              new_elements.push_back( new Tet4 );
-                              Elem * sub_elem = new_elements.back();
-                              sub_elem->set_node(0) = side->node_ptr(sub_tet);
-                              sub_elem->set_node(1) = side->node_ptr(8);                           // centroid of the face
-                              sub_elem->set_node(2) = side->node_ptr(sub_tet==3 ? 0 : sub_tet+1 ); // wrap-around
-                              sub_elem->set_node(3) = apex_node;                                   // apex node always used!
+                    else // type==PYRAMID5 || type==PYRAMID13 || type==PYRAMID14
+                      {
+                        // Build 1 sub-pyramid per side.
+                        new_elements.push_back(new Pyramid5);
+                        Elem * sub_elem = new_elements.back();
 
-                              // If the original hex was a boundary hex, add the new sub_tet's side
-                              // 0 with the same b_id.  Note: the tets are all aligned so that their
-                              // side 0 is on the boundary.
-                              if (b_id != BoundaryInfo::invalid_id)
-                                boundary_info.add_side(sub_elem, 0, b_id);
-                            }
-                        } // end if ((type == TET4) || (type == TET10))
+                        // Set the base.  Note that since the apex is *inside* the base_hex,
+                        // and the pyramid uses a counter-clockwise base numbering, we need to
+                        // reverse the [1] and [3] node indices.
+                        sub_elem->set_node(0) = side->node_ptr(0);
+                        sub_elem->set_node(1) = side->node_ptr(3);
+                        sub_elem->set_node(2) = side->node_ptr(2);
+                        sub_elem->set_node(3) = side->node_ptr(1);
 
-                      else // type==PYRAMID5 || type==PYRAMID13 || type==PYRAMID14
-                        {
-                          // Build 1 sub-pyramid per side.
-                          new_elements.push_back(new Pyramid5);
-                          Elem * sub_elem = new_elements.back();
+                        // Set the apex
+                        sub_elem->set_node(4) = apex_node;
 
-                          // Set the base.  Note that since the apex is *inside* the base_hex,
-                          // and the pyramid uses a counter-clockwise base numbering, we need to
-                          // reverse the [1] and [3] node indices.
-                          sub_elem->set_node(0) = side->node_ptr(0);
-                          sub_elem->set_node(1) = side->node_ptr(3);
-                          sub_elem->set_node(2) = side->node_ptr(2);
-                          sub_elem->set_node(3) = side->node_ptr(1);
-
-                          // Set the apex
-                          sub_elem->set_node(4) = apex_node;
-
-                          // If the original hex was a boundary hex, add the new sub_pyr's side
-                          // 4 (the square base) with the same b_id.
-                          if (b_id != BoundaryInfo::invalid_id)
-                            boundary_info.add_side(sub_elem, 4, b_id);
-                        } // end else type==PYRAMID5 || type==PYRAMID13 || type==PYRAMID14
-                    }
-                }
-            }
+                        // If the original hex was a boundary hex, add the new sub_pyr's side
+                        // 4 (the square base) with the same b_id.
+                        if (b_id != BoundaryInfo::invalid_id)
+                          boundary_info.add_side(sub_elem, 4, b_id);
+                      } // end else type==PYRAMID5 || type==PYRAMID13 || type==PYRAMID14
+                  }
+              }
 
 
             // Delete the original HEX27 elements from the mesh, and the boundary info structure.
-            {
-              MeshBase::element_iterator       el     = mesh.elements_begin();
-              const MeshBase::element_iterator end_el = mesh.elements_end();
-
-              for ( ; el != end_el;  ++el)
-                {
-                  boundary_info.remove(*el); // Safe even if *el has no boundary info.
-                  mesh.delete_elem(*el);
-                }
-            }
+            for (auto & elem : mesh.elements_range())
+              {
+                boundary_info.remove(elem); // Safe even if elem has no boundary info.
+                mesh.delete_elem(elem);
+              }
 
             // Add the new elements
             for (std::size_t i=0; i<new_elements.size(); ++i)

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2079,11 +2079,8 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
   // fix that.
   cross_section.comm().max(next_side_id);
 
-  MeshBase::const_element_iterator       el  = cross_section.elements_begin();
-  const MeshBase::const_element_iterator end = cross_section.elements_end();
-  for (; el!=end; ++el)
+  for (const auto & elem : cross_section.elements_range())
     {
-      const Elem * elem = *el;
       const ElemType etype = elem->type();
 
       // build_extrusion currently only works on coarse meshes

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -810,13 +810,8 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
     unique_id_type max_unique_id = mesh.parallel_max_unique_id();
 #endif
 
-    MeshBase::element_iterator       el  = mesh.elements_begin();
-    const MeshBase::element_iterator end = mesh.elements_end();
-
-    for (; el!=end; ++el)
+    for (auto & elem : mesh.elements_range())
       {
-        Elem * elem = *el;
-
         const ElemType etype = elem->type();
 
         // all_tri currently only works on coarse meshes
@@ -1447,7 +1442,7 @@ void MeshTools::Modification::all_tri (MeshBase & mesh)
 
             for (auto sn : elem->side_index_range())
               {
-                mesh.get_boundary_info().boundary_ids(*el, sn, bc_ids);
+                mesh.get_boundary_info().boundary_ids(elem, sn, bc_ids);
                 for (std::vector<boundary_id_type>::const_iterator id_it=bc_ids.begin(); id_it!=bc_ids.end(); ++id_it)
                   {
                     const boundary_id_type b_id = *id_it;

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -2059,13 +2059,8 @@ void MeshTools::Modification::change_subdomain_id (MeshBase & mesh,
       return;
     }
 
-  MeshBase::element_iterator           el = mesh.elements_begin();
-  const MeshBase::element_iterator end_el = mesh.elements_end();
-
-  for (; el != end_el; ++el)
+  for (auto & elem : mesh.elements_range())
     {
-      Elem * elem = *el;
-
       if (elem->subdomain_id() == old_id)
         elem->subdomain_id() = new_id;
     }

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1855,16 +1855,9 @@ void MeshTools::Modification::flatten(MeshBase & mesh)
     libmesh_assert_equal_to (saved_bc_ids.size(), saved_bc_sides.size());
   }
 
-
   // Loop again, delete any remaining elements
-  {
-    MeshBase::element_iterator       it  = mesh.elements_begin();
-    const MeshBase::element_iterator end = mesh.elements_end();
-
-    for (; it != end; ++it)
-      mesh.delete_elem( *it );
-  }
-
+  for (auto & elem : mesh.elements_range())
+    mesh.delete_elem(elem);
 
   // Add the copied (now level-0) elements back to the mesh
   {

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1543,15 +1543,9 @@ bool MeshRefinement::_refine_elements ()
   // flagged for h refinement.
   dof_id_type n_elems_flagged = 0;
 
-  MeshBase::element_iterator       it  = _mesh.elements_begin();
-  const MeshBase::element_iterator end = _mesh.elements_end();
-
-  for (; it != end; ++it)
-    {
-      Elem * elem = *it;
-      if (elem->refinement_flag() == Elem::REFINE)
-        n_elems_flagged++;
-    }
+  for (auto & elem : _mesh.elements_range())
+    if (elem->refinement_flag() == Elem::REFINE)
+      n_elems_flagged++;
 
   // Construct a local vector of Elem * which have been
   // previously marked for refinement.  We reserve enough

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -656,17 +656,11 @@ bool MeshRefinement::coarsen_elements ()
 
   // Possibly clean up the refinement flags from
   // a previous step
-  MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
+  for (auto & elem : _mesh.elements_range())
     {
-      // Pointer to the element
-      Elem * elem = *elem_it;
-
       // Set refinement flag to INACTIVE if the
       // element isn't active
-      if ( !elem->active())
+      if (!elem->active())
         {
           elem->set_refinement_flag(Elem::INACTIVE);
           elem->set_p_refinement_flag(Elem::INACTIVE);

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -730,17 +730,11 @@ bool MeshRefinement::refine_elements ()
 
   // Possibly clean up the refinement flags from
   // a previous step
-  MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
+  for (auto & elem : _mesh.elements_range())
     {
-      // Pointer to the element
-      Elem * elem = *elem_it;
-
       // Set refinement flag to INACTIVE if the
       // element isn't active
-      if ( !elem->active())
+      if (!elem->active())
         {
           elem->set_refinement_flag(Elem::INACTIVE);
           elem->set_p_refinement_flag(Elem::INACTIVE);

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1425,18 +1425,12 @@ bool MeshRefinement::_coarsen_elements ()
   // do the coarsening; otherwise it is possible to coarsen away a
   // one-element-thick layer partition and leave the partitions on
   // either side unable to figure out how to talk to each other.
-  for (MeshBase::element_iterator
-         it  = _mesh.elements_begin(),
-         end = _mesh.elements_end();
-       it != end; ++it)
-    {
-      Elem * elem = *it;
-      if (elem->refinement_flag() == Elem::COARSEN)
-        {
-          mesh_changed = true;
-          break;
-        }
-    }
+  for (auto & elem : _mesh.elements_range())
+    if (elem->refinement_flag() == Elem::COARSEN)
+      {
+        mesh_changed = true;
+        break;
+      }
 
   // If the mesh changed on any processor, it changed globally
   this->comm().max(mesh_changed);
@@ -1445,13 +1439,8 @@ bool MeshRefinement::_coarsen_elements ()
   if (mesh_changed)
     MeshCommunication().send_coarse_ghosts(_mesh);
 
-  for (MeshBase::element_iterator
-         it  = _mesh.elements_begin(),
-         end = _mesh.elements_end();
-       it != end; ++it)
+  for (auto & elem : _mesh.elements_range())
     {
-      Elem * elem = *it;
-
       // active elements flagged for coarsening will
       // no longer be deleted until MeshRefinement::contract()
       if (elem->refinement_flag() == Elem::COARSEN)

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -527,14 +527,8 @@ bool MeshRefinement::refine_and_coarsen_elements ()
   // a no-op.
   bool elements_flagged = false;
 
-  MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
+  for (auto & elem : _mesh.elements_range())
     {
-      // Pointer to the element
-      Elem * elem = *elem_it;
-
       // This might be left over from the last step
       const Elem::RefinementState flag = elem->refinement_flag();
 

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -660,20 +660,17 @@ void MeshRefinement::flag_elements_by (ElementFlagging & element_flagging)
 
 void MeshRefinement::switch_h_to_p_refinement ()
 {
-  MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
+  for (auto & elem : _mesh.elements_range())
     {
-      if ((*elem_it)->active())
+      if (elem->active())
         {
-          (*elem_it)->set_p_refinement_flag((*elem_it)->refinement_flag());
-          (*elem_it)->set_refinement_flag(Elem::DO_NOTHING);
+          elem->set_p_refinement_flag(elem->refinement_flag());
+          elem->set_refinement_flag(Elem::DO_NOTHING);
         }
       else
         {
-          (*elem_it)->set_p_refinement_flag((*elem_it)->refinement_flag());
-          (*elem_it)->set_refinement_flag(Elem::INACTIVE);
+          elem->set_p_refinement_flag(elem->refinement_flag());
+          elem->set_refinement_flag(Elem::INACTIVE);
         }
     }
 }

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -692,23 +692,17 @@ void MeshRefinement::clean_refinement_flags ()
 {
   // Possibly clean up the refinement flags from
   // a previous step
-  //   elem_iterator       elem_it (_mesh.elements_begin());
-  //   const elem_iterator elem_end(_mesh.elements_end());
-
-  MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
+  for (auto & elem : _mesh.elements_range())
     {
-      if ((*elem_it)->active())
+      if (elem->active())
         {
-          (*elem_it)->set_refinement_flag(Elem::DO_NOTHING);
-          (*elem_it)->set_p_refinement_flag(Elem::DO_NOTHING);
+          elem->set_refinement_flag(Elem::DO_NOTHING);
+          elem->set_p_refinement_flag(Elem::DO_NOTHING);
         }
       else
         {
-          (*elem_it)->set_refinement_flag(Elem::INACTIVE);
-          (*elem_it)->set_p_refinement_flag(Elem::INACTIVE);
+          elem->set_refinement_flag(Elem::INACTIVE);
+          elem->set_p_refinement_flag(Elem::INACTIVE);
         }
     }
 }

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -679,11 +679,8 @@ void MeshRefinement::switch_h_to_p_refinement ()
 
 void MeshRefinement::add_p_to_h_refinement ()
 {
-  MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
-    (*elem_it)->set_p_refinement_flag((*elem_it)->refinement_flag());
+  for (auto & elem : _mesh.elements_range())
+    elem->set_p_refinement_flag(elem->refinement_flag());
 }
 
 

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -206,11 +206,8 @@ void MeshTools::Subdivision::prepare_subdivision_mesh(MeshBase & mesh, bool ghos
 
 void MeshTools::Subdivision::tag_boundary_ghosts(MeshBase & mesh)
 {
-  MeshBase::element_iterator       el     = mesh.elements_begin();
-  const MeshBase::element_iterator end_el = mesh.elements_end();
-  for (; el != end_el; ++el)
+  for (auto & elem : mesh.elements_range())
     {
-      Elem * elem = *el;
       libmesh_assert_equal_to(elem->type(), TRI3SUBDIVISION);
 
       Tri3Subdivision * sd_elem = static_cast<Tri3Subdivision *>(elem);

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -194,14 +194,12 @@ void MeshTools::Subdivision::prepare_subdivision_mesh(MeshBase & mesh, bool ghos
       node->set_valence(valence);
     }
 
-  MeshBase::const_element_iterator       el     = mesh.elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.elements_end();
-  for (; el != end_el; ++el)
+  for (auto & elem : mesh.elements_range())
     {
-      Tri3Subdivision * elem = dynamic_cast<Tri3Subdivision *>(*el);
-      libmesh_assert(elem);
-      if (!elem->is_ghost())
-        elem->prepare_subdivision_properties();
+      Tri3Subdivision * tri3s = dynamic_cast<Tri3Subdivision *>(elem);
+      libmesh_assert(tri3s);
+      if (!tri3s->is_ghost())
+        tri3s->prepare_subdivision_properties();
     }
 }
 

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -101,19 +101,16 @@ void MeshTools::Subdivision::all_subdivision(MeshBase & mesh)
   // Container to catch ids handed back from BoundaryInfo
   std::vector<boundary_id_type> ids;
 
-  MeshBase::const_element_iterator       el     = mesh.elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.elements_end();
-  for (; el != end_el; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert_equal_to(elem->type(), TRI3);
 
       Elem * tri = new Tri3Subdivision;
       tri->set_id(elem->id());
       tri->subdomain_id() = elem->subdomain_id();
-      tri->set_node(0) = (*el)->node_ptr(0);
-      tri->set_node(1) = (*el)->node_ptr(1);
-      tri->set_node(2) = (*el)->node_ptr(2);
+      tri->set_node(0) = elem->node_ptr(0);
+      tri->set_node(1) = elem->node_ptr(1);
+      tri->set_node(2) = elem->node_ptr(2);
 
       if (mesh_has_boundary_data)
         {

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -397,13 +397,8 @@ unsigned TetGenMeshInterface::check_hull_integrity()
   if (_mesh.n_elem() == 0)
     return 3;
 
-  MeshBase::element_iterator it        = this->_mesh.elements_begin();
-  const MeshBase::element_iterator end = this->_mesh.elements_end();
-
-  for (; it != end ; ++it)
+  for (auto & elem : this->_mesh.elements_range())
     {
-      Elem * elem = *it;
-
       // Check for proper element type
       if (elem->type() != TRI3)
         {

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -201,14 +201,10 @@ void TetGenMeshInterface::triangulate_conformingDelaunayMesh_carvehole  (const s
   // from the convex hull.
   {
     int insertnum = 0;
-    MeshBase::element_iterator it        = this->_mesh.elements_begin();
-    const MeshBase::element_iterator end = this->_mesh.elements_end();
-    for (; it != end ; ++it)
+    for (auto & elem : this->_mesh.elements_range())
       {
         tetgen_wrapper.allocate_facet_polygonlist(insertnum, 1);
         tetgen_wrapper.allocate_polygon_vertexlist(insertnum, 0, 3);
-
-        Elem * elem = *it;
 
         for (unsigned int j=0; j<elem->n_nodes(); ++j)
           {

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -445,13 +445,8 @@ void TetGenMeshInterface::process_hull_integrity_result(unsigned result)
 
 void TetGenMeshInterface::delete_2D_hull_elements()
 {
-  MeshBase::element_iterator it        = this->_mesh.elements_begin();
-  const MeshBase::element_iterator end = this->_mesh.elements_end();
-
-  for (; it != end ; ++it)
+  for (auto & elem : this->_mesh.elements_range())
     {
-      Elem * elem = *it;
-
       // Check for proper element type. Yes, we legally delete elements while
       // iterating over them because no entries from the underlying container
       // are actually erased.

--- a/src/mesh/mesh_tetgen_interface.C
+++ b/src/mesh/mesh_tetgen_interface.C
@@ -132,12 +132,8 @@ void TetGenMeshInterface::pointset_convexhull ()
   // Delete *all* old elements.  Yes, we legally delete elements while
   // iterating over them because no entries from the underlying container
   // are actually erased.
-  {
-    MeshBase::element_iterator       it  = this->_mesh.elements_begin();
-    const MeshBase::element_iterator end = this->_mesh.elements_end();
-    for ( ; it != end; ++it)
-      this->_mesh.delete_elem (*it);
-  }
+  for (auto & elem : this->_mesh.elements_range())
+    this->_mesh.delete_elem (elem);
 
   // We just removed any boundary info associated with element faces
   // or edges, so let's update the boundary id caches.

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1020,15 +1020,8 @@ void MeshTools::libmesh_assert_old_dof_objects (const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_old_dof_objects()", "MeshTools");
 
-  MeshBase::const_element_iterator el =
-    mesh.elements_begin();
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-
-  for (; el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
-
       if (elem->refinement_flag() == Elem::JUST_REFINED ||
           elem->refinement_flag() == Elem::INACTIVE)
         continue;

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -655,15 +655,10 @@ unsigned int MeshTools::paranoid_n_levels(const MeshBase & mesh)
 void MeshTools::get_not_subactive_node_ids(const MeshBase & mesh,
                                            std::set<dof_id_type> & not_subactive_node_ids)
 {
-  MeshBase::const_element_iterator el           = mesh.elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.elements_end();
-  for ( ; el != end_el; ++el)
-    {
-      const Elem * elem = (*el);
-      if (!elem->subactive())
-        for (auto & n : elem->node_ref_range())
-          not_subactive_node_ids.insert(n.id());
-    }
+  for (const auto & elem : mesh.elements_range())
+    if (!elem->subactive())
+      for (auto & n : elem->node_ref_range())
+        not_subactive_node_ids.insert(n.id());
 }
 
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1721,12 +1721,8 @@ void MeshTools::libmesh_assert_valid_refinement_tree(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_refinement_tree()", "MeshTools");
 
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-  for (MeshBase::const_element_iterator el =
-         mesh.elements_begin(); el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert(elem);
       if (elem->has_children())
         for (auto & child : elem->child_ref_range())

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1044,12 +1044,11 @@ void MeshTools::libmesh_assert_valid_node_pointers(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_node_pointers()", "MeshTools");
 
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-  for (MeshBase::const_element_iterator el =
-         mesh.elements_begin(); el != el_end; ++el)
+  // Here we specifically do not want "auto &" because we need to
+  // reseat the (temporary) pointer variable in the loop below,
+  // without modifying the original.
+  for (const Elem * elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert (elem);
       while (elem)
         {

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1683,12 +1683,8 @@ void MeshTools::libmesh_assert_valid_refinement_flags(const MeshBase & mesh)
   std::vector<unsigned char> my_elem_h_state(pmax_elem_id, 255);
   std::vector<unsigned char> my_elem_p_state(pmax_elem_id, 255);
 
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-  for (MeshBase::const_element_iterator el =
-         mesh.elements_begin(); el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert (elem);
       dof_id_type elemid = elem->id();
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1148,12 +1148,8 @@ void MeshTools::libmesh_assert_valid_amr_elem_ids(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_amr_elem_ids()", "MeshTools");
 
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-  for (MeshBase::const_element_iterator el =
-         mesh.elements_begin(); el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert (elem);
 
       const Elem * parent = elem->parent();

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1476,13 +1476,8 @@ void libmesh_assert_topology_consistent_procids<Elem>(const MeshBase & mesh)
 
   // Ancestor elements we won't worry about, but subactive and active
   // elements ought to have parents with consistent processor ids
-
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-  for (MeshBase::const_element_iterator el =
-         mesh.elements_begin(); el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert(elem);
 
       if (!elem->active() && !elem->subactive())

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1757,11 +1757,8 @@ void MeshTools::libmesh_assert_valid_neighbors(const MeshBase & mesh,
 {
   LOG_SCOPE("libmesh_assert_valid_neighbors()", "MeshTools");
 
-  const MeshBase::const_element_iterator el_end = mesh.elements_end();
-  for (MeshBase::const_element_iterator el = mesh.elements_begin();
-       el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert (elem);
       elem->libmesh_assert_valid_neighbors();
     }

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -517,18 +517,11 @@ MeshTools::subdomain_bounding_sphere (const MeshBase & mesh,
 void MeshTools::elem_types (const MeshBase & mesh,
                             std::vector<ElemType> & et)
 {
-  MeshBase::const_element_iterator       el  = mesh.elements_begin();
-  const MeshBase::const_element_iterator end = mesh.elements_end();
-
-  // Automatically get the first type
-  et.push_back((*el)->type());  ++el;
-
-  // Loop over the rest of the elements.
-  // If the current element type isn't in the
-  // vector, insert it.
-  for (; el != end; ++el)
-    if (!std::count(et.begin(), et.end(), (*el)->type()))
-      et.push_back((*el)->type());
+  // Loop over the the elements.  If the current element type isn't in
+  // the vector, insert it.
+  for (const auto & elem : mesh.elements_range())
+    if (!std::count(et.begin(), et.end(), elem->type()))
+      et.push_back(elem->type());
 }
 
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -642,14 +642,9 @@ unsigned int MeshTools::paranoid_n_levels(const MeshBase & mesh)
 {
   libmesh_parallel_only(mesh.comm());
 
-  MeshBase::const_element_iterator el =
-    mesh.elements_begin();
-  const MeshBase::const_element_iterator end_el =
-    mesh.elements_end();
-
   unsigned int nl = 0;
-  for ( ; el != end_el; ++el)
-    nl = std::max((*el)->level() + 1, nl);
+  for (const auto & elem : mesh.elements_range())
+    nl = std::max(elem->level() + 1, nl);
 
   mesh.comm().max(nl);
   return nl;

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1168,12 +1168,8 @@ void MeshTools::libmesh_assert_valid_amr_interior_parents(const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_valid_amr_interior_parents()", "MeshTools");
 
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-  for (MeshBase::const_element_iterator el =
-         mesh.elements_begin(); el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert (elem);
 
       // We can skip to the next element if we're full-dimension

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -988,19 +988,14 @@ void MeshTools::libmesh_assert_equal_n_systems (const MeshBase & mesh)
 {
   LOG_SCOPE("libmesh_assert_equal_n_systems()", "MeshTools");
 
-  MeshBase::const_element_iterator el =
-    mesh.elements_begin();
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-  if (el == el_end)
-    return;
+  unsigned int n_sys = libMesh::invalid_uint;
 
-  const unsigned int n_sys = (*el)->n_systems();
-
-  for (; el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
-      libmesh_assert_equal_to (elem->n_systems(), n_sys);
+      if (n_sys == libMesh::invalid_uint)
+        n_sys = elem->n_systems();
+      else
+        libmesh_assert_equal_to (elem->n_systems(), n_sys);
     }
 
   MeshBase::const_node_iterator node_it =

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -259,16 +259,13 @@ void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
 {
   nodes_to_elem_map.resize (mesh.n_nodes());
 
-  MeshBase::const_element_iterator       el  = mesh.elements_begin();
-  const MeshBase::const_element_iterator end = mesh.elements_end();
-
-  for (; el != end; ++el)
-    for (auto & node : (*el)->node_ref_range())
+  for (const auto & elem : mesh.elements_range())
+    for (auto & node : elem->node_ref_range())
       {
         libmesh_assert_less (node.id(), nodes_to_elem_map.size());
-        libmesh_assert_less ((*el)->id(), mesh.n_elem());
+        libmesh_assert_less (elem->id(), mesh.n_elem());
 
-        nodes_to_elem_map[node.id()].push_back((*el)->id());
+        nodes_to_elem_map[node.id()].push_back(elem->id());
       }
 }
 
@@ -279,15 +276,12 @@ void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
 {
   nodes_to_elem_map.resize (mesh.n_nodes());
 
-  MeshBase::const_element_iterator       el  = mesh.elements_begin();
-  const MeshBase::const_element_iterator end = mesh.elements_end();
-
-  for (; el != end; ++el)
-    for (auto & node : (*el)->node_ref_range())
+  for (const auto & elem : mesh.elements_range())
+    for (auto & node : elem->node_ref_range())
       {
         libmesh_assert_less (node.id(), nodes_to_elem_map.size());
 
-        nodes_to_elem_map[node.id()].push_back(*el);
+        nodes_to_elem_map[node.id()].push_back(elem);
       }
 }
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1206,12 +1206,8 @@ void MeshTools::libmesh_assert_connected_nodes (const MeshBase & mesh)
 
   std::set<const Node *> used_nodes;
 
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-  for (MeshBase::const_element_iterator el =
-         mesh.elements_begin(); el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert (elem);
 
       for (auto & n : elem->node_ref_range())

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1100,12 +1100,8 @@ void MeshTools::libmesh_assert_valid_remote_elems(const MeshBase & mesh)
 void MeshTools::libmesh_assert_no_links_to_elem(const MeshBase & mesh,
                                                 const Elem * bad_elem)
 {
-  const MeshBase::const_element_iterator el_end =
-    mesh.elements_end();
-  for (MeshBase::const_element_iterator el =
-         mesh.elements_begin(); el != el_end; ++el)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *el;
       libmesh_assert (elem);
       libmesh_assert_not_equal_to (elem->parent(), bad_elem);
       for (auto n : elem->neighbor_ptr_range())

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -298,19 +298,13 @@ void UCDIO::write_nodes(std::ostream & out_stream,
 void UCDIO::write_interior_elems(std::ostream & out_stream,
                                  const MeshBase & mesh)
 {
-  MeshBase::const_element_iterator it  = mesh.elements_begin();
-  const MeshBase::const_element_iterator end = mesh.elements_end();
-
   // 1-based element number for UCD
   unsigned int e=1;
 
   // Write element information
-  for (; it != end; ++it)
+  for (const auto & elem : mesh.elements_range())
     {
       libmesh_assert (out_stream.good());
-
-      // Get pointer to Elem for convenience.
-      const Elem * elem = *it;
 
       // Look up the corresponding UCD element type in the static map.
       const ElemType etype = elem->type();

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -119,14 +119,9 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
     map_type old_elems_to_new_elems;
 
     // Loop over the elements
-    MeshBase::const_element_iterator it = other_mesh.elements_begin();
-    const MeshBase::const_element_iterator end = other_mesh.elements_end();
-
-    for (; it != end; ++it)
+    for (const auto & old : other_mesh.elements_range())
       {
-        //Look at the old element
-        const Elem * old = *it;
-        //Build a new element
+        // Build a new element
         Elem * newparent = old->parent() ?
           this->elem_ptr(old->parent()->id()) : libmesh_nullptr;
         UniquePtr<Elem> ap = Elem::build(old->type(), newparent);
@@ -194,10 +189,8 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
     // Loop (again) over the elements to fill in the neighbors
     if (skip_find_neighbors)
       {
-        it = other_mesh.elements_begin();
-        for (; it != end; ++it)
+        for (const auto & old_elem : other_mesh.elements_range())
           {
-            Elem * old_elem = *it;
             Elem * new_elem = old_elems_to_new_elems[old_elem];
             for (auto s : old_elem->side_index_range())
               {

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -983,13 +983,8 @@ void UNVIO::elements_out(std::ostream & out_file)
   // A reference to the parent class's mesh
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
 
-  MeshBase::const_element_iterator it  = mesh.elements_begin();
-  const MeshBase::const_element_iterator end = mesh.elements_end();
-
-  for (; it != end; ++it)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *it;
-
       switch (elem->type())
         {
 

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -241,16 +241,9 @@ void UNVIO::read_implementation (std::istream & in_stream)
 
       unsigned char max_dim = this->max_elem_dimension_seen();
 
-      MeshBase::const_element_iterator       el     = mesh.elements_begin();
-      const MeshBase::const_element_iterator end_el = mesh.elements_end();
-
-      for (; el != end_el; ++el)
-        {
-          Elem * elem = *el;
-
-          if (elem->dim() < max_dim)
-            mesh.delete_elem(elem);
-        }
+      for (const auto & elem : mesh.elements_range())
+        if (elem->dim() < max_dim)
+          mesh.delete_elem(elem);
     }
 
     if (this->verbose())

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -1254,11 +1254,8 @@ void EquationSystems::_add_system_to_nodes_and_elems()
     (*node_it)->add_system();
 
   // All the elements
-  MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
-    (*elem_it)->add_system();
+  for (auto & elem : _mesh.elements_range())
+    elem->add_system();
 }
 
 } // namespace libMesh

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -144,11 +144,8 @@ void EquationSystems::reinit ()
       for ( ; node_it != node_end; ++node_it)
         (*node_it)->set_n_systems(n_sys);
 
-      MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-      const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-      for ( ; elem_it != elem_end; ++elem_it)
-        (*elem_it)->set_n_systems(n_sys);
+      for (auto & elem : _mesh.elements_range())
+        elem->set_n_systems(n_sys);
 
       // And any new systems will need initialization
       for (unsigned int i=0; i != n_sys; ++i)

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -106,11 +106,8 @@ void EquationSystems::init ()
     for ( ; node_it != node_end; ++node_it)
       (*node_it)->set_n_systems(n_sys);
 
-    MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-    const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-    for ( ; elem_it != elem_end; ++elem_it)
-      (*elem_it)->set_n_systems(n_sys);
+    for (auto & elem : _mesh.elements_range())
+      elem->set_n_systems(n_sys);
   }
 
   for (unsigned int i=0; i != this->n_systems(); ++i)

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -298,11 +298,8 @@ void EquationSystems::allgather ()
     for ( ; node_it != node_end; ++node_it)
       (*node_it)->set_n_systems(n_sys);
 
-    MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-    const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-    for ( ; elem_it != elem_end; ++elem_it)
-      (*elem_it)->set_n_systems(n_sys);
+    for (auto & elem : _mesh.elements_range())
+      elem->set_n_systems(n_sys);
   }
 
   // And distribute each system's dofs

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -173,14 +173,8 @@ void EquationSystems::reinit ()
       }
 
     // All the elements
-    MeshBase::element_iterator       elem_it  = _mesh.elements_begin();
-    const MeshBase::element_iterator elem_end = _mesh.elements_end();
-
-    for ( ; elem_it != elem_end; ++elem_it)
-      {
-        Elem * elem = *elem_it;
-        elem->set_n_systems(this->n_systems());
-      }
+    for (auto & elem : _mesh.elements_range())
+      elem->set_n_systems(this->n_systems());
   }
 
   // Localize each system's vectors

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -568,84 +568,8 @@ void EquationSystems::build_solution_vector (std::vector<Number> &,
                                              const std::string &,
                                              const std::string &) const
 {
-  //TODO:[BSK] re-implement this from the method below
+  // TODO:[BSK] re-implement this from the method below
   libmesh_not_implemented();
-
-  //   // Get a reference to the named system
-  //   const System & system = this->get_system(system_name);
-
-  //   // Get the number associated with the variable_name we are passed
-  //   const unsigned short int variable_num = system.variable_number(variable_name);
-
-  //   // Get the dimension of the current mesh
-  //   const unsigned int dim = _mesh.mesh_dimension();
-
-  //   // If we're on processor 0, allocate enough memory to hold the solution.
-  //   // Since we're only looking at one variable, there will be one solution value
-  //   // for each node in the mesh.
-  //   if (_mesh.processor_id() == 0)
-  //     soln.resize(_mesh.n_nodes());
-
-  //   // Vector to hold the global solution from all processors
-  //   std::vector<Number> sys_soln;
-
-  //   // Update the global solution from all processors
-  //   system.update_global_solution (sys_soln, 0);
-
-  //   // Temporary vector to store the solution on an individual element.
-  //   std::vector<Number>       elem_soln;
-
-  //   // The FE solution interpolated to the nodes
-  //   std::vector<Number>       nodal_soln;
-
-  //   // The DOF indices for the element
-  //   std::vector<dof_id_type> dof_indices;
-
-  //   // Determine the finite/infinite element type used in this system
-  //   const FEType & fe_type    = system.variable_type(variable_num);
-
-  //   // Define iterators to iterate over all the elements of the mesh
-  //   const_active_elem_iterator       it (_mesh.elements_begin());
-  //   const const_active_elem_iterator end(_mesh.elements_end());
-
-  //   // Loop over elements
-  //   for ( ; it != end; ++it)
-  //     {
-  //       // Convenient shortcut to the element pointer
-  //       const Elem * elem = *it;
-
-  //       // Fill the dof_indices vector for this variable
-  //       system.get_dof_map().dof_indices(elem,
-  //        dof_indices,
-  //        variable_num);
-
-  //       // Resize the element solution vector to fit the
-  //       // dof_indices for this element.
-  //       elem_soln.resize(dof_indices.size());
-
-  //       // Transfer the system solution to the element
-  //       // solution by mapping it through the dof_indices vector.
-  //       for (std::size_t i=0; i<dof_indices.size(); i++)
-  // elem_soln[i] = sys_soln[dof_indices[i]];
-
-  //       // Using the FE interface, compute the nodal_soln
-  //       // for the current element type given the elem_soln
-  //       FEInterface::nodal_soln (dim,
-  //        fe_type,
-  //        elem,
-  //        elem_soln,
-  //        nodal_soln);
-
-  //       // Sanity check -- make sure that there are the same number
-  //       // of entries in the nodal_soln as there are nodes in the
-  //       // element!
-  //       libmesh_assert_equal_to (nodal_soln.size(), elem->n_nodes());
-
-  //       // Copy the nodal solution over into the correct place in
-  //       // the global soln vector which will be returned to the user.
-  //       for (unsigned int n=0; n<elem->n_nodes(); n++)
-  // soln[elem->node_id(n)] = nodal_soln[n];
-  //     }
 }
 
 

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -219,19 +219,11 @@ void ErrorVector::plot_error(const std::string & filename,
 #ifdef LIBMESH_ENABLE_AMR
   // We don't want p elevation when plotting a single constant value
   // per element
-  {
-    MeshBase::element_iterator       el     =
-      mesh.elements_begin();
-    const MeshBase::element_iterator end_el =
-      mesh.elements_end();
-
-    for ( ; el != end_el; ++el)
-      {
-        Elem * elem = *el;
-        elem->set_p_refinement_flag(Elem::DO_NOTHING);
-        elem->set_p_level(0);
-      }
-  }
+  for (auto & elem : mesh.elements_range())
+    {
+      elem->set_p_refinement_flag(Elem::DO_NOTHING);
+      elem->set_p_level(0);
+    }
 #endif // LIBMESH_ENABLE_AMR
 
   EquationSystems temp_es (mesh);

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -139,13 +139,8 @@ dof_id_type TopologyMap::find(dof_id_type bracket_node1,
 void TopologyMap::fill(const MeshBase & mesh)
 {
   // Populate the nodes map
-  MeshBase::const_element_iterator
-    it = mesh.elements_begin(),
-    end = mesh.elements_end();
-  for (; it != end; ++it)
+  for (const auto & elem : mesh.elements_range())
     {
-      const Elem * elem = *it;
-
       // We only need to add nodes which might be added during mesh
       // refinement; this means they need to be child nodes.
       if (!elem->has_children())

--- a/tests/mesh/mapped_subdomain_partitioner_test.C
+++ b/tests/mesh/mapped_subdomain_partitioner_test.C
@@ -87,14 +87,9 @@ public:
 
     // Assign subdomain ids to elements sequentially.
     {
-      MeshBase::element_iterator       el     = mesh.elements_begin();
-      const MeshBase::element_iterator end_el = mesh.elements_end();
-
       subdomain_id_type current_subdomain_id = 0;
-      for ( ; el != end_el; ++el)
+      for (auto & elem : mesh.elements_range())
         {
-          Elem * elem = *el;
-
           elem->subdomain_id() = current_subdomain_id++;
 
           // Wrap around
@@ -107,20 +102,12 @@ public:
     mesh.partition();
 
     // Assert that the partitioning worked as expected.
-    {
-      MeshBase::element_iterator       el     = mesh.elements_begin();
-      const MeshBase::element_iterator end_el = mesh.elements_end();
-
-      for ( ; el != end_el; ++el)
-        {
-          Elem * elem = *el;
-
-          // Subdomain id n should map to processor id n/2.
-          CPPUNIT_ASSERT_EQUAL(static_cast<int>(elem->subdomain_id()/2),
-                               static_cast<int>(elem->processor_id()));
-        }
-    }
-
+    for (auto & elem : mesh.elements_range())
+      {
+        // Subdomain id n should map to processor id n/2.
+        CPPUNIT_ASSERT_EQUAL(static_cast<int>(elem->subdomain_id()/2),
+                             static_cast<int>(elem->processor_id()));
+      }
   }
 };
 


### PR DESCRIPTION
Subsequent PRs will add range functions for the other Elem and Node iterator types in MeshBase. 

Large number of commits as requested by @roystgnr.
