### PR TITLE
Updates to --with-thread-model

### DIFF
--- a/configure
+++ b/configure
@@ -1210,7 +1210,6 @@ enable_tbb
 with_tbb
 with_tbb_lib
 enable_pthreads
-enable_openmp
 enable_laspack
 enable_sfc
 enable_gzstreams
@@ -2000,7 +1999,6 @@ Optional Features:
   --disable-tbb           build without threading support via Threading
                           Building Blocks
   --disable-pthreads      build without POSIX threading (pthreads) support
-  --disable-openmp        Build without OpenMP Support
   --disable-laspack       build without LASPACK iterative solver support
   --disable-sfc           build without space-filling curves support
   --disable-gzstreams     build without gzstreams compressed I/O support
@@ -2086,7 +2084,7 @@ Optional Packages:
   --with-ml=PATH          Specify the path to ML installation
   --with-tpetra=PATH      Specify the path to Tpetra installation
   --with-dtk=PATH         Specify the path to Dtk installation
-  --with-thread-model=tbb,pthread,auto,none
+  --with-thread-model=tbb,pthread,openmp,auto,none
                           Specify the thread model to use
   --with-tbb=PATH         Specify the path where Threading Building Blocks is
                           installed
@@ -35716,6 +35714,7 @@ if test "${with_thread_model+set}" = set; then :
                 tbb)     requested_thread_model=tbb     ;;
                 pthread) requested_thread_model=pthread ;;
                 pthreads) requested_thread_model=pthread ;;
+                openmp)  requested_thread_model=openmp ;;
                 auto)    requested_thread_model=auto    ;;
                 none)    requested_thread_model=none    ;;
                 *)       as_fn_error $? "bad value ${withval} for --with-thread-model" "$LINENO" 5 ;;
@@ -35731,12 +35730,8 @@ $as_echo "<<< User requested thread model: $requested_thread_model >>>" >&6; }
   # Set this variable when a threading model is found
   found_thread_model=none
 
-  # Test different threading models, enabling only one.  For auto-detection, the
-  # ordering of the tests is:
-  # .) TBB
-  # .) OpenMP
-  # .) Pthread
-  if (test "x$requested_thread_model" = "xtbb" -o "x$requested_thread_model" = "xauto"); then
+  # Only configure TBB if the user explicitly requested it.
+  if (test "x$requested_thread_model" = "xtbb"); then
 
   # Check whether --enable-tbb was given.
 if test "${enable_tbb+set}" = set; then :
@@ -35953,15 +35948,15 @@ $as_echo "$ac_cv_tls" >&6; }
     # If TBB was not enabled, but the user requested it, we treat that as an error:
     # we want to alert the user as soon as possible that their requested thread model
     # could not be configured correctly.
-    if (test $enabletbb = no -a "x$requested_thread_model" = "xtbb"); then
+    if (test $enabletbb = no); then
       as_fn_error $? "requested threading model, TBB, could not be found." "$LINENO" 5
     fi
   fi
 
-  # If TBB wasn't selected, try pthreads as long as the user requested it (or auto)
+  # If TBB wasn't selected, try pthreads/openmp as long as the user
+  # requested it (or auto).
   if (test "$found_thread_model" = none) ; then
-    if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
-
+    if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto" -o "x$requested_thread_model" = "xopenmp"); then
       # Let the user explicitly specify --{enable,disable}-pthreads.
       # Check whether --enable-pthreads was given.
 if test "${enable_pthreads+set}" = set; then :
@@ -36408,28 +36403,15 @@ $as_echo "<<< Configuring library with pthread support >>>" >&6; }
       if (test $enablepthreads = no -a "x$requested_thread_model" = "xpthread"); then
         as_fn_error $? "requested threading model, pthreads, could not be found." "$LINENO" 5
       fi
-    fi
-  fi
+      if (test $enablepthreads = no -a "x$requested_thread_model" = "xopenmp"); then
+        as_fn_error $? "openmp threading model requested, but required pthread support unavailable." "$LINENO" 5
+      fi
 
-  # OpenMP support -- enabled unless the user has requested no
-  # threading, or no valid threading models could be found.
-  #
-  # OpenMP can be enabled independently of whether we are using the
-  # TBB or pthread threading models.  The pthread parallel_for() and
-  # parallel_reduce() implementations use openmp pragmas directly,
-  # while the TBB implementation does not.  We do the test here simply
-  # because it makes sense to keep all the threading stuff together
-  # rather than spreading it out across different m4 files.
-  if (test "$found_thread_model" != none) ; then
-    # Check whether --enable-openmp was given.
-if test "${enable_openmp+set}" = set; then :
-  enableval=$enable_openmp; enableopenmp=$enableval
-else
-  enableopenmp=yes
-fi
-
-
-    if (test "$enableopenmp" != no) ; then
+      if (test "x$requested_thread_model" = "xopenmp"); then
+        # OpenMP support
+        # The pthread model can optionally use OpenMP pragmas for its
+        # parallel_for() and parallel_reduce() implementations, so we
+        # configure the compiler's OpenMP options here.
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OpenMP flag of C++ compiler" >&5
@@ -36502,27 +36484,29 @@ $as_echo "#define HAVE_OPENMP 1" >>confdefs.h
 fi
 
 
-      # The above call only sets the flag for C++
-      if (test "x$OPENMP_CXXFLAGS" != x) ; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with OpenMP support >>>" >&5
+        # The above call only sets the flag for C++
+        if (test "x$OPENMP_CXXFLAGS" != x) ; then
+           { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with OpenMP support >>>" >&5
 $as_echo "<<< Configuring library with OpenMP support >>>" >&6; }
