### PR TITLE
Support dash or underscore in on_command_line, command_line_next

### DIFF
--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -158,6 +158,9 @@ void enableSEGV(bool on);
  * then with all underscores changed to dashes, then with all dashes
  * (except any leading dashes) changed to underscores, and returns
  * true if any of the above finds a match.
+ *
+ * This routine manipulates the command_line cursor and should not be
+ * called concurrently with similar utilities in multiple threads.
  */
 bool on_command_line (std::string arg);
 
@@ -165,6 +168,9 @@ bool on_command_line (std::string arg);
  * \returns The value associated with name on the command line if it is specified,
  * otherwise return the default, provided value.  A second template function is provided
  * to support recognizing multiple variations of a given option
+ *
+ * This routine manipulates the command_line cursor and should not be
+ * called concurrently with similar utilities in multiple threads.
  */
 template <typename T>
 T command_line_value (const std::string &, T);
@@ -180,6 +186,9 @@ T command_line_value (const std::vector<std::string> &, T);
  * then with all underscores changed to dashes, then with all dashes
  * (except any leading dashes) changed to underscores, and returns
  * true if any of the above finds a match.
+ *
+ * This routine manipulates the command_line cursor and should not be
+ * called concurrently with similar utilities in multiple threads.
  */
 template <typename T>
 T command_line_next (std::string name, T default_value);
@@ -187,6 +196,9 @@ T command_line_next (std::string name, T default_value);
 /**
  * \returns The array of values associated with name on the command line if it is specified,
  * otherwise return the default, provided array.
+ *
+ * This routine manipulates the command_line cursor and should not be
+ * called concurrently with similar utilities in multiple threads.
  */
 template <typename T>
 void command_line_vector (const std::string &, std::vector<T> &);

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -153,7 +153,7 @@ void enableSEGV(bool on);
  * \returns \p true if the argument \p arg was specified on the command line,
  * \p false otherwise.
  */
-bool on_command_line (const std::string & arg);
+bool on_command_line (std::string arg);
 
 /**
  * \returns The value associated with name on the command line if it is specified,

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -152,6 +152,12 @@ void enableSEGV(bool on);
 /**
  * \returns \p true if the argument \p arg was specified on the command line,
  * \p false otherwise.
+ *
+ * For backwards compatibility with past option naming conventions,
+ * libMesh searches for the given argument first in its original form,
+ * then with all underscores changed to dashes, then with all dashes
+ * (except any leading dashes) changed to underscores, and returns
+ * true if any of the above finds a match.
  */
 bool on_command_line (std::string arg);
 

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -174,9 +174,15 @@ T command_line_value (const std::vector<std::string> &, T);
 /**
  * Use GetPot's search()/next() functions to get following arguments
  * from the command line.
+ *
+ * For backwards compatibility with past option naming conventions,
+ * libMesh searches for the given argument first in its original form,
+ * then with all underscores changed to dashes, then with all dashes
+ * (except any leading dashes) changed to underscores, and returns
+ * true if any of the above finds a match.
  */
 template <typename T>
