### PR TITLE
More std::unique_ptr updates (second try)

### DIFF
--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -375,7 +375,6 @@ int main (int argc, char ** argv)
               // solution and assigns to each element a positive error value.
               // This value is used for deciding which elements to refine
               // and which to coarsen.
-              //ErrorEstimator* error_estimator = new KellyErrorEstimator;
               KellyErrorEstimator error_estimator;
 
               // Compute the error for each active element using the provided

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -217,8 +217,7 @@ int main (int argc, char ** argv)
   const bool have_expression = false;
 #endif
   if (have_expression)
-    parsed_solution.reset
-      (new ParsedFunction<Number>(command_line.next(std::string())));
+    parsed_solution = libmesh_make_unique<ParsedFunction<Number>>(command_line.next(std::string()));
 
   // Skip this 2D example if libMesh was compiled as 1D-only.
   libmesh_example_requires(2 <= LIBMESH_DIM, "2D support");
@@ -447,7 +446,6 @@ int main (int argc, char ** argv)
               // solution and assigns to each element a positive error value.
               // This value is used for deciding which elements to refine
               // and which to coarsen.
-              //ErrorEstimator* error_estimator = new KellyErrorEstimator;
               KellyErrorEstimator error_estimator;
 
               // Compute the error for each active element using the provided

