### PR TITLE
Replace more round robin communications with parallel_sync

### DIFF
--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -580,11 +580,11 @@ bool sync_node_data_by_element_id_once(MeshBase & mesh,
   // Now repeat that iteration, filling request sets this time.
 
   // Request sets to send to each processor
-  std::map<dof_id_type, std::vector<std::pair<dof_id_type, unsigned char>>>
+  std::map<processor_id_type, std::vector<std::pair<dof_id_type, unsigned char>>>
     requested_objs_elem_id_node_num;
 
   // Keep track of current local ids for each too
-  std::map<dof_id_type, std::vector<dof_id_type>>
+  std::map<processor_id_type, std::vector<dof_id_type>>
     requested_objs_id;
 
   // We know how many objects live on each processor, so reserve()

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -132,7 +132,7 @@ void pull_parallel_vector_data(const Communicator & comm,
                                RequestContainer & reqs,
                                GatherFunctor & gather_data,
                                ActionFunctor & act_on_data,
-                               datum * example);
+                               const datum * example);
 
 /**
  * Send query vectors, receive and answer them with vectors of data,
@@ -169,7 +169,7 @@ void pull_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & queries,
                                GatherFunctor & gather_data,
                                ActionFunctor & act_on_data,
-                               datum * example);
+                               const datum * example);
 
 //------------------------------------------------------------------------
 // Parallel function overloads
@@ -221,7 +221,7 @@ void pull_parallel_vector_data(const Communicator & comm,
                                RequestContainer & reqs,
                                GatherFunctor & gather_data,
                                ActionFunctor & act_on_data,
-                               std::vector<datum,A> * example);
+                               const std::vector<datum,A> * example);
 
 
 
@@ -448,7 +448,7 @@ void pull_parallel_vector_data(const Communicator & comm,
                                RequestContainer & reqs,
                                GatherFunctor & gather_data,
                                ActionFunctor & act_on_data,
-                               datum *)
+                               const datum *)
 {
   typedef typename MapToVectors::mapped_type query_type;
 
@@ -512,7 +512,7 @@ void pull_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & queries,
                                GatherFunctor & gather_data,
                                ActionFunctor & act_on_data,
-                               datum * example)
+                               const datum * example)
 {
   std::vector<Request> requests;
 
@@ -534,7 +534,7 @@ void pull_parallel_vector_data(const Communicator & comm,
                                RequestContainer & reqs,
                                GatherFunctor & gather_data,
                                ActionFunctor & act_on_data,
-                               std::vector<datum,A> *)
+                               const std::vector<datum,A> *)
 {
   typedef typename MapToVectors::mapped_type query_type;
 

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -464,6 +464,7 @@ void pull_parallel_vector_data(const Communicator & comm,
     {
       Request sendreq;
       gather_data(pid, query, response_data[pid]);
+      libmesh_assert_equal_to(query.size(), response_data[pid].size());
       comm.send(pid, response_data[pid], datatype, sendreq);
       response_reqs.push_back(sendreq);
     };
@@ -496,6 +497,8 @@ void pull_parallel_vector_data(const Communicator & comm,
       receive_procids.erase(receive_procids.begin() + completed);
 
       libmesh_assert(queries.count(proc_id));
+      libmesh_assert_equal_to(queries.at(proc_id).size(),
+                              received_data[proc_id].size());
       act_on_data(proc_id, queries.at(proc_id), received_data[proc_id]);
       received_data.erase(proc_id);
     }
@@ -548,6 +551,8 @@ void pull_parallel_vector_data(const Communicator & comm,
     {
       Request sendreq;
       gather_data(pid, query, response_data[pid]);
+      libmesh_assert_equal_to(query.size(),
+                              response_data[pid].size());
       comm.send(pid, response_data[pid], sendreq);
       response_reqs.push_back(sendreq);
     };
@@ -576,6 +581,7 @@ void pull_parallel_vector_data(const Communicator & comm,
 
       libmesh_assert(queries.count(proc_id));
       auto & querydata = queries.at(proc_id);
+      libmesh_assert_equal_to(querydata.size(), received_data.size());
       act_on_data(proc_id, querydata, received_data);
     }
 

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -187,7 +187,7 @@ template <template <typename, typename, typename ...> class MapType,
           typename RequestContainer,
           typename ActionFunctor>
 void push_parallel_vector_data(const Communicator & comm,
-                               const MapType<dof_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
+                               const MapType<processor_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
                                RequestContainer & reqs,
                                ActionFunctor & act_on_data);
 
@@ -204,7 +204,7 @@ template <template <typename, typename, typename ...> class MapType,
           typename ... ExtraTypes,
           typename ActionFunctor>
 void push_parallel_vector_data(const Communicator & comm,
-                               const MapType<dof_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
+                               const MapType<processor_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
                                ActionFunctor & act_on_data);
 
 /*
@@ -338,7 +338,7 @@ template <template <typename, typename, typename ...> class MapType,
           typename RequestContainer,
           typename ActionFunctor>
 void push_parallel_vector_data(const Communicator & comm,
-                               const MapType<dof_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
+                               const MapType<processor_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
                                RequestContainer & reqs,
                                ActionFunctor & act_on_data)
 {
@@ -434,7 +434,7 @@ template <template <typename, typename, typename ...> class MapType,
           typename ... ExtraTypes,
           typename ActionFunctor>
 void push_parallel_vector_data(const Communicator & comm,
-                               const MapType<dof_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
+                               const MapType<processor_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
                                ActionFunctor & act_on_data)
 {
   std::vector<Request> requests;

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -356,7 +356,12 @@ void DofMap::set_nonlocal_dof_objects(iterator_type objects_begin,
     }
 #ifdef DEBUG
   for (processor_id_type p=0; p != this->n_processors(); ++p)
-    libmesh_assert_equal_to (requested_ids[p].size(), ghost_objects_from_proc[p]);
+    {
+      if (ghost_objects_from_proc[p])
+        libmesh_assert_equal_to (requested_ids[p].size(), ghost_objects_from_proc[p]);
+      else
+        libmesh_assert(!requested_ids.count(p));
+    }
 #endif
 
   typedef std::vector<dof_id_type> datum;

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3166,7 +3166,6 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
             {
               dof_id_type constrained_id = ids[i];
               const Node * constrained_node = mesh.node_ptr(constrained_id);
-              NodeConstraintRow & row = _node_constraints[constrained_node].first;
 
               if (!libmesh_isnan(data[i](0)))
                 _node_constraints[constrained_node].second = data[i];

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -796,11 +796,11 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
     // all objects, not just local ones
 
     // Request sets to send to each processor
-    std::vector<std::vector<Parallel::DofObjectKey>>
-      requested_ids (communicator.size());
+    std::map<processor_id_type, std::vector<Parallel::DofObjectKey>>
+      requested_ids;
     // Results to gather from each processor
-    std::vector<std::vector<dof_id_type>>
-      filled_request (communicator.size());
+    std::map<processor_id_type, std::vector<dof_id_type>>
+      filled_request;
 
     // build up list of requests
     std::vector<Parallel::DofObjectKey>::const_iterator hi =
@@ -828,143 +828,107 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
         index_map.push_back(pid);
       }
 
-    // start with pid=0, so that we will trade with ourself
-    std::vector<std::vector<dof_id_type>> global_id_returns(communicator.size());
+  auto gather_functor =
+    [
+#ifndef NDEBUG
+     & upper_bounds,
+     & communicator,
+#endif
+     & bbox,
+     & my_bin,
+       my_offset
+    ]
+    (processor_id_type, const std::vector<Parallel::DofObjectKey> & keys,
+     std::vector<dof_id_type> & global_ids)
+    {
+      const std::size_t keys_size = keys.size();
+      // Fill the requests
+      global_ids.clear();
+      global_ids.reserve(keys_size);
+      for (std::size_t idx=0; idx != keys_size; idx++)
+        {
+          const Parallel::DofObjectKey & hilbert_indices = keys[idx];
+          libmesh_assert_less_equal (hilbert_indices, upper_bounds[communicator.rank()]);
 
-    std::vector<Parallel::Request> key_send_requests(communicator.size()),
-      id_return_requests;
-
-    Parallel::MessageTag
-      key_send_tag = communicator.get_unique_tag(867),
-      id_return_tag = communicator.get_unique_tag(5309);
-
-    // If we have lots of empty requests, an alltoall to communicate that fact may
-    // be cheaper than Nproc^2 individual sends.
-    std::vector<unsigned char> request_non_empty(communicator.size());
-    for (processor_id_type pid=0; pid<communicator.size(); pid++)
-      request_non_empty[pid] = !requested_ids[pid].empty();
-
-    communicator.alltoall(request_non_empty);
-
-    processor_id_type non_empty_requests = 0;
-
-    for (processor_id_type pid=0; pid<communicator.size(); pid++)
-      {
-        // Send requests
-        const processor_id_type procup = cast_int<processor_id_type>
-          ((communicator.rank() + pid) % communicator.size());
-
-        if (requested_ids[procup].empty())
-          continue;
-
-        communicator.send(procup, requested_ids[procup],
-                          key_send_requests[procup], key_send_tag);
-
-        non_empty_requests++;
-      }
-
-    // Receive and process requests as they come in
-    for (processor_id_type pid=0; pid<communicator.size(); pid++)
-      {
-        if (!request_non_empty[pid])
-          continue;
-
-        std::vector<Parallel::DofObjectKey> request_to_fill;
-        communicator.receive (pid, request_to_fill, key_send_tag);
-
-        std::vector<dof_id_type> & global_ids = global_id_returns[pid];
-
-        // Fill the requests
-        global_ids.clear(); /**/ global_ids.reserve(request_to_fill.size());
-        for (std::size_t idx=0; idx<request_to_fill.size(); idx++)
-          {
-            const Parallel::DofObjectKey & hilbert_indices = request_to_fill[idx];
-            libmesh_assert_less_equal (hilbert_indices, upper_bounds[communicator.rank()]);
-
-            // find the requested index in my node bin
-            std::vector<Parallel::DofObjectKey>::const_iterator pos =
-              std::lower_bound (my_bin.begin(), my_bin.end(), hilbert_indices);
-            libmesh_assert (pos != my_bin.end());
+          // find the requested index in my node bin
+          std::vector<Parallel::DofObjectKey>::const_iterator pos =
+            std::lower_bound (my_bin.begin(), my_bin.end(), hilbert_indices);
+          libmesh_assert (pos != my_bin.end());
 #ifdef DEBUG
-            // If we could not find the requested Hilbert index in
-            // my_bin, something went terribly wrong, possibly the
-            // Mesh was displaced differently on different processors,
-            // and therefore the Hilbert indices don't agree.
-            if (*pos != hilbert_indices)
-              {
-                // The input will be hilbert_indices.  We convert it
-                // to BitVecType using the operator= provided by the
-                // BitVecType class. BitVecType is a CBigBitVec!
-                Hilbert::BitVecType input;
+          // If we could not find the requested Hilbert index in
+          // my_bin, something went terribly wrong, possibly the
+          // Mesh was displaced differently on different processors,
+          // and therefore the Hilbert indices don't agree.
+          if (*pos != hilbert_indices)
+            {
+              // The input will be hilbert_indices.  We convert it
+              // to BitVecType using the operator= provided by the
+              // BitVecType class. BitVecType is a CBigBitVec!
+              Hilbert::BitVecType input;
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-                input = hilbert_indices.first;
+              input = hilbert_indices.first;
 #else
-                input = hilbert_indices;
+              input = hilbert_indices;
 #endif
 
-                // Get output in a vector of CBigBitVec
-                std::vector<CBigBitVec> output(3);
+              // Get output in a vector of CBigBitVec
+              std::vector<CBigBitVec> output(3);
 
-                // Call the indexToCoords function
-                Hilbert::indexToCoords(&output[0], 8*sizeof(Hilbert::inttype), 3, input);
+              // Call the indexToCoords function
+              Hilbert::indexToCoords(&output[0], 8*sizeof(Hilbert::inttype), 3, input);
 
-                // The entries in the output racks are integers in the
-                // range [0, Hilbert::inttype::max] which can be
-                // converted to floating point values in [0,1] and
-                // finally to actual values using the bounding box.
-                Real max_int_as_real = static_cast<Real>(std::numeric_limits<Hilbert::inttype>::max());
+              // The entries in the output racks are integers in the
+              // range [0, Hilbert::inttype::max] which can be
+              // converted to floating point values in [0,1] and
+              // finally to actual values using the bounding box.
+              const Real max_int_as_real =
+                static_cast<Real>(std::numeric_limits<Hilbert::inttype>::max());
 
-                // Get the points in [0,1]^3.  The zeroth rack of each entry in
-                // 'output' maps to the normalized x, y, and z locations,
-                // respectively.
-                Point p_hat(static_cast<Real>(output[0].racks()[0]) / max_int_as_real,
-                            static_cast<Real>(output[1].racks()[0]) / max_int_as_real,
-                            static_cast<Real>(output[2].racks()[0]) / max_int_as_real);
+              // Get the points in [0,1]^3.  The zeroth rack of each entry in
+              // 'output' maps to the normalized x, y, and z locations,
+              // respectively.
+              Point p_hat(static_cast<Real>(output[0].racks()[0]) / max_int_as_real,
+                          static_cast<Real>(output[1].racks()[0]) / max_int_as_real,
+                          static_cast<Real>(output[2].racks()[0]) / max_int_as_real);
 
-                // Convert the points from [0,1]^3 to their actual (x,y,z) locations
-                Real
-                  xmin = bbox.first(0),
-                  xmax = bbox.second(0),
-                  ymin = bbox.first(1),
-                  ymax = bbox.second(1),
-                  zmin = bbox.first(2),
-                  zmax = bbox.second(2);
+              // Convert the points from [0,1]^3 to their actual (x,y,z) locations
+              Real
+                xmin = bbox.first(0),
+                xmax = bbox.second(0),
+                ymin = bbox.first(1),
+                ymax = bbox.second(1),
+                zmin = bbox.first(2),
+                zmax = bbox.second(2);
 
-                // Convert the points from [0,1]^3 to their actual (x,y,z) locations
-                Point p(xmin + (xmax-xmin)*p_hat(0),
-                        ymin + (ymax-ymin)*p_hat(1),
-                        zmin + (zmax-zmin)*p_hat(2));
+              // Convert the points from [0,1]^3 to their actual (x,y,z) locations
+              Point p(xmin + (xmax-xmin)*p_hat(0),
+                      ymin + (ymax-ymin)*p_hat(1),
+                      zmin + (zmax-zmin)*p_hat(2));
 
-                libmesh_error_msg("Could not find hilbert indices: "
-                                  << hilbert_indices
-                                  << " corresponding to point " << p);
-              }
+              libmesh_error_msg("Could not find hilbert indices: "
+                                << hilbert_indices
+                                << " corresponding to point " << p);
+            }
 #endif
 
-            // Finally, assign the global index based off the position of the index
-            // in my array, properly offset.
-            global_ids.push_back (cast_int<dof_id_type>(std::distance(my_bin.begin(), pos) + my_offset));
-          }
+          // Finally, assign the global index based off the position of the index
+          // in my array, properly offset.
+          global_ids.push_back (cast_int<dof_id_type>(std::distance(my_bin.begin(), pos) + my_offset));
+        }
+    };
 
