### PR TITLE
Improvement to how we handle overlapping periodic BCs

### DIFF
--- a/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
+++ b/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
@@ -112,7 +112,6 @@ public:
     set_variable(1);
     set_variable(2);
     set_transformation_matrix(get_rotation_matrix());
-    set_point_locator_subdomains(o.get_point_locator_subdomains());
   }
 
   /**
@@ -391,9 +390,6 @@ int main (int argc, char ** argv)
     AzimuthalPeriodicBoundary periodic_bc(center, axis, angle);
     periodic_bc.myboundary = 301;
     periodic_bc.pairedboundary = 302;
-    std::set<subdomain_id_type> point_locator_subdomains;
-    point_locator_subdomains.insert(1);
-    periodic_bc.set_point_locator_subdomains(point_locator_subdomains);
     system.get_dof_map().add_periodic_boundary(periodic_bc);
   }
   {
@@ -403,9 +399,6 @@ int main (int argc, char ** argv)
     AzimuthalPeriodicBoundary periodic_bc(center, axis, angle);
     periodic_bc.myboundary = 401;
     periodic_bc.pairedboundary = 402;
-    std::set<subdomain_id_type> point_locator_subdomains;
-    point_locator_subdomains.insert(101);
-    periodic_bc.set_point_locator_subdomains(point_locator_subdomains);
     system.get_dof_map().add_periodic_boundary(periodic_bc);
   }
 

--- a/include/base/periodic_boundary_base.h
+++ b/include/base/periodic_boundary_base.h
@@ -127,26 +127,6 @@ public:
    */
   const std::set<unsigned int> & get_variables() const;
 
-  /**
-   * Set the PointLocator subdomains.
-   *
-   * Imposing a periodic boundary uses a PointLocator to match points on
-   * the two sides of the boundary. This set specifies the subdomains
-   * that the PointLocator searches over. If it is empty, then it is
-   * ignored and we search over all subdomains.
-   *
-   * The use of this setter is demonstrated in systems_of_equations_ex9
-   * in which we have a two distinct periodic boundary conditions which
-   * are on overlapping surfaces, and hence we need to specify subdomains
-   * to allow the PointLocator to find the relevant elements.
-   */
-  void set_point_locator_subdomains(const std::set<subdomain_id_type> & point_locator_subdomains);
-
-  /**
-   * Get the PointLocator subdomains.
-   */
-  const std::set<subdomain_id_type> & get_point_locator_subdomains() const;
-
 protected:
 
   /**
@@ -166,11 +146,6 @@ protected:
    */
   std::unique_ptr<DenseMatrix<Real>> _transformation_matrix;
 
-  /**
-   * The set of subdomains that is used by the PointLocator associated
-   * with this boundary condition.
-   */
-  std::set<subdomain_id_type> _point_locator_subdomains;
 };
 
 } // namespace libmesh

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -161,6 +161,11 @@ public:
   virtual void unset_close_to_point_tol();
 
   /**
+   * Get a const reference to this PointLocator's mesh.
+   */
+  const MeshBase & get_mesh() const;
+
+  /**
    * Boolean flag to indicate whether to print out extra info.
    */
   bool _verbose;

--- a/src/base/periodic_boundary_base.C
+++ b/src/base/periodic_boundary_base.C
@@ -108,20 +108,6 @@ const std::set<unsigned int> & PeriodicBoundaryBase::get_variables() const
   return variables;
 }
 
-
-
-void PeriodicBoundaryBase::set_point_locator_subdomains(const std::set<subdomain_id_type> & point_locator_subdomains)
-{
-  _point_locator_subdomains = point_locator_subdomains;
-}
-
-
-
-const std::set<subdomain_id_type> & PeriodicBoundaryBase::get_point_locator_subdomains() const
-{
-  return _point_locator_subdomains;
-}
-
 } // namespace libMesh
 
 #endif // LIBMESH_ENABLE_PERIODIC

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -96,6 +96,12 @@ void PointLocatorBase::unset_close_to_point_tol ()
 }
 
 
+const MeshBase & PointLocatorBase::get_mesh () const
+{
+  return _mesh;
+}
+
+
 const Node *
 PointLocatorBase::
 locate_node(const Point & p,


### PR DESCRIPTION
Roy Stogner suggested a better way to handle overlapping periodic BCs: use point_locator.operator()(p, candidate_elements) and find the element that contains the correct boundary ID. This is more user-friendly and less error-prone since it does not require the users to specify subdomain IDs themselves.

systems_of_equations_ex9 has been updated by removing the part where we set the subdomain IDs, and it works.