### PR TITLE
Moving discontinuous data setup to MeshOutput.

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -202,7 +202,7 @@ public:
    */
   void write_nodal_data_discontinuous (const std::string &,
                                        const std::vector<Number> &,
-                                       const std::vector<std::string> &);
+                                       const std::vector<std::string> &) libmesh_override;
 
   /**
    * Write out global variables.

--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -90,12 +90,30 @@ public:
                                        const std::set<std::string> * system_names=libmesh_nullptr);
 
   /**
+   * This method implements writing a mesh with discontinuous data to a
+   * specified file where the data is taken from the \p EquationSystems
+   * object.
+   */
+  virtual void write_discontinuous_equation_systems (const std::string &,
+                                                     const EquationSystems &,
+                                                     const std::set<std::string> * system_names=libmesh_nullptr);
+
+  /**
    * This method implements writing a mesh with nodal data to a
    * specified file where the nodal data and variable names are provided.
    */
   virtual void write_nodal_data (const std::string &,
                                  const std::vector<Number> &,
                                  const std::vector<std::string> &)
+  { libmesh_not_implemented(); }
+
+  /**
+   * This method implements writing a mesh with discontinuous data to a
+   * specified file where the nodal data and variables names are provided.
+   */
+  virtual void write_nodal_data_discontinuous (const std::string &,
+                                               const std::vector<Number> &,
+                                               const std::vector<std::string> &)
   { libmesh_not_implemented(); }
 
   /**
@@ -114,6 +132,15 @@ public:
   virtual void write_nodal_data (const std::string &,
                                  const NumericVector<Number> &,
                                  const std::vector<std::string> &);
+
+  /**
+   * This method should be overridden by output formats wanting to
+   * export discontinuous data.
+   */
+  virtual void write_nodal_data_discontinuous (const std::string &,
+                                               const NumericVector<Number> &,
+                                               const std::vector<std::string> &)
+  { libmesh_not_implemented(); }
 
   /**
    * Return/set the precision to use when writing ASCII files.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -108,7 +108,7 @@ void ExodusII_IO::write_timestep_discontinuous (const std::string &fname,
                                                 const std::set<std::string> * system_names)
 {
   _timestep = timestep;
-  write_discontinuous_exodusII(fname,es,system_names);
+  write_discontinuous_equation_systems (fname,es,system_names);
 
   if (MeshOutput<MeshBase>::mesh().processor_id())
     return;

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -88,7 +88,63 @@ void MeshOutput<MT>::write_equation_systems (const std::string & fname,
     }
 }
 
+template <class MT>
+void MeshOutput<MT>::write_discontinuous_equation_systems (const std::string & fname,
+                                                           const EquationSystems & es,
+                                                           const std::set<std::string> * system_names)
+{
+  LOG_SCOPE("write_discontinuous_equation_systems()", "MeshOutput");
 
+  // We may need to gather and/or renumber a DistributedMesh to output
+  // it, making that const qualifier in our constructor a dirty lie
+  MT & my_mesh = const_cast<MT &>(*_obj);
+
+  // If we're asked to write data that's associated with a different
+  // mesh, output files full of garbage are the result.
+  libmesh_assert_equal_to(&es.get_mesh(), _obj);
+
+  // A non-renumbered mesh may not have a contiguous numbering, and
+  // that needs to be fixed before we can build a solution vector.
+  if (my_mesh.max_elem_id() != my_mesh.n_elem() ||
+      my_mesh.max_node_id() != my_mesh.n_nodes())
+    {
+      // If we were allowed to renumber then we should have already
+      // been properly renumbered...
+      libmesh_assert(!my_mesh.allow_renumbering());
+
+      libmesh_do_once(libMesh::out <<
+                      "Warning:  This MeshOutput subclass only supports meshes which are contiguously renumbered!"
+                      << std::endl;);
+
+      my_mesh.allow_renumbering(true);
+
+      my_mesh.renumber_nodes_and_elements();
+
+      // Not sure what good going back to false will do here, the
+      // renumbering horses have already left the barn...
+      my_mesh.allow_renumbering(false);
+    }
+
+  MeshSerializer serialize(const_cast<MT &>(*_obj), !_is_parallel_format, _serial_only_needed_on_proc_0);
+
+  // Build the list of variable names that will be written.
+  std::vector<std::string> names;
+  es.build_variable_names  (names, libmesh_nullptr, system_names);
+
+  if (!_is_parallel_format)
+    {
+      // Build the nodal solution values & get the variable
+      // names from the EquationSystems object
+      std::vector<Number> soln;
+      es.build_discontinuous_solution_vector (soln, system_names);
+
+      this->write_nodal_data_discontinuous (fname, soln, names);
+    }
+  else // _is_parallel_format
+    {
+      libmesh_not_implemented();
+    }
+}
 
 template <class MT>
 void MeshOutput<MT>::write_nodal_data (const std::string & fname,


### PR DESCRIPTION
These changes make the outputting of discontinuous nodal data more uniform with continuous nodal data. This should resolve #1503 and enable the merge in idaholab/moose#11210. 

These changes have been tested with the moose test suite using the `--distributed-mesh -p 4` option. 