### PR TITLE
Remove error-then-return code sections.

### DIFF
--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -955,8 +955,7 @@ unsigned int DofObject::var_to_vg (const unsigned int s,
       if (var < vg_end) return vg;
     }
 
-  libmesh_error_msg("We'll never get here!");
-  return 0;
+  libmesh_error_msg("Error: could not map variable " << var << " to variable group.");
 }
 
 

--- a/include/base/factory.h
+++ b/include/base/factory.h
@@ -140,9 +140,6 @@ std::unique_ptr<Base> Factory<Base>::build (const std::string & name)
         libMesh::err << "  " << it->first << std::endl;
 
       libmesh_error_msg("Exiting...");
-
-      // We'll never get here
-      return std::unique_ptr<Base>();
     }
 
   Factory<Base> * f = factory_map()[name];

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -251,9 +251,6 @@ std::unique_ptr<FEAbstract> FEAbstract::build(const unsigned int dim,
     default:
       libmesh_error_msg("Invalid dimension dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<FEAbstract>();
 }
 
 void FEAbstract::get_refspace_nodes(const ElemType itemType, std::vector<Point> & nodes)

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -374,9 +374,6 @@ FEGenericBase<Real>::build (const unsigned int dim,
     default:
       libmesh_error_msg("Invalid dimension dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<FEBase>();
 }
 
 
@@ -443,9 +440,6 @@ FEGenericBase<RealGradient>::build (const unsigned int dim,
     default:
       libmesh_error_msg("Invalid dimension dim = " << dim);
     } // switch(dim)
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<FEVectorBase>();
 }
 
 
@@ -657,9 +651,6 @@ FEGenericBase<Real>::build_InfFE (const unsigned int dim,
     default:
       libmesh_error_msg("Invalid dimension dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<FEBase>();
 }
 
 

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -168,9 +168,6 @@ unsigned int bernstein_n_dofs(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(t) << " selected for BERNSTEIN FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // bernstein_n_dofs()
 
 
@@ -331,9 +328,6 @@ unsigned int bernstein_n_dofs_at_node(const ElemType t,
     default:
       libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(t) << " selected for BERNSTEIN FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // bernstein_n_dofs_at_node()
 
 
@@ -380,9 +374,6 @@ unsigned int bernstein_n_dofs_per_elem(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(t) << " selected for BERNSTEIN FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // bernstein_n_dofs_per_elem
 
 } // anonymous namespace

--- a/src/fe/fe_bernstein_shape_1D.C
+++ b/src/fe/fe_bernstein_shape_1D.C
@@ -181,9 +181,6 @@ Real FE<1,BERNSTEIN>::shape(const ElemType,
           }
       }
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -354,9 +351,6 @@ Real FE<1,BERNSTEIN>::shape_deriv(const ElemType,
       }
 
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -378,9 +378,6 @@ Real FE<2,BERNSTEIN>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     } // switch type
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -558,9 +555,6 @@ Real FE<2,BERNSTEIN>::shape_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -1373,9 +1373,6 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
     }
 
 #endif
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -2960,9 +2957,6 @@ Real FE<3,BERNSTEIN>::shape_deriv(const Elem * elem,
     }
 
 #endif
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_clough.C
+++ b/src/fe/fe_clough.C
@@ -126,9 +126,6 @@ unsigned int clough_n_dofs(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for CLOUGH FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // clough_n_dofs()
 
 
@@ -202,9 +199,6 @@ unsigned int clough_n_dofs_at_node(const ElemType t,
     default:
       libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for CLOUGH FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // clough_n_dofs_at_node()
 
 
@@ -233,9 +227,6 @@ unsigned int clough_n_dofs_per_elem(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for CLOUGH FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // clough_n_dofs_per_elem()
 
 } // anonymous

--- a/src/fe/fe_clough_shape_1D.C
+++ b/src/fe/fe_clough_shape_1D.C
@@ -142,9 +142,6 @@ Real clough_raw_shape_second_deriv(const unsigned int basis_num,
       libmesh_error_msg("Invalid shape function derivative j = " <<
                         deriv_type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -178,9 +175,6 @@ Real clough_raw_shape_deriv(const unsigned int basis_num,
       libmesh_error_msg("Invalid shape function derivative j = " <<
                         deriv_type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 Real clough_raw_shape(const unsigned int basis_num,
@@ -203,9 +197,6 @@ Real clough_raw_shape(const unsigned int basis_num,
       libmesh_error_msg("Invalid shape function index i = " <<
                         basis_num);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -277,9 +268,6 @@ Real FE<1,CLOUGH>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << totalorder);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -345,9 +333,6 @@ Real FE<1,CLOUGH>::shape_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << totalorder);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -400,9 +385,6 @@ Real FE<1,CLOUGH>::shape_second_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << totalorder);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 } // namespace libMesh

--- a/src/fe/fe_clough_shape_2D.C
+++ b/src/fe/fe_clough_shape_2D.C
@@ -1121,9 +1121,6 @@ Real clough_raw_shape_second_deriv(const unsigned int basis_num,
       libmesh_error_msg("Invalid shape function derivative j = " <<
                         deriv_type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -1561,9 +1558,6 @@ Real clough_raw_shape_deriv(const unsigned int basis_num,
       libmesh_error_msg("Invalid shape function derivative j = " <<
                         deriv_type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 Real clough_raw_shape(const unsigned int basis_num,
@@ -1794,9 +1788,6 @@ Real clough_raw_shape(const unsigned int basis_num,
       libmesh_error_msg("Invalid shape function index i = " <<
                         basis_num);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -1995,9 +1986,6 @@ Real FE<2,CLOUGH>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -2192,9 +2180,6 @@ Real FE<2,CLOUGH>::shape_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -2372,9 +2357,6 @@ Real FE<2,CLOUGH>::shape_second_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 } // namespace libMesh

--- a/src/fe/fe_hermite.C
+++ b/src/fe/fe_hermite.C
@@ -114,9 +114,6 @@ unsigned int hermite_n_dofs(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Bad ElemType = " << Utility::enum_to_string(t) << " for " << Utility::enum_to_string(o) << " order approximation!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // hermite_n_dofs()
 
 
@@ -238,9 +235,6 @@ unsigned int hermite_n_dofs_at_node(const ElemType t,
     default:
       libmesh_error_msg("ERROR: Bad ElemType = " << Utility::enum_to_string(t) << " for " << Utility::enum_to_string(o) << " order approximation!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // hermite_n_dofs_at_node()
 
 
@@ -278,9 +272,6 @@ unsigned int hermite_n_dofs_per_elem(const ElemType t,
     default:
       libmesh_error_msg("ERROR: Bad ElemType = " << Utility::enum_to_string(t) << " for " << Utility::enum_to_string(o) << " order approximation!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // hermite_n_dofs_per_elem()
 
 

--- a/src/fe/fe_hermite_shape_1D.C
+++ b/src/fe/fe_hermite_shape_1D.C
@@ -103,9 +103,6 @@ Real FEHermite<1>::hermite_raw_shape_second_deriv (const unsigned int i, const R
               (8.*(i-4)+4.)*xi*xi*xipower*(xi*xi-1.) +
               (i-4)*(i-5)*xipower*(xi*xi-1.)*(xi*xi-1.))/denominator;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -139,9 +136,6 @@ Real FEHermite<1>::hermite_raw_shape_deriv(const unsigned int i, const Real xi)
       return (4*xi*xi*xi*xipower*(xi*xi-1.) +
               (i-4)*xi*xipower*(xi*xi-1.)*(xi*xi-1.))/denominator;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 template<>
@@ -174,9 +168,6 @@ Real FEHermite<1>::hermite_raw_shape(const unsigned int i, const Real xi)
       return (xi*xi*xipower*(xi*xi-1.)*(xi*xi-1.))/denominator;
 
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -238,9 +229,6 @@ Real FE<1,HERMITE>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -305,9 +293,6 @@ Real FE<1,HERMITE>::shape_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -359,9 +344,6 @@ Real FE<1,HERMITE>::shape_second_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 } // namespace libMesh

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -243,9 +243,6 @@ Real FE<2,HERMITE>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -322,9 +319,6 @@ Real FE<2,HERMITE>::shape_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -392,9 +386,6 @@ Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 } // namespace libMesh

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -439,9 +439,6 @@ Real FE<3,HERMITE>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order " << totalorder);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -536,9 +533,6 @@ Real FE<3,HERMITE>::shape_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order " << totalorder);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -637,9 +631,6 @@ Real FE<3,HERMITE>::shape_second_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order " << totalorder);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 } // namespace libMesh

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -136,9 +136,6 @@ unsigned int hierarchic_n_dofs(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(t) << " selected for HIERARCHIC FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // hierarchic_n_dofs()
 
 
@@ -272,9 +269,6 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
     default:
       libmesh_error_msg("ERROR: Bad ElemType = " << Utility::enum_to_string(t) << " for " << Utility::enum_to_string(o) << " order approximation!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // hierarchic_n_dofs_at_node()
 
 
@@ -313,9 +307,6 @@ unsigned int hierarchic_n_dofs_per_elem(const ElemType t,
     default:
       libmesh_error_msg("ERROR: Bad ElemType = " << Utility::enum_to_string(t) << " for " << Utility::enum_to_string(o) << " order approximation!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // hierarchic_n_dofs_per_elem()
 
 } // anonymous namespace

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -695,9 +695,6 @@ Real FE<3,HIERARCHIC>::shape(const Elem * elem,
     }
 
 #endif
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -765,9 +762,6 @@ Real FE<3,HIERARCHIC>::shape_deriv(const Elem * elem,
   return (FE<3,HIERARCHIC>::shape(elem, order, i, pp) -
           FE<3,HIERARCHIC>::shape(elem, order, i, pm))/2./eps;
 #endif
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -402,9 +402,6 @@ unsigned int FEInterface::n_shape_functions(const unsigned int dim,
   const Order o = fe_t.order;
 
   fe_with_vec_switch(n_shape_functions(t, o));
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -425,9 +422,6 @@ unsigned int FEInterface::n_dofs(const unsigned int dim,
   const Order o = fe_t.order;
 
   fe_with_vec_switch(n_dofs(t, o));
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -448,9 +442,6 @@ unsigned int FEInterface::n_dofs_at_node(const unsigned int dim,
   const Order o = fe_t.order;
 
   fe_with_vec_switch(n_dofs_at_node(t, o, n));
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -460,9 +451,6 @@ FEInterface::n_dofs_at_node_function(const unsigned int dim,
                                      const FEType & fe_t)
 {
   fe_with_vec_switch(n_dofs_at_node);
-
-  libmesh_error_msg("We'll never get here!");
-  return libmesh_nullptr;
 }
 
 
@@ -484,9 +472,6 @@ unsigned int FEInterface::n_dofs_per_elem(const unsigned int dim,
   const Order o = fe_t.order;
 
   fe_with_vec_switch(n_dofs_per_elem(t, o));
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -501,8 +486,6 @@ void FEInterface::dofs_on_side(const Elem * const elem,
   const Order o = fe_t.order;
 
   void_fe_with_vec_switch(dofs_on_side(elem, o, s, di));
-
-  libmesh_error_msg("We'll never get here!");
 }
 
 
@@ -516,8 +499,6 @@ void FEInterface::dofs_on_edge(const Elem * const elem,
   const Order o = fe_t.order;
 
   void_fe_with_vec_switch(dofs_on_edge(elem, o, e, di));
-
-  libmesh_error_msg("We'll never get here!");
 }
 
 
@@ -557,9 +538,6 @@ Point FEInterface::map(unsigned int dim,
     return ifem_map(dim, fe_t, elem, p);
 #endif
   fe_with_vec_switch(map(elem, p));
-
-  libmesh_error_msg("We'll never get here!");
-  return Point();
 }
 
 
@@ -581,9 +559,6 @@ Point FEInterface::inverse_map (const unsigned int dim,
 #endif
 
   fe_with_vec_switch(inverse_map(elem, p, tolerance, secure));
-
-  libmesh_error_msg("We'll never get here!");
-  return Point();
 }
 
 
@@ -622,8 +597,6 @@ void FEInterface::inverse_map (const unsigned int dim,
 #endif
 
   void_fe_with_vec_switch(inverse_map(elem, physical_points, reference_points, tolerance, secure));
-
-  libmesh_error_msg("We'll never get here!");
 }
 
 
@@ -654,9 +627,6 @@ Real FEInterface::shape(const unsigned int dim,
   const Order o = fe_t.order;
 
   fe_switch(shape(t,o,i,p));
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 Real FEInterface::shape(const unsigned int dim,
@@ -675,9 +645,6 @@ Real FEInterface::shape(const unsigned int dim,
   const Order o = fe_t.order;
 
   fe_switch(shape(elem,o,i,p));
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 template<>

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -62,9 +62,6 @@ unsigned int FEInterface::ifem_n_shape_functions(const unsigned int dim,
     default:
       libmesh_error_msg("Unsupported dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -97,9 +94,6 @@ unsigned int FEInterface::ifem_n_dofs(const unsigned int dim,
     default:
       libmesh_error_msg("Unsupported dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -132,9 +126,6 @@ unsigned int FEInterface::ifem_n_dofs_at_node(const unsigned int dim,
     default:
       libmesh_error_msg("Unsupported dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -167,9 +158,6 @@ unsigned int FEInterface::ifem_n_dofs_per_elem(const unsigned int dim,
     default:
       libmesh_error_msg("Unsupported dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -545,10 +533,6 @@ Point FEInterface::ifem_inverse_map (const unsigned int dim,
     default:
       libmesh_error_msg("Invalid dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  Point pt;
-  return pt;
 }
 
 
@@ -718,9 +702,6 @@ Real FEInterface::ifem_shape(const unsigned int dim,
     default:
       libmesh_error_msg("Invalid dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -819,9 +800,6 @@ Real FEInterface::ifem_shape(const unsigned int dim,
     default:
       libmesh_error_msg("Invalid dim = " << dim);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -130,9 +130,6 @@ unsigned int l2_hierarchic_n_dofs(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid ElemType " << Utility::enum_to_string(t) << " selected for L2_HIERARCHIC FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // l2_hierarchic_n_dofs()
 
 

--- a/src/fe/fe_l2_hierarchic_shape_3D.C
+++ b/src/fe/fe_l2_hierarchic_shape_3D.C
@@ -695,9 +695,6 @@ Real FE<3,L2_HIERARCHIC>::shape(const Elem * elem,
     }
 
 #endif
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -765,9 +762,6 @@ Real FE<3,L2_HIERARCHIC>::shape_deriv(const Elem * elem,
   return (FE<3,L2_HIERARCHIC>::shape(elem, order, i, pp) -
           FE<3,L2_HIERARCHIC>::shape(elem, order, i, pm))/2./eps;
 #endif
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_l2_lagrange.C
+++ b/src/fe/fe_l2_lagrange.C
@@ -411,9 +411,6 @@ unsigned int l2_lagrange_n_dofs(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for L2_LAGRANGE FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 } // anonymous namespace

--- a/src/fe/fe_l2_lagrange_shape_1D.C
+++ b/src/fe/fe_l2_lagrange_shape_1D.C
@@ -109,9 +109,6 @@ Real FE<1,L2_LAGRANGE>::shape(const ElemType,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -214,9 +211,6 @@ Real FE<1,L2_LAGRANGE>::shape_deriv(const ElemType,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -303,9 +297,6 @@ Real FE<1,L2_LAGRANGE>::shape_second_deriv(const ElemType,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     } // end switch (order)
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_l2_lagrange_shape_2D.C
+++ b/src/fe/fe_l2_lagrange_shape_2D.C
@@ -199,10 +199,6 @@ Real FE<2,L2_LAGRANGE>::shape(const ElemType type,
     default:
       libmesh_error_msg("ERROR: Unsupported 2D FE order: " << order);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
-
 #endif
 }
 
@@ -545,11 +541,6 @@ Real FE<2,L2_LAGRANGE>::shape_deriv(const ElemType type,
     default:
       libmesh_error_msg("ERROR: Unsupported 2D FE order: " << order);
     }
-
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
-
 #endif
 }
 
@@ -904,9 +895,6 @@ Real FE<2,L2_LAGRANGE>::shape_second_deriv(const ElemType type,
 
     } // end switch (order)
 
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 #endif // LIBMESH_DIM > 1
 }
 

--- a/src/fe/fe_l2_lagrange_shape_3D.C
+++ b/src/fe/fe_l2_lagrange_shape_3D.C
@@ -348,9 +348,6 @@ Real FE<3,L2_LAGRANGE>::shape(const ElemType type,
     }
 
 #endif
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -1190,9 +1187,6 @@ Real FE<3,L2_LAGRANGE>::shape_deriv(const ElemType type,
     }
 
 #endif
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -1446,9 +1440,6 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const ElemType type,
     }
 
 #endif
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -461,9 +461,6 @@ unsigned int lagrange_n_dofs(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for LAGRANGE FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -666,10 +663,6 @@ unsigned int lagrange_n_dofs_at_node(const ElemType t,
     default:
       libmesh_error_msg("Unsupported order: " << o );
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
-
 }
 
 

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -109,9 +109,6 @@ Real FE<1,LAGRANGE>::shape(const ElemType,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -214,9 +211,6 @@ Real FE<1,LAGRANGE>::shape_deriv(const ElemType,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -303,9 +297,6 @@ Real FE<1,LAGRANGE>::shape_second_deriv(const ElemType,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     } // end switch (order)
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -199,10 +199,9 @@ Real FE<2,LAGRANGE>::shape(const ElemType type,
     default:
       libmesh_error_msg("ERROR: Unsupported 2D FE order: " << order);
     }
-
-  libmesh_error_msg("We'll never get here!");
-#endif // LIBMESH_DIM > 1
+#else // LIBMESH_DIM > 1
   return 0.;
+#endif
 }
 
 
@@ -542,11 +541,9 @@ Real FE<2,LAGRANGE>::shape_deriv(const ElemType type,
     default:
       libmesh_error_msg("ERROR: Unsupported 2D FE order: " << order);
     }
-
-
-  libmesh_error_msg("We'll never get here!");
-#endif // LIBMESH_DIM > 1
+#else // LIBMESH_DIM > 1
   return 0.;
+#endif
 }
 
 
@@ -900,9 +897,9 @@ Real FE<2,LAGRANGE>::shape_second_deriv(const ElemType type,
 
     } // end switch (order)
 
-  libmesh_error_msg("We'll never get here!");
-#endif // LIBMESH_DIM > 1
+#else // LIBMESH_DIM > 1
   return 0.;
+#endif
 }
 
 

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -547,10 +547,9 @@ Real FE<3,LAGRANGE>::shape(const ElemType type,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << order);
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
+#endif
 }
 
 
@@ -1904,10 +1903,9 @@ Real FE<3,LAGRANGE>::shape_deriv(const ElemType type,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << order);
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
+#endif
 }
 
 
@@ -3636,10 +3634,9 @@ Real FE<3,LAGRANGE>::shape_second_deriv(const ElemType type,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << order);
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
+#endif
 }
 
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -58,9 +58,6 @@ std::unique_ptr<FEMap> FEMap::build( FEType fe_type )
     default:
       return libmesh_make_unique<FEMap>();
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<FEMap>();
 }
 
 

--- a/src/fe/fe_monomial.C
+++ b/src/fe/fe_monomial.C
@@ -337,9 +337,6 @@ unsigned int monomial_n_dofs(const ElemType t, const Order o)
           }
       }
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // monomial_n_dofs()
 
 

--- a/src/fe/fe_monomial_shape_1D.C
+++ b/src/fe/fe_monomial_shape_1D.C
@@ -62,9 +62,6 @@ Real FE<1,MONOMIAL>::shape(const ElemType,
         val *= xi;
       return val;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -121,9 +118,6 @@ Real FE<1,MONOMIAL>::shape_deriv(const ElemType,
         val *= xi;
       return val;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -179,9 +173,6 @@ Real FE<1,MONOMIAL>::shape_second_deriv(const ElemType,
         val *= (index+1) * xi;
       return val;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_monomial_shape_2D.C
+++ b/src/fe/fe_monomial_shape_2D.C
@@ -107,9 +107,8 @@ Real FE<2,MONOMIAL>::shape(const ElemType,
       return val;
     }
 
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
-
 #endif
 }
 
@@ -294,9 +293,8 @@ Real FE<2,MONOMIAL>::shape_deriv(const ElemType,
       libmesh_error_msg("Invalid shape function derivative j = " << j);
     }
 
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
-
 #endif
 }
 
@@ -529,9 +527,8 @@ Real FE<2,MONOMIAL>::shape_second_deriv(const ElemType,
       libmesh_error_msg("Invalid shape function derivative j = " << j);
     }
 
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
-
 #endif
 }
 

--- a/src/fe/fe_monomial_shape_3D.C
+++ b/src/fe/fe_monomial_shape_3D.C
@@ -175,10 +175,9 @@ Real FE<3,MONOMIAL>::shape(const ElemType,
       return val;
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
+#endif
 }
 
 
@@ -628,10 +627,9 @@ Real FE<3,MONOMIAL>::shape_deriv(const ElemType,
       libmesh_error_msg("Invalid shape function derivative j = " << j);
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
+#endif
 }
 
 
@@ -1292,10 +1290,9 @@ Real FE<3,MONOMIAL>::shape_second_deriv(const ElemType,
       libmesh_error_msg("Invalid j = " << j);
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
+#endif
 }
 
 

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -183,9 +183,6 @@ unsigned int nedelec_one_n_dofs(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for NEDELEC_ONE FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -360,9 +357,6 @@ unsigned int nedelec_one_n_dofs_at_node(const ElemType t,
     default:
       libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for NEDELEC_ONE FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -154,10 +154,9 @@ RealGradient FE<2,NEDELEC_ONE>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported 2D FE order!: " << total_order);
     }
-#endif // LIBMESH_DIM > 1
-
-  libmesh_error_msg("We'll never get here!");
+#else // LIBMESH_DIM > 1
   return RealGradient();
+#endif
 }
 
 
@@ -319,10 +318,9 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported 2D FE order!: " << total_order);
     }
-#endif // LIBMESH_DIM > 1
-
-  libmesh_error_msg("We'll never get here!");
+#else // LIBMESH_DIM > 1
   return RealGradient();
+#endif
 }
 
 
@@ -392,10 +390,9 @@ RealGradient FE<2,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
 
     } // end switch (order)
 
-#endif // LIBMESH_DIM > 1
-
-  libmesh_error_msg("We'll never get here!");
+#else // LIBMESH_DIM > 1
   return RealGradient();
+#endif
 }
 
 } // namespace libMesh

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -182,10 +182,9 @@ RealGradient FE<3,NEDELEC_ONE>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << totalorder);
     }
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return RealGradient();
+#endif
 }
 
 
@@ -481,10 +480,9 @@ RealGradient FE<3,NEDELEC_ONE>::shape_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << totalorder);
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return RealGradient();
+#endif
 }
 
 
@@ -740,10 +738,9 @@ RealGradient FE<3,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << totalorder);
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return RealGradient();
+#endif
 }
 
 } // namespace libMesh

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -183,9 +183,6 @@ Real FESubdivision::regular_shape(const unsigned int i,
     default:
       libmesh_error_msg("Invalid i = " << i);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -275,9 +272,6 @@ Real FESubdivision::regular_shape_deriv(const unsigned int i,
     default:
       libmesh_error_msg("Invalid j = " << j);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -391,9 +385,6 @@ Real FESubdivision::regular_shape_second_deriv(const unsigned int i,
     default:
       libmesh_error_msg("Invalid j = " << j);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -727,9 +718,6 @@ Real FE<2,SUBDIVISION>::shape(const ElemType type,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -769,9 +757,6 @@ Real FE<2,SUBDIVISION>::shape_deriv(const ElemType type,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -812,9 +797,6 @@ Real FE<2,SUBDIVISION>::shape_second_deriv(const ElemType type,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_szabab.C
+++ b/src/fe/fe_szabab.C
@@ -317,9 +317,6 @@ unsigned int szabab_n_dofs(const ElemType t, const Order o)
     default:
       libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for SZABAB FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // szabab_n_dofs()
 
 
@@ -930,9 +927,6 @@ unsigned int szabab_n_dofs_at_node(const ElemType t,
     default:
       libmesh_error_msg("ERROR: Invalid Order " << Utility::enum_to_string(o) << " selected for SZABAB FE family!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 } // szabab_n_dofs_at_node()
 
 

--- a/src/fe/fe_szabab_shape_1D.C
+++ b/src/fe/fe_szabab_shape_1D.C
@@ -71,9 +71,6 @@ Real FE<1,SZABAB>::shape(const ElemType,
     default:
       libmesh_error_msg("Invalid shape function index!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -133,9 +130,6 @@ Real FE<1,SZABAB>::shape_deriv(const ElemType,
     default:
       libmesh_error_msg("Invalid shape function index!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_szabab_shape_2D.C
+++ b/src/fe/fe_szabab_shape_2D.C
@@ -727,9 +727,6 @@ Real FE<2,SZABAB>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order!");
     } // switch order
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -1395,9 +1392,6 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported polynomial order!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/fe/fe_transformation_base.C
+++ b/src/fe/fe_transformation_base.C
@@ -61,9 +61,6 @@ std::unique_ptr<FETransformationBase<OutputShape>> FETransformationBase<OutputSh
     default:
       libmesh_error_msg("Unknown family = " << fe_type.family);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<FETransformationBase<OutputShape>>();
 }
 
 template class FETransformationBase<Real>;

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -334,9 +334,6 @@ unsigned int xyz_n_dofs(const ElemType t, const Order o)
           }
       }
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 

--- a/src/fe/fe_xyz_shape_1D.C
+++ b/src/fe/fe_xyz_shape_1D.C
@@ -85,10 +85,6 @@ Real FE<1,XYZ>::shape(const Elem * elem,
         val *= dx;
       return val;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
-
 }
 
 
@@ -156,9 +152,6 @@ Real FE<1,XYZ>::shape_deriv(const Elem * elem,
         val *= dx;
       return val/max_distance;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -225,9 +218,6 @@ Real FE<1,XYZ>::shape_second_deriv(const Elem * elem,
         val *= (index+1) * dx;
       return val/dist2;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 } // namespace libMesh

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -141,9 +141,8 @@ Real FE<2,XYZ>::shape(const Elem * elem,
       return val;
     }
 
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
-
 #endif
 }
 
@@ -346,9 +345,8 @@ Real FE<2,XYZ>::shape_deriv(const Elem * elem,
       libmesh_error_msg("Invalid j = " << j);
     }
 
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
-
 #endif
 }
 
@@ -598,9 +596,8 @@ Real FE<2,XYZ>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("Invalid shape function derivative j = " << j);
     }
 
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
-
 #endif
 }
 

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -211,10 +211,9 @@ Real FE<3,XYZ>::shape(const Elem * elem,
       return val;
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
+#endif
 }
 
 
@@ -686,10 +685,9 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
       libmesh_error_msg("Invalid j = " << j);
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
+#endif
 }
 
 
@@ -1379,10 +1377,9 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("Invalid j = " << j);
     }
 
-#endif
-
-  libmesh_error_msg("We'll never get here!");
+#else
   return 0.;
+#endif
 }
 
 } // namespace libMesh

--- a/src/fe/inf_fe_base_radial.C
+++ b/src/fe/inf_fe_base_radial.C
@@ -88,9 +88,6 @@ ElemType InfFE<Dim,T_radial,T_base>::Base::get_elem_type (const ElemType type)
     default:
       libmesh_error_msg("ERROR: Unsupported element type!: " << type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return INVALID_ELEM;
 }
 
 

--- a/src/fe/inf_fe_jacobi_20_00_eval.C
+++ b/src/fe/inf_fe_jacobi_20_00_eval.C
@@ -241,9 +241,6 @@ Real jacobi_20_00_eval(Real v, unsigned i)
     default:
       libmesh_error_msg("bad index i = " << i);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 } // jacobi_20_00_eval()
 
 
@@ -453,9 +450,6 @@ Real jacobi_20_00_eval_deriv(Real v, unsigned i)
     default:
       libmesh_error_msg("bad index i = " << i);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 } // jacobi_20_00_eval_deriv()
 
 

--- a/src/fe/inf_fe_jacobi_30_00_eval.C
+++ b/src/fe/inf_fe_jacobi_30_00_eval.C
@@ -241,9 +241,6 @@ Real jacobi_30_00_eval(Real v, unsigned i)
     default:
       libmesh_error_msg("bad index i = " << i);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 } // jacobi_30_00_eval()
 
 
@@ -448,9 +445,6 @@ Real jacobi_30_00_eval_deriv(Real v, unsigned i)
     default:
       libmesh_error_msg("bad index i = " << i);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 } // jacobi_30_00_eval_deriv()
 
 

--- a/src/fe/inf_fe_lagrange_eval.C
+++ b/src/fe/inf_fe_lagrange_eval.C
@@ -1277,9 +1277,6 @@ Real lagrange_eval(Real v, Order o_radial, unsigned i)
     default:
       libmesh_error_msg("Lagrange polynomials only defined up to 15.");
     } // switch (o_radial)
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 } // lagrange_eval()
 
 
@@ -2599,9 +2596,6 @@ Real lagrange_eval_deriv(Real v, Order o_radial, unsigned i)
     default:
       libmesh_error_msg("Lagrange polynomials only defined up to 15.");
     } // switch (o_radial)
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 } // lagrange_eval_deriv()
 
 } // anonymous namespace

--- a/src/fe/inf_fe_legendre_eval.C
+++ b/src/fe/inf_fe_legendre_eval.C
@@ -163,9 +163,6 @@ Real legendre_eval(Real v,  unsigned i)
     default:
       libmesh_error_msg("bad index i = " << i);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 } // legendre_eval()
 
 
@@ -300,9 +297,6 @@ Real legendre_eval_deriv(Real v, unsigned i)
     default:
       libmesh_error_msg("bad index i = " << i);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 } // legendre_eval_deriv()
 
 } // anonymous namespace

