### PR TITLE
Add MeshBase::active_local_element_ptr_range() 

### DIFF
--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -246,15 +246,8 @@ void assemble_1D(EquationSystems & es,
   // the matrix and right-hand-side contribution from each element. Use a
   // const_element_iterator to loop over the elements. We make
   // el_end const as it is used only for the stopping condition of the loop.
-  MeshBase::const_element_iterator el = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator el_end = mesh.active_local_elements_end();
-
-  // Note that ++el is preferred to el++ when using loops with iterators
-  for ( ; el != el_end; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // It is convenient to store a pointer to the current element
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the current element.
       // These define where in the global matrix and right-hand-side this
       // element will contribute to.

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -563,15 +563,8 @@ void assemble_cd (EquationSystems & es,
   // matrix and right-hand-side contribution.  Since the mesh
   // will be refined we want to only consider the ACTIVE elements,
   // hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -706,19 +706,12 @@ void assemble_laplace(EquationSystems & es,
   // processor to compute its components of the global matrix for
   // active elements while ignoring parent elements which have been
   // refined.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
       // Start logging the shape function initialization.
       // This is done through a simple function call with
       // the name of the event to log.
       perf_log.push("elem init");
-
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
 
       // Get the degree of freedom indices for the
       // current element.  These define where in the global

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -757,20 +757,12 @@ void assemble_biharmonic(EquationSystems & es,
   // Now we will loop over all the elements in the mesh.  We will
   // compute the element matrix and right-hand-side contribution.  See
   // example 3 for a discussion of the element iterators.
-
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
       // Start logging the shape function initialization.
       // This is done through a simple function call with
       // the name of the event to log.
       perf_log.push("elem init");
-
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
 
       // Get the degree of freedom indices for the
       // current element.  These define where in the global

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -647,15 +647,8 @@ void assemble_cd (EquationSystems & es,
   // matrix and right-hand-side contribution.  Since the mesh
   // will be refined we want to only consider the ACTIVE elements,
   // hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
+++ b/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
@@ -243,15 +243,8 @@ void assemble_mass(EquationSystems & es,
   // later modify this program to include refinement, we will
   // be safe and will only consider the active elements;
   // hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -281,15 +281,8 @@ void assemble_mass(EquationSystems & es,
   // later modify this program to include refinement, we will
   // be safe and will only consider the active elements;
   // hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -350,15 +350,8 @@ void assemble_matrices(EquationSystems & es,
   // later modify this program to include refinement, we will
   // be safe and will only consider the active elements;
   // hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/introduction/introduction_ex3/introduction_ex3.C
+++ b/examples/introduction/introduction_ex3/introduction_ex3.C
@@ -273,18 +273,8 @@ void assemble_poisson(EquationSystems & es,
   // mess it up!  In case users later modify this program to include
   // refinement, we will be safe and will only consider the active
   // elements; hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  // Loop over the elements.  Note that  ++el is preferred to
-  // el++ since the latter requires an unnecessary temporary
-  // object.
-  for ( ; el != end_el ; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/introduction/introduction_ex4/introduction_ex4.C
+++ b/examples/introduction/introduction_ex4/introduction_ex4.C
@@ -413,19 +413,12 @@ void assemble_poisson(EquationSystems & es,
   // We will compute the element matrix and right-hand-side
   // contribution.  See example 3 for a discussion of the
   // element iterators.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
       // Start logging the shape function initialization.
       // This is done through a simple function call with
       // the name of the event to log.
       perf_log.push("elem init");
-
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
 
       // Get the degree of freedom indices for the
       // current element.  These define where in the global

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -301,13 +301,8 @@ void assemble_poisson(EquationSystems & es,
 
   // Now we will loop over all the elements in the mesh.
   // See example 3 for details.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       dof_map.dof_indices (elem, dof_indices);
 
       fe->reinit (elem);

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -296,15 +296,8 @@ void assemble_wave(EquationSystems & es,
   // Now we will loop over all the elements in the mesh.
   // We will compute the element matrix and right-hand-side
   // contribution.
-  MeshBase::const_element_iterator           el = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
+++ b/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
@@ -267,13 +267,8 @@ void assemble_poisson(EquationSystems & es,
 
   std::vector<dof_id_type> dof_indices;
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       dof_map.dof_indices (elem, dof_indices);
 
       fe->reinit (elem);

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -349,15 +349,8 @@ void assemble_shell (EquationSystems & es,
 
   // Now we will loop over all the elements in the mesh.  We will
   // compute the element matrix and right-hand-side contribution.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for (; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // The ghost elements at the boundaries need to be excluded
       // here, as they don't belong to the physical shell,
       // but serve for a proper boundary treatment only.
@@ -574,14 +567,8 @@ void assemble_shell (EquationSystems & es,
   // for subdivision shells.  We use the simplest way here,
   // which is known to be overly restrictive and will lead to
   // a slightly too small deformation of the plate.
-  el = mesh.active_local_elements_begin();
-
-  for (; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // For the boundary conditions, we only need to loop over
       // the ghost elements.
       libmesh_assert_equal_to (elem->type(), TRI3SUBDIVISION);

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -427,15 +427,8 @@ void assemble_shell (EquationSystems & es,
 
   // Now we will loop over all the elements in the mesh.  We will
   // compute the element matrix and right-hand-side contribution.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for (; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       dof_map.dof_indices (elem, dof_indices);
       for (unsigned int var=0; var<6; var++)
         dof_map.dof_indices (elem, dof_indices_var[var], var);

--- a/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
+++ b/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
@@ -429,15 +429,8 @@ void assemble_shell (EquationSystems & es,
 
   // Now we will loop over all the elements in the mesh.  We will
   // compute the element matrix and right-hand-side contribution.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for (; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       dof_map.dof_indices (elem, dof_indices);
       for (unsigned int var=0; var<6; var++)
         dof_map.dof_indices (elem, dof_indices_var[var], var);

--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -369,17 +369,10 @@ void assemble_helmholtz(EquationSystems & es,
 
   // Now we will loop over all the elements in the mesh, and compute
   // the element matrix and right-hand-side contributions.
-  MeshBase::const_element_iterator           el = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
       // Start logging the element initialization.
       START_LOG("elem init", "assemble_helmholtz");
-
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
 
       // Get the degree of freedom indices for the
       // current element.  These define where in the global

--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -369,15 +369,8 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
   // We will compute the element residual.
   residual.zero();
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will
@@ -531,15 +524,8 @@ void LaplaceYoung::jacobian (const NumericVector<Number> & soln,
   // Now we will loop over all the active elements in the mesh which
   // are local to this processor.
   // We will compute the element Jacobian contribution.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -316,15 +316,8 @@ void assemble (EquationSystems & es,
   // matrix and right-hand-side contribution.  Since the mesh
   // will be refined we want to only consider the ACTIVE elements,
   // hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -234,15 +234,8 @@ void assemble_ellipticdg(EquationSystems & es,
   // Now we will loop over all the elements in the mesh.  We will
   // compute first the element interior matrix and right-hand-side contribution
   // and then the element and neighbors boundary matrix contributions.
-  MeshBase::const_element_iterator el = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
@@ -255,16 +255,8 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
   // Now we will loop over all the elements in the mesh.  We will
   // compute the element matrix and right-hand-side contribution.  See
   // example 3 for a discussion of the element iterators.
-
-  MeshBase::const_element_iterator       el     = _biharmonic._mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = _biharmonic._mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : _biharmonic._mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will
@@ -520,10 +512,7 @@ void Biharmonic::JR::bounds(NumericVector<Number> & XL,
   // the element degrees of freedom get mapped.
   std::vector<dof_id_type> dof_indices;
 
-  MeshBase::const_element_iterator       el     = _biharmonic._mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = _biharmonic._mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : _biharmonic._mesh.active_local_element_ptr_range())
     {
       // Extract the shape function to be evaluated at the nodes
       const std::vector<std::vector<Real>> & phi = fe->get_phi();
@@ -531,7 +520,7 @@ void Biharmonic::JR::bounds(NumericVector<Number> & XL,
       // Get the degree of freedom indices for the current element.
       // They are in 1-1 correspondence with shape functions phi
       // and define where in the global vector this element will.
-      dof_map.dof_indices (*el, dof_indices);
+      dof_map.dof_indices (elem, dof_indices);
 
       // Resize the local bounds vectors (zeroing them out in the process).
       XLe.resize(dof_indices.size());
@@ -539,10 +528,10 @@ void Biharmonic::JR::bounds(NumericVector<Number> & XL,
 
       // Extract the element node coordinates in the reference frame
       std::vector<Point> nodes;
-      fe->get_refspace_nodes((*el)->type(), nodes);
+      fe->get_refspace_nodes(elem->type(), nodes);
 
       // Evaluate the shape functions at the nodes
-      fe->reinit(*el, &nodes);
+      fe->reinit(elem, &nodes);
 
       // Construct the bounds based on the value of the i-th phi at the nodes.
       // Observe that this doesn't really work in general: we rely on the fact

--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -249,13 +249,8 @@ void assemble_poisson(EquationSystems & es,
 
   std::vector<dof_id_type> dof_indices;
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       dof_map.dof_indices (elem, dof_indices);
       const unsigned int n_dofs = dof_indices.size();
 

--- a/examples/optimization/optimization_ex1/optimization_ex1.C
+++ b/examples/optimization/optimization_ex1/optimization_ex1.C
@@ -152,13 +152,8 @@ void AssembleOptimization::assemble_A_and_F()
   DenseMatrix<Number> Ke;
   DenseVector<Number> Fe;
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       dof_map.dof_indices (elem, dof_indices);
 
       const unsigned int n_dofs = dof_indices.size();

--- a/examples/optimization/optimization_ex2/optimization_ex2.C
+++ b/examples/optimization/optimization_ex2/optimization_ex2.C
@@ -184,13 +184,8 @@ void AssembleOptimization::assemble_A_and_F()
   DenseMatrix<Number> Ke;
   DenseVector<Number> Fe;
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       dof_map.dof_indices (elem, dof_indices);
 
       const unsigned int n_dofs = dof_indices.size();

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -390,13 +390,8 @@ void compute_stresses(EquationSystems & es)
   // To store the stress tensor on each element
   DenseMatrix<Number> elem_sigma;
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       for (unsigned int var=0; var<3; var++)
         dof_map.dof_indices (elem, dof_indices_var[var], displacement_vars[var]);
 

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -417,15 +417,8 @@ void assemble_poisson(EquationSystems & es,
   // We will compute the element matrix and right-hand-side
   // contribution.  See example 3 for a discussion of the
   // element iterators.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Elements with subdomain_id other than 1 are not in the active
       // subdomain.  We don't assemble anything for them.
       if (elem->subdomain_id()==1)

--- a/examples/subdomains/subdomains_ex3/subdomains_ex3.C
+++ b/examples/subdomains/subdomains_ex3/subdomains_ex3.C
@@ -120,8 +120,6 @@ int main (int argc, char ** argv)
 void integrate_function (const MeshBase & mesh)
 {
 #if defined(LIBMESH_HAVE_TRIANGLE) && defined(LIBMESH_HAVE_TETGEN)
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
 
   std::vector<Real> vertex_distance;
 
@@ -135,10 +133,8 @@ void integrate_function (const MeshBase & mesh)
   const std::vector<Point> & q_points = fe->get_xyz();
   const std::vector<Real>  & JxW      = fe->get_JxW();
 
-  for (; el!=end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       vertex_distance.clear();
 
       for (unsigned int v=0; v<elem->n_vertices(); v++)

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -240,16 +240,8 @@ void assemble_stokes (EquationSystems & es,
   // modify this program to include refinement, we will be safe and
   // will only consider the active elements; hence we use a variant of
   // the active_elem_iterator.
-
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -455,15 +455,8 @@ void assemble_stokes (EquationSystems & es,
   // matrix and right-hand-side contribution.  Since the mesh
   // will be refined we want to only consider the ACTIVE elements,
   // hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -448,15 +448,8 @@ void assemble_stokes (EquationSystems & es,
   // matrix and right-hand-side contribution.  Since the mesh
   // will be refined we want to only consider the ACTIVE elements,
   // hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -196,13 +196,8 @@ void assemble_elasticity(EquationSystems & es,
   std::vector<dof_id_type> dof_indices_u;
   std::vector<dof_id_type> dof_indices_v;
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       dof_map.dof_indices (elem, dof_indices);
       dof_map.dof_indices (elem, dof_indices_u, u_var);
       dof_map.dof_indices (elem, dof_indices_v, v_var);

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -209,13 +209,8 @@ void assemble_elasticity(EquationSystems & es,
   std::vector<dof_id_type> dof_indices_v;
   std::vector<dof_id_type> dof_indices_lambda;
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       dof_map.dof_indices (elem, dof_indices);
       dof_map.dof_indices (elem, dof_indices_u, u_var);
       dof_map.dof_indices (elem, dof_indices_v, v_var);

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -195,13 +195,8 @@ public:
     std::vector<dof_id_type> dof_indices;
     std::vector<std::vector<dof_id_type>> dof_indices_var(3);
 
-    MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-    for ( ; el != end_el; ++el)
+    for (const auto & elem : mesh.active_local_element_ptr_range())
       {
-        const Elem * elem = *el;
-
         dof_map.dof_indices (elem, dof_indices);
         for (unsigned int var=0; var<3; var++)
           dof_map.dof_indices (elem, dof_indices_var[var], var);
@@ -313,13 +308,8 @@ public:
     std::vector<dof_id_type> stress_dof_indices_var;
     std::vector<dof_id_type> vonmises_dof_indices_var;
 
-    MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-    for ( ; el != end_el; ++el)
+    for (const auto & elem : mesh.active_local_element_ptr_range())
       {
-        const Elem * elem = *el;
-
         for (unsigned int var=0; var<3; var++)
           dof_map.dof_indices (elem, dof_indices_var[var], displacement_vars[var]);
 

--- a/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
+++ b/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
@@ -167,12 +167,8 @@ public:
 
     jacobian.zero();
 
-    MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-    for ( ; el != end_el; ++el)
+    for (const auto & elem : mesh.active_local_element_ptr_range())
       {
-        const Elem * elem = *el;
         dof_map.dof_indices (elem, dof_indices);
         for (unsigned int var=0; var<3; var++)
           dof_map.dof_indices (elem, dof_indices_var[var], var);
@@ -309,12 +305,8 @@ public:
 
     residual.zero();
 
-    MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-    for ( ; el != end_el; ++el)
+    for (const auto & elem : mesh.active_local_element_ptr_range())
       {
-        const Elem * elem = *el;
         dof_map.dof_indices (elem, dof_indices);
         for (unsigned int var=0; var<3; var++)
           dof_map.dof_indices (elem, dof_indices_var[var], var);
@@ -441,13 +433,8 @@ public:
     // To store the stress tensor on each element
     DenseMatrix<Number> elem_avg_stress_tensor(3, 3);
 
-    MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-    for ( ; el != end_el; ++el)
+    for (const auto & elem : mesh.active_local_element_ptr_range())
       {
-        const Elem * elem = *el;
-
         for (unsigned int var=0; var<3; var++)
           dof_map.dof_indices (elem, dof_indices_var[var], displacement_vars[var]);
 

--- a/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/linear_elasticity_with_contact.C
@@ -284,13 +284,8 @@ void LinearElasticityWithContact::residual_and_jacobian (const NumericVector<Num
   std::vector<dof_id_type> dof_indices;
   std::vector<std::vector<dof_id_type>> dof_indices_var(3);
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       if( elem->type() == EDGE2 )
         {
           // We do not do any assembly on the contact connector elements.
@@ -526,13 +521,8 @@ void LinearElasticityWithContact::compute_stresses()
   // To store the stress tensor on each element
   DenseMatrix<Number> elem_avg_stress_tensor(3, 3);
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       if( elem->type() == EDGE2 )
         {
           // We do not compute stress on the contact connector elements.

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -378,15 +378,8 @@ void assemble_cd (EquationSystems & es,
   // matrix and right-hand-side contribution.  Since the mesh
   // will be refined we want to only consider the ACTIVE elements,
   // hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -404,15 +404,8 @@ void assemble_wave(EquationSystems & es,
   // Now we will loop over all the elements in the mesh.
   // We will compute the element matrix and right-hand-side
   // contribution.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -268,18 +268,8 @@ void assemble_poisson(EquationSystems & es,
   // mess it up!  In case users later modify this program to include
   // refinement, we will be safe and will only consider the active
   // elements; hence we use a variant of the active_elem_iterator.
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  // Loop over the elements.  Note that  ++el is preferred to
-  // el++ since the latter requires an unnecessary temporary
-  // object.
-  for ( ; el != end_el ; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      // Store a pointer to the element we are currently
-      // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
-
       // Get the degree of freedom indices for the
       // current element.  These define where in the global
       // matrix and right-hand-side this element will

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -355,6 +355,8 @@ public:
   virtual element_iterator active_local_elements_end () libmesh_override;
   virtual const_element_iterator active_local_elements_begin () const libmesh_override;
   virtual const_element_iterator active_local_elements_end () const libmesh_override;
+  virtual SimpleRange<element_iterator> active_local_element_ptr_range() libmesh_override { return {active_local_elements_begin(), active_local_elements_end()}; }
+  virtual SimpleRange<const_element_iterator> active_local_element_ptr_range() const libmesh_override  { return {active_local_elements_begin(), active_local_elements_end()}; }
 
   virtual element_iterator active_not_local_elements_begin () libmesh_override;
   virtual element_iterator active_not_local_elements_end () libmesh_override;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1182,6 +1182,8 @@ public:
   virtual element_iterator active_local_elements_end () = 0;
   virtual const_element_iterator active_local_elements_begin () const = 0;
   virtual const_element_iterator active_local_elements_end () const = 0;
+  virtual SimpleRange<element_iterator> active_local_element_ptr_range() = 0;
+  virtual SimpleRange<const_element_iterator> active_local_element_ptr_range() const = 0;
 
   virtual element_iterator active_not_local_elements_begin () = 0;
   virtual element_iterator active_not_local_elements_end () = 0;

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -296,6 +296,8 @@ public:
   virtual element_iterator active_local_elements_end () libmesh_override;
   virtual const_element_iterator active_local_elements_begin () const libmesh_override;
   virtual const_element_iterator active_local_elements_end () const libmesh_override;
+  virtual SimpleRange<element_iterator> active_local_element_ptr_range() libmesh_override { return {active_local_elements_begin(), active_local_elements_end()}; }
+  virtual SimpleRange<const_element_iterator> active_local_element_ptr_range() const libmesh_override  { return {active_local_elements_begin(), active_local_elements_end()}; }
 
   virtual element_iterator active_not_local_elements_begin () libmesh_override;
   virtual element_iterator active_not_local_elements_end () libmesh_override;

--- a/src/apps/amr.C
+++ b/src/apps/amr.C
@@ -172,13 +172,8 @@ void assemble(EquationSystems & es,
 
   Real vol=0., area=0.;
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for (; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       // recompute the element-specific data for the current element
       fe->reinit (elem);
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2568,62 +2568,6 @@ void DofMap::old_dof_indices (const Elem * const elem,
       } // end loop over variables
 }
 
-
-
-/*
-  void DofMap::augment_send_list_for_projection(const MeshBase & mesh)
-  {
-  // Loop over the active local elements in the mesh.
-  // If the element was just refined and its parent lives
-  // on a different processor then we need to augment the
-  // _send_list with the parent's DOF indices so that we
-  // can access the parent's data for computing solution
-  // projections, etc...
-
-  // The DOF indices for the parent
-  std::vector<dof_id_type> di;
-
-  // Flag telling us if we need to re-sort the send_list.
-  // Note we won't need to re-sort unless a child with a
-  // parent belonging to a different processor is found
-  bool needs_sorting = false;
-
-
-  MeshBase::const_element_iterator       elem_it  = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator elem_end = mesh.active_local_elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
-  {
-  const Elem * const elem   = *elem_it;
-
-  // We only need to consider the children that
-  // were just refined
-  if (elem->refinement_flag() != Elem::JUST_REFINED) continue;
-
-  const Elem * const parent = elem->parent();
-
-  // If the parent lives on another processor
-  // than the child
-  if (parent != libmesh_nullptr)
-  if (parent->processor_id() != elem->processor_id())
-  {
-  // Get the DOF indices for the parent
-  this->dof_indices (parent, di);
-
-  // Insert the DOF indices into the send list
-  _send_list.insert (_send_list.end(),
-  di.begin(), di.end());
-
-  // We will need to re-sort the send list
-  needs_sorting = true;
-  }
-  }
-
-  // The send-list might need to be sorted again.
-  if (needs_sorting) this->sort_send_list ();
-  }
-*/
-
 #endif // LIBMESH_ENABLE_AMR
 
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1156,14 +1156,10 @@ void DofMap::distribute_local_dofs_node_major(dof_id_type & next_free_dof,
 
   //-------------------------------------------------------------------------
   // First count and assign temporary numbers to local dofs
-  MeshBase::element_iterator       elem_it  = mesh.active_local_elements_begin();
-  const MeshBase::element_iterator elem_end = mesh.active_local_elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
+  for (auto & elem : mesh.active_local_element_ptr_range())
     {
       // Only number dofs connected to active
       // elements on this processor.
-      Elem * elem                 = *elem_it;
       const unsigned int n_nodes = elem->n_nodes();
 
       // First number the nodal DOFS

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1073,14 +1073,10 @@ void DofMap::local_variable_indices(std::vector<dof_id_type> & idx,
   // dofs on the mesh
   if (this->variable_type(var_num).family != SCALAR)
     {
-      MeshBase::const_element_iterator       elem_it  = mesh.active_local_elements_begin();
-      const MeshBase::const_element_iterator elem_end = mesh.active_local_elements_end();
-
-      for ( ; elem_it != elem_end; ++elem_it)
+      for (auto & elem : mesh.active_local_element_ptr_range())
         {
           // Only count dofs connected to active
           // elements on this processor.
-          Elem * elem                 = *elem_it;
           const unsigned int n_nodes = elem->n_nodes();
 
           // First get any new nodal DOFS

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1316,17 +1316,11 @@ void DofMap::distribute_local_dofs_var_major(dof_id_type & next_free_dof,
       if (vg_description.type().family == SCALAR)
         continue;
 
-      MeshBase::element_iterator       elem_it  = mesh.active_local_elements_begin();
-      const MeshBase::element_iterator elem_end = mesh.active_local_elements_end();
-
-      for ( ; elem_it != elem_end; ++elem_it)
+      for (auto & elem : mesh.active_local_element_ptr_range())
         {
-          // Only number dofs connected to active
-          // elements on this processor.
-          Elem * elem  = *elem_it;
-
-          // ... and only variables which are active on
-          // on this element's subdomain
+          // Only number dofs connected to active elements on this
+          // processor and only variables which are active on on this
+          // element's subdomain.
           if (!vg_description.active_on_subdomain(elem->subdomain_id()))
             continue;
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2298,15 +2298,8 @@ DofMap::max_constraint_error (const System & system,
   // indices on each element
   std::vector<dof_id_type> local_dof_indices;
 
-  MeshBase::const_element_iterator       elem_it  =
-    mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator elem_end =
-    mesh.active_local_elements_end();
-
-  for ( ; elem_it != elem_end; ++elem_it)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *elem_it;
-
       this->dof_indices(elem, local_dof_indices);
       std::vector<dof_id_type> raw_dof_indices = local_dof_indices;
 

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -316,15 +316,8 @@ void ExactErrorEstimator::estimate_error (const System & system,
 
       // Iterate over all the active elements in the mesh
       // that live on this processor.
-      MeshBase::const_element_iterator
-        elem_it  = mesh.active_local_elements_begin();
-      const MeshBase::const_element_iterator
-        elem_end = mesh.active_local_elements_end();
-
-      for (;elem_it != elem_end; ++elem_it)
+      for (const auto & elem : mesh.active_local_element_ptr_range())
         {
-          // e is necessarily an active element on the local processor
-          const Elem * elem = *elem_it;
           const dof_id_type e_id = elem->id();
 
 #ifdef LIBMESH_ENABLE_AMR

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -630,14 +630,10 @@ void ExactSolution::_compute_error(const std::string & sys_name,
   // TODO: this ought to be threaded (and using subordinate
   // MeshFunction objects in each thread rather than a single
   // master)
-  MeshBase::const_element_iterator       el     = _mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = _mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : _mesh.active_local_element_ptr_range())
     {
       // Store a pointer to the element we are currently
       // working on.  This allows for nicer syntax later.
-      const Elem * elem = *el;
       const unsigned int dim = elem->dim();
 
       const subdomain_id_type elem_subid = elem->subdomain_id();

--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -240,16 +240,8 @@ void HPCoarsenTest::select_refinement (System & system)
 
       // Iterate over all the active elements in the mesh
       // that live on this processor.
-
-      MeshBase::const_element_iterator       elem_it  =
-        mesh.active_local_elements_begin();
-      const MeshBase::const_element_iterator elem_end =
-        mesh.active_local_elements_end();
-
-      for (; elem_it != elem_end; ++elem_it)
+      for (const auto & elem : mesh.active_local_element_ptr_range())
         {
-          const Elem * elem = *elem_it;
-
           // We're only checking elements that are already flagged for h
           // refinement
           if (elem->refinement_flag() != Elem::REFINE)
@@ -517,16 +509,8 @@ void HPCoarsenTest::select_refinement (System & system)
 
   // Iterate over all the active elements in the mesh
   // that live on this processor.
-
-  MeshBase::element_iterator       elem_it  =
-    mesh.active_local_elements_begin();
-  const MeshBase::element_iterator elem_end =
-    mesh.active_local_elements_end();
-
-  for (; elem_it != elem_end; ++elem_it)
+  for (auto & elem : mesh.active_local_element_ptr_range())
     {
-      Elem * elem = *elem_it;
-
       // We're only checking elements that are already flagged for h
       // refinement
       if (elem->refinement_flag() != Elem::REFINE)

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -173,13 +173,8 @@ void JumpErrorEstimator::estimate_error (const System & system,
 
   // Iterate over all the active elements in the mesh
   // that live on this processor.
-  MeshBase::const_element_iterator       elem_it  = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator elem_end = mesh.active_local_elements_end();
-
-  for (; elem_it != elem_end; ++elem_it)
+  for (const auto & e : mesh.active_local_element_ptr_range())
     {
-      // e is necessarily an active element on the local processor
-      const Elem * e = *elem_it;
       const dof_id_type e_id = e->id();
 
 #ifdef LIBMESH_ENABLE_AMR

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -511,14 +511,8 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
 
           // Iterate over all the active elements in the fine mesh
           // that live on this processor.
-          MeshBase::const_element_iterator       elem_it  = mesh.active_local_elements_begin();
-          const MeshBase::const_element_iterator elem_end = mesh.active_local_elements_end();
-
-          for (; elem_it != elem_end; ++elem_it)
+          for (const auto & elem : mesh.active_local_element_ptr_range())
             {
-              // e is necessarily an active element on the local processor
-              const Elem * elem = *elem_it;
-
               // Find the element id for the corresponding coarse grid element
               const Elem * coarse = elem;
               dof_id_type e_id = coarse->id();

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -476,10 +476,6 @@ void EnsightIO::write_vector_ascii(const std::string & sys,
   std::vector<dof_id_type> dof_indices_v;
   std::vector<dof_id_type> dof_indices_w;
 
-  // Now we will loop over all the elements in the mesh.
-  MeshBase::const_element_iterator       el     = the_mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = the_mesh.active_local_elements_end();
-
   // Map from node id -> solution value.  We end up just writing this
   // map out in order, not sure what would happen if there were holes
   // in the numbering...
@@ -487,10 +483,9 @@ void EnsightIO::write_vector_ascii(const std::string & sys,
   typedef map_local_soln::iterator  local_soln_iterator;
   map_local_soln local_soln;
 
-  for ( ; el != end_el ; ++el)
+  // Now we will loop over all the elements in the mesh.
+  for (const auto & elem : the_mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       const FEType & fe_type = system.variable_type(u_var);
 
       dof_map.dof_indices (elem, dof_indices_u, u_var);

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -388,10 +388,6 @@ void EnsightIO::write_scalar_ascii(const std::string & sys,
 
   std::vector<dof_id_type> dof_indices_scl;
 
-  // Loop over active local elements, construct the nodal solution, and write it to file.
-  MeshBase::const_element_iterator       el     = the_mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = the_mesh.active_local_elements_end();
-
   // Map from node id -> solution value.  We end up just writing this
   // map out in order, not sure what would happen if there were holes
   // in the numbering...
@@ -402,10 +398,9 @@ void EnsightIO::write_scalar_ascii(const std::string & sys,
   std::vector<Number> elem_soln;
   std::vector<Number> nodal_soln;
 
-  for ( ; el != end_el ; ++el)
+  // Loop over active local elements, construct the nodal solution, and write it to file.
+  for (const auto & elem : the_mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       const FEType & fe_type = system.variable_type(var);
 
       dof_map.dof_indices (elem, dof_indices_scl, var);

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -198,19 +198,13 @@ void EnsightIO::write_geometry_ascii()
   const MeshBase & the_mesh = MeshOutput<MeshBase>::mesh();
 
   // Construct the various required maps
-  {
-    MeshBase::const_element_iterator       el     = the_mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_el = the_mesh.active_local_elements_end();
+  for (const auto & elem : the_mesh.active_local_element_ptr_range())
+    {
+      ensight_parts_map[elem->type()].push_back(elem);
 
-    for ( ; el != end_el ; ++el)
-      {
-        const Elem * elem = *el;
-        ensight_parts_map[elem->type()].push_back(elem);
-
-        for (unsigned int i = 0; i < elem->n_nodes(); i++)
-          mesh_nodes_map[elem->node_id(i)] = elem->point(i);
-      }
-  }
+      for (unsigned int i = 0; i < elem->n_nodes(); i++)
+        mesh_nodes_map[elem->node_id(i)] = elem->point(i);
+    }
 
   // Write number of local points
   mesh_stream << std::setw(10) << mesh_nodes_map.size() << "\n";

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -619,12 +619,8 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
     std::set<dof_id_type> my_interface_node_set;
 
     // since parent nodes are a subset of children nodes, this should be sufficient
-    MeshBase::const_element_iterator       it     = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator it_end = mesh.active_local_elements_end();
-
-    for (; it != it_end; ++it)
+    for (const auto & elem : mesh.active_local_element_ptr_range())
       {
-        const Elem * const elem = *it;
         libmesh_assert(elem);
 
         if (elem->on_boundary()) // denotes *any* side has a NULL neighbor

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -447,31 +447,23 @@ bool MeshRefinement::test_unflagged (bool libmesh_dbg_var(libmesh_assert_pass))
 
   bool found_flag = false;
 
-  // Search for local flags
-  MeshBase::element_iterator       elem_it  = _mesh.active_local_elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh.active_local_elements_end();
-
 #ifndef NDEBUG
   Elem * failed_elem = libmesh_nullptr;
 #endif
 
-  for ( ; elem_it != elem_end; ++elem_it)
-    {
-      // Pointer to the element
-      Elem * elem = *elem_it;
-
-      if (elem->refinement_flag() == Elem::REFINE ||
-          elem->refinement_flag() == Elem::COARSEN ||
-          elem->p_refinement_flag() == Elem::REFINE ||
-          elem->p_refinement_flag() == Elem::COARSEN)
-        {
-          found_flag = true;
+  // Search for local flags
+  for (auto & elem : _mesh.active_local_element_ptr_range())
+    if (elem->refinement_flag() == Elem::REFINE ||
+        elem->refinement_flag() == Elem::COARSEN ||
+        elem->p_refinement_flag() == Elem::REFINE ||
+        elem->p_refinement_flag() == Elem::COARSEN)
+      {
+        found_flag = true;
 #ifndef NDEBUG
-          failed_elem = elem;
+        failed_elem = elem;
 #endif
-          break;
-        }
-    }
+        break;
+      }
 
   // If we found a flag on any processor, it counts
   this->comm().max(found_flag);

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -263,11 +263,8 @@ void MeshRefinement::create_parent_error_vector(const ErrorVector & error_per_ce
 
   {
     // Find which elements are uncoarsenable
-    MeshBase::element_iterator       elem_it  = _mesh.active_local_elements_begin();
-    const MeshBase::element_iterator elem_end = _mesh.active_local_elements_end();
-    for (; elem_it != elem_end; ++elem_it)
+    for (auto & elem : _mesh.active_local_element_ptr_range())
       {
-        Elem * elem   = *elem_it;
         Elem * parent = elem->parent();
 
         // Active elements are uncoarsenable
@@ -301,30 +298,24 @@ void MeshRefinement::create_parent_error_vector(const ErrorVector & error_per_ce
   // calculate local contributions to the parents' errors squared
   // first, then sum across processors and take the square roots
   // second.
-  {
-    MeshBase::element_iterator       elem_it  = _mesh.active_local_elements_begin();
-    const MeshBase::element_iterator elem_end = _mesh.active_local_elements_end();
+  for (auto & elem : _mesh.active_local_element_ptr_range())
+    {
+      Elem * parent = elem->parent();
 
-    for (; elem_it != elem_end; ++elem_it)
-      {
-        Elem * elem   = *elem_it;
-        Elem * parent = elem->parent();
+      // Calculate each contribution to parent cells
+      if (parent)
+        {
+          const dof_id_type parentid  = parent->id();
+          libmesh_assert_less (parentid, error_per_parent.size());
 
-        // Calculate each contribution to parent cells
-        if (parent)
-          {
-            const dof_id_type parentid  = parent->id();
-            libmesh_assert_less (parentid, error_per_parent.size());
-
-            // If the parent has grandchildren we won't be able to
-            // coarsen it, so forget it.  Otherwise, add this child's
-            // contribution to the sum of the squared child errors
-            if (error_per_parent[parentid] != -1.0)
-              error_per_parent[parentid] += (error_per_cell[elem->id()] *
-                                             error_per_cell[elem->id()]);
-          }
-      }
-  }
+          // If the parent has grandchildren we won't be able to
+          // coarsen it, so forget it.  Otherwise, add this child's
+          // contribution to the sum of the squared child errors
+          if (error_per_parent[parentid] != -1.0)
+            error_per_parent[parentid] += (error_per_cell[elem->id()] *
+                                           error_per_cell[elem->id()]);
+        }
+    }
 
   // Sum the vector across all processors
   this->comm().sum(static_cast<std::vector<ErrorVectorReal> &>(error_per_parent));

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1544,31 +1544,18 @@ bool MeshRefinement::_refine_elements ()
   // assigns temporary ids, so we need to synchronize ids afterward to
   // be safe anyway, so we might as well use the distributed mesh code
   // path.
-  {
-    MeshBase::element_iterator
-      elem_it  = _mesh.active_local_elements_begin(),
-      elem_end = _mesh.active_local_elements_end();
-
-    if (_mesh.is_replicated())
-      {
-        elem_it  = _mesh.active_elements_begin();
-        elem_end = _mesh.active_elements_end();
-      }
-
-    for (; elem_it != elem_end; ++elem_it)
-      {
-        Elem * elem = *elem_it;
-        if (elem->refinement_flag() == Elem::REFINE)
-          local_copy_of_elements.push_back(elem);
-        if (elem->p_refinement_flag() == Elem::REFINE &&
-            elem->active())
-          {
-            elem->set_p_level(elem->p_level()+1);
-            elem->set_p_refinement_flag(Elem::JUST_REFINED);
-            mesh_p_changed = true;
-          }
-      }
-  }
+  for (auto & elem : _mesh.is_replicated() ? _mesh.active_element_ptr_range() : _mesh.active_local_element_ptr_range())
+    {
+      if (elem->refinement_flag() == Elem::REFINE)
+        local_copy_of_elements.push_back(elem);
+      if (elem->p_refinement_flag() == Elem::REFINE &&
+          elem->active())
+        {
+          elem->set_p_level(elem->p_level()+1);
+          elem->set_p_refinement_flag(Elem::JUST_REFINED);
+          mesh_p_changed = true;
+        }
+    }
 
   if (!_mesh.is_replicated())
     {

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -488,11 +488,8 @@ void MeshRefinement::flag_elements_by_elem_fraction (const ErrorVector & error_p
 
   // Loop over the active elements and create the entry
   // in the sorted_error vector
-  MeshBase::element_iterator       elem_it  = _mesh.active_local_elements_begin();
-  const MeshBase::element_iterator elem_end = _mesh.active_local_elements_end();
-
-  for (; elem_it != elem_end; ++elem_it)
-    sorted_error.push_back (error_per_cell[(*elem_it)->id()]);
+  for (auto & elem : _mesh.active_local_element_ptr_range())
+    sorted_error.push_back (error_per_cell[elem->id()]);
 
   this->comm().allgather(sorted_error);
 

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -95,14 +95,9 @@ void MeshRefinement::flag_elements_by_error_fraction (const ErrorVector & error_
     }
 
   // We need to loop over all active elements to find the minimum
-  MeshBase::element_iterator       el_it  =
-    _mesh.active_local_elements_begin();
-  const MeshBase::element_iterator el_end =
-    _mesh.active_local_elements_end();
-
-  for (; el_it != el_end; ++el_it)
+  for (auto & elem : _mesh.active_local_element_ptr_range())
     {
-      const dof_id_type id  = (*el_it)->id();
+      const dof_id_type id  = elem->id();
       libmesh_assert_less (id, error_per_cell.size());
 
       error_max = std::max (error_max, error_per_cell[id]);

--- a/src/mesh/mesh_refinement_flagging.C
+++ b/src/mesh/mesh_refinement_flagging.C
@@ -274,11 +274,9 @@ bool MeshRefinement::flag_elements_by_nelem_target (const ErrorVector & error_pe
   {
     std::vector<bool> is_active(max_elem_id, false);
 
-    MeshBase::element_iterator       elem_it  = _mesh.active_local_elements_begin();
-    const MeshBase::element_iterator elem_end = _mesh.active_local_elements_end();
-    for (; elem_it != elem_end; ++elem_it)
+    for (auto & elem : _mesh.active_local_element_ptr_range())
       {
-        const dof_id_type eid = (*elem_it)->id();
+        const dof_id_type eid = elem->id();
         is_active[eid] = true;
         libmesh_assert_less (eid, error_per_cell.size());
         sorted_error.push_back

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -873,102 +873,88 @@ void MeshTools::find_nodal_neighbors(const MeshBase &,
 void MeshTools::find_hanging_nodes_and_parents(const MeshBase & mesh,
                                                std::map<dof_id_type, std::vector<dof_id_type>> & hanging_nodes)
 {
-  MeshBase::const_element_iterator it  = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end = mesh.active_local_elements_end();
-
-  //Loop through all the elements
-  for (; it != end; ++it)
-    {
-      //Save it off for easier access
-      const Elem * elem = (*it);
-
-      //Right now this only works for quad4's
-      //libmesh_assert_equal_to (elem->type(), QUAD4);
-      if (elem->type() == QUAD4)
+  // Loop through all the elements
+  for (auto & elem : mesh.active_local_element_ptr_range())
+    if (elem->type() == QUAD4)
+      for (auto s : elem->side_index_range())
         {
-          //Loop over the sides looking for sides that have hanging nodes
-          //This code is inspired by compute_proj_constraints()
-          for (auto s : elem->side_index_range())
+          // Loop over the sides looking for sides that have hanging nodes
+          // This code is inspired by compute_proj_constraints()
+          const Elem * neigh = elem->neighbor_ptr(s);
+
+          // If not a boundary side
+          if (neigh != libmesh_nullptr)
             {
-              const Elem * neigh = elem->neighbor_ptr(s);
-
-              //If not a boundary side
-              if (neigh != libmesh_nullptr)
+              // Is there a coarser element next to this one?
+              if (neigh->level() < elem->level())
                 {
-                  //Is there a coarser element next to this one?
-                  if (neigh->level() < elem->level())
+                  const Elem * ancestor = elem;
+                  while (neigh->level() < ancestor->level())
+                    ancestor = ancestor->parent();
+                  unsigned int s_neigh = neigh->which_neighbor_am_i(ancestor);
+                  libmesh_assert_less (s_neigh, neigh->n_neighbors());
+
+                  // Couple of helper uints...
+                  unsigned int local_node1=0;
+                  unsigned int local_node2=0;
+
+                  bool found_in_neighbor = false;
+
+                  // Find the two vertices that make up this side
+                  while (!elem->is_node_on_side(local_node1++,s)) { }
+                  local_node1--;
+
+                  // Start looking for the second one with the next node
+                  local_node2=local_node1+1;
+
+                  // Find the other one
+                  while (!elem->is_node_on_side(local_node2++,s)) { }
+                  local_node2--;
+
+                  //Pull out their global ids:
+                  dof_id_type node1 = elem->node_id(local_node1);
+                  dof_id_type node2 = elem->node_id(local_node2);
+
+                  // Now find which node is present in the neighbor
+                  // FIXME This assumes a level one rule!
+                  // The _other_ one is the hanging node
+
+                  // First look for the first one
+                  // FIXME could be streamlined a bit
+                  for (unsigned int n=0;n<neigh->n_sides();n++)
+                    if (neigh->node_id(n) == node1)
+                      found_in_neighbor=true;
+
+                  dof_id_type hanging_node=0;
+
+                  if (!found_in_neighbor)
+                    hanging_node=node1;
+                  else // If it wasn't node1 then it must be node2!
+                    hanging_node=node2;
+
+                  // Reset these for reuse
+                  local_node1=0;
+                  local_node2=0;
+
+                  // Find the first node that makes up the side in the neighbor (these should be the parent nodes)
+                  while (!neigh->is_node_on_side(local_node1++,s_neigh)) { }
+                  local_node1--;
+
+                  local_node2=local_node1+1;
+
+                  // Find the second node...
+                  while (!neigh->is_node_on_side(local_node2++,s_neigh)) { }
+                  local_node2--;
+
+                  // Save them if we haven't already found the parents for this one
+                  if (hanging_nodes[hanging_node].size()<2)
                     {
-                      const Elem * ancestor = elem;
-                      while (neigh->level() < ancestor->level())
-                        ancestor = ancestor->parent();
-                      unsigned int s_neigh = neigh->which_neighbor_am_i(ancestor);
-                      libmesh_assert_less (s_neigh, neigh->n_neighbors());
-
-                      //Couple of helper uints...
-                      unsigned int local_node1=0;
-                      unsigned int local_node2=0;
-
-                      bool found_in_neighbor = false;
-
-                      // Find the two vertices that make up this side
-                      while (!elem->is_node_on_side(local_node1++,s)) { }
-                      local_node1--;
-
-                      // Start looking for the second one with the next node
-                      local_node2=local_node1+1;
-
-                      // Find the other one
-                      while (!elem->is_node_on_side(local_node2++,s)) { }
-                      local_node2--;
-
-                      //Pull out their global ids:
-                      dof_id_type node1 = elem->node_id(local_node1);
-                      dof_id_type node2 = elem->node_id(local_node2);
-
-                      //Now find which node is present in the neighbor
-                      //FIXME This assumes a level one rule!
-                      //The _other_ one is the hanging node
-
-                      //First look for the first one
-                      //FIXME could be streamlined a bit
-                      for (unsigned int n=0;n<neigh->n_sides();n++)
-                        {
-                          if (neigh->node_id(n) == node1)
-                            found_in_neighbor=true;
-                        }
-
-                      dof_id_type hanging_node=0;
-
-                      if (!found_in_neighbor)
-                        hanging_node=node1;
-                      else // If it wasn't node1 then it must be node2!
-                        hanging_node=node2;
-
-                      // Reset these for reuse
-                      local_node1=0;
-                      local_node2=0;
-
-                      // Find the first node that makes up the side in the neighbor (these should be the parent nodes)
-                      while (!neigh->is_node_on_side(local_node1++,s_neigh)) { }
-                      local_node1--;
-
-                      local_node2=local_node1+1;
-
-                      //Find the second node...
-                      while (!neigh->is_node_on_side(local_node2++,s_neigh)) { }
-                      local_node2--;
-
-                      //Save them if we haven't already found the parents for this one
-                      if (hanging_nodes[hanging_node].size()<2)
-                        {
-                          hanging_nodes[hanging_node].push_back(neigh->node_id(local_node1));
-                          hanging_nodes[hanging_node].push_back(neigh->node_id(local_node2));
-                        }
+                      hanging_nodes[hanging_node].push_back(neigh->node_id(local_node1));
+                      hanging_nodes[hanging_node].push_back(neigh->node_id(local_node2));
                     }
                 }
             }
         }
-    }
 }
 
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -556,11 +556,8 @@ unsigned int MeshTools::n_active_local_levels(const MeshBase & mesh)
 {
   unsigned int nl = 0;
 
-  MeshBase::const_element_iterator el = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
-    nl = std::max((*el)->level() + 1, nl);
+  for (auto & elem : mesh.active_local_element_ptr_range())
+    nl = std::max(elem->level() + 1, nl);
 
   return nl;
 }

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1787,13 +1787,8 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
 
 
   // First loop over the elements to figure out which elements are in which subdomain
-  MeshBase::const_element_iterator elem_it = pmesh.active_local_elements_begin();
-  MeshBase::const_element_iterator elem_end = pmesh.active_local_elements_end();
-
-  for (; elem_it != elem_end; ++elem_it)
+  for (const auto & elem : pmesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *elem_it;
-
       // Grab the nodes while we're here.
       for (unsigned int n=0; n<elem->n_nodes(); ++n)
         this->nodes_attached_to_local_elems.insert( elem->node_id(n) );

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1642,13 +1642,8 @@ void Nemesis_IO_Helper::compute_num_global_elem_blocks(const MeshBase & pmesh)
   // This map keeps track of the number of elements in each subdomain over all processors
   std::map<subdomain_id_type, unsigned> global_subdomain_counts;
 
-  MeshBase::const_element_iterator elem_it = pmesh.active_local_elements_begin();
-  MeshBase::const_element_iterator elem_end = pmesh.active_local_elements_end();
-
-  for (; elem_it != elem_end; ++elem_it)
+  for (const auto & elem : pmesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *elem_it;
-
       subdomain_id_type cur_subdomain = elem->subdomain_id();
 
       /*

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1269,13 +1269,8 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
   // element numberings into Nemesis numberings.
   ExodusII_IO_Helper::ElementMaps element_mapper;
 
-  MeshBase::const_element_iterator elem_it = pmesh.active_local_elements_begin();
-  MeshBase::const_element_iterator elem_end = pmesh.active_local_elements_end();
-
-  for (; elem_it != elem_end; ++elem_it)
+  for (const auto & elem : pmesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *elem_it;
-
       // Add this Elem's ID to all_elem_ids, later we will take the difference
       // between this set and the set of border_elem_ids, to get the set of
       // internal_elem_ids.

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -410,7 +410,6 @@ void VTKIO::cells_to_vtk()
   vtkSmartPointer<vtkIdList> pts = vtkSmartPointer<vtkIdList>::New();
 
   std::vector<int> types(mesh.n_active_local_elem());
-  unsigned active_element_counter = 0;
 
   vtkSmartPointer<vtkIntArray> elem_id = vtkSmartPointer<vtkIntArray>::New();
   elem_id->SetName("libmesh_elem_id");
@@ -424,12 +423,9 @@ void VTKIO::cells_to_vtk()
   elem_proc_id->SetName("processor_id");
   elem_proc_id->SetNumberOfComponents(1);
 
-  MeshBase::const_element_iterator it = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end = mesh.active_local_elements_end();
-  for (; it != end; ++it, ++active_element_counter)
+  unsigned active_element_counter = 0;
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      Elem * elem = *it;
-
       pts->SetNumberOfIds(elem->n_nodes());
 
       // get the connectivity for this element
@@ -471,6 +467,7 @@ void VTKIO::cells_to_vtk()
       elem_id->InsertTuple1(vtkcellid, elem->id());
       subdomain_id->InsertTuple1(vtkcellid, elem->subdomain_id());
       elem_proc_id->InsertTuple1(vtkcellid, elem->processor_id());
+      ++active_element_counter;
     } // end loop over active elements
 
   _vtk_grid->SetCells(&types[0], cells);

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -362,13 +362,8 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
 
     libmesh_assert_equal_to (subdomain_bounds.back(), n_active_elem);
 
-    MeshBase::const_element_iterator       elem_it  = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator elem_end = mesh.active_local_elements_end();
-
-    for (; elem_it != elem_end; ++elem_it)
+    for (const auto & elem : mesh.active_local_element_ptr_range())
       {
-        const Elem * elem = *elem_it;
-
         libmesh_assert (_global_index_by_pid_map.count(elem->id()));
         const dof_id_type global_index_by_pid =
           _global_index_by_pid_map[elem->id()];

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -443,13 +443,8 @@ void ParmetisPartitioner::build_graph (const MeshBase & mesh)
 
   const dof_id_type first_local_elem = _pmetis->vtxdist[mesh.processor_id()];
 
-  MeshBase::const_element_iterator       elem_it  = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator elem_end = mesh.active_local_elements_end();
-
-  for (; elem_it != elem_end; ++elem_it)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *elem_it;
-
       libmesh_assert (_global_index_by_pid_map.count(elem->id()));
       const dof_id_type global_index_by_pid =
         _global_index_by_pid_map[elem->id()];

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -689,15 +689,11 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
 
   this->init_context(context);
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
       // Subdivision elements need special care:
       // - skip ghost elements
       // - init special quadrature rule
-      const Elem * elem = *el;
       UniquePtr<QBase> qrule;
       if (elem->type() == TRI3SUBDIVISION)
         {
@@ -717,7 +713,7 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
           elem_fe->attach_quadrature_rule (qrule.get());
         }
 
-      context.pre_fe_reinit(*this, *el);
+      context.pre_fe_reinit(*this, elem);
       context.elem_fe_reinit();
       elem_assembly->interior_assembly(context);
 

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -627,14 +627,11 @@ Real RBEIMConstruction::truth_solve(int plot_solution)
       std::vector<std::vector<Real>> JxW_values(mesh.n_elem());
       std::vector<std::vector<std::vector<Real>>> phi_values(mesh.n_elem());
 
-      MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-      const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-      for ( ; el != end_el; ++el)
+      for (const auto & elem : mesh.active_local_element_ptr_range())
         {
-          dof_id_type elem_id = (*el)->id();
+          dof_id_type elem_id = elem->id();
 
-          context.pre_fe_reinit(*this, *el);
+          context.pre_fe_reinit(*this, elem);
           context.elem_fe_reinit();
 
           FEBase * elem_fe = libmesh_nullptr;
@@ -663,7 +660,7 @@ Real RBEIMConstruction::truth_solve(int plot_solution)
               parametrized_fn_vals[elem_id][qp].resize(get_explicit_system().n_vars());
               for (unsigned int var=0; var<get_explicit_system().n_vars(); var++)
                 {
-                  Number eval_result = eim_eval.evaluate_parametrized_function(var, xyz[qp], *(*el));
+                  Number eval_result = eim_eval.evaluate_parametrized_function(var, xyz[qp], *elem);
                   parametrized_fn_vals[elem_id][qp][var] = eval_result;
                 }
             }
@@ -674,14 +671,11 @@ Real RBEIMConstruction::truth_solve(int plot_solution)
         {
           rhs->zero();
 
-          MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-          const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-          for ( ; el != end_el; ++el)
+          for (const auto & elem : mesh.active_local_element_ptr_range())
             {
-              dof_id_type elem_id = (*el)->id();
+              dof_id_type elem_id = elem->id();
 
-              context.pre_fe_reinit(*this, *el);
+              context.pre_fe_reinit(*this, elem);
               //context.elem_fe_reinit(); <--- skip this because we cached all the FE data
 
               // Loop over qp before var because parametrized functions often use

--- a/src/reduced_basis/rb_eim_construction.C
+++ b/src/reduced_basis/rb_eim_construction.C
@@ -377,12 +377,9 @@ void RBEIMConstruction::enrich_RB_space()
   DGFEMContext & explicit_context = cast_ref<DGFEMContext &>(*explicit_c);
   init_context_with_sys(explicit_context, get_explicit_system());
 
-  MeshBase::const_element_iterator       el     = mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      explicit_context.pre_fe_reinit(get_explicit_system(), *el);
+      explicit_context.pre_fe_reinit(get_explicit_system(), elem);
       explicit_context.elem_fe_reinit();
 
       for (unsigned int var=0; var<get_explicit_system().n_vars(); var++)
@@ -399,7 +396,7 @@ void RBEIMConstruction::enrich_RB_space()
                   optimal_value = value;
                   largest_abs_value = abs_value;
                   optimal_var = var;
-                  optimal_elem_id = (*el)->id();
+                  optimal_elem_id = elem->id();
 
                   FEBase * elem_fe = libmesh_nullptr;
                   explicit_context.get_element_fe( var, elem_fe );

--- a/src/solution_transfer/boundary_volume_solution_transfer.C
+++ b/src/solution_transfer/boundary_volume_solution_transfer.C
@@ -71,18 +71,13 @@ transfer_volume_boundary(const Variable & from_var, const Variable & to_var)
   // Sanity check that the variables have the same number of components
   libmesh_assert_equal_to(from_n_comp, to_n_comp);
 
-  // Iterator for BoundaryMesh.
-  MeshBase::const_element_iterator       el     = to_mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = to_mesh.active_local_elements_end();
-
   // Construct map from "from" dofs to "to" dofs.
   typedef std::map<numeric_index_type, numeric_index_type> DofMapping;
   DofMapping dof_mapping;
 
   // Loop through all boundary elements.
-  for ( ; el != end_el; ++el)
+  for (const auto & to_elem : to_mesh.active_local_element_ptr_range())
     {
-      const Elem * to_elem = *el;
       const Elem * from_elem = to_elem->interior_parent();
 
       if (!from_elem)

--- a/src/solution_transfer/boundary_volume_solution_transfer.C
+++ b/src/solution_transfer/boundary_volume_solution_transfer.C
@@ -169,18 +169,13 @@ transfer_boundary_volume(const Variable & from_var, const Variable & to_var)
   const unsigned short int from_var_number = from_var.number();
   const unsigned short int to_n_comp = to_var.n_components();
 
-  // Iterator for BoundaryMesh.
-  MeshBase::const_element_iterator       el     = from_mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el = from_mesh.active_local_elements_end();
-
   // In order to get solution vectors from BoundaryMesh
   std::vector<dof_id_type> from_dof_indices;
   std::vector<Number> value;
 
   // Loop through all boundary elements.
-  for (; el != end_el; ++el)
+  for (const auto & from_elem : from_mesh.active_local_element_ptr_range())
     {
-      const Elem * from_elem = *el;
       const Elem * to_elem = from_elem->interior_parent();
 
       if (!to_elem)

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -607,12 +607,6 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
     nv = n_scalar_vars + dim*n_vector_vars;
   }
 
-  // Get the number of elements that share each node.  We will
-  // compute the average value at each node.  This is particularly
-  // useful for plotting discontinuous data.
-  MeshBase::element_iterator       e_it  = _mesh.active_local_elements_begin();
-  const MeshBase::element_iterator e_end = _mesh.active_local_elements_end();
-
   // Get the number of local nodes
   dof_id_type n_local_nodes = cast_int<dof_id_type>
     (std::distance(_mesh.local_nodes_begin(),

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -894,22 +894,15 @@ void EquationSystems::get_solution (std::vector<Number> & soln,
           const Variable & variable = system.variable(var);
           const DofMap & dof_map = system.get_dof_map();
 
-          MeshBase::element_iterator       it       = _mesh.active_local_elements_begin();
-          const MeshBase::element_iterator end_elem = _mesh.active_local_elements_end();
+          for (const auto & elem : _mesh.active_local_element_ptr_range())
+            if (variable.active_on_subdomain(elem->subdomain_id()))
+              {
+                dof_map.dof_indices (elem, dof_indices, var);
 
-          for ( ; it != end_elem; ++it)
-            {
-              const Elem * elem = *it;
+                libmesh_assert_equal_to (1, dof_indices.size());
 
-              if (variable.active_on_subdomain(elem->subdomain_id()))
-                {
-                  dof_map.dof_indices (elem, dof_indices, var);
-
-                  libmesh_assert_equal_to (1, dof_indices.size());
-
-                  parallel_soln.set((ne*var_num)+elem->id(), sys_soln(dof_indices[0]));
-                }
-            }
+                parallel_soln.set((ne*var_num)+elem->id(), sys_soln(dof_indices[0]));
+              }
 
           var_num++;
         } // end loop on variables in this system

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -692,14 +692,9 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
 
           unsigned int n_vec_dim = FEInterface::n_vec_dim( pos->second->get_mesh(), fe_type );
 
-          MeshBase::element_iterator       it       = _mesh.active_local_elements_begin();
-          const MeshBase::element_iterator end_elem = _mesh.active_local_elements_end();
-
-          for ( ; it != end_elem; ++it)
+          for (const auto & elem : _mesh.active_local_element_ptr_range())
             {
-              const Elem * elem = *it;
-
-              if (var_description.active_on_subdomain((*it)->subdomain_id()))
+              if (var_description.active_on_subdomain(elem->subdomain_id()))
                 {
                   dof_map.dof_indices (elem, dof_indices, var);
 

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1399,19 +1399,14 @@ void FEMSystem::mesh_position_get()
   // Loop over every active mesh element on this processor
   const MeshBase & mesh = this->get_mesh();
 
-  MeshBase::const_element_iterator el =
-    mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el =
-    mesh.active_local_elements_end();
-
   UniquePtr<DiffContext> con = this->build_context();
   FEMContext & _femcontext = cast_ref<FEMContext &>(*con);
   this->init_context(_femcontext);
 
   // Get the solution's mesh variables from every element
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      _femcontext.pre_fe_reinit(*this, *el);
+      _femcontext.pre_fe_reinit(*this, elem);
 
       _femcontext.elem_position_get();
 

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -1073,15 +1073,10 @@ void FEMSystem::mesh_position_set()
   this->init_context(_femcontext);
 
   // Move every mesh element we can
-  MeshBase::const_element_iterator el =
-    mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el =
-    mesh.active_local_elements_end();
-
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
       // We need the algebraic data
-      _femcontext.pre_fe_reinit(*this, *el);
+      _femcontext.pre_fe_reinit(*this, elem);
       // And when asserts are on, we also need the FE so
       // we can assert that the mesh data is of the right type.
 #ifndef NDEBUG

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1350,21 +1350,16 @@ void System::zero_variable (NumericVector<Number> & v,
       }
   }
 
-  /* Loop over elements.  */
-  {
-    MeshBase::const_element_iterator it = mesh.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_it = mesh.active_local_elements_end();
-    for ( ; it != end_it; ++it)
-      {
-        const Elem * elem = *it;
-        unsigned int n_comp = elem->n_comp(sys_num,var_num);
-        for (unsigned int i=0; i<n_comp; i++)
-          {
-            const dof_id_type index = elem->dof_number(sys_num,var_num,i);
-            v.set(index,0.0);
-          }
-      }
-  }
+  // Loop over elements.
+  for (const auto & elem : mesh.active_local_element_ptr_range())
+    {
+      unsigned int n_comp = elem->n_comp(sys_num,var_num);
+      for (unsigned int i=0; i<n_comp; i++)
+        {
+          const dof_id_type index = elem->dof_number(sys_num,var_num,i);
+          v.set(index,0.0);
+        }
+    }
 }
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1300,19 +1300,13 @@ void System::local_dof_indices(const unsigned int var,
 
   std::vector<dof_id_type> dof_indices;
 
-  // Begin the loop over the elements
-  MeshBase::const_element_iterator       el     =
-    this->get_mesh().active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el =
-    this->get_mesh().active_local_elements_end();
-
   const dof_id_type
     first_local = this->get_dof_map().first_dof(),
     end_local   = this->get_dof_map().end_dof();
 
-  for ( ; el != end_el; ++el)
+  // Begin the loop over the elements
+  for (const auto & elem : this->get_mesh().active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
       this->get_dof_map().dof_indices (elem, dof_indices, var);
 
       for (std::size_t i=0; i<dof_indices.size(); i++)

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1525,14 +1525,8 @@ Real System::calculate_norm(const NumericVector<Number> & v,
       std::vector<dof_id_type> dof_indices;
 
       // Begin the loop over the elements
-      MeshBase::const_element_iterator       el     =
-        this->get_mesh().active_local_elements_begin();
-      const MeshBase::const_element_iterator end_el =
-        this->get_mesh().active_local_elements_end();
-
-      for ( ; el != end_el; ++el)
+      for (const auto & elem : this->get_mesh().active_local_element_ptr_range())
         {
-          const Elem * elem = *el;
           const unsigned int dim = elem->dim();
 
           if (skip_dimensions && skip_dimensions->find(dim) != skip_dimensions->end())

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -233,17 +233,10 @@ void ErrorVector::plot_error(const std::string & filename,
   temp_es.init();
 
   const DofMap & error_dof_map = error_system.get_dof_map();
-
-  MeshBase::const_element_iterator       el     =
-    mesh.active_local_elements_begin();
-  const MeshBase::const_element_iterator end_el =
-    mesh.active_local_elements_end();
   std::vector<dof_id_type> dof_indices;
 
-  for ( ; el != end_el; ++el)
+  for (const auto & elem : mesh.active_local_element_ptr_range())
     {
-      const Elem * elem = *el;
-
       error_dof_map.dof_indices(elem, dof_indices);
 
       const dof_id_type elem_id = elem->id();

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -275,28 +275,25 @@ const Elem * PointLocatorTree::perform_linear_search(const Point & p,
   // used for this PointLocator.  If it's
   // TREE_LOCAL_ELEMENTS, we only want to double check
   // local elements during this linear search.
-  MeshBase::const_element_iterator pos =
+  SimpleRange<MeshBase::const_element_iterator> r =
     this->_build_type == Trees::LOCAL_ELEMENTS ?
-    this->_mesh.active_local_elements_begin() : this->_mesh.active_elements_begin();
+    this->_mesh.active_local_element_ptr_range() :
+    this->_mesh.active_element_ptr_range();
 
-  const MeshBase::const_element_iterator end_pos =
-    this->_build_type == Trees::LOCAL_ELEMENTS ?
-    this->_mesh.active_local_elements_end() : this->_mesh.active_elements_end();
-
-  for ( ; pos != end_pos; ++pos)
+  for (const auto & elem : r)
     {
       if (!allowed_subdomains ||
-          allowed_subdomains->count((*pos)->subdomain_id()))
+          allowed_subdomains->count(elem->subdomain_id()))
         {
           if (!use_close_to_point)
             {
-              if ((*pos)->contains_point(p))
-                return (*pos);
+              if (elem->contains_point(p))
+                return elem;
             }
           else
             {
-              if ((*pos)->close_to_point(p, close_to_point_tolerance))
-                return (*pos);
+              if (elem->close_to_point(p, close_to_point_tolerance))
+                return elem;
             }
         }
     }

--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -314,20 +314,14 @@ std::set<const Elem *> PointLocatorTree::perform_fuzzy_linear_search(const Point
   // used for this PointLocator.  If it's
   // TREE_LOCAL_ELEMENTS, we only want to double check
   // local elements during this linear search.
-  MeshBase::const_element_iterator pos =
+  SimpleRange<MeshBase::const_element_iterator> r =
     this->_build_type == Trees::LOCAL_ELEMENTS ?
-    this->_mesh.active_local_elements_begin() : this->_mesh.active_elements_begin();
+    this->_mesh.active_local_element_ptr_range() :
+    this->_mesh.active_element_ptr_range();
 
-  const MeshBase::const_element_iterator end_pos =
-    this->_build_type == Trees::LOCAL_ELEMENTS ?
-    this->_mesh.active_local_elements_end() : this->_mesh.active_elements_end();
-
-  for ( ; pos != end_pos; ++pos)
-    {
-      if ((!allowed_subdomains || allowed_subdomains->count((*pos)->subdomain_id())) &&
-          (*pos)->close_to_point(p, close_to_point_tolerance))
-        candidate_elements.insert(*pos);
-    }
+  for (const auto & elem : r)
+    if ((!allowed_subdomains || allowed_subdomains->count(elem->subdomain_id())) && elem->close_to_point(p, close_to_point_tolerance))
+      candidate_elements.insert(elem);
 
   return candidate_elements;
 }

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -85,15 +85,12 @@ Tree<N>::Tree (const MeshBase & m,
     {
       // Add all active, local elements to the root node.  It will
       // automatically build the tree for us.
-      MeshBase::const_element_iterator       it  = mesh.active_local_elements_begin();
-      const MeshBase::const_element_iterator end = mesh.active_local_elements_end();
-
-      for (; it != end; ++it)
+      for (const auto & elem : mesh.active_local_element_ptr_range())
         {
 #ifndef NDEBUG
           bool elem_was_inserted =
 #endif
-            root.insert (*it);
+            root.insert (elem);
           libmesh_assert(elem_was_inserted);
         }
     }

--- a/tests/base/default_coupling_test.C
+++ b/tests/base/default_coupling_test.C
@@ -90,46 +90,40 @@ public:
     es.init();
     sys.project_solution(cubic_default_coupling_test, NULL, es.parameters);
 
-    for (MeshBase::const_element_iterator
-           elem_it  = mesh.active_local_elements_begin(),
-           elem_end = mesh.active_local_elements_end();
-         elem_it != elem_end; ++elem_it)
-      {
-        const Elem * elem = *elem_it;
-        for (unsigned int s1=0; s1 != elem->n_neighbors(); ++s1)
-          {
-            const Elem * n1 = elem->neighbor_ptr(s1);
-            if (!n1)
-              continue;
+    for (const auto & elem : mesh.active_local_element_ptr_range())
+      for (unsigned int s1=0; s1 != elem->n_neighbors(); ++s1)
+        {
+          const Elem * n1 = elem->neighbor_ptr(s1);
+          if (!n1)
+            continue;
 
-            // Let's speed up this test by only checking the ghosted
-            // elements which are most likely to break.
-            if (n1->processor_id() == mesh.processor_id())
-              continue;
+          // Let's speed up this test by only checking the ghosted
+          // elements which are most likely to break.
+          if (n1->processor_id() == mesh.processor_id())
+            continue;
 
-            for (unsigned int s2=0; s2 != elem->n_neighbors(); ++s2)
-              {
-                const Elem * n2 = elem->neighbor_ptr(s2);
-                if (!n2 ||
-                    n2->processor_id() == mesh.processor_id())
-                  continue;
+          for (unsigned int s2=0; s2 != elem->n_neighbors(); ++s2)
+            {
+              const Elem * n2 = elem->neighbor_ptr(s2);
+              if (!n2 ||
+                  n2->processor_id() == mesh.processor_id())
+                continue;
 
-                for (unsigned int s3=0; s3 != elem->n_neighbors(); ++s3)
-                  {
-                    const Elem * n3 = elem->neighbor_ptr(s3);
-                    if (!n3 ||
-                        n3->processor_id() == mesh.processor_id())
-                      continue;
+              for (unsigned int s3=0; s3 != elem->n_neighbors(); ++s3)
+                {
+                  const Elem * n3 = elem->neighbor_ptr(s3);
+                  if (!n3 ||
+                      n3->processor_id() == mesh.processor_id())
+                    continue;
 
-                    Point p = n3->centroid();
+                  Point p = n3->centroid();
 
-                    CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p,n3)),
-                                                 libmesh_real(cubic_default_coupling_test(p,es.parameters,"","")),
-                                                 TOLERANCE*TOLERANCE);
-                  }
-              }
-          }
-      }
+                  CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p,n3)),
+                                               libmesh_real(cubic_default_coupling_test(p,es.parameters,"","")),
+                                               TOLERANCE*TOLERANCE);
+                }
+            }
+        }
   }
 
 

--- a/tests/base/point_neighbor_coupling_test.C
+++ b/tests/base/point_neighbor_coupling_test.C
@@ -108,52 +108,46 @@ public:
     es.init();
     sys.project_solution(cubic_point_neighbor_coupling_test, NULL, es.parameters);
 
-    for (MeshBase::const_element_iterator
-           elem_it  = mesh.active_local_elements_begin(),
-           elem_end = mesh.active_local_elements_end();
-         elem_it != elem_end; ++elem_it)
-      {
-        const Elem * elem = *elem_it;
-        for (unsigned int s1=0; s1 != elem->n_neighbors(); ++s1)
-          {
-            const Elem * n1 = elem->neighbor_ptr(s1);
-            if (!n1)
-              continue;
+    for (const auto & elem : mesh.active_local_element_ptr_range())
+      for (unsigned int s1=0; s1 != elem->n_neighbors(); ++s1)
+        {
+          const Elem * n1 = elem->neighbor_ptr(s1);
+          if (!n1)
+            continue;
 
-            libmesh_assert(sys.get_dof_map().is_evaluable(*n1, 0));
+          libmesh_assert(sys.get_dof_map().is_evaluable(*n1, 0));
 
-            // Let's speed up this test by only checking the ghosted
-            // elements which are most likely to break.
-            if (n1->processor_id() == mesh.processor_id())
-              continue;
+          // Let's speed up this test by only checking the ghosted
+          // elements which are most likely to break.
+          if (n1->processor_id() == mesh.processor_id())
+            continue;
 
-            for (unsigned int s2=0; s2 != elem->n_neighbors(); ++s2)
-              {
-                const Elem * n2 = elem->neighbor_ptr(s2);
-                if (!n2 ||
-                    n2->processor_id() == mesh.processor_id())
-                  continue;
+          for (unsigned int s2=0; s2 != elem->n_neighbors(); ++s2)
+            {
+              const Elem * n2 = elem->neighbor_ptr(s2);
+              if (!n2 ||
+                  n2->processor_id() == mesh.processor_id())
+                continue;
 
-                libmesh_assert(sys.get_dof_map().is_evaluable(*n2, 0));
+              libmesh_assert(sys.get_dof_map().is_evaluable(*n2, 0));
 
-                for (unsigned int s3=0; s3 != elem->n_neighbors(); ++s3)
-                  {
-                    const Elem * n3 = elem->neighbor_ptr(s3);
-                    if (!n3 ||
-                        n3->processor_id() == mesh.processor_id())
-                      continue;
+              for (unsigned int s3=0; s3 != elem->n_neighbors(); ++s3)
+                {
+                  const Elem * n3 = elem->neighbor_ptr(s3);
+                  if (!n3 ||
+                      n3->processor_id() == mesh.processor_id())
+                    continue;
 
-                    libmesh_assert(sys.get_dof_map().is_evaluable(*n3, 0));
+                  libmesh_assert(sys.get_dof_map().is_evaluable(*n3, 0));
 
-                    Point p = n3->centroid();
+                  Point p = n3->centroid();
 
-                    CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p,n3)),
-                                                 libmesh_real(cubic_point_neighbor_coupling_test(p,es.parameters,"","")),
-                                                 TOLERANCE*TOLERANCE);
-                  }
-              }
-          }
-      }
+                  CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p,n3)),
+                                               libmesh_real(cubic_point_neighbor_coupling_test(p,es.parameters,"","")),
+                                               TOLERANCE*TOLERANCE);
+                }
+            }
+        }
   }
 
 

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -381,15 +381,8 @@ public:
     if (!_mesh->is_serial())
       locator->enable_out_of_mesh_mode();
 
-    MeshBase::const_element_iterator       el     =
-      mesh2.active_local_elements_begin();
-    const MeshBase::const_element_iterator end_el =
-      mesh2.active_local_elements_end();
-
-    for (; el != end_el; ++el)
+    for (const auto & elem : mesh2.active_local_element_ptr_range())
       {
-        const Elem * elem = *el;
-
         const Elem * mesh1_elem = (*locator)(elem->centroid());
         if (mesh1_elem)
           {


### PR DESCRIPTION
This removes the majority of the remaining mesh iterator boilerplate code. 

I count about 150 other miscellaneous mesh iterator loops (`flagged_pid_elements_begin()`, etc.) but I don't plan on fixing them since the net number of lines saved won't be as large.
