### PR TITLE
Add missing return in switch statement

### DIFF
--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -247,6 +247,7 @@ void InfQuad4::connectivity(const unsigned int libmesh_dbg_var(sf),
         conn[1] = this->node_id(1);
         conn[2] = this->node_id(3);
         conn[3] = this->node_id(2);
+        return;
       }
     default:
       libmesh_error_msg("Unsupported IO package " << iop);


### PR DESCRIPTION
Previously all the many many people who use VTK output of infinite
quads would hit errors!

This bug dates back to commit 4859f74, a refactoring in July 2004.

Hopefully this record for "longest-unfixed libMesh bug ever" will
never be beaten.