--- a/src/fe/inf_fe_map_eval.C
+++ b/src/fe/inf_fe_map_eval.C
@@ -41,9 +41,6 @@ Real infinite_map_eval(Real v, unsigned i)
     default:
       libmesh_error_msg("bad index i = " << i);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 
@@ -62,9 +59,6 @@ Real infinite_map_eval_deriv(Real v, unsigned i)
     default:
       libmesh_error_msg("bad index i = " << i);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 } // anonymous namespace

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -179,9 +179,6 @@ unsigned int Hex::opposite_node(const unsigned int node_in,
     default:
       libmesh_error_msg("Unsupported side_in = " << side_in);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 255;
 }
 
 
@@ -322,9 +319,6 @@ Real Hex::quality (const ElemQuality q) const
     default:
       return Elem::quality(q);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -160,9 +160,6 @@ std::unique_ptr<Elem> Hex20::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -195,9 +195,6 @@ dof_id_type Hex27::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -231,9 +228,6 @@ std::unique_ptr<Elem> Hex27::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 
@@ -561,9 +555,6 @@ unsigned int Hex27::n_second_order_adjacent_vertices (const unsigned int n) cons
     default:
       libmesh_error_msg("Invalid node number n = " << n);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return libMesh::invalid_uint;
 }
 
 

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -135,9 +135,6 @@ std::unique_ptr<Elem> Hex8::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -277,9 +277,6 @@ Real InfHex::quality (const ElemQuality q) const
     default:
       return Elem::quality(q);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -184,9 +184,6 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 std::unique_ptr<Elem> InfHex16::build_edge_ptr (const unsigned int i)

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -124,9 +124,6 @@ dof_id_type InfHex18::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side s = " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -209,9 +206,6 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 
@@ -329,9 +323,6 @@ unsigned int InfHex18::n_second_order_adjacent_vertices (const unsigned int n) c
     default:
       libmesh_error_msg("Invalid node n = " << n);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return libMesh::invalid_uint;
 }
 
 

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -161,9 +161,6 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -82,9 +82,6 @@ dof_id_type InfPrism::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side s = " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -173,9 +173,6 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -156,9 +156,6 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -83,9 +83,6 @@ dof_id_type Prism::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -200,9 +200,6 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -165,9 +165,6 @@ dof_id_type Prism18::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -243,9 +240,6 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 
@@ -554,9 +548,6 @@ unsigned int Prism18::n_second_order_adjacent_vertices (const unsigned int n) co
     default:
       libmesh_error_msg("Invalid node n = " << n);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return libMesh::invalid_uint;
 }
 
 

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -171,9 +171,6 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -77,9 +77,6 @@ dof_id_type Pyramid::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side s = " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -185,9 +185,6 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 
@@ -247,9 +244,6 @@ unsigned int Pyramid13::n_second_order_adjacent_vertices (const unsigned int n) 
     default:
       libmesh_error_msg("Invalid node n = " << n);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return libMesh::invalid_uint;
 }
 
 
