### PR TITLE
Convert some m4 code to use AS_IF, AS_CASE macros

### DIFF
--- a/configure
+++ b/configure
@@ -7272,35 +7272,36 @@ fi
   # First the flags for gcc compilers
   if test "$GXX" = yes -a "x$REAL_GXX" != "x"; then :
 
-    CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -funroll-loops -fstrict-aliasing -Wdisabled-optimization"
-    CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -funroll-loops -fstrict-aliasing -Woverloaded-virtual -Wdisabled-optimization"
-    CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Woverloaded-virtual"
-    NODEPRECATEDFLAG="-Wno-deprecated"
+          CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -funroll-loops -fstrict-aliasing -Wdisabled-optimization"
+                    CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused"
+          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -funroll-loops -fstrict-aliasing -Woverloaded-virtual -Wdisabled-optimization"
+          CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Woverloaded-virtual"
+          NODEPRECATEDFLAG="-Wno-deprecated"
 
-    CFLAGS_OPT="-O2 -funroll-loops -fstrict-aliasing"
-    CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -funroll-loops -fstrict-aliasing"
-    CFLAGS_DBG="-g -Wimplicit"
-    ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm"
+          CFLAGS_OPT="-O2 -funroll-loops -fstrict-aliasing"
+          CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -funroll-loops -fstrict-aliasing"
+          CFLAGS_DBG="-g -Wimplicit"
+          ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm"
 
-    if test "x$enableglibcxxdebugging" = "xyes"; then :
+          if test "x$enableglibcxxdebugging" = "xyes"; then :
   CPPFLAGS_DBG="$CPPFLAGS_DBG -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC"
 fi
 
-    # GCC 4.6.3 warns about variadic macros but supports them just
-    # fine, so let's turn off that warning.
-    case "$GXX_VERSION" in #(
+          # GCC 4.6.3 warns about variadic macros but supports them just
+          # fine, so let's turn off that warning.
+          case "$GXX_VERSION" in #(
   gcc4.6 | gcc5) :
     CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
-                              CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
-                              CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros" ;; #(
+                                    CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
+                                    CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros" ;; #(
   *) :
      ;;
 esac
 
-                case "$target" in #(
+                                        case "$target" in #(
   *solaris*) :
     RPATHFLAG="-Wl,-R,"
-                          LIBS="-lrpcsvc $LIBS" ;; #(
+                                LIBS="-lrpcsvc $LIBS" ;; #(
   *) :
      ;;
 esac
@@ -7376,8 +7377,10 @@ fi
   clang) :
 
                        CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -Qunused-arguments -Wunused-parameter -Wunused"
-                       CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
-                       CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+                                              CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long"
+                       CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+                                              CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long"
+                       CXXFLAGS_DBG="$CXXFLAGS_DBG -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
                        NODEPRECATEDFLAG="-Wno-deprecated"
 
                        CFLAGS_OPT="-O2 -Qunused-arguments -Wunused"

--- a/configure
+++ b/configure
@@ -5608,41 +5608,45 @@ fi
 
 fi
 
-    if (test "x$compiler_brand_detected" = "xno"); then
-    is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
-    if test "x$is_intel_icc" != "x" ; then
-      GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
-      case "$GXX_VERSION_STRING" in #(
+    if test "x$compiler_brand_detected" = "xno"; then :
+
+          is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
+          if test "x$is_intel_icc" != "x"; then :
+
+                  GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
+                  case "$GXX_VERSION_STRING" in #(
   *18.*) :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 18 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 18 >>>" >&6; }
-                GXX_VERSION=intel_icc_v18.x ;; #(
+                            GXX_VERSION=intel_icc_v18.x ;; #(
   *17.*) :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 17 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 17 >>>" >&6; }
-                GXX_VERSION=intel_icc_v17.x ;; #(
+                            GXX_VERSION=intel_icc_v17.x ;; #(
   *16.*) :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 16 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 16 >>>" >&6; }
-                GXX_VERSION=intel_icc_v16.x ;; #(
+                            GXX_VERSION=intel_icc_v16.x ;; #(
   *15.*) :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 15 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 15 >>>" >&6; }
-                GXX_VERSION=intel_icc_v15.x ;; #(
+                            GXX_VERSION=intel_icc_v15.x ;; #(
   *14.*) :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 14 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 14 >>>" >&6; }
-                GXX_VERSION=intel_icc_v14.x ;; #(
+                            GXX_VERSION=intel_icc_v14.x ;; #(
   *13.*) :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 13 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 13 >>>" >&6; }
-                GXX_VERSION=intel_icc_v13.x ;; #(
+                            GXX_VERSION=intel_icc_v13.x ;; #(
   *) :
     as_fn_error $? "Unsupported Intel compiler detected" "$LINENO" 5 ;;
 esac
-      compiler_brand_detected=yes
-    fi
-  fi
+                  compiler_brand_detected=yes
+
+fi
+
+fi
 
               if (test "x$compiler_brand_detected" = "xno"); then
     is_ibm_xlc="`($CXX 2>&1) | egrep -i 'xlc'`"

--- a/configure
+++ b/configure
@@ -5535,48 +5535,41 @@ fi
   if test "$GXX" = yes -a "x$REAL_GXX" != "x"; then :
 
                     GXX_VERSION_STRING=`($CXX -v 2>&1) | grep "gcc version"`
-          case "$GXX_VERSION_STRING" in
-            *gcc\ version\ 7.*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-7.x >>>" >&5
+
+          case "$GXX_VERSION_STRING" in #(
+  *gcc\ version\ 7.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-7.x >>>" >&5
 $as_echo "<<< C++ compiler is gcc-7.x >>>" >&6; }
-              GXX_VERSION=gcc7
-              ;;
-            *gcc\ version\ 6.*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-6.x >>>" >&5
+                                         GXX_VERSION=gcc7 ;; #(
+  *gcc\ version\ 6.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-6.x >>>" >&5
 $as_echo "<<< C++ compiler is gcc-6.x >>>" >&6; }
-              GXX_VERSION=gcc6
-              ;;
-            *gcc\ version\ 5.*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-5.x >>>" >&5
+                                         GXX_VERSION=gcc6 ;; #(
+  *gcc\ version\ 5.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-5.x >>>" >&5
 $as_echo "<<< C++ compiler is gcc-5.x >>>" >&6; }
-              GXX_VERSION=gcc5
-              ;;
-            *4.9.*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.9 >>>" >&5
+                                         GXX_VERSION=gcc5 ;; #(
+  *4.9.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.9 >>>" >&5
 $as_echo "<<< C++ compiler is gcc-4.9 >>>" >&6; }
-              GXX_VERSION=gcc4.9
-              ;;
-            *4.8.*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.8 >>>" >&5
+                             GXX_VERSION=gcc4.9 ;; #(
+  *4.8.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.8 >>>" >&5
 $as_echo "<<< C++ compiler is gcc-4.8 >>>" >&6; }
-              GXX_VERSION=gcc4.8
-              ;;
-            *4.7.*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.7 >>>" >&5
+                             GXX_VERSION=gcc4.8 ;; #(
+  *4.7.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.7 >>>" >&5
 $as_echo "<<< C++ compiler is gcc-4.7 >>>" >&6; }
-              GXX_VERSION=gcc4.7
-              ;;
-            *4.6.*)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.6 >>>" >&5
+                             GXX_VERSION=gcc4.7 ;; #(
+  *4.6.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.6 >>>" >&5
 $as_echo "<<< C++ compiler is gcc-4.6 >>>" >&6; }
-              GXX_VERSION=gcc4.6
-              ;;
-            *)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is unknown but accepted gcc version >>>" >&5
+                             GXX_VERSION=gcc4.6 ;; #(
+  *) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is unknown but accepted gcc version >>>" >&5
 $as_echo "<<< C++ compiler is unknown but accepted gcc version >>>" >&6; }
-              GXX_VERSION=gcc-other
-              ;;
-          esac
+                   GXX_VERSION=gcc-other ;;
+esac
 
                     compiler_brand_detected=yes
 

--- a/configure
+++ b/configure
@@ -5579,29 +5579,31 @@ fi
     clang_version="`($CXX --version 2>&1)`"
     is_clang="`echo $clang_version | grep 'clang'`"
 
-    if test "x$is_clang" != "x" ; then
-                        is_apple_clang="`echo $clang_version | grep 'Apple'`"
-      clang_vendor="clang"
-      if test "x$is_apple_clang" != "x"; then :
+    if test "x$is_clang" != "x"; then :
+
+                                                is_apple_clang="`echo $clang_version | grep 'Apple'`"
+            clang_vendor="clang"
+            if test "x$is_apple_clang" != "x"; then :
   clang_vendor="Apple clang"
 fi
 
-                  clang_major_minor=unknown
+                                    clang_major_minor=unknown
 
-      if test "x$PERL" != "x"; then :
+            if test "x$PERL" != "x"; then :
 
-              clang_major_minor=`echo $clang_version | $PERL -ne 'print $1 if /version\s(\d+\.\d+)/'`
-              if test "x$clang_major_minor" = "x"; then :
+                    clang_major_minor=`echo $clang_version | $PERL -ne 'print $1 if /version\s(\d+\.\d+)/'`
+                    if test "x$clang_major_minor" = "x"; then :
   clang_major_minor=unknown
 fi
 
 fi
 
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&5
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&5
 $as_echo "<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&6; }
-      GXX_VERSION=clang
-      compiler_brand_detected=yes
-    fi
+            GXX_VERSION=clang
+            compiler_brand_detected=yes
+
+fi
   fi
 
     if (test "x$compiler_brand_detected" = "xno"); then

--- a/configure
+++ b/configure
@@ -5612,38 +5612,34 @@ fi
     is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
     if test "x$is_intel_icc" != "x" ; then
       GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
-      case "$GXX_VERSION_STRING" in
-        *18.*)
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 18 >>>" >&5
+      case "$GXX_VERSION_STRING" in #(
+  *18.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 18 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 18 >>>" >&6; }
-          GXX_VERSION=intel_icc_v18.x
-          ;;
-        *17.*)
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 17 >>>" >&5
+                GXX_VERSION=intel_icc_v18.x ;; #(
+  *17.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 17 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 17 >>>" >&6; }
-          GXX_VERSION=intel_icc_v17.x
-          ;;
-        *16.*)
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 16 >>>" >&5
+                GXX_VERSION=intel_icc_v17.x ;; #(
+  *16.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 16 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 16 >>>" >&6; }
-          GXX_VERSION=intel_icc_v16.x
-          ;;
-        *15.*)
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 15 >>>" >&5
+                GXX_VERSION=intel_icc_v16.x ;; #(
+  *15.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 15 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 15 >>>" >&6; }
-          GXX_VERSION=intel_icc_v15.x
-          ;;
-        *14.*)
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 14 >>>" >&5
+                GXX_VERSION=intel_icc_v15.x ;; #(
+  *14.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 14 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 14 >>>" >&6; }
-          GXX_VERSION=intel_icc_v14.x
-          ;;
-        *13.*)
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 13 >>>" >&5
+                GXX_VERSION=intel_icc_v14.x ;; #(
+  *13.*) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Intel(R) icc 13 >>>" >&5
 $as_echo "<<< C++ compiler is Intel(R) icc 13 >>>" >&6; }
-          GXX_VERSION=intel_icc_v13.x
-          ;;
-      esac
+                GXX_VERSION=intel_icc_v13.x ;; #(
+  *) :
+    as_fn_error $? "Unsupported Intel compiler detected" "$LINENO" 5 ;;
+esac
       compiler_brand_detected=yes
     fi
   fi

--- a/configure
+++ b/configure
@@ -5582,18 +5582,20 @@ fi
     if test "x$is_clang" != "x" ; then
                         is_apple_clang="`echo $clang_version | grep 'Apple'`"
       clang_vendor="clang"
-      if test "x$is_apple_clang" != "x" ; then
-        clang_vendor="Apple clang"
-      fi
+      if test "x$is_apple_clang" != "x"; then :
+  clang_vendor="Apple clang"
+fi
 
                   clang_major_minor=unknown
 
-      if test "x$PERL" != "x" ; then
-         clang_major_minor=`echo $clang_version | $PERL -ne 'print $1 if /version\s(\d+\.\d+)/'`
-         if test "x$clang_major_minor" = "x" ; then
-           clang_major_minor=unknown
-         fi
-      fi
+      if test "x$PERL" != "x"; then :
+
+              clang_major_minor=`echo $clang_version | $PERL -ne 'print $1 if /version\s(\d+\.\d+)/'`
+              if test "x$clang_major_minor" = "x"; then :
+  clang_major_minor=unknown
+fi
+
+fi
 
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&5
 $as_echo "<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&6; }

--- a/configure
+++ b/configure
@@ -7186,31 +7186,20 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
                                                                         libmesh_LDFLAGS="$libmesh_LDFLAGS -Wc,-fsanitize=address"
 
                   for method in ${SANITIZE_METHODS}; do
