### PR TITLE
Node partitioning rework

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -483,9 +483,9 @@ void MeshBase::partition (const unsigned int n_parts)
       // Adaptive coarsening may have "orphaned" nodes on processors
       // whose elements no longer share them.  We need to check for
       // and possibly fix that.
-      Partitioner::set_node_processor_ids(*this);
+      MeshTools::correct_node_proc_ids(*this);
 
-      // Make sure locally cached partition count
+      // Make sure locally cached partition count is correct
       this->recalculate_n_partitions();
 
       // Make sure any other locally cached data is correct

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -35,6 +35,7 @@
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_ghost_sync.h"
+#include "libmesh/partitioner.h"
 #include "libmesh/remote_elem.h"
 #include "libmesh/sync_refinement_flags.h"
 
@@ -1584,6 +1585,9 @@ bool MeshRefinement::_refine_elements ()
       _mesh.libmesh_assert_valid_parallel_ids();
 #endif
     }
+
+  if (mesh_changed && _mesh.is_replicated())
+    Partitioner::set_node_processor_ids(_mesh);
 
   if (mesh_p_changed && !_mesh.is_replicated())
     {

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1586,7 +1586,12 @@ bool MeshRefinement::_refine_elements ()
 #endif
     }
 
-  if (mesh_changed && _mesh.is_replicated())
+  // If we're refining a ReplicatedMesh, then we haven't yet assigned
+  // node processor ids.  But if we're refining a partitioned
+  // ReplicatedMesh, then we *need* to assign node processor ids.
+  if (mesh_changed && _mesh.is_replicated() &&
+      (_mesh.unpartitioned_elements_begin() ==
+       _mesh.unpartitioned_elements_end()))
     Partitioner::set_node_processor_ids(_mesh);
 
   if (mesh_p_changed && !_mesh.is_replicated())


### PR DESCRIPTION
These first four commits (cherry-picked from #1621 and tweaked) should only make node partitioning slightly more robust for future changes, but I'm going to test with them first in the hopes of pinning down that Civet Rattlesnake failure.

Assuming they work, I'm also going to tack on the work that delays new node repartitioning.