### PR TITLE
Don't turn on verbose ExodusII_IO output by default in debug mode.

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -147,10 +147,6 @@ void ExodusII_IO::read (const std::string & fname)
   elems_of_dimension.clear();
   elems_of_dimension.resize(4, false);
 
-#ifdef DEBUG
-  this->verbose(true);
-#endif
-
   // Instantiate the ElementMaps interface
   ExodusII_IO_Helper::ElementMaps em;
 


### PR DESCRIPTION
This prevents some unnecessary output during debug unit tests, and is less surprising when comparing the output of optimized and debug runs.

This has been like this forever so we may not want to just change it, but I thought we could at least start a discussion...