### PR TITLE
read/write checkpoint files to/from nprocs-suffixed directories

### DIFF
--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -117,6 +117,29 @@ public:
   virtual void write (const std::string & name) libmesh_override;
 
   /**
+   * Used to remove a checkpoint directory and its corresponding files.  This effectively undoes
+   * all the work done be calls to write(...).  For example, if a checkpoint configuration was
+   * written via:
+   *
+   *     unsigned int n_splits = 42;
+   *     std::unique_ptr<CheckpointIO> cp = split_mesh(my_mesh, n_splits);
+   *     // ...
+   *     cp->write("foo.cpr");
+   *
+   * then you could remove all the corresponding created files/dirs by:
+   *
+   *     CheckpointIO::cleanup(my_mesh, n_splits);
+   *
+   * Or for cases where the split configuration was determined automatically (e.g. via number of
+   * running procs with distributed/parallel mesh), then you could:
+   *
+   *     CheckpointIO::cleanup(your_mesh, your_mesh.comm().size());
+   *
+   * Other remaining checkpoint split configurations for the mesh are left unmodified.
+   */
+  static void cleanup(const std::string & input_name, processor_id_type n_procs);
+
+  /**
    * Get/Set the flag indicating if we should read/write binary.
    */
   bool   binary() const { return _binary; }
@@ -278,6 +301,8 @@ private:
    */
   unsigned int n_active_levels_in(MeshBase::const_element_iterator begin,
                                   MeshBase::const_element_iterator end) const;
+
+  processor_id_type select_split_config(const std::string & input_name, header_id_type & data_size);
 
   bool _binary;
   bool _parallel;

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -94,14 +94,27 @@ public:
   virtual ~CheckpointIO ();
 
   /**
-   * This method implements reading a mesh from a specified file.
+   * This method implements reading a mesh from a specified file.  If the mesh has been split for
+   * running on several processors, input_name should simply be the name of the mesh split
+   * directory without the "-split[n]" suffix.  The number of splits will be determined
+   * automatically by the number of processes being used for the mesh at the time of reading.
    */
-  virtual void read (const std::string &) libmesh_override;
+  virtual void read (const std::string & input_name) libmesh_override;
 
   /**
-   * This method implements writing a mesh to a specified file.
+   * This method implements writing a mesh to a specified file.  If the mesh has been split
+   * for running on several processors, this will create a subdirectory named
+   * "[name]-split[n]" where name is the given name argument and n is the number of
+   * processors the mesh is split for running on.  For example:
+   *
+   *     unsigned int n_splits = 42;
+   *     std::unique_ptr<CheckpointIO> cp = split_mesh(my_mesh, n_splits);
+   *     // ...
+   *     cp->write("foo.cpr");
+   *
+   * would create a directory named "foo.cpr-split42".
    */
-  virtual void write (const std::string &) libmesh_override;
+  virtual void write (const std::string & name) libmesh_override;
 
   /**
    * Get/Set the flag indicating if we should read/write binary.

--- a/tests/mesh/checkpoint.C
+++ b/tests/mesh/checkpoint.C
@@ -110,6 +110,7 @@ public:
     {
       MeshB mesh(*TestCommWorld);
       CheckpointIO cpr(mesh);
+      cpr.current_n_processors() = n_procs;
       cpr.binary() = binary;
       cpr.read(filename);
 


### PR DESCRIPTION
When writing and reading checkpoint files, put sets of checkpoint files
for a single mesh into a subdirectory with the given checkpoint object
input_name.  Within this directory, every different split
configuration of the mesh gets its own subdirectory named "[n]".  Within
those directories, headers are named "header.cpr" and the actual split
files are named "split-[proc]-[n_procs]".

When reading checkpoint files, only the name if the top-level directory
(e.g. "foo.cpr") need be specified.  A split configuration will be
automatically selected based on the current number of procs being run.

Added a ``cleanup`` function for robustly removing files+dirs associated with a particular checkpoint configuration.  This will help users of the checkpoint code to be able to remove/modify checkpoint files without having to write checkpoint file format specific code.