### PR TITLE
Updating/Fixing PetscDiffSolver reinit()

### DIFF
--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -652,11 +652,12 @@ int main (int argc, char ** argv)
                    << sensitivity_0_0
                    << std::endl;
 
-      // Hard coded assert to ensure that the actual numbers we are
+      // Hard coded test to ensure that the actual numbers we are
       // getting are what they should be
       // The 2e-4 tolerance is chosen to ensure success even with
       // 32-bit floats
-      libmesh_assert_less(std::abs(sensitivity_0_0 - (-5.37173)), 2.e-4);
+      if(std::abs(sensitivity_0_0 - (-5.37173)) >= 2.e-4)
+        libmesh_error_msg("Mismatch in sensitivity gold value!");
 
 #ifdef NDEBUG
     }

--- a/examples/adjoints/adjoints_ex5/heatsystem.C
+++ b/examples/adjoints/adjoints_ex5/heatsystem.C
@@ -164,6 +164,8 @@ void HeatSystem::perturb_accumulate_residuals(ParameterVector & parameters_in)
 {
   const unsigned int Np = parameters_in.size();
 
+  this->update();
+
   for (unsigned int j=0; j != Np; ++j)
     {
       Number old_parameter = *parameters_in[j];

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -93,6 +93,13 @@ protected:
    * Nonlinear solver context
    */
   SNES _snes;
+
+private:
+
+  /**
+   * Common helper function to setup PETSc data structures
+   */
+  void setup_petsc_data();
 };
 
 } // namespace libMesh

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -69,14 +69,12 @@ public:
   virtual void reinit () libmesh_override;
 
   /**
-   * The initialization function.  solve() calls this to create
-   * a new SNES context.
+   * The initialization function.
    */
   virtual void init () libmesh_override;
 
   /**
-   * The clear function.  solve() calls this to destroy
-   * a used SNES context.
+   * The clear function. Called if we reinit or when we destroy this object.
    */
   void clear ();
 

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -94,7 +94,13 @@ public:
 
   /**
    * Prepares \p matrix and \p rhs for matrix assembly.
-   * Users should not reimplement this
+   * Users should not reimplement this.
+   * Note that in some cases only
+   * \link current_local_solution \endlink is used during assembly,
+   * and, therefore, if \link solution \endlink has been altered
+   * without \link update() \endlink being called, then the
+   * user must call \link update() \endlink before calling
+   * this function.
    */
   virtual void assemble () libmesh_override;
 
