### PR TITLE
System reinit tweaks

### DIFF
--- a/include/systems/explicit_system.h
+++ b/include/systems/explicit_system.h
@@ -71,12 +71,6 @@ public:
   virtual void clear () libmesh_override;
 
   /**
-   * Reinitializes the member data fields associated with
-   * the system, so that, e.g., \p assemble() may be used.
-   */
-  virtual void reinit () libmesh_override;
-
-  /**
    * Prepares \p qoi for quantity of interest assembly, then calls
    * user qoi function.
    * Can be overridden in derived classes.

--- a/include/systems/transient_system.h
+++ b/include/systems/transient_system.h
@@ -82,12 +82,6 @@ public:
   virtual void clear () libmesh_override;
 
   /**
-   * Reinitializes the member data fields associated with
-   * the system, so that, e.g., \p assemble() may be used.
-   */
-  virtual void reinit () libmesh_override;
-
-  /**
    * \returns \p "Transient" prepended to T::system_type().
    * Helps in identifying the system type in an equation
    * system file.

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2424,9 +2424,10 @@ void DofMap::old_dof_indices (const Elem * const elem,
   for (unsigned int v=0; v<n_vars; v++)
     if ((v == vn) || (vn == libMesh::invalid_uint))
       {
-        if (this->variable(v).type().family == SCALAR &&
+        const Variable & var = this->variable(v);
+        if (var.type().family == SCALAR &&
             (!elem ||
-             this->variable(v).active_on_subdomain(elem->subdomain_id())))
+             var.active_on_subdomain(elem->subdomain_id())))
           {
             // We asked for this variable, so add it to the vector.
             std::vector<dof_id_type> di_new;
@@ -2434,7 +2435,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
             di.insert( di.end(), di_new.begin(), di_new.end());
           }
         else
-          if (this->variable(v).active_on_subdomain(elem->subdomain_id()))
+          if (var.active_on_subdomain(elem->subdomain_id()))
             { // Do this for all the variables if one was not specified
               // or just for the specified variable
 
@@ -2451,7 +2452,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                 {
                   p_adjustment = 1;
                 }
-              FEType fe_type = this->variable_type(v);
+              FEType fe_type = var.type();
               fe_type.order = static_cast<Order>(fe_type.order +
                                                  elem->p_level() +
                                                  p_adjustment);
@@ -2486,8 +2487,8 @@ void DofMap::old_dof_indices (const Elem * const elem,
                   // simplify p refinement)
                   if (extra_hanging_dofs && !elem->is_vertex(n))
                     {
-                      const int dof_offset =
-                        node->old_dof_object->n_comp(sys_num,v) - nc;
+                      const int n_comp = node->old_dof_object->n_comp(sys_num,v);
+                      const int dof_offset = n_comp - nc;
 
                       // We should never have fewer dofs than necessary on a
                       // node unless we're getting indices on a parent element
@@ -2499,8 +2500,7 @@ void DofMap::old_dof_indices (const Elem * const elem,
                           di.resize(di.size() + nc, DofObject::invalid_id);
                         }
                       else
-                        for (int i=node->old_dof_object->n_comp(sys_num,v)-1;
-                             i>=dof_offset; i--)
+                        for (int i=n_comp-1; i>=dof_offset; i--)
                           {
                             libmesh_assert_not_equal_to (node->old_dof_object->dof_number(sys_num,v,i),
                                                          DofObject::invalid_id);

--- a/src/systems/explicit_system.C
+++ b/src/systems/explicit_system.C
@@ -53,18 +53,6 @@ void ExplicitSystem::clear ()
 
 
 
-void ExplicitSystem::reinit ()
-{
-  // initialize parent data
-  Parent::reinit();
-
-  // not necessary, handled by the parent!
-  // Resize the RHS conformal to the current mesh
-  //rhs->init (this->n_dofs(), this->n_local_dofs());
-}
-
-
-
 void ExplicitSystem::assemble_qoi (const QoISet & qoi_indices)
 {
   // The user quantity of interest assembly gets to expect to

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -355,6 +355,9 @@ void System::restrict_vectors ()
   // Restrict the solution on the coarsened cells
   if (_solution_projection)
     this->project_vector (*solution);
+  // Or at least make sure the solution vector is the correct size
+  else
+    solution->init (this->n_dofs(), this->n_local_dofs(), true, PARALLEL);
 
 #ifdef LIBMESH_ENABLE_GHOSTED
   current_local_solution->init(this->n_dofs(),
@@ -384,30 +387,8 @@ void System::prolong_vectors ()
 
 void System::reinit ()
 {
-  //If no variables have been added to this system
-  //don't do anything
-  if (!this->n_vars())
-    return;
-
-  // Constraints get handled in EquationSystems::reinit now
-  //  _dof_map->create_dof_constraints(this->get_mesh());
-
-  // Update the solution based on the projected
-  // current_local_solution.
-  solution->init (this->n_dofs(), this->n_local_dofs(), true, PARALLEL);
-
+  // project_vector handles vector initialization now
   libmesh_assert_equal_to (solution->size(), current_local_solution->size());
-  // Not true with ghosted vectors
-  // libmesh_assert_equal_to (solution->size(), current_local_solution->local_size());
-
-  const dof_id_type first_local_dof = solution->first_local_index();
-  const dof_id_type local_size      = solution->local_size();
-
-  for (dof_id_type i=0; i<local_size; i++)
-    solution->set(i+first_local_dof,
-                  (*current_local_solution)(i+first_local_dof));
-
-  solution->close();
 }
 
 

--- a/src/systems/transient_system.C
+++ b/src/systems/transient_system.C
@@ -84,20 +84,6 @@ void TransientSystem<Base>::clear ()
 
 
 template <class Base>
-void TransientSystem<Base>::reinit ()
-{
-  // initialize parent data
-  Base::reinit();
-
-  // Project the old & older vectors to the new mesh
-  // The System::reinit handles this now
-  // this->project_vector (*old_local_solution);
-  // this->project_vector (*older_local_solution);
-}
-
-
-
-template <class Base>
 void TransientSystem<Base>::re_update ()
 {
   // re_update the parent system


### PR DESCRIPTION
Our solution update in System::reinit() has long been redundant; this PR removes it.  If we projected our solution then the solution is already up to date; if not then we only need a new init() (which can be done in the projection codepath for simplicity), and we don't need to actually set any values.

We have a few other reinit() overload which have been vestigial ever since we moved our System subclass's vectors into System control via the add_vector() interface revamp many years ago; this PR removes them.