### PR TITLE
Use MPI_IN_PLACE for reductions when available

### DIFF
--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -76,29 +76,7 @@ public:
 #ifdef LIBMESH_HAVE_MPI
         StandardType<T> T_type(&((*ex)(0)));
 
-#if MPI_VERSION == 1
-
-        int blocklengths[3] = {1, LIBMESH_DIM, 1};
-        MPI_Aint displs[3];
-        MPI_Datatype types[3] = {MPI_LB, T_type, MPI_UB};
-        MPI_Aint start, later;
-
-        libmesh_call_mpi
-          (MPI_Address(ex, &start));
-        displs[0] = 0;
-        libmesh_call_mpi
-          (MPI_Address(&((*ex)(0)), &later));
-        displs[1] = later - start;
-        libmesh_call_mpi
-          (MPI_Address((ex+1), &later));
-        displs[2] = later - start;
-
-        libmesh_call_mpi
-          (MPI_Type_struct (3, blocklengths, displs, types,
-                            &_static_type));
-
-#else // MPI_VERSION >= 2
-
+        // We require MPI-2 here:
         int blocklength = LIBMESH_DIM;
         MPI_Aint displs, start;
         MPI_Datatype tmptype, type = T_type;
@@ -122,7 +100,6 @@ public:
         libmesh_call_mpi
           (MPI_Type_create_resized (tmptype, 0, sizeof(TypeVector<T>),
                                     &_static_type));
-#endif
 
         libmesh_call_mpi
           (MPI_Type_commit (&_static_type));
@@ -160,29 +137,6 @@ public:
 #ifdef LIBMESH_HAVE_MPI
         StandardType<T> T_type(&((*ex)(0)));
 
-#if MPI_VERSION == 1
-
-        int blocklengths[3] = {1, LIBMESH_DIM, 1};
-        MPI_Aint displs[3];
-        MPI_Datatype types[3] = {MPI_LB, T_type, MPI_UB};
-        MPI_Aint start, later;
-
-        libmesh_call_mpi
-          (MPI_Address(ex, &start));
-        displs[0] = 0;
-        libmesh_call_mpi
-          (MPI_Address(&((*ex)(0)), &later));
-        displs[1] = later - start;
-        libmesh_call_mpi
-          (MPI_Address((ex+1), &later));
-        displs[2] = later - start;
-
-        libmesh_call_mpi
-          (MPI_Type_struct (3, blocklengths, displs, types,
-                            &_static_type));
-
-#else // MPI_VERSION >= 2
-
         int blocklength = LIBMESH_DIM;
         MPI_Aint displs, start;
         MPI_Datatype tmptype, type = T_type;
@@ -207,7 +161,6 @@ public:
           (MPI_Type_create_resized (tmptype, 0,
                                     sizeof(VectorValue<T>),
                                     &_static_type));
-#endif
 
         libmesh_call_mpi
           (MPI_Type_commit (&_static_type));
@@ -251,29 +204,6 @@ public:
 
         StandardType<Real> T_type(&((*ex)(0)));
 
-#if MPI_VERSION == 1
-
-        int blocklengths[3] = {1, LIBMESH_DIM, 1};
-        MPI_Aint displs[3];
-        MPI_Datatype types[3] = {MPI_LB, T_type, MPI_UB};
-        MPI_Aint start, later;
-
-        libmesh_call_mpi
-          (MPI_Address(ex, &start));
-        displs[0] = 0;
-        libmesh_call_mpi
-          (MPI_Address(&((*ex)(0)), &later));
-        displs[1] = later - start;
-        libmesh_call_mpi
-          (MPI_Address((ex+1), &later));
-        displs[2] = later - start;
-
-        libmesh_call_mpi
-          (MPI_Type_struct (3, blocklengths, displs, types,
-                            &_static_type));
-
-#else // MPI_VERSION >= 2
-
         int blocklength = LIBMESH_DIM;
         MPI_Aint displs, start;
         MPI_Datatype tmptype, type = T_type;
@@ -297,7 +227,6 @@ public:
         libmesh_call_mpi
           (MPI_Type_create_resized (tmptype, 0, sizeof(Point),
                                     &_static_type));
