### PR TITLE
PetscDMWrapper Part 1

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -454,7 +454,7 @@ am__libmesh_dbg_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -859,6 +859,7 @@ am__objects_1 = src/base/libmesh_dbg_la-default_coupling.lo \
 	src/solvers/libmesh_dbg_la-optimization_solver.lo \
 	src/solvers/libmesh_dbg_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_dbg_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_dbg_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_dbg_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_dbg_la-petscdmlibmesh.lo \
@@ -1179,7 +1180,7 @@ am__libmesh_devel_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -1583,6 +1584,7 @@ am__objects_2 = src/base/libmesh_devel_la-default_coupling.lo \
 	src/solvers/libmesh_devel_la-optimization_solver.lo \
 	src/solvers/libmesh_devel_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_devel_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_devel_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_devel_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_devel_la-petscdmlibmesh.lo \
@@ -1900,7 +1902,7 @@ am__libmesh_oprof_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -2304,6 +2306,7 @@ am__objects_3 = src/base/libmesh_oprof_la-default_coupling.lo \
 	src/solvers/libmesh_oprof_la-optimization_solver.lo \
 	src/solvers/libmesh_oprof_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_oprof_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_oprof_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_oprof_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_oprof_la-petscdmlibmesh.lo \
@@ -2621,7 +2624,7 @@ am__libmesh_opt_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -3025,6 +3028,7 @@ am__objects_4 = src/base/libmesh_opt_la-default_coupling.lo \
 	src/solvers/libmesh_opt_la-optimization_solver.lo \
 	src/solvers/libmesh_opt_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_opt_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_opt_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_opt_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_opt_la-petscdmlibmesh.lo \
@@ -3341,7 +3345,7 @@ am__libmesh_prof_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -3745,6 +3749,7 @@ am__objects_5 = src/base/libmesh_prof_la-default_coupling.lo \
 	src/solvers/libmesh_prof_la-optimization_solver.lo \
 	src/solvers/libmesh_prof_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_prof_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_prof_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_prof_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_prof_la-petscdmlibmesh.lo \
@@ -5177,6 +5182,7 @@ libmesh_SOURCES = \
         src/solvers/optimization_solver.C \
         src/solvers/petsc_auto_fieldsplit.C \
         src/solvers/petsc_diff_solver.C \
+        src/solvers/petsc_dm_wrapper.C \
         src/solvers/petsc_linear_solver.C \
         src/solvers/petsc_nonlinear_solver.C \
         src/solvers/petscdmlibmesh.C \
@@ -6575,6 +6581,9 @@ src/solvers/libmesh_dbg_la-petsc_auto_fieldsplit.lo:  \
 src/solvers/libmesh_dbg_la-petsc_diff_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_dbg_la-petsc_linear_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -7623,6 +7632,9 @@ src/solvers/libmesh_devel_la-petsc_auto_fieldsplit.lo:  \
 src/solvers/libmesh_devel_la-petsc_diff_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_devel_la-petsc_linear_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -8659,6 +8671,9 @@ src/solvers/libmesh_oprof_la-petsc_auto_fieldsplit.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_oprof_la-petsc_diff_solver.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_oprof_la-petsc_linear_solver.lo:  \
@@ -9698,6 +9713,9 @@ src/solvers/libmesh_opt_la-petsc_auto_fieldsplit.lo:  \
 src/solvers/libmesh_opt_la-petsc_diff_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_opt_la-petsc_linear_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -10731,6 +10749,9 @@ src/solvers/libmesh_prof_la-petsc_auto_fieldsplit.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_prof_la-petsc_diff_solver.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_prof_la-petsc_linear_solver.lo:  \
@@ -13183,6 +13204,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petscdmlibmesh.Plo@am__quote@
@@ -13215,6 +13237,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petscdmlibmesh.Plo@am__quote@
@@ -13247,6 +13270,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petscdmlibmesh.Plo@am__quote@
@@ -13279,6 +13303,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petscdmlibmesh.Plo@am__quote@
@@ -13311,6 +13336,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petscdmlibmesh.Plo@am__quote@
@@ -16123,6 +16149,13 @@ src/solvers/libmesh_dbg_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_diff_solver.C' object='src/solvers/libmesh_dbg_la-petsc_diff_solver.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_dbg_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
+
+src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
 
 src/solvers/libmesh_dbg_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_dbg_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_dbg_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C
