### PR TITLE
Drop configure support for ancient compilers

### DIFF
--- a/configure
+++ b/configure
@@ -5525,22 +5525,17 @@ fi
   # you are using.
   # --------------------------------------------------------------
 
-  # First check for gcc version, avoids intel's icc from
-  # pretending to be gcc
-  REAL_GXX=`($CXX -v 2>&1) | grep "gcc version"`
+    compiler_brand_detected=no
 
-  # Intel's v12.1 does this:
-  # $ icpc -v
-  #   icpc version 12.1.0 (gcc version 4.4.4 compatibility)
-  # cath that and do not interpret it as 'REAL_GXX' compiler
-  is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
+      REAL_GXX=`($CXX -v 2>&1) | grep "gcc version"`
+
+    is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
   if test "x$is_intel_icc" != "x" ; then
     REAL_GXX=""
   fi
 
   if (test "$GXX" = yes -a "x$REAL_GXX" != "x" ) ; then
-    # find out the right version
-    GXX_VERSION_STRING=`($CXX -v 2>&1) | grep "gcc version"`
+        GXX_VERSION_STRING=`($CXX -v 2>&1) | grep "gcc version"`
     case "$GXX_VERSION_STRING" in
       *gcc\ version\ 7.*)
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-7.x >>>" >&5
@@ -5577,386 +5572,125 @@ $as_echo "<<< C++ compiler is gcc-4.7 >>>" >&6; }
 $as_echo "<<< C++ compiler is gcc-4.6 >>>" >&6; }
         GXX_VERSION=gcc4.6
         ;;
-      *4.5.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.5 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-4.5 >>>" >&6; }
-        GXX_VERSION=gcc4.5
-        ;;
-      *4.4.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.4 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-4.4 >>>" >&6; }
-        GXX_VERSION=gcc4.4
-        ;;
-      *4.3.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.3 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-4.3 >>>" >&6; }
-        GXX_VERSION=gcc4.3
-        ;;
-      *4.2.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.2 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-4.2 >>>" >&6; }
-        GXX_VERSION=gcc4.2
-        ;;
-      *4.1.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.1 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-4.1 >>>" >&6; }
-        GXX_VERSION=gcc4.1
-        ;;
-      *4.0.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.0 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-4.0 >>>" >&6; }
-        GXX_VERSION=gcc4.0
-        ;;
-      *3.4.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-3.4 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-3.4 >>>" >&6; }
-        GXX_VERSION=gcc3.4
-        ;;
-      *3.3.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-3.3 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-3.3 >>>" >&6; }
-        GXX_VERSION=gcc3.3
-        ;;
-      *3.2.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-3.2 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-3.2 >>>" >&6; }
-        GXX_VERSION=gcc3.2
-        ;;
-      *3.1.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-3.1 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-3.1 >>>" >&6; }
-        GXX_VERSION=gcc3.1
-        ;;
-      *3.0.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-3.0 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-3.0 >>>" >&6; }
-        GXX_VERSION=gcc3.0
-        ;;
-      *2.97*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-2.97 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-2.97 >>>" >&6; }
-        GXX_VERSION=gcc2.97
-        ;;
-      *2.96*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-2.96 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-2.96 >>>" >&6; }
-        GXX_VERSION=gcc2.96
-
-$as_echo "#define BROKEN_IOSTREAM 1" >>confdefs.h
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library for broken iostream >>>" >&5
-$as_echo "<<< Configuring library for broken iostream >>>" >&6; }
-        ;;
-      *2.95*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-2.95 >>>" >&5
-$as_echo "<<< C++ compiler is gcc-2.95 >>>" >&6; }
-        GXX_VERSION=gcc2.95
-
-$as_echo "#define BROKEN_IOSTREAM 1" >>confdefs.h
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library for broken iostream >>>" >&5
-$as_echo "<<< Configuring library for broken iostream >>>" >&6; }
-        ;;
-      *"egcs-1.1"*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is egcs-1.1 >>>" >&5
-$as_echo "<<< C++ compiler is egcs-1.1 >>>" >&6; }
-        GXX_VERSION=egcs1.1
-        ;;
-      *2.4* | *2.5* | *2.6* | *2.7* | *2.8*)
-        # These compilers are too old to support a useful subset
-        # of modern C++, so we don't support them
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is $GXX_VERSION_STRING >>>" >&5
-$as_echo "<<< C++ compiler is $GXX_VERSION_STRING >>>" >&6; }
-        as_fn_error $? "<<< C++ compiler is not supported >>>" "$LINENO" 5
-        ;;
       *)
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is unknown but accepted gcc version >>>" >&5
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is unknown but accepted gcc version >>>" >&5
 $as_echo "<<< C++ compiler is unknown but accepted gcc version >>>" >&6; }
-  GXX_VERSION=gcc-other
-  ;;
-    esac
-    # Check for Apple compilers
-    case "$GXX_VERSION_STRING" in
-      *Apple*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is built by Apple >>>" >&5
-$as_echo "<<< C++ compiler is built by Apple >>>" >&6; }
-        APPLE_GCC=true
-        ;;
-      *)
-        APPLE_GCC=false
+        GXX_VERSION=gcc-other
         ;;
     esac