-        OPENMP_CFLAGS=$OPENMP_CXXFLAGS
-        OPENMP_FFLAGS=$OPENMP_CXXFLAGS
-        CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
-        CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
-        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
-        CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
-        CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
-        CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
-        CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
-        CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
-        CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
-        CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
-        FFLAGS="$FFLAGS $OPENMP_FFLAGS"
+           OPENMP_CFLAGS=$OPENMP_CXXFLAGS
+           OPENMP_FFLAGS=$OPENMP_CXXFLAGS
+           CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
+           CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
+           CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
+           CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
+           CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
+           CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
+           CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
+           CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
+           CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
+           CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
+           FFLAGS="$FFLAGS $OPENMP_FFLAGS"
 
 
 
-        break
+        else
+           as_fn_error $? "requested openmp threading model, but compiler does not support openmp." "$LINENO" 5
+        fi
       fi
     fi
   fi

--- a/configure
+++ b/configure
@@ -793,6 +793,8 @@ LIBMESH_ENABLE_LASPACK_FALSE
 LIBMESH_ENABLE_LASPACK_TRUE
 LASPACK_LIB
 LASPACK_INCLUDE
+TBB_INCLUDE
+TBB_LIBRARY
 OPENMP_FFLAGS
 OPENMP_CFLAGS
 OPENMP_CXXFLAGS
@@ -800,8 +802,6 @@ PTHREAD_CFLAGS
 PTHREAD_LIBS
 PTHREAD_CC
 ax_pthread_config
-TBB_INCLUDE
-TBB_LIBRARY
 TPETRA_INCLUDES
 TPETRA_LIBS
 ML_INCLUDES
@@ -1206,10 +1206,10 @@ with_ml
 with_tpetra
 with_dtk
 with_thread_model
+enable_pthreads
 enable_tbb
 with_tbb
 with_tbb_lib
-enable_pthreads
 enable_laspack
 enable_sfc
 enable_gzstreams
@@ -1996,9 +1996,9 @@ Optional Features:
   --enable-petsc-required Error if PETSc is not detected by configure
   --disable-slepc         build without SLEPc eigen solver support
   --disable-trilinos      build without Trilinos support
+  --disable-pthreads      build without POSIX threading (pthreads) support
   --disable-tbb           build without threading support via Threading
                           Building Blocks
-  --disable-pthreads      build without POSIX threading (pthreads) support
   --disable-laspack       build without LASPACK iterative solver support
   --disable-sfc           build without space-filling curves support
   --disable-gzstreams     build without gzstreams compressed I/O support
@@ -35730,247 +35730,22 @@ $as_echo "<<< User requested thread model: $requested_thread_model >>>" >&6; }
   # Set this variable when a threading model is found
   found_thread_model=none
 
-  # Only configure TBB if the user explicitly requested it.
-  if (test "x$requested_thread_model" = "xtbb"); then
-
-  # Check whether --enable-tbb was given.
-if test "${enable_tbb+set}" = set; then :
-  enableval=$enable_tbb; case "${enableval}" in
-                  yes)  enabletbb=yes ;;
-                  no)  enabletbb=no ;;
-                  *)  as_fn_error $? "bad value ${enableval} for --enable-tbb" "$LINENO" 5 ;;
-                esac
-else
-  enabletbb=$enableoptional
-fi
-
-
-  if (test $enabletbb = yes); then
-
-
-# Check whether --with-tbb was given.
-if test "${with_tbb+set}" = set; then :
-  withval=$with_tbb; withtbb=$withval
-else
-  withtbb=$TBB_DIR
-fi
-
-
-
-# Check whether --with-tbb-lib was given.
-if test "${with_tbb_lib+set}" = set; then :
-  withval=$with_tbb_lib; withtbblib=$withval
-else
-  withtbblib=$TBB_LIB_PATH
-fi
-
-
-    if test "$withtbb" != no ; then
-      if test "x$withtbb" = x ; then
-        withtbb=/usr
-      fi
-      as_ac_Header=`$as_echo "ac_cv_header_$withtbb/include/tbb/task_scheduler_init.h" | $as_tr_sh`
-ac_fn_cxx_check_header_mongrel "$LINENO" "$withtbb/include/tbb/task_scheduler_init.h" "$as_ac_Header" "$ac_includes_default"
-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
-  TBB_INCLUDE_PATH=$withtbb/include
-fi
-
-
-      if test "x$withtbblib" != "x" ; then
-        TBB_LIBS=$withtbblib
-      else
-        TBB_LIBS=$withtbb/lib
-      fi
-    fi
-
-    if (test -r $TBB_INCLUDE_PATH/tbb/task_scheduler_init.h) ; then
-      TBB_LIBRARY="-L$TBB_LIBS -ltbb -ltbbmalloc"
-      TBB_INCLUDE=-I$TBB_INCLUDE_PATH
-
-            if (test "x$RPATHFLAG" != "x" -a -d $TBB_LIBS); then
-        TBB_LIBRARY="${RPATHFLAG}${TBB_LIBS} $TBB_LIBRARY"
-      fi
-
-                        tbbmajor=`grep "define TBB_VERSION_MAJOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MAJOR[ ]*//g"`
-      tbbminor=`grep "define TBB_VERSION_MINOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MINOR[ ]*//g"`
-    else
-      enabletbb=no
-    fi
-
-    # If TBB is still enabled at this point, make sure we can compile
-    # a test code which uses tbb::tbb_thread
-    if test "$enabletbb" != no ; then
-
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for tbb::tbb_thread support" >&5
-$as_echo_n "checking for tbb::tbb_thread support... " >&6; }
-      ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-      # Add TBB headers to CXXFLAGS, which will be used by AC_COMPILE_IFELSE.
-      saveCXXFLAGS="$CXXFLAGS"
-      CXXFLAGS="$saveCXXFLAGS $TBB_INCLUDE"
-
-      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-          #include <tbb/tbb_thread.h>
-
-int
-main ()
-{
-
-          tbb::tbb_thread t;
-          t.join();
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-          enabletbb=yes
-
-else
-
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-          enabletbb=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-      # Restore original flags
-      CXXFLAGS=$saveCXXFLAGS
-
-      ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-    fi
-
-
-    # If TBB is still enabled at this point, set all the necessary defines and print
-    # a success message.
-    if test "$enabletbb" != no ; then
-
-cat >>confdefs.h <<_ACEOF
-#define DETECTED_TBB_VERSION_MAJOR $tbbmajor
-_ACEOF
-
-
-
-cat >>confdefs.h <<_ACEOF
-#define DETECTED_TBB_VERSION_MINOR $tbbminor
-_ACEOF
-
-
-
-
-
-
-$as_echo "#define USING_THREADS 1" >>confdefs.h
-
-
-$as_echo "#define HAVE_TBB_API 1" >>confdefs.h
-
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with Intel TBB threading support >>>" >&5
-$as_echo "<<< Configuring library with Intel TBB threading support >>>" >&6; }
-
-
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for thread local storage (TLS) class" >&5
-$as_echo_n "checking for thread local storage (TLS) class... " >&6; }
-  if ${ac_cv_tls+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-
-    ax_tls_keywords="__thread __declspec(thread) none"
-    for ax_tls_keyword in $ax_tls_keywords; do
-      case $ax_tls_keyword in
-        none) ac_cv_tls=none ; break ;;
-        *)
-           cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <stdlib.h>
-               static void
-               foo(void) {
-               static  $ax_tls_keyword  int bar;
-               exit(1);
-               }
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-  ac_cv_tls=$ax_tls_keyword ; break
-else
-  ac_cv_tls=none
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-      esac
-    done
-
-fi
-
-
-  if test "$ac_cv_tls" != "none"; then
-
-cat >>confdefs.h <<_ACEOF
-#define TLS $ac_cv_tls
-_ACEOF
-
-  fi
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_tls" >&5
-$as_echo "$ac_cv_tls" >&6; }
-
-    fi
-  fi
-
-
-    if (test $enabletbb = yes); then
-      libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
-      libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
-      found_thread_model=tbb
-    fi
-
-    # If TBB was not enabled, but the user requested it, we treat that as an error:
-    # we want to alert the user as soon as possible that their requested thread model
-    # could not be configured correctly.
-    if (test $enabletbb = no); then
-      as_fn_error $? "requested threading model, TBB, could not be found." "$LINENO" 5
-    fi
-  fi
-
-  # If TBB wasn't selected, try pthreads/openmp as long as the user
-  # requested it (or auto).
-  if (test "$found_thread_model" = none) ; then
-    if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto" -o "x$requested_thread_model" = "xopenmp"); then
-      # Let the user explicitly specify --{enable,disable}-pthreads.
-      # Check whether --enable-pthreads was given.
+  # First, try pthreads/openmp as long as the user requested it (or auto).
+  if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto" -o "x$requested_thread_model" = "xopenmp"); then
+    # Let the user explicitly specify --{enable,disable}-pthreads.
+    # Check whether --enable-pthreads was given.
 if test "${enable_pthreads+set}" = set; then :
   enableval=$enable_pthreads; case "${enableval}" in
