### PR TITLE
Get exio helper

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -572,7 +572,6 @@ DISTCLEANFILES = libmesh_config.h
 # details which are not required for the public interface
 noinst_HEADERS = \
         base/libmesh_augment_std_namespace.h \
-        mesh/exodusII_io_helper.h \
         mesh/nemesis_io_helper.h \
         numerics/laspack_matrix.h \
         numerics/laspack_vector.h \
@@ -738,6 +737,7 @@ include_HEADERS = \
         mesh/distributed_mesh.h \
         mesh/ensight_io.h \
         mesh/exodusII_io.h \
+        mesh/exodusII_io_helper.h \
         mesh/fro_io.h \
         mesh/gmsh_io.h \
         mesh/gmv_io.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -4,7 +4,6 @@
 # details which are not required for the public interface
 noinst_HEADERS =  \
         base/libmesh_augment_std_namespace.h \
-        mesh/exodusII_io_helper.h \
         mesh/nemesis_io_helper.h \
         numerics/laspack_matrix.h \
         numerics/laspack_vector.h \
@@ -169,6 +168,7 @@ include_HEADERS =  \
         mesh/distributed_mesh.h \
         mesh/ensight_io.h \
         mesh/exodusII_io.h \
+        mesh/exodusII_io_helper.h \
         mesh/fro_io.h \
         mesh/gmsh_io.h \
         mesh/gmv_io.h \

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -298,6 +298,13 @@ public:
    */
   const std::vector<std::string> & get_nodal_var_names();
 
+#ifdef LIBMESH_HAVE_EXODUS_API
+  /**
+   * Return a reference to the ExodusII_IO_Helper object.
+   */
+  ExodusII_IO_Helper & get_exio_helper();
+#endif
+
 private:
   /**
    * Only attempt to instantiate an ExodusII helper class

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -305,6 +305,14 @@ public:
   ExodusII_IO_Helper & get_exio_helper();
 #endif
 
+  /**
+   * This function factors out a bunch of code which is common to the
+   * write_nodal_data() and write_nodal_data_discontinuous() functions
+   */
+  void write_nodal_data_common(std::string fname,
+                               const std::vector<std::string> & names,
+                               bool continuous=true);
+
 private:
   /**
    * Only attempt to instantiate an ExodusII helper class
@@ -337,14 +345,6 @@ private:
    * If this is empty then all variables are output.
    */
   std::vector<std::string> _output_variables;
-
-  /**
-   * This function factors out a bunch of code which is common to the
-   * write_nodal_data() and write_nodal_data_discontinuous() functions
-   */
-  void write_nodal_data_common(std::string fname,
-                               const std::vector<std::string> & names,
-                               bool continuous=true);
 
   /**
    * If true, _output_variables is allowed to remain empty.

--- a/include/rebuild_include_HEADERS.sh
+++ b/include/rebuild_include_HEADERS.sh
@@ -3,7 +3,6 @@
 # these specific headers are required to build libMesh
 # but we do not want to install them!
 noinst_blacklist="base/libmesh_augment_std_namespace.h \
-mesh/exodusII_io_helper.h \
 mesh/nemesis_io_helper.h \
 numerics/laspack_matrix.h \
 numerics/laspack_vector.h \

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1041,6 +1041,11 @@ const std::vector<std::string> & ExodusII_IO::get_elem_var_names()
   return exio_helper->elem_var_names;
 }
 
+ExodusII_IO_Helper & ExodusII_IO::get_exio_helper()
+{
+  return *exio_helper;
+}
+
 
 // LIBMESH_HAVE_EXODUS_API is not defined, declare error() versions of functions...
 #else

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1043,6 +1043,11 @@ const std::vector<std::string> & ExodusII_IO::get_elem_var_names()
 
 ExodusII_IO_Helper & ExodusII_IO::get_exio_helper()
 {
+  // Provide a warning when accessing the helper object
+  // since it is a non-public API and is likely to see
+  // future API changes
+  libmesh_experimental();
+
   return *exio_helper;
 }
 


### PR DESCRIPTION
In order to have full flexibility with ExodusII input/output, it can be useful to have access to the ExodusII_IO_helper object. This PR provides a "getter" for that object.

We also had to remove exodusII_io_helper.h from the noinst_blacklist so that it is accessible from app codes.