### PR TITLE
Cache dof indices when computing sparsity

### DIFF
--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -87,9 +87,12 @@ private:
   const bool implicit_neighbor_dofs;
   const bool need_full_sparsity_pattern;
 
-  void handle_vi_vj(const Elem * partner,
-                    const std::vector<dof_id_type> & element_dofs_i,
-                    unsigned int vj);
+  void handle_vi_vj(const std::vector<dof_id_type> & element_dofs_i,
+                    const std::vector<dof_id_type> & element_dofs_j);
+
+  void sorted_connected_dofs(const Elem * elem,
+                             std::vector<dof_id_type> & dofs_vi,
+                             unsigned int vi);
 
 public:
 


### PR DESCRIPTION
This gives me about 85% speedup on the test case in
https://github.com/idaholab/moose/issues/9480