### PR TITLE
Allow users to provide separate functions for fd and mffd evaluations

### DIFF
--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -138,6 +138,23 @@ public:
   NonlinearImplicitSystem::ComputeResidual * residual_object;
 
   /**
+   * Function that computes the residual \p R(X) of the nonlinear system
+   * at the input iterate \p X for the purpose of forming a finite-differenced Jacobian.
+   */
+  void (* fd_residual) (const NumericVector<Number> & X,
+                        NumericVector<Number> & R,
+                        sys_type & S);
+
+  /**
+   * Function that computes the residual \p R(X) of the nonlinear system
+   * at the input iterate \p X for the purpose of forming Jacobian-vector products
+   * via finite differencing.
+   */
+  void (* mffd_residual) (const NumericVector<Number> & X,
+                          NumericVector<Number> & R,
+                          sys_type & S);
+
+  /**
    * Function that computes the Jacobian \p J(X) of the nonlinear system
    * at the input iterate \p X.
    */
@@ -366,6 +383,8 @@ NonlinearSolver<T>::NonlinearSolver (sys_type & s) :
   ParallelObject               (s),
   residual                     (libmesh_nullptr),
   residual_object              (libmesh_nullptr),
+  fd_residual                  (libmesh_nullptr),
+  mffd_residual                (libmesh_nullptr),
   jacobian                     (libmesh_nullptr),
   jacobian_object              (libmesh_nullptr),
   matvec                       (libmesh_nullptr),

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -138,21 +138,17 @@ public:
   NonlinearImplicitSystem::ComputeResidual * residual_object;
 
   /**
-   * Function that computes the residual \p R(X) of the nonlinear system
+   * Object that computes the residual \p R(X) of the nonlinear system
    * at the input iterate \p X for the purpose of forming a finite-differenced Jacobian.
    */
-  void (* fd_residual) (const NumericVector<Number> & X,
-                        NumericVector<Number> & R,
-                        sys_type & S);
+  NonlinearImplicitSystem::ComputeResidual * fd_residual_object;
 
   /**
-   * Function that computes the residual \p R(X) of the nonlinear system
+   * Object that computes the residual \p R(X) of the nonlinear system
    * at the input iterate \p X for the purpose of forming Jacobian-vector products
    * via finite differencing.
    */
-  void (* mffd_residual) (const NumericVector<Number> & X,
-                          NumericVector<Number> & R,
-                          sys_type & S);
+  NonlinearImplicitSystem::ComputeResidual * mffd_residual_object;
 
   /**
    * Function that computes the Jacobian \p J(X) of the nonlinear system
@@ -383,8 +379,8 @@ NonlinearSolver<T>::NonlinearSolver (sys_type & s) :
   ParallelObject               (s),
   residual                     (libmesh_nullptr),
   residual_object              (libmesh_nullptr),
-  fd_residual                  (libmesh_nullptr),
-  mffd_residual                (libmesh_nullptr),
+  fd_residual_object           (libmesh_nullptr),
+  mffd_residual_object         (libmesh_nullptr),
   jacobian                     (libmesh_nullptr),
   jacobian_object              (libmesh_nullptr),
   matvec                       (libmesh_nullptr),

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -41,6 +41,7 @@ extern "C"
   PetscErrorCode __libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *);
   PetscErrorCode __libmesh_petsc_snes_residual (SNES, Vec x, Vec r, void * ctx);
   PetscErrorCode __libmesh_petsc_snes_fd_residual (SNES, Vec x, Vec r, void * ctx);
+  PetscErrorCode __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);
   PetscErrorCode __libmesh_petsc_snes_mffd_residual (SNES, Vec x, Vec r, void * ctx);
 #if PETSC_RELEASE_LESS_THAN(3,5,0)
   PetscErrorCode __libmesh_petsc_snes_jacobian (SNES, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
@@ -155,6 +156,11 @@ public:
    */
   void use_default_monitor(bool state) { _default_monitor = state; }
 