@@ -121,6 +127,12 @@ public:
   /**
    * Assembles a residual in \p rhs and/or a jacobian in \p matrix,
    * as requested.
+   * Note that in some cases only
+   * \link current_local_solution \endlink is used during assembly,
+   * and, therefore, if \link solution \endlink has been altered
+   * without \link update() \endlink being called, then the
+   * user must call \link update() \endlink before calling
+   * this function.
    */
   virtual void assembly (bool get_residual,
                          bool get_jacobian,

--- a/include/systems/fem_system.h
+++ b/include/systems/fem_system.h
@@ -81,7 +81,13 @@ public:
   /**
    * Prepares \p matrix or \p rhs for matrix assembly.
    * Users may reimplement this to add pre- or post-assembly
-   * code before or after calling FEMSystem::assembly()
+   * code before or after calling FEMSystem::assembly().
+   * Note that in some cases only
+   * \link current_local_solution \endlink is used during assembly,
+   * and, therefore, if \link solution \endlink has been altered
+   * without \link update() \endlink being called, then the
+   * user must call \link update() \endlink before calling
+   * this function.
    */
   virtual void assembly (bool get_residual,
                          bool get_jacobian,

--- a/include/systems/implicit_system.h
+++ b/include/systems/implicit_system.h
@@ -256,6 +256,13 @@ public:
    * H_ij = (d^2 q)/(d p_i d p_j)
    * This Hessian is the output of this method, where for each q_i,
    * H_jk is stored in \p hessian.second_derivative(i,j,k).
+   *
+   * Note that in some cases only
+   * \link current_local_solution \endlink is used during assembly,
+   * and, therefore, if \link solution \endlink has been altered
+   * without \link update() \endlink being called, then the
+   * user must call \link update() \endlink before calling
+   * this function.
    */
   virtual void qoi_parameter_hessian(const QoISet & qoi_indices,
                                      const ParameterVector & parameters,

--- a/src/solvers/adaptive_time_solver.C
+++ b/src/solvers/adaptive_time_solver.C
@@ -90,7 +90,6 @@ void AdaptiveTimeSolver::advance_timestep ()
     _system.get_vector("_old_nonlinear_solution");
   NumericVector<Number> & nonlinear_solution =
     *(_system.solution);
-  //    _system.get_vector("_nonlinear_solution");
 
   old_nonlinear_soln = nonlinear_solution;
 

--- a/src/solvers/newton_solver.C
+++ b/src/solvers/newton_solver.C
@@ -79,6 +79,9 @@ Real NewtonSolver::line_search(Real tol,
         libMesh::out << "  Shrinking Newton step to "
                      << bx << std::endl;
 
+      // We may need to localize a parallel solution
+      _system.update();
+
       // Check residual with fractional Newton step
       _system.assembly (true, false);
 
@@ -186,6 +189,8 @@ Real NewtonSolver::line_search(Real tol,
         libMesh::out << "  Shrinking Newton step to "
                      << bx << std::endl;
 
+      // We may need to localize a parallel solution
+      _system.update();
       _system.assembly (true, false);
 
       rhs.close();
@@ -307,6 +312,9 @@ unsigned int NewtonSolver::solve()
   for (_outer_iterations=0; _outer_iterations<max_nonlinear_iterations;
        ++_outer_iterations)
     {
+      // We may need to localize a parallel solution
+      _system.update();
+
       if (verbose)
         libMesh::out << "Assembling the System" << std::endl;
 
@@ -459,6 +467,7 @@ unsigned int NewtonSolver::solve()
           _outer_iterations+1 < max_nonlinear_iterations ||
           !continue_after_max_iterations)
         {
+          _system.update ();
           _system.assembly(true, false);
 
           rhs.close();

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -109,11 +109,11 @@ extern "C"
     X_input.swap(X_system);
     R_input.swap(R_system);
 
-    // We may need to correct a non-conforming solution
-    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
-
     // We may need to localize a parallel solution
     sys.update();
+
+    // We may need to correct a non-conforming solution
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     // Do DiffSystem assembly
     sys.assembly(true, false);
@@ -176,11 +176,11 @@ extern "C"
     X_input.swap(X_system);
     J_input.swap(J_system);
 
-    // We may need to correct a non-conforming solution
-    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
-
     // We may need to localize a parallel solution
     sys.update();
+
+    // We may need to correct a non-conforming solution
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     // Do DiffSystem assembly
     sys.assembly(false, true);

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -310,10 +310,6 @@ unsigned int PetscDiffSolver::solve()
   PetscVector<Number> & r =
     *(cast_ptr<PetscVector<Number> *>(_system.rhs));
 
-#ifdef LIBMESH_ENABLE_CONSTRAINTS
-  _system.get_dof_map().enforce_constraints_exactly(_system);
-#endif
-
   int ierr = 0;
 
   ierr = SNESSetFunction (_snes, r.vec(),
@@ -326,6 +322,10 @@ unsigned int PetscDiffSolver::solve()
 
   ierr = SNESSolve (_snes, PETSC_NULL, x.vec());
   LIBMESH_CHKERR(ierr);
+
+#ifdef LIBMESH_ENABLE_CONSTRAINTS
+  _system.get_dof_map().enforce_constraints_exactly(_system);
+#endif
 
   SNESConvergedReason reason;
   SNESGetConvergedReason(_snes, &reason);

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -212,33 +212,7 @@ void PetscDiffSolver::init ()
 
   Parent::init();
 
-  int ierr=0;
-
-  ierr = SNESCreate(this->comm().get(),&_snes);
-  LIBMESH_CHKERR(ierr);
-
-  ierr = SNESMonitorSet (_snes, __libmesh_petsc_diff_solver_monitor,
-                         this, PETSC_NULL);
-  LIBMESH_CHKERR(ierr);
-
-  if (libMesh::on_command_line("--solver_system_names"))
-    {
-      ierr = SNESSetOptionsPrefix(_snes, (_system.name()+"_").c_str());
-      LIBMESH_CHKERR(ierr);
-    }
-
-  ierr = SNESSetFromOptions(_snes);
-  LIBMESH_CHKERR(ierr);
-
-  KSP my_ksp;
-  ierr = SNESGetKSP(_snes, &my_ksp);
-  LIBMESH_CHKERR(ierr);
-
-  PC my_pc;
-  ierr = KSPGetPC(my_ksp, &my_pc);
-  LIBMESH_CHKERR(ierr);
-
-  petsc_auto_fieldsplit(my_pc, _system);
+  this->setup_petsc_data();
 }
 
 
@@ -363,6 +337,36 @@ unsigned int PetscDiffSolver::solve()
   return convert_solve_result(reason);
 }
 
+void PetscDiffSolver::setup_petsc_data()
+{
+  int ierr=0;
+
+  ierr = SNESCreate(this->comm().get(),&_snes);
+  LIBMESH_CHKERR(ierr);
+
+  ierr = SNESMonitorSet (_snes, __libmesh_petsc_diff_solver_monitor,
+                         this, PETSC_NULL);
+  LIBMESH_CHKERR(ierr);
+
+  if (libMesh::on_command_line("--solver_system_names"))
+    {
+      ierr = SNESSetOptionsPrefix(_snes, (_system.name()+"_").c_str());
+      LIBMESH_CHKERR(ierr);
+    }
+
+  ierr = SNESSetFromOptions(_snes);
+  LIBMESH_CHKERR(ierr);
+
+  KSP my_ksp;
+  ierr = SNESGetKSP(_snes, &my_ksp);
+  LIBMESH_CHKERR(ierr);
+
+  PC my_pc;
+  ierr = KSPGetPC(my_ksp, &my_pc);
+  LIBMESH_CHKERR(ierr);
+
+  petsc_auto_fieldsplit(my_pc, _system);
+}
 
 } // namespace libMesh
 

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -870,19 +870,13 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
 
   const MeshBase & mesh = this->get_mesh();
 
-  //  this->get_vector("_nonlinear_solution").localize
-  //    (*current_local_nonlinear_solution,
-  //     dof_map.get_send_list());
-
   if (print_solution_norms)
     {
-      //      this->get_vector("_nonlinear_solution").close();
       this->solution->close();
 
       std::streamsize old_precision = libMesh::out.precision();
       libMesh::out.precision(16);
       libMesh::out << "|U| = "
-        //                    << this->get_vector("_nonlinear_solution").l1_norm()
                    << this->solution->l1_norm()
                    << std::endl;
       libMesh::out.precision(old_precision);
@@ -891,7 +885,6 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
     {
       std::streamsize old_precision = libMesh::out.precision();
       libMesh::out.precision(16);
-      //      libMesh::out << "U = [" << this->get_vector("_nonlinear_solution")
       libMesh::out << "U = [" << *(this->solution)
                    << "];" << std::endl;
       libMesh::out.precision(old_precision);

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -873,7 +873,6 @@ void FEMSystem::assembly (bool get_residual, bool get_jacobian,
   //  this->get_vector("_nonlinear_solution").localize
   //    (*current_local_nonlinear_solution,
   //     dof_map.get_send_list());
-  this->update();
 
   if (print_solution_norms)
     {

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -1323,6 +1323,10 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
       *this->solution = this->get_sensitivity_solution(k);
       *this->solution *= delta_p;
       *this->solution += *oldsolution;
+
+      // We've modified solution, so we need to update before calling
+      // assembly since assembly may only use current_local_solution
+      this->update();
       this->assembly(false, true);
       this->matrix->close();
       this->assemble_qoi_derivative(qoi_indices,
@@ -1355,6 +1359,10 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
       *this->solution = this->get_sensitivity_solution(k);
       *this->solution *= -delta_p;
       *this->solution += *oldsolution;
+
+      // We've modified solution, so we need to update before calling
+      // assembly since assembly may only use current_local_solution
+      this->update();
       this->assembly(false, true);
       this->matrix->close();
       this->assemble_qoi_derivative(qoi_indices,
@@ -1384,6 +1392,9 @@ void ImplicitSystem::qoi_parameter_hessian (const QoISet & qoi_indices,
   // All parameters have been reset.
   // Don't leave the qoi or system changed - principle of least
   // surprise.
+  // We've modified solution, so we need to update before calling
+  // assembly since assembly may only use current_local_solution
+  this->update();
   this->assembly(true, true);
   this->rhs->close();
   this->matrix->close();


### PR DESCRIPTION
@roystgnr 

This is still not completely correct as it still fails for AMR problems, see grinsfem/grins#528. Therefore, labeling as do not merge for the time being.

#1304 was the initial fix for dealing with the PETSc-debug-mode-lock issue. There were other problems that prevented AMR runs within the FEMSystem framework to work; d9fae0c is the state that I thought should allow AMR runs to proceed correctly (if a bit more inefficiently), but produces the problem described in grinsfem/grins#528.

Note that grinsfem/grins#528 will run correctly at d9fae0c if I run with PETSc opt and remove the change from #1304, that is we enforce constraints on the whole solution vector and not just current_local_solution in the residual and Jacobian functions (of course, PETSc will error in PETSc debug mode).

Commits  6092e29  e41672b 20b9b7e is basically cleanup/efficiency (and what I actually did first before hitting the AMR snag) and can probably be squashed together once we get to the bottom of this, but being overly pedantic now to try and see what's going on.