### PR TITLE
Check for cyclic constraints.

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -433,6 +433,14 @@ public:
   void add_variable_group (const VariableGroup & var_group);
 
   /**
+   * Specify whether or not we perform an extra (opt-mode enabled) check
+   * for cyclic constraints. If a cyclic constraint is present then
+   * the system constraints are not valid, so if \p error_on_cyclic_constraint
+   * is true we will throw an error in this case.
+   */
+  void set_error_on_cyclic_constraint(bool error_on_cyclic_constraint);
+
+  /**
    * \returns The \p VariableGroup description object for group \p g.
    */
   const VariableGroup & variable_group (const unsigned int c) const;
@@ -783,6 +791,13 @@ public:
    * user constraints have all been added.
    */
   void process_constraints (MeshBase &);
+
+  /**
+   * Throw an error if we detect and cyclic constraints, since these
+   * are not supported by libMesh and give erroneous results if they
+   * are present.
+   */
+  void check_for_cyclic_constraints();
 
   /**
    * Adds a copy of the user-defined row to the constraint matrix, using
@@ -1402,6 +1417,12 @@ private:
   void add_constraints_to_send_list();
 
 #endif // LIBMESH_ENABLE_CONSTRAINTS
+
+  /**
+   * This flag indicates whether or not we do an opt-mode check for
+   * the presence of cyclic constraints.
+   */
+  bool _error_on_cyclic_constraint;
 
   /**
    * The finite element type for each variable.

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -128,6 +128,7 @@ DofMap::DofMap(const unsigned int number,
                MeshBase & mesh) :
   ParallelObject (mesh.comm()),
   _dof_coupling(libmesh_nullptr),
+  _error_on_cyclic_constraint(false),
   _variables(),
   _variable_groups(),
   _sys_number(number),
@@ -228,6 +229,12 @@ bool DofMap::is_periodic_boundary (const boundary_id_type boundaryid) const
 //   libmesh_not_implemented();
 //   _variables.push_back (var);
 // }
+
+
+void DofMap::set_error_on_cyclic_constraint(bool error_on_cyclic_constraint)
+{
+  _error_on_cyclic_constraint = error_on_cyclic_constraint;
+}
 
 
 


### PR DESCRIPTION
A simple example of a cyclic constraint is if dof 1 is constrained in terms of dof 0,
and dof 0 constrained in terms of dof 1. In this case libMesh will not resolve the
constraints correctly and we will get an incorrect solution.

This change asserts that cyclic constraints are not present in debug/devel mode, and
gives us the option to check for cyclic constraints and throw an error in opt mode.