### PR TITLE
LIBMESH_BROKEN_IOSTREAM no longer exists.

### DIFF
--- a/src/numerics/dense_matrix_base.C
+++ b/src/numerics/dense_matrix_base.C
@@ -85,8 +85,6 @@ void DenseMatrixBase<T>::condense(const unsigned int iv,
 template<typename T>
 void DenseMatrixBase<T>::print_scientific (std::ostream & os, unsigned precision) const
 {
-#ifndef LIBMESH_BROKEN_IOSTREAM
-
   // save the initial format flags
   std::ios_base::fmtflags os_flags = os.flags();
 
@@ -104,22 +102,6 @@ void DenseMatrixBase<T>::print_scientific (std::ostream & os, unsigned precision
 
   // reset the original format flags
   os.flags(os_flags);
-
-#else
-
-  // Print the matrix entries.
-  for (unsigned int i=0; i<this->m(); i++)
-    {
-      for (unsigned int j=0; j<this->n(); j++)
-        os << std::setprecision(precision)
-           << this->el(i,j)
-           << " ";
-
-      os << std::endl;
-    }
-
-
-#endif
 }
 
 

--- a/src/numerics/dense_vector_base.C
+++ b/src/numerics/dense_vector_base.C
@@ -29,8 +29,6 @@ namespace libMesh
 template<typename T>
 void DenseVectorBase<T>::print_scientific (std::ostream & os, unsigned precision) const
 {
-#ifndef LIBMESH_BROKEN_IOSTREAM
-
   // save the initial format flags
   std::ios_base::fmtflags os_flags = os.flags();
 
@@ -44,16 +42,6 @@ void DenseVectorBase<T>::print_scientific (std::ostream & os, unsigned precision
 
   // reset the original format flags
   os.flags(os_flags);
-
-#else
-
-  // Print the matrix entries.
-  for (unsigned int i=0; i<this->size(); i++)
-    os << std::setprecision(precision)
-       << this->el(i)
-       << std::endl;
-
-#endif
 }
 
 

--- a/src/utils/plt_loader_write.C
+++ b/src/utils/plt_loader_write.C
@@ -498,15 +498,9 @@ void PltLoader::write_dat (const std::string & name,
                 for (unsigned int j=0; j<this->jmax(z); j++)
                   for (unsigned int i=0; i<this->imax(z); i++)
                     {
-                      // GCC 2.95.3 has scientific in the ios class instead
-                      // of in namespace std::
-#ifndef LIBMESH_BROKEN_IOSTREAM
                       out_stream << std::scientific
                                  << _data[z][v][l++] << " ";
-#else
-                      out_stream << std::ios::scientific
-                                 << _data[z][v][l++] << " ";
-#endif
+
                       // Throw in a newline every 5 entries to
                       // avoid really long lines.
                       if (l%5 == 0)
@@ -546,16 +540,9 @@ void PltLoader::write_dat (const std::string & name,
                 for (unsigned int i=0; i<this->imax(z); i++)
                   {
                     for (unsigned int v=0; v<this->n_vars(); v++)
-
-                      // GCC 2.95.3 has scientific in the ios class instead
-                      // of in namespace std::
-#ifndef LIBMESH_BROKEN_IOSTREAM
                       out_stream << std::scientific
                                  << _data[z][v][l] << " ";
-#else
-                    out_stream << std::ios::scientific
-                               << _data[z][v][l] << " ";
-#endif
+
                     out_stream << '\n';
 
                     l++;


### PR DESCRIPTION
This #define only applied to really old versions of GCC (2.95 and 2.96) which we no longer support.