### PR TITLE
Add support for detecting Intel 18

### DIFF
--- a/configure
+++ b/configure
@@ -5767,6 +5767,11 @@ $as_echo "<<< C++ compiler is Intel Itanium ICC 7.0 >>>" >&6; }
           if test "x$is_intel_icc" != "x" ; then
             GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
             case "$GXX_VERSION_STRING" in
+              *18.*)
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 18 >>>" >&5
+$as_echo "<<< C++ compiler is Intel(R) icc 18 >>>" >&6; }
+                GXX_VERSION=intel_icc_v18.x
+                ;;
               *17.*)
                 { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 17 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 17 >>>" >&6; }
@@ -7686,7 +7691,7 @@ fi
         case "$GXX_VERSION" in
 
           # Intel ICC >= v11.x
-          intel_icc_v11.x | intel_icc_v12.x | intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x)
+          intel_icc_v11.x | intel_icc_v12.x | intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x)
               # Disable some warning messages:
               # #161: 'unrecognized #pragma
               #       #pragma GCC diagnostic warning "-Wdeprecated-declarations"'

--- a/examples/adjoints/adjoints_ex6/adjoints_ex6.C
+++ b/examples/adjoints/adjoints_ex6/adjoints_ex6.C
@@ -215,7 +215,9 @@ int main (int argc, char ** argv)
 #else
 
   // This doesn't converge with Eigen BICGSTAB for some reason...
-  libmesh_example_requires(libMesh::default_solver_package() != EIGEN_SOLVERS, "--enable-petsc");
+  libmesh_example_requires((libMesh::default_solver_package() != EIGEN_SOLVERS) &&
+                           (libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE),
+                           "--enable-petsc or --enable-trilinos");
 
   libMesh::out << "Started " << argv[0] << std::endl;
 

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -362,6 +362,10 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
           if test "x$is_intel_icc" != "x" ; then
             GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
             case "$GXX_VERSION_STRING" in
+              *18.*)
+                AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 18 >>>)
+                GXX_VERSION=intel_icc_v18.x
+                ;;
               *17.*)
                 AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 17 >>>)
                 GXX_VERSION=intel_icc_v17.x
@@ -834,7 +838,7 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
         case "$GXX_VERSION" in
 
           # Intel ICC >= v11.x
-          intel_icc_v11.x | intel_icc_v12.x | intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x)
+          intel_icc_v11.x | intel_icc_v12.x | intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x)
               # Disable some warning messages:
               # #161: 'unrecognized #pragma
               #       #pragma GCC diagnostic warning "-Wdeprecated-declarations"'


### PR DESCRIPTION
This bug recently hit an Intel 18 user whose compiler was actually
detected to be Intel 8 (a compiler from circa 2004!) due to the
overzealous pattern matching used in compiler.m4.

A larger question is whether we should being removing support for
older compilers, especially those that don't support C++11, since we
now require that in the library.