-        // and send back
-        id_return_requests.push_back(Parallel::Request());
-        communicator.send (pid, global_ids,
-                           id_return_requests.back(), id_return_tag);
-      }
+  auto action_functor =
+    [&filled_request]
+    (processor_id_type pid,
+     const std::vector<Parallel::DofObjectKey> &,
+     const std::vector<dof_id_type> & global_ids)
+    {
+      filled_request[pid] = global_ids;
+    };
 
-    // Receive and process returns
-    for (processor_id_type pid=0; pid<communicator.size(); pid++)
-      {
-        const processor_id_type procup = cast_int<processor_id_type>
-          ((communicator.rank() + pid) % communicator.size());
-
-        if (requested_ids[procup].empty())
-          continue;
-
-        std::vector<dof_id_type> & this_filled_request = filled_request[procup];
-
-        communicator.receive(procup, this_filled_request, id_return_tag);
-      }
+  const dof_id_type * ex = libmesh_nullptr;
+  Parallel::pull_parallel_vector_data
+    (communicator, requested_ids, gather_functor, action_functor, ex);
 
     // We now have all the filled requests, so we can loop through our
     // nodes once and assign the global index to each one.
@@ -989,9 +953,6 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
           ++next_obj_on_proc[pid];
         }
     }
-
-    Parallel::wait(key_send_requests);
-    Parallel::wait(id_return_requests);
   }
 
   libmesh_assert_equal_to(index_map.size(), n_objects);

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -27,6 +27,7 @@
 #include "libmesh/parallel.h"
 #include "libmesh/parallel_hilbert.h"
 #include "libmesh/parallel_sort.h"