@@ -294,9 +288,6 @@ unsigned short int Pyramid13::second_order_adjacent_vertex (const unsigned int n
       libmesh_error_msg("Invalid n = " << n);
 
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return static_cast<unsigned short int>(-1);
 }
 
 

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -137,9 +137,6 @@ dof_id_type Pyramid14::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side s = " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -214,9 +211,6 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 
@@ -279,9 +273,6 @@ unsigned int Pyramid14::n_second_order_adjacent_vertices (const unsigned int n) 
     default:
       libmesh_error_msg("Invalid node n = " << n);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return libMesh::invalid_uint;
 }
 
 
@@ -337,9 +328,6 @@ unsigned short int Pyramid14::second_order_adjacent_vertex (const unsigned int n
       libmesh_error_msg("Invalid n = " << n);
 
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return static_cast<unsigned short int>(-1);
 }
 
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -160,9 +160,6 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -182,9 +182,6 @@ std::unique_ptr<Elem> Tet10::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -145,9 +145,6 @@ std::unique_ptr<Elem> Tet4::build_side_ptr (const unsigned int i,
 
       return face;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -324,9 +324,6 @@ std::unique_ptr<Elem> Elem::build(const ElemType type,
     default:
       libmesh_error_msg("ERROR: Undefined element type!");
     }
-
-  // We'll never get here.
-  return libmesh_nullptr;
 }
 
 
