### PR TITLE
Add configure test of C++11 enum forward declaration syntax

### DIFF
--- a/configure
+++ b/configure
@@ -954,6 +954,8 @@ HAVE_CXX11_MOVE_CONSTRUCTORS_FALSE
 HAVE_CXX11_MOVE_CONSTRUCTORS_TRUE
 HAVE_CXX11_MOVE_FALSE
 HAVE_CXX11_MOVE_TRUE
+HAVE_CXX11_FIXED_TYPE_ENUM_FWD_FALSE
+HAVE_CXX11_FIXED_TYPE_ENUM_FWD_TRUE
 HAVE_CXX11_FIXED_TYPE_ENUM_FALSE
 HAVE_CXX11_FIXED_TYPE_ENUM_TRUE
 HAVE_CXX11_LAMBDA_FALSE
@@ -8351,6 +8353,79 @@ fi
 
 if test "x$have_cxx11_fixed_type_enum" != "xyes"; then :
   as_fn_error $? "libMesh requires C++11 fixed type enumeration support" "$LINENO" 5
+fi
+
+
+    have_cxx11_fixed_type_enum_fwd=no
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 fixed type enumeration forward declaration support" >&5
+$as_echo_n "checking for C++11 fixed type enumeration forward declaration support... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <iostream>
+    enum Foo : int;
+    void func(Foo f) { std::cout << f << std::endl; }
+    enum Foo : int { FOO0 = 0, FOO1 = 1, FOO2 = 2 };
+
+int
+main ()
+{
+
+    func(FOO0);
+    func(FOO1);
+    func(FOO2);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_CXX11_FIXED_TYPE_ENUM_FWD 1" >>confdefs.h
+
+        have_cxx11_fixed_type_enum_fwd=yes
+
+else
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+        CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+     if test x$have_cxx11_fixed_type_enum_fwd == xyes; then
+  HAVE_CXX11_FIXED_TYPE_ENUM_FWD_TRUE=
+  HAVE_CXX11_FIXED_TYPE_ENUM_FWD_FALSE='#'
+else
+  HAVE_CXX11_FIXED_TYPE_ENUM_FWD_TRUE='#'
+  HAVE_CXX11_FIXED_TYPE_ENUM_FWD_FALSE=
+fi
+
+
+if test "x$have_cxx11_fixed_type_enum_fwd" != "xyes"; then :
+  as_fn_error $? "libMesh requires C++11 fixed type enumeration forward declaration support" "$LINENO" 5
 fi
 
 # --------------------------------------------------------------
@@ -41429,6 +41504,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX11_FIXED_TYPE_ENUM_TRUE}" && test -z "${HAVE_CXX11_FIXED_TYPE_ENUM_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_FIXED_TYPE_ENUM\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${HAVE_CXX11_FIXED_TYPE_ENUM_FWD_TRUE}" && test -z "${HAVE_CXX11_FIXED_TYPE_ENUM_FWD_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_CXX11_FIXED_TYPE_ENUM_FWD\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX11_MOVE_TRUE}" && test -z "${HAVE_CXX11_MOVE_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -232,6 +232,10 @@ LIBMESH_TEST_CXX11_FIXED_TYPE_ENUM
 AS_IF([test "x$have_cxx11_fixed_type_enum" != "xyes"],
       [AC_MSG_ERROR([libMesh requires C++11 fixed type enumeration support])])
 
+LIBMESH_TEST_CXX11_FIXED_TYPE_ENUM_FWD
+AS_IF([test "x$have_cxx11_fixed_type_enum_fwd" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires C++11 fixed type enumeration forward declaration support])])
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -246,6 +246,9 @@
 /* Flag indicating whether compiler supports fixed type enumerations */
 #undef HAVE_CXX11_FIXED_TYPE_ENUM
 
+/* Flag indicating whether compiler supports fixed type enumerations */
+#undef HAVE_CXX11_FIXED_TYPE_ENUM_FWD
+
 /* Flag indicating whether compiler supports initializer lists */
 #undef HAVE_CXX11_INITIALIZER_LIST
 

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -134,6 +134,41 @@ AC_DEFUN([LIBMESH_TEST_CXX11_FIXED_TYPE_ENUM],
     AM_CONDITIONAL(HAVE_CXX11_FIXED_TYPE_ENUM, test x$have_cxx11_fixed_type_enum == xyes)
   ])
 
+dnl Test C++11 fixed type enumeration forward declarations.
+AC_DEFUN([LIBMESH_TEST_CXX11_FIXED_TYPE_ENUM_FWD],
+  [
+    have_cxx11_fixed_type_enum_fwd=no
+
+    AC_MSG_CHECKING(for C++11 fixed type enumeration forward declaration support)
+    AC_LANG_PUSH([C++])
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include <iostream>
+    enum Foo : int;
+    void func(Foo f) { std::cout << f << std::endl; }
+    enum Foo : int { FOO0 = 0, FOO1 = 1, FOO2 = 2 };
+    ]], [[
+    func(FOO0);
+    func(FOO1);
+    func(FOO2);
+    ]])],[
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_CXX11_FIXED_TYPE_ENUM_FWD, 1, [Flag indicating whether compiler supports fixed type enumerations])
+        have_cxx11_fixed_type_enum_fwd=yes
+    ],[
+        AC_MSG_RESULT(no)
+    ])
+
+    dnl Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    AC_LANG_POP([C++])
+
+    AM_CONDITIONAL(HAVE_CXX11_FIXED_TYPE_ENUM_FWD, test x$have_cxx11_fixed_type_enum_fwd == xyes)
+  ])
+
 dnl Properly implemented move constructors require rvalue references,
 dnl std::move, and noexcept, so this tests for all of those features.
 AC_DEFUN([LIBMESH_TEST_CXX11_MOVE_CONSTRUCTORS],


### PR DESCRIPTION
This capability is not currently used in the library, but will be introduced in a forthcoming PR.