### PR TITLE
Add shape and skew metrics for Quad4.

### DIFF
--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -218,7 +218,7 @@ Real Quad::quality (const ElemQuality q) const
 
         // Nodal Jacobians. These are 3x2 matrices, hence we represent
         // them by Array6.
-        std::vector<Array6> A(4);
+        std::array<Array6, 4> A;
         for (unsigned int k=0; k<4; ++k)
           {
             unsigned int
@@ -234,7 +234,7 @@ Real Quad::quality (const ElemQuality q) const
 
         // Compute metric tensors, T_k = A_k^T * A_k. These are 2x2
         // square matrices, hence we represent them by Array4.
-        std::vector<Array4> T(4);
+        std::array<Array4, 4> T;
         for (unsigned int k=0; k<4; ++k)
           {
             Real


### PR DESCRIPTION
For some simple test cases, I think these new metrics work better than the ASPECT_RATIO, DISTORTION/DIAGONAL, and STRETCH metrics we currently have.

Results with existing metrics:

ASPECT_RATIO:
![aspect](https://user-images.githubusercontent.com/1775907/34014918-10e33eec-e0da-11e7-9979-f17bf0d1cff9.png)

DISTORTION:
![distort](https://user-images.githubusercontent.com/1775907/34014926-19cd4fb6-e0da-11e7-9abe-24957fef718b.png)

STRETCH:
![stretch](https://user-images.githubusercontent.com/1775907/34014952-29e60ea6-e0da-11e7-898c-6821340b047d.png)


Results with new metrics:

SHAPE:
![shape](https://user-images.githubusercontent.com/1775907/34014998-4f20b680-e0da-11e7-8079-6237891a0411.png)

SKEW:
![skew](https://user-images.githubusercontent.com/1775907/34015006-5475cd14-e0da-11e7-872e-799a5eebbf5b.png)

Note that these metrics are in the range [0=bad,1=good] except for ASPECT_RATIO, which is always >= 1, and the larger the value, the worse the element is. I'd actually vote for the current DISTORTION metric to be removed entirely, as it seems to think the nearly triangular element in the center of the domain is OK. SHAPE and SKEW correctly flag both of these nearly triangular elements as being of relatively low quality.

This is follow-up work to #1533.
