### PR TITLE
find_local_indices() for Parmetis setup

### DIFF
--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -25,6 +25,9 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/mesh_tools.h"
 
+// C++ Includes
+#include <unordered_map>
+
 namespace libMesh
 {
 
@@ -165,6 +168,16 @@ public:
    * assign_global_indices.
    */
   void check_for_duplicate_global_indices (MeshBase & ) const;
+
+  /**
+   * This method determines a locally unique, contiguous
+   * index for each object in the input range.
+   */
+  template <typename ForwardIterator>
+  void find_local_indices (const libMesh::BoundingBox &,
+                           const ForwardIterator &,
+                           const ForwardIterator &,
+                           std::unordered_map<dof_id_type, dof_id_type> &) const;
 
   /**
    * This method determines a globally unique, partition-agnostic

--- a/include/partitioning/parmetis_partitioner.h
+++ b/include/partitioning/parmetis_partitioner.h
@@ -23,11 +23,11 @@
 // Local Includes
 #include "libmesh/id_types.h"
 #include "libmesh/partitioner.h"
-#include "libmesh/vectormap.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // C++ Includes
 #include <cstddef>
+#include <unordered_map>
 #include <vector>
 
 namespace libMesh
@@ -117,7 +117,7 @@ private:
   /**
    * Maps active element ids into a contiguous range, as needed by ParMETIS.
    */
-  vectormap<dof_id_type, dof_id_type> _global_index_by_pid_map;
+  std::unordered_map<dof_id_type, dof_id_type> _global_index_by_pid_map;
 
   /**
    * Pointer to the Parmetis-specific data structures.  Lets us avoid


### PR DESCRIPTION
This PR replaces the "find_global_indices over and over for each rank's elements" strategy with a new "find_local_indices for your own elements, then sync" strategy.  It turns out that one round of communication is much, much cheaper than n_processors rounds.

On the test case from @bboutkov, refining to ~2.5M elements on 320 processors, the combination of this PR and #1600 speeds up repartitioning by a little more than an order of magnitude, which IMHO qualifies as a fix for #1598.  There's definitely a little room for more improvement, but probably "10%" not "10x".

This probably shouldn't be backported to 1.3.0 since it's a performance fix rather than a correctness fix and since it makes a major change to library internals.  On the other hand, *order of magnitude*, so I could be talked into changing my mind.