### PR TITLE
Break EquationSystems::reinit() into solutions,systems parts

### DIFF
--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -109,7 +109,8 @@ public:
   virtual void init ();
 
   /**
-   * Reinitialize all the systems
+   * Handle any mesh changes and reinitialize all the systems on the
+   * updated mesh
    */
   virtual void reinit ();
 
@@ -460,6 +461,18 @@ public:
    **/
   bool refine_in_reinit_flag() { return this->_refine_in_reinit; }
 
+  /**
+   * Handle any mesh changes and project any solutions onto the
+   * updated mesh.
+   *
+   * \returns Whether or not the mesh may have changed.
+   */
+  bool reinit_solutions ();
+
+  /**
+   * Reinitialize all systems on the current mesh.
+   */
+  virtual void reinit_systems ();
 
   /**
    * Data structure holding arbitrary parameters.

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -118,6 +118,18 @@ void EquationSystems::init ()
 
 void EquationSystems::reinit ()
 {
+  const bool mesh_changed = this->reinit_solutions();
+
+  // If the mesh has changed, systems will need to reinitialize their
+  // own data on the new mesh.
+  if (mesh_changed)
+    this->reinit_systems();
+}
+
+
+
+bool EquationSystems::reinit_solutions ()
+{
   parallel_object_only();
 
   const unsigned int n_sys = this->n_systems();
@@ -249,15 +261,17 @@ void EquationSystems::reinit ()
           // dof_constraints_created = true;
         }
     }
-
-  // If the mesh has changed, systems will need to create new dof
-  // constraints and update their global solution vectors
-  if (mesh_changed)
-    {
-      for (unsigned int i=0; i != this->n_systems(); ++i)
-        this->get_system(i).reinit();
-    }
 #endif // #ifdef LIBMESH_ENABLE_AMR
+
+  return mesh_changed;
+}
+
+
+
+void EquationSystems::reinit_systems()
+{
+  for (unsigned int i=0; i != this->n_systems(); ++i)
+    this->get_system(i).reinit();
 }
 
 


### PR DESCRIPTION
This may let savvy users call only the former if they don't (yet) need
the latter.

As discussed in https://groups.google.com/d/msg/moose-users/ewSE3PsOkoE/FRIAu3P7CwAJ

The goal here was to avoid unnecessary Jacobian reallocation when doing multiple adaptivity steps per time step.  The benefit seems to be mediocre (2% speed up on the test application @jessecarterMOOSE gave me) and the MOOSE half of the update isn't ready to go yet (and won't be compatible with libMesh pre-this-PR), but even if the optimization never goes into MOOSE this is a sensible refactoring for libMesh, so I'd like to put it in regardless.