### PR TITLE
Fixing Warnings about Virtual Methods

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -189,6 +189,7 @@ public:
    * avoid warnings about hidden overloaded virtual functions.
    */
   using MeshOutput<MeshBase>::write_nodal_data;
+  using MeshOutput<MeshBase>::write_nodal_data_discontinuous;
 
   /**
    * Write out a nodal solution.

--- a/include/mesh/mesh_output.h
+++ b/include/mesh/mesh_output.h
@@ -134,15 +134,6 @@ public:
                                  const std::vector<std::string> &);
 
   /**
-   * This method should be overridden by output formats wanting to
-   * export discontinuous data.
-   */
-  virtual void write_nodal_data_discontinuous (const std::string &,
-                                               const NumericVector<Number> &,
-                                               const std::vector<std::string> &)
-  { libmesh_not_implemented(); }
-
-  /**
    * Return/set the precision to use when writing ASCII files.
    *
    * By default we use numeric_limits<Real>::digits10 + 2, which


### PR DESCRIPTION
These changes resolve warnings about hidden virtual methods. Related to #1503, #1644 idaholab/moose#2716