### PR TITLE
Fix mis-branching in CouplingMatrix iterator++

### DIFF
--- a/include/numerics/coupling_matrix.h
+++ b/include/numerics/coupling_matrix.h
@@ -482,7 +482,7 @@ public:
     libmesh_assert_not_equal_to
       (_location, std::numeric_limits<std::size_t>::max());
 
-    if (_location == _it->second)
+    if (_location >= _it->second)
       {
         ++_it;
 


### PR DESCRIPTION
This was causing a *huge* performance penalty in cases where we had
many variables.

Hopefully https://github.com/idaholab/moose/issues/9480 will be fully
resolved by the fix.  I see orders of magnitude speedup in our test
case.

Assuming this doesn't break a hundred test cases (whether by exposing an underlying bug, or by failing to match a regression standard generated with the broken version, although I don't think either is likely to happen), @dschwen would you mind checking the asymptotic behavior again?  There's still some slight optimizations that might be possible here, but I think I've caught the entire O(N^3) mistake.