### PR TITLE
Fix check in PetscVector<Complex>::localize_to_one

### DIFF
--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1072,7 +1072,7 @@ void PetscVector<Complex>::localize_to_one (std::vector<Complex> & v_local,
     v_local[i] = 0.;
 
   // only one processor
-  if (n == nl)
+  if (n_processors() == 1)
     {
       ierr = VecGetArray (_vec, &values);
       LIBMESH_CHKERR(ierr);


### PR DESCRIPTION
If we're in parallel, but all our DoFs are on one processor for some
reason, the PetscVector code on that processor currently thinks it's
in serial and loses sync with its peers.

This fixes --enable-complex "make check" in parallel for me.  In 1D
the adaptivity_ex3 code was actually starting with a single-element
mesh.  See #1495 for details.