-  else
-    # Check other (non-gcc) compilers
 
-    # Check for IBM xlC. For some reasons, depending on some environment
-    # variables, moon position, and other reasons unknown to me, the
-    # compiler displays different names in the first line of output, so
-    # check various possibilities.  Calling xlC with no arguments displays
-    # the man page.  Grepping for case-sensitive xlc is not enough if the
-    # user wants xlC, so we used case-insensitive grep instead.
+        compiler_brand_detected=yes
+  fi
+
+    if (test "x$compiler_brand_detected" = "xno"); then
+    clang_version="`($CXX --version 2>&1)`"
+    is_clang="`echo $clang_version | grep 'clang'`"
+
+    if test "x$is_clang" != "x" ; then
+                        is_apple_clang="`echo $clang_version | grep 'Apple'`"
+      clang_vendor="clang"
+      if test "x$is_apple_clang" != "x" ; then
+        clang_vendor="Apple clang"
+      fi
+
+                  clang_major_minor=unknown
+
+      if test "x$PERL" != "x" ; then
+         clang_major_minor=`echo $clang_version | $PERL -ne 'print $1 if /version\s(\d+\.\d+)/'`
+         if test "x$clang_major_minor" = "x" ; then
+           clang_major_minor=unknown
+         fi
+      fi
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&5
+$as_echo "<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&6; }
+      GXX_VERSION=clang
+      compiler_brand_detected=yes
+    fi
+  fi
+
+    if (test "x$compiler_brand_detected" = "xno"); then
+    is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
+    if test "x$is_intel_icc" != "x" ; then
+      GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
+      case "$GXX_VERSION_STRING" in
+        *18.*)
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 18 >>>" >&5
+$as_echo "<<< C++ compiler is Intel(R) icc 18 >>>" >&6; }
+          GXX_VERSION=intel_icc_v18.x
+          ;;
+        *17.*)
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 17 >>>" >&5
+$as_echo "<<< C++ compiler is Intel(R) icc 17 >>>" >&6; }
+          GXX_VERSION=intel_icc_v17.x
+          ;;
+        *16.*)
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 16 >>>" >&5
+$as_echo "<<< C++ compiler is Intel(R) icc 16 >>>" >&6; }
+          GXX_VERSION=intel_icc_v16.x
+          ;;
+        *15.*)
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 15 >>>" >&5
+$as_echo "<<< C++ compiler is Intel(R) icc 15 >>>" >&6; }
+          GXX_VERSION=intel_icc_v15.x
+          ;;
+        *14.*)
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 14 >>>" >&5
+$as_echo "<<< C++ compiler is Intel(R) icc 14 >>>" >&6; }
+          GXX_VERSION=intel_icc_v14.x
+          ;;
+        *13.*)
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 13 >>>" >&5
+$as_echo "<<< C++ compiler is Intel(R) icc 13 >>>" >&6; }
+          GXX_VERSION=intel_icc_v13.x
+          ;;
+      esac
+      compiler_brand_detected=yes
+    fi
+  fi
+
+              if (test "x$compiler_brand_detected" = "xno"); then
     is_ibm_xlc="`($CXX 2>&1) | egrep -i 'xlc'`"
     if test "x$is_ibm_xlc" != "x"  ; then
-      # IBM's C++ compiler.
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is IBM xlC >>>" >&5
 $as_echo "<<< C++ compiler is IBM xlC >>>" >&6; }
       GXX_VERSION=ibm_xlc
