### PR TITLE
MetaPhysicL license stamp fix from upstream

### DIFF
--- a/contrib/metaphysicl/0.2.0/configure.ac
+++ b/contrib/metaphysicl/0.2.0/configure.ac
@@ -110,6 +110,23 @@ DX_INIT_DOXYGEN(metaphysicl, doxygen/metaphysicl.dox, docs/doxygen)
 
 AC_CONFIG_FILES(doxygen/txt_common/about_vpath.page)
 
+dnl------------------------------------------
+dnl License stamping for non-dist builds
+dnl------------------------------------------
+
+# PB: Although the documentation says that ac_top_srcdir should be defined,
+#     it doesn't get activated until _AC_SRCDIRS gets called
+#     (used to be _AC_SRCPATHS), according to this thread:
+#     http://lists.gnu.org/archive/html/autoconf-patches/2003-02/msg00003.html
+#     My own hacking revealed that we could also do the following:
+#     TOP_SEARCH_DIR=$ac_pwd/$srcdir
+#     I'm not sure which will be more "future proof", but this is the alternative
+#     to using $(shell) calls in the Makefile.am which 1. requires
+#     GNU Make and 2. Causes automake to issue a warning
+_AC_SRCDIRS(.)
+ABS_TOP_SRC_DIR=$ac_abs_top_srcdir
+AM_CONDITIONAL(METAPHYSICL_LICENSESTAMPEXISTS, [test -f $ABS_TOP_SRC_DIR/src/common/lic_utils/update_license.pl])
+
 dnl-----------------------------------------------
 dnl Generate header files
 dnl-----------------------------------------------

--- a/contrib/metaphysicl/0.2.0/src/Makefile.am
+++ b/contrib/metaphysicl/0.2.0/src/Makefile.am
@@ -1,5 +1,3 @@
-BUILT_SOURCES   = .license.stamp
-
 #----------------------------------------
 # Programs and libraries we want to build
 #----------------------------------------
@@ -104,13 +102,14 @@ endif
 # Embedded license header support
 #---------------------------------
 
+if METAPHYSICL_LICENSESTAMPEXISTS
 STAMPED_FILES = $(libmetaphysicl_la_SOURCES) $(include_HEADERS) $(metaphysicl_version_SOURCES)
+
+BUILT_SOURCES = .license.stamp
 
 .license.stamp: $(top_srcdir)/LICENSE
 	$(top_srcdir)/src/common/lic_utils/update_license.pl -S=$(top_srcdir)/src $(top_srcdir)/LICENSE $(STAMPED_FILES)
 	echo 'updated source license headers' >$@
 
 CLEANFILES += .license.stamp
-
-EXTRA_DIST = common
-
+endif

--- a/contrib/metaphysicl/0.2.0/test/Makefile.am
+++ b/contrib/metaphysicl/0.2.0/test/Makefile.am
@@ -1,5 +1,3 @@
-BUILT_SOURCES   = .license.stamp
-
 check_PROGRAMS  =
 check_PROGRAMS += compare_types_unit
 check_PROGRAMS += derivs_unit
@@ -161,12 +159,16 @@ if CODE_COVERAGE_ENABLED
   CLEANFILES += *.gcda *.gcno
 endif
 
+if METAPHYSICL_LICENSESTAMPEXISTS
+BUILT_SOURCES   = .license.stamp
+
 .license.stamp: $(top_srcdir)/LICENSE
 	$(top_srcdir)/src/common/lic_utils/update_license.pl $(top_srcdir)/LICENSE \
 	$(top_srcdir)/test/*.C
 	echo 'updated source license headers' >$@
 
 CLEANFILES += .license.stamp
+endif
 
 # Required for AX_AM_MACROS
 ###@INC_AMINCLUDE@


### PR DESCRIPTION
A copy of the changeset in
https://github.com/roystgnr/MetaPhysicL/pull/10
Based on @pbauman's work in
https://github.com/grinsfem/grins/commit/9329336
which fixes the false positive warnings @jwpeterson noticed in
https://github.com/roystgnr/MetaPhysicL/issues/8