-                      yes)  enablepthreads=yes ;;
-                      no)  enablepthreads=no ;;
-                      *)  as_fn_error $? "bad value ${enableval} for --enable-pthreads" "$LINENO" 5 ;;
-                    esac
+                    yes)  enablepthreads=yes ;;
+                    no)  enablepthreads=no ;;
+                    *)  as_fn_error $? "bad value ${enableval} for --enable-pthreads" "$LINENO" 5 ;;
+                  esac
 else
   enablepthreads=$enableoptional
 fi
 
 
-      if (test "$enablepthreads" = yes) ; then
+    if (test "$enablepthreads" = yes) ; then
 
 
 ac_ext=c
@@ -36383,35 +36158,35 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
 
-        if (test x$ax_pthread_ok = xyes); then
+      if (test x$ax_pthread_ok = xyes); then
 
 $as_echo "#define USING_THREADS 1" >>confdefs.h
 
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with pthread support >>>" >&5
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with pthread support >>>" >&5
 $as_echo "<<< Configuring library with pthread support >>>" >&6; }
-          libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
-          libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
-          found_thread_model=pthread
-        else
-          enablepthreads=no
-        fi
+        libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
+        libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
+        found_thread_model=pthread
+      else
+        enablepthreads=no
       fi
+    fi
 
-      # If pthreads were not enabled, but the user requested it, we treat that as an error:
-      # we want to alert the user as soon as possible that their requested thread model
-      # could not be configured correctly.
-      if (test $enablepthreads = no -a "x$requested_thread_model" = "xpthread"); then
-        as_fn_error $? "requested threading model, pthreads, could not be found." "$LINENO" 5
-      fi
-      if (test $enablepthreads = no -a "x$requested_thread_model" = "xopenmp"); then
-        as_fn_error $? "openmp threading model requested, but required pthread support unavailable." "$LINENO" 5
-      fi
+    # If pthreads were not enabled, but the user requested it, we treat that as an error:
+    # we want to alert the user as soon as possible that their requested thread model
+    # could not be configured correctly.
+    if (test $enablepthreads = no -a "x$requested_thread_model" = "xpthread"); then
+      as_fn_error $? "requested threading model, pthreads, could not be found." "$LINENO" 5
+    fi
+    if (test $enablepthreads = no -a "x$requested_thread_model" = "xopenmp"); then
+      as_fn_error $? "openmp threading model requested, but required pthread support unavailable." "$LINENO" 5
+    fi
 
-      if (test "x$requested_thread_model" = "xopenmp"); then
-        # OpenMP support
-        # The pthread model can optionally use OpenMP pragmas for its
-        # parallel_for() and parallel_reduce() implementations, so we
-        # configure the compiler's OpenMP options here.
+    if (test "x$requested_thread_model" = "xopenmp"); then
+      # OpenMP support
+      # The pthread model can optionally use OpenMP pragmas for its
+      # parallel_for() and parallel_reduce() implementations, so we
+      # configure the compiler's OpenMP options here.
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for OpenMP flag of C++ compiler" >&5
@@ -36484,29 +36259,255 @@ $as_echo "#define HAVE_OPENMP 1" >>confdefs.h
 fi
 
 
