### PR TITLE
Get revision information when libmesh is a submodule

### DIFF
--- a/configure
+++ b/configure
@@ -41917,7 +41917,7 @@ fi
 
 
 
-if (test "x${gitquery}" = "x" -o ! -d $srcdir/.git) ; then
+if (test "x${gitquery}" = "x" -o ! -e $srcdir/.git) ; then
    GIT_REVISION="external" #"cat $srcdir/dist_version"
    GIT_CHECKOUT=false
    BUILD_DEVSTATUS="External Release"

--- a/m4/config_environment.m4
+++ b/m4/config_environment.m4
@@ -35,7 +35,7 @@ BUILD_DATE=`date +'%F %H:%M'`
 
 AC_PATH_PROG(gitquery,git)
 
-if (test "x${gitquery}" = "x" -o ! -d $srcdir/.git) ; then
+if (test "x${gitquery}" = "x" -o ! -e $srcdir/.git) ; then
    GIT_REVISION="external" #"cat $srcdir/dist_version"
    GIT_CHECKOUT=false
    BUILD_DEVSTATUS="External Release"


### PR DESCRIPTION
Changed the test to allow `$srcdir/.git` to be a file or a directory to allow for the case when libmesh is being used as a submodule.

Closes #1476