### PR TITLE
Fix potential overflow issue in NemesisIO.

### DIFF
--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -2528,7 +2528,7 @@ void Nemesis_IO_Helper::write_nodal_solution(const NumericVector<Number> & paral
       std::vector<numeric_index_type> required_indices(num_nodes);
 
       for (int i=0; i<num_nodes; i++)
-        required_indices[i] = this->exodus_node_num_to_libmesh[i]*num_vars + c;
+        required_indices[i] = static_cast<dof_id_type>(this->exodus_node_num_to_libmesh[i]) * num_vars + c;
 
       // Get the dof values required to write just our local part of
       // the solution vector.


### PR DESCRIPTION
The original line of code had an arithmetic expression involving the
product of two ints in order to compute an implied degree of freedom
index. Unfortunately, in some cases this product was large enough to
overflow, leading to a negative value which was subsequently cast to
an (unsigned) dof_id_type, leading to a huge number. Upgrading the
first operand to dof_id_type is a simple fix for the problem.

cc: @YaqiWang