### PR TITLE
Use jacobi preconditioning on adjoints_ex3

### DIFF
--- a/examples/adjoints/adjoints_ex3/run.sh
+++ b/examples/adjoints/adjoints_ex3/run.sh
@@ -8,4 +8,6 @@ example_name=adjoints_ex3
 
 example_dir=examples/adjoints/$example_name
 
-run_example "$example_name"
+options="-pc_type jacobi"
+
+run_example "$example_name" $options


### PR DESCRIPTION
PETSc defaults (BJ+ILU?) don't work so well when we experiment with
different nodal (and thus DoF) partitioning.