### PR TITLE
 Add NemesisIO::set_output_variables() interface

### DIFF
--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -87,6 +87,18 @@ public:
                        const Real time);
 
   /**
+   * Specify the list of variables which should be included in the
+   * output (whitelist) If empty, then all variables will be present
+   * in the output.
+   *
+   * This interface is copied from ExodusII_IO since it was found to
+   * be useful there, but perhaps eventually these implementations
+   * could somehow be combined.
+   */
+  void set_output_variables(const std::vector<std::string> & output_variables,
+                            bool allow_empty = true);
+
+  /**
    * Output a nodal solution.
    */
   virtual void write_nodal_data (const std::string & fname,
@@ -152,6 +164,19 @@ private:
    */
   void prepare_to_write_nodal_data (const std::string & fname,
                                     const std::vector<std::string> & names);
+
+  /**
+   * The names of the variables to be output.
+   * If this is empty then all variables are output.
+   */
+  std::vector<std::string> _output_variables;
+
+  /**
+   * If true, _output_variables is allowed to remain empty.
+   * If false, if _output_variables is empty it will be populated with a complete list of all variables
+   * By default, calling set_output_variables() sets this flag to true, but it provides an override.
+   */
+  bool _allow_empty_variables;
 };
 
 

--- a/include/mesh/nemesis_io_helper.h
+++ b/include/mesh/nemesis_io_helper.h
@@ -298,6 +298,10 @@ public:
   /**
    * Takes a parallel solution vector containing the node-major
    * solution vector for all variables and outputs it to the files.
+   * \param parallel_soln
+   * \param names A vector containing the names of _all_ variables in parallel_soln.
+   * \param timestep To be passed to the ExodusII_IO_Helper::write_nodal_values() function.
+   * \param output_names A vector containing the names of variables in parallel_soln that should actually be written (whitelist).
    *
    * \note This version of write_nodal_solution() is called by the
    * parallel version of Nemesis_IO::write_nodal_data(), which is
@@ -308,7 +312,8 @@ public:
    */
   void write_nodal_solution(const NumericVector<Number> & parallel_soln,
                             const std::vector<std::string> & names,
-                            int timestep);
+                            int timestep,
+                            const std::vector<std::string> & output_names);
 
   /**
    * Takes a solution vector containing the solution for all variables and outputs it to the files

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -765,22 +765,17 @@ void ExodusII_IO::write_nodal_data (const std::string & fname,
       // order of [num_vars * node_id + var_id]. We now copy the
       // proper solution values contiguously into "cur_soln",
       // removing the gaps.
-      {
-        MeshBase::const_node_iterator it = mesh.nodes_begin();
-        const MeshBase::const_node_iterator end = mesh.nodes_end();
-        for (; it != end; ++it)
-          {
-            const Node * node = *it;
-            dof_id_type idx = node->id()*num_vars + c;
+      for (const auto & node : mesh.node_ptr_range())
+        {
+          dof_id_type idx = node->id()*num_vars + c;
 #ifdef LIBMESH_USE_REAL_NUMBERS
-            cur_soln.push_back(soln[idx]);
+          cur_soln.push_back(soln[idx]);
 #else
-            real_parts.push_back(soln[idx].real());
-            imag_parts.push_back(soln[idx].imag());
-            magnitudes.push_back(std::abs(soln[idx]));
+          real_parts.push_back(soln[idx].real());
+          imag_parts.push_back(soln[idx].imag());
+          magnitudes.push_back(std::abs(soln[idx]));
 #endif
-          }
-      }
+        }
 
       // Finally, actually call the Exodus API to write to file.
 #ifdef LIBMESH_USE_REAL_NUMBERS

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -1348,11 +1348,21 @@ void Nemesis_IO::write_nodal_data (const std::string & base_filename,
 {
   LOG_SCOPE("write_nodal_data(parallel)", "Nemesis_IO");
 
-  this->prepare_to_write_nodal_data(base_filename, names);
+  // Only prepare and write nodal variables that are also in
+  // _output_variables, unless _output_variables is empty. This is the
+  // same logic that is in ExodusII_IO::write_nodal_data().
+  std::vector<std::string> output_names;
+
+  if (_allow_empty_variables || !_output_variables.empty())
+    output_names = _output_variables;
+  else
+    output_names = names;
+
+  this->prepare_to_write_nodal_data(base_filename, output_names);
 
   // Call the new version of write_nodal_solution() that takes a
   // NumericVector directly without localizing.
-  nemhelper->write_nodal_solution(parallel_soln, names, _timestep);
+  nemhelper->write_nodal_solution(parallel_soln, names, _timestep, output_names);
 }
 
 #else

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -97,7 +97,8 @@ Nemesis_IO::Nemesis_IO (MeshBase & mesh,
   _timestep(1),
 #endif
   _verbose (false),
-  _append(false)
+  _append(false),
+  _allow_empty_variables(false)
 {
 }
 
@@ -127,6 +128,15 @@ void Nemesis_IO::verbose (bool set_verbosity)
 void Nemesis_IO::append(bool val)
 {
   _append = val;
+}
+
+
+
+void Nemesis_IO::set_output_variables(const std::vector<std::string> & output_variables,
+                                      bool allow_empty)
+{
+  _output_variables = output_variables;
+  _allow_empty_variables = allow_empty;
 }
 
 

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2516,8 +2516,6 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
 {
   int num_vars = cast_int<int>(names.size());
 
-#ifndef LIBMESH_USE_COMPLEX_NUMBERS
-
   for (int c=0; c<num_vars; c++)
     {
       // If we are not writing this variable, skip to the next loop
@@ -2537,31 +2535,10 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
       std::vector<Number> local_soln;
       parallel_soln.localize(local_soln, required_indices);
 
+#ifndef LIBMESH_USE_COMPLEX_NUMBERS
       // Call the ExodusII_IO_Helper function to write the data.
       write_nodal_values(c+1, local_soln, timestep);
-    }
-
-#else // LIBMESH_USE_COMPLEX_NUMBERS
-
-  for (int c=0; c<num_vars; c++)
-    {
-      // If we are not writing this variable, skip to the next loop
-      // iteration. This is needed to keep the indexing consistent
-      // with the ordering of parallel_soln.
-      if (std::find(output_names.begin(), output_names.end(), names[c]) == output_names.end())
-        continue;
-
-      // Fill up a std::vector with the dofs for the current variable
-      std::vector<numeric_index_type> required_indices(num_nodes);
-
-      for (int i=0; i<num_nodes; i++)
-        required_indices[i] = this->exodus_node_num_to_libmesh[i]*num_vars + c;
-
-      // Get the dof values required to write just our local part of
-      // the solution vector.
-      std::vector<Number> local_soln;
-      parallel_soln.localize(local_soln, required_indices);
-
+#else
       // We have the local (complex) values. Now extract the real,
       // imaginary, and magnitude values from them.
       std::vector<Real> real_parts(num_nodes);
@@ -2579,11 +2556,8 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
       write_nodal_values(3*c+1, real_parts, timestep);
       write_nodal_values(3*c+2, imag_parts, timestep);
       write_nodal_values(3*c+3, magnitudes, timestep);
-    }
-
 #endif
-
-
+    }
 }
 
 

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2511,7 +2511,8 @@ void Nemesis_IO_Helper::write_nodal_solution(const std::vector<Number> & values,
 
 void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & parallel_soln,
                                              const std::vector<std::string> & names,
-                                             int timestep)
+                                             int timestep,
+                                             const std::vector<std::string> & output_names)
 {
   int num_vars = cast_int<int>(names.size());
 
@@ -2519,6 +2520,12 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
 
   for (int c=0; c<num_vars; c++)
     {
+      // If we are not writing this variable, skip to the next loop
+      // iteration. This is needed to keep the indexing consistent
+      // with the ordering of parallel_soln.
+      if (std::find(output_names.begin(), output_names.end(), names[c]) == output_names.end())
+        continue;
+
       // Fill up a std::vector with the dofs for the current variable
       std::vector<numeric_index_type> required_indices(num_nodes);
 
@@ -2538,6 +2545,12 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
 
   for (int c=0; c<num_vars; c++)
     {
+      // If we are not writing this variable, skip to the next loop
+      // iteration. This is needed to keep the indexing consistent
+      // with the ordering of parallel_soln.
+      if (std::find(output_names.begin(), output_names.end(), names[c]) == output_names.end())
+        continue;
+
       // Fill up a std::vector with the dofs for the current variable
       std::vector<numeric_index_type> required_indices(num_nodes);
 


### PR DESCRIPTION
This PR allows us to specify exactly which nodal variables are written to Nemesis files. 

It duplicates some functionality that was already present in the Exodus writer, but never ported over to the Nemesis side. It would be nice to avoid this feature disparity/code duplication issue. One idea for doing so is to have `NemesisIO` derive from `ExodusII_IO` as the helper classes already do...