### PR TITLE
dof_indices, old_dof_indices optimizations

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1253,7 +1253,7 @@ private:
    * In DEBUG mode, the tot_size parameter will add up the total
    * number of dof indices that should have been added to di.
    */
-  void _dof_indices (const Elem * const elem,
+  void _dof_indices (const Elem & elem,
                      int p_level,
                      std::vector<dof_id_type> & di,
                      const unsigned int v,

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -25,6 +25,7 @@
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/vector_value.h"
 #include "libmesh/enum_fe_family.h"
+#include "libmesh/enum_order.h"
 
 // C++ includes
 #include <map>
@@ -108,6 +109,18 @@ public:
                                      const FEType & fe_t,
                                      const ElemType t,
                                      const unsigned int n);
+
+  typedef unsigned int (*n_dofs_at_node_ptr) (const ElemType,
+                                              const Order,
+                                              const unsigned int);
+
+  /**
+   * \returns A function which evaluates n_dofs_at_node for the
+   * requested FE type and dimension.
+   */
+  static n_dofs_at_node_ptr
+  n_dofs_at_node_function(const unsigned int dim,
+                          const FEType & fe_t);
 
   /**
    * \returns The number of dofs interior to the element,

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2009,7 +2009,8 @@ void DofMap::dof_indices (const Elem * const elem,
       return;
     }
 
-  // Get the dof numbers
+  // Get the dof numbers for each variable
+  const unsigned int n_nodes = elem ? elem->n_nodes() : 0;
   for (unsigned int v=0; v<n_vars; v++)
     {
       const Variable & var = this->variable(v);
@@ -2026,7 +2027,7 @@ void DofMap::dof_indices (const Elem * const elem,
         }
       else if (elem)
         _dof_indices(elem, elem->p_level(), di, v, elem->get_nodes(),
-                     elem->n_nodes()
+                     n_nodes
 #ifdef DEBUG
                      , tot_size
 #endif

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2437,18 +2437,21 @@ void DofMap::old_dof_indices (const Elem * const elem,
 
   // Determine the nodes contributing to element elem
   std::vector<const Node *> elem_nodes;
+  const Node * const * nodes_ptr;
+  unsigned int n_nodes;
   if (elem->type() == TRI3SUBDIVISION)
     {
       // Subdivision surface FE require the 1-ring around elem
       const Tri3Subdivision * sd_elem = static_cast<const Tri3Subdivision *>(elem);
       MeshTools::Subdivision::find_one_ring(sd_elem, elem_nodes);
+      nodes_ptr = &elem_nodes[0];
+      n_nodes = elem_nodes.size();
     }
   else
     {
       // All other FE use only the nodes of elem itself
-      elem_nodes.resize(elem->n_nodes(), libmesh_nullptr);
-      for (unsigned int i=0; i<elem->n_nodes(); i++)
-        elem_nodes[i] = elem->node_ptr(i);
+      nodes_ptr = elem->get_nodes();
+      n_nodes = elem->n_nodes();
     }
 
   // Get the dof numbers
@@ -2494,9 +2497,9 @@ void DofMap::old_dof_indices (const Elem * const elem,
                 FEInterface::n_dofs_at_node_function(dim, fe_type);
 
               // Get the node-based DOF numbers
-              for (std::size_t n=0; n<elem_nodes.size(); n++)
+              for (std::size_t n=0; n<n_nodes; n++)
                 {
-                  const Node * node      = elem_nodes[n];
+                  const Node * node = nodes_ptr[n];
 
                   // There is a potential problem with h refinement.  Imagine a
                   // quad9 that has a linear FE on it.  Then, on the hanging side,

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -455,6 +455,21 @@ unsigned int FEInterface::n_dofs_at_node(const unsigned int dim,
 
 
 
+FEInterface::n_dofs_at_node_ptr
+FEInterface::n_dofs_at_node_function(const unsigned int dim,
+                                     const FEType & fe_t)
+{
+  const Order o = fe_t.order;
+
+  fe_with_vec_switch(n_dofs_at_node);
+
+  libmesh_error_msg("We'll never get here!");
+  return libmesh_nullptr;
+}
+
+
+
+
 
 
 unsigned int FEInterface::n_dofs_per_elem(const unsigned int dim,

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -459,8 +459,6 @@ FEInterface::n_dofs_at_node_ptr
 FEInterface::n_dofs_at_node_function(const unsigned int dim,
                                      const FEType & fe_t)
 {
-  const Order o = fe_t.order;
-
   fe_with_vec_switch(n_dofs_at_node);
 
   libmesh_error_msg("We'll never get here!");


### PR DESCRIPTION
When I removed the subdivision-surface "pessimization" from dof_indices() a couple years ago, I apparently neglected to do the same in old_dof_indices(); this PR rectifies that.

We can also get a little bit of speedup by reducing the number of times we hit FEInterface switch statements: instead of using FEInterface at every node, we can use it once to get a function pointer, then reuse that function pointer on every node on the same FE/Elem combo.  This gives me about a 15% speedup even in the QUAD4 case, and ought to be even better for higher order and/or 3D elements.

I also get rid of redundant n_nodes() calls, which is probably a nearly-invisible performance improvement, but in functions which get called a billion times I figure every little bit helps.