### PR TITLE
Use -isystem on Trilinos include directories

### DIFF
--- a/configure
+++ b/configure
@@ -35387,7 +35387,7 @@ $as_echo "<<< Configuring library with Trilinos Epetra support >>>" >&6; }
 
     #echo "Makefile_config_trilinos="
     #cat Makefile_config_trilinos
-    TRILINOS_INCLUDES=`make -sf Makefile_config_trilinos echo_include`
+    TRILINOS_INCLUDES=`make -sf Makefile_config_trilinos echo_include | sed -e 's/-I/-isystem /g'`
     TRILINOS_LIBS=`make -sf Makefile_config_trilinos echo_libs`
 
     #echo TRILINOS_LIBS=$TRILINOS_LIBS

--- a/m4/trilinos.m4
+++ b/m4/trilinos.m4
@@ -232,7 +232,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_10],
 
     #echo "Makefile_config_trilinos="
     #cat Makefile_config_trilinos
-    TRILINOS_INCLUDES=`make -sf Makefile_config_trilinos echo_include`
+    TRILINOS_INCLUDES=`make -sf Makefile_config_trilinos echo_include | sed -e 's/-I/-isystem /g'`
     TRILINOS_LIBS=`make -sf Makefile_config_trilinos echo_libs`
 
     #echo TRILINOS_LIBS=$TRILINOS_LIBS


### PR DESCRIPTION
@jwpeterson mentioned he might want to do this for other libraries (like boost)

Primarily put this up to verify that it silences all the warnings in moose. I created and added a "Test Trilinos" to this PR that has `-Wall -Wextra` on the moose build steps.