@@ -1459,9 +1456,6 @@ Real Elem::quality (const ElemQuality q) const
         return 1.;
       }
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0.;
 }
 
 

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -219,9 +219,6 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
 
       return edge;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -126,9 +126,6 @@ dof_id_type InfQuad6::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side s = " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -198,9 +195,6 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
 
       return edge;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -142,9 +142,6 @@ unsigned int Quad::opposite_node(const unsigned int node_in,
     default:
       libmesh_error_msg("Unsupported side_in = " << side_in);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 255;
 }
 
 

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -143,9 +143,6 @@ std::unique_ptr<Elem> Quad4::build_side_ptr (const unsigned int i,
 
       return edge;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -183,9 +183,6 @@ dof_id_type Quad8::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side s = " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -220,9 +217,6 @@ std::unique_ptr<Elem> Quad8::build_side_ptr (const unsigned int i,
 
       return edge;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -194,9 +194,6 @@ dof_id_type Quad9::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side s = " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -238,9 +235,6 @@ std::unique_ptr<Elem> Quad9::build_side_ptr (const unsigned int i,
 
       return edge;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 
@@ -454,9 +448,6 @@ unsigned int Quad9::n_second_order_adjacent_vertices (const unsigned int n) cons
     default:
       libmesh_error_msg("Invalid n = " << n);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return libMesh::invalid_uint;
 }
 
 

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -125,9 +125,6 @@ std::unique_ptr<Elem> Tri3::build_side_ptr (const unsigned int i,
 
       return edge;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -167,9 +167,6 @@ dof_id_type Tri6::key (const unsigned int s) const
     default:
       libmesh_error_msg("Invalid side s = " << s);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return 0;
 }
 
 
