### PR TITLE
Add as_range() helper function.

### DIFF
--- a/include/utils/simple_range.h
+++ b/include/utils/simple_range.h
@@ -20,6 +20,7 @@
 #ifndef LIBMESH_SIMPLERANGE_H
 #define LIBMESH_SIMPLERANGE_H
 
+#include <utility>
 
 namespace libMesh
 {
@@ -44,6 +45,19 @@ public:
 private:
   I _begin, _end;
 };
+
+
+
+/**
+ * Helper function that allows us to treat a homogenous pair as a
+ * range. Useful for writing range-based for loops over the pair
+ * returned by std::equal_range() and std::map::equal_range().
+ */
+template<typename I>
+SimpleRange<I> as_range(const std::pair<I, I> & p)
+{
+  return {p.first, p.second};
+}
 
 } // namespace libMesh
 

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -1077,21 +1077,17 @@ void AbaqusIO::assign_sideset_ids()
             // this algorithm...
             std::pair<provide_bcs_t::const_iterator,
                       provide_bcs_t::const_iterator>
-              range = provide_bcs.equal_range (elem->key(sn));
+              bounds = provide_bcs.equal_range (elem->key(sn));
 
             // Add boundary information for each side in the range.
-            for (provide_bcs_t::const_iterator s_it = range.first;
-                 s_it != range.second; ++s_it)
+            for (const auto & pr : as_range(bounds))
               {
                 // We'll need to compare the lower dimensional element against the current side.
                 UniquePtr<Elem> side (elem->build_side_ptr(sn));
 
-                // Get the value mapped by the iterator.
-                std::pair<Elem *, boundary_id_type> p = s_it->second;
-
-                // Extract the relevant data from the iterator.
-                Elem * lower_dim_elem = p.first;
-                boundary_id_type bid = p.second;
+                // Extract the relevant data. We don't need the key for anything.
+                Elem * lower_dim_elem = pr.second.first;
+                boundary_id_type bid = pr.second.second;
 
                 // This was a hash, so it might not be perfect.  Let's verify...
                 if (*lower_dim_elem == *side)

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1011,11 +1011,8 @@ void BoundaryInfo::boundary_ids (const Node * node,
   // Clear out any previous contents
   vec_to_fill.clear();
 
-  std::pair<boundary_node_iter, boundary_node_iter>
-    pos = _boundary_node_id.equal_range(node);
-
-  for (; pos.first != pos.second; ++pos.first)
-    vec_to_fill.push_back(pos.first->second);
+  for (const auto & pr : as_range(_boundary_node_id.equal_range(node)))
+    vec_to_fill.push_back(pr.second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -2046,13 +2046,11 @@ void BoundaryInfo::build_side_list_from_node_list()
         for (unsigned node_num=0; node_num < n_nodes; ++node_num)
           {
             const Node * node = side_elem->node_ptr(node_num);
-            std::pair<boundary_node_iter, boundary_node_iter>
-              range = _boundary_node_id.equal_range(node);
 
             // For each nodeset that this node is a member of, increment the associated
             // nodeset ID count
-            for (boundary_node_iter pos = range.first; pos != range.second; ++pos)
-              nodesets_node_count[pos->second]++;
+            for (const auto & pr : as_range(_boundary_node_id.equal_range(node)))
+              nodesets_node_count[pr.second]++;
           }
 
         // Now check to see what nodeset_counts have the correct

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -2493,20 +2493,20 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> & requested_bo
 
       // Find all the boundary side ids for this Elem.
       const std::pair<boundary_side_iter, boundary_side_iter>
-        range = _boundary_side_id.equal_range(top_parent);
+        bounds = _boundary_side_id.equal_range(top_parent);
 
       for (auto s : elem->side_index_range())
         {
           bool add_this_side = false;
           boundary_id_type this_bcid = invalid_id;
 
-          for (boundary_side_iter bsi = range.first; bsi != range.second; ++bsi)
+          for (const auto & pr : as_range(bounds))
             {
-              this_bcid = bsi->second.second;
+              this_bcid = pr.second.second;
 
               // if this side is flagged with a boundary condition
               // and the user wants this id
-              if ((bsi->second.first == s) &&
+              if ((pr.second.first == s) &&
                   (requested_boundary_ids.count(this_bcid)))
                 {
                   add_this_side = true;
@@ -2520,7 +2520,7 @@ void BoundaryInfo::_find_id_maps(const std::set<boundary_id_type> & requested_bo
           // boundary was copied to the BoundaryMesh, and handles the
           // case where elements on the geometric boundary are not in
           // any sidesets.
-          if (range.first == range.second              &&
+          if (bounds.first == bounds.second            &&
               requested_boundary_ids.count(invalid_id) &&
               elem->neighbor_ptr(s) == libmesh_nullptr)
             add_this_side = true;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1332,13 +1332,10 @@ void BoundaryInfo::raw_boundary_ids (const Elem * const elem,
   if (elem->parent())
     return;
 
-  std::pair<boundary_side_iter, boundary_side_iter>
-    e = _boundary_side_id.equal_range(elem);
-
   // Check each element in the range to see if its side matches the requested side.
-  for (; e.first != e.second; ++e.first)
-    if (e.first->second.first == side)
-      vec_to_fill.push_back(e.first->second.second);
+  for (const auto & pr : as_range(_boundary_side_id.equal_range(elem)))
+    if (pr.second.first == side)
+      vec_to_fill.push_back(pr.second.second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -429,20 +429,20 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
 
       // Find all the boundary side ids for this Elem.
       const std::pair<boundary_side_iter, boundary_side_iter>
-        range = _boundary_side_id.equal_range(top_parent);
+        bounds = _boundary_side_id.equal_range(top_parent);
 
       for (auto s : elem->side_index_range())
         {
           bool add_this_side = false;
           boundary_id_type this_bcid = invalid_id;
 
-          for (boundary_side_iter bsi = range.first; bsi != range.second; ++bsi)
+          for (const auto & pr : as_range(bounds))
             {
-              this_bcid = bsi->second.second;
+              this_bcid = pr.second.second;
 
               // if this side is flagged with a boundary condition
               // and the user wants this id
-              if ((bsi->second.first == s) &&
+              if ((pr.second.first == s) &&
                   (requested_boundary_ids.count(this_bcid)))
                 {
                   add_this_side = true;
@@ -456,7 +456,7 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
           // boundary was copied to the BoundaryMesh, and handles the
           // case where elements on the geometric boundary are not in
           // any sidesets.
-          if (range.first == range.second              &&
+          if (bounds.first == bounds.second            &&
               requested_boundary_ids.count(invalid_id) &&
               elem->neighbor_ptr(s) == libmesh_nullptr)
             add_this_side = true;
@@ -641,10 +641,8 @@ void BoundaryInfo::add_node(const Node * node,
                       << "\n That is reserved for internal use.");
 
   // Don't add the same ID twice
-  std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
-
-  for (; pos.first != pos.second; ++pos.first)
-    if (pos.first->second == id)
+  for (const auto & pr : as_range(_boundary_node_id.equal_range(node)))
+    if (pr.second == id)
       return;
 
   _boundary_node_id.insert(std::make_pair(node, id));
@@ -663,7 +661,7 @@ void BoundaryInfo::add_node(const Node * node,
   libmesh_assert(node);
 
   // Don't add the same ID twice
-  std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
+  std::pair<boundary_node_iter, boundary_node_iter> bounds = _boundary_node_id.equal_range(node);
 
   // The entries in the ids vector may be non-unique.  If we expected
   // *lots* of ids, it might be fastest to construct a std::set from
@@ -686,8 +684,8 @@ void BoundaryInfo::add_node(const Node * node,
                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
-      for (boundary_node_iter p = pos.first; p != pos.second; ++p)
-        if (p->second == id)
+      for (const auto & pr : as_range(bounds))
+        if (pr.second == id)
           {
             already_inserted = true;
             break;
@@ -732,11 +730,9 @@ void BoundaryInfo::add_edge(const Elem * elem,
                       << "\n That is reserved for internal use.");
 
   // Don't add the same ID twice
-  std::pair<boundary_edge_iter, boundary_edge_iter> pos = _boundary_edge_id.equal_range(elem);
-
-  for (; pos.first != pos.second; ++pos.first)
-    if (pos.first->second.first == edge &&
-        pos.first->second.second == id)
+  for (const auto & pr : as_range(_boundary_edge_id.equal_range(elem)))
+    if (pr.second.first == edge &&
+        pr.second.second == id)
       return;
 
   _boundary_edge_id.insert(std::make_pair(elem, std::make_pair(edge, id)));
@@ -759,7 +755,7 @@ void BoundaryInfo::add_edge(const Elem * elem,
   libmesh_assert_equal_to (elem->level(), 0);
 
   // Don't add the same ID twice
-  std::pair<boundary_edge_iter, boundary_edge_iter> pos = _boundary_edge_id.equal_range(elem);
+  std::pair<boundary_edge_iter, boundary_edge_iter> bounds = _boundary_edge_id.equal_range(elem);
 
   // The entries in the ids vector may be non-unique.  If we expected
   // *lots* of ids, it might be fastest to construct a std::set from
@@ -782,9 +778,9 @@ void BoundaryInfo::add_edge(const Elem * elem,
                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
-      for (boundary_edge_iter p = pos.first; p != pos.second; ++p)
-        if (p->second.first == edge &&
-            p->second.second == id)
+      for (const auto & pr : as_range(bounds))
+        if (pr.second.first == edge &&
+            pr.second.second == id)
           {
             already_inserted = true;
             break;
@@ -827,11 +823,9 @@ void BoundaryInfo::add_shellface(const Elem * elem,
                       << "\n That is reserved for internal use.");
 
   // Don't add the same ID twice
-  std::pair<boundary_shellface_iter, boundary_shellface_iter> pos = _boundary_shellface_id.equal_range(elem);
-
-  for (; pos.first != pos.second; ++pos.first)
-    if (pos.first->second.first == shellface &&
-        pos.first->second.second == id)
+  for (const auto & pr : as_range(_boundary_shellface_id.equal_range(elem)))
+    if (pr.second.first == shellface &&
+        pr.second.second == id)
       return;
 
   _boundary_shellface_id.insert(std::make_pair(elem, std::make_pair(shellface, id)));

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -915,11 +915,9 @@ void BoundaryInfo::add_side(const Elem * elem,
                       << "\n That is reserved for internal use.");
 
   // Don't add the same ID twice
-  std::pair<boundary_side_iter, boundary_side_iter> pos = _boundary_side_id.equal_range(elem);
-
-  for (; pos.first != pos.second; ++pos.first)
-    if (pos.first->second.first == side &&
-        pos.first->second.second == id)
+  for (const auto & pr : as_range(_boundary_side_id.equal_range(elem)))
+    if (pr.second.first == side &&
+        pr.second.second == id)
       return;
 
   _boundary_side_id.insert(std::make_pair(elem, std::make_pair(side, id)));

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1205,13 +1205,10 @@ void BoundaryInfo::raw_shellface_boundary_ids (const Elem * const elem,
   if (elem->parent())
     return;
 
-  std::pair<boundary_shellface_iter, boundary_shellface_iter>
-    e = _boundary_shellface_id.equal_range(elem);
-
   // Check each element in the range to see if its shellface matches the requested shellface.
-  for (; e.first != e.second; ++e.first)
-    if (e.first->second.first == shellface)
-      vec_to_fill.push_back(e.first->second.second);
+  for (const auto & pr : as_range(_boundary_shellface_id.equal_range(elem)))
+    if (pr.second.first == shellface)
+      vec_to_fill.push_back(pr.second.second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -940,7 +940,7 @@ void BoundaryInfo::add_side(const Elem * elem,
   libmesh_assert_equal_to (elem->level(), 0);
 
   // Don't add the same ID twice
-  std::pair<boundary_side_iter, boundary_side_iter> pos = _boundary_side_id.equal_range(elem);
+  std::pair<boundary_side_iter, boundary_side_iter> bounds = _boundary_side_id.equal_range(elem);
 
   // The entries in the ids vector may be non-unique.  If we expected
   // *lots* of ids, it might be fastest to construct a std::set from
@@ -963,8 +963,8 @@ void BoundaryInfo::add_side(const Elem * elem,
                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
-      for (boundary_side_iter p = pos.first; p != pos.second; ++p)
-        if (p->second.first == side && p->second.second == id)
+      for (const auto & pr : as_range(bounds))
+        if (pr.second.first == side && pr.second.second == id)
           {
             already_inserted = true;
             break;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1137,13 +1137,10 @@ void BoundaryInfo::raw_edge_boundary_ids (const Elem * const elem,
   if (elem->parent())
     return;
 
-  std::pair<boundary_edge_iter, boundary_edge_iter>
-    e = _boundary_edge_id.equal_range(elem);
-
   // Check each element in the range to see if its edge matches the requested edge.
-  for (; e.first != e.second; ++e.first)
-    if (e.first->second.first == edge)
-      vec_to_fill.push_back(e.first->second.second);
+  for (const auto & pr : as_range(_boundary_edge_id.equal_range(elem)))
+    if (pr.second.first == edge)
+      vec_to_fill.push_back(pr.second.second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1171,13 +1171,10 @@ void BoundaryInfo::shellface_boundary_ids (const Elem * const elem,
     }
 #endif
 
-  std::pair<boundary_shellface_iter, boundary_shellface_iter>
-    e = _boundary_shellface_id.equal_range(searched_elem);
-
   // Check each element in the range to see if its shellface matches the requested shellface.
-  for (; e.first != e.second; ++e.first)
-    if (e.first->second.first == shellface)
-      vec_to_fill.push_back(e.first->second.second);
+  for (const auto & pr : as_range(_boundary_shellface_id.equal_range(searched_elem)))
+    if (pr.second.first == shellface)
+      vec_to_fill.push_back(pr.second.second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1092,13 +1092,10 @@ void BoundaryInfo::edge_boundary_ids (const Elem * const elem,
     }
 #endif
 
-  std::pair<boundary_edge_iter, boundary_edge_iter>
-    e = _boundary_edge_id.equal_range(searched_elem);
-
   // Check each element in the range to see if its edge matches the requested edge.
-  for (; e.first != e.second; ++e.first)
-    if (e.first->second.first == edge)
-      vec_to_fill.push_back(e.first->second.second);
+  for (const auto & pr : as_range(_boundary_edge_id.equal_range(searched_elem)))
+    if (pr.second.first == edge)
+      vec_to_fill.push_back(pr.second.second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -851,7 +851,7 @@ void BoundaryInfo::add_shellface(const Elem * elem,
   libmesh_assert_less(shellface, 2);
 
   // Don't add the same ID twice
-  std::pair<boundary_shellface_iter, boundary_shellface_iter> pos = _boundary_shellface_id.equal_range(elem);
+  std::pair<boundary_shellface_iter, boundary_shellface_iter> bounds = _boundary_shellface_id.equal_range(elem);
 
   // The entries in the ids vector may be non-unique.  If we expected
   // *lots* of ids, it might be fastest to construct a std::set from
@@ -874,9 +874,9 @@ void BoundaryInfo::add_shellface(const Elem * elem,
                           << "\n That is reserved for internal use.");
 
       bool already_inserted = false;
-      for (boundary_shellface_iter p = pos.first; p != pos.second; ++p)
-        if (p->second.first == shellface &&
-            p->second.second == id)
+      for (const auto & pr : as_range(bounds))
+        if (pr.second.first == shellface &&
+            pr.second.second == id)
           {
             already_inserted = true;
             break;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -983,10 +983,8 @@ void BoundaryInfo::add_side(const Elem * elem,
 bool BoundaryInfo::has_boundary_id(const Node * const node,
                                    const boundary_id_type id) const
 {
-  std::pair<boundary_node_iter, boundary_node_iter> pos = _boundary_node_id.equal_range(node);
-
-  for (; pos.first != pos.second; ++pos.first)
-    if (pos.first->second == id)
+  for (const auto & pr : as_range(_boundary_node_id.equal_range(node)))
+    if (pr.second == id)
       return true;
 
   return false;

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1286,13 +1286,10 @@ void BoundaryInfo::boundary_ids (const Elem * const elem,
 #endif
     }
 
-  std::pair<boundary_side_iter, boundary_side_iter>
-    e = _boundary_side_id.equal_range(searched_elem);
-
   // Check each element in the range to see if its side matches the requested side.
-  for (; e.first != e.second; ++e.first)
-    if (e.first->second.first == side)
-      vec_to_fill.push_back(e.first->second.second);
+  for (const auto & pr : as_range(_boundary_side_id.equal_range(searched_elem)))
+    if (pr.second.first == side)
+      vec_to_fill.push_back(pr.second.second);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1637,17 +1637,14 @@ unsigned int BoundaryInfo::side_with_boundary_id(const Elem * const elem,
   if (elem->level() != 0)
     searched_elem = elem->top_parent();
 
-  std::pair<boundary_side_iter, boundary_side_iter>
-    e = _boundary_side_id.equal_range(searched_elem);
-
   // elem may have zero or multiple occurrences
-  for (; e.first != e.second; ++e.first)
+  for (const auto & pr : as_range(_boundary_side_id.equal_range(searched_elem)))
     {
       // if this is true we found the requested boundary_id
       // of the element and want to return the side
-      if (e.first->second.second == boundary_id_in)
+      if (pr.second.second == boundary_id_in)
         {
-          unsigned int side = e.first->second.first;
+          unsigned int side = pr.second.first;
 
           // If we're on this external boundary then we share this
           // external boundary id

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -2109,7 +2109,7 @@ void XdrIO::read_serialized_nodesets (Xdr & io, T)
       for (auto & node : mesh.node_ptr_range())
         {
           std::pair<std::vector<DofBCData>::iterator,
-                    std::vector<DofBCData>::iterator> pos =
+                    std::vector<DofBCData>::iterator> bounds =
             std::equal_range (node_bc_data.begin(),
                               node_bc_data.end(),
                               node->id()
@@ -2118,13 +2118,13 @@ void XdrIO::read_serialized_nodesets (Xdr & io, T)
 #endif
                               );
 
-        for (; pos.first != pos.second; ++pos.first)
-          {
-            // Note: dof_id from ElmeBCData is being used to hold node_id here
-            libmesh_assert_equal_to (pos.first->dof_id, node->id());
+          for (const auto & data : as_range(bounds))
+            {
+              // Note: dof_id from ElmeBCData is being used to hold node_id here
+              libmesh_assert_equal_to (data.dof_id, node->id());
 
-            boundary_info.add_node (node, pos.first->bc_id);
-          }
+              boundary_info.add_node (node, data.bc_id);
+            }
         }
     }
 }

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -426,13 +426,9 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
               }
 
             // Check for any boundary neighbors
-            typedef map_type::iterator map_it_type;
-            std::pair<map_it_type, map_it_type>
-              bounds = interior_to_boundary_map.equal_range(elem);
-
-            for (map_it_type it = bounds.first; it != bounds.second; ++it)
+            for (const auto & pr : as_range(interior_to_boundary_map.equal_range(elem)))
               {
-                const Elem * neighbor = it->second;
+                const Elem * neighbor = pr.second;
                 csr_graph(elem_global_index, connection++) =
                   global_index_map[neighbor->id()];
               }

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -552,13 +552,9 @@ void ParmetisPartitioner::build_graph (const MeshBase & mesh)
         }
 
       // Check for any boundary neighbors
-      typedef map_type::iterator map_it_type;
-      std::pair<map_it_type, map_it_type>
-        bounds = interior_to_boundary_map.equal_range(elem);
-
-      for (map_it_type it = bounds.first; it != bounds.second; ++it)
+      for (const auto & pr : as_range(interior_to_boundary_map.equal_range(elem)))
         {
-          const Elem * neighbor = it->second;
+          const Elem * neighbor = pr.second;
 
           const dof_id_type neighbor_global_index_by_pid =
             _global_index_by_pid_map[neighbor->id()];

--- a/src/utils/location_maps.C
+++ b/src/utils/location_maps.C
@@ -117,15 +117,9 @@ T * LocationMap<T>::find(const Point & p,
   unsigned int pointkey = this->key(p);
 
   // Look for the exact key first
-  std::pair<typename map_type::iterator,
-            typename map_type::iterator>
-    pos = _map.equal_range(pointkey);
-
-  while (pos.first != pos.second)
-    if (p.absolute_fuzzy_equals(this->point_of(*(pos.first->second)), tol))
-      return pos.first->second;
-    else
-      ++pos.first;
+  for (const auto & pr : as_range(_map.equal_range(pointkey)))
+    if (p.absolute_fuzzy_equals(this->point_of(*(pr.second)), tol))
+      return pr.second;
 
   // Look for neighboring bins' keys next
   for (int xoffset = -1; xoffset != 2; ++xoffset)
@@ -140,11 +134,9 @@ T * LocationMap<T>::find(const Point & p,
                                            xoffset*chunkmax*chunkmax +
                                            yoffset*chunkmax +
                                            zoffset);
-              while (key_pos.first != key_pos.second)
-                if (p.absolute_fuzzy_equals(this->point_of(*(key_pos.first->second)), tol))
-                  return key_pos.first->second;
-                else
-                  ++key_pos.first;
+              for (const auto & pr : as_range(key_pos))
+                if (p.absolute_fuzzy_equals(this->point_of(*(pr.second)), tol))
+                  return pr.second;
             }
         }
     }


### PR DESCRIPTION
This lets us treat the iterator `std::pairs` returned by `equal_range()` as ranges for the purpose of using range-based for loops. This in turn allows us to remove more bolierplate code.