@@ -19078,6 +19111,13 @@ src/solvers/libmesh_devel_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_devel_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
 
+src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+
 src/solvers/libmesh_devel_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_devel_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_devel_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_linear_solver.Tpo src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_linear_solver.Plo
@@ -22031,6 +22071,13 @@ src/solvers/libmesh_oprof_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_diff_solver.C' object='src/solvers/libmesh_oprof_la-petsc_diff_solver.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_oprof_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
+
+src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
 
 src/solvers/libmesh_oprof_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_oprof_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_oprof_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C
@@ -24986,6 +25033,13 @@ src/solvers/libmesh_opt_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_opt_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
 
+src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+
 src/solvers/libmesh_opt_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_opt_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_opt_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_linear_solver.Tpo src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_linear_solver.Plo
@@ -27939,6 +27993,13 @@ src/solvers/libmesh_prof_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_diff_solver.C' object='src/solvers/libmesh_prof_la-petsc_diff_solver.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_prof_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
+
+src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
 
 src/solvers/libmesh_prof_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_prof_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_prof_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -926,6 +926,7 @@ include_HEADERS = \
         solvers/optimization_solver.h \
         solvers/petsc_auto_fieldsplit.h \
         solvers/petsc_diff_solver.h \
+        solvers/petsc_dm_wrapper.h \
         solvers/petsc_linear_solver.h \
         solvers/petsc_nonlinear_solver.h \
         solvers/petscdmlibmesh.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -356,6 +356,7 @@ include_HEADERS =  \
         solvers/optimization_solver.h \
         solvers/petsc_auto_fieldsplit.h \
         solvers/petsc_diff_solver.h \
+        solvers/petsc_dm_wrapper.h \
         solvers/petsc_linear_solver.h \
         solvers/petsc_nonlinear_solver.h \
         solvers/petscdmlibmesh.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -352,6 +352,7 @@ BUILT_SOURCES = \
         optimization_solver.h \
         petsc_auto_fieldsplit.h \
         petsc_diff_solver.h \
+        petsc_dm_wrapper.h \
         petsc_linear_solver.h \
         petsc_nonlinear_solver.h \
         petscdmlibmesh.h \
@@ -1561,6 +1562,9 @@ petsc_auto_fieldsplit.h: $(top_srcdir)/include/solvers/petsc_auto_fieldsplit.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_diff_solver.h: $(top_srcdir)/include/solvers/petsc_diff_solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_dm_wrapper.h: $(top_srcdir)/include/solvers/petsc_dm_wrapper.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_linear_solver.h: $(top_srcdir)/include/solvers/petsc_linear_solver.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -604,7 +604,7 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	memory_solution_history.h newmark_solver.h newton_solver.h \
 	nlopt_optimization_solver.h no_solution_history.h \
 	nonlinear_solver.h optimization_solver.h \
-	petsc_auto_fieldsplit.h petsc_diff_solver.h \
+	petsc_auto_fieldsplit.h petsc_diff_solver.h petsc_dm_wrapper.h \
 	petsc_linear_solver.h petsc_nonlinear_solver.h \
 	petscdmlibmesh.h second_order_unsteady_solver.h \
 	slepc_eigen_solver.h slepc_macro.h solution_history.h \
@@ -1910,6 +1910,9 @@ petsc_auto_fieldsplit.h: $(top_srcdir)/include/solvers/petsc_auto_fieldsplit.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_diff_solver.h: $(top_srcdir)/include/solvers/petsc_diff_solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_dm_wrapper.h: $(top_srcdir)/include/solvers/petsc_dm_wrapper.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_linear_solver.h: $(top_srcdir)/include/solvers/petsc_linear_solver.h

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -27,6 +27,7 @@
 // Local includes
 #include "libmesh/diff_solver.h"
 #include "libmesh/petsc_macro.h"
+#include "libmesh/petsc_dm_wrapper.h"
 
 // PETSc includes
 # include <petscsnes.h>
@@ -91,6 +92,11 @@ protected:
    * Nonlinear solver context
    */
   SNES _snes;
+
+  /**
+   * Wrapper object for interacting with PetscDM
+   */
+  PetscDMWrapper _dm_wrapper;
 
 private:
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -64,6 +64,20 @@ private:
    */
   void build_section(const System & system, PetscSection & section);
 