--- a/examples/adjoints/adjoints_ex1/adjoints_ex1.C
+++ b/examples/adjoints/adjoints_ex1/adjoints_ex1.C
@@ -180,8 +180,7 @@ void set_system_parameters(LaplaceSystem & system,
   system.print_jacobians      = param.print_jacobians;
 
   // No transient time solver
-  system.time_solver =
-    std::unique_ptr<TimeSolver>(new SteadySolver(system));
+  system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   // Nonlinear solver options
   {
@@ -243,7 +242,7 @@ std::unique_ptr<ErrorEstimator> build_error_estimator(FEMParameters & param,
     {
       libMesh::out << "Using Kelly Error Estimator" << std::endl;
 
-      return std::unique_ptr<ErrorEstimator>(new KellyErrorEstimator);
+      return libmesh_make_unique<KellyErrorEstimator>();
     }
   else if (param.indicator_type == "adjoint_residual")
     {

--- a/examples/adjoints/adjoints_ex1/femparameters.C
+++ b/examples/adjoints/adjoints_ex1/femparameters.C
@@ -137,9 +137,9 @@ std::unique_ptr<FunctionBase<Number>> new_function_base(const std::string & func
                                                         const std::string & func_value)
 {
   if (func_type == "parsed")
-    return std::unique_ptr<FunctionBase<Number>>(new ParsedFunction<Number>(func_value));
+    return libmesh_make_unique<ParsedFunction<Number>>(func_value);
   else if (func_type == "zero")
-    return std::unique_ptr<FunctionBase<Number>>(new ZeroFunction<Number>);
+    return libmesh_make_unique<ZeroFunction<Number>>();
   else
     libmesh_not_implemented();
 

--- a/examples/adjoints/adjoints_ex2/L-qoi.h
+++ b/examples/adjoints/adjoints_ex2/L-qoi.h
@@ -32,7 +32,7 @@ public:
 
   virtual std::unique_ptr<DifferentiableQoI> clone()
   {
-    return std::unique_ptr<DifferentiableQoI> (new LaplaceQoI(*this));
+    return libmesh_make_unique<LaplaceQoI>(*this);
   }
 
 };

--- a/examples/adjoints/adjoints_ex2/L-shaped.h
+++ b/examples/adjoints/adjoints_ex2/L-shaped.h
@@ -34,10 +34,9 @@ public:
 
   ParameterVector & get_parameter_vector()
   {
-    typedef ParameterPointer<Number> PP;
     parameter_vector.clear();
     for (std::size_t i = 0; i != parameters.size(); ++i)
-      parameter_vector.push_back(std::unique_ptr<ParameterAccessor<Number>>(new PP(&parameters[i])));
+      parameter_vector.push_back(libmesh_make_unique<ParameterPointer<Number>>(&parameters[i]));
 
     return parameter_vector;
   }

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -185,8 +185,7 @@ void set_system_parameters(LaplaceSystem & system, FEMParameters & param)
   system.print_jacobians      = param.print_jacobians;
 
   // No transient time solver
-  system.time_solver =
-    std::unique_ptr<TimeSolver>(new SteadySolver(system));
+  system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   // Nonlinear solver options
   {
@@ -246,7 +245,7 @@ std::unique_ptr<ErrorEstimator> build_error_estimator(FEMParameters & param)
     {
       libMesh::out << "Using Kelly Error Estimator" << std::endl;
 
-      return std::unique_ptr<ErrorEstimator>(new KellyErrorEstimator);
+      return libmesh_make_unique<KellyErrorEstimator>();
     }
   else if (param.indicator_type == "adjoint_residual")
     {

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -609,7 +609,7 @@ std::unique_ptr<MeshRefinement> build_mesh_refinement(MeshBase & mesh,
 // for comparisons of adjoint and non-adjoint based error indicators
 std::unique_ptr<ErrorEstimator> build_error_estimator(FEMParameters & /* param */)
 {
-  return std::unique_ptr<ErrorEstimator>(new KellyErrorEstimator);
+  return libmesh_make_unique<KellyErrorEstimator>();
 }
 
 // Functions to build the adjoint based error indicators

--- a/examples/adjoints/adjoints_ex3/coupled_system.C
+++ b/examples/adjoints/adjoints_ex3/coupled_system.C
@@ -62,7 +62,7 @@ public:
   }
 
   virtual std::unique_ptr<FunctionBase<Number>> clone() const
-  { return std::unique_ptr<FunctionBase<Number>> (new BdyFunction(_u_var, _v_var, _sign)); }
+  { return libmesh_make_unique<BdyFunction>(_u_var, _v_var, _sign); }
 
 private:
   const unsigned int _u_var, _v_var;

--- a/examples/adjoints/adjoints_ex3/coupled_system.h
+++ b/examples/adjoints/adjoints_ex3/coupled_system.h
@@ -55,7 +55,7 @@ public:
   {
     if (!parameter_vector.size())
       for (std::size_t i = 0; i != parameters.size(); ++i)
-        parameter_vector.push_back(std::unique_ptr<ParameterAccessor<Number>>(new ParameterPointer<Number>(&parameters[i])));
+        parameter_vector.push_back(libmesh_make_unique<ParameterPointer<Number>>(&parameters[i]));
 
     return parameter_vector;
   }
@@ -116,7 +116,7 @@ public:
 
   virtual std::unique_ptr<FEMFunctionBase<Number>> clone () const
   {
-    return std::unique_ptr<FEMFunctionBase<Number>>(new CoupledFEMFunctionsx(*this));
+    return libmesh_make_unique<CoupledFEMFunctionsx>(*this);
   }
 
   virtual void operator() (const FEMContext &,
@@ -147,7 +147,7 @@ public:
 
   virtual std::unique_ptr<FEMFunctionBase<Number>> clone () const
   {
-    return std::unique_ptr<FEMFunctionBase<Number>>(new CoupledFEMFunctionsy(*this));
+    return libmesh_make_unique<CoupledFEMFunctionsy>(*this);
   }
 
   virtual void operator() (const FEMContext &,

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -175,8 +175,7 @@ void set_system_parameters(LaplaceSystem & system,
   system.print_jacobians      = param.print_jacobians;
 
   // No transient time solver
-  system.time_solver =
-    std::unique_ptr<TimeSolver>(new SteadySolver(system));
+  system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   // Nonlinear solver options
   {

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -211,8 +211,7 @@ void set_system_parameters(HeatSystem & system,
         std::unique_ptr<TimeSolver>(innersolver);
     }
   else
-    system.time_solver =
-      std::unique_ptr<TimeSolver>(new SteadySolver(system));
+    system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   // The Memory Solution History object we will set the system SolutionHistory object to
   MemorySolutionHistory heatsystem_solution_history(system);
@@ -323,7 +322,7 @@ int main (int argc, char ** argv)
   Mesh mesh(init.comm(), param.dimension);
 
   // And an object to refine it
-  std::unique_ptr<MeshRefinement> mesh_refinement(new MeshRefinement(mesh));
+  auto mesh_refinement = libmesh_make_unique<MeshRefinement>(mesh);
 
   // And an EquationSystems to run on it
   EquationSystems equation_systems (mesh);

--- a/examples/adjoints/adjoints_ex5/factoryfunction.C
+++ b/examples/adjoints/adjoints_ex5/factoryfunction.C
@@ -46,7 +46,7 @@ class ExampleOneFunction : public FunctionBase<Number>
   virtual void clear() {}
   virtual std::unique_ptr<FunctionBase<Number>> clone() const
   {
-    return std::unique_ptr<FunctionBase<Number>>(new ExampleOneFunction());
+    return libmesh_make_unique<ExampleOneFunction>();
   }
 };
 

--- a/examples/adjoints/adjoints_ex5/heatsystem.h
+++ b/examples/adjoints/adjoints_ex5/heatsystem.h
@@ -68,7 +68,7 @@ public:
   {
     if (!parameter_vector.size())
       for (std::size_t i = 0; i != parameters.size(); ++i)
-        parameter_vector.push_back(std::unique_ptr<ParameterAccessor<Number>>(new ParameterPointer<Number>(&parameters[i])));
+        parameter_vector.push_back(libmesh_make_unique<ParameterPointer<Number>>(&parameters[i]));
 
     return parameter_vector;
   }

--- a/examples/adjoints/adjoints_ex6/adjoints_ex6.C
+++ b/examples/adjoints/adjoints_ex6/adjoints_ex6.C
@@ -134,8 +134,7 @@ void set_system_parameters(PoissonSystem & system, FEMParameters & param)
   system.print_jacobians      = param.print_jacobians;
 
   // No transient time solver
-  system.time_solver =
-    std::unique_ptr<TimeSolver>(new SteadySolver(system));
+  system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   // Nonlinear solver options
   {

--- a/examples/adjoints/adjoints_ex6/femparameters.C
+++ b/examples/adjoints/adjoints_ex6/femparameters.C
@@ -136,11 +136,9 @@ new_function_base(const std::string & func_type,
                   const std::string & func_value)
 {
   if (func_type == "parsed")
-    return std::unique_ptr<FunctionBase<Number>>
-      (new ParsedFunction<Number>(func_value));
+    return libmesh_make_unique<ParsedFunction<Number>>(func_value);
   else if (func_type == "zero")
-    return std::unique_ptr<FunctionBase<Number>>
-      (new ZeroFunction<Number>);
+    return libmesh_make_unique<ZeroFunction<Number>>();
   else
     libmesh_not_implemented();
 

--- a/examples/adjoints/adjoints_ex6/poisson.C
+++ b/examples/adjoints/adjoints_ex6/poisson.C
@@ -46,7 +46,7 @@ public:
   }
 
   virtual std::unique_ptr<FunctionBase<Number>> clone() const
-  { return std::unique_ptr<FunctionBase<Number>> (new BdyFunction(_T_var)); }
+  { return libmesh_make_unique<BdyFunction>(_T_var); }
 
 private:
   const unsigned int _T_var;

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -146,12 +146,10 @@ int main (int argc, char ** argv)
 
   // Solve this as a time-dependent or steady system
   if (transient)
-    system.time_solver =
-      std::unique_ptr<TimeSolver>(new EulerSolver(system));
+    system.time_solver = libmesh_make_unique<EulerSolver>(system);
   else
     {
-      system.time_solver =
-        std::unique_ptr<TimeSolver>(new SteadySolver(system));
+      system.time_solver = libmesh_make_unique<SteadySolver>(system);
       libmesh_assert_equal_to (n_timesteps, 1);
     }
 

--- a/examples/fem_system/fem_system_ex1/naviersystem.C
+++ b/examples/fem_system/fem_system_ex1/naviersystem.C
@@ -60,7 +60,7 @@ public:
   }
 
   virtual std::unique_ptr<FunctionBase<Number>> clone() const
-  { return std::unique_ptr<FunctionBase<Number>> (new BdyFunction(_u_var, _v_var, _w_var, _Re)); }
+  { return libmesh_make_unique<BdyFunction>(_u_var, _v_var, _w_var, _Re); }
 
 private:
   const unsigned int _u_var, _v_var, _w_var;

--- a/examples/fem_system/fem_system_ex2/fem_system_ex2.C
+++ b/examples/fem_system/fem_system_ex2/fem_system_ex2.C
@@ -92,7 +92,7 @@ void run_timestepping(EquationSystems & systems, GetPot & args)
 
   SolidSystem & solid_system = systems.get_system<SolidSystem>("solid");
 
-  std::unique_ptr<VTKIO> io = std::unique_ptr<VTKIO>(new VTKIO(systems.get_mesh()));
+  std::unique_ptr<VTKIO> io = libmesh_make_unique<VTKIO>(systems.get_mesh());
 
   Real duration = args("duration", 1.0);
 

--- a/examples/fem_system/fem_system_ex2/solid_system.C
+++ b/examples/fem_system/fem_system_ex2/solid_system.C
@@ -55,7 +55,7 @@ SolidSystem::SolidSystem(EquationSystems & es,
 {
 
   // Add a time solver. We are just looking at a steady state problem here.
-  this->time_solver = std::unique_ptr<TimeSolver>(new SteadySolver(*this));
+  this->time_solver = libmesh_make_unique<SteadySolver>(*this);
 }
 
 void SolidSystem::save_initial_mesh()

--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.C
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.C
@@ -162,8 +162,7 @@ int main (int argc, char ** argv)
     equation_systems.add_system<HeatSystem> ("Heat");
 
   // Solve this as a steady system
-  system.time_solver =
-    std::unique_ptr<TimeSolver>(new SteadySolver(system));
+  system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   // Initialize the system
   equation_systems.init ();

--- a/examples/miscellaneous/miscellaneous_ex8/meshless_interpolation_function.h
+++ b/examples/miscellaneous/miscellaneous_ex8/meshless_interpolation_function.h
@@ -144,7 +144,7 @@ inline
 std::unique_ptr<FunctionBase<Number>>
 MeshlessInterpolationFunction::clone () const
 {
-  return std::unique_ptr<FunctionBase<Number>> (new MeshlessInterpolationFunction (_mfi, _mutex));
+  return libmesh_make_unique<MeshlessInterpolationFunction>(_mfi, _mutex);
 }
 
 

--- a/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex4/eim_classes.h
@@ -10,6 +10,9 @@
 // Just the bits we're using, since this is a header.
 using libMesh::EquationSystems;
 using libMesh::RBEIMEvaluation;
+#ifndef LIBMESH_HAVE_CXX14_MAKE_UNIQUE
+using libMesh::make_unique;
+#endif
 
 // A simple subclass of RBEIMEvaluation. Overload
 // evaluate_parametrized_function to define the
@@ -55,7 +58,7 @@ public:
    */
   virtual std::unique_ptr<ElemAssembly> build_eim_assembly(unsigned int index)
   {
-    return std::unique_ptr<ElemAssembly>(new EIM_F(*this, index));
+    return libmesh_make_unique<EIM_F>(*this, index);
   }
 
   /**

--- a/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
+++ b/examples/reduced_basis/reduced_basis_ex6/eim_classes.h
@@ -6,6 +6,10 @@
 #include "libmesh/rb_eim_evaluation.h"
 #include "assembly.h"
 
+#ifndef LIBMESH_HAVE_CXX14_MAKE_UNIQUE
+using libMesh::make_unique;
+#endif
+
 // A simple subclass of RBEIMEvaluation. Overload
 // evaluate_parametrized_function to define the
 // function that we "empirically" interpolate.
@@ -26,7 +30,7 @@ public:
    */
   virtual std::unique_ptr<RBTheta> build_eim_theta(unsigned int index)
   {
-    return std::unique_ptr<RBTheta>(new ThetaEIM(*this, index));
+    return libmesh_make_unique<ThetaEIM>(*this, index);
   }
 
   /**
@@ -62,7 +66,7 @@ public:
    */
   virtual std::unique_ptr<ElemAssembly> build_eim_assembly(unsigned int index)
   {
-    return std::unique_ptr<ElemAssembly>(new AssemblyEIM(*this, index));
+    return libmesh_make_unique<AssemblyEIM>(*this, index);
   }
 
   /**

--- a/examples/vector_fe/vector_fe_ex2/solution_function.h
+++ b/examples/vector_fe/vector_fe_ex2/solution_function.h
@@ -58,7 +58,7 @@ public:
   }
 
   virtual std::unique_ptr<FunctionBase<Number>> clone() const
-  { return std::unique_ptr<FunctionBase<Number>> (new SolutionFunction(_u_var)); }
+  { return libmesh_make_unique<SolutionFunction>(_u_var); }
 
 private:
 
@@ -99,7 +99,7 @@ public:
   }
 
   virtual std::unique_ptr<FunctionBase<Gradient>> clone() const
-  { return std::unique_ptr<FunctionBase<Gradient>> (new SolutionGradient(_u_var)); }
+  { return libmesh_make_unique<SolutionGradient>(_u_var); }
 
 private:
 

--- a/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
+++ b/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
@@ -91,8 +91,7 @@ int main (int argc, char** argv)
     equation_systems.add_system<LaplaceSystem> ("Laplace");
 
   // This example only implements the steady-state problem
-  system.time_solver =
-    std::unique_ptr<TimeSolver>(new SteadySolver(system));
+  system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   // Initialize the system
   equation_systems.init();

--- a/examples/vector_fe/vector_fe_ex3/solution_function.h
+++ b/examples/vector_fe/vector_fe_ex3/solution_function.h
@@ -57,7 +57,7 @@ public:
   }
 
   virtual std::unique_ptr<FunctionBase<Number>> clone() const
-  { return std::unique_ptr<FunctionBase<Number>> (new SolutionFunction(_u_var)); }
+  { return libmesh_make_unique<SolutionFunction>(_u_var); }
 
 private:
 
@@ -95,7 +95,7 @@ public:
   }
 
   virtual std::unique_ptr<FunctionBase<Gradient>> clone() const
-  { return std::unique_ptr<FunctionBase<Gradient>> (new SolutionGradient(_u_var)); }
+  { return libmesh_make_unique<SolutionGradient>(_u_var); }
 
 private:
 

--- a/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
+++ b/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
@@ -97,8 +97,7 @@ int main (int argc, char ** argv)
     equation_systems.add_system<CurlCurlSystem> ("CurlCurl");
 
   // This example only implements the steady-state problem
-  system.time_solver =
-    std::unique_ptr<TimeSolver>(new SteadySolver(system));
+  system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   // Initialize the system
   equation_systems.init();

--- a/examples/vector_fe/vector_fe_ex4/solution_function.h
+++ b/examples/vector_fe/vector_fe_ex4/solution_function.h
@@ -57,7 +57,7 @@ public:
   }
 
   virtual std::unique_ptr<FunctionBase<Number>> clone() const
-  { return std::unique_ptr<FunctionBase<Number>> (new SolutionFunction(_u_var)); }
+  { return libmesh_make_unique<SolutionFunction>(_u_var); }
 
 private:
 
@@ -97,7 +97,7 @@ public:
   }
 
   virtual std::unique_ptr<FunctionBase<Gradient>> clone() const
-  { return std::unique_ptr<FunctionBase<Gradient>> (new SolutionGradient(_u_var)); }
+  { return libmesh_make_unique<SolutionGradient>(_u_var); }
 
 private:
 

--- a/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
+++ b/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
@@ -100,8 +100,7 @@ int main (int argc, char ** argv)
     equation_systems.add_system<CurlCurlSystem> ("CurlCurl");
 
   // This example only implements the steady-state problem
-  system.time_solver =
-    std::unique_ptr<TimeSolver>(new SteadySolver(system));
+  system.time_solver = libmesh_make_unique<SteadySolver>(system);
 
   // Initialize the system
   equation_systems.init();

--- a/include/error_estimation/exact_error_estimator.h
+++ b/include/error_estimation/exact_error_estimator.h
@@ -222,19 +222,19 @@ private:
    * User-provided functors which compute the exact value of the
    * solution for each system.
    */
-  std::vector<FunctionBase<Number> *> _exact_values;
+  std::vector<std::unique_ptr<FunctionBase<Number>>> _exact_values;
 
   /**
    * User-provided functors which compute the exact derivative of the
    * solution for each system.
    */
-  std::vector<FunctionBase<Gradient> *> _exact_derivs;
+  std::vector<std::unique_ptr<FunctionBase<Gradient>>> _exact_derivs;
 
   /**
    * User-provided functors which compute the exact hessians of the
    * solution for each system.
    */
-  std::vector<FunctionBase<Tensor> *> _exact_hessians;
+  std::vector<std::unique_ptr<FunctionBase<Tensor>>> _exact_hessians;
 
   /**
    * Constant pointer to the \p EquationSystems object

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -288,19 +288,19 @@ private:
    * User-provided functors which compute the exact value of the
    * solution for each system.
    */
-  std::vector<FunctionBase<Number> *> _exact_values;
+  std::vector<std::unique_ptr<FunctionBase<Number>>> _exact_values;
 
   /**
    * User-provided functors which compute the exact derivative of the
    * solution for each system.
    */
-  std::vector<FunctionBase<Gradient> *> _exact_derivs;
+  std::vector<std::unique_ptr<FunctionBase<Gradient>>> _exact_derivs;
 
   /**
    * User-provided functors which compute the exact hessians of the
    * solution for each system.
    */
-  std::vector<FunctionBase<Tensor> *> _exact_hessians;
+  std::vector<std::unique_ptr<FunctionBase<Tensor>>> _exact_hessians;
 
   /**
    * Data structure which stores the errors:

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -61,20 +61,12 @@ void ExactErrorEstimator::attach_exact_value (Number fptr(const Point & p,
 
 void ExactErrorEstimator::attach_exact_values (std::vector<FunctionBase<Number> *> f)
 {
-  // Clear out any previous _exact_values entries, then add a new
+  // Automatically delete any previous _exact_values entries, then add a new
   // entry for each system.
-  for (std::size_t i=0; i != _exact_values.size(); ++i)
-    delete (_exact_values[i]);
-
   _exact_values.clear();
-  _exact_values.resize(f.size(), libmesh_nullptr);
 
-  // We use clone() to get non-sliced copies of FunctionBase
-  // subclasses, but we don't currently put the resulting std::unique_ptrs
-  // into an STL container.
-  for (std::size_t i=0; i != f.size(); ++i)
-    if (f[i])
-      _exact_values[i] = f[i]->clone().release();
+  for (auto ptr : f)
+    _exact_values.emplace_back(ptr ? ptr->clone() : libmesh_nullptr);
 }
 
 
@@ -82,10 +74,10 @@ void ExactErrorEstimator::attach_exact_value (unsigned int sys_num,
                                               FunctionBase<Number> * f)
 {
   if (_exact_values.size() <= sys_num)
-    _exact_values.resize(sys_num+1, libmesh_nullptr);
+    _exact_values.resize(sys_num+1);
 
   if (f)
-    _exact_values[sys_num] = f->clone().release();
+    _exact_values[sys_num] = f->clone();
 }
 
 
@@ -107,20 +99,12 @@ void ExactErrorEstimator::attach_exact_deriv (Gradient gptr(const Point & p,
 
 void ExactErrorEstimator::attach_exact_derivs (std::vector<FunctionBase<Gradient> *> g)
 {
-  // Clear out any previous _exact_derivs entries, then add a new
+  // Automatically delete any previous _exact_derivs entries, then add a new
   // entry for each system.
-  for (std::size_t i=0; i != _exact_derivs.size(); ++i)
-    delete (_exact_derivs[i]);
-
   _exact_derivs.clear();
-  _exact_derivs.resize(g.size(), libmesh_nullptr);
 
-  // We use clone() to get non-sliced copies of FunctionBase
-  // subclasses, but we don't currently put the resulting std::unique_ptrs
-  // into an STL container.
-  for (std::size_t i=0; i != g.size(); ++i)
-    if (g[i])
-      _exact_derivs[i] = g[i]->clone().release();
+  for (auto ptr : g)
+    _exact_derivs.emplace_back(ptr ? ptr->clone() : libmesh_nullptr);
 }
 
 
@@ -128,10 +112,10 @@ void ExactErrorEstimator::attach_exact_deriv (unsigned int sys_num,
                                               FunctionBase<Gradient> * g)
 {
   if (_exact_derivs.size() <= sys_num)
-    _exact_derivs.resize(sys_num+1, libmesh_nullptr);
+    _exact_derivs.resize(sys_num+1);
 
   if (g)
-    _exact_derivs[sys_num] = g->clone().release();
+    _exact_derivs[sys_num] = g->clone();
 }
 
 
@@ -155,20 +139,12 @@ void ExactErrorEstimator::attach_exact_hessian (Tensor hptr(const Point & p,
 
 void ExactErrorEstimator::attach_exact_hessians (std::vector<FunctionBase<Tensor> *> h)
 {
-  // Clear out any previous _exact_hessians entries, then add a new
+  // Automatically delete any previous _exact_hessians entries, then add a new
   // entry for each system.
-  for (std::size_t i=0; i != _exact_hessians.size(); ++i)
-    delete (_exact_hessians[i]);
-
   _exact_hessians.clear();
-  _exact_hessians.resize(h.size(), libmesh_nullptr);
 
-  // We use clone() to get non-sliced copies of FunctionBase
-  // subclasses, but we don't currently put the resulting std::unique_ptrs
-  // into an STL container.
-  for (std::size_t i=0; i != h.size(); ++i)
-    if (h[i])
-      _exact_hessians[i] = h[i]->clone().release();
+  for (auto ptr : h)
+    _exact_hessians.emplace_back(ptr ? ptr->clone() : libmesh_nullptr);
 }
 
 
@@ -176,10 +152,10 @@ void ExactErrorEstimator::attach_exact_hessian (unsigned int sys_num,
                                                 FunctionBase<Tensor> * h)
 {
   if (_exact_hessians.size() <= sys_num)
-    _exact_hessians.resize(sys_num+1, libmesh_nullptr);
+    _exact_hessians.resize(sys_num+1);
 
   if (h)
-    _exact_hessians[sys_num] = h->clone().release();
+    _exact_hessians[sys_num] = h->clone();
 }
 
 
@@ -546,17 +522,9 @@ Real ExactErrorEstimator::find_squared_element_error(const System & system,
 
 void ExactErrorEstimator::clear_functors()
 {
-  // delete will clean up any cloned functors and no-op on any NULL
-  // pointers
-
-  for (std::size_t i=0; i != _exact_values.size(); ++i)
-    delete (_exact_values[i]);
-
-  for (std::size_t i=0; i != _exact_derivs.size(); ++i)
-    delete (_exact_derivs[i]);
-
-  for (std::size_t i=0; i != _exact_hessians.size(); ++i)
-    delete (_exact_hessians[i]);
+  _exact_values.clear();
+  _exact_derivs.clear();
+  _exact_hessians.clear();
 }
 
 

--- a/tests/mesh/mapped_subdomain_partitioner_test.C
+++ b/tests/mesh/mapped_subdomain_partitioner_test.C
@@ -64,7 +64,7 @@ public:
 
     // The MappedSubdomainPartitioner partitions based on user-defined
     // assignment of subdomains to processors.
-    mesh.partitioner() = std::unique_ptr<Partitioner>(new MappedSubdomainPartitioner);
+    mesh.partitioner() = libmesh_make_unique<MappedSubdomainPartitioner>();
 
     // Get a pointer to the MappedSubdomainPartitioner so we can call its
     // API specifically.

--- a/tests/mesh/slit_mesh_test.C
+++ b/tests/mesh/slit_mesh_test.C
@@ -41,7 +41,7 @@ public:
   virtual std::unique_ptr<FEMFunctionBase<Number>>
   clone () const libmesh_override
   {
-    return std::unique_ptr<FEMFunctionBase<Number>> (new SlitFunc());
+    return libmesh_make_unique<SlitFunc>();
   }
 
   virtual Number operator() (const FEMContext & c,

--- a/tests/numerics/numeric_vector_test.h
+++ b/tests/numerics/numeric_vector_test.h
@@ -20,6 +20,10 @@
   CPPUNIT_TEST( testLocalizeToOne );            \
   CPPUNIT_TEST( testLocalizeToOneBase );
 
+#ifndef LIBMESH_HAVE_CXX14_MAKE_UNIQUE
+using libMesh::make_unique;
+#endif
+
 template <class DerivedClass>
 class NumericVectorTest : public CppUnit::TestCase {
 
@@ -53,7 +57,7 @@ public:
       global_size += (block_size + static_cast<unsigned int>(p));
 
     {
-      std::unique_ptr<Base> v_ptr(new Derived(*my_comm, global_size, local_size));
+      auto v_ptr = libmesh_make_unique<Derived>(*my_comm, global_size, local_size);
       Base & v = *v_ptr;
       std::vector<libMesh::Number> l(global_size);
 


### PR DESCRIPTION
A follow-up to the changes in #1515.

This PR includes some additional uses of libmesh_make_unique as well as a refactoring of the ExactErrorEstimator and ExactSolution classes to use containers of std::unique_ptrs. (They were always intended to use them, but we couldn't rely on having std containers of smart pointers until now.)
