### PR TITLE
Add custom line search callback

### DIFF
--- a/include/solvers/petsc_linear_solver.h
+++ b/include/solvers/petsc_linear_solver.h
@@ -50,6 +50,24 @@ extern "C"
    * This function is called by PETSc to initialize the preconditioner.
    * ctx will hold the Preconditioner.
    */
+  PetscErrorCode libmesh_petsc_preconditioner_setup (void * ctx);
+
+  /**
+   * This function is called by PETSc to actually apply the preconditioner.
+   * ctx will hold the Preconditioner.
+   */
+  PetscErrorCode libmesh_petsc_preconditioner_apply(void * ctx, Vec x, Vec y);
+#else
+  PetscErrorCode libmesh_petsc_preconditioner_setup (PC);
+  PetscErrorCode libmesh_petsc_preconditioner_apply(PC, Vec x, Vec y);
+#endif
+
+#if LIBMESH_ENABLE_DEPRECATED
+#if PETSC_RELEASE_LESS_THAN(3,0,1)
+  /**
+   * This function is called by PETSc to initialize the preconditioner.
+   * ctx will hold the Preconditioner.
+   */
   PetscErrorCode __libmesh_petsc_preconditioner_setup (void * ctx);
 
   /**
@@ -60,6 +78,7 @@ extern "C"
 #else
   PetscErrorCode __libmesh_petsc_preconditioner_setup (PC);
   PetscErrorCode __libmesh_petsc_preconditioner_apply(PC, Vec x, Vec y);
+#endif
 #endif
 } // end extern "C"
 

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -58,6 +58,7 @@ extern "C"
                                                 SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context
 #endif
                                                 );
+  PetscErrorCode libmesh_petsc_linesearch_shellfunc(SNESLineSearch linesearch, void * ctx);
 }
 
 /**
@@ -157,6 +158,22 @@ public:
    * Set to true to use the libMesh's default monitor, set to false to use your own
    */
   void use_default_monitor(bool state) { _default_monitor = state; }
+
+  /**
+   * Abstract base class to be used to implement a custom line-search algorithm
+   */
+  class ComputeLineSearchObject
+  {
+  public:
+    virtual ~ComputeLineSearchObject () {}
+
+    virtual void linesearch (SNESLineSearch linesearch) = 0;
+  };
+
+  /**
+   * A callable object that can be used to specify a custom line-search
+   */
+  std::unique_ptr<ComputeLineSearchObject> linesearch_object;
 
 protected:
 

--- a/include/solvers/petsc_nonlinear_solver.h
+++ b/include/solvers/petsc_nonlinear_solver.h
@@ -40,11 +40,31 @@ class ResidualContext;
 // need access to these most of the time as they are used internally by this object.
 extern "C"
 {
+  PetscErrorCode libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *);
+  PetscErrorCode libmesh_petsc_snes_residual (SNES, Vec x, Vec r, void * ctx);
+  PetscErrorCode libmesh_petsc_snes_fd_residual (SNES, Vec x, Vec r, void * ctx);
+  PetscErrorCode libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
+  PetscErrorCode libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);
+#if PETSC_RELEASE_LESS_THAN(3,5,0)
+  PetscErrorCode libmesh_petsc_snes_jacobian (SNES, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
+#else
+  PetscErrorCode libmesh_petsc_snes_jacobian (SNES, Vec x, Mat jac, Mat pc, void * ctx);
+#endif
+
+  PetscErrorCode libmesh_petsc_snes_postcheck(
+#if PETSC_VERSION_LESS_THAN(3,3,0)
+                                                SNES, Vec x, Vec y, Vec w, void * context, PetscBool * changed_y, PetscBool * changed_w
+#else
+                                                SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context
+#endif
+                                                );
+  PetscErrorCode libmesh_petsc_linesearch_shellfunc(SNESLineSearch linesearch, void * ctx);
+
+#ifdef LIBMESH_ENABLE_DEPRECATED
   PetscErrorCode __libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *);
   PetscErrorCode __libmesh_petsc_snes_residual (SNES, Vec x, Vec r, void * ctx);
   PetscErrorCode __libmesh_petsc_snes_fd_residual (SNES, Vec x, Vec r, void * ctx);
   PetscErrorCode __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);