+  //! Takes System, empty PetscSF and populates the PetscSF
+  /**
+   * The PetscSF (star forest) is a cousin of PetscSection. PetscSection
+   * has the DoF info, and PetscSF gives the parallel distribution of the
+   * DoF info. So PetscSF should only be necessary when we have more than
+   * one MPI rank. Essentially, we are copying the DofMap.send_list(): we
+   * are specifying the local dofs, what rank communicates that dof info
+   * (for off-processor dofs that are communicated) and the dofs local
+   * index on that rank.
+   *
+   * https://jedbrown.org/files/StarForest.pdf
+   */
+  void build_sf( const System & system, PetscSF & star_forest );
+
   //! Helper function for build_section.
   /**
    * This function will set the id for each "point" on the current processor within

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -22,6 +22,10 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+#include <vector>
+#include <memory>
+
+// PETSc includes
 #include <petsc.h>
 
 namespace libMesh
@@ -49,6 +53,42 @@ public:
   ~PetscDMWrapper(){};
 
 private:
+
+  //! Vector of DMs for all grid levels
+  std::vector<std::unique_ptr<DM>> _dms;
+
+  //! Vector of PETScSections for all grid levels
+  std::vector<std::unique_ptr<PetscSection>> _sections;
+
+  //! Vector of star forests for all grid levels
+  std::vector<std::unique_ptr<PetscSF>> _star_forests;
+
+  //! Init all the n_mesh_level dependent data structures
+  void init_dm_data(unsigned int n_levels);
+
+  //! Get reference to DM for the given mesh level
+  /**
+   * init_dm_data() should be called before this function.
+   */
+  DM & get_dm(unsigned int level)
+  { libmesh_assert(level < _dms.size());
+    return *(_dms[level].get()); }
+
+  //! Get reference to PetscSection for the given mesh level
+  /**
+   * init_dm_data() should be called before this function.
+   */
+  PetscSection & get_section(unsigned int level)
+  { libmesh_assert(level < _sections.size());
+    return *(_sections[level].get()); }
+
+  //! Get reference to PetscSF for the given mesh level
+  /**
+   * init_dm_data() should be called before this function.
+   */
+  PetscSF & get_star_forest(unsigned int level)
+  { libmesh_assert(level < _star_forests.size());
+    return *(_star_forests[level].get()); }
 
   //! Takes System, empty PetscSection and populates the PetscSection
   /**

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -28,6 +28,7 @@ namespace libMesh
 {
   // Forward declarations
   class System;
+  class DofMap;
 
 /**
  * This class defines a wrapper around the PETSc DM infrastructure.
@@ -83,6 +84,12 @@ private:
    * the redundant call to PetscSectionSetDof within add_dofs_to_section.
    */
   void check_section_n_dofs_match( const System & system, PetscSection & section );
+
+  //! Find the MPI rank of the degree of freedom, dof.
+  /**
+   * Helper function for build_sf
+   */
+  PetscInt find_dof_rank( unsigned int dof, const DofMap & dof_map ) const;
 
 };
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -22,8 +22,12 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+#include <petsc.h>
+
 namespace libMesh
 {
+  // Forward declarations
+  class System;
 
 /**
  * This class defines a wrapper around the PETSc DM infrastructure.
@@ -42,6 +46,15 @@ public:
   PetscDMWrapper(){};
 
   ~PetscDMWrapper(){};
+
+private:
+
+  //! Helper function for build_section.
+  /**
+   * This function will set the id for each "point" on the current processor within
+   * the PetscSection. Should be O(n_active_local_elems).
+   */
+  void set_point_range_in_section( const System & system, PetscSection & section);
 
 };
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -1,0 +1,52 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2018 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_PETSC_DM_WRAPPER_H
+#define LIBMESH_PETSC_DM_WRAPPER_H
+
+#include "libmesh/libmesh_common.h"
+
+#ifdef LIBMESH_HAVE_PETSC
+
+namespace libMesh
+{
+
+/**
+ * This class defines a wrapper around the PETSc DM infrastructure.
+ * By coordinating DM data structures with libMesh, we can use libMesh
+ * mesh hierarchies for geometric multigrid. Additionally, by setting the
+ * DM data, we can additionally (with or without multigrid) define recursive
+ * fieldsplits of our variables.
+ *
+ * \author Paul T. Bauman, Boris Boutkov
+ * \date 2018
+ */
+class PetscDMWrapper
+{
+public:
+
+  PetscDMWrapper(){};
+
+  ~PetscDMWrapper(){};
+
+};
+
+}
+
+#endif // #ifdef LIBMESH_HAVE_PETSC
+
+#endif // LIBMESH_PETSC_DM_WRAPPER_H

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -50,9 +50,12 @@ public:
 
   PetscDMWrapper(){};
 