-        # The above call only sets the flag for C++
-        if (test "x$OPENMP_CXXFLAGS" != x) ; then
-           { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with OpenMP support >>>" >&5
+      # The above call only sets the flag for C++
+      if (test "x$OPENMP_CXXFLAGS" != x) ; then
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with OpenMP support >>>" >&5
 $as_echo "<<< Configuring library with OpenMP support >>>" >&6; }
-           OPENMP_CFLAGS=$OPENMP_CXXFLAGS
-           OPENMP_FFLAGS=$OPENMP_CXXFLAGS
-           CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
-           CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
-           CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
-           CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
-           CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
-           CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
-           CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
-           CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
-           CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
-           CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
-           FFLAGS="$FFLAGS $OPENMP_FFLAGS"
+         OPENMP_CFLAGS=$OPENMP_CXXFLAGS
+         OPENMP_FFLAGS=$OPENMP_CXXFLAGS
+         CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
+         CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
+         CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
+         CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
+         CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
+         CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
+         CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
+         CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
+         CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
+         CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
+         FFLAGS="$FFLAGS $OPENMP_FFLAGS"
 
 
 
-        else
-           as_fn_error $? "requested openmp threading model, but compiler does not support openmp." "$LINENO" 5
-        fi
+      else
+         as_fn_error $? "requested openmp threading model, but compiler does not support openmp." "$LINENO" 5
+      fi
+    fi
+  fi
+
+  # Try to configure TBB if the user explicitly requested it, or if we
+  # are doing auto detection and pthreads/openmp detection did not
+  # succeed.
+  if (test "$found_thread_model" = none) ; then
+    if (test "x$requested_thread_model" = "xtbb" -o "x$requested_thread_model" = "xauto"); then
+
+  # Check whether --enable-tbb was given.
+if test "${enable_tbb+set}" = set; then :
+  enableval=$enable_tbb; case "${enableval}" in
+                  yes)  enabletbb=yes ;;
+                  no)  enabletbb=no ;;
+                  *)  as_fn_error $? "bad value ${enableval} for --enable-tbb" "$LINENO" 5 ;;
+                esac
+else
+  enabletbb=$enableoptional
+fi
+
+
+  if (test $enabletbb = yes); then
+
+
+# Check whether --with-tbb was given.
+if test "${with_tbb+set}" = set; then :
+  withval=$with_tbb; withtbb=$withval
+else
+  withtbb=$TBB_DIR
+fi
+
+
+
+# Check whether --with-tbb-lib was given.
+if test "${with_tbb_lib+set}" = set; then :
+  withval=$with_tbb_lib; withtbblib=$withval
+else
+  withtbblib=$TBB_LIB_PATH
+fi
+
+
+    if test "$withtbb" != no ; then
+      if test "x$withtbb" = x ; then
+        withtbb=/usr
+      fi
+      as_ac_Header=`$as_echo "ac_cv_header_$withtbb/include/tbb/task_scheduler_init.h" | $as_tr_sh`
+ac_fn_cxx_check_header_mongrel "$LINENO" "$withtbb/include/tbb/task_scheduler_init.h" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  TBB_INCLUDE_PATH=$withtbb/include
+fi
+
+
+      if test "x$withtbblib" != "x" ; then
+        TBB_LIBS=$withtbblib
+      else
+        TBB_LIBS=$withtbb/lib
+      fi
+    fi
+
+    if (test -r $TBB_INCLUDE_PATH/tbb/task_scheduler_init.h) ; then
+      TBB_LIBRARY="-L$TBB_LIBS -ltbb -ltbbmalloc"
+      TBB_INCLUDE=-I$TBB_INCLUDE_PATH
+
+            if (test "x$RPATHFLAG" != "x" -a -d $TBB_LIBS); then
+        TBB_LIBRARY="${RPATHFLAG}${TBB_LIBS} $TBB_LIBRARY"
+      fi
+
+                        tbbmajor=`grep "define TBB_VERSION_MAJOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MAJOR[ ]*//g"`
+      tbbminor=`grep "define TBB_VERSION_MINOR" $TBB_INCLUDE_PATH/tbb/tbb_stddef.h | sed -e "s/#define TBB_VERSION_MINOR[ ]*//g"`
+    else
+      enabletbb=no
+    fi
+
+    # If TBB is still enabled at this point, make sure we can compile
+    # a test code which uses tbb::tbb_thread
+    if test "$enabletbb" != no ; then
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for tbb::tbb_thread support" >&5
+$as_echo_n "checking for tbb::tbb_thread support... " >&6; }
+      ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+      # Add TBB headers to CXXFLAGS, which will be used by AC_COMPILE_IFELSE.
+      saveCXXFLAGS="$CXXFLAGS"
+      CXXFLAGS="$saveCXXFLAGS $TBB_INCLUDE"
+
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+          #include <tbb/tbb_thread.h>
+
+int
+main ()
+{
+
+          tbb::tbb_thread t;
+          t.join();
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+          enabletbb=yes
+
+else
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+          enabletbb=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+      # Restore original flags
+      CXXFLAGS=$saveCXXFLAGS
+
+      ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+    fi
+
+
+    # If TBB is still enabled at this point, set all the necessary defines and print
+    # a success message.
+    if test "$enabletbb" != no ; then
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_TBB_VERSION_MAJOR $tbbmajor
+_ACEOF
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define DETECTED_TBB_VERSION_MINOR $tbbminor
+_ACEOF
+
+
+
+
+
+
+$as_echo "#define USING_THREADS 1" >>confdefs.h
+
+
+$as_echo "#define HAVE_TBB_API 1" >>confdefs.h
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with Intel TBB threading support >>>" >&5
+$as_echo "<<< Configuring library with Intel TBB threading support >>>" >&6; }
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for thread local storage (TLS) class" >&5
+$as_echo_n "checking for thread local storage (TLS) class... " >&6; }
+  if ${ac_cv_tls+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+    ax_tls_keywords="__thread __declspec(thread) none"
+    for ax_tls_keyword in $ax_tls_keywords; do
+      case $ax_tls_keyword in
+        none) ac_cv_tls=none ; break ;;
+        *)
+           cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+               static void
+               foo(void) {
+               static  $ax_tls_keyword  int bar;
+               exit(1);
+               }
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ac_cv_tls=$ax_tls_keyword ; break
+else
+  ac_cv_tls=none
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+      esac
+    done
+
+fi
+
+
+  if test "$ac_cv_tls" != "none"; then
+
+cat >>confdefs.h <<_ACEOF
+#define TLS $ac_cv_tls
+_ACEOF
+
+  fi
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_tls" >&5
+$as_echo "$ac_cv_tls" >&6; }
+
+    fi
+  fi
+
+
+      if (test $enabletbb = yes); then
+        libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
+        libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
+        found_thread_model=tbb
+      fi
+
+      # If TBB was not enabled, but the user requested it, we treat that as an error:
+      # we want to alert the user as soon as possible that their requested thread model
+      # could not be configured correctly.
+      if (test $enabletbb = no); then
+        as_fn_error $? "requested threading model, TBB, could not be found." "$LINENO" 5
       fi
     fi
   fi

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -94,27 +94,14 @@ public:
   virtual ~CheckpointIO ();
 
   /**
-   * This method implements reading a mesh from a specified file.  If the mesh has been split for
-   * running on several processors, input_name should simply be the name of the mesh split
-   * directory without the "-split[n]" suffix.  The number of splits will be determined
-   * automatically by the number of processes being used for the mesh at the time of reading.
+   * This method implements reading a mesh from a specified file.
    */
