### PR TITLE
Add configure test for std::tuple

### DIFF
--- a/configure
+++ b/configure
@@ -946,8 +946,6 @@ HAVE_CXX11_ALIAS_DECLARATIONS_FALSE
 HAVE_CXX11_ALIAS_DECLARATIONS_TRUE
 HAVE_CXX11_CONSTEXPR_FALSE
 HAVE_CXX11_CONSTEXPR_TRUE
-HAVE_CXX11_LAMBDA_FALSE
-HAVE_CXX11_LAMBDA_TRUE
 HAVE_CXX11_RVALUE_REFERENCES_FALSE
 HAVE_CXX11_RVALUE_REFERENCES_TRUE
 HAVE_CXX11_DECLTYPE_FALSE
@@ -956,6 +954,10 @@ HAVE_CXX11_MOVE_CONSTRUCTORS_FALSE
 HAVE_CXX11_MOVE_CONSTRUCTORS_TRUE
 HAVE_CXX11_MOVE_FALSE
 HAVE_CXX11_MOVE_TRUE
+HAVE_CXX11_LAMBDA_FALSE
+HAVE_CXX11_LAMBDA_TRUE
+HAVE_CXX11_TUPLE_FALSE
+HAVE_CXX11_TUPLE_TRUE
 HAVE_CXX11_MAKE_UNIQUE_WORKAROUND_FALSE
 HAVE_CXX11_MAKE_UNIQUE_WORKAROUND_TRUE
 HAVE_CXX11_UNIQUE_PTR_FALSE
@@ -8118,6 +8120,169 @@ if test "x$have_cxx11_make_unique_workaround" != "xyes"; then :
   as_fn_error $? "libMesh requires C++11 variadic template support" "$LINENO" 5
 fi
 
+
+    have_cxx11_tuple=no
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 std::tuple support" >&5
+$as_echo_n "checking for C++11 std::tuple support... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+                        old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <tuple>
+    #include <map>
+    #include <string>
+
+int
+main ()
+{
+
+    // Test std::make_tuple
+    std::map<int, std::tuple<double, char, std::string>> students;
+    students[0] = std::make_tuple(3.8, 'A', "Lisa Simpson");
+    students[1] = std::make_tuple(2.9, 'C', "Milhouse Van Houten");
+
+    // Test templated std::get() method.
+    std::get<0>(students[0]);
+    std::get<1>(students[0]);
+    std::get<2>(students[0]);
+
+    // Test std::tie and std::ignore which are declared in the <tuple> header.
+    double gpa1;
+    std::string name1;
+    std::tie(gpa1, std::ignore, name1) = students[1];
+
+    // Test std::tuple_cat(), which combines together one or more
+    // objects, not necessarily tuples, into a single tuple.
+    auto t = std::tuple_cat(students[0], students[1], std::make_pair("foo", 42));
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_CXX11_TUPLE 1" >>confdefs.h
+
+        have_cxx11_tuple=yes
+
+else
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+        CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+     if test x$have_cxx11_tuple == xyes; then
+  HAVE_CXX11_TUPLE_TRUE=
+  HAVE_CXX11_TUPLE_FALSE='#'
+else
+  HAVE_CXX11_TUPLE_TRUE='#'
+  HAVE_CXX11_TUPLE_FALSE=
+fi
+
+
+if test "x$have_cxx11_tuple" != "xyes"; then :
+  as_fn_error $? "libMesh requires C++11 std::tuple support" "$LINENO" 5
+fi
+
+
+    have_cxx11_lambda=no
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 lambda support" >&5
+$as_echo_n "checking for C++11 lambda support... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      // typedef for a function pointer that takes int and returns bool.
+      typedef bool (*FunctionPointer) (int);
+
+      // A function that takes a pointer to a function that takes an int,
+      // calls it with the number 4, and returns the result.
+      bool f(FunctionPointer g) { return g(4); }
+
+int
+main ()
+{
+
+      // Call f, passing it a lambda constructed on the fly instead
+      // of a standard function pointer.  The result should be true.
+      f ( [](int x) { return x > 3; } );
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_CXX11_LAMBDA 1" >>confdefs.h
+
+        have_cxx11_lambda=yes
+
+else
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+    # Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+     if test x$have_cxx11_lambda == xyes; then
+  HAVE_CXX11_LAMBDA_TRUE=
+  HAVE_CXX11_LAMBDA_FALSE='#'
+else
+  HAVE_CXX11_LAMBDA_TRUE='#'
+  HAVE_CXX11_LAMBDA_FALSE=
+fi
+
+
+if test "x$have_cxx11_lambda" != "xyes"; then :
+  as_fn_error $? "libMesh requires C++11 lambda support" "$LINENO" 5
+fi
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.
@@ -8407,78 +8572,6 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 else
   HAVE_CXX11_RVALUE_REFERENCES_TRUE='#'
   HAVE_CXX11_RVALUE_REFERENCES_FALSE=
-fi
-
-
-
-    have_cxx11_lambda=no
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 lambda support" >&5
-$as_echo_n "checking for C++11 lambda support... " >&6; }
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-    old_CXXFLAGS="$CXXFLAGS"
-    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-      // typedef for a function pointer that takes int and returns bool.
-      typedef bool (*FunctionPointer) (int);
-
-      // A function that takes a pointer to a function that takes an int,
-      // calls it with the number 4, and returns the result.
-      bool f(FunctionPointer g) { return g(4); }
-
-int
-main ()
-{
-
-      // Call f, passing it a lambda constructed on the fly instead
-      // of a standard function pointer.  The result should be true.
-      f ( [](int x) { return x > 3; } );
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-$as_echo "#define HAVE_CXX11_LAMBDA 1" >>confdefs.h
-
-        have_cxx11_lambda=yes
-
-else
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-    # Reset the flags
-    CXXFLAGS="$old_CXXFLAGS"
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-     if test x$have_cxx11_lambda == xyes; then
-  HAVE_CXX11_LAMBDA_TRUE=
-  HAVE_CXX11_LAMBDA_FALSE='#'
-else
-  HAVE_CXX11_LAMBDA_TRUE='#'
-  HAVE_CXX11_LAMBDA_FALSE=
 fi
 
 
@@ -41256,6 +41349,14 @@ if test -z "${HAVE_CXX11_MAKE_UNIQUE_WORKAROUND_TRUE}" && test -z "${HAVE_CXX11_
   as_fn_error $? "conditional \"HAVE_CXX11_MAKE_UNIQUE_WORKAROUND\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
+if test -z "${HAVE_CXX11_TUPLE_TRUE}" && test -z "${HAVE_CXX11_TUPLE_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_CXX11_TUPLE\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${HAVE_CXX11_LAMBDA_TRUE}" && test -z "${HAVE_CXX11_LAMBDA_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_CXX11_LAMBDA\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
 if test -z "${HAVE_CXX11_MOVE_TRUE}" && test -z "${HAVE_CXX11_MOVE_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_MOVE\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
@@ -41270,10 +41371,6 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX11_RVALUE_REFERENCES_TRUE}" && test -z "${HAVE_CXX11_RVALUE_REFERENCES_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_RVALUE_REFERENCES\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${HAVE_CXX11_LAMBDA_TRUE}" && test -z "${HAVE_CXX11_LAMBDA_FALSE}"; then
-  as_fn_error $? "conditional \"HAVE_CXX11_LAMBDA\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX11_CONSTEXPR_TRUE}" && test -z "${HAVE_CXX11_CONSTEXPR_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,14 @@ LIBMESH_TEST_CXX11_MAKE_UNIQUE_WORKAROUND
 AS_IF([test "x$have_cxx11_make_unique_workaround" != "xyes"],
       [AC_MSG_ERROR([libMesh requires C++11 variadic template support])])
 
+LIBMESH_TEST_CXX11_TUPLE
+AS_IF([test "x$have_cxx11_tuple" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires C++11 std::tuple support])])
+
+LIBMESH_TEST_CXX11_LAMBDA
+AS_IF([test "x$have_cxx11_lambda" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires C++11 lambda support])])
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.
@@ -228,7 +236,6 @@ LIBMESH_TEST_CXX11_MOVE
 LIBMESH_TEST_CXX11_MOVE_CONSTRUCTORS
 LIBMESH_TEST_CXX11_DECLTYPE
 LIBMESH_TEST_CXX11_RVALUE_REFERENCES
