### PR TITLE
Ignore a few more warnings

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -32,7 +32,11 @@
 #pragma clang diagnostic ignored "-Wnested-anon-types"
 #pragma clang diagnostic ignored "-Wsign-compare"
 #pragma clang diagnostic ignored "-Wunused-private-field"
+#pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wextra"
+#if (__clang_major__ > 3) || ((__clang_major__) == 3 && (__clang_minor__ >= 5))
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)


### PR DESCRIPTION
Don't ignore warngings that don't exist on older clang.

@brianmoose - I'm not exactly sure how to test this. Ideally, we'd test this with your existing PR (https://github.com/idaholab/moose/pull/10852). 