### PR TITLE
Updated ExodusII_IO to skip element variable writing on blocks that are inactive

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -298,7 +298,7 @@ public:
    * Sets up the nodal variables
    */
   void initialize_element_variables(std::vector<std::string> names,
-                                    std::vector<std::set<subdomain_id_type>> vars_active_subdomains);
+                                    const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains);
 
   /**
    * Sets up the nodal variables

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -297,7 +297,8 @@ public:
   /**
    * Sets up the nodal variables
    */
-  void initialize_element_variables(std::vector<std::string> names);
+  void initialize_element_variables(std::vector<std::string> names,
+                                    std::vector<std::set<subdomain_id_type>> vars_active_subdomains);
 
   /**
    * Sets up the nodal variables
@@ -317,7 +318,10 @@ public:
   /**
    * Writes the vector of values to the element variables.
    */
-  void write_element_values(const MeshBase & mesh, const std::vector<Real> & values, int timestep);
+  void write_element_values(const MeshBase & mesh,
+                            const std::vector<Real> & values,
+                            int timestep,
+                            std::vector<std::set<subdomain_id_type>> vars_active_subdomains);
 
   /**
    * Writes the vector of values to a nodal variable.
@@ -374,6 +378,13 @@ public:
    * starting with r_, i_ and a_ respectively.
    */
   std::vector<std::string> get_complex_names(const std::vector<std::string> & names) const;
