### PR TITLE
Take a better guess at which checkpoint files to read

### DIFF
--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -161,7 +161,7 @@ CheckpointIO::CheckpointIO (MeshBase & mesh, const bool binary_in) :
   _parallel           (false),
   _version            ("checkpoint-1.2"),
   _my_processor_ids   (1, processor_id()),
-  _my_n_processors    (n_processors())
+  _my_n_processors    (mesh.is_replicated() ? 1 : n_processors())
 {
 }
 
@@ -171,7 +171,7 @@ CheckpointIO::CheckpointIO (const MeshBase & mesh, const bool binary_in) :
   _binary             (binary_in),
   _parallel           (false),
   _my_processor_ids   (1, processor_id()),
-  _my_n_processors    (n_processors())
+  _my_n_processors    (mesh.is_replicated() ? 1 : n_processors())
 {
 }
 


### PR DESCRIPTION
When asked to read a checkpoint mesh, it makes sense to read the serial
checkpoint mesh if we are actually working with replicated mesh. This
fixes the cases when you are running in parallel with a replicated mesh
but also happen to have parallel checkpoints written for the same number
of files. Without this patch, it's possible to run into having the
EquationSystems checkpoint out of syntax with the mesh Checkpoint.