### PR TITLE
skip_partitioning() should look at _partitioner

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -771,9 +771,13 @@ public:
    * imbalances.  However you might still want to use this if the
    * communication and computation of the rebalance and repartition is
    * too high for your application.
+   *
+   * It is also possible, for backwards-compatibility purposes, to
+   * skip partitioning by resetting the partitioner() pointer for this
+   * mesh.
    */
   void skip_partitioning(bool skip) { _skip_partitioning = skip; }
-  bool skip_partitioning() const { return _skip_partitioning; }
+  bool skip_partitioning() const { return _skip_partitioning || !_partitioner.get(); }
 
   /**
    * Adds a functor which can specify ghosting requirements for use on

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -471,9 +471,10 @@ void MeshBase::partition (const unsigned int n_parts)
       libmesh_assert (this->is_serial());
       partitioner()->partition (*this, n_parts);
     }
-  // NULL partitioner means don't repartition
+  // NULL partitioner means don't repartition; skip_partitioning()
+  // checks on this.
   // Non-serial meshes may not be ready for repartitioning here.
-  else if (!skip_partitioning() && partitioner().get())
+  else if (!skip_partitioning())
     {
       partitioner()->partition (*this, n_parts);
     }


### PR DESCRIPTION
If the user chose a different means to disable partitioning, we should
make that clear to code.