+
+  /**
+   * returns a "tripled" copy of \p vars_active_subdomains, which is necessary in the
+   * complex-valued case.
+   */
+  std::vector<std::set<subdomain_id_type>> get_complex_vars_active_subdomains(
+    const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains) const;
 
   /**
    * This is the \p ExodusII_IO_Helper Conversion class.  It provides

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -321,7 +321,7 @@ public:
   void write_element_values(const MeshBase & mesh,
                             const std::vector<Real> & values,
                             int timestep,
-                            std::vector<std::set<subdomain_id_type>> vars_active_subdomains);
+                            const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains);
 
   /**
    * Writes the vector of values to a nodal variable.

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -304,6 +304,13 @@ public:
   build_parallel_solution_vector(const std::set<std::string> * system_names=libmesh_nullptr) const;
 
   /**
+   * Retrieve \p vars_active_subdomains, which indicates the active
+   * subdomains for each variable in \p names.
+   */
+  void get_vars_active_subdomains(const std::vector<std::string> & names,
+                                  std::vector<std::set<subdomain_id_type>> & vars_active_subdomains) const;
+
+  /**
    * Retrieve the solution data for CONSTANT MONOMIALs.  If \p names
    * is populated, only the variables corresponding to those names will
    * be retrieved.  This can be used to filter which variables are retrieved.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -686,7 +686,7 @@ void ExodusII_IO::write_element_data (const EquationSystems & es)
         }
     }
 
-  exio_helper->write_element_values(mesh, complex_soln, _timestep, vars_active_subdomains);
+  exio_helper->write_element_values(mesh, complex_soln, _timestep, complex_vars_active_subdomains);
 
 #else
   exio_helper->initialize_element_variables(names, vars_active_subdomains);

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -636,6 +636,10 @@ void ExodusII_IO::write_element_data (const EquationSystems & es)
   std::vector<Number> soln;
   es.get_solution(soln, names);
 
+  // Also, store the list of subdomains on which each variable is active
+  std::vector<std::set<subdomain_id_type>> vars_active_subdomains;
+  es.get_vars_active_subdomains(names, vars_active_subdomains);
+
   if (soln.empty()) // If there is nothing to write just return
     return;
 
@@ -650,7 +654,9 @@ void ExodusII_IO::write_element_data (const EquationSystems & es)
 
   std::vector<std::string> complex_names = exio_helper->get_complex_names(names);
 
-  exio_helper->initialize_element_variables(complex_names);
+  std::vector<std::set<subdomain_id_type>> complex_vars_active_subdomains =
+    exio_helper->get_complex_vars_active_subdomains(vars_active_subdomains);
+  exio_helper->initialize_element_variables(complex_names, complex_vars_active_subdomains);
 
   unsigned int num_values = soln.size();
   unsigned int num_vars = names.size();
@@ -680,11 +686,11 @@ void ExodusII_IO::write_element_data (const EquationSystems & es)
         }
     }
 
-  exio_helper->write_element_values(mesh, complex_soln, _timestep);
+  exio_helper->write_element_values(mesh, complex_soln, _timestep, vars_active_subdomains);
 
 #else
-  exio_helper->initialize_element_variables(names);
-  exio_helper->write_element_values(mesh, soln, _timestep);
+  exio_helper->initialize_element_variables(names, vars_active_subdomains);
+  exio_helper->write_element_values(mesh, soln, _timestep, vars_active_subdomains);
 #endif
 }
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1878,7 +1878,7 @@ void ExodusII_IO_Helper::write_timestep(int timestep, Real time)
 void ExodusII_IO_Helper::write_element_values(const MeshBase & mesh,
                                               const std::vector<Real> & values,
                                               int timestep,
-                                              std::vector<std::set<subdomain_id_type>> vars_active_subdomains)
+                                              const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains)
 {
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1887,6 +1887,7 @@ void ExodusII_IO_Helper::write_element_values(const MeshBase & mesh,
   // For each variable, create a 'data' array which holds all the elemental variable
   // values *for a given block* on this processor, then write that data vector to file
   // before moving onto the next block.
+  libmesh_assert_equal_to(vars_active_subdomains.size(), static_cast<unsigned>(num_elem_vars));
   for (unsigned int i=0; i<static_cast<unsigned>(num_elem_vars); ++i)
     {
       // The size of the subdomain map is the number of blocks.

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2105,13 +2105,13 @@ std::vector<std::set<subdomain_id_type>> ExodusII_IO_Helper::get_complex_vars_ac
 {
   std::vector<std::set<subdomain_id_type>> complex_vars_active_subdomains;
 
-  for (auto it : vars_active_subdomains)
+  for (auto & s : vars_active_subdomains)
     {
       // Push back the same data three times to match the tripling of the variables
       // for the real, imag, and modulus for the complex-valued solution.
-      complex_vars_active_subdomains.push_back(it);
-      complex_vars_active_subdomains.push_back(it);
-      complex_vars_active_subdomains.push_back(it);
+      complex_vars_active_subdomains.push_back(s);
+      complex_vars_active_subdomains.push_back(s);
+      complex_vars_active_subdomains.push_back(s);
     }
 
   return complex_vars_active_subdomains;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1405,7 +1405,7 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
   // to the corresponding discontinuous node index. This ordering must match the ordering
   // used in write_nodal_coordinates.
   std::map< std::pair<dof_id_type,unsigned int>, dof_id_type > discontinuous_node_indices;
-  if(use_discontinuous)
+  if (use_discontinuous)
   {
     dof_id_type node_counter = 1; // Exodus numbering is 1-based
     for (const auto & elem : mesh.active_element_ptr_range())
@@ -1734,14 +1734,14 @@ void ExodusII_IO_Helper::initialize_element_variables(std::vector<std::string> n
   // Use the truth table to indicate which subdomain/variable pairs are
   // active according to vars_active_subdomains.
   std::vector<int> truth_tab(num_elem_blk*num_elem_vars, 0);
-  for(unsigned int var_num=0; var_num<vars_active_subdomains.size(); var_num++)
+  for (unsigned int var_num=0; var_num<vars_active_subdomains.size(); var_num++)
     {
       // If the list of active subdomains is empty, it is interpreted as being
       // active on *all* subdomains.
       std::set<subdomain_id_type> var_active_subdomains;
-      if(vars_active_subdomains[var_num].empty())
+      if (vars_active_subdomains[var_num].empty())
         {
-          for(unsigned int block_id=0; block_id<num_elem_blk; block_id++)
+          for (auto block_id : block_ids)
             {
               var_active_subdomains.insert(block_id);
             }
@@ -1751,7 +1751,7 @@ void ExodusII_IO_Helper::initialize_element_variables(std::vector<std::string> n
           var_active_subdomains = vars_active_subdomains[var_num];
         }
 
-      for(auto block_id : var_active_subdomains)
+      for (auto block_id : var_active_subdomains)
         {
           unsigned int block_index =
             std::distance(block_ids.begin(), std::find(block_ids.begin(), block_ids.end(), block_id));
@@ -1914,8 +1914,8 @@ void ExodusII_IO_Helper::write_element_values(const MeshBase & mesh,
           // Skip any variable/subdomain pairs that are inactive.
           // Note that if active_subdomains is empty, it is interpreted
           // as being active on *all* subdomains.
-          if(!active_subdomains.empty())
-            if(active_subdomains.find(it->first) == active_subdomains.end())
+          if (!active_subdomains.empty())
+            if (active_subdomains.find(it->first) == active_subdomains.end())
               {
                 continue;
               }

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2103,9 +2103,6 @@ std::vector<std::string> ExodusII_IO_Helper::get_complex_names(const std::vector
 std::vector<std::set<subdomain_id_type>> ExodusII_IO_Helper::get_complex_vars_active_subdomains(
   const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains) const
 {
-  auto it = vars_active_subdomains.begin();
-  auto it_end = vars_active_subdomains.end();
-
   std::vector<std::set<subdomain_id_type>> complex_vars_active_subdomains;
 
   for (auto it : vars_active_subdomains)

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1705,7 +1705,7 @@ void ExodusII_IO_Helper::write_nodesets(const MeshBase & mesh)
 
 
 void ExodusII_IO_Helper::initialize_element_variables(std::vector<std::string> names,
-                                                      std::vector<std::set<subdomain_id_type>> vars_active_subdomains)
+                                                      const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains)
 {
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
@@ -2108,13 +2108,13 @@ std::vector<std::set<subdomain_id_type>> ExodusII_IO_Helper::get_complex_vars_ac
 
   std::vector<std::set<subdomain_id_type>> complex_vars_active_subdomains;
 
-  for (; it != it_end; ++it)
+  for (auto it : vars_active_subdomains)
     {
       // Push back the same data three times to match the tripling of the variables
       // for the real, imag, and modulus for the complex-valued solution.
-      complex_vars_active_subdomains.push_back(*it);
-      complex_vars_active_subdomains.push_back(*it);
-      complex_vars_active_subdomains.push_back(*it);
+      complex_vars_active_subdomains.push_back(it);
+      complex_vars_active_subdomains.push_back(it);
+      complex_vars_active_subdomains.push_back(it);
     }
 
   return complex_vars_active_subdomains;

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -825,6 +825,38 @@ void EquationSystems::build_solution_vector (std::vector<Number> & soln,
 
 
 
+void EquationSystems::get_vars_active_subdomains(const std::vector<std::string> & names,
+                                                 std::vector<std::set<subdomain_id_type>> & vars_active_subdomains) const
+{
+  unsigned int var_num=0;
+
+  vars_active_subdomains.clear();
+  vars_active_subdomains.resize(names.size());
+
+  const_system_iterator       pos = _systems.begin();
+  const const_system_iterator end = _systems.end();
+
+  for (; pos != end; ++pos)
+    {
+      for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
+        {
+          std::string var_name = pos->second->variable_name(vn);
+
+          auto names_it = std::find(names.begin(), names.end(), var_name);
+          if(names_it != names.end())
+            {
+              const Variable & variable = pos->second->variable(vn);
+              const std::set<subdomain_id_type> & active_subdomains = variable.active_subdomains();
+              vars_active_subdomains[var_num++] = active_subdomains;
+            }
+        }
+    }
+
+  libmesh_assert_equal_to(var_num, names.size());
+}
+
+
+
 void EquationSystems::get_solution (std::vector<Number> & soln,
                                     std::vector<std::string> & names) const
 {


### PR DESCRIPTION
We use the "truth table" feature of the ExodusII API to skip writing element variables on inactive blocks.