### PR TITLE
Avoid -Wmissing-field-initializers warning on GCC 4.9.2.

### DIFF
--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -500,7 +500,7 @@ const Elem * TreeNode<N>::find_element_in_children (const Point & p,
   libmesh_assert (!this->active());
 
   // value-initialization sets all array members to false
-  std::array<bool,N> searched_child{};
+  auto searched_child = std::array<bool, N>();
 
   // First only look in the children whose bounding box
   // contain the point p.


### PR DESCRIPTION
The previous syntax is correct and should be accepted by C++11
conforming compilers, unfortunately we still have to support some
not-quite-standards-conforming compilers.

Refs #1613.