-  ~PetscDMWrapper(){};
+  ~PetscDMWrapper();
 
   void init_and_attach_petscdm(const System & system, SNES & snes);
+
+  //! Destroys and clears all build DM-related data
+  void clear();
 
 private:
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -49,6 +49,20 @@ public:
 
 private:
 
+  //! Takes System, empty PetscSection and populates the PetscSection
+  /**
+   * Take the System in its current take and an empty PetscSection and then
+   * populate the PetscSection. The PetscSection is comprised of global "point"
+   * numbers, where a "point" in PetscDM parlance is a geometric entity: node, edge,
+   * face, or element. Then, we also add the DoF numbering for each variable
+   * for each of the "points". The PetscSection, together the with PetscSF
+   * will allow for recursive fieldsplits from the command line using PETSc.
+   *
+   * TODO: Currently only populates nodal DoF data. Need to generalize
+   *       to edge, face, and interior DoFs as well.
+   */
+  void build_section(const System & system, PetscSection & section);
+
   //! Helper function for build_section.
   /**
    * This function will set the id for each "point" on the current processor within

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -56,6 +56,13 @@ private:
    */
   void set_point_range_in_section( const System & system, PetscSection & section);
 
+  //! Helper function for build_section.
+  /**
+   * This function will set the DoF info for each "point" in the PetscSection.
+   * Should be O(n_active_local_elems).
+   */
+  void add_dofs_to_section( const System & system, PetscSection & section );
+
 };
 
 }

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -52,6 +52,8 @@ public:
 
   ~PetscDMWrapper(){};
 
+  void init_and_attach_petscdm(const System & system, SNES & snes);
+
 private:
 
   //! Vector of DMs for all grid levels

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -77,6 +77,13 @@ private:
    */
   void add_dofs_to_section( const System & system, PetscSection & section );
 
+  //! Helper function to sanity check PetscSection construction
+  /**
+   * I needed this originally to help check parallel cases and the (what I think is)
+   * the redundant call to PetscSectionSetDof within add_dofs_to_section.
+   */
+  void check_section_n_dofs_match( const System & system, PetscSection & section );
+
 };
 
 }

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -367,6 +367,7 @@ libmesh_SOURCES =  \
         src/solvers/optimization_solver.C \
         src/solvers/petsc_auto_fieldsplit.C \
         src/solvers/petsc_diff_solver.C \
+        src/solvers/petsc_dm_wrapper.C \
         src/solvers/petsc_linear_solver.C \
         src/solvers/petsc_nonlinear_solver.C \
         src/solvers/petscdmlibmesh.C \

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -230,6 +230,8 @@ void PetscDiffSolver::clear()
 
   int ierr = LibMeshSNESDestroy(&_snes);
   LIBMESH_CHKERR(ierr);
+
+  _dm_wrapper.clear();
 }
 
 
@@ -350,18 +352,29 @@ void PetscDiffSolver::setup_petsc_data()
       LIBMESH_CHKERR(ierr);
     }
 
+  bool use_petsc_dm = libMesh::on_command_line("--use_petsc_dm");
+
+  // This needs to be called before SNESSetFromOptions
+  if (use_petsc_dm)
+    this->_dm_wrapper.init_and_attach_petscdm(_system, _snes);
+
   ierr = SNESSetFromOptions(_snes);
   LIBMESH_CHKERR(ierr);
 