-    else
-
-      # Check whether we are dealing with the MIPSpro C++ compiler
-      is_mips_pro="`($CXX -version 2>&1) | grep MIPSpro`"
-      if test "x$is_mips_pro" != "x" ; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is MIPSpro C++ compiler >>>" >&5
-$as_echo "<<< C++ compiler is MIPSpro C++ compiler >>>" >&6; }
-        GXX_VERSION=MIPSpro
-      else
-
-        # Intel's ICC C++ compiler for Itanium?
-        is_intel_ecc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Itanium(R)' | grep 'Compiler'`"
-        if test "x$is_intel_ecc" = "x" ; then
-          is_intel_ecc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'IA-64' | grep 'Compiler'`"
-        fi
-        if test "x$is_intel_ecc" != "x" ; then
-          GXX_VERSION_STRING="`($CXX -V -help 2>&1) | grep 'Version '`"
-          case "$GXX_VERSION_STRING" in
-            *10.1*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel Itanium ICC 10.1 >>>" >&5
-$as_echo "<<< C++ compiler is Intel Itanium ICC 10.1 >>>" >&6; }
-              GXX_VERSION=intel_itanium_icc_v10.1
-              ;;
-            *10.0*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel Itanium ICC 10.0 >>>" >&5
-$as_echo "<<< C++ compiler is Intel Itanium ICC 10.0 >>>" >&6; }
-              GXX_VERSION=intel_itanium_icc_v10.0
-              ;;
-            *9.1*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel Itanium ICC 9.1 >>>" >&5
-$as_echo "<<< C++ compiler is Intel Itanium ICC 9.1 >>>" >&6; }
-              GXX_VERSION=intel_itanium_icc_v9.1
-              ;;
-            *9.0*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel Itanium ICC 9.0 >>>" >&5
-$as_echo "<<< C++ compiler is Intel Itanium ICC 9.0 >>>" >&6; }
-              GXX_VERSION=intel_itanium_icc_v9.0
-              ;;
-            *8.1*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel Itanium ICC 8.1 >>>" >&5
-$as_echo "<<< C++ compiler is Intel Itanium ICC 8.1 >>>" >&6; }
-              GXX_VERSION=intel_itanium_icc_v8.1
-              ;;
-            *8.0*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel Itanium ICC 8.0 >>>" >&5
-$as_echo "<<< C++ compiler is Intel Itanium ICC 8.0 >>>" >&6; }
-              GXX_VERSION=intel_itanium_icc_v8.0
-              ;;
-            *7.1*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel Itanium ICC 7.1 >>>" >&5
-$as_echo "<<< C++ compiler is Intel Itanium ICC 7.1 >>>" >&6; }
-              GXX_VERSION=intel_itanium_icc_v7.1
-              ;;
-            *7.0*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel Itanium ICC 7.0 >>>" >&5
-$as_echo "<<< C++ compiler is Intel Itanium ICC 7.0 >>>" >&6; }
-              GXX_VERSION=intel_itanium_icc_v7.0
-              ;;
-          esac
-        else
-
-          # Intel's ICC C++ compiler?
-          is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
-          if test "x$is_intel_icc" != "x" ; then
-            GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
-            case "$GXX_VERSION_STRING" in
-              *18.*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 18 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 18 >>>" >&6; }
-                GXX_VERSION=intel_icc_v18.x
-                ;;
-              *17.*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 17 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 17 >>>" >&6; }
-                GXX_VERSION=intel_icc_v17.x
-                ;;
-              *16.*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 16 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 16 >>>" >&6; }
-                GXX_VERSION=intel_icc_v16.x
-                ;;
-              *15.*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 15 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 15 >>>" >&6; }
-                GXX_VERSION=intel_icc_v15.x
-                ;;
-              *14.*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 14 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 14 >>>" >&6; }
-                GXX_VERSION=intel_icc_v14.x
-                ;;
-              *13.*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 13 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 13 >>>" >&6; }
-                GXX_VERSION=intel_icc_v13.x
-                ;;
-              *12.1*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 12.1 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 12.1 >>>" >&6; }
-                GXX_VERSION=intel_icc_v12.x
-                ;;
-              *12.*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 12 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 12 >>>" >&6; }
-                GXX_VERSION=intel_icc_v12.x
-                ;;
-              *11.*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 11 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 11 >>>" >&6; }
-                GXX_VERSION=intel_icc_v11.x
-                ;;
-              *10.1*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 10.1 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 10.1 >>>" >&6; }
-                GXX_VERSION=intel_icc_v10.1
-                ;;
-              *10.0*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 10.0 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 10.0 >>>" >&6; }
-                GXX_VERSION=intel_icc_v10.0
-                ;;
-              *9.1*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 9.1 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 9.1 >>>" >&6; }
-                GXX_VERSION=intel_icc_v9.1
-                ;;
-              *9.0*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 9.0 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 9.0 >>>" >&6; }
-                GXX_VERSION=intel_icc_v9.0
-                ;;
-              *8.1*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 8.1 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 8.1 >>>" >&6; }
-                GXX_VERSION=intel_icc_v8.1
-                ;;
-              *8.0*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 8.0 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 8.0 >>>" >&6; }
-                GXX_VERSION=intel_icc_v8.0
-                ;;
-              *7.1*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 7.1 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 7.1 >>>" >&6; }
-                GXX_VERSION=intel_icc_v7.1
-                ;;
-              *7.0*)
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 7.0 >>>" >&5
-$as_echo "<<< C++ compiler is Intel(R) icc 7.0 >>>" >&6; }
-                GXX_VERSION=intel_icc_v7.0
-                ;;
-            esac
-          else
-
-          # Or Compaq's cxx compiler?
-          is_dec_cxx="`($CXX -V 2>&1) | grep 'Compaq C++'`"
-          if test "x$is_dec_cxx" != "x" ; then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Compaq cxx >>>" >&5
-$as_echo "<<< C++ compiler is Compaq cxx >>>" >&6; }
-            GXX_VERSION=compaq_cxx
-          else
-
-            # Sun Studio?
-            is_sun_cc="`($CXX -V 2>&1) | grep 'Sun C++'`"
-            if test "x$is_sun_cc" != "x" ; then
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Sun Studio compiler >>>" >&5
-$as_echo "<<< C++ compiler is Sun Studio compiler >>>" >&6; }
-              GXX_VERSION=sun_studio
-            else
-
-              # Sun Forte?
-              is_sun_forte_cc="`($CXX -V 2>&1) | grep 'Forte'`"
-              if test "x$is_sun_forte_cc" != "x" ; then
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Sun Forte compiler >>>" >&5
-$as_echo "<<< C++ compiler is Sun Forte compiler >>>" >&6; }
-                GXX_VERSION=sun_forte
-              else
-
-                # Cray C++?
-                is_cray_cc="`($CXX -V 2>&1) | grep 'Cray '`"
-                if test "x$is_cray_cc" != "x" ; then
-                  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Cray C++ >>>" >&5
-$as_echo "<<< C++ compiler is Cray C++ >>>" >&6; }
-                  GXX_VERSION=cray_cc
-                else
-
-                  # Portland Group C++?
-                  is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group'`"
-                  if test "x$is_pgcc" != "x" ; then
-                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Portland Group C++ >>>" >&5
-$as_echo "<<< C++ compiler is Portland Group C++ >>>" >&6; }
-                    GXX_VERSION=portland_group
-                  else
-
-                    # HP-UX 11.11 aCC?
-                    is_hpux_acc="`($CXX -V 2>&1) | grep 'aCC: HP ANSI C++'`"
-                    if test "x$is_hpux_acc" != "x" ; then
-                      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is HP-UX C++ >>>" >&5
-$as_echo "<<< C++ compiler is HP-UX C++ >>>" >&6; }
-                      GXX_VERSION=hpux_acc
-                    else
-
-                      # Clang/LLVM C++?
-                      clang_version="`($CXX --version 2>&1)`"
-                      is_clang="`echo $clang_version | grep 'clang'`"
-
-                        if test "x$is_clang" != "x" ; then
-                          # Detect if clang is the version built by
-                          # Apple, because then the version number means
-                          # something different...
-                          is_apple_clang="`echo $clang_version | grep 'Apple'`"
-                          clang_vendor="clang"
-                          if test "x$is_apple_clang" != "x" ; then
-                            clang_vendor="Apple clang"
-                          fi
-
-                          # If we have perl, we can also pull out the clang version number using regexes.
-                          # Note that $ is a quadrigraph for the dollar sign.
-                          clang_major_minor=unknown
-
-                          if test "x$PERL" != "x" ; then
-                             clang_major_minor=`echo $clang_version | $PERL -ne 'print $1 if /version\s(\d+\.\d+)/'`
-                             if test "x$clang_major_minor" = "x" ; then
-                               clang_major_minor=unknown
-                             fi
-                          fi
-
-                          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&5
-$as_echo "<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&6; }
-                          GXX_VERSION=clang
-                        else
-
-                          # No recognized compiler found...
-                          # warn the user and continue
-                          { $as_echo "$as_me:${as_lineno-$LINENO}: result: WARNING:" >&5
-$as_echo "WARNING:" >&6; }
-                          { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Unrecognized compiler: \"$CXX\" <<<" >&5
-$as_echo ">>> Unrecognized compiler: \"$CXX\" <<<" >&6; }
-                          { $as_echo "$as_me:${as_lineno-$LINENO}: result: You will likely need to modify" >&5
-$as_echo "You will likely need to modify" >&6; }
-                          { $as_echo "$as_me:${as_lineno-$LINENO}: result: Make.common directly to specify" >&5
-$as_echo "Make.common directly to specify" >&6; }
-                          { $as_echo "$as_me:${as_lineno-$LINENO}: result: proper compiler flags" >&5
-$as_echo "proper compiler flags" >&6; }
-                          GXX_VERSION=unknown
-                        fi
-                      fi
-                    fi
-                  fi
-                fi
-              fi
-            fi
-          fi
-        fi
-      fi
+      compiler_brand_detected=yes
     fi