-#endif
 
         libmesh_call_mpi
           (MPI_Type_commit (&_static_type));

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -40,21 +40,6 @@ namespace Parallel {
 
 #ifdef LIBMESH_HAVE_MPI
 
-#if MPI_VERSION > 1
-/**
- * Macros to do MPI_IN_PLACE when available or use a temporary buffer
- * otherwise.
- */
-#define LIBMESH_MPI_TEMP_BUF(declaration) ((void) 0)
-#define LIBMESH_MPI_IN_PLACE_OR(addr) MPI_IN_PLACE
-
-#else
-
-#define LIBMESH_MPI_TEMP_BUF(declaration) declaration
-#define LIBMESH_MPI_IN_PLACE_OR(addr) addr
-
-#endif
-
 /**
  * Templated function to return the appropriate MPI datatype
  * for use with built-in C types when combined with an int
@@ -965,9 +950,8 @@ inline void Communicator::min(T & r) const
     {
       LOG_SCOPE("min(scalar)", "Parallel");
 
-      LIBMESH_MPI_TEMP_BUF(T temp = r);
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&temp), &r, 1,
+        (MPI_Allreduce (MPI_IN_PLACE, &r, 1,
                         StandardType<T>(&r), OpFunction<T>::min(),
                         this->get()));
     }
@@ -981,9 +965,8 @@ inline void Communicator::min(bool & r) const
       LOG_SCOPE("min(bool)", "Parallel");
 
       unsigned int temp = r;
-      LIBMESH_MPI_TEMP_BUF(unsigned int tempsend = r);
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&tempsend), &temp, 1,
+        (MPI_Allreduce (MPI_IN_PLACE, &temp, 1,
                         StandardType<unsigned int>(),
                         OpFunction<unsigned int>::min(),
                         this->get()));
@@ -1001,9 +984,8 @@ inline void Communicator::min(std::vector<T> & r) const
 
       libmesh_assert(this->verify(r.size()));
 
-      LIBMESH_MPI_TEMP_BUF(std::vector<T> temp(r));
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&temp[0]), &r[0],
+        (MPI_Allreduce (MPI_IN_PLACE, &r[0],
                         cast_int<int>(r.size()),
                         StandardType<T>(&r[0]),
                         OpFunction<T>::min(),
@@ -1157,9 +1139,8 @@ inline void Communicator::max(T & r) const
     {
       LOG_SCOPE("max(scalar)", "Parallel");
 
-      LIBMESH_MPI_TEMP_BUF(T temp = r);
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&temp), &r, 1,
+        (MPI_Allreduce (MPI_IN_PLACE, &r, 1,
                         StandardType<T>(&r),
                         OpFunction<T>::max(),
                         this->get()));
@@ -1174,9 +1155,8 @@ inline void Communicator::max(bool & r) const
       LOG_SCOPE("max(bool)", "Parallel");
 
       unsigned int temp = r;
-      LIBMESH_MPI_TEMP_BUF(unsigned int tempsend = r);
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&tempsend), &temp, 1,
+        (MPI_Allreduce (MPI_IN_PLACE, &temp, 1,
                         StandardType<unsigned int>(),
                         OpFunction<unsigned int>::max(),
                         this->get()));
@@ -1194,9 +1174,8 @@ inline void Communicator::max(std::vector<T> & r) const
 
       libmesh_assert(this->verify(r.size()));
 
-      LIBMESH_MPI_TEMP_BUF(std::vector<T> temp(r));
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&temp[0]), &r[0],
+        (MPI_Allreduce (MPI_IN_PLACE, &r[0],
                         cast_int<int>(r.size()),
                         StandardType<T>(&r[0]),
                         OpFunction<T>::max(),
@@ -1355,9 +1334,8 @@ inline void Communicator::sum(T & r) const
     {
       LOG_SCOPE("sum()", "Parallel");
 
-      LIBMESH_MPI_TEMP_BUF(T temp = r);
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&temp), &r, 1,
+        (MPI_Allreduce (MPI_IN_PLACE, &r, 1,
                         StandardType<T>(&r),
                         OpFunction<T>::sum(),
                         this->get()));
@@ -1374,9 +1352,8 @@ inline void Communicator::sum(std::vector<T> & r) const
 
       libmesh_assert(this->verify(r.size()));
 
-      LIBMESH_MPI_TEMP_BUF(std::vector<T> temp(r));
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&temp[0]), &r[0],
+        (MPI_Allreduce (MPI_IN_PLACE, &r[0],
                         cast_int<int>(r.size()),
                         StandardType<T>(&r[0]),
                         OpFunction<T>::sum(),
@@ -1394,9 +1371,8 @@ inline void Communicator::sum(std::complex<T> & r) const
     {
       LOG_SCOPE("sum()", "Parallel");
 
-      LIBMESH_MPI_TEMP_BUF(std::complex<T> temp(r));
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&temp), &r, 2,
+        (MPI_Allreduce (MPI_IN_PLACE, &r, 2,
                         StandardType<T>(),
                         OpFunction<T>::sum(),
                         this->get()));
@@ -1413,9 +1389,8 @@ inline void Communicator::sum(std::vector<std::complex<T>> & r) const
 
       libmesh_assert(this->verify(r.size()));
 
-      LIBMESH_MPI_TEMP_BUF(std::vector<std::complex<T>> temp(r));
       libmesh_call_mpi
-        (MPI_Allreduce (LIBMESH_MPI_IN_PLACE_OR(&temp[0]), &r[0],
+        (MPI_Allreduce (MPI_IN_PLACE, &r[0],
                         cast_int<int>(r.size() * 2),
                         StandardType<T>(libmesh_nullptr),
                         OpFunction<T>::sum(), this->get()));
@@ -2253,20 +2228,11 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
   // MPI_STATUS_IGNORE is from MPI-2; using it with some versions of
   // MPICH may cause a crash:
   // https://bugzilla.mcs.anl.gov/globus/show_bug.cgi?id=1798
-#if MPI_VERSION > 1
   libmesh_call_mpi
     (MPI_Sendrecv(const_cast<T1*>(&sendvec), 1, StandardType<T1>(&sendvec),
                   dest_processor_id, send_tag.value(), &recv, 1,
                   StandardType<T2>(&recv), source_processor_id,
                   recv_tag.value(), this->get(), MPI_STATUS_IGNORE));
-#else
-  MPI_Status stat;
-  libmesh_call_mpi
-    (MPI_Sendrecv(const_cast<T1*>(&sendvec), 1, StandardType<T1>(&sendvec),
-                  dest_processor_id, send_tag.value(), &recv, 1,
-                  StandardType<T2>(&recv), source_processor_id,
-                  recv_tag.value(), this->get(), &stat));
-#endif
 }
 
 

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -408,7 +408,6 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
 
       if (!flag)
         {
-#if MPI_VERSION > 1
           int mpi_thread_provided;
           const int mpi_thread_requested = libMesh::n_threads() > 1 ?
             MPI_THREAD_FUNNELED :
@@ -439,17 +438,6 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
               // libMesh::libMeshPrivateData::_n_threads = 1;
               // task_scheduler.reset (new Threads::task_scheduler_init(libMesh::n_threads()));
             }
-#else
-          if (libMesh::libMeshPrivateData::_n_threads > 1)
-            {
-              libmesh_warning("Warning: using MPI1 for threaded code.\n" <<
-                              "Be sure your library is funneled-thread-safe..." <<
-                              std::endl);
-            }
-
-          libmesh_call_mpi
-            (MPI_Init (&argc, const_cast<char ***>(&argv)));
-#endif
           libmesh_initialized_mpi = true;
         }
 
@@ -477,21 +465,12 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
       // into a debugger with a proper stack when an MPI error occurs.
       if (libMesh::on_command_line ("--handle-mpi-errors"))
         {
-#if MPI_VERSION > 1
           libmesh_call_mpi
             (MPI_Comm_create_errhandler(libMesh_MPI_Handler, &libmesh_errhandler));
           libmesh_call_mpi
             (MPI_Comm_set_errhandler(libMesh::GLOBAL_COMM_WORLD, libmesh_errhandler));
           libmesh_call_mpi
             (MPI_Comm_set_errhandler(MPI_COMM_WORLD, libmesh_errhandler));
-#else
-          libmesh_call_mpi
-            (MPI_Errhandler_create(libMesh_MPI_Handler, &libmesh_errhandler));
-          libmesh_call_mpi
-            (MPI_Errhandler_set(libMesh::GLOBAL_COMM_WORLD, libmesh_errhandler));
-          libmesh_call_mpi
-            (MPI_Errhandler_set(MPI_COMM_WORLD, libmesh_errhandler));
-#endif // #if MPI_VERSION > 1
         }
     }
 

--- a/src/parallel/request.C
+++ b/src/parallel/request.C
@@ -149,17 +149,8 @@ bool Request::test ()
 #ifdef LIBMESH_HAVE_MPI
   int val=0;
 
-  // MPI_STATUS_IGNORE is from MPI-2; using it with some versions of
-  // MPICH may cause a crash:
-  // https://bugzilla.mcs.anl.gov/globus/show_bug.cgi?id=1798
-#if MPI_VERSION > 1
   libmesh_call_mpi
     (MPI_Test (&_request, &val, MPI_STATUS_IGNORE));
-#else
-  MPI_Status stat;
-  libmesh_call_mpi
-    (MPI_Test (&_request, &val, &stat));
-#endif
 
   if (val)
     {


### PR DESCRIPTION
This ought to make sum/max/min of vectors a tiny bit faster.

See #1617 for general MPI optimization and "we still can't assume
everybody at least has MPI-2 already?!?" discussion

I'd like to test this against an MPI-1-only library before we merge; if nobody's Civet has such a module handy then we can wait until I build one myself.