### PR TITLE
DistributedMesh::all_second_order() fix

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -269,6 +269,14 @@ public:
    */
   virtual Node * insert_node(Node * n) libmesh_override;
 
+  /**
+   * Takes ownership of node \p n on this partition of a distributed
+   * mesh, by setting n.processor_id() to this->processor_id(), as
+   * well as changing n.id() and moving it in the mesh's internal
+   * container to give it a new authoritative id.
+   */
+  virtual void own_node (Node & n);
+
   virtual void delete_node (Node * n) libmesh_override;
   virtual void renumber_node (dof_id_type old_id, dof_id_type new_id) libmesh_override;
   virtual Elem * add_elem (Elem * e) libmesh_override;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -618,6 +618,14 @@ public:
   virtual void delete_node (Node * n) = 0;
 
   /**
+   * Takes ownership of node \p n on this partition of a distributed
+   * mesh, by setting n.processor_id() to this->processor_id(), as
+   * well as changing n.id() and moving it in the mesh's internal
+   * container to give it a new authoritative id.
+   */
+  virtual void own_node (Node &) {}
+
+  /**
    * Changes the id of node \p old_id, both by changing node(old_id)->id() and
    * by moving node(old_id) in the mesh's internal container.  No element with
    * the id \p new_id should already exist.

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -602,6 +602,19 @@ Node * DistributedMesh::add_point (const Point & p,
 }
 
 
+void DistributedMesh::own_node (Node & n)
+{
+  // This had better be a node in our mesh
+  libmesh_assert(_nodes[n.id()] == &n);
+
+  _nodes[n.id()] = libmesh_nullptr;
+
+  n.set_id(DofObject::invalid_id);
+  n.processor_id() = this->processor_id();
+
+  this->add_node(&n);
+}
+
 
 Node * DistributedMesh::add_node (Node * n)
 {


### PR DESCRIPTION
Another independent chunk of #1621 cleaned up and factored out.

I've never managed to trigger this bug before playing with different Node::choose_processor_id() settings, but even with the default setting I think it would be theoretically possible to end up with invalid new node ids, by repartitioning with renumbering disabled and then calling all_second_order() afterward.