-                      case "${method}" in
-                          optimized|opt)
-                            SANITIZE_OPT_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          debug|dbg)
-                            SANITIZE_DBG_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          devel)
-                            SANITIZE_DEVEL_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          profiling|pro|prof)
-                            SANITIZE_PROF_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          oprofile|oprof)
-                            SANITIZE_OPROF_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          *)
-                            as_fn_error $? "bad value ${method} for --enable-sanitize" "$LINENO" 5
-                            ;;
-                      esac
+                      case "${method}" in #(
+  optimized|opt) :
+    SANITIZE_OPT_FLAGS=$COMMON_SANITIZE_OPTIONS ;; #(
+  debug|dbg) :
+    SANITIZE_DBG_FLAGS=$COMMON_SANITIZE_OPTIONS ;; #(
+  devel) :
+    SANITIZE_DEVEL_FLAGS=$COMMON_SANITIZE_OPTIONS ;; #(
+  profiling|pro|prof) :
+    SANITIZE_PROF_FLAGS=$COMMON_SANITIZE_OPTIONS ;; #(
+  oprofile|oprof) :
+    SANITIZE_OPROF_FLAGS=$COMMON_SANITIZE_OPTIONS ;; #(
+  *) :
+    as_fn_error $? "bad value ${method} for --enable-sanitize" "$LINENO" 5 ;;
+esac
                   done
 
 fi

--- a/configure
+++ b/configure
@@ -6272,13 +6272,12 @@ else
 fi
 
 
-  if (test "x$enablefortran" = xyes); then
+  if test "x$enablefortran" = xyes; then :
 
-    # look for a decent F90+ compiler or honor --with-fc=...
-    FC_TRY_LIST="gfortran ifort pgf90 xlf95"
-    if  (test "$enablempi" != no) ; then
-      FC_TRY_LIST="mpif90 $FC_TRY_LIST"
-    fi
+                    FC_TRY_LIST="gfortran ifort pgf90 xlf95"
+          if  (test "$enablempi" != no) ; then
+            FC_TRY_LIST="mpif90 $FC_TRY_LIST"
+          fi
 
 # Check whether --with-fc was given.
 if test "${with_fc+set}" = set; then :
@@ -6286,10 +6285,7 @@ if test "${with_fc+set}" = set; then :
 fi
 
 
-    # --------------------------------------------------------------
-    # Determine a F90+ compiler to use.
-    # --------------------------------------------------------------
-    ac_ext=${ac_fc_srcext-f}
+                                        ac_ext=${ac_fc_srcext-f}
 ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
 ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_fc_compiler_gnu
@@ -6501,22 +6497,17 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-    if (test "x$FC" = "x"); then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> No valid Fortran compiler <<<" >&5
+          if (test "x$FC" = "x"); then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> No valid Fortran compiler <<<" >&5
 $as_echo ">>> No valid Fortran compiler <<<" >&6; }
-      FC=no
-      enablefortran=no
-    fi
-    # --------------------------------------------------------------
+            FC=no
+            enablefortran=no
+          fi
 
-
-
-    # --------------------------------------------------------------
-    # look for a decent F77 compiler or honor --with-77=...
-    F77_TRY_LIST="gfortran g77 ifort f77 xlf frt pgf77 fort77 fl32 af77 f90 xlf90 pgf90 epcf90 f95 fort xlf95 ifc efc pgf95 lf95"
-    if  (test "$enablempi" != no) ; then
-      F77_TRY_LIST="mpif77 $F77_TRY_LIST"
-    fi
+                    F77_TRY_LIST="gfortran g77 ifort f77 xlf frt pgf77 fort77 fl32 af77 f90 xlf90 pgf90 epcf90 f95 fort xlf95 ifc efc pgf95 lf95"
+          if  (test "$enablempi" != no) ; then
+            F77_TRY_LIST="mpif77 $F77_TRY_LIST"
+          fi
 
 # Check whether --with-f77 was given.
 if test "${with_f77+set}" = set; then :
@@ -6524,10 +6515,7 @@ if test "${with_f77+set}" = set; then :
 fi
 
 
-    # --------------------------------------------------------------
-    # Determine a F77 compiler to use.
-    # --------------------------------------------------------------
-    ac_ext=f
+                                        ac_ext=f
 ac_compile='$F77 -c $FFLAGS conftest.$ac_ext >&5'
 ac_link='$F77 -o conftest$ac_exeext $FFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_f77_compiler_gnu
@@ -6739,22 +6727,21 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-    if (test "x$F77" = "x"); then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> No valid Fortran 77 compiler <<<" >&5
+          if (test "x$F77" = "x"); then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> No valid Fortran 77 compiler <<<" >&5
 $as_echo ">>> No valid Fortran 77 compiler <<<" >&6; }
-      F77=no
-      enablefortran=no
-    fi
+            F77=no
+            enablefortran=no
+          fi
 
-    # --------------------------------------------------------------
-  else
-      # when --disable-fortran is specified, explicitly set these
-      # to "no" to instruct libtool not to bother with them.
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Disabling Fortran language support per user request <<<" >&5
+else
+
+                              { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Disabling Fortran language support per user request <<<" >&5
 $as_echo ">>> Disabling Fortran language support per user request <<<" >&6; }
-      FC=no
-      F77=no
-  fi # end enablefortran
+          FC=no
+          F77=no
+
+fi
 
 
 # --------------------------------------------------------------

--- a/configure
+++ b/configure
@@ -5697,9 +5697,9 @@ $as_echo "proper compiler flags" >&6; }
   # --------------------------------------------------------------
   # look for a decent C compiler or honor --with-cc=...
   CC_TRY_LIST="gcc icc pgcc cc"
-  if  (test "$enablempi" != no) ; then
-    CC_TRY_LIST="mpicc $CC_TRY_LIST"
-  fi
+  if test "$enablempi" != no; then :
+  CC_TRY_LIST="mpicc $CC_TRY_LIST"
+fi
 
 # Check whether --with-cc was given.
 if test "${with_cc+set}" = set; then :

--- a/configure
+++ b/configure
@@ -4850,11 +4850,14 @@ fi
      # -------------------------------------------------------------------
      # Check whether --enable-mpi was given.
 if test "${enable_mpi+set}" = set; then :
-  enableval=$enable_mpi; case "${enableval}" in
-                     yes)  enablempi=yes ;;
-                     no)  enablempi=no ;;
-                     *)  as_fn_error $? "bad value ${enableval} for --enable-mpi" "$LINENO" 5 ;;
-                   esac
+  enableval=$enable_mpi; case "${enableval}" in #(
+  yes) :
+    enablempi=yes ;; #(
+  no) :
+    enablempi=no ;; #(
+  *) :
+    as_fn_error $? "bad value ${enableval} for --enable-mpi" "$LINENO" 5 ;;
+esac
 else
   enablempi=yes
 fi

--- a/configure
+++ b/configure
@@ -7307,105 +7307,97 @@ esac
 
 else
 
+        case "$GXX_VERSION" in #(
+  ibm_xlc) :
 
-    case "$GXX_VERSION" in
-      ibm_xlc)
-          CXXFLAGS_OPT="-O3 -qmaxmem=-1 -w -qansialias -Q=10 -qrtti=all -qstaticinline"
-          CXXFLAGS_DBG="-qmaxmem=-1 -qansialias -qrtti=all -g -qstaticinline"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
-          NODEPRECATEDFLAG=""
-          CFLAGS_OPT="-O3 -qmaxmem=-1 -w -qansialias -Q=10"
-          CFLAGS_DBG="-qansialias -g"
-          CFLAGS_DEVEL="$CFLAGS_DBG"
-          ;;
+                          CXXFLAGS_OPT="-O3 -qmaxmem=-1 -w -qansialias -Q=10 -qrtti=all -qstaticinline"
+                          CXXFLAGS_DBG="-qmaxmem=-1 -qansialias -qrtti=all -g -qstaticinline"
+                          CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
+                          NODEPRECATEDFLAG=""
+                          CFLAGS_OPT="-O3 -qmaxmem=-1 -w -qansialias -Q=10"
+                          CFLAGS_DBG="-qansialias -g"
+                          CFLAGS_DEVEL="$CFLAGS_DBG"
+                         ;; #(
+              intel_*) :
 
-      # All Intel ICC/ECC flavors
-      intel_*)
+                                                    NODEPRECATEDFLAG="-Wno-deprecated"
 
-        # Intel understands the gcc-like no-deprecated flag
-        NODEPRECATEDFLAG="-Wno-deprecated"
+                                                    PROFILING_FLAGS="-qp"
 
-        # Intel compilers use -qp for profiling
-        PROFILING_FLAGS="-qp"
+                                                    ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm -fsource-asm"
 
-        # Intel options for annotated assembly
-        ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm -fsource-asm"
+                                                    OPROFILE_FLAGS="-g"
 
-        # The -g flag is all OProfile needs to produce annotations
-        OPROFILE_FLAGS="-g"
-
-                                                                                                                                                                case "$GXX_VERSION" in #(
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        case "$GXX_VERSION" in #(
   intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x) :
 
-                  PROFILING_FLAGS="-p"
-                  CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
-                  CXXFLAGS_OPT="$CXXFLAGS_OPT -O3 -unroll -w0 -ftz"
-                  CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
-                  CFLAGS_DBG="$CFLAGS_DBG -w1 -g -wd266 -wd1572 -wd488 -wd161"
-                  CFLAGS_OPT="$CFLAGS_OPT -O3 -unroll -w0 -ftz"
-                  CFLAGS_DEVEL="$CFLAGS_DBG"
-                 ;; #(
+                                    PROFILING_FLAGS="-p"
+                                    CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
+                                    CXXFLAGS_OPT="$CXXFLAGS_OPT -O3 -unroll -w0 -ftz"
+                                    CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
+                                    CFLAGS_DBG="$CFLAGS_DBG -w1 -g -wd266 -wd1572 -wd488 -wd161"
+                                    CFLAGS_OPT="$CFLAGS_OPT -O3 -unroll -w0 -ftz"
+                                    CFLAGS_DEVEL="$CFLAGS_DBG"
+                                   ;; #(
   *) :
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: Unknown Intel compiler" >&5
 $as_echo "Unknown Intel compiler" >&6; } ;;
 esac
-      ;;
+                        ;; #(
+  portland_group) :
 
-      portland_group)
-          CXXFLAGS_DBG="-g --no_using_std"
-          CXXFLAGS_OPT="-O2 --no_using_std -fast -Minform=severe"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
+                                CXXFLAGS_DBG="-g --no_using_std"
+                                CXXFLAGS_OPT="-O2 --no_using_std -fast -Minform=severe"
+                                CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
 
-          # PG C++ definitely doesn't understand -Wno-deprecated...
-          NODEPRECATEDFLAG=""
+                                                                NODEPRECATEDFLAG=""
 
-          CFLAGS_DBG="-g"
-          CFLAGS_OPT="-O2"
-          CFLAGS_DEVEL="$CFLAGS_DBG"
+                                CFLAGS_DBG="-g"
+                                CFLAGS_OPT="-O2"
+                                CFLAGS_DEVEL="$CFLAGS_DBG"
 
-          # Disable exception handling if we don't use it
-          if test "$enableexceptions" = no; then :
+                                                                if test "$enableexceptions" = no; then :
 
-                  CXXFLAGS_DBG="$CXXFLAGS_DBG --no_exceptions"
-                  CXXFLAGS_OPT="$CXXFLAGS_OPT --no_exceptions"
+                                        CXXFLAGS_DBG="$CXXFLAGS_DBG --no_exceptions"
+                                        CXXFLAGS_OPT="$CXXFLAGS_OPT --no_exceptions"
 
 fi
-          ;;
+                               ;; #(
+  cray_cc) :
 
-      cray_cc)
-          CXXFLAGS_DBG="-h conform,one_instantiation_per_object,instantiate=used,noimplicitinclude -G n"
-          CXXFLAGS_OPT="-h conform,one_instantiation_per_object,instantiate=used,noimplicitinclude -G n"
-          CXXFLAGS_DEVEL="-h conform,one_instantiation_per_object,instantiate=used,noimplicitinclude -G n"
-          NODEPRECATEDFLAG=""
-          CFLAGS_DBG="-G n"
-          CFLAGS_OPT="-G n"
-          CFLAGS_DEVEL="-G n"
-          ;;
+                         CXXFLAGS_DBG="-h conform,one_instantiation_per_object,instantiate=used,noimplicitinclude -G n"
+                         CXXFLAGS_OPT="-h conform,one_instantiation_per_object,instantiate=used,noimplicitinclude -G n"
+                         CXXFLAGS_DEVEL="-h conform,one_instantiation_per_object,instantiate=used,noimplicitinclude -G n"
+                         NODEPRECATEDFLAG=""
+                         CFLAGS_DBG="-G n"
+                         CFLAGS_OPT="-G n"
+                         CFLAGS_DEVEL="-G n"
+                        ;; #(
+  clang) :
 
-      clang)
-          CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -Qunused-arguments -Wunused-parameter -Wunused"
-          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
-          CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
-          NODEPRECATEDFLAG="-Wno-deprecated"
+                       CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -Qunused-arguments -Wunused-parameter -Wunused"
+                       CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+                       CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+                       NODEPRECATEDFLAG="-Wno-deprecated"
 
-          CFLAGS_OPT="-O2 -Qunused-arguments -Wunused"
-          CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -fno-limit-debug-info -Wunused"
-          CFLAGS_DBG="-g -Wimplicit -Qunused-arguments -fno-limit-debug-info -Wunused"
-          ;;
+                       CFLAGS_OPT="-O2 -Qunused-arguments -Wunused"
+                       CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -fno-limit-debug-info -Wunused"
+                       CFLAGS_DBG="-g -Wimplicit -Qunused-arguments -fno-limit-debug-info -Wunused"
+                      ;; #(
+  *) :
 
-      *)
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: No specific options for this C++ compiler known" >&5
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: No specific options for this C++ compiler known" >&5
 $as_echo "No specific options for this C++ compiler known" >&6; }
