### PR TITLE
Added comment to ReplicatedMesh::stitch_meshes

### DIFF
--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -204,6 +204,14 @@ public:
    * If \p skip_find_neighbors is true, a faster stitching method is used, where the lists of
    * neighbors for each elements are copied as well and patched, without calling the time-consuming
    * find_neighbors() function.
+   * 
+   * Note that the element IDs for elements in the stitched mesh corresponding to "this" mesh
+   * will be unchanged. The IDs for elements corresponding to \p other_mesh will be incremented
+   * by this->max_elem_id().
+   * 
+   * There is no simple a priori relationship between node IDs in "this" mesh
+   * and other_mesh and node IDs in the stitched mesh because the number of nodes (and hence
+   * the node IDs) in the stitched mesh depend on how many nodes are stitched.
    */
   void stitch_meshes (ReplicatedMesh & other_mesh,
                       boundary_id_type this_mesh_boundary,


### PR DESCRIPTION
The comment specifies how element and node IDs in the stitched mesh correspond
to element and node IDs in the original meshes. This should be considered part
of the specification of this method so that we can rely on it in user code.