### PR TITLE
Don't try to test acos() outside its domain

### DIFF
--- a/contrib/metaphysicl/0.2.0/test/derivs_unit.C
+++ b/contrib/metaphysicl/0.2.0/test/derivs_unit.C
@@ -81,10 +81,10 @@ int vectester (void)
 
   std::srand(12345); // Fixed seed for reproduceability of failures
 
-  // Avoid divide by zero errors later
+  // Avoid divide by zero errors or acos(x>1) NaNs later
   for (unsigned int i=0; i != N; ++i)
     {
-      random_vec[i] = .25 + (static_cast<Scalar>(std::rand())/RAND_MAX);
+      random_vec[i] = .25 + (static_cast<Scalar>(std::rand())/RAND_MAX/2);
       random_vec[i].derivatives() = 1;
     }
 

--- a/contrib/metaphysicl/0.2.0/test/identities_unit.C
+++ b/contrib/metaphysicl/0.2.0/test/identities_unit.C
@@ -78,9 +78,9 @@ int vectester (void)
 
   std::srand(12345); // Fixed seed for reproduceability of failures
 
-  // Avoid divide by zero errors later
+  // Avoid divide by zero errors or acos(x>1) NaNs later
   for (unsigned int i=0; i != random_vec.size(); ++i)
-    random_vec[i] = .25 + (static_cast<Scalar>(std::rand())/RAND_MAX);
+    random_vec[i] = .25 + (static_cast<Scalar>(std::rand())/RAND_MAX/2);
 
   Scalar pi = acos(Scalar(-1));
 

--- a/contrib/metaphysicl/0.2.0/test/sparse_derivs_unit.C
+++ b/contrib/metaphysicl/0.2.0/test/sparse_derivs_unit.C
@@ -85,10 +85,10 @@ int vectester (Vector zerovec)
 
   std::srand(12345); // Fixed seed for reproduceability of failures
 
-  // Avoid divide by zero errors later
+  // Avoid divide by zero errors or acos(x>1) NaNs later
   for (unsigned int i=0; i != N; ++i)
     {
-      random_vec.raw_at(i) = .25 + (static_cast<Scalar>(std::rand())/RAND_MAX);
+      random_vec.raw_at(i) = .25 + (static_cast<Scalar>(std::rand())/RAND_MAX/2);
       random_vec.raw_at(i).derivatives() = 1;
     }
 

--- a/contrib/metaphysicl/0.2.0/test/sparse_identities_unit.C
+++ b/contrib/metaphysicl/0.2.0/test/sparse_identities_unit.C
@@ -75,8 +75,9 @@ int vectester (Vector zerovec)
 
   std::srand(12345); // Fixed seed for reproduceability of failures
 
+  // Avoid divide by zero errors or acos(x>1) NaNs later
   for (unsigned int i=0; i != random_vec.size(); ++i)
-    random_vec[i] = .25 + (static_cast<Scalar>(std::rand())/RAND_MAX);
+    random_vec[i] = .25 + (static_cast<Scalar>(std::rand())/RAND_MAX/2);
 
   int returnval = 0;
 


### PR DESCRIPTION
Thanks to @dschwen for catching this in #1509.

I'm actually kind of disturbed that these worked on Linux.

I double checked and, for the seed 12345, the PRNG apparently only gives me values between 0 and 0.4 times RAND_MAX for its first 10 outputs (and possibly more, but 10 is all I asked for in those unit tests).  I'm not sure what the proper Bonferroni correction factor is here, but I hope it's big, because without correction I'm forced to assume that the Linux rand() implementation sucks with p~=1e-4.  I know rand() sucks in *general* but I thought the Linux implementation was supposed to be half decent.