-          CXXFLAGS_DBG="$CXXFLAGS"
-          CXXFLAGS_OPT="$CXXFLAGS"
-          CXXFLAGS_DEVEL="$CXXFLAGS"
-          NODEPRECATEDFLAG=""
+              CXXFLAGS_DBG="$CXXFLAGS"
+              CXXFLAGS_OPT="$CXXFLAGS"
+              CXXFLAGS_DEVEL="$CXXFLAGS"
+              NODEPRECATEDFLAG=""
 
-          CFLAGS_DBG="$CFLAGS"
-          CFLAGS_OPT="$CFLAGS"
-          CFLAGS_DEVEL="$CFLAGS"
-          ;;
-    esac
+              CFLAGS_DBG="$CFLAGS"
+              CFLAGS_OPT="$CFLAGS"
+              CFLAGS_DEVEL="$CFLAGS"
+             ;;
+esac
 
 fi
 

--- a/configure
+++ b/configure
@@ -7246,11 +7246,14 @@ fi
   # us to increase our unit test coverage.
   # Check whether --enable-glibcxx-debugging-cppunit was given.
 if test "${enable_glibcxx_debugging_cppunit+set}" = set; then :
-  enableval=$enable_glibcxx_debugging_cppunit; case "${enableval}" in
-	   yes)  enableglibcxxdebuggingcppunit=yes ;;
-	    no)  enableglibcxxdebuggingcppunit=no ;;
- 	     *)  as_fn_error $? "bad value ${enableval} for --enable-glibcxx-debugging-cppunit" "$LINENO" 5 ;;
-	  esac
+  enableval=$enable_glibcxx_debugging_cppunit; case "${enableval}" in #(
+  yes) :
+    enableglibcxxdebuggingcppunit=yes ;; #(
+  no) :
+    enableglibcxxdebuggingcppunit=no ;; #(
+  *) :
+    as_fn_error $? "bad value ${enableval} for --enable-glibcxx-debugging-cppunit" "$LINENO" 5 ;;
+esac
 else
   enableglibcxxdebuggingcppunit=no
 fi

--- a/configure
+++ b/configure
@@ -4860,12 +4860,12 @@ else
 fi
 
 
-  if  (test "$enablempi" != no) ; then
-    CXX_TRY_LIST="mpicxx mpiCC mpicc $CXX_TRY_LIST"
-  else
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Disabling MPI per user request <<<" >&5
+  if test "$enablempi" != no; then :
+  CXX_TRY_LIST="mpicxx mpiCC mpicc $CXX_TRY_LIST"
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Disabling MPI per user request <<<" >&5
 $as_echo ">>> Disabling MPI per user request <<<" >&6; }
-  fi
+fi
 
 
 # Check whether --with-cxx was given.

--- a/configure
+++ b/configure
@@ -6280,11 +6280,14 @@ fi
   # --------------------------------------------------------------
   # Check whether --enable-fortran was given.
 if test "${enable_fortran+set}" = set; then :
-  enableval=$enable_fortran; case "${enableval}" in
-                  yes)  enablefortran=yes ;;
-                  no)  enablefortran=no ;;
-                  *)  as_fn_error $? "bad value ${enableval} for --enable-fortran" "$LINENO" 5 ;;
-                esac
+  enableval=$enable_fortran; case "${enableval}" in #(
+  yes) :
+    enablefortran=yes ;; #(
+  no) :
+    enablefortran=no ;; #(
+  *) :
+    as_fn_error $? "bad value ${enableval} for --enable-fortran" "$LINENO" 5 ;;
+esac
 else
   enablefortran=yes
 fi

--- a/configure
+++ b/configure
@@ -6275,9 +6275,9 @@ fi
   if test "x$enablefortran" = xyes; then :
 
                     FC_TRY_LIST="gfortran ifort pgf90 xlf95"
-          if  (test "$enablempi" != no) ; then
-            FC_TRY_LIST="mpif90 $FC_TRY_LIST"
-          fi
+          if test "$enablempi" != no; then :
+  FC_TRY_LIST="mpif90 $FC_TRY_LIST"
+fi
 
 # Check whether --with-fc was given.
 if test "${with_fc+set}" = set; then :
@@ -6497,17 +6497,17 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-          if (test "x$FC" = "x"); then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> No valid Fortran compiler <<<" >&5
+          if test "x$FC" = "x"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> No valid Fortran compiler <<<" >&5
 $as_echo ">>> No valid Fortran compiler <<<" >&6; }
-            FC=no
-            enablefortran=no
-          fi
+                FC=no
+                enablefortran=no
+fi
 
                     F77_TRY_LIST="gfortran g77 ifort f77 xlf frt pgf77 fort77 fl32 af77 f90 xlf90 pgf90 epcf90 f95 fort xlf95 ifc efc pgf95 lf95"
-          if  (test "$enablempi" != no) ; then
-            F77_TRY_LIST="mpif77 $F77_TRY_LIST"
-          fi
+          if test "$enablempi" != no; then :
+  F77_TRY_LIST="mpif77 $F77_TRY_LIST"
+fi
 
 # Check whether --with-f77 was given.
 if test "${with_f77+set}" = set; then :
@@ -6727,12 +6727,12 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-          if (test "x$F77" = "x"); then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> No valid Fortran 77 compiler <<<" >&5
+          if test "x$F77" = "x"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> No valid Fortran 77 compiler <<<" >&5
 $as_echo ">>> No valid Fortran 77 compiler <<<" >&6; }
-            F77=no
-            enablefortran=no
-          fi
+                 F77=no
+                 enablefortran=no
+fi
 
 else
 

--- a/configure
+++ b/configure
@@ -7079,20 +7079,14 @@ $as_echo "#define HAVE_CXX11 1" >>confdefs.h
   # Check whether --enable-sanitize was given.
 if test "${enable_sanitize+set}" = set; then :
   enableval=$enable_sanitize; for method in ${enableval} ; do
-                 # make sure each method specified makes sense
-                 case "${method}" in
-                     optimized|opt)      ;;
-                     debug|dbg)          ;;
-                     devel)              ;;
-                     profiling|pro|prof) ;;
-                     oprofile|oprof)     ;;
-                     *)
-                         as_fn_error $? "bad value ${method} for --enable-sanitize" "$LINENO" 5
-                         ;;
-                 esac
+                                  case "${method}" in #(
+  optimized|opt|debug|dbg|devel|profiling|pro|prof|oprofile|oprof) :
+     ;; #(
+  *) :
+    as_fn_error $? "bad value ${method} for --enable-sanitize" "$LINENO" 5 ;;
+esac
                done
-               # If we made it here, the case statement didn't detect any errors
-               SANITIZE_METHODS=${enableval}
+                              SANITIZE_METHODS=${enableval}
 fi
 
 

--- a/configure
+++ b/configure
@@ -5528,57 +5528,59 @@ fi
       REAL_GXX=`($CXX -v 2>&1) | grep "gcc version"`
 
     is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
-  if test "x$is_intel_icc" != "x" ; then
-    REAL_GXX=""
-  fi
+  if test "x$is_intel_icc" != "x"; then :
+  REAL_GXX=""
+fi
 
-  if (test "$GXX" = yes -a "x$REAL_GXX" != "x" ) ; then
-        GXX_VERSION_STRING=`($CXX -v 2>&1) | grep "gcc version"`
-    case "$GXX_VERSION_STRING" in
-      *gcc\ version\ 7.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-7.x >>>" >&5
+  if test "$GXX" = yes -a "x$REAL_GXX" != "x"; then :
+
+                    GXX_VERSION_STRING=`($CXX -v 2>&1) | grep "gcc version"`
+          case "$GXX_VERSION_STRING" in
+            *gcc\ version\ 7.*)
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-7.x >>>" >&5
 $as_echo "<<< C++ compiler is gcc-7.x >>>" >&6; }
-        GXX_VERSION=gcc7
-        ;;
-      *gcc\ version\ 6.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-6.x >>>" >&5
+              GXX_VERSION=gcc7
+              ;;
+            *gcc\ version\ 6.*)
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-6.x >>>" >&5
 $as_echo "<<< C++ compiler is gcc-6.x >>>" >&6; }
-        GXX_VERSION=gcc6
-        ;;
-      *gcc\ version\ 5.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-5.x >>>" >&5
+              GXX_VERSION=gcc6
+              ;;
+            *gcc\ version\ 5.*)
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-5.x >>>" >&5
 $as_echo "<<< C++ compiler is gcc-5.x >>>" >&6; }
-        GXX_VERSION=gcc5
-        ;;
-      *4.9.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.9 >>>" >&5
+              GXX_VERSION=gcc5
+              ;;
+            *4.9.*)
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.9 >>>" >&5
 $as_echo "<<< C++ compiler is gcc-4.9 >>>" >&6; }
-        GXX_VERSION=gcc4.9
-        ;;
-      *4.8.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.8 >>>" >&5
+              GXX_VERSION=gcc4.9
+              ;;
+            *4.8.*)
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.8 >>>" >&5
 $as_echo "<<< C++ compiler is gcc-4.8 >>>" >&6; }
-        GXX_VERSION=gcc4.8
-        ;;
-      *4.7.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.7 >>>" >&5
+              GXX_VERSION=gcc4.8
+              ;;
+            *4.7.*)
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.7 >>>" >&5
 $as_echo "<<< C++ compiler is gcc-4.7 >>>" >&6; }
-        GXX_VERSION=gcc4.7
-        ;;
-      *4.6.*)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.6 >>>" >&5
+              GXX_VERSION=gcc4.7
+              ;;
+            *4.6.*)
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is gcc-4.6 >>>" >&5
 $as_echo "<<< C++ compiler is gcc-4.6 >>>" >&6; }
-        GXX_VERSION=gcc4.6
-        ;;
-      *)
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is unknown but accepted gcc version >>>" >&5
+              GXX_VERSION=gcc4.6
+              ;;
+            *)
+              { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is unknown but accepted gcc version >>>" >&5
 $as_echo "<<< C++ compiler is unknown but accepted gcc version >>>" >&6; }
-        GXX_VERSION=gcc-other
-        ;;
-    esac
+              GXX_VERSION=gcc-other
+              ;;
+          esac
 
-        compiler_brand_detected=yes
-  fi
+                    compiler_brand_detected=yes
+
+fi
 
     if (test "x$compiler_brand_detected" = "xno"); then
     clang_version="`($CXX --version 2>&1)`"

--- a/configure
+++ b/configure
@@ -5648,49 +5648,63 @@ fi
 
 fi
 
-              if (test "x$compiler_brand_detected" = "xno"); then
-    is_ibm_xlc="`($CXX 2>&1) | egrep -i 'xlc'`"
-    if test "x$is_ibm_xlc" != "x"  ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is IBM xlC >>>" >&5
+              if test "x$compiler_brand_detected" = "xno"; then :
+
+          is_ibm_xlc="`($CXX 2>&1) | egrep -i 'xlc'`"
+          if test "x$is_ibm_xlc" != "x"; then :
+
+                  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is IBM xlC >>>" >&5
 $as_echo "<<< C++ compiler is IBM xlC >>>" >&6; }
-      GXX_VERSION=ibm_xlc
-      compiler_brand_detected=yes
-    fi
-  fi
+                  GXX_VERSION=ibm_xlc
+                  compiler_brand_detected=yes
 
-    if (test "x$compiler_brand_detected" = "xno"); then
-    is_cray_cc="`($CXX -V 2>&1) | grep 'Cray '`"
-    if test "x$is_cray_cc" != "x" ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Cray C++ >>>" >&5
+fi
+
+fi
+
+    if test "x$compiler_brand_detected" = "xno"; then :
+
+          is_cray_cc="`($CXX -V 2>&1) | grep 'Cray '`"
+          if test "x$is_cray_cc" != "x"; then :
+
+                  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Cray C++ >>>" >&5
 $as_echo "<<< C++ compiler is Cray C++ >>>" >&6; }
-      GXX_VERSION=cray_cc
-      compiler_brand_detected=yes
-    fi
-  fi
+                  GXX_VERSION=cray_cc
+                  compiler_brand_detected=yes
 
-    if (test "x$compiler_brand_detected" = "xno"); then
-    is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group'`"
-    if test "x$is_pgcc" != "x" ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Portland Group C++ >>>" >&5
+fi
+
+fi
+
+    if test "x$compiler_brand_detected" = "xno"; then :
+
+          is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group'`"
+          if test "x$is_pgcc" != "x"; then :
+
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Portland Group C++ >>>" >&5
 $as_echo "<<< C++ compiler is Portland Group C++ >>>" >&6; }
-      GXX_VERSION=portland_group
-      compiler_brand_detected=yes
-    fi
-  fi
+            GXX_VERSION=portland_group
+            compiler_brand_detected=yes
 
-    if (test "x$compiler_brand_detected" = "xno"); then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: WARNING:" >&5
+fi
+
+fi
+
+    if test "x$compiler_brand_detected" = "xno"; then :
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: WARNING:" >&5
 $as_echo "WARNING:" >&6; }
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Unrecognized compiler: \"$CXX\" <<<" >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Unrecognized compiler: \"$CXX\" <<<" >&5
 $as_echo ">>> Unrecognized compiler: \"$CXX\" <<<" >&6; }
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: You will likely need to modify" >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: You will likely need to modify" >&5
 $as_echo "You will likely need to modify" >&6; }
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: Make.common directly to specify" >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: Make.common directly to specify" >&5
 $as_echo "Make.common directly to specify" >&6; }
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: proper compiler flags" >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: proper compiler flags" >&5
 $as_echo "proper compiler flags" >&6; }
