### PR TITLE
Don't use LIBMESH_TLS in contrib/metis.

### DIFF
--- a/contrib/metis/GKlib/error.c
+++ b/contrib/metis/GKlib/error.c
@@ -15,42 +15,20 @@ This file contains functions dealing with error reporting and termination
 
 #include <GKlib.h>
 
-/**
- * LIBMESH CHANGE: __thread is not portable across all platforms.  We detect
- * this using configure and set the appropriate value in LIBMESH_TLS, which is
- * defined in libmesh_config.h
- */
-#ifdef LIBMESH_IS_COMPILING_METIS
-#  include "libmesh/libmesh_config.h"
-#endif
-
 /* These are the jmp_buf for the graceful exit in case of severe errors.
    Multiple buffers are defined to allow for recursive invokation. */
 #define MAX_JBUFS 128
-#ifdef LIBMESH_TLS
-LIBMESH_TLS int gk_cur_jbufs=-1;
-LIBMESH_TLS jmp_buf gk_jbufs[MAX_JBUFS];
-LIBMESH_TLS jmp_buf gk_jbuf;
-#else
-int gk_cur_jbufs=-1;
-jmp_buf gk_jbufs[MAX_JBUFS];
-jmp_buf gk_jbuf;
-#endif
+/*LIBMESH_TLS*/ int gk_cur_jbufs=-1;
+/*LIBMESH_TLS*/ jmp_buf gk_jbufs[MAX_JBUFS];
+/*LIBMESH_TLS*/ jmp_buf gk_jbuf;
 
 typedef void (*gksighandler_t)(int);
 
 /* These are the holders of the old singal handlers for the trapped signals */
-#ifdef LIBMESH_TLS
-static LIBMESH_TLS gksighandler_t old_SIGMEM_handler;  /* Custom signal */
-static LIBMESH_TLS gksighandler_t old_SIGERR_handler;  /* Custom signal */
-static LIBMESH_TLS gksighandler_t old_SIGMEM_handlers[MAX_JBUFS];  /* Custom signal */
-static LIBMESH_TLS gksighandler_t old_SIGERR_handlers[MAX_JBUFS];  /* Custom signal */
-#else
-static gksighandler_t old_SIGMEM_handler;  /* Custom signal */
-static gksighandler_t old_SIGERR_handler;  /* Custom signal */
-static gksighandler_t old_SIGMEM_handlers[MAX_JBUFS];  /* Custom signal */
-static gksighandler_t old_SIGERR_handlers[MAX_JBUFS];  /* Custom signal */
-#endif
+static /*LIBMESH_TLS*/ gksighandler_t old_SIGMEM_handler;  /* Custom signal */
+static /*LIBMESH_TLS*/ gksighandler_t old_SIGERR_handler;  /* Custom signal */
+static /*LIBMESH_TLS*/ gksighandler_t old_SIGMEM_handlers[MAX_JBUFS];  /* Custom signal */
+static /*LIBMESH_TLS*/ gksighandler_t old_SIGERR_handlers[MAX_JBUFS];  /* Custom signal */
 
 /* The following is used to control if the gk_errexit() will actually abort or not.
    There is always a single copy of this variable */
@@ -199,11 +177,7 @@ char *gk_strerror(int errnum)
   return strerror(errnum);
 #else
 #ifndef SUNOS
-#ifdef LIBMESH_TLS
-  static LIBMESH_TLS char buf[1024];
-#else
-  static char buf[1024];
-#endif
+  static /*LIBMESH_TLS*/ char buf[1024];
 
   strerror_r(errnum, buf, 1024);
 

--- a/contrib/metis/GKlib/gk_externs.h
+++ b/contrib/metis/GKlib/gk_externs.h
@@ -10,30 +10,15 @@
 #ifndef _GK_EXTERNS_H_
 #define _GK_EXTERNS_H_
 
-/**
- * LIBMESH CHANGE: __thread is not portable across all platforms.  We detect
- * this using configure and set the appropriate value in LIBMESH_TLS, which is
- * defined in libmesh_config.h
- */
-#ifdef LIBMESH_IS_COMPILING_METIS
-#  include "libmesh/libmesh_config.h"
-#endif
-
 /*************************************************************************
 * Extern variable definition. Hopefully, the __thread makes them thread-safe.
 **************************************************************************/
 #ifndef _GK_ERROR_C_
 
 /* declared in error.c */
-#ifdef LIBMESH_TLS
-extern LIBMESH_TLS int gk_cur_jbufs;
-extern LIBMESH_TLS jmp_buf gk_jbufs[];
-extern LIBMESH_TLS jmp_buf gk_jbuf;
-#else
-extern int gk_cur_jbufs;
-extern jmp_buf gk_jbufs[];
-extern jmp_buf gk_jbuf;
-#endif // LIBMESH_TLS
+extern /*LIBMESH_TLS*/ int gk_cur_jbufs;
+extern /*LIBMESH_TLS*/ jmp_buf gk_jbufs[];
+extern /*LIBMESH_TLS*/ jmp_buf gk_jbuf;
 
 #endif
 

--- a/contrib/metis/GKlib/memory.c
+++ b/contrib/metis/GKlib/memory.c
@@ -15,21 +15,8 @@ can be used to define other memory allocation routines.
 
 #include <GKlib.h>
 
-/**
- * LIBMESH CHANGE: __thread is not portable across all platforms.  We detect
- * this using configure and set the appropriate value in LIBMESH_TLS, which is
- * defined in libmesh_config.h
- */
-#ifdef LIBMESH_IS_COMPILING_METIS
-#  include "libmesh/libmesh_config.h"
-#endif
-
 /* This is for the global mcore that tracks all heap allocations */
-#ifdef LIBMESH_TLS
-static LIBMESH_TLS gk_mcore_t *gkmcore = NULL;
-#else
-static gk_mcore_t *gkmcore = NULL;
-#endif
+static /*LIBMESH_TLS*/ gk_mcore_t *gkmcore = NULL;
 
 /*************************************************************************/
 /*! Define the set of memory allocation routines for each data type */


### PR DESCRIPTION
This change was also made in PETSc's "pkg-metis" repo
(https://bitbucket.org/petsc/pkg-metis) in c27a7c3 (tag: v5.1.0-p3),
originally in response to a problem with Xcode 7.3, and it has never
been reenabled, so I don't think it can be very important.

It is also nice to be remove libmesh-specific stuff from Metis, and
get rid of the LIBMESH_IS_COMPILING_METIS define. For now I have left
a comment on the variables that originally used thread local storage,
just in case we need to switch it back on later.