### PR TITLE
Node::choose_processor_id refactoring

### DIFF
--- a/include/geom/node.h
+++ b/include/geom/node.h
@@ -178,6 +178,12 @@ public:
    */
   void set_valence(unsigned int val);
 
+  /**
+   * Return which of pid1 and pid2 would be preferred by the current
+   * load-balancing heuristic applied to this node.
+   */
+  processor_id_type choose_processor_id(processor_id_type pid1, processor_id_type pid2) const;
+
 private:
 
   /**
@@ -349,9 +355,6 @@ void Node::set_valence (unsigned int)
 }
 
 #endif // #ifdef LIBMESH_ENABLE_NODE_VALENCE
-
-
-
 
 } // namespace libMesh
 

--- a/src/geom/node.C
+++ b/src/geom/node.C
@@ -74,4 +74,33 @@ std::string Node::get_info () const
 }
 
 
+processor_id_type
+Node::choose_processor_id(processor_id_type pid1, processor_id_type pid2) const
+{
+  if (pid1 == DofObject::invalid_processor_id)
+    return pid2;
+
+  // Do we want the new load-balanced node partitioning heuristic
+  // instead of the default partitioner-friendlier heuristic?
+  static bool load_balanced_nodes =
+    libMesh::on_command_line ("--load_balanced_nodes");
+
+  // For better load balancing, we can use the min
+  // even-numberered nodes and the max for odd-numbered.
+  if (load_balanced_nodes)
+    {
+      if (this->id() % 2 &&
+          pid2 != DofObject::invalid_processor_id)
+        return std::max(pid1, pid2);
+      else
+        return std::min(pid1, pid2);
+    }
+
+  // Our default behavior, which puts too many nodes on lower MPI
+  // ranks but which keeps elements' nodes on the same partition more
+  // often, is simply:
+  return std::min(pid1, pid2);
+}
+
+
 } // namespace libMesh

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -165,8 +165,8 @@ Node * MeshRefinement::add_node(Elem & parent,
   if (new_node_id != DofObject::invalid_id)
     {
       Node * node = _mesh.node_ptr(new_node_id);
-      if (proc_id < node->processor_id())
-        node->processor_id() = proc_id;
+      processor_id_type & pid = node->processor_id();
+      pid = node->choose_processor_id(pid, proc_id);
       return node;
     }
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1829,7 +1829,7 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
           if (it == new_proc_ids.end())
             new_proc_ids.insert(std::make_pair(id,pid));
           else
-            it->second = std::min(it->second, pid);
+            it->second = node.choose_processor_id(it->second, pid);
         }
     }
 
@@ -1886,7 +1886,10 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
           if (it == new_proc_ids.end())
             new_proc_ids.insert(std::make_pair(id,pid));
           else
-            it->second = std::min(it->second, pid);
+            {
+              const Node & node = mesh.node_ref(id);
+              it->second = node.choose_processor_id(it->second, pid);
+            }
         }
     }
 

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -481,16 +481,13 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
 
       libmesh_assert_not_equal_to (elem->processor_id(), DofObject::invalid_processor_id);
 
-      // For each node, set the processor ID to the min of
-      // its current value and this Element's processor id.
-      //
-      // TODO: we would probably get better parallel partitioning if
-      // we did something like "min for even numbered nodes, max for
-      // odd numbered".  We'd need to be careful about how that would
-      // affect solution ordering for I/O, though.
+      // Consider updating the processor id on this element's nodes
       for (unsigned int n=0; n<elem->n_nodes(); ++n)
-        elem->node_ptr(n)->processor_id() = std::min(elem->node_ptr(n)->processor_id(),
-                                                     elem->processor_id());
+        {
+          Node & node = elem->node_ref(n);
+          processor_id_type & pid = node.processor_id();
+          pid = node.choose_processor_id(pid, elem->processor_id());
+        }
     }
 
   // And loop over the subactive elements, but don't reassign


### PR DESCRIPTION
This is just the refactoring, cherry-picked and with fixups squashed; load_balanced_nodes defaults to off and so the heuristic defaults to our usual std::min.