-  KSP my_ksp;
-  ierr = SNESGetKSP(_snes, &my_ksp);
-  LIBMESH_CHKERR(ierr);
+  // If we're not using PETSc DM, let's keep around
+  // the old style for fieldsplit
+  if (!use_petsc_dm)
+    {
+      KSP my_ksp;
+      ierr = SNESGetKSP(_snes, &my_ksp);
+      LIBMESH_CHKERR(ierr);
 
-  PC my_pc;
-  ierr = KSPGetPC(my_ksp, &my_pc);
-  LIBMESH_CHKERR(ierr);
+      PC my_pc;
+      ierr = KSPGetPC(my_ksp, &my_pc);
+      LIBMESH_CHKERR(ierr);
 
-  petsc_auto_fieldsplit(my_pc, _system);
+      petsc_auto_fieldsplit(my_pc, _system);
+    }
 }
 
 } // namespace libMesh

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -32,6 +32,24 @@
 namespace libMesh
 {
 
+PetscDMWrapper::~PetscDMWrapper()
+{
+  this->clear();
+}
+
+void PetscDMWrapper::clear()
+{
+  // This will also Destroy the attached PetscSection and PetscSF as well
+  // Destroy doesn't free the memory, but just resets points internally
+  // in the struct, so we'd still need to wipe out the memory on our side
+  for( auto dm_it = _dms.begin(); dm_it < _dms.end(); ++dm_it )
+    DMDestroy( dm_it->get() );
+
+  _dms.clear();
+  _sections.clear();
+  _star_forests.clear();
+}
+
 void PetscDMWrapper::init_and_attach_petscdm(const System & system, SNES & snes)
 {
   START_LOG ("init_and_attach_petscdm", "PetscDMWrapper");

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -1,0 +1,22 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2018 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/libmesh_common.h"
+
+#ifdef LIBMESH_HAVE_PETSC
+
+#endif // LIBMESH_HAVE_PETSC

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -19,6 +19,8 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+#include <petscsf.h>
+
 #include "libmesh/petsc_dm_wrapper.h"
 
 #include "libmesh/system.h"
@@ -65,6 +67,71 @@ void PetscDMWrapper::build_section( const System & system, PetscSection & sectio
 #endif
 
   STOP_LOG ("build_section", "PetscDMWrapper");
+}
+
+void PetscDMWrapper::build_sf( const System & system, PetscSF & star_forest )
+{
+  START_LOG ("build_sf", "PetscDMWrapper");
+
+  const DofMap & dof_map = system.get_dof_map();
+
+  const std::vector<dof_id_type> & send_list = dof_map.get_send_list();
+
+  // Number of ghost dofs that send information to this processor
+  PetscInt n_leaves = send_list.size();
+
+  // Number of local dofs, including ghosts dofs
+  PetscInt n_roots = dof_map.n_local_dofs();
+  n_roots += send_list.size();
+
+  // This is the vector of dof indices coming from other processors
+  // TODO: We do a stupid copy here since we can't convert an
+  //       unsigned int* to PetscInt*
+  std::vector<PetscInt> send_list_copy(send_list.size());
+  for( unsigned int i = 0; i < send_list.size(); i++ )
+    send_list_copy[i] = send_list[i];
+
+  PetscInt * local_dofs = send_list_copy.data();
+
+  // This is the vector of PetscSFNode's for the local_dofs.
+  // For each entry in local_dof, we have to supply the rank from which
+  // that dof stems and its local index on that rank.
+  // PETSc documentation here:
+  // http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/PetscSF/PetscSFNode.html
+  std::vector<PetscSFNode> sf_nodes(send_list.size());
+
+  for( unsigned int i = 0; i < send_list.size(); i++ )
+    {
+      unsigned int incoming_dof = send_list[i];
+
+      PetscInt rank = this->find_dof_rank( incoming_dof, dof_map );
+
+      /* Dofs are sorted and continuous on the processor so local index
+         is counted up from the first dof on the processor. */
+      PetscInt index = incoming_dof - dof_map.first_dof(rank);
+
+      sf_nodes[i].rank  = rank; /* Rank of owner */
+      sf_nodes[i].index = index;/* Index of dof on rank */
+    }
+
+  PetscSFNode * remote_dofs = sf_nodes.data();
+
+  PetscErrorCode ierr;
+  ierr = PetscSFCreate(system.comm().get(), &star_forest);CHKERRABORT(system.comm().get(),ierr);
+
+  // TODO: We should create pointers to arrays so we don't have to copy
+  //       and case use PETSC_OWN_POINTER where PETSc will take ownership
+  //       and delete the memory for us. But then we have to use PetscMalloc.
+  ierr = PetscSFSetGraph(star_forest,
+                         n_roots,
+                         n_leaves,
+                         local_dofs,
+                         PETSC_COPY_VALUES,
+                         remote_dofs,
+                         PETSC_COPY_VALUES);
+  CHKERRABORT(system.comm().get(),ierr);
+
+  STOP_LOG ("build_sf", "PetscDMWrapper");
 }
 
 void PetscDMWrapper::set_point_range_in_section( const System & system, PetscSection & section)

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -19,4 +19,68 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+#include "libmesh/petsc_dm_wrapper.h"
+
+#include "libmesh/system.h"
+#include "libmesh/mesh_base.h"
+#include "libmesh/elem.h"
+
+namespace libMesh
+{
+
+void PetscDMWrapper::set_point_range_in_section( const System & system, PetscSection & section)
+{
+  const MeshBase & mesh = system.get_mesh();
+
+  unsigned int pstart = 2^30;
+  unsigned int pend = 0;
+
+  // Find minimum and maximum (inclusive) global id numbers on the current processor
+  // to build PetscSection. Currently, we're using the global node number as the point index.
+  // TODO: This is currently restricted to nodal dofs only!
+  //       Need to generalize to the cases where there's dofs at edges, faces, and interiors
+  //       as well as vertices. When we generalize, we must guarantee that each id() is unique!
+  //       We'll then add each edge, face, and/or interior as a new "point" in the PetscSection.
+  if (mesh.n_active_local_elem() > 0)
+    {
+      for (MeshBase::const_element_iterator el = mesh.active_local_elements_begin();
+           el != mesh.active_local_elements_end(); el++)
+        {
+          const Elem * elem = *el;
+
+          if (mesh.query_elem_ptr(elem->id()))
+            {
+              for (unsigned int n = 0; n < elem->n_nodes(); n++)
+                {
+                  // get the global id number of local node n
+                  dof_id_type node = elem->node(n);
+
+                  if (node < pstart)
+                    pstart = node;
+
+                  if (node > pend)
+                    pend = node;
+                }
+            }
+        }
+
+      // PetscSectionSetChart is expecting [pstart,pend), so pad pend by 1.
+      pend +=1;
+    }
+
+  // If we're on a processor who coarsened the mesh to have no local elements,
+  // we should make an empty PetscSection. An empty PetscSection is specified
+  // by passing [0,0) to the PetscSectionSetChart call.
+  else
+    {
+      pstart = 0;
+      pend = 0;
+    }
+
+  PetscErrorCode ierr = PetscSectionSetChart(section, pstart, pend);
+  CHKERRABORT(system.comm().get(),ierr);
+}
+
+} // end namespace libMesh
+
 #endif // LIBMESH_HAVE_PETSC

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -19,6 +19,7 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+// PETSc includes
 #include <petscsf.h>
 
 #include "libmesh/petsc_dm_wrapper.h"
@@ -304,6 +305,20 @@ PetscInt PetscDMWrapper::find_dof_rank( unsigned int dof, const DofMap& dof_map 
   libmesh_assert_greater_equal( dof, dof_map.first_dof(current_rank) );
 
   return current_rank;
+}
+
+void PetscDMWrapper::init_dm_data(unsigned int n_levels)
+{
+  _dms.resize(n_levels);
+  _sections.resize(n_levels);
+  _star_forests.resize(n_levels);
+
+  for( unsigned int i = 0; i < n_levels; i++ )
+    {
+      _dms[i] = libmesh_make_unique<DM>();
+      _sections[i] = libmesh_make_unique<PetscSection>();
+      _star_forests[i] = libmesh_make_unique<PetscSF>();
+    }
 }
 
 } // end namespace libMesh


### PR DESCRIPTION
This implements Step 1 in the discussion in #1567.

I've marked this as do not merge until I can add testing into both libMesh and GRINS. I did testing way back when I wrote this code, but it was never formalized.

The testing to be added here is 1. The command line options for fieldsplit in this code path (both serial and parallel) and 2. recursive fieldsplit that I believe the current interface doesn't support. I'm thinking the Laplace/LAGRANGE_VEC example (where we have 3 decouple Laplace equations) and a incompressible thermal flow regression in GRINS. Also, I need to check the min PETSc version. Changelogs in PETSc aren't super helpful. I recall starting this work at PETSc 3.6.X, so was thinking I'll try that. Any urgent need to test earlier? Otherwise I'll just restrict this to PETSc 3.6.4 or later.

And dammit I just noticed I forgot documentation on the `init_and_attach_petscdm` function so I need to add that too.

Anyway, want to let folks start commenting on the design while I get tests into build system since I'm pretty confident this code will work correctly (famous last words...).