-T command_line_next (const std::string &, T);
+T command_line_next (std::string name, T default_value);
 
 /**
  * \returns The array of values associated with name on the command line if it is specified,

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -908,7 +908,7 @@ void DofMap::distribute_dofs (MeshBase & mesh)
   // By default distribute variables in a
   // var-major fashion, but allow run-time
   // specification
-  bool node_major_dofs = libMesh::on_command_line ("--node_major_dofs");
+  bool node_major_dofs = libMesh::on_command_line ("--node-major-dofs");
 
   // The DOF counter, will be incremented as we encounter
   // new degrees of freedom
@@ -1678,7 +1678,7 @@ bool DofMap::use_coupled_neighbor_dofs(const MeshBase & mesh) const
   // If we were asked on the command line, then we need to
   // include sensitivities between neighbor degrees of freedom
   bool implicit_neighbor_dofs =
-    libMesh::on_command_line ("--implicit_neighbor_dofs");
+    libMesh::on_command_line ("--implicit-neighbor-dofs");
 
   // If the user specifies --implicit_neighbor_dofs 0, then
   // presumably he knows what he is doing and we won't try to

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1680,7 +1680,7 @@ bool DofMap::use_coupled_neighbor_dofs(const MeshBase & mesh) const
   bool implicit_neighbor_dofs =
     libMesh::on_command_line ("--implicit-neighbor-dofs");
 
-  // If the user specifies --implicit_neighbor_dofs 0, then
+  // If the user specifies --implicit-neighbor-dofs 0, then
   // presumably he knows what he is doing and we won't try to
   // automatically turn it on even when all the variables are
   // discontinuous.
@@ -1688,11 +1688,11 @@ bool DofMap::use_coupled_neighbor_dofs(const MeshBase & mesh) const
     {
       // No flag provided defaults to 'true'
       int flag = 1;
-      flag = libMesh::command_line_next ("--implicit_neighbor_dofs", flag);
+      flag = libMesh::command_line_next ("--implicit-neighbor-dofs", flag);
 
       if (!flag)
         {
-          // The user said --implicit_neighbor_dofs 0, so he knows
+          // The user said --implicit-neighbor-dofs 0, so he knows
           // what he is doing and really doesn't want it.
           return false;
         }

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -940,32 +940,9 @@ T command_line_value (const std::vector<std::string> & name, T value)
 template <typename T>
 T command_line_next (std::string name, T value)
 {
-  // Make sure the command line parser is ready for use
-  libmesh_assert(command_line.get());
-
-  // Users had better not be asking about an empty string
-  libmesh_assert(!name.empty());
-
-  bool found_it = command_line->search(1, name.c_str());
-
-  if (found_it)
-    return command_line->next(value);
-
-  // Try with all dashes instead of underscores
-  std::replace(name.begin(), name.end(), '_', '-');
-  found_it = command_line->search(1, name.c_str());
-
-  if (found_it)
-    return command_line->next(value);
-
-  // OK, try with all underscores instead of dashes
-  auto name_begin = name.begin();
-  while (*name_begin == '-')
-    ++name_begin;
-  std::replace(name_begin, name.end(), '-', '_');
-  found_it = command_line->search(name);
-
-  if (found_it)
+  // on_command_line also puts the command_line cursor in the spot we
+  // need
+  if (on_command_line(name))
     return command_line->next(value);
 
   return value;

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -873,12 +873,34 @@ void enableSEGV(bool on)
 
 
 
-bool on_command_line (const std::string & arg)
+bool on_command_line (std::string arg)
 {
   // Make sure the command line parser is ready for use
   libmesh_assert(command_line.get());
 
-  return command_line->search (arg);
+  // Users had better not be asking about an empty string
+  libmesh_assert(!arg.empty());
+
+  bool found_it = command_line->search(arg);
+
+  if (!found_it)
+    {
+      // Try with all dashes instead of underscores
+      std::replace(arg.begin(), arg.end(), '_', '-');
+      found_it = command_line->search(arg);
+    }
+
+  if (!found_it)
+    {
+      // OK, try with all underscores instead of dashes
+      auto name_begin = arg.begin();
+      while (*name_begin == '-')
+        ++name_begin;
+      std::replace(name_begin, arg.end(), '-', '_');
+      found_it = command_line->search(arg);
+    }
+
+  return found_it;
 }
 
 

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -938,13 +938,35 @@ T command_line_value (const std::vector<std::string> & name, T value)
 
 
 template <typename T>
-T command_line_next (const std::string & name, T value)
+T command_line_next (std::string name, T value)
 {
   // Make sure the command line parser is ready for use
   libmesh_assert(command_line.get());
 
-  if (command_line->search(1, name.c_str()))
-    value = command_line->next(value);
+  // Users had better not be asking about an empty string
+  libmesh_assert(!name.empty());
+
+  bool found_it = command_line->search(1, name.c_str());
+
+  if (found_it)
+    return command_line->next(value);
+
+  // Try with all dashes instead of underscores
+  std::replace(name.begin(), name.end(), '_', '-');
+  found_it = command_line->search(1, name.c_str());
+
+  if (found_it)
+    return command_line->next(value);
+
+  // OK, try with all underscores instead of dashes
+  auto name_begin = name.begin();
+  while (*name_begin == '-')
+    ++name_begin;
+  std::replace(name_begin, name.end(), '-', '_');
+  found_it = command_line->search(name);
+
+  if (found_it)
+    return command_line->next(value);
 
   return value;
 }
@@ -1045,11 +1067,11 @@ template double       command_line_value<double>      (const std::vector<std::st
 template long double  command_line_value<long double> (const std::vector<std::string> &, long double);
 template std::string  command_line_value<std::string> (const std::vector<std::string> &, std::string);
 
-template int          command_line_next<int>         (const std::string &, int);
-template float        command_line_next<float>       (const std::string &, float);
-template double       command_line_next<double>      (const std::string &, double);
-template long double  command_line_next<long double> (const std::string &, long double);
-template std::string  command_line_next<std::string> (const std::string &, std::string);
+template int          command_line_next<int>         (std::string, int);
+template float        command_line_next<float>       (std::string, float);
+template double       command_line_next<double>      (std::string, double);
+template long double  command_line_next<long double> (std::string, long double);
+template std::string  command_line_next<std::string> (std::string, std::string);
 
 template void         command_line_vector<int>         (const std::string &, std::vector<int> &);
 template void         command_line_vector<float>       (const std::string &, std::vector<float> &);

--- a/src/base/libmesh_common.C
+++ b/src/base/libmesh_common.C
@@ -81,8 +81,6 @@ void report_error(const char * file, int line, const char * date, const char * t
   reporting_error = true;
 
   if (libMesh::global_n_processors() == 1 ||
-      // Note: support both 'underscore' and 'dash' flavors of the option
-      libMesh::on_command_line("--print_trace") ||
       libMesh::on_command_line("--print-trace"))
     libMesh::print_trace();
   else

--- a/src/geom/node.C
+++ b/src/geom/node.C
@@ -83,7 +83,7 @@ Node::choose_processor_id(processor_id_type pid1, processor_id_type pid2) const
   // Do we want the new load-balanced node partitioning heuristic
   // instead of the default partitioner-friendlier heuristic?
   static bool load_balanced_nodes =
-    libMesh::on_command_line ("--load_balanced_nodes");
+    libMesh::on_command_line ("--load-balanced-nodes");
 
   // For better load balancing, we can use the min
   // even-numberered nodes and the max for odd-numbered.

--- a/src/solvers/newton_solver.C
+++ b/src/solvers/newton_solver.C
@@ -258,7 +258,7 @@ void NewtonSolver::init()
 {
   Parent::init();
 
-  if (libMesh::on_command_line("--solver_system_names"))
+  if (libMesh::on_command_line("--solver-system-names"))
     _linear_solver->init((_system.name()+"_").c_str());
   else
     _linear_solver->init();

--- a/src/solvers/petsc_auto_fieldsplit.C
+++ b/src/solvers/petsc_auto_fieldsplit.C
@@ -60,14 +60,14 @@ void petsc_auto_fieldsplit (PC my_pc,
 {
   std::string sys_prefix = "--solver_group_";
 
-  if (libMesh::on_command_line("--solver_system_names"))
+  if (libMesh::on_command_line("--solver-system-names"))
     {
       sys_prefix = sys_prefix + sys.name() + "_";
     }
 
   std::map<std::string, std::vector<dof_id_type>> group_indices;
 
-  if (libMesh::on_command_line("--solver_variable_names"))
+  if (libMesh::on_command_line("--solver-variable-names"))
     {
       for (unsigned int v = 0; v != sys.n_vars(); ++v)
         {
@@ -115,7 +115,7 @@ namespace libMesh
 void petsc_auto_fieldsplit (PC /* my_pc */,
                             const System & /* sys */)
 {
-  if (libMesh::on_command_line("--solver_variable_names"))
+  if (libMesh::on_command_line("--solver-variable-names"))
     {
       libmesh_do_once(
                       libMesh::out << "WARNING: libMesh does not support setting field splits" <<

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -340,7 +340,7 @@ void PetscDiffSolver::setup_petsc_data()
                          this, PETSC_NULL);
   LIBMESH_CHKERR(ierr);
 
-  if (libMesh::on_command_line("--solver_system_names"))
+  if (libMesh::on_command_line("--solver-system-names"))
     {
       ierr = SNESSetOptionsPrefix(_snes, (_system.name()+"_").c_str());
       LIBMESH_CHKERR(ierr);

--- a/src/solvers/time_solver.C
+++ b/src/solvers/time_solver.C
@@ -53,7 +53,7 @@ void TimeSolver::reinit ()
 
   libmesh_assert(this->linear_solver().get());
   this->linear_solver()->clear();
-  if (libMesh::on_command_line("--solver_system_names"))
+  if (libMesh::on_command_line("--solver-system-names"))
     this->linear_solver()->init((_system.name()+"_").c_str());
   else
     this->linear_solver()->init();
@@ -78,7 +78,7 @@ void TimeSolver::init_data ()
 {
   this->diff_solver()->init();
 
-  if (libMesh::on_command_line("--solver_system_names"))
+  if (libMesh::on_command_line("--solver-system-names"))
     this->linear_solver()->init((_system.name()+"_").c_str());
   else
     this->linear_solver()->init();

--- a/src/systems/continuation_system.C
+++ b/src/systems/continuation_system.C
@@ -60,7 +60,7 @@ ContinuationSystem::ContinuationSystem (EquationSystems & es,
   // Warn about using untested code
   libmesh_experimental();
 
-  if (libMesh::on_command_line("--solver_system_names"))
+  if (libMesh::on_command_line("--solver-system-names"))
     linear_solver->init((this->name()+"_").c_str());
   else
     linear_solver->init();

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -1411,7 +1411,7 @@ LinearSolver<Number> * ImplicitSystem::get_linear_solver() const
   LinearSolver<Number> * new_solver =
     LinearSolver<Number>::build(this->comm()).release();
 
-  if (libMesh::on_command_line("--solver_system_names"))
+  if (libMesh::on_command_line("--solver-system-names"))
     new_solver->init((this->name()+"_").c_str());
   else
     new_solver->init();

--- a/src/systems/linear_implicit_system.C
+++ b/src/systems/linear_implicit_system.C
@@ -116,7 +116,7 @@ void LinearImplicitSystem::solve ()
     this->get_equation_systems();
 
   // If the linear solver hasn't been initialized, we do so here.
-  if (libMesh::on_command_line("--solver_system_names"))
+  if (libMesh::on_command_line("--solver-system-names"))
     linear_solver->init((this->name()+"_").c_str());
   else
     linear_solver->init();

--- a/src/systems/nonlinear_implicit_system.C
+++ b/src/systems/nonlinear_implicit_system.C
@@ -171,7 +171,7 @@ void NonlinearImplicitSystem::solve ()
     }
   else
     {
-      if (libMesh::on_command_line("--solver_system_names"))
+      if (libMesh::on_command_line("--solver-system-names"))
         nonlinear_solver->init((this->name()+"_").c_str());
       else
         nonlinear_solver->init();

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -159,7 +159,7 @@ void System::read_header (Xdr & io,
   // This will be true if the version string contains " with infinite elements"
   const bool read_ifem_info =
     (version.rfind(" with infinite elements") < version.size()) ||
-    libMesh::on_command_line ("--read_ifem_systems");
+    libMesh::on_command_line ("--read-ifem-systems");
 
 
   {

--- a/tests/base/getpot_test.C
+++ b/tests/base/getpot_test.C
@@ -6,6 +6,9 @@
 
 #include <libmesh/getpot.h>
 
+// For command_line shim methods
+#include <libmesh/libmesh.h>
+
 // THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
 // std::auto_ptr, which in turn produces -Wdeprecated-declarations
 // warnings.  These can be ignored in GCC as long as we wrap the
@@ -26,6 +29,7 @@ public:
   CPPUNIT_TEST( testVariables );
   CPPUNIT_TEST( testSections );
   CPPUNIT_TEST( testSubSections );
+  CPPUNIT_TEST( testCommandLine );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -172,6 +176,23 @@ public:
       input.get_subsection_names("Section3");
 
     CPPUNIT_ASSERT(subsections3.empty());
+  }
+
+  void testCommandLine()
+  {
+    // Test whether the new dash/underscore agnosticism works
+    //
+    // This means the unit_tests-foo executable *must* be run with
+    // options equivalent to the asserted ones and without options
+    // equivalent to the anti-asserted ones.
+    CPPUNIT_ASSERT(libMesh::on_command_line("--option-with-underscores"));
+    CPPUNIT_ASSERT(libMesh::on_command_line("--option_with_underscores"));
+    CPPUNIT_ASSERT(libMesh::on_command_line("--option-with-dashes"));
+    CPPUNIT_ASSERT(libMesh::on_command_line("--option_with_dashes"));
+    CPPUNIT_ASSERT(!libMesh::on_command_line("--option-with-lies"));
+    CPPUNIT_ASSERT(!libMesh::on_command_line("--option_with_lies"));
+    CPPUNIT_ASSERT_EQUAL(libMesh::command_line_next("--option-with-underscores", 2), 3);
+    CPPUNIT_ASSERT_EQUAL(libMesh::command_line_next("--option_with_underscores", 2), 3);
   }
 
 };

--- a/tests/run_unit_tests.sh.in
+++ b/tests/run_unit_tests.sh.in
@@ -7,5 +7,5 @@ for method in @METHODS@; do
 @LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@      continue;
 @LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@    fi
     echo $LIBMESH_RUN ./unit_tests-$method
-    $LIBMESH_RUN ./unit_tests-$method
+    $LIBMESH_RUN ./unit_tests-$method --option-with-dashes --option_with_underscores 3
 done


### PR DESCRIPTION
This should resolve #1269.

Hopefully the new unit tests are enough to make sure that's true.  We don't seem to actually have any previous CI coverage of these options, and I don't know how often folks are currently running FIN-S with an updated libMesh.