### PR TITLE
Fix GCC 4.8.4 compiler error.

### DIFF
--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -302,7 +302,7 @@ void MeshTools::find_boundary_nodes (const MeshBase & mesh,
     for (auto s : elem->side_index_range())
       if (elem->neighbor_ptr(s) == libmesh_nullptr) // on the boundary
         {
-          const UniquePtr<const Elem> side = elem->build_side_ptr(s);
+          UniquePtr<const Elem> side = elem->build_side_ptr(s);
 
           for (auto & node : side->node_ref_range())
             on_boundary[node.id()] = true;


### PR DESCRIPTION
I suspect the old compiler is actually wrong here, but I also don't
think the extra const qualifier is necessary/useful, so I'm removing
it.

Refs idaholab/moose#10205.
Refs #1490.