+  fi
+
+    if (test "x$compiler_brand_detected" = "xno"); then
+    is_cray_cc="`($CXX -V 2>&1) | grep 'Cray '`"
+    if test "x$is_cray_cc" != "x" ; then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Cray C++ >>>" >&5
+$as_echo "<<< C++ compiler is Cray C++ >>>" >&6; }
+      GXX_VERSION=cray_cc
+      compiler_brand_detected=yes
+    fi
+  fi
+
+    if (test "x$compiler_brand_detected" = "xno"); then
+    is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group'`"
+    if test "x$is_pgcc" != "x" ; then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Portland Group C++ >>>" >&5
+$as_echo "<<< C++ compiler is Portland Group C++ >>>" >&6; }
+      GXX_VERSION=portland_group
+      compiler_brand_detected=yes
+    fi
+  fi
+
+    if (test "x$compiler_brand_detected" = "xno"); then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: WARNING:" >&5
+$as_echo "WARNING:" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Unrecognized compiler: \"$CXX\" <<<" >&5
+$as_echo ">>> Unrecognized compiler: \"$CXX\" <<<" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: You will likely need to modify" >&5
+$as_echo "You will likely need to modify" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: Make.common directly to specify" >&5
+$as_echo "Make.common directly to specify" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: proper compiler flags" >&5
+$as_echo "proper compiler flags" >&6; }
+    GXX_VERSION=unknown
   fi
 
 