-    GXX_VERSION=unknown
-  fi
+          GXX_VERSION=unknown
+
+fi
 
 
 

--- a/configure
+++ b/configure
@@ -7363,10 +7363,12 @@ esac
           CFLAGS_DEVEL="$CFLAGS_DBG"
 
           # Disable exception handling if we don't use it
-          if test "$enableexceptions" = no ; then
-            CXXFLAGS_DBG="$CXXFLAGS_DBG --no_exceptions"
-            CXXFLAGS_OPT="$CXXFLAGS_OPT --no_exceptions"
-          fi
+          if test "$enableexceptions" = no; then :
+
+                  CXXFLAGS_DBG="$CXXFLAGS_DBG --no_exceptions"
+                  CXXFLAGS_OPT="$CXXFLAGS_OPT --no_exceptions"
+
+fi
           ;;
 
       cray_cc)

--- a/configure
+++ b/configure
@@ -7333,47 +7333,21 @@ esac
         # The -g flag is all OProfile needs to produce annotations
         OPROFILE_FLAGS="-g"
 
-        # Specific flags for specific versions
-        case "$GXX_VERSION" in
+                                                                                                                                                                case "$GXX_VERSION" in #(
+  intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x) :
 
-          # Intel ICC >= v13.x
-          intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x)
-              # Disable some warning messages:
-              # #161: 'unrecognized #pragma
-              #       #pragma GCC diagnostic warning "-Wdeprecated-declarations"'
-              #       I don't understand this, pragmas for other compilers should
-              #       just be silently ignored, isn't that the whole point of pragmas?
-              # #175: 'subscript out of range'
-              #       FIN-S application code causes many false
-              #       positives with this
-              # #266: 'function declared implicitly'
-              #       Metis function "GKfree" caused this error
-              #       in almost every file.
-              # #488: 'template parameter "Scalar1" is not used in declaring the
-              #       parameter types of function template'
-              #       This warning was generated from one of the type_vector.h
-              #       constructors that uses some SFINAE tricks.
-              # #1476: 'field uses tail padding of a base class'
-              # #1505: 'size of class is affected by tail padding'
-              #        simply warns of a possible incompatibility with
-              #        the g++ ABI for this case
-              # #1572: 'floating-point equality and inequality comparisons are unreliable'
-              #        Well, duh, when the tested value is computed...  OK when it
-              #        was from an assignment.
-              PROFILING_FLAGS="-p"
-              CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
-              CXXFLAGS_OPT="$CXXFLAGS_OPT -O3 -unroll -w0 -ftz"
-              CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
-              CFLAGS_DBG="$CFLAGS_DBG -w1 -g -wd266 -wd1572 -wd488 -wd161"
-              CFLAGS_OPT="$CFLAGS_OPT -O3 -unroll -w0 -ftz"
-              CFLAGS_DEVEL="$CFLAGS_DBG"
-              ;;
-
-          *)
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: Unknown Intel compiler" >&5
-$as_echo "Unknown Intel compiler" >&6; }
-              ;;
-        esac
+                  PROFILING_FLAGS="-p"
+                  CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
+                  CXXFLAGS_OPT="$CXXFLAGS_OPT -O3 -unroll -w0 -ftz"
+                  CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
+                  CFLAGS_DBG="$CFLAGS_DBG -w1 -g -wd266 -wd1572 -wd488 -wd161"
+                  CFLAGS_OPT="$CFLAGS_OPT -O3 -unroll -w0 -ftz"
+                  CFLAGS_DEVEL="$CFLAGS_DBG"
+                 ;; #(
+  *) :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: Unknown Intel compiler" >&5
+$as_echo "Unknown Intel compiler" >&6; } ;;
+esac
       ;;
 
       portland_group)

--- a/configure
+++ b/configure
@@ -7096,21 +7096,13 @@ if test "${enable_sanitize+set}" = set; then :
 fi
 
 
-  if test "x$SANITIZE_METHODS" != x; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Testing sanitizer flags for method(s) \"$SANITIZE_METHODS\" >>>" >&5
+  if test "x$SANITIZE_METHODS" != x; then :
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Testing sanitizer flags for method(s) \"$SANITIZE_METHODS\" >>>" >&5
 $as_echo "<<< Testing sanitizer flags for method(s) \"$SANITIZE_METHODS\" >>>" >&6; }
 
-    # Both Clang and GCC docs suggest using "-fsanitize=address -fno-omit-frame-pointer".
-    # The Clang documentation further suggests using "-O1 -g -fno-optimize-sibling-calls".
-    # Since these flags also work in GCC, we'll use them there as well...
-    COMMON_SANITIZE_OPTIONS="-fsanitize=address -fno-omit-frame-pointer -O1 -g -fno-optimize-sibling-calls"
+                                        COMMON_SANITIZE_OPTIONS="-fsanitize=address -fno-omit-frame-pointer -O1 -g -fno-optimize-sibling-calls"
 
-    # Test the sanitizer flags.  Currently Clang and GCC are the only
-    # compilers that support the address sanitizer, and they use the
-    # same set of flags.  If the set of flags used by Clang and GCC ever
-    # diverges, we'll need to set up separate flags and test them in the
-    # case blocks below...  The LIBMESH_TEST_SANITIZE_FLAGS function sets
-    # the variable have_address_sanitizer to either "no" or "yes"
 
     # Save current lang and CXXFLAGS values
     ac_ext=cpp
@@ -7189,42 +7181,41 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
 
-    # Enable the address sanitizer stuff if the test code compiled
-    if test "x$have_address_sanitizer" = xyes; then
-      # As of clang 3.9.0 or so, we also need to pass the sanitize flag to the linker
-      # if it's being used during compiling. It seems that we do not need to pass all
-      # the flags above, just the sanitize flag itself.
-      libmesh_LDFLAGS="$libmesh_LDFLAGS -Wc,-fsanitize=address"
+                    if test "x$have_address_sanitizer" = xyes; then :
 
-      for method in ${SANITIZE_METHODS}; do
-          case "${method}" in
-              optimized|opt)
-                SANITIZE_OPT_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                                                                        libmesh_LDFLAGS="$libmesh_LDFLAGS -Wc,-fsanitize=address"
 
-              debug|dbg)
-                SANITIZE_DBG_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                  for method in ${SANITIZE_METHODS}; do
+                      case "${method}" in
+                          optimized|opt)
+                            SANITIZE_OPT_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
 
-              devel)
-                SANITIZE_DEVEL_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                          debug|dbg)
+                            SANITIZE_DBG_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
 
-              profiling|pro|prof)
-                SANITIZE_PROF_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                          devel)
+                            SANITIZE_DEVEL_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
 
-              oprofile|oprof)
-                SANITIZE_OPROF_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                          profiling|pro|prof)
+                            SANITIZE_PROF_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
 
-              *)
-                as_fn_error $? "bad value ${method} for --enable-sanitize" "$LINENO" 5
-                ;;
-          esac
-      done
-    fi
-  fi
+                          oprofile|oprof)
+                            SANITIZE_OPROF_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
+
+                          *)
+                            as_fn_error $? "bad value ${method} for --enable-sanitize" "$LINENO" 5
+                            ;;
+                      esac
+                  done
+
+fi
+
+fi
 
   # in the case blocks below we may add GLIBCXX-specific pedantic debugging preprocessor
   # definitions. however, allow the knowing user to preclude that if they need to.
@@ -7241,11 +7232,13 @@ fi
 
 
   # GLIBCXX debugging causes untold woes on mac machines - so disable it
-  if (test `uname` = "Darwin"); then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Disabling GLIBCXX debugging on Darwin >>>" >&5
+  if test `uname` = "Darwin"; then :
+
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Disabling GLIBCXX debugging on Darwin >>>" >&5
 $as_echo "<<< Disabling GLIBCXX debugging on Darwin >>>" >&6; }
-    enableglibcxxdebugging=no
-  fi
+          enableglibcxxdebugging=no
+
+fi
    if test x$enableglibcxxdebugging = xyes; then
   LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE=
   LIBMESH_ENABLE_GLIBCXX_DEBUGGING_FALSE='#'
@@ -7293,9 +7286,9 @@ fi
     CFLAGS_DBG="-g -Wimplicit"
     ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm"
 
-    if (test "x$enableglibcxxdebugging" = "xyes"); then
-      CPPFLAGS_DBG="$CPPFLAGS_DBG -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC"
-    fi
+    if test "x$enableglibcxxdebugging" = "xyes"; then :
+  CPPFLAGS_DBG="$CPPFLAGS_DBG -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC"
+fi
 
     # GCC 4.6.3 warns about variadic macros but supports them just
     # fine, so let's turn off that warning.

--- a/configure
+++ b/configure
@@ -7296,20 +7296,13 @@ fi
      ;;
 esac
 
-    # Set OS-specific flags for linkers & other stuff
-    case "$target" in
-
-      # For Solaris we need to pass a different flag to the linker for specifying the
-      # dynamic library search path and add -lrpcsvc to use XDR
-      *solaris*)
-          RPATHFLAG="-Wl,-R,"
-          LIBS="-lrpcsvc $LIBS"
-          ;;
-
-      *)
-          ;;
-    esac
-
+                case "$target" in #(
+  *solaris*) :
+    RPATHFLAG="-Wl,-R,"
+                          LIBS="-lrpcsvc $LIBS" ;; #(
+  *) :
+     ;;
+esac
 
   else
     # Non-gcc compilers

--- a/configure
+++ b/configure
@@ -7270,7 +7270,8 @@ fi
 
 
   # First the flags for gcc compilers
-  if (test "$GXX" = yes -a "x$REAL_GXX" != "x" ) ; then
+  if test "$GXX" = yes -a "x$REAL_GXX" != "x"; then :
+
     CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -funroll-loops -fstrict-aliasing -Wdisabled-optimization"
     CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -funroll-loops -fstrict-aliasing -Woverloaded-virtual -Wdisabled-optimization"
     CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Woverloaded-virtual"
@@ -7304,8 +7305,8 @@ esac
      ;;
 esac
 
-  else
-    # Non-gcc compilers
+else
+
 
     case "$GXX_VERSION" in
       ibm_xlc)
@@ -7405,7 +7406,8 @@ $as_echo "No specific options for this C++ compiler known" >&6; }
           CFLAGS_DEVEL="$CFLAGS"
           ;;
     esac
-  fi
+
+fi
 
 
 #------------------------------------------------------

--- a/configure
+++ b/configure
@@ -7287,17 +7287,14 @@ fi
 
     # GCC 4.6.3 warns about variadic macros but supports them just
     # fine, so let's turn off that warning.
-    case "$GXX_VERSION" in
-      gcc4.6 | gcc5)
-        CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
-        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
-        CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"
-        ;;
-
-      *)
-        ;;
-    esac
-
+    case "$GXX_VERSION" in #(
+  gcc4.6 | gcc5) :
+    CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
+                              CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
+                              CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros" ;; #(
+  *) :
+     ;;
+esac
 
     # Set OS-specific flags for linkers & other stuff
     case "$target" in

--- a/configure
+++ b/configure
@@ -5575,36 +5575,38 @@ esac
 
 fi
 
-    if (test "x$compiler_brand_detected" = "xno"); then
-    clang_version="`($CXX --version 2>&1)`"
-    is_clang="`echo $clang_version | grep 'clang'`"
+    if test "x$compiler_brand_detected" = "xno"; then :
 
-    if test "x$is_clang" != "x"; then :
+          clang_version="`($CXX --version 2>&1)`"
+          is_clang="`echo $clang_version | grep 'clang'`"
 
-                                                is_apple_clang="`echo $clang_version | grep 'Apple'`"
-            clang_vendor="clang"
-            if test "x$is_apple_clang" != "x"; then :
+          if test "x$is_clang" != "x"; then :
+
+                                                                        is_apple_clang="`echo $clang_version | grep 'Apple'`"
+                  clang_vendor="clang"
+                  if test "x$is_apple_clang" != "x"; then :
   clang_vendor="Apple clang"
 fi
 
-                                    clang_major_minor=unknown
+                                                      clang_major_minor=unknown
 
-            if test "x$PERL" != "x"; then :
+                  if test "x$PERL" != "x"; then :
 
-                    clang_major_minor=`echo $clang_version | $PERL -ne 'print $1 if /version\s(\d+\.\d+)/'`
-                    if test "x$clang_major_minor" = "x"; then :
+                          clang_major_minor=`echo $clang_version | $PERL -ne 'print $1 if /version\s(\d+\.\d+)/'`
+                          if test "x$clang_major_minor" = "x"; then :
   clang_major_minor=unknown
 fi
 
 fi
 
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&5
+                  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&5
 $as_echo "<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>" >&6; }
-            GXX_VERSION=clang
-            compiler_brand_detected=yes
+                  GXX_VERSION=clang
+                  compiler_brand_detected=yes
 
 fi
-  fi
+
+fi
 
     if (test "x$compiler_brand_detected" = "xno"); then
     is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"

--- a/configure
+++ b/configure
@@ -7210,11 +7210,14 @@ fi
   # definitions. however, allow the knowing user to preclude that if they need to.
   # Check whether --enable-glibcxx-debugging was given.
 if test "${enable_glibcxx_debugging+set}" = set; then :