@@ -204,9 +201,6 @@ std::unique_ptr<Elem> Tri6::build_side_ptr (const unsigned int i,
 
       return edge;
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<Elem>();
 }
 
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2053,9 +2053,6 @@ ExodusII_IO_Helper::Conversion ExodusII_IO_Helper::ElementMaps::assign_conversio
     return assign_conversion( it->second );
   else
     libmesh_error_msg("ERROR! Unrecognized element type_str: " << type_str);
-
-  libmesh_error_msg("We'll never get here!");
-  return assign_conversion (EDGE2);
 }
 
 
@@ -2418,19 +2415,6 @@ ExodusII_IO_Helper::Conversion ExodusII_IO_Helper::ElementMaps::assign_conversio
     default:
       libmesh_error_msg("Unsupported element type: " << type);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  const Conversion conv(tri3_node_map,
-                        ARRAY_LENGTH(tri3_node_map),
-                        tri3_node_map, // inverse node map same as forward node map
-                        ARRAY_LENGTH(tri3_node_map),
-                        tri_edge_map,
-                        ARRAY_LENGTH(tri_edge_map),
-                        tri_inverse_edge_map,
-                        ARRAY_LENGTH(tri_inverse_edge_map),
-                        TRI3,
-                        "TRI3");
-  return conv;
 }
 
 

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -73,9 +73,6 @@ NumericVector<T>::build(const Parallel::Communicator & comm, const SolverPackage
     default:
       return libmesh_make_unique<DistributedVector<T>>(comm, AUTOMATIC);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<NumericVector<T>>();
 }
 
 

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -169,9 +169,6 @@ SparseMatrix<T>::build(const Parallel::Communicator & comm,
     default:
       libmesh_error_msg("ERROR:  Unrecognized solver package: " << solver_package);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<SparseMatrix<T>>();
 }
 
 

