### PR TITLE
One more SparsityPattern::Build optimization

### DIFF
--- a/include/numerics/coupling_matrix.h
+++ b/include/numerics/coupling_matrix.h
@@ -482,7 +482,7 @@ public:
     libmesh_assert_not_equal_to
       (_location, std::numeric_limits<std::size_t>::max());
 
-    if (_location == _it->second)
+    if (_location >= _it->second)
       {
         ++_it;
 


### PR DESCRIPTION
This adds one commit to the tail of #1577, with a different (and independent, and not nearly as impressive) optimization targeting the same problem.

We'll often be adding new j dofs which are already all subsequent to
all existing j dofs in a row; in that case we can avoid searches and
sorts entirely.

This seems to give me another 40% or so speedup, but I'm not sure I trust my now-gratifyingly-short timings anymore on only 1000 variables; let's wait for @dschwen to look at more precise timings and scaling before we decide whether or not to merge this.