-  enableval=$enable_glibcxx_debugging; case "${enableval}" in
-                  yes)  enableglibcxxdebugging=yes ;;
-                  no)  enableglibcxxdebugging=no ;;
-                  *)  as_fn_error $? "bad value ${enableval} for --enable-glibcxx-debugging" "$LINENO" 5 ;;
-                esac
+  enableval=$enable_glibcxx_debugging; case "${enableval}" in #(
+  yes) :
+    enableglibcxxdebugging=yes ;; #(
+  no) :
+    enableglibcxxdebugging=no ;; #(
+  *) :
+    as_fn_error $? "bad value ${enableval} for --enable-glibcxx-debugging" "$LINENO" 5 ;;
+esac
 else
   enableglibcxxdebugging=yes
 fi

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -156,51 +156,51 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
 
   dnl Do not allow Intel to masquerade as a "real" GCC.
   is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
-  if test "x$is_intel_icc" != "x" ; then
-    REAL_GXX=""
-  fi
+  AS_IF([test "x$is_intel_icc" != "x"],
+        [REAL_GXX=""])
 
-  if (test "$GXX" = yes -a "x$REAL_GXX" != "x" ) ; then
-    dnl find out the right version
-    GXX_VERSION_STRING=`($CXX -v 2>&1) | grep "gcc version"`
-    case "$GXX_VERSION_STRING" in
-      *gcc\ version\ 7.*)
-        AC_MSG_RESULT(<<< C++ compiler is gcc-7.x >>>)
-        GXX_VERSION=gcc7
-        ;;
-      *gcc\ version\ 6.*)
-        AC_MSG_RESULT(<<< C++ compiler is gcc-6.x >>>)
-        GXX_VERSION=gcc6
-        ;;
-      *gcc\ version\ 5.*)
-        AC_MSG_RESULT(<<< C++ compiler is gcc-5.x >>>)
-        GXX_VERSION=gcc5
-        ;;
-      *4.9.*)
-        AC_MSG_RESULT(<<< C++ compiler is gcc-4.9 >>>)
-        GXX_VERSION=gcc4.9
-        ;;
-      *4.8.*)
-        AC_MSG_RESULT(<<< C++ compiler is gcc-4.8 >>>)
-        GXX_VERSION=gcc4.8
-        ;;
-      *4.7.*)
-        AC_MSG_RESULT(<<< C++ compiler is gcc-4.7 >>>)
-        GXX_VERSION=gcc4.7
-        ;;
-      *4.6.*)
-        AC_MSG_RESULT(<<< C++ compiler is gcc-4.6 >>>)
-        GXX_VERSION=gcc4.6
-        ;;
-      *)
-        AC_MSG_RESULT(<<< C++ compiler is unknown but accepted gcc version >>>)
-        GXX_VERSION=gcc-other
-        ;;
-    esac
+  AS_IF([test "$GXX" = yes -a "x$REAL_GXX" != "x"],
+        [
+          dnl find out the right version
+          GXX_VERSION_STRING=`($CXX -v 2>&1) | grep "gcc version"`
+          case "$GXX_VERSION_STRING" in
+            *gcc\ version\ 7.*)
+              AC_MSG_RESULT(<<< C++ compiler is gcc-7.x >>>)
+              GXX_VERSION=gcc7
+              ;;
+            *gcc\ version\ 6.*)
+              AC_MSG_RESULT(<<< C++ compiler is gcc-6.x >>>)
+              GXX_VERSION=gcc6
+              ;;
+            *gcc\ version\ 5.*)
+              AC_MSG_RESULT(<<< C++ compiler is gcc-5.x >>>)
+              GXX_VERSION=gcc5
+              ;;
+            *4.9.*)
+              AC_MSG_RESULT(<<< C++ compiler is gcc-4.9 >>>)
+              GXX_VERSION=gcc4.9
+              ;;
+            *4.8.*)
+              AC_MSG_RESULT(<<< C++ compiler is gcc-4.8 >>>)
+              GXX_VERSION=gcc4.8
+              ;;
+            *4.7.*)
+              AC_MSG_RESULT(<<< C++ compiler is gcc-4.7 >>>)
+              GXX_VERSION=gcc4.7
+              ;;
+            *4.6.*)
+              AC_MSG_RESULT(<<< C++ compiler is gcc-4.6 >>>)
+              GXX_VERSION=gcc4.6
+              ;;
+            *)
+              AC_MSG_RESULT(<<< C++ compiler is unknown but accepted gcc version >>>)
+              GXX_VERSION=gcc-other
+              ;;
+          esac
 
-    dnl Detection was successful, so set the flag.
-    compiler_brand_detected=yes
-  fi
+          dnl Detection was successful, so set the flag.
+          compiler_brand_detected=yes
+        ])
 
   dnl Clang/LLVM C++?
   if (test "x$compiler_brand_detected" = "xno"); then

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -79,11 +79,10 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
   AC_ARG_ENABLE(fortran,
                 AS_HELP_STRING([--disable-fortran],
                                [build without Fortran language support]),
-                [case "${enableval}" in
-                  yes)  enablefortran=yes ;;
-                  no)  enablefortran=no ;;
-                  *)  AC_MSG_ERROR(bad value ${enableval} for --enable-fortran) ;;
-                esac],
+                [AS_CASE("${enableval}",
+                         [yes], [enablefortran=yes],
+                         [no],  [enablefortran=no],
+                         [AC_MSG_ERROR(bad value ${enableval} for --enable-fortran)])],
                 [enablefortran=yes])
 
   AS_IF([test "x$enablefortran" = xyes],

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -506,46 +506,37 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
         # The -g flag is all OProfile needs to produce annotations
         OPROFILE_FLAGS="-g"
 
-        # Specific flags for specific versions
-        case "$GXX_VERSION" in
-
-          # Intel ICC >= v13.x
-          intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x)
-              # Disable some warning messages:
-              # #161: 'unrecognized #pragma
-              #       #pragma GCC diagnostic warning "-Wdeprecated-declarations"'
-              #       I don't understand this, pragmas for other compilers should
-              #       just be silently ignored, isn't that the whole point of pragmas?
-              # #175: 'subscript out of range'
-              #       FIN-S application code causes many false
-              #       positives with this
-              # #266: 'function declared implicitly'
-              #       Metis function "GKfree" caused this error
-              #       in almost every file.
-              # #488: 'template parameter "Scalar1" is not used in declaring the
-              #       parameter types of function template'
-              #       This warning was generated from one of the type_vector.h
-              #       constructors that uses some SFINAE tricks.
-              # #1476: 'field uses tail padding of a base class'
-              # #1505: 'size of class is affected by tail padding'
-              #        simply warns of a possible incompatibility with
-              #        the g++ ABI for this case
-              # #1572: 'floating-point equality and inequality comparisons are unreliable'
-              #        Well, duh, when the tested value is computed...  OK when it
-              #        was from an assignment.
-              PROFILING_FLAGS="-p"
-              CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
-              CXXFLAGS_OPT="$CXXFLAGS_OPT -O3 -unroll -w0 -ftz"
-              CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
-              CFLAGS_DBG="$CFLAGS_DBG -w1 -g -wd266 -wd1572 -wd488 -wd161"
-              CFLAGS_OPT="$CFLAGS_OPT -O3 -unroll -w0 -ftz"
-              CFLAGS_DEVEL="$CFLAGS_DBG"
-              ;;
-
-          *)
-              AC_MSG_RESULT(Unknown Intel compiler, "$GXX_VERSION")
-              ;;
-        esac
+        dnl Disable some warning messages on Intel compilers:
+        dnl 161:  unrecognized pragma GCC diagnostic warning "-Wdeprecated-declarations"
+        dnl 175:  subscript out of range
+        dnl       FIN-S application code causes many false
+        dnl       positives with this
+        dnl 266:  function declared implicitly
+        dnl       Metis function "GKfree" caused this error
+        dnl       in almost every file.
+        dnl 488:  template parameter "Scalar1" is not used in declaring the
+        dnl       parameter types of function template
+        dnl       This warning was generated from one of the type_vector.h
+        dnl       constructors that uses some SFINAE tricks.
+        dnl 1476: field uses tail padding of a base class
+        dnl 1505: size of class is affected by tail padding
+        dnl       simply warns of a possible incompatibility with
+        dnl       the g++ ABI for this case
+        dnl 1572: floating-point equality and inequality comparisons are unreliable
+        dnl       Well, duh, when the tested value is computed...  OK when it
+        dnl       was from an assignment.
+        AS_CASE("$GXX_VERSION",
+                [intel_icc_v13.x | intel_icc_v14.x | intel_icc_v15.x | intel_icc_v16.x | intel_icc_v17.x | intel_icc_v18.x],
+                [
+                  PROFILING_FLAGS="-p"
+                  CXXFLAGS_DBG="$CXXFLAGS_DBG -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
+                  CXXFLAGS_OPT="$CXXFLAGS_OPT -O3 -unroll -w0 -ftz"
+                  CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -w1 -g -wd175 -wd1476 -wd1505 -wd1572 -wd488 -wd161"
+                  CFLAGS_DBG="$CFLAGS_DBG -w1 -g -wd266 -wd1572 -wd488 -wd161"
+                  CFLAGS_OPT="$CFLAGS_OPT -O3 -unroll -w0 -ftz"
+                  CFLAGS_DEVEL="$CFLAGS_DBG"
+                ],
+                [AC_MSG_RESULT(Unknown Intel compiler, "$GXX_VERSION")])
       ;;
 
       portland_group)

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -442,32 +442,34 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
   # First the flags for gcc compilers
   AS_IF([test "$GXX" = yes -a "x$REAL_GXX" != "x"],
         [
-    CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -funroll-loops -fstrict-aliasing -Wdisabled-optimization"
-    CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -funroll-loops -fstrict-aliasing -Woverloaded-virtual -Wdisabled-optimization"
-    CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Woverloaded-virtual"
-    NODEPRECATEDFLAG="-Wno-deprecated"
+          CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -funroll-loops -fstrict-aliasing -Wdisabled-optimization"
+          dnl devel flags are added on two lines since there are so many
+          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused"
+          CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -funroll-loops -fstrict-aliasing -Woverloaded-virtual -Wdisabled-optimization"
+          CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Woverloaded-virtual"
+          NODEPRECATEDFLAG="-Wno-deprecated"
 
-    CFLAGS_OPT="-O2 -funroll-loops -fstrict-aliasing"
-    CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -funroll-loops -fstrict-aliasing"
-    CFLAGS_DBG="-g -Wimplicit"
-    ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm"
+          CFLAGS_OPT="-O2 -funroll-loops -fstrict-aliasing"
+          CFLAGS_DEVEL="$CFLAGS_OPT -g -Wimplicit -funroll-loops -fstrict-aliasing"
+          CFLAGS_DBG="-g -Wimplicit"
+          ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm"
 
-    AS_IF([test "x$enableglibcxxdebugging" = "xyes"],
-          [CPPFLAGS_DBG="$CPPFLAGS_DBG -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC"])
+          AS_IF([test "x$enableglibcxxdebugging" = "xyes"],
+                [CPPFLAGS_DBG="$CPPFLAGS_DBG -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC"])
 
-    # GCC 4.6.3 warns about variadic macros but supports them just
-    # fine, so let's turn off that warning.
-    AS_CASE("$GXX_VERSION",
-            [gcc4.6 | gcc5], [CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
-                              CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
-                              CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"])
+          # GCC 4.6.3 warns about variadic macros but supports them just
+          # fine, so let's turn off that warning.
+          AS_CASE("$GXX_VERSION",
+                  [gcc4.6 | gcc5], [CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
+                                    CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
+                                    CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"])
 
-    dnl Set OS-specific flags for linkers & other stuff
-    dnl For Solaris we need to pass a different flag to the linker for specifying the
-    dnl dynamic library search path and add -lrpcsvc to use XDR
-    AS_CASE("$target",
-            [*solaris*], [RPATHFLAG="-Wl,-R,"
-                          LIBS="-lrpcsvc $LIBS"])
+          dnl Set OS-specific flags for linkers & other stuff
+          dnl For Solaris we need to pass a different flag to the linker for specifying the
+          dnl dynamic library search path and add -lrpcsvc to use XDR
+          AS_CASE("$target",
+                  [*solaris*], [RPATHFLAG="-Wl,-R,"
+                                LIBS="-lrpcsvc $LIBS"])
         ],
         [
     dnl Non-gcc compilers
@@ -561,8 +563,12 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
 
             [clang], [
                        CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -Qunused-arguments -Wunused-parameter -Wunused"
-                       CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
-                       CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+                       dnl devel flags are added on two lines since there are so many
+                       CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long"
+                       CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
+                       dnl dbg flags are added on two lines since there are so many
+                       CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long"
+                       CXXFLAGS_DBG="$CXXFLAGS_DBG -Wunused-parameter -Wunused -Wpointer-arith -Wformat -Wparentheses -Qunused-arguments -Woverloaded-virtual -fno-limit-debug-info"
                        NODEPRECATEDFLAG="-Wno-deprecated"
 
                        CFLAGS_OPT="-O2 -Qunused-arguments -Wunused"

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -552,10 +552,11 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
           CFLAGS_DEVEL="$CFLAGS_DBG"
 
           # Disable exception handling if we don't use it
-          if test "$enableexceptions" = no ; then
-            CXXFLAGS_DBG="$CXXFLAGS_DBG --no_exceptions"
-            CXXFLAGS_OPT="$CXXFLAGS_OPT --no_exceptions"
-          fi
+          AS_IF([test "$enableexceptions" = no],
+                [
+                  CXXFLAGS_DBG="$CXXFLAGS_DBG --no_exceptions"
+                  CXXFLAGS_OPT="$CXXFLAGS_OPT --no_exceptions"
+                ])
           ;;
 
       cray_cc)

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -468,8 +468,7 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
     AS_CASE("$GXX_VERSION",
             [gcc4.6 | gcc5], [CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
                               CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
-                              CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"],
-            [])
+                              CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"])
 
     # Set OS-specific flags for linkers & other stuff
     case "$target" in

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -191,30 +191,31 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
     clang_version="`($CXX --version 2>&1)`"
     is_clang="`echo $clang_version | grep 'clang'`"
 
-    if test "x$is_clang" != "x" ; then
-      dnl Detect if clang is the version built by
-      dnl Apple, because then the version number means
-      dnl something different...
-      is_apple_clang="`echo $clang_version | grep 'Apple'`"
-      clang_vendor="clang"
-      AS_IF([test "x$is_apple_clang" != "x"],
-            [clang_vendor="Apple clang"])
+    AS_IF([test "x$is_clang" != "x"],
+          [
+            dnl Detect if clang is the version built by
+            dnl Apple, because then the version number means
+            dnl something different...
+            is_apple_clang="`echo $clang_version | grep 'Apple'`"
+            clang_vendor="clang"
+            AS_IF([test "x$is_apple_clang" != "x"],
+                  [clang_vendor="Apple clang"])
 
-      dnl If we have perl, we can also pull out the clang version number using regexes.
-      dnl Note that @S|@ is a quadrigraph for the dollar sign.
-      clang_major_minor=unknown
+            dnl If we have perl, we can also pull out the clang version number using regexes.
+            dnl Note that @S|@ is a quadrigraph for the dollar sign.
+            clang_major_minor=unknown
 
-      AS_IF([test "x$PERL" != "x"],
-            [
-              clang_major_minor=`echo $clang_version | $PERL -ne 'print @S|@1 if /version\s(\d+\.\d+)/'`
-              AS_IF([test "x$clang_major_minor" = "x"],
-                    [clang_major_minor=unknown])
-            ])
+            AS_IF([test "x$PERL" != "x"],
+                  [
+                    clang_major_minor=`echo $clang_version | $PERL -ne 'print @S|@1 if /version\s(\d+\.\d+)/'`
+                    AS_IF([test "x$clang_major_minor" = "x"],
+                          [clang_major_minor=unknown])
+                  ])
 
-      AC_MSG_RESULT([<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>])
-      GXX_VERSION=clang
-      compiler_brand_detected=yes
-    fi
+            AC_MSG_RESULT([<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>])
+            GXX_VERSION=clang
+            compiler_brand_detected=yes
+          ])
   fi
 
   dnl Intel's ICC C++ compiler?

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -13,11 +13,10 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
      AC_ARG_ENABLE(mpi,
                    AS_HELP_STRING([--disable-mpi],
                                   [build without MPI message passing support]),
-                   [case "${enableval}" in
-                     yes)  enablempi=yes ;;
-                     no)  enablempi=no ;;
-                     *)  AC_MSG_ERROR(bad value ${enableval} for --enable-mpi) ;;
-                   esac],
+                   [AS_CASE("${enableval}",
+                            [yes], [enablempi=yes],
+                            [no],  [enablempi=no],
+                            [AC_MSG_ERROR(bad value ${enableval} for --enable-mpi)])],
                    [enablempi=yes])
 
   AS_IF([test "$enablempi" != no],

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -437,14 +437,13 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
   # our users' systems.  However, being able to override this allows
   # us to increase our unit test coverage.
   AC_ARG_ENABLE(glibcxx-debugging-cppunit,
-	 [AS_HELP_STRING([--enable-glibcxx-debugging-cppunit],
-	                 [Use GLIBCXX debugging flags for unit tests])],
-	 [case "${enableval}" in
-	   yes)  enableglibcxxdebuggingcppunit=yes ;;
-	    no)  enableglibcxxdebuggingcppunit=no ;;
- 	     *)  AC_MSG_ERROR(bad value ${enableval} for --enable-glibcxx-debugging-cppunit) ;;
-	  esac],
-	[enableglibcxxdebuggingcppunit=no])
+                [AS_HELP_STRING([--enable-glibcxx-debugging-cppunit],
+                [Use GLIBCXX debugging flags for unit tests])],
+                [AS_CASE("${enableval}",
+                         [yes], [enableglibcxxdebuggingcppunit=yes],
+                         [no],  [enableglibcxxdebuggingcppunit=no],
+                         [AC_MSG_ERROR(bad value ${enableval} for --enable-glibcxx-debugging-cppunit)])],
+                [enableglibcxxdebuggingcppunit=no])
 
   AM_CONDITIONAL(LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT, test x$enableglibcxxdebuggingcppunit = xyes)
 

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -376,58 +376,60 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
                SANITIZE_METHODS=${enableval}],
                [])
 
