### PR TITLE
Updates to reduced basis code related to recent unique_ptr changes.

### DIFF
--- a/include/reduced_basis/rb_assembly_expansion.h
+++ b/include/reduced_basis/rb_assembly_expansion.h
@@ -144,6 +144,13 @@ public:
    * (both interior and boundary assembly).
    * In this case we pass in vector arguments to allow for Q_l > 1.
    */
+  virtual void attach_output_assembly(std::vector<std::unique_ptr<ElemAssembly>> & output_assembly);
+
+  /**
+   * Attach ElemAssembly object for an output
+   * (both interior and boundary assembly).
+   * In this case we pass in vector arguments to allow for Q_l > 1.
+   */
   virtual void attach_output_assembly(std::vector<ElemAssembly *> output_assembly);
 
   /**

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -195,7 +195,7 @@ public:
    * written.
    */
   virtual void write_out_vectors(System & sys,
-                                 std::vector<std::unique_ptr<NumericVector<Number>>> & vectors,
+                                 std::vector<NumericVector<Number>*> & vectors,
                                  const std::string & directory_name = "offline_data",
                                  const std::string & data_name = "bf",
                                  const bool write_binary_basis_functions = true);

--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -126,7 +126,13 @@ public:
    * Attach a vector of pointers to functor objects that define one
    * of the outputs.
    */
-  virtual void attach_output_theta(std::vector<RBTheta *> theta_q_l);
+  virtual void attach_output_theta(std::vector<std::unique_ptr<RBTheta>> & theta_q_l);
+
+  /**
+   * Attach a vector of pointers to functor objects that define one
+   * of the outputs.
+   */
+  virtual void attach_output_theta(std::vector<RBTheta*> theta_q_l);
 
   /**
    * Attach a pointer to a functor object that defines one

--- a/src/reduced_basis/rb_assembly_expansion.C
+++ b/src/reduced_basis/rb_assembly_expansion.C
@@ -150,6 +150,16 @@ void RBAssemblyExpansion::attach_multiple_F_assembly(std::vector<std::unique_ptr
     _F_assembly_vector.push_back(Fq_assembly[i].get());
 }
 
+void RBAssemblyExpansion::attach_output_assembly(std::vector<std::unique_ptr<ElemAssembly>> & output_assembly)
+{
+  std::vector<ElemAssembly *> output_assembly_ptr;
+  for(std::size_t i=0; i<output_assembly.size(); i++)
+  {
+    output_assembly_ptr.push_back( output_assembly[i].get() );
+  }
+  _output_assembly_vector.push_back(output_assembly_ptr);
+}
+
 void RBAssemblyExpansion::attach_output_assembly(std::vector<ElemAssembly *> output_assembly)
 {
   _output_assembly_vector.push_back(output_assembly);

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -885,15 +885,21 @@ void RBEvaluation::write_out_basis_functions(System & sys,
 {
   LOG_SCOPE("write_out_basis_functions()", "RBEvaluation");
 
+  std::vector<NumericVector<Number>*> basis_functions_ptrs;
+  for(std::size_t i=0; i<basis_functions.size(); i++)
+  {
+    basis_functions_ptrs.push_back(basis_functions[i].get());
+  }
+
   write_out_vectors(sys,
-                    basis_functions,
+                    basis_functions_ptrs,
                     directory_name,
                     "bf",
                     write_binary_basis_functions);
 }
 
 void RBEvaluation::write_out_vectors(System & sys,
-                                     std::vector<std::unique_ptr<NumericVector<Number>>> & vectors,
+                                     std::vector<NumericVector<Number>*> & vectors,
                                      const std::string & directory_name,
                                      const std::string & data_name,
                                      const bool write_binary_vectors)
@@ -933,7 +939,7 @@ void RBEvaluation::write_out_vectors(System & sys,
     // Note the API wants pointers to constant vectors, hence this...
     std::vector<const NumericVector<Number> *> bf_out;
     for (const auto & vec : vectors)
-      bf_out.push_back(vec.get());
+      bf_out.push_back(vec);
 
     // for (std::size_t i=0; i<vectors.size(); i++)
     //   bf_out.push_back(vectors[i]);

--- a/src/reduced_basis/rb_theta_expansion.C
+++ b/src/reduced_basis/rb_theta_expansion.C
@@ -91,6 +91,16 @@ void RBThetaExpansion::attach_multiple_F_theta(std::vector<std::unique_ptr<RBThe
     }
 }
 
+void RBThetaExpansion::attach_output_theta(std::vector<std::unique_ptr<RBTheta>> & theta_q_l)
+{
+  std::vector<RBTheta *> theta_q_l_ptr;
+  for(std::size_t i=0; i<theta_q_l.size(); i++)
+  {
+    theta_q_l_ptr.push_back( theta_q_l[i].get() );
+  }
+  _output_theta_vector.push_back(theta_q_l_ptr);
+}
+
 void RBThetaExpansion::attach_output_theta(std::vector<RBTheta *> theta_q_l)
 {
   _output_theta_vector.push_back(theta_q_l);


### PR DESCRIPTION
This is a small change to the reduced basis code. Change some functions (or add new versions of existing functions) to take raw pointers instead of unique_ptrs, for easier compatibility with existing code bases.