### PR TITLE
projection_matrix() requires MetaPhysicL

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1658,6 +1658,7 @@ public:
    */
   bool & hide_output() { return _hide_output; }
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
   /**
    * This method creates a projection matrix which corresponds to the
    * operation of project_vector between old and new solution spaces.
@@ -1669,6 +1670,7 @@ public:
    * approximation of the BC, not the fine grid approximation.
    */
   void projection_matrix (SparseMatrix<Number> & proj_mat) const;
+#endif // LIBMESH_HAVE_METAPHYSICL
 
 protected:
 

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -55,11 +55,13 @@ public:
   CPPUNIT_TEST( testProjectMeshFunctionHex27 );
 
 #ifdef LIBMESH_ENABLE_AMR
+#ifdef LIBMESH_HAVE_METAPHYSICL
   CPPUNIT_TEST( testProjectMatrixEdge2 );
   CPPUNIT_TEST( testProjectMatrixQuad4 );
   CPPUNIT_TEST( testProjectMatrixTri3 );
   CPPUNIT_TEST( testProjectMatrixHex8 );
   CPPUNIT_TEST( testProjectMatrixTet4 );
+#endif // LIBMESH_HAVE_METAPHYSICL
 #endif // LIBMESH_ENABLE_AMR
 
   CPPUNIT_TEST_SUITE_END();
@@ -211,6 +213,7 @@ public:
   }
 
 #ifdef LIBMESH_ENABLE_AMR
+#ifdef LIBMESH_HAVE_METAPHYSICL
   void testProjectMatrix1D(const ElemType elem_type)
   {
     // Use ReplicatedMesh to get consistent child element node
@@ -666,6 +669,7 @@ public:
     Real diff_norm = proj_mat.linfty_norm();
     CPPUNIT_ASSERT(diff_norm/gold_norm < TOLERANCE*TOLERANCE);
   }
+#endif // LIBMESH_HAVE_METAPHYSICL
 #endif // LIBMESH_ENABLE_AMR
 
 
@@ -676,12 +680,14 @@ public:
   void testProjectMeshFunctionHex27() { testProjectCubeWithMeshFunction(HEX27); }
 
 #ifdef LIBMESH_ENABLE_AMR
+#ifdef LIBMESH_HAVE_METAPHYSICL
   // projection matrix tests
   void testProjectMatrixEdge2() { testProjectMatrix1D(EDGE2); }
   void testProjectMatrixQuad4() { testProjectMatrix2D(QUAD4); }
   void testProjectMatrixTri3() { testProjectMatrix2D(TRI3); }
   void testProjectMatrixHex8() { testProjectMatrix3D(HEX8); }
   void testProjectMatrixTet4() { testProjectMatrix3D(TET4); }
+#endif // LIBMESH_HAVE_METAPHYSICL
 #endif // LIBMESH_ENABLE_AMR
 
 };


### PR DESCRIPTION
So we shouldn't declare it or test it if we don't have MetaPhysicL
configured.

Hopefully this fixes the bugs triggered by
https://github.com/idaholab/moose/pull/10410