### PR TITLE
Deprecate Preconditioner::build().

### DIFF
--- a/include/numerics/preconditioner.h
+++ b/include/numerics/preconditioner.h
@@ -70,12 +70,25 @@ public:
   virtual ~Preconditioner ();
 
   /**
+   * Builds a \p Preconditioner using the linear solver package
+   * specified by \p solver_package, returning the result wrapped in a
+   * std::unique_ptr for safety.
+   */
+  static std::unique_ptr<Preconditioner<T>>
+  build_preconditioner(const libMesh::Parallel::Communicator & comm LIBMESH_CAN_DEFAULT_TO_COMMWORLD,
+                       const SolverPackage solver_package = libMesh::default_solver_package());
+
+  /**
    * Builds a \p Preconditioner using the linear solver package specified by
    * \p solver_package
+   *
+   * \deprecated Use build_preconditioner() instead.
    */
-  static Preconditioner<T> * build(const libMesh::Parallel::Communicator & comm
-                                   LIBMESH_CAN_DEFAULT_TO_COMMWORLD,
-                                   const SolverPackage solver_package = libMesh::default_solver_package());
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  static Preconditioner<T> *
+  build(const libMesh::Parallel::Communicator & comm LIBMESH_CAN_DEFAULT_TO_COMMWORLD,
+        const SolverPackage solver_package = libMesh::default_solver_package());
+#endif
 
   /**
    * \returns \p true if the data structures are initialized, \p false


### PR DESCRIPTION
This method returns dumb pointers to heap-allocated objects and
therefore is prone to creating memory leaks. The new
build_preconditioner() method should be used instead.