-  if test "x$SANITIZE_METHODS" != x; then
-    AC_MSG_RESULT([<<< Testing sanitizer flags for method(s) "$SANITIZE_METHODS" >>>])
+  AS_IF([test "x$SANITIZE_METHODS" != x],
+        [
+          AC_MSG_RESULT([<<< Testing sanitizer flags for method(s) "$SANITIZE_METHODS" >>>])
 
-    # Both Clang and GCC docs suggest using "-fsanitize=address -fno-omit-frame-pointer".
-    # The Clang documentation further suggests using "-O1 -g -fno-optimize-sibling-calls".
-    # Since these flags also work in GCC, we'll use them there as well...
-    COMMON_SANITIZE_OPTIONS="-fsanitize=address -fno-omit-frame-pointer -O1 -g -fno-optimize-sibling-calls"
+          dnl Both Clang and GCC docs suggest using "-fsanitize=address -fno-omit-frame-pointer".
+          dnl The Clang documentation further suggests using "-O1 -g -fno-optimize-sibling-calls".
+          dnl Since these flags also work in GCC, we'll use them there as well...
+          COMMON_SANITIZE_OPTIONS="-fsanitize=address -fno-omit-frame-pointer -O1 -g -fno-optimize-sibling-calls"
 
-    # Test the sanitizer flags.  Currently Clang and GCC are the only
-    # compilers that support the address sanitizer, and they use the
-    # same set of flags.  If the set of flags used by Clang and GCC ever
-    # diverges, we'll need to set up separate flags and test them in the
-    # case blocks below...  The LIBMESH_TEST_SANITIZE_FLAGS function sets
-    # the variable have_address_sanitizer to either "no" or "yes"
-    LIBMESH_TEST_SANITIZE_FLAGS([$COMMON_SANITIZE_OPTIONS])
+          dnl Test the sanitizer flags.  Currently Clang and GCC are the only
+          dnl compilers that support the address sanitizer, and they use the
+          dnl same set of flags.  If the set of flags used by Clang and GCC ever
+          dnl diverges, we'll need to set up separate flags and test them in the
+          dnl case blocks below...  The LIBMESH_TEST_SANITIZE_FLAGS function sets
+          dnl the variable have_address_sanitizer to either "no" or "yes"
+          LIBMESH_TEST_SANITIZE_FLAGS([$COMMON_SANITIZE_OPTIONS])
 
-    # Enable the address sanitizer stuff if the test code compiled
-    if test "x$have_address_sanitizer" = xyes; then
-      # As of clang 3.9.0 or so, we also need to pass the sanitize flag to the linker
-      # if it's being used during compiling. It seems that we do not need to pass all
-      # the flags above, just the sanitize flag itself.
-      libmesh_LDFLAGS="$libmesh_LDFLAGS -Wc,-fsanitize=address"
+          dnl Enable the address sanitizer stuff if the test code compiled
+          AS_IF([test "x$have_address_sanitizer" = xyes],
+                [
+                  dnl As of clang 3.9.0 or so, we also need to pass the sanitize flag to the linker
+                  dnl if it is being used during compiling. It seems that we do not need to pass all
+                  dnl the flags above, just the sanitize flag itself.
+                  libmesh_LDFLAGS="$libmesh_LDFLAGS -Wc,-fsanitize=address"
 
-      for method in ${SANITIZE_METHODS}; do
-          case "${method}" in
-              optimized|opt)
-                SANITIZE_OPT_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                  for method in ${SANITIZE_METHODS}; do
+                      case "${method}" in
+                          optimized|opt)
+                            SANITIZE_OPT_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
 
-              debug|dbg)
-                SANITIZE_DBG_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                          debug|dbg)
+                            SANITIZE_DBG_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
 
-              devel)
-                SANITIZE_DEVEL_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                          devel)
+                            SANITIZE_DEVEL_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
 
-              profiling|pro|prof)
-                SANITIZE_PROF_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                          profiling|pro|prof)
+                            SANITIZE_PROF_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
 
-              oprofile|oprof)
-                SANITIZE_OPROF_FLAGS=$COMMON_SANITIZE_OPTIONS
-                ;;
+                          oprofile|oprof)
+                            SANITIZE_OPROF_FLAGS=$COMMON_SANITIZE_OPTIONS
+                            ;;
 
-              *)
-                AC_MSG_ERROR(bad value ${method} for --enable-sanitize)
-                ;;
-          esac
-      done
-    fi
-  fi
+                          *)
+                            AC_MSG_ERROR(bad value ${method} for --enable-sanitize)
+                            ;;
+                      esac
+                  done
+                ])
+        ])
 
   # in the case blocks below we may add GLIBCXX-specific pedantic debugging preprocessor
   # definitions. however, allow the knowing user to preclude that if they need to.
@@ -442,10 +444,11 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
                 [enableglibcxxdebugging=yes])
 
   # GLIBCXX debugging causes untold woes on mac machines - so disable it
-  if (test `uname` = "Darwin"); then
-    AC_MSG_RESULT(<<< Disabling GLIBCXX debugging on Darwin >>>)
-    enableglibcxxdebugging=no
-  fi
+  AS_IF([test `uname` = "Darwin"],
+        [
+          AC_MSG_RESULT(<<< Disabling GLIBCXX debugging on Darwin >>>)
+          enableglibcxxdebugging=no
+        ])
   AM_CONDITIONAL(LIBMESH_ENABLE_GLIBCXX_DEBUGGING, test x$enableglibcxxdebugging = xyes)
 
 
@@ -477,9 +480,8 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
     CFLAGS_DBG="-g -Wimplicit"
     ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm"
 
-    if (test "x$enableglibcxxdebugging" = "xyes"); then
-      CPPFLAGS_DBG="$CPPFLAGS_DBG -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC"
-    fi
+    AS_IF([test "x$enableglibcxxdebugging" = "xyes"],
+          [CPPFLAGS_DBG="$CPPFLAGS_DBG -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC"])
 
     # GCC 4.6.3 warns about variadic macros but supports them just
     # fine, so let's turn off that warning.

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -250,44 +250,51 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
   dnl check various possibilities.  Calling xlC with no arguments displays
   dnl the man page.  Grepping for case-sensitive xlc is not enough if the
   dnl user wants xlC, so we use case-insensitive grep instead.
-  if (test "x$compiler_brand_detected" = "xno"); then
-    is_ibm_xlc="`($CXX 2>&1) | egrep -i 'xlc'`"
-    if test "x$is_ibm_xlc" != "x"  ; then
-      AC_MSG_RESULT(<<< C++ compiler is IBM xlC >>>)
-      GXX_VERSION=ibm_xlc
-      compiler_brand_detected=yes
-    fi
-  fi
+  AS_IF([test "x$compiler_brand_detected" = "xno"],
+        [
+          is_ibm_xlc="`($CXX 2>&1) | egrep -i 'xlc'`"
+          AS_IF([test "x$is_ibm_xlc" != "x"],
+                [
+                  AC_MSG_RESULT(<<< C++ compiler is IBM xlC >>>)
+                  GXX_VERSION=ibm_xlc
+                  compiler_brand_detected=yes
+                ])
+        ])
 
   dnl Cray C++?
-  if (test "x$compiler_brand_detected" = "xno"); then
-    is_cray_cc="`($CXX -V 2>&1) | grep 'Cray '`"
-    if test "x$is_cray_cc" != "x" ; then
-      AC_MSG_RESULT(<<< C++ compiler is Cray C++ >>>)
-      GXX_VERSION=cray_cc
-      compiler_brand_detected=yes
-    fi
-  fi
+  AS_IF([test "x$compiler_brand_detected" = "xno"],
+        [
+          is_cray_cc="`($CXX -V 2>&1) | grep 'Cray '`"
+          AS_IF([test "x$is_cray_cc" != "x"],
+                [
+                  AC_MSG_RESULT(<<< C++ compiler is Cray C++ >>>)
+                  GXX_VERSION=cray_cc
+                  compiler_brand_detected=yes
+                ])
+        ])
 
   dnl Portland Group C++?
-  if (test "x$compiler_brand_detected" = "xno"); then
-    is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group'`"
-    if test "x$is_pgcc" != "x" ; then
-      AC_MSG_RESULT(<<< C++ compiler is Portland Group C++ >>>)
-      GXX_VERSION=portland_group
-      compiler_brand_detected=yes
-    fi
-  fi
+  AS_IF([test "x$compiler_brand_detected" = "xno"],
+        [
+          is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group'`"
+          AS_IF([test "x$is_pgcc" != "x"],
+          [
+            AC_MSG_RESULT(<<< C++ compiler is Portland Group C++ >>>)
+            GXX_VERSION=portland_group
+            compiler_brand_detected=yes
+          ])
+        ])
 
   dnl Could not recognize the compiler. Warn the user and continue.