-LIBMESH_TEST_CXX11_LAMBDA
 LIBMESH_TEST_CXX11_CONSTEXPR
 LIBMESH_TEST_CXX11_ALIAS_DECLARATIONS
 LIBMESH_TEST_CXX11_SHARED_PTR

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -313,6 +313,9 @@
 /* Flag indicating whether compiler supports std::to_string() */
 #undef HAVE_CXX11_TO_STRING
 
+/* Flag indicating whether compiler supports std::move */
+#undef HAVE_CXX11_TUPLE
+
 /* Flag indicating whether compiler supports <type_traits> */
 #undef HAVE_CXX11_TYPE_TRAITS
 

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -700,6 +700,14 @@ public:
                                std::vector<boundary_id_type> &   bc_id_list) const;
 
   /**
+   * As above, but the library creates and fills in a vector of
+   * (elem-id, side-id, bc-id) triplets and returns it to the user,
+   * taking advantage of guaranteed RVO.
+   */
+  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+  build_active_side_list () const;
+
+  /**
    * Creates a list of element numbers, edges, and boundary ids for those edges.
    *
    * On a ReplicatedMesh this will include all edges; on a

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -647,6 +647,16 @@ public:
                         std::vector<boundary_id_type> & bc_id_list) const;
 
   /**
+   * As above, but the library creates and fills in a vector of
+   * (node-id, bc-id) pairs and returns it to the user, taking
+   * advantage of guaranteed RVO. Note: we could use std::pairs for
+   * this, but for consistency with the other build_XYZ_list
+   * functions, we're using tuples.
+   */
+  std::vector<std::tuple<dof_id_type, boundary_id_type>>
+  build_node_list() const;
+
+  /**
    * Adds nodes with boundary ids based on the side's boundary
    * ids they are connected to.
    */

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -701,6 +701,14 @@ public:
                         std::vector<boundary_id_type> &   bc_id_list) const;
 
   /**
+   * As above, but the library creates and fills in a vector of
+   * (elem-id, side-id, bc-id) triplets and returns it to the user,
+   * taking advantage of guaranteed RVO.
+   */
+  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+  build_edge_list() const;
+
+  /**
    * Creates a list of element numbers, shellfaces, and boundary ids for those shellfaces.
    *
    * On a ReplicatedMesh this will include all shellfaces; on a
@@ -710,6 +718,7 @@ public:
   void build_shellface_list (std::vector<dof_id_type> &        element_id_list,
                              std::vector<unsigned short int> & shellface_list,
                              std::vector<boundary_id_type> &   bc_id_list) const;
+
   /**
    * As above, but the library creates and fills in a vector of
    * (elem-id, side-id, bc-id) triplets and returns it to the user,

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -710,6 +710,13 @@ public:
   void build_shellface_list (std::vector<dof_id_type> &        element_id_list,
                              std::vector<unsigned short int> & shellface_list,
                              std::vector<boundary_id_type> &   bc_id_list) const;
+  /**
+   * As above, but the library creates and fills in a vector of
+   * (elem-id, side-id, bc-id) triplets and returns it to the user,
+   * taking advantage of guaranteed RVO.
+   */
+  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+  build_shellface_list() const;
 
   /**
    * \returns A set of the boundary ids which exist on semilocal parts

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -668,6 +668,15 @@ public:
   void build_side_list (std::vector<dof_id_type> &        element_id_list,
                         std::vector<unsigned short int> & side_list,
                         std::vector<boundary_id_type> &   bc_id_list) const;
+
+  /**
+   * As above, but the library creates and fills in a vector of
+   * (elem-id, side-id, bc-id) triplets and returns it to the user,
+   * taking advantage of guaranteed RVO.
+   */
+  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+  build_side_list() const;
+
   /**
    * Creates a list of active element numbers, sides, and ids for those sides.
    *

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -642,9 +642,14 @@ public:
    *
    * On a ReplicatedMesh this will include all nodes; on a
    * DistributedMesh only semilocal nodes will be included.
+   *
+   * \deprecated Use the version of build_node_list() below that
+   * returns a std::vector of tuples instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   void build_node_list (std::vector<dof_id_type> &      node_id_list,
                         std::vector<boundary_id_type> & bc_id_list) const;
+#endif
 
   /**
    * As above, but the library creates and fills in a vector of
@@ -673,12 +678,16 @@ public:
    *
    * On a ReplicatedMesh this will include all sides; on a
    * DistributedMesh only sides of semilocal elements will be
-   * included. This function is deprecated in favor of the version of
-   * build_side_list() below that returns a std::vector of tuples.
+   * included.
+   *
+   * \deprecated Use the version of build_side_list() below that
+   * returns a std::vector of tuples instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   void build_side_list (std::vector<dof_id_type> &        element_id_list,
                         std::vector<unsigned short int> & side_list,
                         std::vector<boundary_id_type> &   bc_id_list) const;
+#endif
 
   /**
    * As above, but the library creates and fills in a vector of
@@ -694,10 +703,15 @@ public:
    * On a ReplicatedMesh this will include all sides; on a
    * DistributedMesh only sides of semilocal elements will be
    * included.
+   *
+   * \deprecated Use the version of build_active_side_list() below
+   * that returns a std::vector of tuples instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   void build_active_side_list (std::vector<dof_id_type> &        element_id_list,
                                std::vector<unsigned short int> & side_list,
                                std::vector<boundary_id_type> &   bc_id_list) const;
+#endif
 
   /**
    * As above, but the library creates and fills in a vector of
@@ -713,10 +727,15 @@ public:
    * On a ReplicatedMesh this will include all edges; on a
    * DistributedMesh only edges of semilocal elements will be
    * included.
+   *
+   * \deprecated Use the version of build_edge_list() below
+   * that returns a std::vector of tuples instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   void build_edge_list (std::vector<dof_id_type> &        element_id_list,
                         std::vector<unsigned short int> & edge_list,
                         std::vector<boundary_id_type> &   bc_id_list) const;
+#endif
 
   /**
    * As above, but the library creates and fills in a vector of
@@ -732,10 +751,15 @@ public:
    * On a ReplicatedMesh this will include all shellfaces; on a
    * DistributedMesh only shellfaces of semilocal elements will be
    * included.
+   *
+   * \deprecated Use the version of build_shellface_list() below
+   * that returns a std::vector of tuples instead.
    */