@@ -7549,65 +7283,19 @@ fi
 
   # First the flags for gcc compilers
   if (test "$GXX" = yes -a "x$REAL_GXX" != "x" ) ; then
-    CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors"
-    CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized"
-    CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses"
+    CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -funroll-loops -fstrict-aliasing -Wdisabled-optimization"
+    CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -funroll-loops -fstrict-aliasing -Woverloaded-virtual -Wdisabled-optimization"
+    CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Woverloaded-virtual"
     NODEPRECATEDFLAG="-Wno-deprecated"
 
-    CFLAGS_OPT="-O2"
-    CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit"
+    CFLAGS_OPT="-O2 -funroll-loops -fstrict-aliasing"
+    CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -funroll-loops -fstrict-aliasing"
     CFLAGS_DBG="-g -Wimplicit"
     ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm"
 
-    # set some flags that are specific to some versions of the
-    # compiler:
-    # - egcs1.1 yielded incorrect code with some loop unrolling
-    # - after egcs1.1, the optimization flag -fstrict-aliasing was
-    #   introduced, which enables better optimizations for
-    #   well-written C++ code. (Your code *is* well-written, right?)
-
-    case "$GXX_VERSION" in
-      egcs1.1)
-          ;;
-
-      # All other gcc versions
-      *)
-          CXXFLAGS_OPT="$CXXFLAGS_OPT -funroll-loops -fstrict-aliasing"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -funroll-loops -fstrict-aliasing"
-
-          CFLAGS_OPT="$CFLAGS_OPT -funroll-loops -fstrict-aliasing"
-          CFLAGS_DEVEL="$CFLAGS_DEVEL -funroll-loops -fstrict-aliasing"
-          ;;
-    esac
-
-
-    case "$GXX_VERSION" in
-      # - after gcc2.95, some flags were deemed obsolete for C++
-      #   (and are only supported for C any more), so only define them for
-      #   previous compilers
-      egcs1.1 | gcc2.95)
-         CXXFLAGS_OPT="$CXXFLAGS_OPT -fnonnull-objects"
-         CXXFLAGS_DBG="$CXXFLAGS_DBG -Wmissing-declarations -Wbad-function-cast -Wtraditional -Wnested-externs"
-         ;;
-
-      # - define additional debug flags for newer versions of gcc which support them.
-      #
-      # Note:  do not use -Wold-style-cast...  creates a lot of unavoidable warnings
-      #        when dealing with C APIs that take void* pointers.
-      gcc3.* | gcc4.* | gcc5 | gcc6)
-        CXXFLAGS_OPT="$CXXFLAGS_OPT -Wdisabled-optimization"
-        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Woverloaded-virtual -Wdisabled-optimization"
-        CXXFLAGS_DBG="$CXXFLAGS_DBG -Woverloaded-virtual"
-
-        if (test "x$enableglibcxxdebugging" = "xyes"); then
-          CPPFLAGS_DBG="$CPPFLAGS_DBG -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC"
-        fi
-        ;;
-
-      *)
-        ;;
-    esac
-
+    if (test "x$enableglibcxxdebugging" = "xyes"); then
+      CPPFLAGS_DBG="$CPPFLAGS_DBG -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC"
+    fi
 
     # GCC 4.6.3 warns about variadic macros but supports them just
     # fine, so let's turn off that warning.
@@ -7652,26 +7340,6 @@ fi
           CFLAGS_DEVEL="$CFLAGS_DBG"
           ;;
 
-      MIPSpro)
-          CXXFLAGS_OPT="-LANG:std -LANG:libc_in_namespace_std -no_auto_include -ansi -O2 -w"
-          CXXFLAGS_DBG="-LANG:std -LANG:libc_in_namespace_std -no_auto_include -ansi -g -woff 1460"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-          NODEPRECATEDFLAG=""
-          CFLAGS_OPT="-O2 -w"
-          CFLAGS_DBG="-g"
-          CFLAGS_DEVEL="$CFLAGS_DBG"
-
-          # For some reason, CC forgets to add the math lib to the
-          # linker line, so we do that ourselves
-          LDFLAGS="$LDFLAGS -lm"
-
-          # Augment CXXFLAGS to include -LANG:std if not there.  This is
-          # needed to compile the remaining configure tests
-          if test "x`echo $CXXFLAGS | grep 'LANG:std'`" = "x" ; then
-            CXXFLAGS="$CXXFLAGS -LANG:std"
-          fi
-          ;;
-
       # All Intel ICC/ECC flavors
       intel_*)
 
@@ -7690,8 +7358,8 @@ fi
         # Specific flags for specific versions
         case "$GXX_VERSION" in
 