-  if (test "x$compiler_brand_detected" = "xno"); then
-    AC_MSG_RESULT( WARNING:)
-    AC_MSG_RESULT( >>> Unrecognized compiler: "$CXX" <<<)
-    AC_MSG_RESULT( You will likely need to modify)
-    AC_MSG_RESULT( Make.common directly to specify)
-    AC_MSG_RESULT( proper compiler flags)
-    GXX_VERSION=unknown
-  fi
+  AS_IF([test "x$compiler_brand_detected" = "xno"],
+        [
+          AC_MSG_RESULT( WARNING:)
+          AC_MSG_RESULT( >>> Unrecognized compiler: "$CXX" <<<)
+          AC_MSG_RESULT( You will likely need to modify)
+          AC_MSG_RESULT( Make.common directly to specify)
+          AC_MSG_RESULT( proper compiler flags)
+          GXX_VERSION=unknown
+        ])
 ])
 
 

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -50,9 +50,8 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
   # --------------------------------------------------------------
   # look for a decent C compiler or honor --with-cc=...
   CC_TRY_LIST="gcc icc pgcc cc"
-  if  (test "$enablempi" != no) ; then
-    CC_TRY_LIST="mpicc $CC_TRY_LIST"
-  fi
+  AS_IF([test "$enablempi" != no],
+        [CC_TRY_LIST="mpicc $CC_TRY_LIST"])
   AC_ARG_WITH([cc],
               AS_HELP_STRING([--with-cc=CC], [C compiler to use]),
               [CC="$withval"],

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -470,20 +470,12 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
                               CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
                               CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"])
 
-    # Set OS-specific flags for linkers & other stuff
-    case "$target" in
-
-      # For Solaris we need to pass a different flag to the linker for specifying the
-      # dynamic library search path and add -lrpcsvc to use XDR
-      *solaris*)
-          RPATHFLAG="-Wl,-R,"
-          LIBS="-lrpcsvc $LIBS"
-          ;;
-
-      *)
-          ;;
-    esac
-
+    dnl Set OS-specific flags for linkers & other stuff
+    dnl For Solaris we need to pass a different flag to the linker for specifying the
+    dnl dynamic library search path and add -lrpcsvc to use XDR
+    AS_CASE("$target",
+            [*solaris*], [RPATHFLAG="-Wl,-R,"
+                          LIBS="-lrpcsvc $LIBS"])
 
   else
     # Non-gcc compilers

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -402,31 +402,13 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
                   libmesh_LDFLAGS="$libmesh_LDFLAGS -Wc,-fsanitize=address"
 
                   for method in ${SANITIZE_METHODS}; do
-                      case "${method}" in
-                          optimized|opt)
-                            SANITIZE_OPT_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          debug|dbg)
-                            SANITIZE_DBG_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          devel)
-                            SANITIZE_DEVEL_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          profiling|pro|prof)
-                            SANITIZE_PROF_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          oprofile|oprof)
-                            SANITIZE_OPROF_FLAGS=$COMMON_SANITIZE_OPTIONS
-                            ;;
-
-                          *)
-                            AC_MSG_ERROR(bad value ${method} for --enable-sanitize)
-                            ;;
-                      esac
+                      AS_CASE("${method}",
+                              [optimized|opt],      [SANITIZE_OPT_FLAGS=$COMMON_SANITIZE_OPTIONS],
+                              [debug|dbg],          [SANITIZE_DBG_FLAGS=$COMMON_SANITIZE_OPTIONS],
+                              [devel],              [SANITIZE_DEVEL_FLAGS=$COMMON_SANITIZE_OPTIONS],
+                              [profiling|pro|prof], [SANITIZE_PROF_FLAGS=$COMMON_SANITIZE_OPTIONS],
+                              [oprofile|oprof],     [SANITIZE_OPROF_FLAGS=$COMMON_SANITIZE_OPTIONS],
+                              [AC_MSG_ERROR(bad value ${method} for --enable-sanitize)])
                   done
                 ])
         ])

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -187,36 +187,37 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
         ])
 
   dnl Clang/LLVM C++?
-  if (test "x$compiler_brand_detected" = "xno"); then
-    clang_version="`($CXX --version 2>&1)`"
-    is_clang="`echo $clang_version | grep 'clang'`"
+  AS_IF([test "x$compiler_brand_detected" = "xno"],
+        [
+          clang_version="`($CXX --version 2>&1)`"
+          is_clang="`echo $clang_version | grep 'clang'`"
 
-    AS_IF([test "x$is_clang" != "x"],
-          [
-            dnl Detect if clang is the version built by
-            dnl Apple, because then the version number means
-            dnl something different...
-            is_apple_clang="`echo $clang_version | grep 'Apple'`"
-            clang_vendor="clang"
-            AS_IF([test "x$is_apple_clang" != "x"],
-                  [clang_vendor="Apple clang"])
+          AS_IF([test "x$is_clang" != "x"],
+                [
+                  dnl Detect if clang is the version built by
+                  dnl Apple, because then the version number means
+                  dnl something different...
+                  is_apple_clang="`echo $clang_version | grep 'Apple'`"
+                  clang_vendor="clang"
+                  AS_IF([test "x$is_apple_clang" != "x"],
+                        [clang_vendor="Apple clang"])
 
-            dnl If we have perl, we can also pull out the clang version number using regexes.
-            dnl Note that @S|@ is a quadrigraph for the dollar sign.
-            clang_major_minor=unknown
+                  dnl If we have perl, we can also pull out the clang version number using regexes.
+                  dnl Note that @S|@ is a quadrigraph for the dollar sign.
+                  clang_major_minor=unknown
 
-            AS_IF([test "x$PERL" != "x"],
-                  [
-                    clang_major_minor=`echo $clang_version | $PERL -ne 'print @S|@1 if /version\s(\d+\.\d+)/'`
-                    AS_IF([test "x$clang_major_minor" = "x"],
-                          [clang_major_minor=unknown])
-                  ])
+                  AS_IF([test "x$PERL" != "x"],
+                        [
+                          clang_major_minor=`echo $clang_version | $PERL -ne 'print @S|@1 if /version\s(\d+\.\d+)/'`
+                          AS_IF([test "x$clang_major_minor" = "x"],
+                                [clang_major_minor=unknown])
+                        ])
 
-            AC_MSG_RESULT([<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>])
-            GXX_VERSION=clang
-            compiler_brand_detected=yes
-          ])
-  fi
+                  AC_MSG_RESULT([<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>])
+                  GXX_VERSION=clang
+                  compiler_brand_detected=yes
+                ])
+        ])
 
   dnl Intel's ICC C++ compiler?
   if (test "x$compiler_brand_detected" = "xno"); then

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -197,20 +197,19 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
       dnl something different...
       is_apple_clang="`echo $clang_version | grep 'Apple'`"
       clang_vendor="clang"
-      if test "x$is_apple_clang" != "x" ; then
-        clang_vendor="Apple clang"
-      fi
+      AS_IF([test "x$is_apple_clang" != "x"],
+            [clang_vendor="Apple clang"])
 
       dnl If we have perl, we can also pull out the clang version number using regexes.
       dnl Note that @S|@ is a quadrigraph for the dollar sign.
       clang_major_minor=unknown
 
-      if test "x$PERL" != "x" ; then
-         clang_major_minor=`echo $clang_version | $PERL -ne 'print @S|@1 if /version\s(\d+\.\d+)/'`
-         if test "x$clang_major_minor" = "x" ; then
-           clang_major_minor=unknown
-         fi
-      fi
+      AS_IF([test "x$PERL" != "x"],
+            [
+              clang_major_minor=`echo $clang_version | $PERL -ne 'print @S|@1 if /version\s(\d+\.\d+)/'`
+              AS_IF([test "x$clang_major_minor" = "x"],
+                    [clang_major_minor=unknown])
+            ])
 
       AC_MSG_RESULT([<<< C++ compiler is ${clang_vendor}, version ${clang_major_minor} >>>])
       GXX_VERSION=clang

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -360,19 +360,12 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
               AS_HELP_STRING([--enable-sanitize="opt dbg devel prof oprof"],
                              [turn on sanitizer flags for the given methods]),
               [for method in ${enableval} ; do
-                 # make sure each method specified makes sense
-                 case "${method}" in
-                     optimized|opt)      ;;
-                     debug|dbg)          ;;
-                     devel)              ;;
-                     profiling|pro|prof) ;;
-                     oprofile|oprof)     ;;
-                     *)
-                         AC_MSG_ERROR(bad value ${method} for --enable-sanitize)
-                         ;;
-                 esac
+                 dnl make sure each method specified makes sense
+                 AS_CASE("${method}",
+                         [optimized|opt|debug|dbg|devel|profiling|pro|prof|oprofile|oprof], [],
+                         [AC_MSG_ERROR(bad value ${method} for --enable-sanitize)])
                done
-               # If we made it here, the case statement didn't detect any errors
+               dnl If we made it here, the case statement didn't detect any errors
                SANITIZE_METHODS=${enableval}],
                [])
 

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -440,7 +440,8 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
 
 
   # First the flags for gcc compilers
-  if (test "$GXX" = yes -a "x$REAL_GXX" != "x" ) ; then
+  AS_IF([test "$GXX" = yes -a "x$REAL_GXX" != "x"],
+        [
     CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 -felide-constructors -funroll-loops -fstrict-aliasing -Wdisabled-optimization"
     CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -O2 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Wuninitialized -funroll-loops -fstrict-aliasing -Woverloaded-virtual -Wdisabled-optimization"
     CXXFLAGS_DBG="$CXXFLAGS_DBG -O0 -felide-constructors -g -pedantic -W -Wall -Wextra -Wno-long-long -Wunused -Wpointer-arith -Wformat -Wparentheses -Woverloaded-virtual"
@@ -467,9 +468,9 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
     AS_CASE("$target",
             [*solaris*], [RPATHFLAG="-Wl,-R,"
                           LIBS="-lrpcsvc $LIBS"])
-
-  else
-    # Non-gcc compilers
+        ],
+        [
+    dnl Non-gcc compilers
 
     case "$GXX_VERSION" in
       ibm_xlc)
@@ -583,5 +584,5 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
           CFLAGS_DEVEL="$CFLAGS"
           ;;
     esac
-  fi
+  ])
 ])

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -91,9 +91,8 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
         [
           dnl look for a decent F90+ compiler or honor --with-fc=...
           FC_TRY_LIST="gfortran ifort pgf90 xlf95"
-          if  (test "$enablempi" != no) ; then
-            FC_TRY_LIST="mpif90 $FC_TRY_LIST"
-          fi
+          AS_IF([test "$enablempi" != no],
+                [FC_TRY_LIST="mpif90 $FC_TRY_LIST"])
           AC_ARG_WITH([fc],
                       AS_HELP_STRING([--with-fc=FC], [Fortran compiler to use]),
                       [FC="$withval"],
@@ -104,17 +103,15 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
           dnl --------------------------------------------------------------
           AC_PROG_FC([$FC_TRY_LIST])
 
-          if (test "x$FC" = "x"); then
-            AC_MSG_RESULT(>>> No valid Fortran compiler <<<)
-            FC=no
-            enablefortran=no
-          fi
+          AS_IF([test "x$FC" = "x"],
+                [AC_MSG_RESULT(>>> No valid Fortran compiler <<<)
+                FC=no
+                enablefortran=no])
 
           dnl look for a decent F77 compiler or honor --with-77=...
           F77_TRY_LIST="gfortran g77 ifort f77 xlf frt pgf77 fort77 fl32 af77 f90 xlf90 pgf90 epcf90 f95 fort xlf95 ifc efc pgf95 lf95"
-          if  (test "$enablempi" != no) ; then
-            F77_TRY_LIST="mpif77 $F77_TRY_LIST"
-          fi
+          AS_IF([test "$enablempi" != no],
+                [F77_TRY_LIST="mpif77 $F77_TRY_LIST"])
           AC_ARG_WITH([f77],
                       AS_HELP_STRING([--with-f77=F77], [Fortran compiler to use]),
                       [F77="$withval"],
@@ -125,11 +122,10 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
           dnl --------------------------------------------------------------
           AC_PROG_F77([$F77_TRY_LIST])
 
-          if (test "x$F77" = "x"); then
-            AC_MSG_RESULT(>>> No valid Fortran 77 compiler <<<)
-            F77=no
-            enablefortran=no
-          fi
+          AS_IF([test "x$F77" = "x"],
+                [AC_MSG_RESULT(>>> No valid Fortran 77 compiler <<<)
+                 F77=no
+                 enablefortran=no])
         ],
         [
           dnl when --disable-fortran is specified, explicitly set these

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -418,11 +418,10 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
   AC_ARG_ENABLE(glibcxx-debugging,
                 [AS_HELP_STRING([--disable-glibcxx-debugging],
                                 [omit -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC even in dbg mode])],
-                [case "${enableval}" in
-                  yes)  enableglibcxxdebugging=yes ;;
-                  no)  enableglibcxxdebugging=no ;;
-                  *)  AC_MSG_ERROR(bad value ${enableval} for --enable-glibcxx-debugging) ;;
-                esac],
+                [AS_CASE("${enableval}",
+                         [yes], [enableglibcxxdebugging=yes],
+                         [no],  [enableglibcxxdebugging=no],
+                         [AC_MSG_ERROR(bad value ${enableval} for --enable-glibcxx-debugging)])],
                 [enableglibcxxdebugging=yes])
 
   # GLIBCXX debugging causes untold woes on mac machines - so disable it

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -20,11 +20,9 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
                    esac],
                    [enablempi=yes])
 
