### PR TITLE
Metis USE_GKRAND

### DIFF
--- a/contrib/metis/Makefile.am
+++ b/contrib/metis/Makefile.am
@@ -1,4 +1,5 @@
 pkg_cppflags  = -DLIBMESH_IS_COMPILING_METIS
+pkg_cppflags += -DUSE_GKRAND
 pkg_cppflags += -I$(srcdir)/include  -I$(srcdir)/GKlib -I$(srcdir)/libmetis
 pkg_cppflags += -I$(top_builddir)/include #for #include "libmesh/libmesh_config.h"
 pkg_sources = \

--- a/contrib/metis/Makefile.in
+++ b/contrib/metis/Makefile.in
@@ -862,8 +862,8 @@ top_srcdir = @top_srcdir@
 vtkbuild = @vtkbuild@
 vtkmajor = @vtkmajor@
 vtkversion = @vtkversion@
-pkg_cppflags = -DLIBMESH_IS_COMPILING_METIS -I$(srcdir)/include \
-	-I$(srcdir)/GKlib -I$(srcdir)/libmetis \
+pkg_cppflags = -DLIBMESH_IS_COMPILING_METIS -DUSE_GKRAND \
+	-I$(srcdir)/include -I$(srcdir)/GKlib -I$(srcdir)/libmetis \
 	-I$(top_builddir)/include #for #include \
 	"libmesh/libmesh_config.h"
 pkg_sources = \


### PR DESCRIPTION
This mimics the behavior implemented in petsc/petsc@b003188 which tells Metis to use "portable" random number generation. That behavior has been in place since PETSc 3.8. Users who already build libmesh with PETSc+Metis will not notice any difference from this PR, this change only affects builds of our contrib/metis.
