### PR TITLE
Work around GCC 4.9.2 issue.

### DIFF
--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -98,7 +98,7 @@ std::unique_ptr<Elem> Hex::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 
-  auto face = libmesh_make_unique<Quad4>();
+  std::unique_ptr<Elem> face = libmesh_make_unique<Quad4>();
 
   for (unsigned n=0; n<face->n_nodes(); ++n)
     face->set_node(n) = this->node_ptr(Hex8::side_nodes_map[i][n]);

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -152,7 +152,7 @@ std::unique_ptr<Elem> Hex20::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto face = libmesh_make_unique<Quad8>();
+      std::unique_ptr<Elem> face = libmesh_make_unique<Quad8>();
       face->subdomain_id() = this->subdomain_id();
 
       for (unsigned n=0; n<face->n_nodes(); ++n)

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -220,7 +220,7 @@ std::unique_ptr<Elem> Hex27::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto face = libmesh_make_unique<Quad9>();
+      std::unique_ptr<Elem> face = libmesh_make_unique<Quad9>();
       face->subdomain_id() = this->subdomain_id();
 
       for (unsigned n=0; n<face->n_nodes(); ++n)

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -127,7 +127,7 @@ std::unique_ptr<Elem> Hex8::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto face = libmesh_make_unique<Quad4>();
+      std::unique_ptr<Elem> face = libmesh_make_unique<Quad4>();
       face->subdomain_id() = this->subdomain_id();
 
       for (unsigned n=0; n<face->n_nodes(); ++n)

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -78,7 +78,7 @@ std::unique_ptr<Elem> Tet::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 
-  auto face = libmesh_make_unique<Tri3>();
+  std::unique_ptr<Elem> face = libmesh_make_unique<Tri3>();
 
   for (unsigned n=0; n<face->n_nodes(); ++n)
     face->set_node(n) = this->node_ptr(Tet4::side_nodes_map[i][n]);

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -174,7 +174,7 @@ std::unique_ptr<Elem> Tet10::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto face = libmesh_make_unique<Tri6>();
+      std::unique_ptr<Elem> face = libmesh_make_unique<Tri6>();
       face->subdomain_id() = this->subdomain_id();
 
       for (unsigned n=0; n<face->n_nodes(); ++n)

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -137,7 +137,7 @@ std::unique_ptr<Elem> Tet4::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto face = libmesh_make_unique<Tri3>();
+      std::unique_ptr<Elem> face = libmesh_make_unique<Tri3>();
       face->subdomain_id() = this->subdomain_id();
 
       for (unsigned n=0; n<face->n_nodes(); ++n)

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -36,7 +36,7 @@ unsigned int Edge::which_node_am_i(unsigned int side,
 std::unique_ptr<Elem> Edge::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, 2);
-  auto nodeelem = libmesh_make_unique<NodeElem>(this);
+  std::unique_ptr<Elem> nodeelem = libmesh_make_unique<NodeElem>(this);
   nodeelem->set_node(0) = this->node_ptr(i);
   return nodeelem;
 }
@@ -45,7 +45,7 @@ std::unique_ptr<Elem> Edge::side_ptr (const unsigned int i)
 std::unique_ptr<Elem> Edge::build_side_ptr (const unsigned int i, bool)
 {
   libmesh_assert_less (i, 2);
-  auto nodeelem = libmesh_make_unique<NodeElem>(this);
+  std::unique_ptr<Elem> nodeelem = libmesh_make_unique<NodeElem>(this);
   nodeelem->set_node(0) = this->node_ptr(i);
   return nodeelem;
 }

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -85,7 +85,7 @@ std::unique_ptr<Elem> Quad::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 
-  auto edge = libmesh_make_unique<Edge2>();
+  std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
 
   for (unsigned n=0; n<edge->n_nodes(); ++n)
     edge->set_node(n) = this->node_ptr(Quad4::side_nodes_map[i][n]);

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -134,7 +134,7 @@ std::unique_ptr<Elem> Quad4::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto edge = libmesh_make_unique<Edge2>();
+      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -208,7 +208,7 @@ std::unique_ptr<Elem> Quad8::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto edge = libmesh_make_unique<Edge3>();
+      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge3>();
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -226,7 +226,7 @@ std::unique_ptr<Elem> Quad9::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto edge = libmesh_make_unique<Edge3>();
+      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge3>();
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -83,7 +83,7 @@ std::unique_ptr<Elem> Tri::side_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_sides());
 
-  auto edge = libmesh_make_unique<Edge2>();
+  std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
 
   for (unsigned n=0; n<edge->n_nodes(); ++n)
     edge->set_node(n) = this->node_ptr(Tri3::side_nodes_map[i][n]);

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -116,7 +116,7 @@ std::unique_ptr<Elem> Tri3::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto edge = libmesh_make_unique<Edge2>();
+      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge2>();
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -192,7 +192,7 @@ std::unique_ptr<Elem> Tri6::build_side_ptr (const unsigned int i,
 
   else
     {
-      auto edge = libmesh_make_unique<Edge3>();
+      std::unique_ptr<Elem> edge = libmesh_make_unique<Edge3>();
       edge->subdomain_id() = this->subdomain_id();
 
       // Set the nodes


### PR DESCRIPTION
This compiler doesn't like the combination of auto-declared variables
and returning `unique_ptr<Derived>` as `unique_ptr<Base>`. Newer compilers
accept this code just fine, so presumably it is OK, this change is
just to work around the older compiler's limitation.

In playing around with this, we discovered that return by move also
fixed the problem, but according to Meyers' "Effective Modern C++"
pg. 173-174, this would actually prevent compilers from applying the
Return Value Optimization (RVO), otherwise known as copy elision,
in this case.