### PR TITLE
Added infinite element support for System::point_value().

### DIFF
--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -678,9 +678,10 @@ void FEInterface::shape<Real>(const unsigned int dim,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (is_InfFE_elem(t))
-    phi = ifem_shape(dim, fe_t, t, i, p);
-
-  // here we should need an 'or'-statement, right? Else, we will run in trouble!?
+    {
+      phi = ifem_shape(dim, fe_t, t, i, p);
+      return;
+    }
 
 #endif
 
@@ -718,8 +719,10 @@ void FEInterface::shape<Real>(const unsigned int dim,
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
   if (elem && is_InfFE_elem(elem->type()))
-    phi = ifem_shape(dim, fe_t, elem, i, p);
-  // here we should need an 'or'-statement, right? Else, we will run in trouble!?
+    {
+      phi = ifem_shape(dim, fe_t, elem, i, p);
+      return;
+    }
 #endif
 
   const Order o = fe_t.order;

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -680,6 +680,8 @@ void FEInterface::shape<Real>(const unsigned int dim,
   if (is_InfFE_elem(t))
     phi = ifem_shape(dim, fe_t, t, i, p);
 
+  // here we should need an 'or'-statement, right? Else, we will run in trouble!?
+
 #endif
 
   const Order o = fe_t.order;
@@ -717,7 +719,7 @@ void FEInterface::shape<Real>(const unsigned int dim,
 
   if (elem && is_InfFE_elem(elem->type()))
     phi = ifem_shape(dim, fe_t, elem, i, p);
-
+  // here we should need an 'or'-statement, right? Else, we will run in trouble!?
 #endif
 
   const Order o = fe_t.order;
@@ -751,6 +753,7 @@ void FEInterface::shape<RealGradient>(const unsigned int dim,
                                       const Point & p,
                                       RealGradient & phi)
 {
+   // This even does not handle infinite elements at all!?
   const Order o = fe_t.order;
 
   switch(dim)

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -178,6 +178,8 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType & fet,
   compute_shape_indices(fet, inf_elem_type, i, i_base, i_radial);
 
   //TODO:[SP/DD]  exp(ikr) is still missing here!
+  // but is it intended?  It would be probably somehow nice, but than it would be Number, not Real !
+  // --> thus it would destroy the interface...
   if (Dim > 1)
     return FEInterface::shape(Dim-1, fet, base_et, i_base, p)
       * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1464,15 +1464,6 @@ Real System::calculate_norm(const NumericVector<Number> & v,
       return v_norm;
     }
 
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-
-  // One way for implementing this would be to exchange the fe with the FEInterface- class.
-  // However, it needs to be discussed whether integral-norms make sense for infinite elements.
-  // or in which sense they could make sense.
-  libmesh_not_implemented();
-
-#endif
-
   // Localize the potentially parallel vector
   UniquePtr<NumericVector<Number>> local_v = NumericVector<Number>::build(this->comm());
   local_v->init(v.size(), true, SERIAL);
@@ -1556,6 +1547,16 @@ Real System::calculate_norm(const NumericVector<Number> & v,
         {
           const Elem * elem = *el;
           const unsigned int dim = elem->dim();
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+          // One way for implementing this would be to exchange the fe with the FEInterface- class.
+          // However, it needs to be discussed whether integral-norms make sense for infinite elements.
+          // or in which sense they could make sense.
+          if (elem->infinite() )
+            libmesh_not_implemented();
+
+#endif
 
           if (skip_dimensions && skip_dimensions->find(dim) != skip_dimensions->end())
             continue;

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2111,9 +2111,9 @@ Number System::point_value(unsigned int var, const Point & p, const Elem & e) co
   // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h.
   Point coor = FEInterface::inverse_map(e.dim(), fe_type, &e, p);
 
-  // create this object to handle the correct
+  // get the shape function value via the FEInterface to also handle the case
+  // of infinite elements correcly, the shape function is not fe->phi().
   FEComputeData fe_data(this->get_equation_systems(), coor);
-
   FEInterface::compute_data(e.dim(), fe_type, &e, fe_data);
 
   // Get ready to accumulate a value


### PR DESCRIPTION
In this pr I addressed the improvements @roystgnr suggested in #1479.
It is a separate pr because I think, this could lead to some discussions:
The changes in `System::point_value()` should work and I think, they correspond to what you expected, but I came across some further issues:

- in the FEInterface I am not sure whether there is a bug or if I don't understand how the code works?
- The `System::point_hessian()` is not implemented for infinite elements and currently there is no reason to implement second derivatives for infinite elements.
- The `System::point_gradient()` could in principle be generalised, but would require to add gradients to the `FEInterface` / `FEComputeData` as well.

Probably I will fix the latter at some point because I might want gradients at some point, but currently it is probably not necessary...