### PR TITLE
Set node processor ids less unevenly

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -210,10 +210,12 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
 
   // Mesh modification operations might not leave us with consistent
   // id counts, but our partitioner might need that consistency.
-  if (!_skip_renumber_nodes_and_elements)
-    this->renumber_nodes_and_elements();
-  else
-    this->update_parallel_id_counts();
+  //
+  // We just call renumber_nodes_and_elements() here because it
+  // currently handles stripping of disconnected nodes and updating of
+  // parallel id counts; it will skip renumbering if the mesh is so
+  // configured.
+  this->renumber_nodes_and_elements();
 
   // Let all the elements find their neighbors
   if (!skip_find_neighbors)

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -2077,9 +2077,8 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
 
       SyncNodeSet syncv(valid_nodes, mesh);
 
-      Parallel::sync_node_data_by_element_id
-        (mesh, mesh.elements_begin(), mesh.elements_end(),
-         Parallel::SyncEverything(), Parallel::SyncEverything(), syncv);
+      Parallel::sync_dofobject_data_by_id
+        (mesh.comm(), mesh.nodes_begin(), mesh.nodes_end(), syncv);
     }
 
   // We build up a set of compatible processor ids for each node

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -828,7 +828,18 @@ bool UnstructuredMesh::contract ()
           }
       }
 
-  // Strip any newly-created NULL voids out of the element array
+  // Strip any newly-created NULL voids out of the element array, if
+  // we're allowed to.
+  //
+  // We just call renumber_nodes_and_elements() here because it
+  // currently handles stripping of disconnected nodes and updating of
+  // parallel id counts; it will skip renumbering if the mesh is so
+  // configured.
+  //
+  // Note that renumbering may cause node processor ids to no longer
+  // match an id-number-based canonical processor partitioning
+  // algorithm, but it's probably not a safe time for us to go back
+  // and fix that.
   this->renumber_nodes_and_elements();
 
   // FIXME: Need to understand why deleting subactive children

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -581,6 +581,7 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
 
 #ifdef DEBUG
   MeshTools::libmesh_assert_valid_procids<Node>(mesh);
+  MeshTools::libmesh_assert_canonical_node_procids(mesh);
 #endif
 }
 


### PR DESCRIPTION
Hopefully this will reduce the load imbalance we can get with nodes when
using large numbers of processors without extremely large numbers of
elements.

@fdkong, can you try this on the same problem you gave results for in #1617?  I can set up a new benchmark myself but it would be nice to get apples-to-apples numbers on a known-bad case.