+  /**
+   * Whether the Jacobian is matrix-free
+   */
+  bool mf;
+
 protected:
   /**
    * Nonlinear solver context
@@ -206,6 +212,7 @@ protected:
 private:
   friend PetscErrorCode __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode __libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx);
+  friend PetscErrorCode __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);
   friend PetscErrorCode __libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
 #if PETSC_RELEASE_LESS_THAN(3,5,0)
   friend PetscErrorCode __libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -40,6 +40,8 @@ extern "C"
 {
   PetscErrorCode __libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *);
   PetscErrorCode __libmesh_petsc_snes_residual (SNES, Vec x, Vec r, void * ctx);
+  PetscErrorCode __libmesh_petsc_snes_fd_residual (SNES, Vec x, Vec r, void * ctx);
+  PetscErrorCode __libmesh_petsc_snes_mffd_residual (SNES, Vec x, Vec r, void * ctx);
 #if PETSC_RELEASE_LESS_THAN(3,5,0)
   PetscErrorCode __libmesh_petsc_snes_jacobian (SNES, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
 #else
@@ -203,6 +205,8 @@ protected:
 #endif
 private:
   friend PetscErrorCode __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);
+  friend PetscErrorCode __libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx);
+  friend PetscErrorCode __libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
 #if PETSC_RELEASE_LESS_THAN(3,5,0)
   friend PetscErrorCode __libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
 #else

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -34,6 +34,8 @@
 
 namespace libMesh
 {
+class ResidualContext;
+
 // Allow users access to these functions in case they want to reuse them.  Users shouldn't
 // need access to these most of the time as they are used internally by this object.
 extern "C"
@@ -210,6 +212,7 @@ protected:
                             MatNullSpace *);
 #endif
 private:
+  friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode __libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -159,9 +159,16 @@ public:
   void use_default_monitor(bool state) { _default_monitor = state; }
 
   /**
-   * Whether the Jacobian is matrix-free
+   * Petsc solve type
    */
-  bool mf;
+  enum SolveType
+  {
+    MF_OPERATOR, ///< Preconditioned Jacobian-free Newton
+    MF,          ///< Jacobian-free Newton
+    STANDARD     ///< Newton with explicit matrix
+  };
+
+  SolveType solve_type;
 
 protected:
   /**

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -163,14 +163,28 @@ public:
    */
   enum SolveType
   {
-    MF_OPERATOR, ///< Preconditioned Jacobian-free Newton
-    MF,          ///< Jacobian-free Newton
-    STANDARD     ///< Newton with explicit matrix
+    MF_OPERATOR, ///< Preconditioned Jacobian-free Newton-Krylov
+    MF,          ///< Jacobian-free Newton-Krylov
+    STANDARD     ///< Newton-Krylov with explicit matrix
   };
 
-  SolveType solve_type;
+  /**
+   * \returns A constant reference to our solve type
+   */
+  const SolveType & solve_type() const { return _solve_type; }
+
+  /**
+   * \returns A writable reference to our solve type
+   */
+  SolveType & solve_type() { return _solve_type; }
 
 protected:
+
+  /**
+   * Stores the Petsc solve type
+   */
+  SolveType _solve_type;
+
   /**
    * Nonlinear solver context
    */

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -212,7 +212,7 @@ protected:
                             MatNullSpace *);
 #endif
 private:
-  friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, Vec r, void * ctx);
+  friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx);
   friend PetscErrorCode __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode __libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx);
   friend PetscErrorCode __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -55,14 +55,13 @@ public:
 };
 
 ResidualContext
-libmesh_petsc_snes_residual_helper (SNES snes, Vec x, Vec r, void * ctx)
+libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx)
 {
   LOG_SCOPE("residual()", "PetscNonlinearSolver");
 
   PetscErrorCode ierr = 0;
 
   libmesh_assert(x);
-  libmesh_assert(r);
   libmesh_assert(ctx);
 
   // No way to safety-check this cast, since we got a void *...
@@ -136,8 +135,9 @@ extern "C"
   PetscErrorCode
   __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
-    ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, r, ctx);
+    ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, ctx);
 
+    libmesh_assert(r);
     PetscVector<Number> R(r, rc.sys.comm());
 
     if (rc.solver->_zero_out_residual)
@@ -177,8 +177,9 @@ extern "C"
   PetscErrorCode
   __libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
-    ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, r, ctx);
+    ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, ctx);
 
+    libmesh_assert(r);
     PetscVector<Number> R(r, rc.sys.comm());
 
     if (rc.solver->_zero_out_residual)
@@ -220,8 +221,9 @@ extern "C"
   PetscErrorCode
   __libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
-    ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, r, ctx);
+    ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, ctx);
 
+    libmesh_assert(r);
     PetscVector<Number> R(r, rc.sys.comm());
 
     if (rc.solver->_zero_out_residual)
@@ -766,6 +768,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
     ierr = MatMFFDSetFunction(J, __libmesh_petsc_snes_mffd_interface, this);
     LIBMESH_CHKERR(ierr);
     ierr = SNESSetJacobian(_snes, J, 0, 0, 0);
