### PR TITLE
Fix missing includes found by test_installed_headers.sh

### DIFF
--- a/contrib/bin/test_headers.sh
+++ b/contrib/bin/test_headers.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This script assumes you have libMesh installed at $LIBMESH_DIR, and
+# calls test_installed_headers.sh with specific arguments.
+script_full_path=$(dirname "$0")
+test_CXXFLAGS="`$LIBMESH_DIR/bin/libmesh-config --cppflags --cxxflags --include`" HEADERS_TO_TEST="`find $LIBMESH_DIR/include/libmesh -name "*.h" -type f -exec basename {} \;`" ${script_full_path}/test_installed_headers.sh

--- a/contrib/bin/test_installed_headers.sh
+++ b/contrib/bin/test_installed_headers.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 #set -e
 
+# This script is designed to be run as part of "make installcheck"
+# but you can also run it manually from the source tree if you have a
+# libMesh installed in $LIBMESH_DIR.
+
+# You can run the script on a single header file by doing:
+# test_CXXFLAGS="`$LIBMESH_DIR/bin/libmesh-config --cppflags --cxxflags --include`" HEADERS_TO_TEST=exact_solution.h ./contrib/bin/test_installed_headers.sh
+
+# To run this script on *every* header file in an installed libMesh:
+# test_CXXFLAGS="`$LIBMESH_DIR/bin/libmesh-config --cppflags --cxxflags --include`" HEADERS_TO_TEST="`find $LIBMESH_DIR/include/libmesh -name "*.h" -type f -exec basename {} \;`" ./contrib/bin/test_installed_headers.sh
+
 # Respect the JOBS environment variable, if it is set
 if [ -n "$JOBS" ]; then
     n_concurrent=$JOBS

--- a/contrib/bin/test_installed_headers.sh
+++ b/contrib/bin/test_installed_headers.sh
@@ -39,14 +39,14 @@ if (test "x$test_CXXFLAGS" = "x"); then
     testing_installed_tree="yes"
 
     if (test "x$PKG_CONFIG" != "xno"); then
-	test_CXXFLAGS=`pkg-config libmesh --cflags`
+        test_CXXFLAGS=`pkg-config libmesh --cflags`
 
     elif (test -x $LIBMESH_CONFIG_PATH/libmesh-config); then
-	test_CXXFLAGS=`$LIBMESH_CONFIG_PATH/libmesh-config --cppflags --cxxflags --include`
+        test_CXXFLAGS=`$LIBMESH_CONFIG_PATH/libmesh-config --cppflags --cxxflags --include`
 
     else
-	echo "Cannot query package installation!!"
-	exit 1
+        echo "Cannot query package installation!!"
+        exit 1
     fi
 fi
 
@@ -115,9 +115,9 @@ for header_to_test in $HEADERS_TO_TEST ; do
     # skip the files that live in contrib that we are installing when testing
     # from the source tree - paths will not be correct
     if (test "x$testing_installed_tree" = "xno"); then
-	if (test "x`dirname $header_to_test`" = "xcontrib"); then
-	    continue
-	fi
+        if (test "x`dirname $header_to_test`" = "xcontrib"); then
+            continue
+        fi
     fi
 
     if [ $nrunning -lt $n_concurrent ]; then
@@ -138,4 +138,3 @@ done
 wait
 
 exit $returnval
-

--- a/include/base/multi_predicates.h
+++ b/include/base/multi_predicates.h
@@ -19,6 +19,7 @@
 #define LIBMESH_MULTI_PREDICATES_H
 
 // Local includes
+#include "libmesh/libmesh.h" // libMesh::invalid_uint
 #include "libmesh/single_predicates.h"
 
 // C++ includes

--- a/include/error_estimation/exact_error_estimator.h
+++ b/include/error_estimation/exact_error_estimator.h
@@ -23,6 +23,8 @@
 // Local Includes
 #include "libmesh/error_estimator.h"
 #include "libmesh/function_base.h"
+#include "libmesh/vector_value.h"
+#include "libmesh/tensor_value.h"
 
 // C++ includes
 #include <cstddef>
@@ -39,19 +41,7 @@ typedef FEGenericBase<Real> FEBase;
 class MeshFunction;
 class Point;
 class Parameters;
-
 template <typename T> class DenseVector;
-
-// Is there any way to simplify this?
-// All we need are Tensor and Gradient. - RHS
-template <typename T> class TensorValue;
-template <typename T> class VectorValue;
-typedef TensorValue<Number> NumberTensorValue;
-typedef NumberTensorValue   Tensor;
-typedef VectorValue<Number> NumberVectorValue;
-typedef NumberVectorValue   Gradient;
-
-
 
 /**
  * This class implements an "error estimator"

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -26,6 +26,7 @@
 // C++ includes
 #include <map>
 #include <vector>
+#include <memory>
 
 namespace libMesh
 {


### PR DESCRIPTION
This PR also includes a handy helper script which calls `test_installed_headers.sh` with some useful arguments, since that script is designed to work with the `make installcheck` target.

Refs #1594.
