### PR TITLE
Make PointLocatorTree threadsafe again

### DIFF
--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -220,11 +220,6 @@ private:
    * Does this node contain any infinite elements.
    */
   bool contains_ifems;
-
-  /**
-   * Used in find_element_in_children
-   */
-  mutable std::vector<bool> searched_child;
 };
 
 

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -19,6 +19,7 @@
 
 // C++ includes
 #include <set>
+#include <array>
 
 // Local includes
 #include "libmesh/libmesh_config.h"
@@ -498,7 +499,8 @@ const Elem * TreeNode<N>::find_element_in_children (const Point & p,
 {
   libmesh_assert (!this->active());
 
-  searched_child.assign(children.size(), false);
+  // value-initialization sets all array members to false
+  std::array<bool,N> searched_child{};
 
   // First only look in the children whose bounding box
   // contain the point p.


### PR DESCRIPTION
Implements @roystgnr's original suggestion for using a stack based `std::array` instead of a `mutable` member vector. I confirmed this to fix the threading crashes in magpie which heavily pounds this PL in a threaded region.

Closes #1612