-  virtual void read (const std::string & input_name) libmesh_override;
+  virtual void read (const std::string &) libmesh_override;
 
   /**
-   * This method implements writing a mesh to a specified file.  If the mesh has been split
-   * for running on several processors, this will create a subdirectory named
-   * "[name]-split[n]" where name is the given name argument and n is the number of
-   * processors the mesh is split for running on.  For example:
-   *
-   *     unsigned int n_splits = 42;
-   *     std::unique_ptr<CheckpointIO> cp = split_mesh(my_mesh, n_splits);
-   *     // ...
-   *     cp->write("foo.cpr");
-   *
-   * would create a directory named "foo.cpr-split42".
+   * This method implements writing a mesh to a specified file.
    */
-  virtual void write (const std::string & name) libmesh_override;
+  virtual void write (const std::string &) libmesh_override;
 
   /**
    * Get/Set the flag indicating if we should read/write binary.

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -4,11 +4,12 @@
 AC_DEFUN([ACX_BEST_THREAD],
 [
   AC_ARG_WITH(thread-model,
-              AS_HELP_STRING([--with-thread-model=tbb,pthread,auto,none],[Specify the thread model to use]),
+              AS_HELP_STRING([--with-thread-model=tbb,pthread,openmp,auto,none],[Specify the thread model to use]),
               [case "${withval}" in
                 tbb)     requested_thread_model=tbb     ;;
                 pthread) requested_thread_model=pthread ;;
                 pthreads) requested_thread_model=pthread ;;
+                openmp)  requested_thread_model=openmp ;;
                 auto)    requested_thread_model=auto    ;;
                 none)    requested_thread_model=none    ;;
                 *)       AC_MSG_ERROR(bad value ${withval} for --with-thread-model) ;;
@@ -20,12 +21,8 @@ AC_DEFUN([ACX_BEST_THREAD],
   # Set this variable when a threading model is found
   found_thread_model=none
 
-  # Test different threading models, enabling only one.  For auto-detection, the
-  # ordering of the tests is:
-  # .) TBB
-  # .) OpenMP
-  # .) Pthread
-  if (test "x$requested_thread_model" = "xtbb" -o "x$requested_thread_model" = "xauto"); then
+  # Only configure TBB if the user explicitly requested it.
+  if (test "x$requested_thread_model" = "xtbb"); then
     CONFIGURE_TBB
 
     if (test $enabletbb = yes); then
@@ -37,15 +34,15 @@ AC_DEFUN([ACX_BEST_THREAD],
     # If TBB was not enabled, but the user requested it, we treat that as an error:
     # we want to alert the user as soon as possible that their requested thread model
     # could not be configured correctly.
-    if (test $enabletbb = no -a "x$requested_thread_model" = "xtbb"); then
+    if (test $enabletbb = no); then
       AC_MSG_ERROR([requested threading model, TBB, could not be found.])
     fi
   fi
 
-  # If TBB wasn't selected, try pthreads as long as the user requested it (or auto)
+  # If TBB wasn't selected, try pthreads/openmp as long as the user
+  # requested it (or auto).
   if (test "$found_thread_model" = none) ; then
-    if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto"); then
-
+    if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto" -o "x$requested_thread_model" = "xopenmp"); then
       # Let the user explicitly specify --{enable,disable}-pthreads.
       AC_ARG_ENABLE(pthreads,
                     AS_HELP_STRING([--disable-pthreads],
@@ -78,48 +75,39 @@ AC_DEFUN([ACX_BEST_THREAD],
       if (test $enablepthreads = no -a "x$requested_thread_model" = "xpthread"); then
         AC_MSG_ERROR([requested threading model, pthreads, could not be found.])
       fi
-    fi
-  fi
+      if (test $enablepthreads = no -a "x$requested_thread_model" = "xopenmp"); then
+        AC_MSG_ERROR([openmp threading model requested, but required pthread support unavailable.])
+      fi
 
-  # OpenMP support -- enabled unless the user has requested no
-  # threading, or no valid threading models could be found.
-  #
-  # OpenMP can be enabled independently of whether we are using the
-  # TBB or pthread threading models.  The pthread parallel_for() and
-  # parallel_reduce() implementations use openmp pragmas directly,
-  # while the TBB implementation does not.  We do the test here simply
-  # because it makes sense to keep all the threading stuff together
-  # rather than spreading it out across different m4 files.
-  if (test "$found_thread_model" != none) ; then
-    AC_ARG_ENABLE(openmp,
-                  AS_HELP_STRING([--disable-openmp],
-                                 [Build without OpenMP Support]),
-                  enableopenmp=$enableval,
-                  enableopenmp=yes)
+      if (test "x$requested_thread_model" = "xopenmp"); then
+        # OpenMP support
+        # The pthread model can optionally use OpenMP pragmas for its
+        # parallel_for() and parallel_reduce() implementations, so we
+        # configure the compiler's OpenMP options here.
+        AX_OPENMP([],[enableopenmp=no])
 
-    if (test "$enableopenmp" != no) ; then
-      AX_OPENMP([],[enableopenmp=no])
-
-      # The above call only sets the flag for C++
-      if (test "x$OPENMP_CXXFLAGS" != x) ; then
-        AC_MSG_RESULT(<<< Configuring library with OpenMP support >>>)
-        OPENMP_CFLAGS=$OPENMP_CXXFLAGS
-        OPENMP_FFLAGS=$OPENMP_CXXFLAGS
-        CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
-        CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
-        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
-        CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
-        CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
-        CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
-        CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
-        CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
-        CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
-        CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
-        FFLAGS="$FFLAGS $OPENMP_FFLAGS"
-        AC_SUBST(OPENMP_CXXFLAGS)
-        AC_SUBST(OPENMP_CFLAGS)
-        AC_SUBST(OPENMP_FFLAGS)
-        break
+        # The above call only sets the flag for C++
+        if (test "x$OPENMP_CXXFLAGS" != x) ; then
+           AC_MSG_RESULT(<<< Configuring library with OpenMP support >>>)
+           OPENMP_CFLAGS=$OPENMP_CXXFLAGS
+           OPENMP_FFLAGS=$OPENMP_CXXFLAGS
+           CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
+           CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
+           CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
+           CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
+           CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
+           CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
+           CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
+           CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
+           CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
+           CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
+           FFLAGS="$FFLAGS $OPENMP_FFLAGS"
+           AC_SUBST(OPENMP_CXXFLAGS)
+           AC_SUBST(OPENMP_CFLAGS)
+           AC_SUBST(OPENMP_FFLAGS)
+        else
+           AC_MSG_ERROR([requested openmp threading model, but compiler does not support openmp.])
+        fi
       fi
     fi
   fi

--- a/m4/threads.m4
+++ b/m4/threads.m4
@@ -21,93 +21,94 @@ AC_DEFUN([ACX_BEST_THREAD],
   # Set this variable when a threading model is found
   found_thread_model=none
 
-  # Only configure TBB if the user explicitly requested it.
-  if (test "x$requested_thread_model" = "xtbb"); then
-    CONFIGURE_TBB
+  # First, try pthreads/openmp as long as the user requested it (or auto).
+  if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto" -o "x$requested_thread_model" = "xopenmp"); then
+    # Let the user explicitly specify --{enable,disable}-pthreads.
+    AC_ARG_ENABLE(pthreads,
+                  AS_HELP_STRING([--disable-pthreads],
+                                 [build without POSIX threading (pthreads) support]),
+                  [case "${enableval}" in
+                    yes)  enablepthreads=yes ;;
+                    no)  enablepthreads=no ;;
+                    *)  AC_MSG_ERROR(bad value ${enableval} for --enable-pthreads) ;;
+                  esac],
+                  [enablepthreads=$enableoptional])
 
-    if (test $enabletbb = yes); then
-      libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
-      libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
-      found_thread_model=tbb
+    if (test "$enablepthreads" = yes) ; then
+      AX_PTHREAD
+
+      if (test x$ax_pthread_ok = xyes); then
+        AC_DEFINE(USING_THREADS, 1,
+                  [Flag indicating whether the library shall be compiled to use any particular thread API.])
+        AC_MSG_RESULT(<<< Configuring library with pthread support >>>)
+        libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
+        libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
+        found_thread_model=pthread
+      else
+        enablepthreads=no
+      fi
     fi
 
-    # If TBB was not enabled, but the user requested it, we treat that as an error:
+    # If pthreads were not enabled, but the user requested it, we treat that as an error:
     # we want to alert the user as soon as possible that their requested thread model
     # could not be configured correctly.
-    if (test $enabletbb = no); then
-      AC_MSG_ERROR([requested threading model, TBB, could not be found.])
+    if (test $enablepthreads = no -a "x$requested_thread_model" = "xpthread"); then
+      AC_MSG_ERROR([requested threading model, pthreads, could not be found.])
+    fi
+    if (test $enablepthreads = no -a "x$requested_thread_model" = "xopenmp"); then
+      AC_MSG_ERROR([openmp threading model requested, but required pthread support unavailable.])
+    fi
+
+    if (test "x$requested_thread_model" = "xopenmp"); then
+      # OpenMP support
+      # The pthread model can optionally use OpenMP pragmas for its
+      # parallel_for() and parallel_reduce() implementations, so we
+      # configure the compiler's OpenMP options here.
+      AX_OPENMP([],[enableopenmp=no])
+
+      # The above call only sets the flag for C++
+      if (test "x$OPENMP_CXXFLAGS" != x) ; then
+         AC_MSG_RESULT(<<< Configuring library with OpenMP support >>>)
+         OPENMP_CFLAGS=$OPENMP_CXXFLAGS
+         OPENMP_FFLAGS=$OPENMP_CXXFLAGS
+         CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
+         CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
+         CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
+         CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
+         CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
+         CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
+         CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
+         CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
+         CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
+         CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
+         FFLAGS="$FFLAGS $OPENMP_FFLAGS"
+         AC_SUBST(OPENMP_CXXFLAGS)
+         AC_SUBST(OPENMP_CFLAGS)
+         AC_SUBST(OPENMP_FFLAGS)
+      else
+         AC_MSG_ERROR([requested openmp threading model, but compiler does not support openmp.])
+      fi
     fi
   fi
 
-  # If TBB wasn't selected, try pthreads/openmp as long as the user
-  # requested it (or auto).
+  # Try to configure TBB if the user explicitly requested it, or if we
+  # are doing auto detection and pthreads/openmp detection did not
+  # succeed.
   if (test "$found_thread_model" = none) ; then
-    if (test "x$requested_thread_model" = "xpthread" -o "x$requested_thread_model" = "xauto" -o "x$requested_thread_model" = "xopenmp"); then
-      # Let the user explicitly specify --{enable,disable}-pthreads.
-      AC_ARG_ENABLE(pthreads,
-                    AS_HELP_STRING([--disable-pthreads],
-                                   [build without POSIX threading (pthreads) support]),
-                    [case "${enableval}" in
-                      yes)  enablepthreads=yes ;;
-                      no)  enablepthreads=no ;;
-                      *)  AC_MSG_ERROR(bad value ${enableval} for --enable-pthreads) ;;
-                    esac],
-                    [enablepthreads=$enableoptional])
+    if (test "x$requested_thread_model" = "xtbb" -o "x$requested_thread_model" = "xauto"); then
+      CONFIGURE_TBB
 
-      if (test "$enablepthreads" = yes) ; then
-        AX_PTHREAD
-
-        if (test x$ax_pthread_ok = xyes); then
-          AC_DEFINE(USING_THREADS, 1,
-                    [Flag indicating whether the library shall be compiled to use any particular thread API.])
-          AC_MSG_RESULT(<<< Configuring library with pthread support >>>)
-          libmesh_optional_INCLUDES="$PTHREAD_CFLAGS $libmesh_optional_INCLUDES"
-          libmesh_optional_LIBS="$PTHREAD_LIBS $libmesh_optional_LIBS"
-          found_thread_model=pthread
-        else
-          enablepthreads=no
-        fi
+      if (test $enabletbb = yes); then
+        libmesh_optional_INCLUDES="$TBB_INCLUDE $libmesh_optional_INCLUDES"
+        libmesh_optional_LIBS="$TBB_LIBRARY $libmesh_optional_LIBS"
+        found_thread_model=tbb
       fi
 
-      # If pthreads were not enabled, but the user requested it, we treat that as an error:
+      # If TBB was not enabled, but the user requested it, we treat that as an error:
       # we want to alert the user as soon as possible that their requested thread model
       # could not be configured correctly.
-      if (test $enablepthreads = no -a "x$requested_thread_model" = "xpthread"); then
-        AC_MSG_ERROR([requested threading model, pthreads, could not be found.])
-      fi
-      if (test $enablepthreads = no -a "x$requested_thread_model" = "xopenmp"); then
-        AC_MSG_ERROR([openmp threading model requested, but required pthread support unavailable.])
-      fi
-
-      if (test "x$requested_thread_model" = "xopenmp"); then
-        # OpenMP support
-        # The pthread model can optionally use OpenMP pragmas for its
-        # parallel_for() and parallel_reduce() implementations, so we
-        # configure the compiler's OpenMP options here.
-        AX_OPENMP([],[enableopenmp=no])
-
-        # The above call only sets the flag for C++
-        if (test "x$OPENMP_CXXFLAGS" != x) ; then
-           AC_MSG_RESULT(<<< Configuring library with OpenMP support >>>)
-           OPENMP_CFLAGS=$OPENMP_CXXFLAGS
-           OPENMP_FFLAGS=$OPENMP_CXXFLAGS
-           CXXFLAGS_OPT="$CXXFLAGS_OPT $OPENMP_CXXFLAGS"
-           CXXFLAGS_DBG="$CXXFLAGS_DBG $OPENMP_CXXFLAGS"
-           CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL $OPENMP_CXXFLAGS"
-           CXXFLAGS_PROF="$CXXFLAGS_PROF $OPENMP_CXXFLAGS"
-           CXXFLAGS_OPROF="$CXXFLAGS_OPROF $OPENMP_CXXFLAGS"
-           CFLAGS_OPT="$CFLAGS_OPT $OPENMP_CFLAGS"
-           CFLAGS_DBG="$CFLAGS_DBG $OPENMP_CFLAGS"
-           CFLAGS_DEVEL="$CFLAGS_DEVEL $OPENMP_CFLAGS"
-           CFLAGS_PROF="$CFLAGS_PROF $OPENMP_CFLAGS"
-           CFLAGS_OPROF="$CFLAGS_OPROF $OPENMP_CFLAGS"
-           FFLAGS="$FFLAGS $OPENMP_FFLAGS"
-           AC_SUBST(OPENMP_CXXFLAGS)
-           AC_SUBST(OPENMP_CFLAGS)
-           AC_SUBST(OPENMP_FFLAGS)
-        else
-           AC_MSG_ERROR([requested openmp threading model, but compiler does not support openmp.])
-        fi
+      if (test $enabletbb = no); then
+        AC_MSG_ERROR([requested threading model, TBB, could not be found.])
       fi
     fi
   fi

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -42,7 +42,6 @@
 #include "libmesh/remote_elem.h"
 #include "libmesh/xdr_io.h"
 #include "libmesh/xdr_cxx.h"
-#include "libmesh/utility.h"
 
 namespace libMesh
 {
@@ -116,6 +115,8 @@ CheckpointIO::CheckpointIO (MeshBase & mesh, const bool binary_in) :
 {
 }
 
+
+
 CheckpointIO::CheckpointIO (const MeshBase & mesh, const bool binary_in) :
   MeshOutput<MeshBase>(mesh,/* is_parallel_format = */ true),
   ParallelObject      (mesh),
