### PR TITLE
Node processor id tweaks

### DIFF
--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -2077,9 +2077,8 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
 
       SyncNodeSet syncv(valid_nodes, mesh);
 
-      Parallel::sync_node_data_by_element_id
-        (mesh, mesh.elements_begin(), mesh.elements_end(),
-         Parallel::SyncEverything(), Parallel::SyncEverything(), syncv);
+      Parallel::sync_dofobject_data_by_id
+        (mesh.comm(), mesh.nodes_begin(), mesh.nodes_end(), syncv);
     }
 
   // We build up a set of compatible processor ids for each node

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -581,6 +581,7 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
 
 #ifdef DEBUG
   MeshTools::libmesh_assert_valid_procids<Node>(mesh);
+  MeshTools::libmesh_assert_canonical_node_procids(mesh);
 #endif
 }
 


### PR DESCRIPTION
Another assert, which should be useful when trying different partitioning schemes, plus a slightly more efficient way of synchronizing them.

These ought to be the last MOOSE-app-friendly bits of #1621