### PR TITLE
Include the right header for PetscBLASInt.

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -27,7 +27,7 @@
 // For the definition of PetscBLASInt.
 #if (LIBMESH_HAVE_PETSC)
 # include "libmesh/petsc_macro.h"
-# include <petscblaslapack.h>
+# include <petscsys.h>
 #endif
 
 // C++ includes


### PR DESCRIPTION
For some reason in c3659b11 I thought this type was defined in
petscblaslapack.h, but it seems to have been in petscsys.h for some
time. This should help fix an issue raised over in xikaij/fredkin-koehler#3
where conflicting BLAS functions were being defined in both scalfmm
and PETSc.