### PR TITLE
Add MeshBase::local_node_ptr_range()

### DIFF
--- a/examples/fem_system/fem_system_ex2/solid_system.C
+++ b/examples/fem_system/fem_system_ex2/solid_system.C
@@ -66,19 +66,14 @@ void SolidSystem::save_initial_mesh()
 
   // Loop over all nodes and copy the location from the current system to
   // the auxiliary system.
-  MeshBase::const_node_iterator nd = this->get_mesh().local_nodes_begin();
-  const MeshBase::const_node_iterator nd_end = this->get_mesh().local_nodes_end();
-  for (; nd != nd_end; ++nd)
-    {
-      const Node * node = *nd;
-      for (unsigned int d = 0; d < dim; ++d)
-        {
-          unsigned int source_dof = node->dof_number(this->number(), var[d], 0);
-          unsigned int dest_dof = node->dof_number(aux_sys.number(), undefo_var[d], 0);
-          Number value = this->current_local_solution->el(source_dof);
-          aux_sys.current_local_solution->set(dest_dof, value);
-        }
-    }
+  for (const auto & node : this->get_mesh().local_node_ptr_range())
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        unsigned int source_dof = node->dof_number(this->number(), var[d], 0);
+        unsigned int dest_dof = node->dof_number(aux_sys.number(), undefo_var[d], 0);
+        Number value = this->current_local_solution->el(source_dof);
+        aux_sys.current_local_solution->set(dest_dof, value);
+      }
 }
 
 void SolidSystem::init_data()

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -467,28 +467,16 @@ void assemble_wave(EquationSystems & es,
 
   // Note that we have not applied any boundary conditions so far.
   // Here we apply a unit load at the node located at (0,0,0).
-  {
-    // Iterate over local nodes
-    MeshBase::const_node_iterator           nd = mesh.local_nodes_begin();
-    const MeshBase::const_node_iterator nd_end = mesh.local_nodes_end();
-
-    for (; nd != nd_end; ++nd)
+  for (const auto & node : mesh.local_node_ptr_range())
+    if (std::abs(node(0)) < TOLERANCE &&
+        std::abs(node(1)) < TOLERANCE &&
+        std::abs(node(2)) < TOLERANCE)
       {
-        // Get a reference to the current node.
-        const Node & node = **nd;
+        // The global number of the respective degree of freedom.
+        unsigned int dn = node.dof_number(0,0,0);
 
-        // Check the location of the current node.
-        if (std::abs(node(0)) < TOLERANCE &&
-            std::abs(node(1)) < TOLERANCE &&
-            std::abs(node(2)) < TOLERANCE)
-          {
-            // The global number of the respective degree of freedom.
-            unsigned int dn = node.dof_number(0,0,0);
-
-            system.rhs->add (dn, 1.);
-          }
+        system.rhs->add (dn, 1.);
       }
-  }
 
 #else
 

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -468,12 +468,12 @@ void assemble_wave(EquationSystems & es,
   // Note that we have not applied any boundary conditions so far.
   // Here we apply a unit load at the node located at (0,0,0).
   for (const auto & node : mesh.local_node_ptr_range())
-    if (std::abs(node(0)) < TOLERANCE &&
-        std::abs(node(1)) < TOLERANCE &&
-        std::abs(node(2)) < TOLERANCE)
+    if (std::abs((*node)(0)) < TOLERANCE &&
+        std::abs((*node)(1)) < TOLERANCE &&
+        std::abs((*node)(2)) < TOLERANCE)
       {
         // The global number of the respective degree of freedom.
-        unsigned int dn = node.dof_number(0,0,0);
+        unsigned int dn = node->dof_number(0,0,0);
 
         system.rhs->add (dn, 1.);
       }

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -253,16 +253,13 @@ int main (int argc, char ** argv)
         // Find the closest local node.  On a DistributedMesh we may
         // not even know about the existence of closer non-local
         // nodes.
-        libMesh::MeshBase::const_node_iterator it = mesh.local_nodes_begin();
-        const libMesh::MeshBase::const_node_iterator end = mesh.local_nodes_end();
-        for (; it != end; ++it)
+        for (auto & node : mesh.local_node_ptr_range())
           {
-            Node * n = *it;
-            const Real dist_sq = (*n-point_C).norm_sq();
+            const Real dist_sq = (*node - point_C).norm_sq();
             if (dist_sq < nearest_dist_sq)
               {
                 nearest_dist_sq = dist_sq;
-                node_C = n;
+                node_C = node;
               }
           }
 

--- a/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
+++ b/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
@@ -255,16 +255,13 @@ int main (int argc, char ** argv)
         // Find the closest local node.  On a DistributedMesh we may
         // not even know about the existence of closer non-local
         // nodes.
-        libMesh::MeshBase::const_node_iterator it = mesh.local_nodes_begin();
-        const libMesh::MeshBase::const_node_iterator end = mesh.local_nodes_end();
-        for (; it != end; ++it)
+        for (const auto & node : mesh.local_node_ptr_range())
           {
-            Node * n = *it;
-            const Real dist_sq = (*n-point_C).norm_sq();
+            const Real dist_sq = (*node - point_C).norm_sq();
             if (dist_sq < nearest_dist_sq)
               {
                 nearest_dist_sq = dist_sq;
-                node_C = n;
+                node_C = node;
               }
           }
 

--- a/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
+++ b/examples/miscellaneous/miscellaneous_ex8/miscellaneous_ex8.C
@@ -249,21 +249,15 @@ int main(int argc, char ** argv)
 
       // We now will loop over every node in the source mesh
       // and add it to a source point list, along with the solution
-      {
-        MeshBase::const_node_iterator nd  = mesh_a.local_nodes_begin();
-        MeshBase::const_node_iterator end = mesh_a.local_nodes_end();
+      for (const auto & node : mesh_a.local_node_ptr_range())
+        {
+          src_pts.push_back(*node);
+          src_vals.push_back(sys_a.current_solution(node->dof_number(0, 0, 0)));
+        }
 
-        for (; nd!=end; ++nd)
-          {
-            const Node * node = *nd;
-            src_pts.push_back(*node);
-            src_vals.push_back(sys_a.current_solution(node->dof_number(0, 0, 0)));
-          }
-
-        rbi.set_field_variables(field_vars);
-        rbi.get_source_points() = idi.get_source_points();
-        rbi.get_source_vals()   = idi.get_source_vals();
-      }
+      rbi.set_field_variables(field_vars);
+      rbi.get_source_points() = idi.get_source_points();
+      rbi.get_source_vals()   = idi.get_source_vals();
 
       // We have only set local values - prepare for use by gathering remote data
       idi.prepare_for_use();

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -484,6 +484,8 @@ public:
   virtual node_iterator local_nodes_end () libmesh_override;
   virtual const_node_iterator local_nodes_begin () const libmesh_override;
   virtual const_node_iterator local_nodes_end () const libmesh_override;
+  virtual SimpleRange<node_iterator> local_node_ptr_range() libmesh_override { return {local_nodes_begin(), local_nodes_end()}; }
+  virtual SimpleRange<const_node_iterator> local_node_ptr_range() const libmesh_override { return {local_nodes_begin(), local_nodes_end()}; }
 
   virtual node_iterator pid_nodes_begin (processor_id_type proc_id) libmesh_override;
   virtual node_iterator pid_nodes_end (processor_id_type proc_id) libmesh_override;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1239,6 +1239,8 @@ public:
   virtual node_iterator local_nodes_end () = 0;
   virtual const_node_iterator local_nodes_begin () const = 0;
   virtual const_node_iterator local_nodes_end () const = 0;
+  virtual SimpleRange<node_iterator> local_node_ptr_range() = 0;
+  virtual SimpleRange<const_node_iterator> local_node_ptr_range() const = 0;
 
   /**
    * Iterate over nodes with processor_id() == proc_id

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -425,6 +425,8 @@ public:
   virtual node_iterator local_nodes_end () libmesh_override;
   virtual const_node_iterator local_nodes_begin () const libmesh_override;
   virtual const_node_iterator local_nodes_end () const libmesh_override;
+  virtual SimpleRange<node_iterator> local_node_ptr_range() libmesh_override { return {local_nodes_begin(), local_nodes_end()}; }
+  virtual SimpleRange<const_node_iterator> local_node_ptr_range() const libmesh_override { return {local_nodes_begin(), local_nodes_end()}; }
 
   virtual node_iterator pid_nodes_begin (processor_id_type proc_id) libmesh_override;
   virtual node_iterator pid_nodes_end (processor_id_type proc_id) libmesh_override;

--- a/src/apps/solution_components.C
+++ b/src/apps/solution_components.C
@@ -140,15 +140,11 @@ int main(int argc, char ** argv)
 
 
   // Copy over any element degree of freedom coefficients
+  MeshBase::const_element_iterator new_eit = mesh2.active_local_elements_begin();
 
-  MeshBase::const_element_iterator       old_eit     = mesh1.active_local_elements_begin(),
-    new_eit     = mesh2.active_local_elements_begin();
-  const MeshBase::const_element_iterator old_eit_end = mesh1.active_local_elements_end();
-
-  for (; old_eit != old_eit_end; ++old_eit, ++new_eit)
+  for (const auto & old_elem : mesh1.active_local_element_ptr_range())
     {
-      const Elem * old_elem = *old_eit;
-      const Elem * new_elem = *new_eit;
+      const Elem * new_elem = *new_eit++;
 
       // Mesh::operator= hopefully preserved elem/node orderings...
       libmesh_assert (*old_elem == *new_elem);

--- a/src/apps/solution_components.C
+++ b/src/apps/solution_components.C
@@ -105,15 +105,11 @@ int main(int argc, char ** argv)
   // non-solution vectors too.
 
   // Copy over any nodal degree of freedom coefficients
+  MeshBase::const_node_iterator new_nit = mesh2.local_nodes_begin();
 
-  MeshBase::const_node_iterator       old_nit     = mesh1.local_nodes_begin(),
-    new_nit     = mesh2.local_nodes_begin();
-  const MeshBase::const_node_iterator old_nit_end = mesh1.local_nodes_end();
-
-  for (; old_nit != old_nit_end; ++old_nit, ++new_nit)
+  for (const auto & old_node : mesh1.local_node_ptr_range())
     {
-      const Node * old_node = *old_nit;
-      const Node * new_node = *new_nit;
+      const Node * new_node = *new_nit++;
 
       // Mesh::operator= hopefully preserved elem/node orderings...
       libmesh_assert (*old_node == *new_node);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1118,24 +1118,18 @@ void DofMap::local_variable_indices(std::vector<dof_id_type> & idx,
       // *connected* to elements which do.  in this scenario these nodes
       // will presently have unnumbered DOFs. we need to take care of
       // them here since we own them and no other processor will touch them.
-      {
-        MeshBase::const_node_iterator       node_it  = mesh.local_nodes_begin();
-        const MeshBase::const_node_iterator node_end = mesh.local_nodes_end();
+      for (const auto & node : mesh.local_node_ptr_range())
+        {
+          libmesh_assert(node);
 
-        for (; node_it != node_end; ++node_it)
-          {
-            Node * node = *node_it;
-            libmesh_assert(node);
-
-            const unsigned int n_comp = node->n_comp(sys_num, var_num);
-            for (unsigned int i=0; i<n_comp; i++)
-              {
-                const dof_id_type index = node->dof_number(sys_num,var_num,i);
-                if (idx.empty() || index > idx.back())
-                  idx.push_back(index);
-              }
-          }
-      }
+          const unsigned int n_comp = node->n_comp(sys_num, var_num);
+          for (unsigned int i=0; i<n_comp; i++)
+            {
+              const dof_id_type index = node->dof_number(sys_num,var_num,i);
+              if (idx.empty() || index > idx.back())
+                idx.push_back(index);
+            }
+        }
     }
   // Otherwise, count up the SCALAR dofs, if we're on the processor
   // that holds this SCALAR variable

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1348,27 +1348,17 @@ void DofMap::distribute_local_dofs_var_major(dof_id_type & next_free_dof,
       // *connected* to elements which do.  in this scenario these nodes
       // will presently have unnumbered DOFs. we need to take care of
       // them here since we own them and no other processor will touch them.
-      {
-        MeshBase::node_iterator       node_it  = mesh.local_nodes_begin();
-        const MeshBase::node_iterator node_end = mesh.local_nodes_end();
+      for (auto & node : mesh.local_node_ptr_range())
+        if (node->n_comp_group(sys_num,vg))
+          if (node->vg_dof_base(sys_num,vg) == DofObject::invalid_id)
+            {
+              node->set_vg_dof_base (sys_num,
+                                     vg,
+                                     next_free_dof);
 
-        for (; node_it != node_end; ++node_it)
-          {
-            Node * node = *node_it;
-            libmesh_assert(node);
-
-            if (node->n_comp_group(sys_num,vg))
-              if (node->vg_dof_base(sys_num,vg) == DofObject::invalid_id)
-                {
-                  node->set_vg_dof_base (sys_num,
-                                         vg,
-                                         next_free_dof);
-
-                  next_free_dof += (n_vars_in_group*
-                                    node->n_comp_group(sys_num,vg));
-                }
-          }
-      }
+              next_free_dof += (n_vars_in_group*
+                                node->n_comp_group(sys_num,vg));
+            }
     } // end loop on variable groups
 
   // Finally, count up the SCALAR dofs

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1385,19 +1385,15 @@ void DofMap::distribute_local_dofs_var_major(dof_id_type & next_free_dof,
     // Make sure we didn't miss any nodes
     MeshTools::libmesh_assert_valid_procids<Node>(mesh);
 
-    MeshBase::node_iterator       node_it  = mesh.local_nodes_begin();
-    const MeshBase::node_iterator node_end = mesh.local_nodes_end();
-    for (; node_it != node_end; ++node_it)
+    for (auto & node : mesh.local_node_ptr_range())
       {
-        Node * obj = *node_it;
-        libmesh_assert(obj);
-        unsigned int n_var_g = obj->n_var_groups(this->sys_number());
+        unsigned int n_var_g = node->n_var_groups(this->sys_number());
         for (unsigned int vg=0; vg != n_var_g; ++vg)
           {
             unsigned int n_comp_g =
-              obj->n_comp_group(this->sys_number(), vg);
+              node->n_comp_group(this->sys_number(), vg);
             dof_id_type my_first_dof = n_comp_g ?
-              obj->vg_dof_base(this->sys_number(), vg) : 0;
+              node->vg_dof_base(this->sys_number(), vg) : 0;
             libmesh_assert_not_equal_to (my_first_dof, DofObject::invalid_id);
           }
       }

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1260,19 +1260,15 @@ void DofMap::distribute_local_dofs_node_major(dof_id_type & next_free_dof,
     // Make sure we didn't miss any nodes
     MeshTools::libmesh_assert_valid_procids<Node>(mesh);
 
-    MeshBase::node_iterator       node_it  = mesh.local_nodes_begin();
-    const MeshBase::node_iterator node_end = mesh.local_nodes_end();
-    for (; node_it != node_end; ++node_it)
+    for (auto & node : mesh.local_node_ptr_range())
       {
-        Node * obj = *node_it;
-        libmesh_assert(obj);
-        unsigned int n_var_g = obj->n_var_groups(this->sys_number());
+        unsigned int n_var_g = node->n_var_groups(this->sys_number());
         for (unsigned int vg=0; vg != n_var_g; ++vg)
           {
             unsigned int n_comp_g =
-              obj->n_comp_group(this->sys_number(), vg);
+              node->n_comp_group(this->sys_number(), vg);
             dof_id_type my_first_dof = n_comp_g ?
-              obj->vg_dof_base(this->sys_number(), vg) : 0;
+              node->vg_dof_base(this->sys_number(), vg) : 0;
             libmesh_assert_not_equal_to (my_first_dof, DofObject::invalid_id);
           }
       }

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1929,12 +1929,8 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
   // first we'll need to keep track of which nodes we used to own,
   // lest we get them confused with nodes we newly own.
   std::unordered_set<Node *> ex_local_nodes;
-  for (MeshBase::node_iterator
-         n_it = mesh.local_nodes_begin(),
-         n_end = mesh.local_nodes_end();
-       n_it != n_end; ++n_it)
+  for (auto & node : mesh.local_node_ptr_range())
     {
-      Node * node = *n_it;
       const proc_id_map_type::iterator it = new_proc_ids.find(node->id());
       if (it != new_proc_ids.end() && it->second != mesh.processor_id())
         ex_local_nodes.insert(node);

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1546,13 +1546,9 @@ void libmesh_assert_topology_consistent_procids<Node>(const MeshBase & mesh)
   std::vector<bool> node_touched_by_anyone(node_touched_by_me);
   mesh.comm().max(node_touched_by_anyone);
 
-  const MeshBase::const_node_iterator nd_end = mesh.local_nodes_end();
-  for (MeshBase::const_node_iterator nd = mesh.local_nodes_begin();
-       nd != nd_end; ++nd)
+  for (const auto & node : mesh.local_node_ptr_range())
     {
-      const Node * node = *nd;
       libmesh_assert(node);
-
       dof_id_type nodeid = node->id();
       libmesh_assert(!node_touched_by_anyone[nodeid] ||
                      node_touched_by_me[nodeid]);

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -372,11 +372,9 @@ void VTKIO::nodes_to_vtk()
 
   unsigned int local_node_counter = 0;
 
-  MeshBase::const_node_iterator nd = mesh.local_nodes_begin();
-  MeshBase::const_node_iterator nd_end = mesh.local_nodes_end();
-  for (; nd != nd_end; nd++, ++local_node_counter)
+  for (const auto & node_ptr : mesh.local_node_ptr_range())
     {
-      Node & node = **nd;
+      const Node & node = *node_ptr;
 
       double pnt[3] = {0, 0, 0};
       for (unsigned int i=0; i<LIBMESH_DIM; ++i)
@@ -391,6 +389,7 @@ void VTKIO::nodes_to_vtk()
 #else
       pcoords->InsertNextTuple(pnt);
 #endif
+      ++local_node_counter;
     }
 
   // add coordinates to points

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1217,21 +1217,16 @@ void XdrIO::write_serialized_nodesets (Xdr & io, const new_header_id_type n_node
   // Container to catch boundary IDs handed back by BoundaryInfo
   std::vector<boundary_id_type> nodeset_ids;
 
-  MeshBase::const_node_iterator
-    it  = mesh.local_nodes_begin(),
-    end = mesh.local_nodes_end();
-
   dof_id_type n_node=0;
-  for (; it!=end; ++it)
+  for (const auto & node : mesh.local_node_ptr_range())
     {
-      const Node * node = *it;
       boundary_info.boundary_ids (node, nodeset_ids);
       for (std::vector<boundary_id_type>::const_iterator id_it=nodeset_ids.begin(); id_it!=nodeset_ids.end(); ++id_it)
         {
           const boundary_id_type bc_id = *id_it;
           if (bc_id != BoundaryInfo::invalid_id)
             {
-              xfer_bcs.push_back ((*it)->id());
+              xfer_bcs.push_back (node->id());
               xfer_bcs.push_back (bc_id);
             }
         }

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -743,31 +743,26 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
       last_node = std::min((blk+1)*io_blksize, std::size_t(n_nodes));
 
       // Build up the xfer buffers on each processor
-      MeshBase::const_node_iterator
-        it  = mesh.local_nodes_begin(),
-        end = mesh.local_nodes_end();
-
       xfer_ids.clear();
       xfer_coords.clear();
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
       xfer_unique_ids.clear();
 #endif // LIBMESH_ENABLE_UNIQUE_ID
 
-      for (; it!=end; ++it)
-        if (((*it)->id() >= first_node) && // node in [first_node, last_node)
-            ((*it)->id() <  last_node))
+      for (const auto & node : mesh.local_node_ptr_range())
+        if ((node->id() >= first_node) && // node in [first_node, last_node)
+            (node->id() <  last_node))
           {
-            xfer_ids.push_back((*it)->id());
+            xfer_ids.push_back(node->id());
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-            xfer_unique_ids.push_back((*it)->unique_id());
+            xfer_unique_ids.push_back(node->unique_id());
 #endif // LIBMESH_ENABLE_UNIQUE_ID
-            const Point & p = **it;
-            xfer_coords.push_back(p(0));
+            xfer_coords.push_back((*node)(0));
 #if LIBMESH_DIM > 1
-            xfer_coords.push_back(p(1));
+            xfer_coords.push_back((*node)(1));
 #endif
 #if LIBMESH_DIM > 2
-            xfer_coords.push_back(p(2));
+            xfer_coords.push_back((*node)(2));
 #endif
           }
 

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -926,19 +926,15 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type n_nodes) const
       last_node = std::min((blk+1)*io_blksize, std::size_t(n_nodes));
 
       // Build up the xfer buffers on each processor
-      MeshBase::const_node_iterator
-        it  = mesh.local_nodes_begin(),
-        end = mesh.local_nodes_end();
-
       xfer_ids.clear();
       xfer_unique_ids.clear();
 
-      for (; it!=end; ++it)
-        if (((*it)->id() >= first_node) && // node in [first_node, last_node)
-            ((*it)->id() <  last_node))
+      for (const auto & node : mesh.local_node_ptr_range())
+        if ((node->id() >= first_node) && // node in [first_node, last_node)
+            (node->id() <  last_node))
           {
-            xfer_ids.push_back((*it)->id());
-            xfer_unique_ids.push_back((*it)->unique_id());
+            xfer_ids.push_back(node->id());
+            xfer_unique_ids.push_back(node->unique_id());
           }
 
       //-------------------------------------

--- a/src/solution_transfer/meshfree_solution_transfer.C
+++ b/src/solution_transfer/meshfree_solution_transfer.C
@@ -111,17 +111,11 @@ MeshfreeSolutionTransfer::transfer(const Variable & from_var,
 
   // We now will loop over every node in the source mesh
   // and add it to a source point list, along with the solution
-  {
-    MeshBase::const_node_iterator nd  = from_mesh.local_nodes_begin();
-    MeshBase::const_node_iterator end = from_mesh.local_nodes_end();
-
-    for (; nd!=end; ++nd)
-      {
-        const Node * node = *nd;
-        src_pts.push_back(*node);
-        src_vals.push_back((*from_sys->solution)(node->dof_number(from_sys->number(),from_var.number(),0)));
-      }
-  }
+  for (const auto & node : from_mesh.local_node_ptr_range())
+    {
+      src_pts.push_back(*node);
+      src_vals.push_back((*from_sys->solution)(node->dof_number(from_sys->number(),from_var.number(),0)));
+    }
 
   // We have only set local values - prepare for use by gathering remote data
   idi.prepare_for_use();

--- a/src/solution_transfer/meshfunction_solution_transfer.C
+++ b/src/solution_transfer/meshfunction_solution_transfer.C
@@ -64,13 +64,9 @@ MeshFunctionSolutionTransfer::transfer(const Variable & from_var,
   MeshFunction from_func(from_es, *serialized_solution, from_sys->get_dof_map(), to_var_num);
   from_func.init();
 
-  MeshBase::const_node_iterator nd     = to_sys->get_mesh().local_nodes_begin();
-  MeshBase::const_node_iterator nd_end = to_sys->get_mesh().local_nodes_end();
-
   // Now loop over the nodes of the 'To' mesh setting values for each variable.
-  for (;nd != nd_end; ++nd)
-    // 0 is for the value component
-    to_sys->solution->set((*nd)->dof_number(to_sys_num, to_var_num, 0), from_func(**nd));
+  for (const auto & node : to_sys->get_mesh().local_node_ptr_range())
+    to_sys->solution->set(node->dof_number(to_sys_num, to_var_num, 0), from_func(*node)); // 0 is for the value component
 
   to_sys->solution->close();
   to_sys->update();

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1334,21 +1334,16 @@ void System::zero_variable (NumericVector<Number> & v,
   /* Check which system we are.  */
   const unsigned int sys_num = this->number();
 
-  /* Loop over nodes.  */
-  {
-    MeshBase::const_node_iterator it = mesh.local_nodes_begin();
-    const MeshBase::const_node_iterator end_it = mesh.local_nodes_end();
-    for ( ; it != end_it; ++it)
-      {
-        const Node * node = *it;
-        unsigned int n_comp = node->n_comp(sys_num,var_num);
-        for (unsigned int i=0; i<n_comp; i++)
-          {
-            const dof_id_type index = node->dof_number(sys_num,var_num,i);
-            v.set(index,0.0);
-          }
-      }
-  }
+  // Loop over nodes.
+  for (const auto & node : mesh.local_node_ptr_range())
+    {
+      unsigned int n_comp = node->n_comp(sys_num,var_num);
+      for (unsigned int i=0; i<n_comp; i++)
+        {
+          const dof_id_type index = node->dof_number(sys_num,var_num,i);
+          v.set(index,0.0);
+        }
+    }
 
   // Loop over elements.
   for (const auto & elem : mesh.active_local_element_ptr_range())


### PR DESCRIPTION
Turned out to be a fair number of places where we could replace `mesh.local_nodes_begin/end()` calls with range objects.
