### PR TITLE
New parallel_sync.h algorithms for parallel_ghost_sync.h backend

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -851,6 +851,7 @@ include_HEADERS = \
         parallel/parallel_object.h \
         parallel/parallel_only.h \
         parallel/parallel_sort.h \
+        parallel/parallel_sync.h \
         parallel/post_wait_copy_buffer.h \
         parallel/post_wait_delete_buffer.h \
         parallel/post_wait_free_buffer.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -282,6 +282,7 @@ include_HEADERS =  \
         parallel/parallel_object.h \
         parallel/parallel_only.h \
         parallel/parallel_sort.h \
+        parallel/parallel_sync.h \
         parallel/post_wait_copy_buffer.h \
         parallel/post_wait_delete_buffer.h \
         parallel/post_wait_free_buffer.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -276,6 +276,7 @@ BUILT_SOURCES = \
         parallel_object.h \
         parallel_only.h \
         parallel_sort.h \
+        parallel_sync.h \
         post_wait_copy_buffer.h \
         post_wait_delete_buffer.h \
         post_wait_free_buffer.h \
@@ -1349,6 +1350,9 @@ parallel_only.h: $(top_srcdir)/include/parallel/parallel_only.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 parallel_sort.h: $(top_srcdir)/include/parallel/parallel_sort.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+parallel_sync.h: $(top_srcdir)/include/parallel/parallel_sync.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 post_wait_copy_buffer.h: $(top_srcdir)/include/parallel/post_wait_copy_buffer.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -572,12 +572,12 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	parallel_conversion_utils.h parallel_elem.h \
 	parallel_ghost_sync.h parallel_hilbert.h parallel_histogram.h \
 	parallel_implementation.h parallel_node.h parallel_object.h \
-	parallel_only.h parallel_sort.h post_wait_copy_buffer.h \
-	post_wait_delete_buffer.h post_wait_free_buffer.h \
-	post_wait_unpack_buffer.h post_wait_work.h request.h \
-	standard_type.h status.h threads.h threads_allocators.h \
-	threads_none.h threads_pthread.h threads_tbb.h \
-	centroid_partitioner.h hilbert_sfc_partitioner.h \
+	parallel_only.h parallel_sort.h parallel_sync.h \
+	post_wait_copy_buffer.h post_wait_delete_buffer.h \
+	post_wait_free_buffer.h post_wait_unpack_buffer.h \
+	post_wait_work.h request.h standard_type.h status.h threads.h \
+	threads_allocators.h threads_none.h threads_pthread.h \
+	threads_tbb.h centroid_partitioner.h hilbert_sfc_partitioner.h \
 	linear_partitioner.h mapped_subdomain_partitioner.h \
 	metis_csr_graph.h metis_partitioner.h morton_sfc_partitioner.h \
 	parmetis_helper.h parmetis_partitioner.h partitioner.h \
@@ -1686,6 +1686,9 @@ parallel_only.h: $(top_srcdir)/include/parallel/parallel_only.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 parallel_sort.h: $(top_srcdir)/include/parallel/parallel_sort.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+parallel_sync.h: $(top_srcdir)/include/parallel/parallel_sync.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 post_wait_copy_buffer.h: $(top_srcdir)/include/parallel/post_wait_copy_buffer.h

