### PR TITLE
Possibly fix issue with "EDGE" elements in Exodus files.

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -61,6 +61,7 @@ void init_element_equivalence_map()
       element_equivalence_map["SPHERE"] = NODEELEM;
 
       // EDGE2 equivalences
+      element_equivalence_map["EDGE"]   = EDGE2;
       element_equivalence_map["EDGE2"]  = EDGE2;
       element_equivalence_map["TRUSS"]  = EDGE2;
       element_equivalence_map["BEAM"]   = EDGE2;


### PR DESCRIPTION
Since the Exodus file format is completely customizable, we don't
always know exactly what strings will be present in Exodus files
written by a particular mesh generator. According to #1546, it sounds
like the Python meshio/pygmsh writes "EDGE" element, so this commit
adds another equivalence to our EDGE2 type for this string.

Refs #1546.