-          # Intel ICC >= v11.x
-          intel_icc_v11.x | intel_icc_v12.x | intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x)
+          # Intel ICC >= v13.x
+          intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x)
               # Disable some warning messages:
               # #161: 'unrecognized #pragma
               #       #pragma GCC diagnostic warning "-Wdeprecated-declarations"'
@@ -7723,227 +7391,12 @@ fi
               CFLAGS_DEVEL="$CFLAGS_DBG"
               ;;
 
-          intel_icc_v10.1)
-              # Disable some warning messages:
-              # #175: 'subscript out of range'
-              #       FIN-S application code causes many false
-              #       positives with this
-              # #266: 'function declared implicitly'
-              #       Metis function "GKfree" caused this error
-              #       in almost every file.
-              # #1476: 'field uses tail padding of a base class'
-              # #1505: 'size of class is affected by tail padding'
-              #        simply warns of a possible incompatibility with
-              #        the g++ ABI for this case
-              # #1572: 'floating-point equality and inequality comparisons are unreliable'
-              #        Well, duh, when the tested value is computed...  OK when it
-              #        was from an assignment.
-              PROFILING_FLAGS="-p"
-              CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572"
-              CXXFLAGS_OPT="$CXXFLAGS_OPT -O3 -unroll -w0 -ftz -par_report0 -openmp_report0"
-              CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -w1 -g -wd175 -wd1476 -wd1505 -wd1572"
-              CFLAGS_DBG="$CFLAGS_DBG -w1 -g -wd266 -wd1572"
-              CFLAGS_OPT="$CFLAGS_OPT -O3 -unroll -w0 -ftz -par_report0 -openmp_report0"
-              CFLAGS_DEVEL="$CFLAGS_DBG"
-              ;;
-
-          # Intel ICC >= 10.0
-          intel_icc_v10.0)
-              # Disable some warning messages:
-              # #266: 'function declared implicitly'
-              #       Metis function "GKfree" caused this error
-              #       in almost every file.
-              # #1572: 'floating-point equality and inequality comparisons are unreliable'
-              #        Well, duh, when the tested value is computed...  OK when it
-              #        was from an assignment.
-              # Note: In Version 8.1 (and possibly newer?) the -inline_debug_info
-              #       option causes a segmentation fault in libmesh.C, probably others...
-
-              # CPU-specific flags: -axK is for ia32, -xW is for x86_64
-              INTEL_AX_FLAG="-tpp6 -axK"
-              if test $target_cpu = "x86_64" ; then
-                INTEL_AX_FLAG="-xW"
-              fi
-
-              PROFILING_FLAGS="-p"
-              CXXFLAGS_DBG="$CXXFLAGS_DBG -Kc++eh -Krtti -O1 -w1 -g -wd504 -wd1572"
-              CXXFLAGS_OPT="$CXXFLAGS_OPT -Kc++eh -Krtti -O2 $INTEL_AX_FLAG -unroll -w0 -vec_report0 -par_report0 -openmp_report0"
-              CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-              CFLAGS_DBG="$CFLAGS_DBG -w1 -g -inline_debug_info -wd266 -wd1572"
-              CFLAGS_OPT="$CFLAGS_OPT -O2 $INTEL_AX_FLAG -unroll -w0 -vec_report0 -par_report0 -openmp_report0"
-              CFLAGS_DEVEL="$CFLAGS_DBG"
-              ;;
-
-          # Intel ICC >= 8.1
-          intel_icc_v8.1 | intel_icc_v9.0 | intel_icc_v9.1 | intel_icc_v10.0)
-              # Disable some warning messages:
-              # #266: 'function declared implicitly'
-              #       Metis function "GKfree" caused this error
-              #       in almost every file.
-              # #1572: 'floating-point equality and inequality comparisons are unreliable'
-              #        Well, duh, when the tested value is computed...  OK when it
-              #        was from an assignment.
-              # Note: In Version 8.1 (and possibly newer?) the -inline_debug_info
-              #       option causes a segmentation fault in libmesh.C, probably others...
-
-              # CPU-specific flags: -axK is for ia32, -xW is for x86_64
-              INTEL_AX_FLAG="-tpp6 -axK"
-              if test $target_cpu = "x86_64" ; then
-                INTEL_AX_FLAG="-xW"
-              fi
-
-              CXXFLAGS_DBG="$CXXFLAGS_DBG -Kc++eh -Krtti -O1 -w1 -g -wd504 -wd1572"
-              CXXFLAGS_OPT="$CXXFLAGS_OPT -Kc++eh -Krtti -O2 -Ob2 $INTEL_AX_FLAG -unroll -w0 -vec_report0 -par_report0 -openmp_report0"
-              CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-              CFLAGS_DBG="$CFLAGS_DBG -w1 -g -inline_debug_info -wd266 -wd1572"
-              CFLAGS_OPT="$CFLAGS_OPT -O2 -Ob2 $INTEL_AX_FLAG -unroll -w0 -vec_report0 -par_report0 -openmp_report0"
-              CFLAGS_DEVEL="$CFLAGS_DBG"
-              ;;
-
-          # Intel ICC < v8.1
-          intel_icc*)
-              # Disable some warning messages:
-              # #266: 'function declared implicitly'
-              #       Metis function "GKfree" caused this error
-              #       in almost every file.
-              CXXFLAGS_OPT="-Kc++eh -Krtti -O2 -Ob2 -tpp6 -axiMK -unroll -w0 -vec_report0 -par_report0 -openmp_report0"
-              CXXFLAGS_DEVEL="-Kc++eh -Krtti -O1 -w1 -inline_debug_info -g -wd504"
-              CXXFLAGS_DBG="-Kc++eh -Krtti -O0 -w1 -inline_debug_info -g -wd504"
-              CFLAGS_DBG="-w1 -inline_debug_info -wd266"
-              CFLAGS_OPT="-O2 -Ob2 -tpp6 -axiMK -unroll -w0 -vec_report0 -par_report0 -openmp_report0"
-              CFLAGS_DEVEL="$CFLAGS_DBG"
-              ;;
-
-          # Intel Itanium ICC >= v10.1
-          intel_itanium_icc_v10.1)
-              # Disable some warning messages:
-              # #266: 'function declared implicitly'
-              #       Metis function "GKfree" caused this error
-              #       in almost every file.
-              # #1476: 'field uses tail padding of a base class'
-              # #1505: 'size of class is affected by tail padding'
-              #        simply warns of a possible incompatibility with
-              #        the g++ ABI for this case
-              # #1572: 'floating-point equality and inequality comparisons are unreliable'
-              #        Well, duh, when the tested value is computed...  OK when it
-              #        was from an assignment.
-              CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -inline_debug_info -g -wd1476 -wd1505 -wd1572"
-              CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -unroll -w0 -ftz -par_report0 -openmp_report0"
-              CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-              CFLAGS_DBG="$CFLAGS_DBG -w1 -inline_debug_info -g -wd266 -wd1572"
-              CFLAGS_OPT="$CFLAGS_OPT -O2 -unroll -w0 -ftz -par_report0 -openmp_report0"
-              CFLAGS_DEVEL="$CFLAGS_DBG"
-              ;;
-
-          intel_itanium_icc_v8.1 | intel_itanium_icc_v9.0 | intel_itanium_icc_v9.1 | intel_itanium_icc_v10.0)
-              # Disable some warning messages:
-              # #266: 'function declared implicitly'
-              #       Metis function "GKfree" caused this error
-              #       in almost every file.
-              # #1476: 'field uses tail padding of a base class'
-              # #1505: 'size of class is affected by tail padding'
-              #        simply warns of a possible incompatibility with
-              #        the g++ ABI for this case
-              # #1572: 'floating-point equality and inequality comparisons are unreliable'
-              #        Well, duh, when the tested value is computed...  OK when it
-              #        was from an assignment.
-              CXXFLAGS_DBG="$CXXFLAGS_DBG -Kc++eh -Krtti -w1 -inline_debug_info -g -wd1476 -wd1505 -wd1572"
-              CXXFLAGS_OPT="$CXXFLAGS_OPT -Kc++eh -Krtti -O2 -unroll -w0 -ftz -par_report0 -openmp_report0"
-              CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-              CFLAGS_DBG="$CFLAGS_DBG -w1 -inline_debug_info -g -wd266 -wd1572"
-              CFLAGS_OPT="$CFLAGS_OPT -O2 -unroll -w0 -ftz -par_report0 -openmp_report0"
-              CFLAGS_DEVEL="$CFLAGS_DBG"
-              ;;
-
-          # Intel Itanium ICC < v8.1
-          intel_itanium_icc*)
-              # Disable some warning messages:
-              # #266: 'function declared implicitly'
-              #       Metis function "GKfree" caused this error
-              #       in almost every file.
-              CXXFLAGS_DBG="-Kc++eh -Krtti -w1 -inline_debug_info -g"
-              CXXFLAGS_OPT="-Kc++eh -Krtti -O2 -unroll -w0 -ftz"
-              CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-              CFLAGS_DBG="-w1 -inline_debug_info -g -wd266"
-              CFLAGS_OPT="-O2 -unroll -w0 -ftz"
-              CFLAGS_DEVEL="$CFLAGS_DBG"
-              ;;
-
           *)
               { $as_echo "$as_me:${as_lineno-$LINENO}: result: Unknown Intel compiler" >&5
 $as_echo "Unknown Intel compiler" >&6; }
               ;;
         esac
       ;;