--- a/include/mesh/sync_refinement_flags.h
+++ b/include/mesh/sync_refinement_flags.h
@@ -73,14 +73,14 @@ struct SyncRefinementFlags
   }
 
   void act_on_data (const std::vector<dof_id_type> & ids,
-                    std::vector<datum> & flags)
+                    const std::vector<datum> & flags)
   {
     for (std::size_t i=0; i != ids.size(); ++i)
       {
         Elem & elem = mesh.elem_ref(ids[i]);
 
         datum old_flag = (elem.*get_flag)();
-        datum & new_flag = flags[i];
+        datum new_flag = flags[i];
 
         if (old_flag != new_flag)
           {

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -27,6 +27,7 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_algebra.h"
+#include "libmesh/parallel_sync.h"
 
 
 namespace libMesh

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -552,8 +552,6 @@ bool sync_node_data_by_element_id_once(MeshBase & mesh,
 {
   const Communicator & comm (mesh.comm());
 
-  bool data_changed = false;
-
   // Count the objects to ask each processor about
   std::vector<dof_id_type>
     ghost_objects_from_proc(comm.size(), 0);
@@ -582,17 +580,17 @@ bool sync_node_data_by_element_id_once(MeshBase & mesh,
   // Now repeat that iteration, filling request sets this time.
 
   // Request sets to send to each processor
-  std::vector<std::vector<std::pair<dof_id_type, unsigned char>>>
-    requested_objs_elem_id_node_num(comm.size());
+  std::map<dof_id_type, std::vector<std::pair<dof_id_type, unsigned char>>>
+    requested_objs_elem_id_node_num;
 
   // Keep track of current local ids for each too
-  std::vector<std::vector<dof_id_type>>
-    requested_objs_id(comm.size());
+  std::map<dof_id_type, std::vector<dof_id_type>>
+    requested_objs_id;
 
   // We know how many objects live on each processor, so reserve()
   // space for each.
   for (processor_id_type p=0; p != comm.size(); ++p)
-    if (p != comm.rank())
+    if (p != comm.rank() && ghost_objects_from_proc[p])
       {
         requested_objs_elem_id_node_num[p].reserve(ghost_objects_from_proc[p]);
         requested_objs_id[p].reserve(ghost_objects_from_proc[p]);
@@ -628,35 +626,20 @@ bool sync_node_data_by_element_id_once(MeshBase & mesh,
         }
     }
 
-  // Trade requests with other processors
-  for (processor_id_type p=1; p != comm.size(); ++p)
+  auto gather_functor =
+    [&mesh, &sync]
+    (processor_id_type,
+     const std::vector<std::pair<dof_id_type, unsigned char>> & elem_id_node_num,
+     std::vector<typename SyncFunctor::datum> & data)
     {
-      // Trade my requests with processor procup and procdown
-      const processor_id_type procup =
-        cast_int<processor_id_type>
-        ((comm.rank() + p) % comm.size());
-      const processor_id_type procdown =
-        cast_int<processor_id_type>
-        ((comm.size() + comm.rank() - p) %
-         comm.size());
-
-      libmesh_assert_equal_to (requested_objs_id[procup].size(),
-                               ghost_objects_from_proc[procup]);
-      libmesh_assert_equal_to (requested_objs_elem_id_node_num[procup].size(),
-                               ghost_objects_from_proc[procup]);
-
-      std::vector<std::pair<dof_id_type,unsigned char>> request_to_fill;
-      comm.send_receive(procup, requested_objs_elem_id_node_num[procup],
-                        procdown, request_to_fill);
-
       // Find the id of each requested element
-      std::size_t request_size = request_to_fill.size();
-      std::vector<dof_id_type> request_to_fill_id(request_size);
+      std::size_t request_size = elem_id_node_num.size();
+      std::vector<dof_id_type> query_id(request_size);
       for (std::size_t i=0; i != request_size; ++i)
         {
-          const Elem & elem = mesh.elem_ref(request_to_fill[i].first);
+          const Elem & elem = mesh.elem_ref(elem_id_node_num[i].first);
 
-          const unsigned int n = request_to_fill[i].second;
+          const unsigned int n = elem_id_node_num[i].second;
           libmesh_assert_less (n, elem.n_nodes());
 
           const Node & node = elem.node_ref(n);
@@ -665,27 +648,34 @@ bool sync_node_data_by_element_id_once(MeshBase & mesh,
           // syncing processor ids
           // libmesh_assert_equal_to (node->processor_id(), comm.rank());
 
-          request_to_fill_id[i] = node.id();
+          query_id[i] = node.id();
         }
 
       // Gather whatever data the user wants
-      std::vector<typename SyncFunctor::datum> data;
-      sync.gather_data(request_to_fill_id, data);
+      sync.gather_data(query_id, data);
+    };
 
-      // Trade back the results
-      std::vector<typename SyncFunctor::datum> received_data;
-      comm.send_receive(procdown, data,
-                        procup, received_data);
-      libmesh_assert_equal_to (requested_objs_elem_id_node_num[procup].size(),
-                               received_data.size());
+  bool data_changed = false;
 
+  auto action_functor =
+    [&sync, &requested_objs_id, &data_changed]
+    (processor_id_type pid,
+     const std::vector<std::pair<dof_id_type, unsigned char>> &,
+     const std::vector<typename SyncFunctor::datum> & data)
+    {
       // Let the user process the results.  If any of the results
-      // were different than what the user expected, then we'll
+      // were different than what the user expected, then we may
       // need to sync again just in case this processor has to
       // pass on the changes to yet another processor.
-      if (sync.act_on_data(requested_objs_id[procup], received_data))
+      if (sync.act_on_data(requested_objs_id[pid], data))
         data_changed = true;
-    }
+    };
+
+  // Trade requests with other processors
+  typename SyncFunctor::datum * ex = libmesh_nullptr;
+  pull_parallel_vector_data
+    (comm, requested_objs_elem_id_node_num, gather_functor,
+     action_functor, ex);
 
   comm.max(data_changed);
 

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -756,7 +756,7 @@ struct SyncNodalPositions
 
   // Second required interface.  This function must do something with the data in
   // the data vector for the ids in the ids vector.
-  void act_on_data (const std::vector<dof_id_type> & ids, std::vector<datum> & data) const;
+  void act_on_data (const std::vector<dof_id_type> & ids, const std::vector<datum> & data) const;
 
   MeshBase & mesh;
 };

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -441,13 +441,15 @@ void pull_parallel_vector_data(const Communicator & comm,
     response_data, received_data;
   std::vector<Request> response_reqs;
 
+  StandardType<datum> datatype;
+
   auto gather_functor =
-    [&comm, &gather_data, &response_data, &response_reqs]
+    [&comm, &gather_data, &response_data, &response_reqs, &datatype]
     (processor_id_type pid, query_type query)
     {
       Request sendreq;
       gather_data(pid, query, response_data[pid]);
-      comm.send(pid, response_data[pid], sendreq);
+      comm.send(pid, response_data[pid], datatype, sendreq);
       response_reqs.push_back(sendreq);
     };
 
@@ -464,7 +466,7 @@ void pull_parallel_vector_data(const Communicator & comm,
       Request req;
       auto & incoming_data = received_data[proc_id];
       incoming_data.resize(querydata.size());
-      comm.receive(proc_id, incoming_data, req);
+      comm.receive(proc_id, incoming_data, datatype, req);
       receive_reqs.push_back(req);
       receive_procids.push_back(proc_id);
     }

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -1,0 +1,331 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2018 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_PARALLEL_SYNC_H
+#define LIBMESH_PARALLEL_SYNC_H
+
+// Local Includes
+#include "libmesh/parallel.h"
+
+// C++ includes
+#include <map>
+#include <vector>
+
+
+namespace libMesh
+{
+
+
+
+//--------------------------------------------------------------------------
+namespace Parallel {
+
+//------------------------------------------------------------------------
+/**
+ * Send and receive and act on vectors of data.
+ *
+ * The \p data map is indexed by processor ids as keys, and for each
+ * processor id in the map there should be a vector of data to send.
+ *
+ * Data which is received from other processors will be operated on by
+ * act_on_data(processor_id_type pid, const std::vector<datum> & data)
+ *
+ * No guarantee about operation ordering is made - this function will
+ * attempt to act on data in the order in which it is received.
+ *
+ * All receives and actions are completed before this function
+ * returns.
+ *
+ * Not all sends may have yet completed.  The supplied container of
+ * Request objects, \p req, has more requests inserted, one for each
+ * of the data sends.  These requests must be waited on before the \p
+ * data map is deleted.
+ */
+template <typename MapToVectors,
+          typename RequestContainer,
+          typename ActionFunctor>
+void push_parallel_vector_data(const Communicator & comm,
+                               const MapToVectors & data,
+                               RequestContainer & reqs,
+                               ActionFunctor & act_on_data);
+
+
+
+/**
+ * Send and receive and act on vectors of data.
+ *
+ * The \p data map is indexed by processor ids as keys, and for each
+ * processor id in the map there should be a vector of data to send.
+ *
+ * Data which is received from other processors will be operated on by
+ * act_on_data(processor_id_type pid, const std::vector<datum> & data);
+ *
+ * No guarantee about operation ordering is made - this function will
+ * attempt to act on data in the order in which it is received.
+ *
+ * All communication and actions are complete when this function
+ * returns.
+ */
+template <typename MapToVectors,
+          typename ActionFunctor>
+void push_parallel_vector_data(const Communicator & comm,
+                               const MapToVectors & data,
+                               ActionFunctor & act_on_data);
+
+
+/**
+ * Send query vectors, receive and answer them with vectors of data,
+ * then act on those answers.
+ *
+ * The \p data map is indexed by processor ids as keys, and for each
+ * processor id in the map there should be a vector of query ids to send.
+ *
+ * Query data which is received from other processors will be operated
+ * on by
+ * gather_data(processor_id_type pid, const std::vector<id> & ids,
+ *             std::vector<datum> & data)
+ *
+ * Answer data which is received from other processors will be operated on by
+ * act_on_data(processor_id_type pid, const std::vector<id> & ids,
+ *             const std::vector<datum> & data);
+ *
+ * No guarantee about operation ordering is made - this function will
+ * attempt to act on data in the order in which it is received.
+ *
+ * All receives and actions are completed before this function
+ * returns.
+ *
+ * Not all sends may have yet completed.  The supplied container of
+ * Request objects, \p req, has more requests inserted, one for each
+ * of the data sends.  These requests must be waited on before the \p
+ * data map is deleted.
+ */
+template <typename datum,
+          typename MapToVectors,
+          typename RequestContainer,
+          typename GatherFunctor,
+          typename ActionFunctor>
+void pull_parallel_vector_data(const Communicator & comm,
+                               const MapToVectors & queries,
+                               RequestContainer & reqs,
+                               GatherFunctor & gather_data,
+                               ActionFunctor & act_on_data);
+
+/**
+ * Send query vectors, receive and answer them with vectors of data,
+ * then act on those answers.
+ *
+ * The \p data map is indexed by processor ids as keys, and for each
+ * processor id in the map there should be a vector of query ids to send.
+ *
+ * Query data which is received from other processors will be operated
+ * on by
+ * gather_data(processor_id_type pid, const std::vector<id> & ids,
+ *             std::vector<datum> & data)
+ *
+ * Answer data which is received from other processors will be operated on by
+ * act_on_data(processor_id_type pid, const std::vector<id> & ids,
+ *             const std::vector<datum> & data);
+ *
+ * No guarantee about operation ordering is made - this function will
+ * attempt to act on data in the order in which it is received.
+ *
+ * All communication and actions are complete when this function
+ * returns.
+ */
+template <typename datum,
+          typename MapToVectors,
+          typename GatherFunctor,
+          typename ActionFunctor>
+void pull_parallel_vector_data(const Communicator & comm,
+                               const MapToVectors & queries,
+                               GatherFunctor & gather_data,
+                               ActionFunctor & act_on_data);
+
+
+//------------------------------------------------------------------------
+// Parallel members
+//
+
+template <typename MapToVectors,
+          typename RequestContainer,
+          typename ActionFunctor>
+void push_parallel_vector_data(const Communicator & comm,
+                               const MapToVectors & data,
+                               RequestContainer & reqs,
+                               ActionFunctor & act_on_data)
+{
+  // This function must be run on all processors at once
+  libmesh_parallel_only(comm);
+
+  processor_id_type num_procs = comm.size();
+
+  // Size of vectors to send to each procesor
+  std::vector<std::size_t> will_send_to(num_procs, 0);
+  processor_id_type num_sends = 0;
+  for (auto & datapair : data)
+    {
+      will_send_to[datapair.first] = datapair.second.size();
+      num_sends++;
+    }
+
+  // Tell everyone about where everyone will send to
+  comm.alltoall(will_send_to);
+
+  // will_send_to now represents who we'll receive from
+  // give it a good name
+  auto & will_receive_from = will_send_to;
+
+  // Post all of the sends, non-blocking
+  for (auto & datapair : data)
+    {
+      processor_id_type destid = datapair.first;
+      auto & datum = datapair.second;
+      Request sendreq;
+      comm.send(destid, datum, sendreq);
+      reqs.insert(reqs.end(), sendreq);
+    }
+
+  // Post all of the receives, non-blocking
+  std::vector<Request> receive_reqs;
+  std::vector<processor_id_type> receive_procids;
+  MapToVectors received_data;
+  for (processor_id_type proc_id = 0; proc_id < num_procs; proc_id++)
+    if (will_receive_from[proc_id])
+      {
+        Request req;
+        auto & incoming_data = received_data[proc_id];
+        incoming_data.resize(will_receive_from[proc_id]);
+        comm.receive(proc_id, incoming_data, req);
+        receive_reqs.push_back(req);
+        receive_procids.push_back(proc_id);
+      }
+
+  while(receive_reqs.size())
+    {
+      std::size_t completed = waitany(receive_reqs);
+      processor_id_type proc_id = receive_procids[completed];
+      receive_reqs.erase(receive_reqs.begin() + completed);
+      receive_procids.erase(receive_procids.begin() + completed);
+
+      act_on_data(proc_id, received_data[proc_id]);
+      received_data.erase(proc_id);
+    }
+}
+
+
+template <typename MapToVectors,
+          typename ActionFunctor>
+void push_parallel_vector_data(const Communicator & comm,
+                               const MapToVectors & data,
+                               ActionFunctor & act_on_data)
+{
+  std::vector<Request> requests;
+
+  push_parallel_vector_data(comm, data, requests, act_on_data);
+
+  wait(requests);
+}
+
+
+template <typename datum,
+          typename MapToVectors,
+          typename RequestContainer,
+          typename GatherFunctor,
+          typename ActionFunctor>
+void pull_parallel_vector_data(const Communicator & comm,
+                               const MapToVectors & queries,
+                               RequestContainer & reqs,
+                               GatherFunctor & gather_data,
+                               ActionFunctor & act_on_data)
+{
+  typedef typename MapToVectors::mapped_type query_type;
+
+  std::map<processor_id_type, std::vector<datum> >
+    response_data, received_data;
+  std::vector<Request> response_reqs;
+
+  auto gather_functor =
+    [&comm, &gather_data, &response_data, &response_reqs]
+    (processor_id_type pid, query_type query)
+    {
+      Request sendreq;
+      gather_data(pid, query, response_data[pid]);
+      comm.send(pid, response_data[pid], sendreq);
+      response_reqs.push_back(sendreq);
+    };
+
+  push_parallel_vector_data (comm, queries, reqs, gather_functor);
+
+  // Every outgoing query should now have an incoming response.
+  // Post all of the receives, non-blocking
+  std::vector<Request> receive_reqs;
+  std::vector<processor_id_type> receive_procids;
+  for (auto & querypair : queries)
+    {
+      processor_id_type proc_id = querypair.first;
+      auto & querydata = querypair.second;
+      Request req;
+      auto & incoming_data = received_data[proc_id];
+      incoming_data.resize(querydata.size());
+      comm.receive(proc_id, incoming_data, req);
+      receive_reqs.push_back(req);
+      receive_procids.push_back(proc_id);
+    }
+
+  while(receive_reqs.size())
+    {
+      std::size_t completed = waitany(receive_reqs);
+      processor_id_type proc_id = receive_procids[completed];
+      receive_reqs.erase(receive_reqs.begin() + completed);
+      receive_procids.erase(receive_procids.begin() + completed);
+
+      act_on_data(proc_id, queries.at(proc_id), received_data[proc_id]);
+      received_data.erase(proc_id);
+    }
+
+  wait(response_reqs);
+}
+
+
+template <typename datum,
+          typename MapToVectors,
+          typename GatherFunctor,
+          typename ActionFunctor>
+void pull_parallel_vector_data(const Communicator & comm,
+                               const MapToVectors & queries,
+                               GatherFunctor & gather_data,
+                               ActionFunctor & act_on_data)
+{
+  std::vector<Request> requests;
+
+  pull_parallel_vector_data<datum>(comm, queries, requests,
+                                   gather_data, act_on_data);
+
+  wait(requests);
+}
+
+
+
+} // namespace Parallel
+
+
+} // namespace libMesh
+
+#endif // LIBMESH_PARALLEL_SYNC_H

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -574,6 +574,7 @@ void pull_parallel_vector_data(const Communicator & comm,
       std::vector<std::vector<datum,A>> received_data;
       comm.receive(proc_id, received_data);
 
+      libmesh_assert(queries.count(proc_id));
       auto & querydata = queries.at(proc_id);
       act_on_data(proc_id, querydata, received_data);
     }

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -251,6 +251,7 @@ void push_parallel_vector_data(const Communicator & comm,
   processor_id_type num_sends = 0;
   for (auto & datapair : data)
     {
+      libmesh_assert_less(datapair.first, num_procs);
       will_send_to[datapair.first] = datapair.second.size();
       num_sends++;
     }
@@ -284,6 +285,7 @@ void push_parallel_vector_data(const Communicator & comm,
   for (auto & datapair : data)
     {
       processor_id_type destid = datapair.first;
+      libmesh_assert_less(destid, num_procs);
       auto & datum = datapair.second;
       Request sendreq;
       comm.send(destid, datum, datatype, sendreq);
@@ -462,6 +464,8 @@ void pull_parallel_vector_data(const Communicator & comm,
   for (auto & querypair : queries)
     {
       processor_id_type proc_id = querypair.first;
+      libmesh_assert_less(proc_id, comm.size());
+
       auto & querydata = querypair.second;
       Request req;
       auto & incoming_data = received_data[proc_id];
@@ -478,6 +482,7 @@ void pull_parallel_vector_data(const Communicator & comm,
       receive_reqs.erase(receive_reqs.begin() + completed);
       receive_procids.erase(receive_procids.begin() + completed);
 
+      libmesh_assert(queries.count(proc_id));
       act_on_data(proc_id, queries.at(proc_id), received_data[proc_id]);
       received_data.erase(proc_id);
     }

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -251,7 +251,12 @@ void push_parallel_vector_data(const Communicator & comm,
   processor_id_type num_sends = 0;
   for (auto & datapair : data)
     {
+      // Don't try to send anywhere that doesn't exist
       libmesh_assert_less(datapair.first, num_procs);
+
+      // Don't give us empty vectors to send
+      libmesh_assert_greater(datapair.second.size(), 0);
+
       will_send_to[datapair.first] = datapair.second.size();
       num_sends++;
     }

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -106,6 +106,11 @@ void push_parallel_vector_data(const Communicator & comm,
  * act_on_data(processor_id_type pid, const std::vector<id> & ids,
  *             const std::vector<datum> & data);
  *
+ * The example pointer may be null; it merely needs to be of the
+ * correct type.  It's just here because function overloading in C++
+ * is easy, whereas SFINAE is hard and partial template specialization
+ * of functions is impossible.
+ *
  * No guarantee about operation ordering is made - this function will
  * attempt to act on data in the order in which it is received.
  *
@@ -126,7 +131,8 @@ void pull_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & queries,
                                RequestContainer & reqs,
                                GatherFunctor & gather_data,
-                               ActionFunctor & act_on_data);
+                               ActionFunctor & act_on_data,
+                               datum * example);
 
 /**
  * Send query vectors, receive and answer them with vectors of data,
@@ -144,6 +150,11 @@ void pull_parallel_vector_data(const Communicator & comm,
  * act_on_data(processor_id_type pid, const std::vector<id> & ids,
  *             const std::vector<datum> & data);
  *
+ * The example pointer may be null; it merely needs to be of the
+ * correct type.  It's just here because function overloading in C++
+ * is easy, whereas SFINAE is hard and partial template specialization
+ * of functions is impossible.
+ *
  * No guarantee about operation ordering is made - this function will
  * attempt to act on data in the order in which it is received.
  *
@@ -157,7 +168,8 @@ template <typename datum,
 void pull_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & queries,
                                GatherFunctor & gather_data,
-                               ActionFunctor & act_on_data);
+                               ActionFunctor & act_on_data,
+                               datum * example);
 
 //------------------------------------------------------------------------
 // Parallel function overloads
@@ -404,7 +416,8 @@ void pull_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & queries,
                                RequestContainer & reqs,
                                GatherFunctor & gather_data,
-                               ActionFunctor & act_on_data)
+                               ActionFunctor & act_on_data,
+                               datum *)
 {
   typedef typename MapToVectors::mapped_type query_type;
 
@@ -462,12 +475,13 @@ template <typename datum,
 void pull_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & queries,
                                GatherFunctor & gather_data,
-                               ActionFunctor & act_on_data)
+                               ActionFunctor & act_on_data,
+                               datum * example)
 {
   std::vector<Request> requests;
 
-  pull_parallel_vector_data<datum>(comm, queries, requests,
-                                   gather_data, act_on_data);
+  pull_parallel_vector_data(comm, queries, requests, gather_data,
+                            act_on_data, example);
 
   wait(requests);
 }

--- a/include/parallel/request.h
+++ b/include/parallel/request.h
@@ -124,10 +124,15 @@ private:
 inline Status wait (Request & r) { return r.wait(); }
 
 /**
- * Wait for a non-blocking send or receive to finish
+ * Wait for all non-blocking operations to finish
  */
-inline void wait (std::vector<Request> & r)
-{ for (std::size_t i=0; i<r.size(); i++) r[i].wait(); }
+void wait (std::vector<Request> & r);
+
+/**
+ * Wait for at least one non-blocking operation to finish.  Return the
+ * index of the request which completed.
+ */
+std::size_t waitany (std::vector<Request> & r);
 
 
 } // namespace Parallel

--- a/include/partitioning/parmetis_partitioner.h
+++ b/include/partitioning/parmetis_partitioner.h
@@ -84,6 +84,7 @@ protected:
   virtual void _do_partition (MeshBase & mesh,
                               const unsigned int n) libmesh_override;
 
+#ifdef LIBMESH_HAVE_PARMETIS
   /**
   * Build the graph.
   */
@@ -93,7 +94,6 @@ private:
 
   // These methods and data only need to be available if the
   // ParMETIS library is available.
-#ifdef LIBMESH_HAVE_PARMETIS
 
   /**
    * Initialize data structures.

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -89,13 +89,13 @@ struct SyncNeighbors
   }
 
   void act_on_data (const std::vector<dof_id_type> & ids,
-                    std::vector<datum> & neighbors) const
+                    const std::vector<datum> & neighbors) const
   {
     for (std::size_t i=0; i != ids.size(); ++i)
       {
         Elem & elem = mesh.elem_ref(ids[i]);
 
-        datum & new_neigh = neighbors[i];
+        const datum & new_neigh = neighbors[i];
 
         const unsigned int n_neigh = elem.n_neighbors();
         libmesh_assert_equal_to (n_neigh, new_neigh.size());
@@ -1246,7 +1246,7 @@ struct SyncIds
   }
 
   void act_on_data (const std::vector<dof_id_type> & old_ids,
-                    std::vector<datum> & new_ids) const
+                    const std::vector<datum> & new_ids) const
   {
     for (std::size_t i=0; i != old_ids.size(); ++i)
       if (old_ids[i] != new_ids[i])
@@ -1298,7 +1298,7 @@ struct SyncNodeIds
   }
 
   bool act_on_data (const std::vector<dof_id_type> & old_ids,
-                    std::vector<datum> & new_ids)
+                    const std::vector<datum> & new_ids)
   {
     bool data_changed = false;
     for (std::size_t i=0; i != old_ids.size(); ++i)
@@ -1374,7 +1374,7 @@ struct SyncPLevels
   }
 
   void act_on_data (const std::vector<dof_id_type> & old_ids,
-                    std::vector<datum> & new_p_levels) const
+                    const std::vector<datum> & new_p_levels) const
   {
     for (std::size_t i=0; i != old_ids.size(); ++i)
       {
@@ -1418,7 +1418,7 @@ struct SyncUniqueIds
   }
 
   void act_on_data (const std::vector<dof_id_type>& ids,
-                    std::vector<datum>& unique_ids) const
+                    const std::vector<datum>& unique_ids) const
   {
     for (std::size_t i=0; i != ids.size(); ++i)
       {
@@ -1559,7 +1559,7 @@ struct SyncProcIds
 
   // ------------------------------------------------------------
   bool act_on_data (const std::vector<dof_id_type> & ids,
-                    std::vector<datum> proc_ids)
+                    const std::vector<datum> proc_ids)
   {
     bool data_changed = false;
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1934,7 +1934,7 @@ struct SyncNodeSet
 
   // ------------------------------------------------------------
   bool act_on_data (const std::vector<dof_id_type> & ids,
-                    std::vector<datum> in_set)
+                    const std::vector<datum> in_set)
   {
     bool data_changed = false;
 
@@ -2012,7 +2012,7 @@ struct SyncProcIdsFromMap
 
   // ------------------------------------------------------------
   void act_on_data (const std::vector<dof_id_type> & ids,
-                    std::vector<datum> proc_ids)
+                    const std::vector<datum> proc_ids)
   {
     // Set the node processor ids we've now been informed of
     for (std::size_t i=0; i != ids.size(); ++i)

--- a/src/parallel/parallel_ghost_sync.C
+++ b/src/parallel/parallel_ghost_sync.C
@@ -48,7 +48,7 @@ void SyncNodalPositions::gather_data (const std::vector<dof_id_type> & ids,
 
 
 void SyncNodalPositions::act_on_data (const std::vector<dof_id_type> & ids,
-                                      std::vector<datum> & data) const
+                                      const std::vector<datum> & data) const
 {
   for (std::size_t i=0; i<ids.size(); ++i)
     {

--- a/src/parallel/request.C
+++ b/src/parallel/request.C
@@ -204,6 +204,28 @@ void Request::add_post_wait_work(PostWaitWork * work)
   post_wait_work->first.push_back(work);
 }
 
+void wait (std::vector<Request> & r)
+{
+  for (std::size_t i=0; i<r.size(); i++) r[i].wait();
+}
+
+std::size_t waitany (std::vector<Request> & r)
+{
+  libmesh_assert(!r.empty());
+
+  int index = 0;
+#ifdef LIBMESH_HAVE_MPI
+  int r_size = cast_int<int>(r.size());
+  std::vector<request> raw(r_size);
+  for (int i=0; i != r_size; ++i)
+    raw[i] = *r[i].get();
+
+  libmesh_call_mpi
+    (MPI_Waitany(r_size, &raw[0], &index, MPI_STATUS_IGNORE));
+#endif
+
+  return index;
+}
 
 } // namespace Parallel
 

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -597,7 +597,7 @@ struct SyncLocalIDs
   map_type & id_map;
 
   void gather_data (const std::vector<dof_id_type> & ids,
-                    std::vector<datum> & local_ids)
+                    std::vector<datum> & local_ids) const
   {
     local_ids.resize(ids.size());
 


### PR DESCRIPTION
The upcoming goal here is to get rid of every single O(N_proc^2) round-robin communication in the whole library, but getting rid of every round-robin in the parallel_ghost_sync.h algorithms actually covers about half of our big communication operations, which is a good start.

The underlying algorithm here is a slight improvement over the one in #1600, and that was a 4-fold speedup for me on the affected sections of code on 320 processors, so I've got a good feeling about this.  I'll want some empirical confirmation or contradiction of that, though.  I'll be running my own tests tomorrow, but if @jwpeterson wants to cook up graphs as useful as the ones in #1598 I'd appreciate it.  More worrisome is that @bboutkov saw contradictory results from #1600, so I'd very much like to find out whether this PR is also a pessimization rather an optimization for him.  At least we now have our communication strategy in one place, so if there turns out to still be a performance issue we can fix it once rather than over and over and over again.

Most importantly, after the #1697 debacle, I'd also like it if such massive refactorings of our communications get tested as widely as possible.  This PR is passing tests so far on my standard configuration, and I'll try the basic libMesh test suite with openmpi myself this time, but @dknez might want to double-check with his applications too.