@@ -126,17 +127,14 @@ CheckpointIO::CheckpointIO (const MeshBase & mesh, const bool binary_in) :
 {
 }
 
+
+
 CheckpointIO::~CheckpointIO ()
 {
 }
 
-std::string extension(const std::string & s)
-{
-  auto pos = s.rfind(".");
-  if (pos == std::string::npos)
-    return "";
-  return s.substr(pos, s.size() - pos);
-}
+
+
 
 void CheckpointIO::write (const std::string & name)
 {
@@ -150,32 +148,11 @@ void CheckpointIO::write (const std::string & name)
   // do a gather_to_zero() and support that case too.
   _parallel = _parallel || !mesh.is_serial();
 
-  auto ext = extension(name);
-  std::string dir_name;
-  std::string str_my_n_procs = "1";
-  if (_parallel)
-    str_my_n_procs = std::to_string(_my_n_processors);
-
-  dir_name = name + "/" + str_my_n_procs;
-  std::string header_file_name = dir_name + "/header" + ext;
-
-  auto errcode = Utility::mkdir(name.c_str());
-  // error only if we failed to create dir - don't care if it was already there
-  if (errcode != 0 && errcode != -1)
-    libmesh_error_msg("Failed to create mesh split directory '" << name << "'");
-
-  errcode = Utility::mkdir(dir_name.c_str());
-  if (errcode == -1)
-    libmesh_warning("In CheckpointIO::write, directory "
-                    << dir_name << " already exists, overwriting contents.");
-  else if (errcode != 0)
-    libmesh_error_msg("Failed to create mesh split directory '" << dir_name << "'");
-
   // We'll write a header file from processor 0 to make it easier to do unambiguous
   // restarts later:
   if (this->processor_id() == 0)
     {
-      Xdr io (header_file_name, this->binary() ? ENCODE : WRITE);
+      Xdr io (name, this->binary() ? ENCODE : WRITE);
 
       // write the version
       io.data(_version, "# version");
@@ -243,8 +220,11 @@ void CheckpointIO::write (const std::string & name)
     {
       const processor_id_type my_pid = *id_it;
 
-      auto file_name = dir_name + "/split-" + str_my_n_procs + "-" + std::to_string(my_pid) + ext;
-      Xdr io (file_name, this->binary() ? ENCODE : WRITE);
+      std::ostringstream file_name_stream;
+
+      file_name_stream << name << "-" << (_parallel ? _my_n_processors : 1) << "-" << my_pid;
+
+      Xdr io (file_name_stream.str(), this->binary() ? ENCODE : WRITE);
 
       std::set<const Elem *, CompareElemIdsByLevel> elements;
 
@@ -633,29 +613,33 @@ void CheckpointIO::read (const std::string & input_name)
   // What size data is being used in this file?
   header_id_type data_size;
 
-  auto ext = extension(input_name);
-  std::string dir_name = input_name + "/" + std::to_string(_my_n_processors);
-  std::string header_name = dir_name + "/header" + ext;
+  // How many per-processor files are here?
+  largest_id_type input_n_procs;
 
-  {
-    // look for header+splits with nprocs equal to _my_n_processors
-    std::ifstream in (header_name.c_str());
-    if (!in.good())
-      {
-        // otherwise fall back to a serial/single-split mesh
-        dir_name = input_name + "/1";
-        header_name = dir_name + "/header" + ext;
-        std::ifstream in (header_name.c_str());
-        if (!in.good())
-          {
-            libmesh_error_msg("ERROR: cannot locate header file '" << header_name << "'");
-          }
-      }
-  }
+  // We might read an exact name like "foo.cpr", or we might read a
+  // generated name like "foo.cpr.128" that we expect to be presplit
+  // for our current number of processors.
+  std::string header_name = input_name;
 
   // We'll read a header file from processor 0 and broadcast.
   if (this->processor_id() == 0)
     {
+      {
+        // Try the exact given name first
+        std::ifstream in (header_name.c_str());
+
+        if (!in.good())
+          {
+            header_name += "-" + std::to_string(mesh.n_processors());
+
+            std::ifstream in_nproc (header_name.c_str());
+
+            if (!in_nproc.good())
+              libmesh_error_msg("ERROR: cannot locate header file:\n\t" <<
+                                input_name << "\nor\n\t" << header_name);
+          }
+      }
+
       Xdr io (header_name, this->binary() ? DECODE : READ);
 
       // read the version, but don't care about it
@@ -667,9 +651,6 @@ void CheckpointIO::read (const std::string & input_name)
     }
 
   this->comm().broadcast(data_size);
-
-  // How many per-processor files are here?
-  largest_id_type input_n_procs;
 
   switch (data_size) {
   case 2:
@@ -707,9 +688,11 @@ void CheckpointIO::read (const std::string & input_name)
 
       for (processor_id_type proc_id = begin_proc_id; proc_id < input_n_procs; proc_id += stride)
         {
-          std::string file_name = dir_name + "/split-" +
-                                  std::to_string(input_parallel ? input_n_procs : 1) + "-" +
-                                  std::to_string(proc_id) + ext;
+          std::string file_name = input_name;
+
+          file_name += "-" +
+            std::to_string(input_parallel ?  input_n_procs : 1) +
+            "-" + std::to_string(proc_id);
 
           {
             std::ifstream in (file_name.c_str());

--- a/tests/mesh/checkpoint.C
+++ b/tests/mesh/checkpoint.C
@@ -110,7 +110,6 @@ public:
     {
       MeshB mesh(*TestCommWorld);
       CheckpointIO cpr(mesh);
-      cpr.current_n_processors() = n_procs;
       cpr.binary() = binary;
       cpr.read(filename);
 


### PR DESCRIPTION
This PR adds the `--with-thread-model=openmp` option, and removes TBB from the list of threading models that are "auto detected". TBB has declined significantly in popularity over time, and probably isn't as safe of a default as pthreads at this point. 