+#include "libmesh/parallel_sync.h"
 #include "libmesh/elem.h"
 #include "libmesh/elem_range.h"
 #include "libmesh/node_range.h"
@@ -333,11 +334,12 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
     // Nodes first -- all nodes, not just local ones
     {
       // Request sets to send to each processor
-      std::vector<std::vector<Parallel::DofObjectKey>>
-        requested_ids (communicator.size());
-      // Results to gather from each processor
-      std::vector<std::vector<dof_id_type>>
-        filled_request (communicator.size());
+      std::map<dof_id_type, std::vector<Parallel::DofObjectKey>>
+        requested_ids;
+      // Results to gather from each processor - kept in a map so we
+      // do only one loop over nodes after all receives are done.
+      std::map<dof_id_type, std::vector<dof_id_type>>
+        filled_request;
 
       // build up list of requests
       for (const auto & node : mesh.node_ptr_range())
@@ -366,25 +368,25 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
       for (processor_id_type pid=0; pid<communicator.rank(); pid++)
         my_offset += node_bin_sizes[pid];
 
-      // start with pid=0, so that we will trade with ourself
-      for (processor_id_type pid=0; pid<communicator.size(); pid++)
+      auto gather_functor =
+        [
+#ifndef NDEBUG
+         & node_upper_bounds,
+         & communicator,
+#endif
+         & my_node_bin,
+         my_offset
+        ]
+        (processor_id_type,
+         const std::vector<Parallel::DofObjectKey> & keys,
+         std::vector<dof_id_type> & global_ids)
         {
-          // Trade my requests with processor procup and procdown
-          const processor_id_type procup = cast_int<processor_id_type>
-            ((communicator.rank() + pid) % communicator.size());
-          const processor_id_type procdown = cast_int<processor_id_type>
-            ((communicator.size() + communicator.rank() - pid) %
-             communicator.size());
-
-          std::vector<Parallel::DofObjectKey> request_to_fill;
-          communicator.send_receive(procup, requested_ids[procup],
-                                    procdown, request_to_fill);
-
           // Fill the requests
-          std::vector<dof_id_type> global_ids; /**/ global_ids.reserve(request_to_fill.size());
-          for (std::size_t idx=0; idx<request_to_fill.size(); idx++)
+          const std::size_t keys_size = keys.size();
+          global_ids.reserve(keys_size);
+          for (std::size_t idx=0; idx != keys_size; idx++)
             {
-              const Parallel::DofObjectKey & hi = request_to_fill[idx];
+              const Parallel::DofObjectKey & hi = keys[idx];
               libmesh_assert_less_equal (hi, node_upper_bounds[communicator.rank()]);
 
               // find the requested index in my node bin
@@ -397,19 +399,29 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
               // in my array, properly offset.
               global_ids.push_back(cast_int<dof_id_type>(std::distance(my_node_bin.begin(), pos) + my_offset));
             }
+        };
 
-          // and trade back
-          communicator.send_receive (procdown, global_ids,
-                                     procup,   filled_request[procup]);
-        }
+      auto action_functor =
+        [&filled_request]
+        (processor_id_type pid,
+         const std::vector<Parallel::DofObjectKey> &,
+         const std::vector<dof_id_type> & global_ids)
+        {
+          filled_request[pid] = global_ids;
+        };
+
+      // Trade requests with other processors
+      const dof_id_type * ex = libmesh_nullptr;
+      Parallel::pull_parallel_vector_data
+        (communicator, requested_ids, gather_functor, action_functor, ex);
 
       // We now have all the filled requests, so we can loop through our
       // nodes once and assign the global index to each one.
       {
-        std::vector<std::vector<dof_id_type>::const_iterator>
-          next_obj_on_proc; next_obj_on_proc.reserve(communicator.size());
-        for (processor_id_type pid=0; pid<communicator.size(); pid++)
-          next_obj_on_proc.push_back(filled_request[pid].begin());
+        std::map<dof_id_type, std::vector<dof_id_type>::const_iterator>
+          next_obj_on_proc;
+        for (auto & p : filled_request)
+          next_obj_on_proc[p.first] = p.second.begin();
 
         for (auto & node : mesh.node_ptr_range())
           {

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -2101,7 +2101,7 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
     }
 
   // Sort the new pids to push to each processor
-  std::map<dof_id_type, std::vector<std::pair<dof_id_type, processor_id_type>>>
+  std::map<processor_id_type, std::vector<std::pair<dof_id_type, processor_id_type>>>
     ids_to_push;
 
   for (const auto & node : mesh.node_ptr_range())

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -650,7 +650,7 @@ void XdrIO::write_serialized_connectivity (Xdr & io, const dof_id_type libmesh_d
       // those parents may have been written by other processors (at this step),
       // so we need to gather them into our *_id_maps.
       {
-        std::map<dof_id_type, std::vector<dof_id_type>> requested_ids;
+        std::map<processor_id_type, std::vector<dof_id_type>> requested_ids;
 
         it  = mesh.local_level_elements_begin(level);
         end = mesh.local_level_elements_end(level);

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -29,6 +29,7 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/dense_subvector.h"
 #include "libmesh/parallel.h"
+#include "libmesh/parallel_sync.h"
 #include "libmesh/tensor_tools.h"
 
 namespace libMesh
@@ -438,9 +439,8 @@ void DistributedVector<T>::localize (std::vector<T> & v_local,
   // We now fill in 'requested_ids' based on the indices.  Also keep
   // track of the local index (in the indices vector) for each of
   // these, since we need that when unpacking.
-  std::vector<std::vector<numeric_index_type>>
-    requested_ids(this->n_processors()),
-    local_requested_ids(this->n_processors());
+  std::map<dof_id_type, std::vector<numeric_index_type>>
+    requested_ids, local_requested_ids;
 
   // We'll use this typedef a couple of times below.
   typedef typename std::vector<numeric_index_type>::iterator iter_t;
@@ -462,53 +462,50 @@ void DistributedVector<T>::localize (std::vector<T> & v_local,
       local_requested_ids[on_proc].push_back(i);
     }
 
-  // First trade indices, then trade values with all other processors.
-  for (processor_id_type pid=0; pid<this->n_processors(); pid++)
+  auto gather_functor =
+    [this]
+    (processor_id_type, const std::vector<dof_id_type> & ids,
+     std::vector<T> & values)
     {
-      // Another data structure which holds the ids that other processors request us to fill.
-      std::vector<numeric_index_type> requests_for_me_to_fill;
-
-      // Trade my requests with processor procup and procdown
-      const processor_id_type procup = (this->processor_id() + pid) % this->n_processors();
-      const processor_id_type procdown = (this->n_processors() + this->processor_id() - pid) % this->n_processors();
-
-      this->comm().send_receive (procup,   requested_ids[procup],
-                                 procdown, requests_for_me_to_fill);
-
       // The first send/receive we did was for indices, the second one will be
       // for corresponding floating point values, so create storage for that now...
-      std::vector<T> values_to_send(requests_for_me_to_fill.size());
+      const std::size_t ids_size = ids.size();
+      values.resize(ids_size);
 
-      for (std::size_t i=0; i<requests_for_me_to_fill.size(); i++)
+      for (std::size_t i=0; i != ids_size; i++)
         {
           // The index of the requested value
-          const numeric_index_type requested_index = requests_for_me_to_fill[i];
+          const numeric_index_type requested_index = ids[i];
 
           // Transform into local numbering, and get requested value.
-          values_to_send[i] = _values[requested_index - _first_local_index];
+          values[i] = _values[requested_index - _first_local_index];
         }
+    };
 
-      // Send the values we were supposed to send, receive the values
-      // we were supposed to receive.
-      std::vector<T> values_to_receive(requested_ids[procup].size());
-      this->comm().send_receive (procdown, values_to_send,
-                                 procup,   values_to_receive);
-
-      // Error checking: make sure that requested_ids[procup] is same
-      // length as values_to_receive.
-      if (requested_ids[procup].size() != values_to_receive.size())
-        libmesh_error_msg("Requested " << requested_ids[procup].size() << " values, but received " << values_to_receive.size() << " values.");
-
+  auto action_functor =
+    [& v_local, & local_requested_ids]
+    (processor_id_type pid,
+     const std::vector<dof_id_type> &,
+     const std::vector<T> & values)
+    {
       // Now write the received values to the appropriate place(s) in v_local
-      for (std::size_t i=0; i<values_to_receive.size(); i++)
+      for (std::size_t i=0, vsize = values.size(); i != vsize; i++)
         {
+          libmesh_assert(local_requested_ids.count(pid));
+          libmesh_assert_less(i, local_requested_ids[pid].size());
+
           // Get the index in v_local where this value needs to be inserted.
-          numeric_index_type local_requested_index = local_requested_ids[procup][i];
+          const numeric_index_type local_requested_index =
+            local_requested_ids[pid][i];
 
           // Actually set the value in v_local
-          v_local[local_requested_index] = values_to_receive[i];
+          v_local[local_requested_index] = values[i];
         }
-    }
+    };
+
+  const T * ex = libmesh_nullptr;
+  Parallel::pull_parallel_vector_data
+    (this->comm(), requested_ids, gather_functor, action_functor, ex);
 }
 
 

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -439,7 +439,7 @@ void DistributedVector<T>::localize (std::vector<T> & v_local,
   // We now fill in 'requested_ids' based on the indices.  Also keep
   // track of the local index (in the indices vector) for each of
   // these, since we need that when unpacking.
-  std::map<dof_id_type, std::vector<numeric_index_type>>
+  std::map<processor_id_type, std::vector<numeric_index_type>>
     requested_ids, local_requested_ids;
 
   // We'll use this typedef a couple of times below.

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -21,6 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/parallel.h"
+#include "libmesh/parallel_sync.h"
 #include "libmesh/partitioner.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/mesh_communication.h"
@@ -433,8 +434,8 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
   //
   // The only remaining issue is what to do with unpartitioned nodes.  Since they are required
   // to live on all processors we can simply rely on ourselves to number them properly.
-  std::vector<std::vector<dof_id_type>>
-    requested_node_ids(mesh.n_processors());
+  std::map<dof_id_type, std::vector<dof_id_type>>
+    requested_node_ids;
 
   // Loop over all the nodes, count the ones on each processor.  We can skip ourself
   std::vector<dof_id_type> ghost_nodes_from_proc(mesh.n_processors(), 0);
@@ -454,7 +455,8 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
   // We know how many objects live on each processor, so reserve()
   // space for each.
   for (processor_id_type pid=0; pid != mesh.n_processors(); ++pid)
-    requested_node_ids[pid].reserve(ghost_nodes_from_proc[pid]);
+    if (ghost_nodes_from_proc[pid])
+      requested_node_ids[pid].reserve(ghost_nodes_from_proc[pid]);
 
   // We need to get the new pid for each node from the processor
   // which *currently* owns the node.  We can safely skip ourself
@@ -465,7 +467,6 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
       if (current_pid != mesh.processor_id() &&
           current_pid != DofObject::invalid_processor_id)
         {
-          libmesh_assert_less (current_pid, requested_node_ids.size());
           libmesh_assert_less (requested_node_ids[current_pid].size(),
                                ghost_nodes_from_proc[current_pid]);
           requested_node_ids[current_pid].push_back(node->id());
@@ -530,23 +531,18 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
   // that we successfully reset their processor ids to something
   // valid.
 
-  // Next set node ids from other processors, excluding self
-  for (processor_id_type p=1; p != mesh.n_processors(); ++p)
+  auto gather_functor =
+    [& mesh]
+    (processor_id_type, const std::vector<dof_id_type> & ids,
+     std::vector<processor_id_type> & new_pids)
     {
-      // Trade my requests with processor procup and procdown
-      processor_id_type procup = cast_int<processor_id_type>
-        ((mesh.processor_id() + p) % mesh.n_processors());
-      processor_id_type procdown = cast_int<processor_id_type>
-        ((mesh.n_processors() + mesh.processor_id() - p) %
-         mesh.n_processors());
-      std::vector<dof_id_type> request_to_fill;
-      mesh.comm().send_receive(procup, requested_node_ids[procup],
-                               procdown, request_to_fill);
+      const std::size_t ids_size = ids.size();
+      new_pids.resize(ids_size);
 
       // Fill those requests in-place
-      for (std::size_t i=0; i != request_to_fill.size(); ++i)
+      for (std::size_t i=0; i != ids_size; ++i)
         {
-          Node & node = mesh.node_ref(request_to_fill[i]);
+          Node & node = mesh.node_ref(ids[i]);
           const processor_id_type new_pid = node.processor_id();
 
           // We may have an invalid processor_id() on nodes that have been
@@ -554,19 +550,21 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
           // themselves been removed.
           // libmesh_assert_not_equal_to (new_pid, DofObject::invalid_processor_id);
           // libmesh_assert_less (new_pid, mesh.n_partitions()); // this is the correct test --
-          request_to_fill[i] = new_pid;           //  the number of partitions may
-        }                                         //  not equal the number of processors
+          new_pids[i] = new_pid;                                 //  the number of partitions may
+        }                                                        //  not equal the number of processors
+    };
 
-      // Trade back the results
-      std::vector<dof_id_type> filled_request;
-      mesh.comm().send_receive(procdown, request_to_fill,
-                               procup,   filled_request);
-      libmesh_assert_equal_to (filled_request.size(), requested_node_ids[procup].size());
-
-      // And copy the id changes we've now been informed of
-      for (std::size_t i=0; i != filled_request.size(); ++i)
+  auto action_functor =
+    [& mesh]
+    (processor_id_type libmesh_dbg_var(pid),
+     const std::vector<dof_id_type> & ids,
+     const std::vector<processor_id_type> & new_pids)
+    {
+      const std::size_t ids_size = ids.size();
+      // Copy the pid changes we've now been informed of
+      for (std::size_t i=0; i != ids_size; ++i)
         {
-          Node & node = mesh.node_ref(requested_node_ids[procup][i]);
+          Node & node = mesh.node_ref(ids[i]);
 
           // this is the correct test -- the number of partitions may
           // not equal the number of processors
@@ -576,9 +574,13 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
           // that have not yet themselves been removed.
           // libmesh_assert_less (filled_request[i], mesh.n_partitions());
 
-          node.processor_id(cast_int<processor_id_type>(filled_request[i]));
+          node.processor_id(new_pids[i]);
         }
-    }
+    };
+
+  const processor_id_type * ex = libmesh_nullptr;
+  Parallel::pull_parallel_vector_data
+    (mesh.comm(), requested_node_ids, gather_functor, action_functor, ex);
 
 #ifdef DEBUG
   MeshTools::libmesh_assert_valid_procids<Node>(mesh);

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -434,7 +434,7 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
   //
   // The only remaining issue is what to do with unpartitioned nodes.  Since they are required
   // to live on all processors we can simply rely on ourselves to number them properly.
-  std::map<dof_id_type, std::vector<dof_id_type>>
+  std::map<processor_id_type, std::vector<dof_id_type>>
     requested_node_ids;
 
   // Loop over all the nodes, count the ones on each processor.  We can skip ourself
@@ -841,12 +841,12 @@ void Partitioner::assign_partitioning (const MeshBase & mesh, const std::vector<
   const dof_id_type n_active_local_elem = mesh.n_active_local_elem();
 #endif
 
-  std::map<dof_id_type, std::vector<dof_id_type>>
+  std::map<processor_id_type, std::vector<dof_id_type>>
     requested_ids;
 
   // Results to gather from each processor - kept in a map so we
   // do only one loop over elements after all receives are done.
-  std::map<dof_id_type, std::vector<processor_id_type>>
+  std::map<processor_id_type, std::vector<processor_id_type>>
     filled_request;
 
   for (auto & elem : mesh.active_element_ptr_range())

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -556,7 +556,7 @@ void Partitioner::set_node_processor_ids(MeshBase & mesh)
 
   auto action_functor =
     [& mesh]
-    (processor_id_type libmesh_dbg_var(pid),
+    (processor_id_type,
      const std::vector<dof_id_type> & ids,
      const std::vector<processor_id_type> & new_pids)
     {

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -839,35 +839,39 @@ void Partitioner::assign_partitioning (const MeshBase & mesh, const std::vector<
   const dof_id_type n_active_local_elem = mesh.n_active_local_elem();
 #endif
 
-  std::vector<std::vector<dof_id_type>>
-    requested_ids(mesh.n_processors()),
-    requests_to_fill(mesh.n_processors());
+  std::map<dof_id_type, std::vector<dof_id_type>>
+    requested_ids;
+
+  // Results to gather from each processor - kept in a map so we
+  // do only one loop over elements after all receives are done.
+  std::map<dof_id_type, std::vector<processor_id_type>>
+    filled_request;
 
   for (auto & elem : mesh.active_element_ptr_range())
     {
       // we need to get the index from the owning processor
       // (note we cannot assign it now -- we are iterating
       // over elements again and this will be bad!)
-      libmesh_assert_less (elem->processor_id(), requested_ids.size());
       requested_ids[elem->processor_id()].push_back(elem->id());
     }
 
-  // Trade with all processors (including self) to get their indices
-  for (processor_id_type pid=0; pid<mesh.n_processors(); pid++)
+  auto gather_functor =
+    [this,
+     & parts,
+#ifndef NDEBUG
+     & mesh,
+     n_active_local_elem,
+#endif
+     first_local_elem]
+    (processor_id_type, const std::vector<dof_id_type> & ids,
+     std::vector<processor_id_type> & data)
     {
-      // Trade my requests with processor procup and procdown
-      const processor_id_type procup = (mesh.processor_id() + pid) % mesh.n_processors();
-      const processor_id_type procdown = (mesh.n_processors() +
-                                          mesh.processor_id() - pid) % mesh.n_processors();
+      const std::size_t ids_size = ids.size();
+      data.resize(ids.size());
 
-      mesh.comm().send_receive (procup,   requested_ids[procup],
-                                procdown, requests_to_fill[procdown]);
-
-      // we can overwrite these requested ids in-place.
-      for (std::size_t i=0; i<requests_to_fill[procdown].size(); i++)
+      for (std::size_t i=0; i != ids_size; i++)
         {
-          const dof_id_type requested_elem_index =
-            requests_to_fill[procdown][i];
+          const dof_id_type requested_elem_index = ids[i];
 
           libmesh_assert(_global_index_by_pid_map.count(requested_elem_index));
 
@@ -880,18 +884,28 @@ void Partitioner::assign_partitioning (const MeshBase & mesh, const std::vector<
           libmesh_assert_less (local_index, parts.size());
           libmesh_assert_less (local_index, n_active_local_elem);
 
-          const unsigned int elem_procid =
-            static_cast<unsigned int>(parts[local_index]);
+          const processor_id_type elem_procid =
+            cast_int<processor_id_type>(parts[local_index]);
 
           libmesh_assert_less (elem_procid, mesh.n_partitions());
 
-          requests_to_fill[procdown][i] = elem_procid;
+          data[i] = elem_procid;
         }
+    };
 
-      // Trade back
-      mesh.comm().send_receive (procdown, requests_to_fill[procdown],
-                                procup,   requested_ids[procup]);
-    }
+  auto action_functor =
+    [&filled_request]
+    (processor_id_type pid,
+     const std::vector<dof_id_type> &,
+     const std::vector<processor_id_type> & new_procids)
+    {
+      filled_request[pid] = new_procids;
+    };
+
+  // Trade requests with other processors
+  const processor_id_type * ex = libmesh_nullptr;
+  Parallel::pull_parallel_vector_data
+    (mesh.comm(), requested_ids, gather_functor, action_functor, ex);
 
   // and finally assign the partitioning.
   // note we are iterating in exactly the same order
@@ -905,7 +919,7 @@ void Partitioner::assign_partitioning (const MeshBase & mesh, const std::vector<
       libmesh_assert_less (counters[current_pid], requested_ids[current_pid].size());
 
       const processor_id_type elem_procid =
-        requested_ids[current_pid][counters[current_pid]++];
+        filled_request[current_pid][counters[current_pid]++];
 
       libmesh_assert_less (elem_procid, mesh.n_partitions());
       elem->processor_id() = elem_procid;

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -56,11 +56,13 @@ public:
 
 #ifdef LIBMESH_ENABLE_AMR
 #ifdef LIBMESH_HAVE_METAPHYSICL
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testProjectMatrixEdge2 );
   CPPUNIT_TEST( testProjectMatrixQuad4 );
   CPPUNIT_TEST( testProjectMatrixTri3 );
   CPPUNIT_TEST( testProjectMatrixHex8 );
   CPPUNIT_TEST( testProjectMatrixTet4 );
+#endif // LIBMESH_HAVE_PETSC
 #endif // LIBMESH_HAVE_METAPHYSICL
 #endif // LIBMESH_ENABLE_AMR
 
@@ -214,6 +216,7 @@ public:
 
 #ifdef LIBMESH_ENABLE_AMR
 #ifdef LIBMESH_HAVE_METAPHYSICL
+#ifdef LIBMESH_HAVE_PETSC
   void testProjectMatrix1D(const ElemType elem_type)
   {
     // Use ReplicatedMesh to get consistent child element node
@@ -669,6 +672,7 @@ public:
     Real diff_norm = proj_mat.linfty_norm();
     CPPUNIT_ASSERT(diff_norm/gold_norm < TOLERANCE*TOLERANCE);
   }
+#endif // LIBMESH_HAVE_PETSC
 #endif // LIBMESH_HAVE_METAPHYSICL
 #endif // LIBMESH_ENABLE_AMR
 
@@ -681,12 +685,14 @@ public:
 
 #ifdef LIBMESH_ENABLE_AMR
 #ifdef LIBMESH_HAVE_METAPHYSICL
+#ifdef LIBMESH_HAVE_PETSC
   // projection matrix tests
   void testProjectMatrixEdge2() { testProjectMatrix1D(EDGE2); }
   void testProjectMatrixQuad4() { testProjectMatrix2D(QUAD4); }
   void testProjectMatrixTri3() { testProjectMatrix2D(TRI3); }
   void testProjectMatrixHex8() { testProjectMatrix3D(HEX8); }
   void testProjectMatrixTet4() { testProjectMatrix3D(TET4); }
+#endif // LIBMESH_HAVE_PETSC
 #endif // LIBMESH_HAVE_METAPHYSICL
 #endif // LIBMESH_ENABLE_AMR
 


### PR DESCRIPTION
This branches off of and can wait on #1702; only the last five commits are new.

The first two tweak parallel_sync and add more assertions to its implementations; the final three replace three more round-robin communication processes with invocations of ```Parallel::pull_parallel_vector_data()```