-
-      compaq_cxx)
-          # Disable some warning messages:
-          # #175: `subscript out of range' (detected when instantiating a
-          #       template and looking at the indices of an array of
-          #       template dependent size, this error is triggered in a
-          #       branch that is not taken for the present space dimension)
-          # #236 and
-          # #237: `controlling expression is constant' (in while(true), or
-          #       switch(dim))
-          # #487: `Inline function ... cannot be explicitly instantiated'
-          #       (also reported when we instantiate the entire class)
-          # #1136:`conversion to integral type of smaller size could lose data'
-          #       (occurs rather often in addition of int and x.size(),
-          #       because the latter is size_t=long unsigned int on Alpha)
-          # #1156:`meaningless qualifiers not compatible with "..." and "..."'
-          #       (cause unknown, happens when taking the address of a
-          #       template member function)
-          # #111 and
-          # #1182:`statement either is unreachable or causes unreachable code'
-          #       (happens in switch(dim) clauses for other dimensions than
-          #       the present one)
-          #
-          # Also disable the following error:
-          # #265: `class "..." is inaccessible' (happens when we try to
-          #       initialize a static member variable in terms of another
-          #       static member variable of the same class if the latter is
-          #       not public and therefore not accessible at global scope in
-          #       general. I nevertheless think that this is valid.)
-          #
-          # Besides this, choose the most standard conforming mode of the
-          # compiler, i.e. -model ansi and -std strict_ansi. Unfortunately,
-          # we have to also add the flag -implicit_local (generating implicit
-          # instantiations of template with the `weak' link flag) since
-          # otherwise not all templates are instantiated (also some from the
-          # standards library are missing).
-
-          CXXFLAGS_DBG="-nousing_std -nocurrent_include -model ansi -std strict_ansi -w1 -msg_display_number -timplicit_local"
-          CXXFLAGS_OPT="-nousing_std -nocurrent_include -model ansi -std strict_ansi -w2 -msg_display_number -timplicit_local -O2 -fast"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-          CFLAGS_DBG="-w1 -msg_display_number -timplicit_local"
-          CFLAGS_OPT="-w2 -msg_display_number -timplicit_local -O2 -fast"
-          CFLAGS_DEVEL="$CFLAGS_DBG"
-
-          NODEPRECATEDFLAG=""
-
-          for i in 175 236 237 487 1136 1156 111 1182 265 ; do
-            CXXFLAGS_DBG="$CXXFLAGS_DBG -msg_disable $i"
-            CXXFLAGS_OPT="$CXXFLAGS_OPT -msg_disable $i"
-            CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -msg_disable $i"
-          done
-
-          # For some reason, cxx also forgets to add the math lib to the
-          # linker line, so we do that ourselves
-          LDFLAGS="$LDFLAGS -lm"
-          ;;
-
-      sun_studio | sun_forte)
-          CXXFLAGS_DBG="-library=stlport4 -g"
-          CXXFLAGS_OPT="-library=stlport4 -fast -xO4"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-          NODEPRECATEDFLAG=""
-          CFLAGS_DBG="-g"
-          CFLAGS_OPT="-xO4"
-          CFLAGS_DEVEL="$CFLAGS_DBG"
-
-          # librpcsvc for XDR
-          LIBS="-lrpcsvc $LIBS"
-          ;;
 
       portland_group)
           CXXFLAGS_DBG="-g --no_using_std"