--- a/src/quadrature/quadrature_build.C
+++ b/src/quadrature/quadrature_build.C
@@ -167,10 +167,6 @@ std::unique_ptr<QBase> QBase::build(const QuadratureType _qt,
     default:
       libmesh_error_msg("ERROR: Bad qt=" << _qt);
     }
-
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<QBase>();
 }
 
 } // namespace libMesh

--- a/src/solvers/nonlinear_solver.C
+++ b/src/solvers/nonlinear_solver.C
@@ -52,9 +52,6 @@ NonlinearSolver<T>::build(sys_type & s, const SolverPackage solver_package)
     default:
       libmesh_error_msg("ERROR:  Unrecognized solver package: " << solver_package);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<NonlinearSolver<T>>();
 }
 
 #else // LIBMESH_HAVE_PETSC || LIBMESH_TRILINOS_HAVE_NOX

--- a/src/solvers/optimization_solver.C
+++ b/src/solvers/optimization_solver.C
@@ -82,9 +82,6 @@ OptimizationSolver<T>::build(sys_type & s, const SolverPackage solver_package)
     default:
       libmesh_error_msg("ERROR:  Unrecognized solver package: " << solver_package);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<OptimizationSolver<T>>();
 }
 
 

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -1007,10 +1007,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       ierr = VecScatterEnd(scatter,solution->vec(),subsolution,INSERT_VALUES,SCATTER_FORWARD);
       LIBMESH_CHKERR(ierr);
 
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-      // This point can't be reached, see above.
-      libmesh_error_msg("We'll never get here!");
-#else
+#if !PETSC_VERSION_LESS_THAN(3,1,0)
       ierr = LibMeshCreateSubMatrix(mat,
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
@@ -1051,10 +1048,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           ierr = VecScale(subvec1,-1.0);
           LIBMESH_CHKERR(ierr);
 
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-          // This point can't be reached, see above.
-          libmesh_error_msg("We'll never get here!");
-#else
+#if !PETSC_VERSION_LESS_THAN(3,1,0)
           ierr = LibMeshCreateSubMatrix(mat,
                                         _restrict_solve_to_is,
                                         _restrict_solve_to_is_complement,
@@ -1284,10 +1278,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
       ierr = VecScatterEnd(scatter,solution->vec(),subsolution,INSERT_VALUES,SCATTER_FORWARD);
       LIBMESH_CHKERR(ierr);
 
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-      // This point can't be reached, see above.
-      libmesh_error_msg("We'll never get here!");
-#else
+#if !PETSC_VERSION_LESS_THAN(3,1,0)
       ierr = LibMeshCreateSubMatrix(mat,
                                     _restrict_solve_to_is,
                                     _restrict_solve_to_is,
@@ -1334,10 +1325,7 @@ PetscLinearSolver<T>::solve (const ShellMatrix<T> & shell_matrix,
           ierr = VecScale(subvec1,-1.0);
           LIBMESH_CHKERR(ierr);
 
-#if PETSC_VERSION_LESS_THAN(3,1,0)
-          // This point can't be reached, see above.
-          libmesh_error_msg("We'll never get here!");
-#else
+#if !PETSC_VERSION_LESS_THAN(3,1,0)
           ierr = LibMeshCreateSubMatrix(mat,
                                         _restrict_solve_to_is,
                                         _restrict_solve_to_is_complement,

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -80,9 +80,6 @@ std::unique_ptr<PointLocatorBase> PointLocatorBase::build (PointLocatorType t,
     default:
       libmesh_error_msg("ERROR: Bad PointLocatorType = " << t);
     }
-
-  libmesh_error_msg("We'll never get here!");
-  return std::unique_ptr<PointLocatorBase>();
 }
 
 void PointLocatorBase::set_close_to_point_tol (Real close_to_point_tol)

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -337,10 +337,6 @@ TreeNode<N>::create_bounding_box (unsigned int c) const
     default:
       libmesh_error_msg("Only implemented for Octrees, QuadTrees, and Binary Trees!");
     }
-
-  libmesh_error_msg("We'll never get here!");
-  Point min, max;
-  return BoundingBox (min, max);
 }
 
 
@@ -490,9 +486,6 @@ TreeNode<N>::find_element (const Point & p,
   else
     return this->find_element_in_children(p,allowed_subdomains,
                                           relative_tol);
-
-  libmesh_error_msg("We'll never get here!");
-  return libmesh_nullptr;
 }
 
 


### PR DESCRIPTION
If I recall correctly, we originally used this idiom to prevent
compiler warnings, but it seems like compilers have gotten smarter
about detecting when something is/is not returned from a non-void
function. I think we can now get rid of these...