### PR TITLE
Fix PerfLog::get_perf_data()

### DIFF
--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -854,6 +854,9 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
                           bool apply_no_constraints)
 {
   libmesh_assert(get_residual || get_jacobian);
+
+// Log residual and jacobian and combined performance separately
+#ifdef LIBMESH_ENABLE_PERFORMANCE_LOGGING
   const char * log_name;
   if (get_residual && get_jacobian)
     log_name = "assembly()";
@@ -863,6 +866,7 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
     log_name = "assembly(get_jacobian)";
 
   LOG_SCOPE(log_name, "FEMSystem");
+#endif
 
   const MeshBase & mesh = this->get_mesh();
 

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -703,9 +703,11 @@ PerfData PerfLog::get_perf_data(const std::string & label, const std::string & h
       return log[std::make_pair(header_c_str, label_c_str)];
     }
 
+  typedef decltype(*log.begin()) map_pair;
+
   auto iter = std::find_if
     (log.begin(), log.end(),
-     [&label, &header] (const auto & a)
+     [&label, &header] (const map_pair & a)
      { return !std::strcmp(header.c_str(), a.first.first) &&
               !std::strcmp(label.c_str(), a.first.second); });
 

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -18,6 +18,7 @@
 #include "libmesh/perf_log.h"
 
 // C++ includes
+#include <algorithm>
 #include <iostream>
 #include <iomanip>
 #include <cstring>
@@ -694,7 +695,23 @@ void PerfLog::print_log() const
 
 PerfData PerfLog::get_perf_data(const std::string & label, const std::string & header)
 {
-  return log[std::make_pair(header.c_str(), label.c_str())];
+  if (non_temporary_strings.count(label) &&
+      non_temporary_strings.count(header))
+    {
+      const char * label_c_str = non_temporary_strings[label];
+      const char * header_c_str = non_temporary_strings[header];
+      return log[std::make_pair(header_c_str, label_c_str)];
+    }
+
+  auto iter = std::find_if
+    (log.begin(), log.end(),
+     [&label, &header] (const auto & a)
+     { return !std::strcmp(header.c_str(), a.first.first) &&
+              !std::strcmp(label.c_str(), a.first.second); });
+
+  libmesh_assert(iter != log.end());
+
+  return iter->second;
 }
 
 void PerfLog::start_event(const std::string & label,


### PR DESCRIPTION
We can no longer directly look up strings in the log.  We'll have to
search for the corresponding character pointers first.

Thanks to @jessecarterMOOSE for finding the regression in #1462.  I haven't tested this for correctness yet, I'm rebuilding MOOSE to do so now, but I just wanted to let him have a chance to do the same ASAP.

This uses a C++11 lambda function; if it turns out to be the right fix then I'll add a second commit (and a third bootstrap commit) to make lambda support mandatory at configure time before we merge.