### PR TITLE
read/write checkpoint files to/from nprocs-suffixed directories

### DIFF
--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -94,14 +94,27 @@ public:
   virtual ~CheckpointIO ();
 
   /**
-   * This method implements reading a mesh from a specified file.
+   * This method implements reading a mesh from a specified file.  If the mesh has been split for
+   * running on several processors, input_name should simply be the name of the mesh split
+   * directory without the "-split[n]" suffix.  The number of splits will be determined
+   * automatically by the number of processes being used for the mesh at the time of reading.
    */
-  virtual void read (const std::string &) libmesh_override;
+  virtual void read (const std::string & input_name) libmesh_override;
 
   /**
-   * This method implements writing a mesh to a specified file.
+   * This method implements writing a mesh to a specified file.  If the mesh has been split
+   * for running on several processors, this will create a subdirectory named
+   * "[name]-split[n]" where name is the given name argument and n is the number of
+   * processors the mesh is split for running on.  For example:
+   *
+   *     unsigned int n_splits = 42;
+   *     std::unique_ptr<CheckpointIO> cp = split_mesh(my_mesh, n_splits);
+   *     // ...
+   *     cp->write("foo.cpr");
+   *
+   * would create a directory named "foo.cpr-split42".
    */
-  virtual void write (const std::string &) libmesh_override;
+  virtual void write (const std::string & name) libmesh_override;
 
   /**
    * Get/Set the flag indicating if we should read/write binary.

--- a/tests/mesh/checkpoint.C
+++ b/tests/mesh/checkpoint.C
@@ -110,6 +110,7 @@ public:
     {
       MeshB mesh(*TestCommWorld);
       CheckpointIO cpr(mesh);
+      cpr.current_n_processors() = n_procs;
       cpr.binary() = binary;
       cpr.read(filename);
 


### PR DESCRIPTION
When writing and reading checkpoint files, put sets of checkpoint files for a single object/split together in a subdirectory named ``[input_name]-split[n]``.  When reading checkpoint files, look for a subdirectory with the ``-split[n]`` suffix for the current/correct number of procs.  This also helps prevent running with a lower number of procs than cpr split files which previously use to run but just with part of the mesh missing.

For non-parallel mesh cases, the single checkpoint file is just written as normal - not into a subdirectory.

Edit:

This now always creates a subdirectory named ``[input_name]`` with subsubdirectories named for the available split configurations for the mesh - e.g. fullpaths of ``[input_name]/[n]``.  Header and split files are ``[input_name]/[n]/header.cpr`` and ``[input_name]/[n]/split-[n]-[id]`` respectively.  When reading - check for nprocs split configuration - if none exists - try to fall back to a serial (nprocs=1) configuration.