+#ifdef LIBMESH_ENABLE_DEPRECATED
   void build_shellface_list (std::vector<dof_id_type> &        element_id_list,
                              std::vector<unsigned short int> & shellface_list,
                              std::vector<boundary_id_type> &   bc_id_list) const;
+#endif
 
   /**
    * As above, but the library creates and fills in a vector of

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -30,6 +30,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <tuple>
 
 namespace libMesh
 {

--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -663,7 +663,8 @@ public:
    *
    * On a ReplicatedMesh this will include all sides; on a
    * DistributedMesh only sides of semilocal elements will be
-   * included.
+   * included. This function is deprecated in favor of the version of
+   * build_side_list() below that returns a std::vector of tuples.
    */
   void build_side_list (std::vector<dof_id_type> &        element_id_list,
                         std::vector<unsigned short int> & side_list,

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -45,6 +45,59 @@ AC_DEFUN([LIBMESH_TEST_CXX11_MOVE],
     AM_CONDITIONAL(HAVE_CXX11_MOVE, test x$have_cxx11_move == xyes)
   ])
 
+dnl Test C++11 std::tuple and several related helper functions.
+AC_DEFUN([LIBMESH_TEST_CXX11_TUPLE],
+  [
+    have_cxx11_tuple=no
+
+    AC_MSG_CHECKING(for C++11 std::tuple support)
+    AC_LANG_PUSH([C++])
+
+    dnl For this and all of the C++ standards tests: Save the original
+    dnl CXXFLAGS (if any) before appending the $switch determined by
+    dnl AX_CXX_COMPILE_STDCXX_11, and any compiler flags specified by
+    dnl the user in the libmesh_CXXFLAGS environment variable, letting
+    dnl that override everything else.
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include <tuple>
+    @%:@include <map>
+    @%:@include <string>
+    ]], [[
+    // Test std::make_tuple
+    std::map<int, std::tuple<double, char, std::string>> students;
+    students[0] = std::make_tuple(3.8, 'A', "Lisa Simpson");
+    students[1] = std::make_tuple(2.9, 'C', "Milhouse Van Houten");
+
+    // Test templated std::get() method.
+    std::get<0>(students[0]);
+    std::get<1>(students[0]);
+    std::get<2>(students[0]);
+
+    // Test std::tie and std::ignore which are declared in the <tuple> header.
+    double gpa1;
+    std::string name1;
+    std::tie(gpa1, std::ignore, name1) = students[1];
+
+    // Test std::tuple_cat(), which combines together one or more
+    // objects, not necessarily tuples, into a single tuple.
+    auto t = std::tuple_cat(students[0], students[1], std::make_pair("foo", 42));
+    ]])],[
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_CXX11_TUPLE, 1, [Flag indicating whether compiler supports std::move])
+        have_cxx11_tuple=yes
+    ],[
+        AC_MSG_RESULT(no)
+    ])
+
+    dnl Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    AC_LANG_POP([C++])
+
+    AM_CONDITIONAL(HAVE_CXX11_TUPLE, test x$have_cxx11_tuple == xyes)
+  ])
 
 dnl Properly implemented move constructors require rvalue references,
 dnl std::move, and noexcept, so this tests for all of those features.

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -2068,6 +2068,8 @@ void BoundaryInfo::build_side_list (std::vector<dof_id_type> & el,
                                     std::vector<unsigned short int> & sl,
                                     std::vector<boundary_id_type> & il) const
 {
+  libmesh_deprecated();
+
   // Clear the input vectors, just in case they were used for
   // something else recently...
   el.clear();

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1813,7 +1813,7 @@ std::size_t BoundaryInfo::n_nodeset_conds () const
 void BoundaryInfo::build_node_list (std::vector<dof_id_type> & nl,
                                     std::vector<boundary_id_type> & il) const
 {
-  libmesh_deprecated();
+  // libmesh_deprecated();
 
   // Clear the input vectors, just in case they were used for
   // something else recently...
@@ -2086,7 +2086,7 @@ void BoundaryInfo::build_side_list (std::vector<dof_id_type> & el,
                                     std::vector<unsigned short int> & sl,
                                     std::vector<boundary_id_type> & il) const
 {
-  libmesh_deprecated();
+  // libmesh_deprecated();
 
   // Clear the input vectors, just in case they were used for
   // something else recently...
@@ -2129,7 +2129,7 @@ void BoundaryInfo::build_active_side_list (std::vector<dof_id_type> & el,
                                            std::vector<unsigned short int> & sl,
                                            std::vector<boundary_id_type> & il) const
 {
-  libmesh_deprecated();
+  // libmesh_deprecated();
 
   // Clear the input vectors, just in case they were used for
   // something else recently...
@@ -2198,7 +2198,7 @@ void BoundaryInfo::build_edge_list (std::vector<dof_id_type> & el,
                                     std::vector<unsigned short int> & sl,
                                     std::vector<boundary_id_type> & il) const
 {
-  libmesh_deprecated();
+  // libmesh_deprecated();
 
   // Clear the input vectors, just in case they were used for
   // something else recently...
@@ -2240,7 +2240,7 @@ void BoundaryInfo::build_shellface_list (std::vector<dof_id_type> & el,
                                          std::vector<unsigned short int> & sl,
                                          std::vector<boundary_id_type> & il) const
 {
-  libmesh_deprecated();
+  // libmesh_deprecated();
 
   // Clear the input vectors, just in case they were used for
   // something else recently...

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1812,6 +1812,8 @@ std::size_t BoundaryInfo::n_nodeset_conds () const
 void BoundaryInfo::build_node_list (std::vector<dof_id_type> & nl,
                                     std::vector<boundary_id_type> & il) const
 {
+  libmesh_deprecated();
+
   // Clear the input vectors, just in case they were used for
   // something else recently...
   nl.clear();
@@ -2159,6 +2161,8 @@ void BoundaryInfo::build_edge_list (std::vector<dof_id_type> & el,
                                     std::vector<unsigned short int> & sl,
                                     std::vector<boundary_id_type> & il) const
 {
+  libmesh_deprecated();
+
   // Clear the input vectors, just in case they were used for
   // something else recently...
   el.clear();
@@ -2186,7 +2190,6 @@ BoundaryInfo::build_edge_list() const
   std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_triples;
   bc_triples.reserve(_boundary_edge_id.size());
 
-
   for (const auto & pr : _boundary_edge_id)
     bc_triples.emplace_back(pr.first->id(), pr.second.first, pr.second.second);
 
@@ -2198,6 +2201,8 @@ void BoundaryInfo::build_shellface_list (std::vector<dof_id_type> & el,
                                          std::vector<unsigned short int> & sl,
                                          std::vector<boundary_id_type> & il) const
 {
+  libmesh_deprecated();
+
   // Clear the input vectors, just in case they were used for
   // something else recently...
   el.clear();
@@ -2224,7 +2229,6 @@ BoundaryInfo::build_shellface_list() const
 {
   std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_triples;
   bc_triples.reserve(_boundary_shellface_id.size());
-
 
   for (const auto & pr : _boundary_shellface_id)
     bc_triples.emplace_back(pr.first->id(), pr.second.first, pr.second.second);

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -2088,6 +2088,22 @@ void BoundaryInfo::build_side_list (std::vector<dof_id_type> & el,
     }
 }
 
+
+
+std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+BoundaryInfo::build_side_list() const
+{
+  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_triples;
+  bc_triples.reserve(_boundary_side_id.size());
+
+  for (const auto & pr : _boundary_side_id)
+    bc_triples.emplace_back(pr.first->id(), pr.second.first, pr.second.second);
+
+  return bc_triples;
+}
+
+
+
 void BoundaryInfo::build_active_side_list (std::vector<dof_id_type> & el,
                                            std::vector<unsigned short int> & sl,
                                            std::vector<boundary_id_type> & il) const

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -2167,6 +2167,20 @@ void BoundaryInfo::build_edge_list (std::vector<dof_id_type> & el,
 }
 
 
+std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+BoundaryInfo::build_edge_list() const
+{
+  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_triples;
+  bc_triples.reserve(_boundary_edge_id.size());
+
+
+  for (const auto & pr : _boundary_edge_id)
+    bc_triples.emplace_back(pr.first->id(), pr.second.first, pr.second.second);
+
+  return bc_triples;
+}
+
+
 void BoundaryInfo::build_shellface_list (std::vector<dof_id_type> & el,
                                          std::vector<unsigned short int> & sl,
                                          std::vector<boundary_id_type> & il) const

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -2192,6 +2192,20 @@ void BoundaryInfo::build_shellface_list (std::vector<dof_id_type> & el,
 }
 
 
+std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
+BoundaryInfo::build_shellface_list() const
+{
+  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bc_triples;
+  bc_triples.reserve(_boundary_shellface_id.size());
+
+
+  for (const auto & pr : _boundary_shellface_id)
+    bc_triples.emplace_back(pr.first->id(), pr.second.first, pr.second.second);
+
+  return bc_triples;
+}
+
+
 void BoundaryInfo::print_info(std::ostream & out_stream) const
 {
   // Print out the nodal BCs

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1830,6 +1830,19 @@ void BoundaryInfo::build_node_list (std::vector<dof_id_type> & nl,
 }
 
 
+std::vector<std::tuple<dof_id_type, boundary_id_type>>
+BoundaryInfo::build_node_list() const
+{
+  std::vector<std::tuple<dof_id_type, boundary_id_type>> bc_tuples;
+  bc_tuples.reserve(_boundary_node_id.size());
+
+  for (const auto & pr : _boundary_node_id)
+    bc_tuples.emplace_back(pr.first->id(), pr.second);
+
+  return bc_tuples;
+}
+
+
 void
 BoundaryInfo::build_node_list_from_side_list()
 {

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1809,6 +1809,7 @@ std::size_t BoundaryInfo::n_nodeset_conds () const
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 void BoundaryInfo::build_node_list (std::vector<dof_id_type> & nl,
                                     std::vector<boundary_id_type> & il) const
 {
@@ -1830,6 +1831,7 @@ void BoundaryInfo::build_node_list (std::vector<dof_id_type> & nl,
       il.push_back (pos->second);
     }
 }
+#endif
 
 
 std::vector<std::tuple<dof_id_type, boundary_id_type>>
@@ -2079,6 +2081,7 @@ void BoundaryInfo::build_side_list_from_node_list()
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 void BoundaryInfo::build_side_list (std::vector<dof_id_type> & el,
                                     std::vector<unsigned short int> & sl,
                                     std::vector<boundary_id_type> & il) const
@@ -2104,7 +2107,7 @@ void BoundaryInfo::build_side_list (std::vector<dof_id_type> & el,
       il.push_back (pos->second.second);
     }
 }
-
+#endif
 
 
 std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
@@ -2121,6 +2124,7 @@ BoundaryInfo::build_side_list() const
 
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 void BoundaryInfo::build_active_side_list (std::vector<dof_id_type> & el,
                                            std::vector<unsigned short int> & sl,
                                            std::vector<boundary_id_type> & il) const
@@ -2157,6 +2161,7 @@ void BoundaryInfo::build_active_side_list (std::vector<dof_id_type> & el,
         }
     }
 }
+#endif
 
 
 std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
@@ -2188,6 +2193,7 @@ BoundaryInfo::build_active_side_list () const
 }
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 void BoundaryInfo::build_edge_list (std::vector<dof_id_type> & el,
                                     std::vector<unsigned short int> & sl,
                                     std::vector<boundary_id_type> & il) const
@@ -2213,6 +2219,7 @@ void BoundaryInfo::build_edge_list (std::vector<dof_id_type> & el,
       il.push_back (pos->second.second);
     }
 }
+#endif
 
 
 std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
@@ -2228,6 +2235,7 @@ BoundaryInfo::build_edge_list() const
 }
 
 
+#ifdef LIBMESH_ENABLE_DEPRECATED
 void BoundaryInfo::build_shellface_list (std::vector<dof_id_type> & el,
                                          std::vector<unsigned short int> & sl,
                                          std::vector<boundary_id_type> & il) const
@@ -2253,6 +2261,7 @@ void BoundaryInfo::build_shellface_list (std::vector<dof_id_type> & el,
       il.push_back (pos->second.second);
     }
 }
+#endif
 
 
 std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -648,13 +648,9 @@ void CheckpointIO::write_nodesets (Xdr & io,
   // and our boundary info object
   const BoundaryInfo & boundary_info = mesh.get_boundary_info();
 
-  std::vector<dof_id_type> full_node_id_list;
-  std::vector<boundary_id_type> full_bc_id_list;
-
-  boundary_info.build_node_list(full_node_id_list, full_bc_id_list);
-
-  std::size_t nodeset_size = full_node_id_list.size();
-  libmesh_assert_equal_to(nodeset_size, full_bc_id_list.size());
+  // Build a list of (node, bc) tuples
+  auto bc_tuples = boundary_info.build_node_list();
+  std::size_t nodeset_size = bc_tuples.size();
 
   std::vector<largest_id_type> node_id_list;
   std::vector<largest_id_type> bc_id_list;
@@ -662,11 +658,11 @@ void CheckpointIO::write_nodesets (Xdr & io,
   node_id_list.reserve(nodeset_size);
   bc_id_list.reserve(nodeset_size);
 
-  for (std::size_t i = 0; i != nodeset_size; ++i)
-    if (nodeset.count(mesh.node_ptr(full_node_id_list[i])))
+  for (const auto & t : bc_tuples)
+    if (nodeset.count(mesh.node_ptr(std::get<0>(t))))
       {
-        node_id_list.push_back(full_node_id_list[i]);
-        bc_id_list.push_back(full_bc_id_list[i]);
+        node_id_list.push_back(std::get<0>(t));
+        bc_id_list.push_back(std::get<1>(t));
       }
 
   io.data(node_id_list, "# node id list");

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1584,14 +1584,8 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
   {
     // add data for shell faces, if needed
 
-    std::vector<dof_id_type > el;
-    std::vector<unsigned short int > sl;
-    std::vector<boundary_id_type > il;
-
-    mesh.get_boundary_info().build_shellface_list(el, sl, il);
-
     // Accumulate the vectors to pass into ex_put_side_set
-    for (std::size_t i=0; i<el.size(); i++)
+    for (const auto & t : mesh.get_boundary_info().build_shellface_list())
       {
         std::vector<const Elem *> family;
 #ifdef LIBMESH_ENABLE_AMR
@@ -1599,9 +1593,9 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
          * We need to build up active elements if AMR is enabled and add
          * them to the exodus sidesets instead of the potentially inactive "parent" elements
          */
-        mesh.elem_ref(el[i]).active_family_tree_by_side(family, sl[i], false);
+        mesh.elem_ref(std::get<0>(t)).active_family_tree_by_side(family, std::get<1>(t), false);
 #else
-        family.push_back(mesh.elem_ptr(el[i]));
+        family.push_back(mesh.elem_ptr(std::get<0>(t)));
 #endif
 
         for (std::size_t j=0; j<family.size(); ++j)
@@ -1611,8 +1605,8 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
 
             // Use the libmesh to exodus data structure map to get the proper sideset IDs
             // The data structure contains the "collapsed" contiguous ids
-            elem[il[i]].push_back(libmesh_elem_num_to_exodus[family[j]->id()]);
-            side[il[i]].push_back(conv.get_inverse_shellface_map(sl[i]));
+            elem[std::get<2>(t)].push_back(libmesh_elem_num_to_exodus[family[j]->id()]);
+            side[std::get<2>(t)].push_back(conv.get_inverse_shellface_map(std::get<1>(t)));
           }
       }
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1650,17 +1650,13 @@ void ExodusII_IO_Helper::write_nodesets(const MeshBase & mesh)
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
 
-  std::vector<dof_id_type > nl;
-  std::vector<boundary_id_type > il;
-
-  mesh.get_boundary_info().build_node_list(nl, il);
-
   // Maps from nodeset id to the nodes
   std::map<boundary_id_type, std::vector<int>> node;
 
   // Accumulate the vectors to pass into ex_put_node_set
-  for (std::size_t i=0; i<nl.size(); i++)
-    node[il[i]].push_back(nl[i]+1);
+  // build_node_list() builds a list of (node-id, bc-id) tuples.
+  for (const auto & t : mesh.get_boundary_info().build_node_list())
+    node[std::get<1>(t)].push_back(std::get<0>(t) + 1);
 
   std::vector<boundary_id_type> node_boundary_ids;
   mesh.get_boundary_info().build_node_boundary_ids(node_boundary_ids);

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1549,11 +1549,9 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
   std::vector<boundary_id_type> side_boundary_ids;
 
   {
-    // Build a list of (elem, side, bc) tuples.
-    auto bc_triples = mesh.get_boundary_info().build_side_list();
-
     // Accumulate the vectors to pass into ex_put_side_set
-    for (const auto & t : bc_triples)
+    // build_side_list() returns a vector of (elem, side, bc) tuples.
+    for (const auto & t : mesh.get_boundary_info().build_side_list())
       {
         std::vector<const Elem *> family;
 #ifdef LIBMESH_ENABLE_AMR

--- a/src/mesh/fro_io.C
+++ b/src/mesh/fro_io.C
@@ -99,12 +99,8 @@ void FroIO::write (const std::string & fname)
         const std::set<boundary_id_type> & bc_ids =
           the_mesh.get_boundary_info().get_boundary_ids();
 
-        std::vector<dof_id_type>        el;
-        std::vector<unsigned short int> sl;
-        std::vector<boundary_id_type>   il;
-
-        the_mesh.get_boundary_info().build_side_list (el, sl, il);
-
+        // Build a list of (elem, side, bc) tuples.
+        auto bc_triples = the_mesh.get_boundary_info().build_side_list();
 
         // Map the boundary ids into [1,n_bc_ids],
         // treat them one at a time.
@@ -117,8 +113,8 @@ void FroIO::write (const std::string & fname)
               forward_edges, backward_edges;
 
             // Get all sides on this element with the relevant BC id.
-            for (std::size_t e=0; e<el.size(); e++)
-              if (il[e] == id)
+            for (const auto & t : bc_triples)
+              if (std::get<2>(t) == id)
                 {
                   // need to build up node_list as a sorted array of edge nodes...
                   // for the following:
@@ -136,7 +132,7 @@ void FroIO::write (const std::string & fname)
                   // and then start with one chain link, and add on...
                   //
                   std::unique_ptr<const Elem> side =
-                    the_mesh.elem_ref(el[e]).build_side_ptr(sl[e]);
+                    the_mesh.elem_ref(std::get<0>(t)).build_side_ptr(std::get<1>(t));
 
                   const dof_id_type
                     n0 = side->node_id(0),

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1892,24 +1892,18 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
   }
 
   {
-    // Build a list of all edges that have boundary IDs
-    std::vector<dof_id_type> elem_list;
-    std::vector<unsigned short int> edge_list;
-    std::vector<boundary_id_type> bc_id_list;
-    bi.build_edge_list (elem_list, edge_list, bc_id_list);
-
     // Temporary vector to hold ids
     std::vector<boundary_id_type> bndry_ids;
 
-    // For each edge with the old_id...
-    for (std::size_t idx=0; idx<elem_list.size(); ++idx)
-      if (bc_id_list[idx] == old_id)
+    // build_edge_list returns a vector of (elem, side, bc) tuples.
+    for (const auto & t : bi.build_edge_list())
+      if (std::get<2>(t) == old_id)
         {
           // Get the elem in question
-          const Elem * elem = mesh.elem_ptr(elem_list[idx]);
+          const Elem * elem = mesh.elem_ptr(std::get<0>(t));
 
           // The edge of the elem in question
-          unsigned short int edge = edge_list[idx];
+          unsigned short int edge = std::get<1>(t);
 
           // Get all the current IDs for the edge in question.
           bi.edge_boundary_ids(elem, edge, bndry_ids);

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1926,14 +1926,11 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
   }
 
   {
-    // Build a list of (elem, side, bc) tuples.
-    auto bc_triples = bi.build_shellface_list();
-
     // Temporary vector to hold ids
     std::vector<boundary_id_type> bndry_ids;
 
-    // For each shellface with the old_id...
-    for (const auto & t : bc_triples)
+    // build_shellface_list returns a vector of (elem, side, bc) tuples.
+    for (const auto & t : bi.build_shellface_list())
       if (std::get<2>(t) == old_id)
         {
           // Get the elem in question
@@ -1957,14 +1954,11 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
   }
 
   {
-    // Build a list of (elem, side, bc) tuples.
-    auto bc_triples = bi.build_side_list();
-
     // Temporary vector to hold ids
     std::vector<boundary_id_type> bndry_ids;
 
-    // For each side with the old_id...
-    for (const auto & t : bc_triples)
+    // build_side_list returns a vector of (elem, side, bc) tuples.
+    for (const auto & t : bi.build_side_list())
       if (std::get<2>(t) == old_id)
         {
           // Get the elem in question

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1960,24 +1960,21 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
   }
 
   {
-    // Build a list of all sides that have boundary IDs
-    std::vector<dof_id_type> elem_list;
-    std::vector<unsigned short int> side_list;
-    std::vector<boundary_id_type> bc_id_list;
-    bi.build_side_list (elem_list, side_list, bc_id_list);
+    // Build a list of (elem, side, bc) tuples.
+    auto bc_triples = bi.build_side_list();
 
     // Temporary vector to hold ids
     std::vector<boundary_id_type> bndry_ids;
 
     // For each side with the old_id...
-    for (std::size_t idx=0; idx<elem_list.size(); ++idx)
-      if (bc_id_list[idx] == old_id)
+    for (const auto & t : bc_triples)
+      if (std::get<2>(t) == old_id)
         {
           // Get the elem in question
-          const Elem * elem = mesh.elem_ptr(elem_list[idx]);
+          const Elem * elem = mesh.elem_ptr(std::get<0>(t));
 
           // The side of the elem in question
-          unsigned short int side = side_list[idx];
+          unsigned short int side = std::get<1>(t);
 
           // Get all the current IDs for the side in question.
           bi.boundary_ids(elem, side, bndry_ids);

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1926,24 +1926,21 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
   }
 
   {
-    // Build a list of all shell-faces that have boundary IDs
-    std::vector<dof_id_type> elem_list;
-    std::vector<unsigned short int> shellface_list;
-    std::vector<boundary_id_type> bc_id_list;
-    bi.build_shellface_list (elem_list, shellface_list, bc_id_list);
+    // Build a list of (elem, side, bc) tuples.
+    auto bc_triples = bi.build_shellface_list();
 
     // Temporary vector to hold ids
     std::vector<boundary_id_type> bndry_ids;
 
     // For each shellface with the old_id...
-    for (std::size_t idx=0; idx<elem_list.size(); ++idx)
-      if (bc_id_list[idx] == old_id)
+    for (const auto & t : bc_triples)
+      if (std::get<2>(t) == old_id)
         {
           // Get the elem in question
-          const Elem * elem = mesh.elem_ptr(elem_list[idx]);
+          const Elem * elem = mesh.elem_ptr(std::get<0>(t));
 
           // The shellface of the elem in question
-          unsigned short int shellface = shellface_list[idx];
+          unsigned short int shellface = std::get<1>(t);
 
           // Get all the current IDs for the shellface in question.
           bi.shellface_boundary_ids(elem, shellface, bndry_ids);

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1862,20 +1862,15 @@ void MeshTools::Modification::change_boundary_id (MeshBase & mesh,
   BoundaryInfo & bi = mesh.get_boundary_info();
 
   {
-    // Build a list of all nodes that have boundary IDs
-    std::vector<dof_id_type> node_list;
-    std::vector<boundary_id_type> bc_id_list;
-    bi.build_node_list (node_list, bc_id_list);
-
     // Temporary vector to hold ids
     std::vector<boundary_id_type> bndry_ids;
 
-    // For each node with the old_id...
-    for (std::size_t idx=0; idx<node_list.size(); ++idx)
-      if (bc_id_list[idx] == old_id)
+    // build_node_list returns a vector of (node, bc) tuples.
+    for (const auto & t : bi.build_node_list())
+      if (std::get<1>(t) == old_id)
         {
           // Get the node in question
-          const Node * node = mesh.node_ptr(node_list[idx]);
+          const Node * node = mesh.node_ptr(std::get<0>(t));
 
           // Get all the current IDs for this node.
           bi.boundary_ids(node, bndry_ids);

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1155,17 +1155,9 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
       BoundaryInfo & boundary = this->get_boundary_info();
       const BoundaryInfo & other_boundary = other_mesh->get_boundary_info();
 
-      {
-        std::vector<dof_id_type>      node_id_list;
-        std::vector<boundary_id_type> bc_id_list;
-
-        other_boundary.build_node_list(node_id_list, bc_id_list);
-        for (std::size_t i=0; i != node_id_list.size(); ++i)
-          {
-            const dof_id_type our_id = node_id_list[i] + node_delta;
-            boundary.add_node(our_id, bc_id_list[i]);
-          }
-      }
+      for (const auto & t : other_boundary.build_node_list())
+        boundary.add_node(std::get<0>(t) + node_delta,
+                          std::get<1>(t));
 
       for (const auto & t : other_boundary.build_side_list())
         boundary.add_side(std::get<0>(t) + elem_delta,

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -864,18 +864,13 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
             // nodeset.
             if (mesh_array[i]->get_boundary_info().n_nodeset_conds() > 0)
               {
-                std::vector<numeric_index_type> node_id_list;
-                std::vector<boundary_id_type> bc_id_list;
-
-                // Get the list of nodes with associated boundary IDs
-                mesh_array[i]->get_boundary_info().build_node_list(node_id_list, bc_id_list);
-
-                for (std::size_t node_index=0; node_index<bc_id_list.size(); node_index++)
+                // build_node_list() returns a vector of (node-id, bc-id) tuples
+                for (const auto & t : mesh_array[i]->get_boundary_info().build_node_list())
                   {
-                    boundary_id_type node_bc_id = bc_id_list[node_index];
+                    boundary_id_type node_bc_id = std::get<1>(t);
                     if (node_bc_id == id_array[i])
                       {
-                        dof_id_type this_node_id = node_id_list[node_index];
+                        dof_id_type this_node_id = std::get<0>(t);
                         set_array[i]->insert( this_node_id );
 
                         // We need to set h_min to some value. It's too expensive to

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1172,18 +1172,10 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
           }
       }
 
-      {
-        std::vector<dof_id_type>        elem_id_list;
-        std::vector<unsigned short int> side_list;
-        std::vector<boundary_id_type>   bc_id_list;
-
-        other_boundary.build_side_list(elem_id_list, side_list, bc_id_list);
-        for (std::size_t i=0; i != elem_id_list.size(); ++i)
-          {
-            const dof_id_type our_id = elem_id_list[i] + elem_delta;
-            boundary.add_side(our_id, side_list[i], bc_id_list[i]);
-          }
-      }
+      for (const auto & t : other_boundary.build_side_list())
+        boundary.add_side(std::get<0>(t) + elem_delta,
+                          std::get<1>(t),
+                          std::get<2>(t));
 
       {
         std::vector<dof_id_type>        elem_id_list;

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1177,18 +1177,10 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
                           std::get<1>(t),
                           std::get<2>(t));
 
-      {
-        std::vector<dof_id_type>        elem_id_list;
-        std::vector<unsigned short int> edge_list;
-        std::vector<boundary_id_type>   bc_id_list;
-
-        other_boundary.build_edge_list(elem_id_list, edge_list, bc_id_list);
-        for (std::size_t i=0; i != elem_id_list.size(); ++i)
-          {
-            const dof_id_type our_id = elem_id_list[i] + elem_delta;
-            boundary.add_edge(our_id, edge_list[i], bc_id_list[i]);
-          }
-      }
+      for (const auto & t : other_boundary.build_edge_list())
+        boundary.add_edge(std::get<0>(t) + elem_delta,
+                          std::get<1>(t),
+                          std::get<2>(t));
 
       for (const auto & t : other_boundary.build_shellface_list())
         boundary.add_shellface(std::get<0>(t) + elem_delta,

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1190,18 +1190,11 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
           }
       }
 
-      {
-        std::vector<dof_id_type>        elem_id_list;
-        std::vector<unsigned short int> shellface_list;
-        std::vector<boundary_id_type>   bc_id_list;
+      for (const auto & t : other_boundary.build_shellface_list())
+        boundary.add_shellface(std::get<0>(t) + elem_delta,
+                               std::get<1>(t),
+                               std::get<2>(t));
 
-        other_boundary.build_shellface_list(elem_id_list, shellface_list, bc_id_list);
-        for (std::size_t i=0; i != elem_id_list.size(); ++i)
-          {
-            const dof_id_type our_id = elem_id_list[i] + elem_delta;
-            boundary.add_shellface(our_id, shellface_list[i], bc_id_list[i]);
-          }
-      }
     } // end if (other_mesh)
 
   // Finally, we need to "merge" the overlapping nodes

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -592,15 +592,10 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
   // where to impose the node-based terms.
   if (mesh.get_boundary_info().n_nodeset_conds() > 0)
     {
-      std::vector<numeric_index_type> node_id_list;
-      std::vector<boundary_id_type> bc_id_list;
-
-      // Get the list of nodes with boundary IDs
-      mesh.get_boundary_info().build_node_list(node_id_list, bc_id_list);
-
-      for (std::size_t i=0; i<node_id_list.size(); i++)
+      // build_node_list() returns a vector of (node-id, bc-id) tuples.
+      for (const auto & t : mesh.get_boundary_info().build_node_list())
         {
-          const Node & node = mesh.node_ref(node_id_list[i]);
+          const Node & node = mesh.node_ref(std::get<0>(t));
 
           // If node is on this processor, then all dofs on node are too
           // so we can do the add below safely


### PR DESCRIPTION
This test (and the lambda configure test) are now required to pass at configure time, since they are used unguarded within the library. 

Also added a new version of `BoundaryInfo::build_side_list()` which uses `std::tuple` and is quite a bit more convenient to work with than the original, as well as facilitating range-based for-loop iteration over the boundary tuples.
