### PR TITLE
Fix warning.

### DIFF
--- a/include/utils/perf_log.h
+++ b/include/utils/perf_log.h
@@ -288,6 +288,12 @@ public:
   PerfData get_perf_data(const std::string & label, const std::string & header="");
 
   /**
+   * Typdef for the underlying logging data structure.
+   */
+  typedef std::map<std::pair<const char *,
+                             const char *>,
+                   PerfData> log_type;
+  /**
    * \returns the raw underlying data structure for the entire performance log.
    *
    * \deprecated because encapsulation is good.
@@ -296,7 +302,7 @@ public:
    * though users who are liberal with "auto" might be safe.
    */
 #ifdef LIBMESH_ENABLE_DEPRECATED
-  const std::map < std::pair<const char *, const char *>, PerfData > & get_log_raw() const
+  const log_type & get_log_raw() const
   {
     libmesh_deprecated();
     return log;
@@ -333,9 +339,7 @@ private:
    * faster, but in my tests for our log sizes there was no
    * improvement.
    */
-  std::map<std::pair<const char *,
-                     const char *>,
-           PerfData> log;
+  log_type log;
 
   /**
    * A stack to hold the current performance log trace.

--- a/src/utils/perf_log.C
+++ b/src/utils/perf_log.C
@@ -703,11 +703,9 @@ PerfData PerfLog::get_perf_data(const std::string & label, const std::string & h
       return log[std::make_pair(header_c_str, label_c_str)];
     }
 
-  typedef decltype(*log.begin()) map_pair;
-
   auto iter = std::find_if
     (log.begin(), log.end(),
-     [&label, &header] (const map_pair & a)
+     [&label, &header] (log_type::const_reference a)
      { return !std::strcmp(header.c_str(), a.first.first) &&
               !std::strcmp(label.c_str(), a.first.second); });
 


### PR DESCRIPTION
Prior to this fix, clang 3.9.0 said:

../src/utils/perf_log.C:710:25: warning: 'const' qualifier on reference type
'map_pair' (aka 'pair<const std::__1::pair<const char *, const char *>, libMesh::PerfData> &')
has no effect [-Wignored-qualifiers]
     [&label, &header] (const map_pair & a)

Note: it is possible to use decltype with *log.cbegin() instead, but
this approach is less confusing IMO to people reading the code.