+    LIBMESH_CHKERR(ierr);
   }
 
   // Have the Krylov subspace method use our good initial guess rather than 0

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -452,7 +452,7 @@ extern "C"
 template <typename T>
 PetscNonlinearSolver<T>::PetscNonlinearSolver (sys_type & system_in) :
   NonlinearSolver<T>(system_in),
-  solve_type(STANDARD),
+  _solve_type(STANDARD),
   _reason(SNES_CONVERGED_ITERATING/*==0*/), // Arbitrary initial value...
   _n_linear_iterations(0),
   _current_nonlinear_iteration_number(0),
@@ -709,13 +709,13 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
 
   // Take care of case where the user specifies matrix-free jacobian
   Mat J;
-  if (solve_type != STANDARD)
+  if (_solve_type != STANDARD)
   {
       ierr = MatCreateSNESMF(_snes, &J);
       LIBMESH_CHKERR(ierr);
       ierr = MatMFFDSetFunction(J, __libmesh_petsc_snes_mffd_interface, this);
       LIBMESH_CHKERR(ierr);
-      if (solve_type == MF_OPERATOR)
+      if (_solve_type == MF_OPERATOR)
         ierr = SNESSetJacobian(_snes, J, 0, 0, 0);
       else
         ierr = SNESSetJacobian(_snes, J, J, MatMFFDComputeJacobian, 0);
@@ -732,7 +732,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
         {
           ierr = MatSetNullSpace(pre->mat(), msp);
           LIBMESH_CHKERR(ierr);
-          if (solve_type != STANDARD)
+          if (_solve_type != STANDARD)
           {
             ierr = MatSetNullSpace(J, msp);
             LIBMESH_CHKERR(ierr);
@@ -755,7 +755,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
         {
           ierr = MatSetTransposeNullSpace(pre->mat(), msp);
           LIBMESH_CHKERR(ierr);
-          if (solve_type != STANDARD)
+          if (_solve_type != STANDARD)
           {
             ierr = MatSetTransposeNullSpace(J, msp);
             LIBMESH_CHKERR(ierr);
@@ -777,7 +777,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
         {
           ierr = MatSetNearNullSpace(pre->mat(), msp);
           LIBMESH_CHKERR(ierr);
-          if (solve_type != STANDARD)
+          if (_solve_type != STANDARD)
           {
             ierr = MatSetNearNullSpace(J, msp);
             LIBMESH_CHKERR(ierr);

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -195,11 +195,11 @@ extern "C"
     if (solver->_zero_out_residual)
       R.zero();
 
-    if (solver->fd_residual != libmesh_nullptr)
-      solver->fd_residual(*sys.current_local_solution.get(), R, sys);
+    if (solver->fd_residual_object != libmesh_nullptr)
+      solver->fd_residual_object->residual(*sys.current_local_solution.get(), R, sys);
 
-    else if (solver->residual != libmesh_nullptr)
-      solver->residual(*sys.current_local_solution.get(), R, sys);
+    else if (solver->residual_object != libmesh_nullptr)
+      solver->residual_object->residual(*sys.current_local_solution.get(), R, sys);
 
     else
       libmesh_error_msg("Error! Unable to compute residual for forming finite difference Jacobian!");
@@ -275,11 +275,11 @@ extern "C"
     if (solver->_zero_out_residual)
       R.zero();
 
-    if (solver->mffd_residual != libmesh_nullptr)
-      solver->mffd_residual(*sys.current_local_solution.get(), R, sys);
+    if (solver->mffd_residual_object != libmesh_nullptr)
+      solver->mffd_residual_object->residual(*sys.current_local_solution.get(), R, sys);
 
-    else if (solver->residual != libmesh_nullptr)
-      solver->residual(*sys.current_local_solution.get(), R, sys);
+    else if (solver->residual_object != libmesh_nullptr)
+      solver->residual_object->residual(*sys.current_local_solution.get(), R, sys);
 
     else
       libmesh_error_msg("Error! Unable to compute residual for forming finite differenced"


### PR DESCRIPTION
Petsc allows different functions to be set with:

- SNESSetFunction
- MatMFFDSetFunction
- MatFDColoringSetFunction

We have a use case in MOOSE with mechanical contact where we may want a contact update to be included in the function passed to `SNESSetFunction` (e.g. non-linear residual evaluations) but not when forming the Jacobian or computing Jacobian-vector products during the linear solve. Thus it would be nice to have a libMesh interface where we can pass different functions depending on the context.