### PR TITLE
Use GCC diagnostic push/pop to ignore warnings.

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -36,8 +36,9 @@
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)
-// GCC > 4.1 supports diagnostic pragmas
-#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 1)
+// GCC > 4.5 supports diagnostic pragmas with push/pop
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 5)
+#pragma GCC diagnostic push
 // These two don't work?
 #pragma GCC diagnostic ignored "-Wpedantic"
 #pragma GCC diagnostic ignored "-Wdeprecated"
@@ -55,5 +56,5 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif // GCC > 6
 #endif // GCC > 5
-#endif // GCC > 4.1
+#endif // GCC > 4.5
 #endif // __GNUC__ && !__INTEL_COMPILER

--- a/include/utils/restore_warnings.h
+++ b/include/utils/restore_warnings.h
@@ -26,20 +26,8 @@
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)
-// GCC > 4.1 supports diagnostic pragmas
-#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 1)
-// TODO: use the gcc 4.6 push/pop when available
-#if (__GNUC__ > 5)
-#pragma GCC diagnostic warning "-Wplacement-new"
-#pragma GCC diagnostic warning "-Wmisleading-indentation"
-#if (__GNUC__ > 6)
-#pragma GCC diagnostic warning "-Wint-in-bool-context"
-#pragma GCC diagnostic warning "-Wimplicit-fallthrough"
-#endif // GCC > 6
-#endif // GCC > 5
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-#pragma GCC diagnostic warning "-Wunused-parameter"
-#pragma GCC diagnostic warning "-Wdeprecated"
-#pragma GCC diagnostic warning "-Wpedantic"
-#endif // GCC > 4.1
+// GCC > 4.5 supports diagnostic pragmas with push/pop
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 5)
+#pragma GCC diagnostic pop
+#endif // GCC > 4.5
 #endif // __GNUC__ && !__INTEL_COMPILER


### PR DESCRIPTION
This came up due to idaholab/moose#10733
Using `-Werror` doesn't turn all the warnings into errors because the GCC diagnostic was restoring
specific warnings as **warnings**, ignoring that they should be treated as errors.
GCC diagnostic with push/pop was introduced in gcc 4.6. I don't think we need to support anything without push/pop support as libmesh now requires a C++-11 compiler (4.8 or later).