### PR TITLE
Enable periodic BCs with transformation between variables

### DIFF
--- a/include/base/periodic_boundary.h
+++ b/include/base/periodic_boundary.h
@@ -79,8 +79,6 @@ public:
   virtual std::unique_ptr<PeriodicBoundaryBase> clone(TransformationType t = FORWARD) const libmesh_override;
 
 protected:
-  // One of these days we'll support rotated boundaries
-  // RealTensor rotation_matrix;
 
   // The vector which is added to points in myboundary
   // to produce corresponding points in pairedboundary

--- a/include/base/periodic_boundary_base.h
+++ b/include/base/periodic_boundary_base.h
@@ -26,6 +26,7 @@
 // Local Includes
 #include "libmesh/point.h"
 #include "libmesh/auto_ptr.h" // deprecated
+#include "libmesh/dense_matrix.h"
 
 // C++ Includes
 #include <set>
@@ -101,12 +102,49 @@ public:
 
   bool is_my_variable(unsigned int var_num) const;
 
+  /**
+   * @return true if _transformation_matrix is not null.
+   */
+  bool has_transformation_matrix() const;
+
+  /**
+   * Get the transformation matrix, if it is defined.
+   * Throw an error if it is not defined.
+   */
+  const DenseMatrix<Real> & get_transformation_matrix() const;
+
+  /**
+   * Set the transformation matrix. When calling this method we
+   * require the following conditions:
+   *  1) \p matrix is square with size that matches this->variables.size()
+   *  2) the list of variables in this->variables set must all have the same FE type
+   * Both of these conditions are asserted in DBG mode.
+   */
+  void set_transformation_matrix(const DenseMatrix<Real> & matrix);
+
+  /**
+   * Get the set of variables for this periodic boundary condition.
+   */
+  const std::set<unsigned int> & get_variables() const;
+
 protected:
 
   /**
    * Set of variables for this periodic boundary, empty means all variables possible
    */
   std::set<unsigned int> variables;
+
+  /**
+   * A DenseMatrix that defines the mapping of variables on this
+   * boundary and the counterpart boundary. This is necessary for
+   * periodic-boundaries with vector-valued quantities (e.g.
+   * velocity or displacement) on a sector of a circular domain,
+   * for exaple, since in that case we must map each variable
+   * to a corresponding linear combination of all the variables.
+   * We store the DenseMatrix via a unique_ptr, and an uninitialized
+   * pointer is treated as equivalent to the identity matrix.
+   */
+  std::unique_ptr<DenseMatrix<Real>> _transformation_matrix;
 };
 
 } // namespace libmesh

--- a/src/base/periodic_boundary_base.C
+++ b/src/base/periodic_boundary_base.C
@@ -39,6 +39,12 @@ PeriodicBoundaryBase::PeriodicBoundaryBase(const PeriodicBoundaryBase & o) :
   pairedboundary(o.pairedboundary),
   variables(o.variables)
 {
+  // Make a deep copy of _transformation_matrix, if it's not null
+  if(o._transformation_matrix)
+  {
+    this->_transformation_matrix = libmesh_make_unique<DenseMatrix<Real>>();
+    *(this->_transformation_matrix) = *(o._transformation_matrix);
+  }
 }
 
 
@@ -63,6 +69,44 @@ bool PeriodicBoundaryBase::is_my_variable(unsigned int var_num) const
   return a;
 }
 
+
+
+bool PeriodicBoundaryBase::has_transformation_matrix() const
+{
+  return bool(_transformation_matrix);
+}
+
+
+
+const DenseMatrix<Real> & PeriodicBoundaryBase::get_transformation_matrix() const
+{
+  if(!has_transformation_matrix())
+  {
+    libmesh_error_msg("Transformation matrix is not defined");
+  }
+
+  return *_transformation_matrix;
+}
+
+
+
+void PeriodicBoundaryBase::set_transformation_matrix(const DenseMatrix<Real> & matrix)
+{
+  // Make a deep copy of matrix
+  this->_transformation_matrix = libmesh_make_unique<DenseMatrix<Real>>();
+  *(this->_transformation_matrix) = matrix;
+
+  // if _transformation_matrix is defined then it must be the same sie as variables.
+  libmesh_assert_equal_to(_transformation_matrix->m(), variables.size());
+  libmesh_assert_equal_to(_transformation_matrix->n(), variables.size());
+}
+
+
+
+const std::set<unsigned int> & PeriodicBoundaryBase::get_variables() const
+{
+  return variables;
+}
 
 } // namespace libMesh
 


### PR DESCRIPTION
Added a DenseMatrix to PeriodicBoundaryBase which defines a transformation between the dofs on the two sides of the periodic boundary. This is relevant for periodic boundaries on a sector of a circular domain with vector-valued quantities such as velocity or displacement, for example.

I think this will need more work, but I wanted to share what I've done so far to get feedback.