### PR TITLE
Explain about calling renumber when skipping renumbering

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -186,10 +186,12 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
 
   // Mesh modification operations might not leave us with consistent
   // id counts, but our partitioner might need that consistency.
-  if (!_skip_renumber_nodes_and_elements)
-    this->renumber_nodes_and_elements();
-  else
-    this->update_parallel_id_counts();
+  //
+  // We just call renumber_nodes_and_elements() here because it
+  // currently handles stripping of disconnected nodes and updating of
+  // parallel id counts; it will skip renumbering if the mesh is so
+  // configured.
+  this->renumber_nodes_and_elements();
 
   // Let all the elements find their neighbors
   if (!skip_find_neighbors)

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -820,7 +820,18 @@ bool UnstructuredMesh::contract ()
           }
       }
 
-  // Strip any newly-created nullptr voids out of the element array
+  // Strip any newly-created nullptr voids out of the element array,
+  // if we're allowed to.
+  //
+  // We just call renumber_nodes_and_elements() here because it
+  // currently handles stripping of disconnected nodes and updating of
+  // parallel id counts; it will skip renumbering if the mesh is so
+  // configured.
+  //
+  // Note that renumbering may cause node processor ids to no longer
+  // match an id-number-based canonical processor partitioning
+  // algorithm, but it's probably not a safe time for us to go back
+  // and fix that.
   this->renumber_nodes_and_elements();
 
   // FIXME: Need to understand why deleting subactive children


### PR DESCRIPTION
In the long run we should perhaps rename that method to
"delete_disconnected_nodes_and_update_counts_and_maybe_renumber" or we
should actually break those into separate methods.

In theory this should just add some comments and remove a little redundancy.

In practice, *something* in #1621 is breaking Rattlesnake and this is the most likely of the very few remaining suspects.