### PR TITLE
Add prepare_for_use call after VTK read.

### DIFF
--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -235,6 +235,8 @@ void VTKIO::read (const std::string & name)
                       << mesh.mesh_dimension()                  \
                       << "D support.");
 #endif // LIBMESH_DIM < 3
+  
+  mesh.prepare_for_use();
 }
 
 


### PR DESCRIPTION
To fix [this issue](https://github.com/libMesh/libmesh/issues/1680)