### PR TITLE
Add ASCII art axes markers indicating reference element coordinates.

### DIFF
--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -39,11 +39,11 @@ namespace libMesh
  *          o    :                        o    |
  *         /     :                       /     |
  *        /    15o                      /    14o
- *       /       :                     /       |
- *     4/        :    16             5/        |
- *     o--------------o--------------o         |
- *     |         :                   |         |
- *     |         :                   |         |
+ *       /       :                     /       |           zeta
+ *     4/        :    16             5/        |            ^   eta (into page)
+ *     o--------------o--------------o         |            | /
+ *     |         :                   |         |            |/
+ *     |         :                   |         |            o---> xi
  *     |         :              10   |         |
  *     |        3o..............o....|.........o
  *     |        .                    |        / 2
@@ -58,6 +58,8 @@ namespace libMesh
  *     o--------------o--------------o
  *     0              8              1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -39,11 +39,11 @@ namespace libMesh
  *         o--------------o--------------o    |
  *        /     :        /              /|    |
  *       /    15o       /    23o       / |  14o
- *      /       :      /              /  |   /|
- *    4/        :   16/             5/   |  / |
- *    o--------------o--------------o    | /  |
- *    |         :    |   26         |    |/   |
- *    |  24o    :    |    o         |  22o    |
+ *      /       :      /              /  |   /|           zeta
+ *    4/        :   16/             5/   |  / |            ^   eta (into page)
+ *    o--------------o--------------o    | /  |            | /
+ *    |         :    |   26         |    |/   |            |/
+ *    |  24o    :    |    o         |  22o    |            o---> xi
  *    |         :    |       10     |   /|    |
  *    |        3o....|.........o....|../.|....o
  *    |        .     |              | /  |   / 2
@@ -58,6 +58,8 @@ namespace libMesh
  *    o--------------o--------------o
  *    0              8              1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -31,18 +31,20 @@ namespace libMesh
  * It is numbered like this:
  * \verbatim
  *   HEX8: 7        6
- *         o--------o
- *        /:       /|
- *       / :      / |
- *    4 /  :   5 /  |
- *     o--------o   |
- *     |   o....|...o 2
+ *         o--------z
+ *        /:       /|         zeta
+ *       / :      / |          ^   eta (into page)
+ *    4 /  :   5 /  |          | /
+ *     o--------o   |          |/
+ *     |   o....|...o 2        o---> xi
  *     |  .3    |  /
  *     | .      | /
  *     |.       |/
  *     o--------o
  *     0        1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -45,11 +45,11 @@ namespace libMesh
  *      o---------o---------o
  *      |         :12       |
  *      |         :         |
- *      |         :         |
- *      |         o         |
- *      |        .2.        |
- *      |       .   .       |
- *    9 o      .     .      o 10
+ *      |         :         |            zeta
+ *      |         o         |             ^   eta (into page)
+ *      |        .2.        |             | /
+ *      |       .   .       |             |/
+ *    9 o      .     .      o 10          o---> xi
  *      |     .       .     |
  *      |  8 o         o 7  |
  *      |   .           .   |
@@ -59,6 +59,8 @@ namespace libMesh
  *      o---------o---------o
  *      0         6         1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2003

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -45,11 +45,11 @@ namespace libMesh
  *     o---------o---------o
  *     |         :12       |
  *     |         :         |
- *     |    o    :    o    |
- *     |   17    o   16    |
- *     |        .2.        |
- *     |       .   .       |
- *   9 o      .  o  .      o 10
+ *     |    o    :    o    |            zeta
+ *     |   17    o   16    |             ^   eta (into page)
+ *     |        .2.        |             | /
+ *     |       .   .       |             |/
+ *   9 o      .  o  .      o 10          o---> xi
  *     |     .  15   .     |
  *     |  8 o         o 7  |
  *     |   .           .   |
@@ -59,6 +59,8 @@ namespace libMesh
  *     o---------o---------o
  *     0         6         1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2003

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -34,14 +34,16 @@ namespace libMesh
  *           5
  *           o
  *          /:\
- *         / : \
- *        /  o  \
- *     3 o-------o 4
- *       | . 2 . |
- *       |.     .|
+ *         / : \             zeta
+ *        /  o  \             ^   eta (into page)
+ *     3 o-------o 4          | /
+ *       | . 2 . |            |/
+ *       |.     .|            o---> xi
  *       o-------o
  *       0       1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -44,11 +44,11 @@ namespace libMesh
  *              12 o/    |    o 11
  *                //     |     \
  *               /o 9    o 10   \
- *              //       |       \
- *             //        |        \
- *          3 o/.......o.|........o 2
- *           ./       7  |       /
- *          ./           |      /
+ *              //       |       \          zeta
+ *             //        |        \          ^   eta (into page)
+ *          3 o/.......o.|........o 2        | /
+ *           ./       7  |       /           |/
+ *          ./           |      /            o---> xi
  *         ./            |     /
  *        ./             |    /
  *     8 o/              |   o 6
@@ -58,6 +58,8 @@ namespace libMesh
  *    o--------o---------o
  *    0        5         1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author John W. Peterson
  * \date 2014

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -47,11 +47,11 @@ namespace libMesh
  *              12 o/    |    o 11
  *                //     |     \
  *               /o 9    o 10   \