-  if  (test "$enablempi" != no) ; then
-    CXX_TRY_LIST="mpicxx mpiCC mpicc $CXX_TRY_LIST"
-  else
-    AC_MSG_RESULT(>>> Disabling MPI per user request <<<)
-  fi
+  AS_IF([test "$enablempi" != no],
+        [CXX_TRY_LIST="mpicxx mpiCC mpicc $CXX_TRY_LIST"],
+        AC_MSG_RESULT([>>> Disabling MPI per user request <<<]))
 
   AC_ARG_WITH([cxx],
               AS_HELP_STRING([--with-cxx=CXX], [C++ compiler to use]),

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -224,32 +224,20 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
     is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
     if test "x$is_intel_icc" != "x" ; then
       GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
-      case "$GXX_VERSION_STRING" in
-        *18.*)
-          AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 18 >>>)
-          GXX_VERSION=intel_icc_v18.x
-          ;;
-        *17.*)
-          AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 17 >>>)
-          GXX_VERSION=intel_icc_v17.x
-          ;;
-        *16.*)
-          AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 16 >>>)
-          GXX_VERSION=intel_icc_v16.x
-          ;;
-        *15.*)
-          AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 15 >>>)
-          GXX_VERSION=intel_icc_v15.x
-          ;;
-        *14.*)
-          AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 14 >>>)
-          GXX_VERSION=intel_icc_v14.x
-          ;;
-        *13.*)
-          AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 13 >>>)
-          GXX_VERSION=intel_icc_v13.x
-          ;;
-      esac
+      AS_CASE("$GXX_VERSION_STRING",
+      [*18.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 18 >>>)
+                GXX_VERSION=intel_icc_v18.x],
+      [*17.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 17 >>>)
+                GXX_VERSION=intel_icc_v17.x],
+      [*16.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 16 >>>)
+                GXX_VERSION=intel_icc_v16.x],
+      [*15.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 15 >>>)
+                GXX_VERSION=intel_icc_v15.x],
+      [*14.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 14 >>>)
+                GXX_VERSION=intel_icc_v14.x],
+      [*13.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 13 >>>)
+                GXX_VERSION=intel_icc_v13.x],
+      [AC_MSG_ERROR(Unsupported Intel compiler detected)])
       compiler_brand_detected=yes
     fi
   fi

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -163,40 +163,24 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
         [
           dnl find out the right version
           GXX_VERSION_STRING=`($CXX -v 2>&1) | grep "gcc version"`
-          case "$GXX_VERSION_STRING" in
-            *gcc\ version\ 7.*)
-              AC_MSG_RESULT(<<< C++ compiler is gcc-7.x >>>)
-              GXX_VERSION=gcc7
-              ;;
-            *gcc\ version\ 6.*)
-              AC_MSG_RESULT(<<< C++ compiler is gcc-6.x >>>)
-              GXX_VERSION=gcc6
-              ;;
-            *gcc\ version\ 5.*)
-              AC_MSG_RESULT(<<< C++ compiler is gcc-5.x >>>)
-              GXX_VERSION=gcc5
-              ;;
-            *4.9.*)
-              AC_MSG_RESULT(<<< C++ compiler is gcc-4.9 >>>)
-              GXX_VERSION=gcc4.9
-              ;;
-            *4.8.*)
-              AC_MSG_RESULT(<<< C++ compiler is gcc-4.8 >>>)
-              GXX_VERSION=gcc4.8
-              ;;
-            *4.7.*)
-              AC_MSG_RESULT(<<< C++ compiler is gcc-4.7 >>>)
-              GXX_VERSION=gcc4.7
-              ;;
-            *4.6.*)
-              AC_MSG_RESULT(<<< C++ compiler is gcc-4.6 >>>)
-              GXX_VERSION=gcc4.6
-              ;;
-            *)
-              AC_MSG_RESULT(<<< C++ compiler is unknown but accepted gcc version >>>)
-              GXX_VERSION=gcc-other
-              ;;
-          esac
+
+          AS_CASE("$GXX_VERSION_STRING",
+                  [*gcc\ version\ 7.*], [AC_MSG_RESULT(<<< C++ compiler is gcc-7.x >>>)
+                                         GXX_VERSION=gcc7],
+                  [*gcc\ version\ 6.*], [AC_MSG_RESULT(<<< C++ compiler is gcc-6.x >>>)
+                                         GXX_VERSION=gcc6],
+                  [*gcc\ version\ 5.*], [AC_MSG_RESULT(<<< C++ compiler is gcc-5.x >>>)
+                                         GXX_VERSION=gcc5],
+                  [*4.9.*], [AC_MSG_RESULT(<<< C++ compiler is gcc-4.9 >>>)
+                             GXX_VERSION=gcc4.9],
+                  [*4.8.*], [AC_MSG_RESULT(<<< C++ compiler is gcc-4.8 >>>)
+                             GXX_VERSION=gcc4.8],
+                  [*4.7.*], [AC_MSG_RESULT(<<< C++ compiler is gcc-4.7 >>>)
+                             GXX_VERSION=gcc4.7],
+                  [*4.6.*], [AC_MSG_RESULT(<<< C++ compiler is gcc-4.6 >>>)
+                             GXX_VERSION=gcc4.6],
+                  [AC_MSG_RESULT(<<< C++ compiler is unknown but accepted gcc version >>>)
+                   GXX_VERSION=gcc-other])
 
           dnl Detection was successful, so set the flag.
           compiler_brand_detected=yes

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -220,27 +220,29 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
         ])
 
   dnl Intel's ICC C++ compiler?
-  if (test "x$compiler_brand_detected" = "xno"); then
-    is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
-    if test "x$is_intel_icc" != "x" ; then
-      GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
-      AS_CASE("$GXX_VERSION_STRING",
-      [*18.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 18 >>>)
-                GXX_VERSION=intel_icc_v18.x],
-      [*17.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 17 >>>)
-                GXX_VERSION=intel_icc_v17.x],
-      [*16.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 16 >>>)
-                GXX_VERSION=intel_icc_v16.x],
-      [*15.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 15 >>>)
-                GXX_VERSION=intel_icc_v15.x],
-      [*14.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 14 >>>)
-                GXX_VERSION=intel_icc_v14.x],
-      [*13.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 13 >>>)
-                GXX_VERSION=intel_icc_v13.x],
-      [AC_MSG_ERROR(Unsupported Intel compiler detected)])
-      compiler_brand_detected=yes
-    fi
-  fi
+  AS_IF([test "x$compiler_brand_detected" = "xno"],
+        [
+          is_intel_icc="`($CXX -V 2>&1) | grep 'Intel(R)' | grep 'Compiler'`"
+          AS_IF([test "x$is_intel_icc" != "x"],
+                [
+                  GXX_VERSION_STRING="`($CXX -V 2>&1) | grep 'Version '`"
+                  AS_CASE("$GXX_VERSION_STRING",
+                  [*18.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 18 >>>)
+                            GXX_VERSION=intel_icc_v18.x],
+                  [*17.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 17 >>>)
+                            GXX_VERSION=intel_icc_v17.x],
+                  [*16.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 16 >>>)
+                            GXX_VERSION=intel_icc_v16.x],
+                  [*15.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 15 >>>)
+                            GXX_VERSION=intel_icc_v15.x],
+                  [*14.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 14 >>>)
+                            GXX_VERSION=intel_icc_v14.x],
+                  [*13.*], [AC_MSG_RESULT(<<< C++ compiler is Intel(R) icc 13 >>>)
+                            GXX_VERSION=intel_icc_v13.x],
+                  [AC_MSG_ERROR(Unsupported Intel compiler detected)])
+                  compiler_brand_detected=yes
+                ])
+        ])
 
   dnl Check for IBM xlC. Depending on environment
   dnl variables, moon position, and other reasons unknown to me, this

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -465,17 +465,11 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
 
     # GCC 4.6.3 warns about variadic macros but supports them just
     # fine, so let's turn off that warning.
-    case "$GXX_VERSION" in
-      gcc4.6 | gcc5)
-        CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
-        CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
-        CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"
-        ;;
-
-      *)
-        ;;
-    esac
-
+    AS_CASE("$GXX_VERSION",
+            [gcc4.6 | gcc5], [CXXFLAGS_OPT="$CXXFLAGS_OPT -Wno-variadic-macros"
+                              CXXFLAGS_DEVEL="$CXXFLAGS_DEVEL -Wno-variadic-macros"
+                              CXXFLAGS_DBG="$CXXFLAGS_DBG -Wno-variadic-macros"],
+            [])
 
     # Set OS-specific flags for linkers & other stuff
     case "$target" in

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -87,62 +87,57 @@ AC_DEFUN([LIBMESH_SET_COMPILERS],
                 esac],
                 [enablefortran=yes])
 
-  if (test "x$enablefortran" = xyes); then
+  AS_IF([test "x$enablefortran" = xyes],
+        [
+          dnl look for a decent F90+ compiler or honor --with-fc=...
+          FC_TRY_LIST="gfortran ifort pgf90 xlf95"
+          if  (test "$enablempi" != no) ; then
+            FC_TRY_LIST="mpif90 $FC_TRY_LIST"
+          fi
+          AC_ARG_WITH([fc],
+                      AS_HELP_STRING([--with-fc=FC], [Fortran compiler to use]),
+                      [FC="$withval"],
+                      [])
 
-    # look for a decent F90+ compiler or honor --with-fc=...
-    FC_TRY_LIST="gfortran ifort pgf90 xlf95"
-    if  (test "$enablempi" != no) ; then
-      FC_TRY_LIST="mpif90 $FC_TRY_LIST"
-    fi
-    AC_ARG_WITH([fc],
-                AS_HELP_STRING([--with-fc=FC], [Fortran compiler to use]),
-                [FC="$withval"],
-                [])
+          dnl --------------------------------------------------------------
+          dnl Determine a F90+ compiler to use.
+          dnl --------------------------------------------------------------
+          AC_PROG_FC([$FC_TRY_LIST])
 
-    # --------------------------------------------------------------
-    # Determine a F90+ compiler to use.
-    # --------------------------------------------------------------
-    AC_PROG_FC([$FC_TRY_LIST])
+          if (test "x$FC" = "x"); then
+            AC_MSG_RESULT(>>> No valid Fortran compiler <<<)
+            FC=no
+            enablefortran=no
+          fi
 
-    if (test "x$FC" = "x"); then
-      AC_MSG_RESULT(>>> No valid Fortran compiler <<<)
-      FC=no
-      enablefortran=no
-    fi
-    # --------------------------------------------------------------
+          dnl look for a decent F77 compiler or honor --with-77=...
+          F77_TRY_LIST="gfortran g77 ifort f77 xlf frt pgf77 fort77 fl32 af77 f90 xlf90 pgf90 epcf90 f95 fort xlf95 ifc efc pgf95 lf95"
+          if  (test "$enablempi" != no) ; then
+            F77_TRY_LIST="mpif77 $F77_TRY_LIST"
+          fi
+          AC_ARG_WITH([f77],
+                      AS_HELP_STRING([--with-f77=F77], [Fortran compiler to use]),
+                      [F77="$withval"],
+                      [])
 
+          dnl --------------------------------------------------------------
+          dnl Determine a F77 compiler to use.
+          dnl --------------------------------------------------------------
+          AC_PROG_F77([$F77_TRY_LIST])
 
-
-    # --------------------------------------------------------------
-    # look for a decent F77 compiler or honor --with-77=...
-    F77_TRY_LIST="gfortran g77 ifort f77 xlf frt pgf77 fort77 fl32 af77 f90 xlf90 pgf90 epcf90 f95 fort xlf95 ifc efc pgf95 lf95"
-    if  (test "$enablempi" != no) ; then
-      F77_TRY_LIST="mpif77 $F77_TRY_LIST"
-    fi
-    AC_ARG_WITH([f77],
-                AS_HELP_STRING([--with-f77=F77], [Fortran compiler to use]),
-                [F77="$withval"],
-                [])
-
-    # --------------------------------------------------------------
-    # Determine a F77 compiler to use.
-    # --------------------------------------------------------------
-    AC_PROG_F77([$F77_TRY_LIST])
-
-    if (test "x$F77" = "x"); then
-      AC_MSG_RESULT(>>> No valid Fortran 77 compiler <<<)
-      F77=no
-      enablefortran=no
-    fi
-
-    # --------------------------------------------------------------
-  else
-      # when --disable-fortran is specified, explicitly set these
-      # to "no" to instruct libtool not to bother with them.
-      AC_MSG_RESULT(>>> Disabling Fortran language support per user request <<<)
-      FC=no
-      F77=no
-  fi # end enablefortran
+          if (test "x$F77" = "x"); then
+            AC_MSG_RESULT(>>> No valid Fortran 77 compiler <<<)
+            F77=no
+            enablefortran=no
+          fi
+        ],
+        [
+          dnl when --disable-fortran is specified, explicitly set these
+          dnl to "no" to instruct libtool not to bother with them.
+          AC_MSG_RESULT(>>> Disabling Fortran language support per user request <<<)
+          FC=no
+          F77=no
+        ])
 ])
 
 


### PR DESCRIPTION
These macros should be preferred to hard-coded `if` and `case` statements for compatibility with the widest possible range of POSIX shells. The macros are also a bit more terse (no closing `fi` or `esac` needed), easier to remember how to use than raw shell syntax, easier to Google when you can't remember exactly how to use them, and Emacs is much better at matching the opening/closing parentheses used by the macros than it is at matching `if`/`fi` in m4 mode. 

The current history has a lot of commits because I wanted to be able to verify that an equivalent configure script was still being generated after each change, but I will squash that down before merging if everything passes.