-  PetscErrorCode __libmesh_petsc_snes_mffd_residual (SNES, Vec x, Vec r, void * ctx);
 #if PETSC_RELEASE_LESS_THAN(3,5,0)
   PetscErrorCode __libmesh_petsc_snes_jacobian (SNES, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
 #else
@@ -58,7 +78,7 @@ extern "C"
                                                 SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context
 #endif
                                                 );
-  PetscErrorCode libmesh_petsc_linesearch_shellfunc(SNESLineSearch linesearch, void * ctx);
+#endif
 }
 
 /**
@@ -226,14 +246,13 @@ protected:
 #endif
 private:
   friend ResidualContext libmesh_petsc_snes_residual_helper (SNES snes, Vec x, void * ctx);
-  friend PetscErrorCode __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);
-  friend PetscErrorCode __libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx);
-  friend PetscErrorCode __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r);
-  friend PetscErrorCode __libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
+  friend PetscErrorCode libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx);
+  friend PetscErrorCode libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx);
+  friend PetscErrorCode libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx);
 #if PETSC_RELEASE_LESS_THAN(3,5,0)
-  friend PetscErrorCode __libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
+  friend PetscErrorCode libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx);
 #else
-  friend PetscErrorCode __libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
+  friend PetscErrorCode libmesh_petsc_snes_jacobian (SNES snes, Vec x, Mat jac, Mat pc, void * ctx);
 #endif
 };
 

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -42,7 +42,7 @@ namespace libMesh
 extern "C"
 {
 #if PETSC_RELEASE_LESS_THAN(3,0,1)
-  PetscErrorCode __libmesh_petsc_preconditioner_setup (void * ctx)
+  PetscErrorCode libmesh_petsc_preconditioner_setup (void * ctx)
   {
     Preconditioner<Number> * preconditioner = static_cast<Preconditioner<Number> *>(ctx);
 
@@ -55,7 +55,7 @@ extern "C"
   }
 
 
-  PetscErrorCode __libmesh_petsc_preconditioner_apply(void * ctx, Vec x, Vec y)
+  PetscErrorCode libmesh_petsc_preconditioner_apply(void * ctx, Vec x, Vec y)
   {
     Preconditioner<Number> * preconditioner = static_cast<Preconditioner<Number> *>(ctx);
 
@@ -67,7 +67,7 @@ extern "C"
     return 0;
   }
 #else
-  PetscErrorCode __libmesh_petsc_preconditioner_setup (PC pc)
+  PetscErrorCode libmesh_petsc_preconditioner_setup (PC pc)
   {
     void * ctx;
     PetscErrorCode ierr = PCShellGetContext(pc,&ctx);CHKERRQ(ierr);
@@ -81,7 +81,7 @@ extern "C"
     return 0;
   }
 
-  PetscErrorCode __libmesh_petsc_preconditioner_apply(PC pc, Vec x, Vec y)
+  PetscErrorCode libmesh_petsc_preconditioner_apply(PC pc, Vec x, Vec y)
   {
     void * ctx;
     PetscErrorCode ierr = PCShellGetContext(pc,&ctx);CHKERRQ(ierr);
@@ -94,6 +94,35 @@ extern "C"
 
     return 0;
   }
+#endif
+
+#ifdef LIBMESH_ENABLE_DEPRECATED
+#if PETSC_RELEASE_LESS_THAN(3,0,1)
+  PetscErrorCode __libmesh_petsc_preconditioner_setup (void * ctx)
+  {
+    libmesh_deprecated();
+    return libmesh_petsc_preconditioner_setup(ctx);
+  }
+
+  PetscErrorCode __libmesh_petsc_preconditioner_apply(void * ctx, Vec x, Vec y)
+  {
+    libmesh_deprecated();
+    return libmesh_petsc_preconditioner_apply(ctx, x, y);
+  }
+
+#else
+  PetscErrorCode __libmesh_petsc_preconditioner_setup (PC pc)
+  {
+    libmesh_deprecated();
+    return libmesh_petsc_preconditioner_setup(pc);
+  }
+
+  PetscErrorCode __libmesh_petsc_preconditioner_apply(PC pc, Vec x, Vec y)
+  {
+    libmesh_deprecated();
+    return libmesh_petsc_preconditioner_apply(pc, x, y);
+  }
+#endif
 #endif
 } // end extern "C"
 
@@ -227,8 +256,8 @@ void PetscLinearSolver<T>::init (const char * name)
         {
           this->_preconditioner->init();
           PCShellSetContext(_pc,(void *)this->_preconditioner);
-          PCShellSetSetUp(_pc,__libmesh_petsc_preconditioner_setup);
-          PCShellSetApply(_pc,__libmesh_petsc_preconditioner_apply);
+          PCShellSetSetUp(_pc,libmesh_petsc_preconditioner_setup);
+          PCShellSetApply(_pc,libmesh_petsc_preconditioner_apply);
         }
     }
 }
@@ -330,8 +359,8 @@ void PetscLinearSolver<T>::init (PetscMatrix<T> * matrix,
           this->_preconditioner->set_matrix(*matrix);
           this->_preconditioner->init();
           PCShellSetContext(_pc,(void *)this->_preconditioner);
-          PCShellSetSetUp(_pc,__libmesh_petsc_preconditioner_setup);
-          PCShellSetApply(_pc,__libmesh_petsc_preconditioner_apply);
+          PCShellSetSetUp(_pc,libmesh_petsc_preconditioner_setup);
+          PCShellSetApply(_pc,libmesh_petsc_preconditioner_apply);
         }
     }
 }

--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -119,7 +119,7 @@ extern "C"
   //-------------------------------------------------------------------
   // this function is called by PETSc at the end of each nonlinear step
   PetscErrorCode
-  __libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *)
+  libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *)
   {
     //PetscErrorCode ierr=0;
 
@@ -134,12 +134,20 @@ extern "C"
     return 0;
   }
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  PetscErrorCode
+  __libmesh_petsc_snes_monitor (SNES, PetscInt its, PetscReal fnorm, void *)
+  {
+    libmesh_deprecated();
+    return libmesh_petsc_snes_monitor(nullptr, its, fnorm, nullptr);
+  }
+#endif
 
 
   //---------------------------------------------------------------
   // this function is called by PETSc to evaluate the residual at X
   PetscErrorCode
-  __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx)
+  libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
     ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, ctx);
 
@@ -178,10 +186,19 @@ extern "C"
     return rc.ierr;
   }
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  PetscErrorCode
+  __libmesh_petsc_snes_residual (SNES snes, Vec x, Vec r, void * ctx)
+  {
+    libmesh_deprecated();
+    return libmesh_petsc_snes_residual(snes, x, r, ctx);
+  }
+#endif
+
   //-----------------------------------------------------------------------------------------
   // this function is called by PETSc to approximate the Jacobian at X via finite differences
   PetscErrorCode
-  __libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx)
+  libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
     ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, ctx);
 
@@ -205,27 +222,20 @@ extern "C"
     return rc.ierr;
   }
 
-
-  //----------------------------------------------------------
-  // this function serves an interface between the petsc layer
-  // and the actual mffd residual computing routine
+#ifdef LIBMESH_ENABLE_DEPRECATED
   PetscErrorCode
-  __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r)
+  __libmesh_petsc_snes_fd_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
-    PetscErrorCode ierr = 0;
-    // No way to safety-check this cast, since we got a void *...
-    PetscNonlinearSolver<Number> * solver =
-      static_cast<PetscNonlinearSolver<Number> *> (ctx);
-
-    ierr = __libmesh_petsc_snes_mffd_residual(solver->snes(), x, r, ctx);
-    return ierr;
+    libmesh_deprecated();
+    return libmesh_petsc_snes_fd_residual(snes, x, r, ctx);
   }
+#endif
 
   //----------------------------------------------------------------
   // this function is called by PETSc to approximate Jacobian-vector
   // products at X via finite differences
   PetscErrorCode
-  __libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx)
+  libmesh_petsc_snes_mffd_residual (SNES snes, Vec x, Vec r, void * ctx)
   {
     ResidualContext rc = libmesh_petsc_snes_residual_helper(snes, x, ctx);
 
@@ -250,16 +260,38 @@ extern "C"
     return rc.ierr;
   }
 
+  //----------------------------------------------------------
+  // this function serves an interface between the petsc layer
+  // and the actual mffd residual computing routine
+  PetscErrorCode
+  libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r)
+  {
+    // No way to safety-check this cast, since we got a void *...
+    PetscNonlinearSolver<Number> * solver =
+      static_cast<PetscNonlinearSolver<Number> *> (ctx);
+
+    return libmesh_petsc_snes_mffd_residual(solver->snes(), x, r, ctx);
+  }
+
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  PetscErrorCode
+  __libmesh_petsc_snes_mffd_interface (void * ctx, Vec x, Vec r)
+  {
+    libmesh_deprecated();
+    return libmesh_petsc_snes_mffd_interface(ctx, x, r);
+  }
+#endif
+
   //---------------------------------------------------------------
   // this function is called by PETSc to evaluate the Jacobian at X
   PetscErrorCode
-  __libmesh_petsc_snes_jacobian(
+  libmesh_petsc_snes_jacobian(
 #if PETSC_RELEASE_LESS_THAN(3,5,0)
-                                SNES snes, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx
+                              SNES snes, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx
 #else
-                                SNES snes, Vec x, Mat jac, Mat pc, void * ctx
+                              SNES snes, Vec x, Mat jac, Mat pc, void * ctx
 #endif
-                                )
+                              )
   {
     LOG_SCOPE("jacobian()", "PetscNonlinearSolver");
 
@@ -351,15 +383,34 @@ extern "C"
   // * "ctx" is the PetscNonlinearSolver context
   PetscErrorCode libmesh_petsc_linesearch_shellfunc (SNESLineSearch linesearch, void * ctx)
   {
-    PetscErrorCode ierr = 0;
-
     // No way to safety-check this cast, since we got a void *...
     PetscNonlinearSolver<Number> * solver =
       static_cast<PetscNonlinearSolver<Number> *> (ctx);
 
     solver->linesearch_object->linesearch(linesearch);
-    return ierr;
+    return 0;
   }
+
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  PetscErrorCode
+  __libmesh_petsc_snes_jacobian(
+#if PETSC_RELEASE_LESS_THAN(3,5,0)
+                                SNES snes, Vec x, Mat * jac, Mat * pc, MatStructure * msflag, void * ctx
+#else
+                                SNES snes, Vec x, Mat jac, Mat pc, void * ctx
+#endif
+                                )
+  {
+    libmesh_deprecated();
+    return libmesh_petsc_snes_jacobian(
+#if PETSC_RELEASE_LESS_THAN(3,5,0)
+                                       snes, x, jac, pc, msflag, ctx
+#else
+                                       snes, x, jac, pc, ctx
+#endif
+                                       );
+  }
+#endif
 
   // This function gets called by PETSc after the SNES linesearch is
   // complete.  We use it to exactly enforce any constraints on the
@@ -371,13 +422,13 @@ extern "C"
   // the user is responsible for setting changed_y and changed_w
   // appropriately, depending on whether or not the search
   // direction or solution vector was changed, respectively.
-  PetscErrorCode __libmesh_petsc_snes_postcheck(
+  PetscErrorCode libmesh_petsc_snes_postcheck(
 #if PETSC_VERSION_LESS_THAN(3,3,0)
-                                                SNES, Vec x, Vec y, Vec w, void * context, PetscBool * changed_y, PetscBool * changed_w
+                                              SNES, Vec x, Vec y, Vec w, void * context, PetscBool * changed_y, PetscBool * changed_w
 #else
-                                                SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context
+                                              SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context
 #endif
-                                                )
+                                              )
   {
     LOG_SCOPE("postcheck()", "PetscNonlinearSolver");
 
@@ -467,6 +518,25 @@ extern "C"
     return ierr;
   }
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
+  PetscErrorCode __libmesh_petsc_snes_postcheck(
+#if PETSC_VERSION_LESS_THAN(3,3,0)
+                                                SNES, Vec x, Vec y, Vec w, void * context, PetscBool * changed_y, PetscBool * changed_w
+#else
+                                                SNESLineSearch, Vec x, Vec y, Vec w, PetscBool * changed_y, PetscBool * changed_w, void * context
+#endif
+                                                )
+  {
+    libmesh_deprecated();
+    return libmesh_petsc_snes_postcheck(
+#if PETSC_VERSION_LESS_THAN(3,3,0)
+                                        nullptr, x, y, w, context, changed_y, changed_w
+#else
+                                        nullptr, x, y, w, changed_y, changed_w, context
+#endif
+                                        );
+  }
+#endif
 } // end extern "C"
 
 
@@ -556,7 +626,7 @@ void PetscNonlinearSolver<T>::init (const char * name)
 
       if (_default_monitor)
         {
-          ierr = SNESMonitorSet (_snes, __libmesh_petsc_snes_monitor,
+          ierr = SNESMonitorSet (_snes, libmesh_petsc_snes_monitor,
                                  this, PETSC_NULL);
           LIBMESH_CHKERR(ierr);
         }
@@ -590,8 +660,8 @@ void PetscNonlinearSolver<T>::init (const char * name)
           PCShellSetContext(pc,(void *)this->_preconditioner);
 
           //Re-Use the shell functions from petsc_linear_solver
-          PCShellSetSetUp(pc,__libmesh_petsc_preconditioner_setup);
-          PCShellSetApply(pc,__libmesh_petsc_preconditioner_apply);
+          PCShellSetSetUp(pc,libmesh_petsc_preconditioner_setup);
+          PCShellSetApply(pc,libmesh_petsc_preconditioner_apply);
         }
     }
 
@@ -603,7 +673,7 @@ void PetscNonlinearSolver<T>::init (const char * name)
   if (this->postcheck || this->postcheck_object)
     {
 #if PETSC_VERSION_LESS_THAN(3,3,0)
-      PetscErrorCode ierr = SNESLineSearchSetPostCheck(_snes, __libmesh_petsc_snes_postcheck, this);
+      PetscErrorCode ierr = SNESLineSearchSetPostCheck(_snes, libmesh_petsc_snes_postcheck, this);
       LIBMESH_CHKERR(ierr);
 
 #else
@@ -611,7 +681,7 @@ void PetscNonlinearSolver<T>::init (const char * name)
       PetscErrorCode ierr = SNESGETLINESEARCH(_snes, &linesearch);
       LIBMESH_CHKERR(ierr);
 
-      ierr = SNESLineSearchSetPostCheck(linesearch, __libmesh_petsc_snes_postcheck, this);
+      ierr = SNESLineSearchSetPostCheck(linesearch, libmesh_petsc_snes_postcheck, this);
       LIBMESH_CHKERR(ierr);
 #endif
     }
@@ -713,14 +783,14 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
   // Should actually be a PetscReal, but I don't know which version of PETSc first introduced PetscReal
   Real final_residual_norm=0.;
 
-  ierr = SNESSetFunction (_snes, r->vec(), __libmesh_petsc_snes_residual, this);
+  ierr = SNESSetFunction (_snes, r->vec(), libmesh_petsc_snes_residual, this);
   LIBMESH_CHKERR(ierr);
 
   // Only set the jacobian function if we've been provided with something to call.
   // This allows a user to set their own jacobian function if they want to
   if (this->jacobian || this->jacobian_object || this->residual_and_jacobian_object)
     {
-      ierr = SNESSetJacobian (_snes, pre->mat(), pre->mat(), __libmesh_petsc_snes_jacobian, this);
+      ierr = SNESSetJacobian (_snes, pre->mat(), pre->mat(), libmesh_petsc_snes_jacobian, this);
       LIBMESH_CHKERR(ierr);
     }
 
@@ -819,7 +889,7 @@ PetscNonlinearSolver<T>::solve (SparseMatrix<T> &  pre_in,  // System Preconditi
   Mat J;
   ierr = SNESGetJacobian(_snes,&J,PETSC_NULL,PETSC_NULL,PETSC_NULL);
   LIBMESH_CHKERR(ierr);
-  ierr = MatMFFDSetFunction(J, __libmesh_petsc_snes_mffd_interface, this);
+  ierr = MatMFFDSetFunction(J, libmesh_petsc_snes_mffd_interface, this);
   LIBMESH_CHKERR(ierr);
 #if !PETSC_RELEASE_LESS_THAN(3, 8, 4)
   // Resue the residual vector from SNES


### PR DESCRIPTION
I've already implemented a `ComputeLinesearchObject` in MOOSE that demonstrates excellent convergence behavior for contact, so this would be very helpful.

I've also removed the double leading underscores for our Petsc methods since it's reserved for the compiler according to the ANSI-C standard. Maybe that should be a separate PR/commit.

The removal of the "dunder" will break MOOSE because of [this](https://github.com/idaholab/moose/blob/devel/framework/src/base/NonlinearSystem.C#L313).