@@ -7962,32 +7415,6 @@ $as_echo "Unknown Intel compiler" >&6; }
             CXXFLAGS_DBG="$CXXFLAGS_DBG --no_exceptions"
             CXXFLAGS_OPT="$CXXFLAGS_OPT --no_exceptions"
           fi
-          ;;
-
-      hpux_acc)
-          # This is for aCC A.03.31
-          # +DA2.0W requires that the code is only working on
-          #  PA-RISC 2.0 systems, i.e. for 64bit
-          # -ext allows various C++ extensions
-          # +z Cause the compiler to generate position independent
-          #  code (PIC) for use in building shared libraries.
-          #  However, currently only static lib seems to work.
-          # for aCC:
-          #  -Aa turns on  newly supported ANSI C++ Standard features
-          #  -AA turns on full new ANSI C++ (this includes -Aa)
-          # for cc:
-          #  -Aa compiles under true ANSI mode
-          #  -Ae turns on ANSI C with some HP extensions
-          CXXFLAGS_DBG="+DA2.0W -AA +z -ext -g"
-          CXXFLAGS_OPT="+DA2.0W -AA +z -ext -O +Onolimit"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-          NODEPRECATEDFLAG=""
-          CFLAGS_DBG="+DA2.0W -Aa +z -Ae -g"
-          CFLAGS_OPT="+DA2.0W -Aa +z -Ae -O +Onolimit"
-          CFLAGS_DEVEL="$CFLAGS_DBG"
-          LDFLAGS="$LDFLAGS -I/usr/lib/pa20_64"
-          LIBS="$LIBS -lrpcsvc"
-          FLIBS="$FLIBS -lF90 -lcl -I/opt/fortran90/lib/pa20_64"
           ;;
 
       cray_cc)

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -18,9 +18,6 @@
 /* size of boundary_id */
 #undef BOUNDARY_ID_BYTES
 
-/* This compiler is known not to support some iostream functionality */
-#undef BROKEN_IOSTREAM
-
 /* Architecture of the build host */
 #undef BUILD_ARCH
 


### PR DESCRIPTION
libmesh now requires C++11, so  we can drop all the configure tests for older compilers that don't support that standard.
