### PR TITLE
Parallelize recent unit test

### DIFF
--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -162,15 +162,15 @@ public:
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,1,0))),
                                      0.0, tol);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2,0))),
-                                     gold_vector[gold_i_ux], tol);
+                                     std::abs(gold_vector[gold_i_ux]), tol);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,4,0))),
                                      0.0, tol);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,5,0))),
-                                     gold_vector[gold_i_uy], tol);
+                                     std::abs(gold_vector[gold_i_uy]), tol);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,7,0))),
                                      0.0, tol);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,8,0))),
-                                     gold_vector[gold_i_v], tol);
+                                     std::abs(gold_vector[gold_i_v]), tol);
 #endif
       }
 #endif // #ifdef LIBMESH_HAVE_EXODUS_API

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -86,6 +86,7 @@ public:
         if (mesh.n_processors() == 1)
           CPPUNIT_ASSERT_EQUAL(initial_vector[node->id()], dof_id*Real(2));
       }
+    sys_solution.close();
 
 #ifdef LIBMESH_HAVE_EXODUS_API
 

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -132,15 +132,44 @@ public:
 
     Real tol = 1e-12;
     NumericVector<Number> & sys2_soln(*sys2.solution);
-    for (unsigned i = 0; i < gold_vector.size(); i++)
-    {
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(3 * i)), gold_vector[i], tol);
-#else
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(i)), gold_vector[i], tol);
-#endif // #ifdef LIBMESH_USE_COMPLEX_NUMBERS
-    }
+    for (const auto & node : read_mesh.node_ptr_range())
+      {
+        if (node->processor_id() != mesh.processor_id())
+          continue;
 
+        // We write out real, imaginary, and magnitude for complex
+        // numbers
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+        const unsigned int v2 = 3;
+#else
+        const unsigned int v2 = 1;
+#endif
+        CPPUNIT_ASSERT_EQUAL(node->n_vars(0), 3*v2);
+
+        const dof_id_type gold_i_ux = node_reordering[node->id()] * 3;
+        const dof_id_type gold_i_uy = gold_i_ux + 1;
+        const dof_id_type gold_i_v  = gold_i_uy + 1;
+
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,0,0)),
+                                     gold_vector[gold_i_ux], tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,v2,0)),
+                                     gold_vector[gold_i_uy], tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,2*v2,0)),
+                                     gold_vector[gold_i_v], tol);
+
+        // Let's check imaginary parts and magnitude for good measure
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,1,0)), 0.0);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,2,0)),
+                                     gold_vector[dof_id_ux], tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,4,0)), 0.0);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,5,0)),
+                                     gold_vector[dof_id_uy], tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,7,0)), 0.0);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,8,0)),
+                                     gold_vector[dof_id_v], tol);
+#endif
+      }
 #endif // #ifdef LIBMESH_HAVE_EXODUS_API
   }
 };

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -150,24 +150,27 @@ public:
         const dof_id_type gold_i_uy = gold_i_ux + 1;
         const dof_id_type gold_i_v  = gold_i_uy + 1;
 
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,0,0)),
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,0,0))),
                                      gold_vector[gold_i_ux], tol);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,v2,0)),
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,v2,0))),
                                      gold_vector[gold_i_uy], tol);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,2*v2,0)),
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2*v2,0))),
                                      gold_vector[gold_i_v], tol);
 
         // Let's check imaginary parts and magnitude for good measure
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,1,0)), 0.0);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,2,0)),
-                                     gold_vector[dof_id_ux], tol);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,4,0)), 0.0);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,5,0)),
-                                     gold_vector[dof_id_uy], tol);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,7,0)), 0.0);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(sys2_soln(node->dof_number(0,8,0)),
-                                     gold_vector[dof_id_v], tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,1,0))),
+                                     0.0, tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,2,0))),
+                                     gold_vector[gold_i_ux], tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,4,0))),
+                                     0.0, tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,5,0))),
+                                     gold_vector[gold_i_uy], tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,7,0))),
+                                     0.0, tol);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys2_soln(node->dof_number(0,8,0))),
+                                     gold_vector[gold_i_v], tol);
 #endif
       }
 #endif // #ifdef LIBMESH_HAVE_EXODUS_API

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -68,11 +68,8 @@ public:
     std::vector<Real> initial_vector({10, 0, 12, 8, 4, 2, 16, 6, 14});
 
     NumericVector<Number> & sys_solution = *(system.solution);
-    for (MeshBase::const_node_iterator it = mesh.local_nodes_begin(),
-                                      end = mesh.local_nodes_end();
-         it != end; ++it)
+    for (const auto & node : mesh.node_ptr_range())
       {
-        const Node *node = *it;
         dof_id_type dof_id;
         if (node->n_comp(0,0))
           {

--- a/tests/mesh/write_vec_and_scalar.C
+++ b/tests/mesh/write_vec_and_scalar.C
@@ -111,8 +111,24 @@ public:
     for (const auto & var_name : nodal_vars)
       exio.copy_nodal_solution(sys2, var_name, var_name, 1);
 
-    std::vector<Real> gold_vector({-1, 3,   10,  0,  1, 12, 2,  0, 14,  0,  1.5, 11, 0.5, 1,
-                                   13, 0.5, 1.5, 12, 3, 4,  16, 3, 1.5, 15, 0.5, 4,  13});
+    // VariableGroup optimization means that DoFs iterate over each of
+    // the 3 variables on each node before proceeding to the next
+    // node.
+                                    //  u_x, u_y,    v
+    const std::vector<Real> gold_vector({-1,   3,   10,
+                                          0,   1,   12,
+                                          2,   0,   14,
+                                          0,   1.5, 11,
+                                          0.5, 1,   13,
+                                          0.5, 1.5, 12,
+                                          3,   4,   16,
+                                          3,   1.5, 15,
+                                          0.5, 4,   13});
+
+    // Translation from node id to dof indexing order as gets done in
+    // serial
+    const std::vector<dof_id_type>
+      node_reordering({0, 3, 1, 8, 5, 4, 6, 7, 2});
 
     Real tol = 1e-12;
     NumericVector<Number> & sys2_soln(*sys2.solution);


### PR DESCRIPTION
This gets our WriteVecAndScalar unit test working consistently in parallel, using the same gold_vector as before, by using a fixed node ordering and querying for ```dof_number()``` values to determine what dof ordering we ended up with.

Could @brianmoose or someone change the "Test"/"Check" and "Test Debug"/"Check" Civet targets to add something like ```LIBMESH_RUN='mpiexec -np 16'``` to the environment?  I'd rather not let something like this slip through unnoticed again.