- *              //       |       \
- *             //        |        \
- *          3 o/.......o.|........o 2
- *           ./       7  |       /
- *          ./           |      /
+ *              //       |       \          zeta
+ *             //        |        \          ^   eta (into page)
+ *          3 o/.......o.|........o 2        | /
+ *           ./       7  |       /           |/
+ *          ./           |      /            o---> xi
  *         ./            |     /
  *        ./             |    /
  *     8 o/       o      |   o 6
@@ -61,6 +61,8 @@ namespace libMesh
  *    o--------o---------o
  *    0        5         1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author John W. Peterson
  * \date 2013

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -33,15 +33,17 @@ namespace libMesh
  *   PYRAMID5:
  *             o 4
  *           //|\
- *          // | \
- *         //  |  \
- *      3 o/...|...o 2
- *       ./    |  /
- *      ./     | /
+ *          // | \          zeta
+ *         //  |  \          ^   eta (into page)
+ *      3 o/...|...o 2       | /
+ *       ./    |  /          |/
+ *      ./     | /           o---> xi
  *     ./      |/
  *    o--------o
  *    0        1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -35,14 +35,14 @@ namespace libMesh
  *              /|\
  *             / | \
  *         7  /  |  \9
- *           o   |   o
- *          /    |8   \
- *         /     o     \
- *        /    6 |      \
- *     0 o.....o.|.......o 2
- *        \      |      /
- *         \     |     /
- *          \    |    /
+ *           o   |   o              zeta
+ *          /    |8   \              ^
+ *         /     o     \             |
+ *        /    6 |      \            |
+ *     0 o.....o.|.......o 2         o---> eta
+ *        \      |      /             \
+ *         \     |     /               \
+ *          \    |    /                 xi (out of page)
  *         4 o   |   o 5
  *            \  |  /
  *             \ | /
@@ -50,6 +50,8 @@ namespace libMesh
  *               o
  *               1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -32,17 +32,19 @@ namespace libMesh
  * \verbatim
  *   TET4:
  *         3
- *         o
- *        /|\
- *       / | \
- *      /  |  \
- *   0 o...|...o 2
- *      \  |  /
- *       \ | /
- *        \|/
+ *         o                 zeta
+ *        /|\                 ^
+ *       / | \                |
+ *      /  |  \               |
+ *   0 o...|...o 2            o---> eta
+ *      \  |  /                \
+ *       \ | /                  \
+ *        \|/                    xi (out of page)
  *         o
  *         1
  * \endverbatim
+ * (xi, eta, zeta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -33,14 +33,16 @@ namespace libMesh
  * \verbatim
  *          3           2
  *   QUAD4: o-----------o
- *          |           |
- *          |           |
- *          |           |
- *          |           |
- *          |           |
+ *          |           |           eta
+ *          |           |            ^
+ *          |           |            |
+ *          |           |            |
+ *          |           |            o---> xi
  *          o-----------o
  *          0           1
  * \endverbatim
+ * (xi, eta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -33,14 +33,16 @@ namespace libMesh
  * \verbatim
  *          3     6     2
  *   QUAD8: o-----o-----o
- *          |           |
- *          |           |
- *        7 o           o 5
- *          |           |
- *          |           |
+ *          |           |           eta
+ *          |           |            ^
+ *        7 o           o 5          |
+ *          |           |            |
+ *          |           |            o---> xi
  *          o-----o-----o
  *          0     4     1
  * \endverbatim
+ * (xi, eta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -33,14 +33,16 @@ namespace libMesh
  * \verbatim
  *          3     6     2
  *   QUAD9: o-----o-----o
- *          |           |
- *          |     8     |
- *        7 o     o     o 5
- *          |           |
- *          |           |
+ *          |           |           eta
+ *          |     8     |            ^
+ *        7 o     o     o 5          |
+ *          |           |            |
+ *          |           |            o---> xi
  *          o-----o-----o
  *          0     4     1
  * \endverbatim
+ * (xi, eta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -38,14 +38,16 @@ namespace libMesh
  *   TRI3:
  *    2
  *    o
- *    |\
- *    | \
- *    |  \
- *    |   \
- *    |    \
+ *    |\            eta
+ *    | \            ^
+ *    |  \           |
+ *    |   \          |
+ *    |    \         o---> xi
  *    o-----o
  *    0      1
  * \endverbatim
+ * (xi, eta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -31,16 +31,23 @@ namespace libMesh
  * The \p Tri6 is an element in 2D composed of 6 nodes.
  * It is numbered like this:
  * \verbatim
- *   TRI6:  2
- *          o
- *         / \
- *        /   \
- *     5 o     o 4
- *      /       \
- *     /         \
- *    o-----o-----o
- *    0     3     1
+ *   TRI6:
+ *    2
+ *    o
+ *    |\
+ *    | \
+ *    |  \            eta
+ *    |   \            ^
+ *    |    \           |
+ *  5 o     o 4        |
+ *    |      \         o---> xi
+ *    |       \
+ *    |        \
+ *    o----o----o
+ *    0    3    1
  * \endverbatim
+ * (xi, eta) are the reference element coordinates associated with
+ * the given numbering.
  *
  * \author Benjamin S. Kirk
  * \date 2002


### PR DESCRIPTION
I had to refresh my memory of the orientation used for Hexes, so I
added ASCII art axes for the other elements as well.

Note: Hex8::side_nodes_map (see cell_hex8.C) is consistent with the
sideset names assigned in MeshTools::Generation::build_cube(), which
are:

x: left/right
y: bottom/top
z: back/front

From the ASCII art, you might conclude that bottom/top would refer to
the z-direction on the reference element, but it actually refers to
the y-direction.