### PR TITLE
Bugfix for ExactSolution::_compute_error with NodeElems in the mesh

### DIFF
--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -701,6 +701,12 @@ void ExactSolution::_compute_error(const std::string & sys_name,
               // FIXME: Needs to be updated for vector-valued elements
               DenseVector<Number> output(1);
               (*coarse_values)(q_point[qp],time,output,&subdomain_id);
+
+              if(output.size() == 0)
+              {
+                libmesh_error_msg("Mesh function failed to find point");
+              }
+
               exact_val = output(0);
             }
           const typename FEGenericBase<OutputShape>::OutputNumber val_error = u_h - exact_val;


### PR DESCRIPTION
ExactSolution::_compute_error was reporting large errors for me in a mesh that included NodeElems, even though the solutions matched almost perfectly. Skipping NodeElems in the element loop fixes the issue for me.

I'm not completely sure what goes wrong when the NodeElems are included in the loop, I didn't investigate that in detail.