### PR TITLE
Move FE ctors from header to C file.

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -1043,23 +1043,6 @@ typedef FE<3,MONOMIAL> FEMonomial3D;
 
 }
 
-
-
-// ------------------------------------------------------------
-// FE class inline members
-template <unsigned int Dim, FEFamily T>
-inline
-FE<Dim,T>::FE (const FEType & fet) :
-  FEGenericBase<typename FEOutputType<T>::type> (Dim,fet),
-  last_side(INVALID_ELEM),
-  last_edge(libMesh::invalid_uint)
-{
-  // Sanity check.  Make sure the
-  // Family specified in the template instantiation
-  // matches the one in the FEType object
-  libmesh_assert_equal_to (T, this->get_family());
-}
-
 } // namespace libMesh
 
 #endif // LIBMESH_FE_H

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -599,37 +599,6 @@ protected:
 
 };
 
-
-
-
-// ------------------------------------------------------------
-// FEAbstract class inline members
-inline
-FEAbstract::FEAbstract(const unsigned int d,
-                       const FEType & fet) :
-  _fe_map( FEMap::build(fet) ),
-  dim(d),
-  calculations_started(false),
-  calculate_phi(false),
-  calculate_dphi(false),
-  calculate_d2phi(false),
-  calculate_curl_phi(false),
-  calculate_div_phi(false),
-  calculate_dphiref(false),
-  fe_type(fet),
-  elem_type(INVALID_ELEM),
-  _p_level(0),
-  qrule(libmesh_nullptr),
-  shapes_on_quadrature(false)
-{
-}
-
-
-inline
-FEAbstract::~FEAbstract()
-{
-}
-
 } // namespace libMesh
 
 #endif // LIBMESH_FE_ABSTRACT_H

--- a/include/fe/fe_macro.h
+++ b/include/fe/fe_macro.h
@@ -42,6 +42,7 @@
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
 #define INSTANTIATE_SUBDIVISION_FE                                      \
+  template FE<2,SUBDIVISION>::FE(const FEType & fet); \
   template unsigned int FE<2,SUBDIVISION>::n_shape_functions () const;  \
   template void         FE<2,SUBDIVISION>::attach_quadrature_rule (QBase *); \
   template unsigned int FE<2,SUBDIVISION>::n_quadrature_points () const; \
@@ -52,6 +53,7 @@
 #else // LIBMESH_ENABLE_INFINITE_ELEMENTS
 
 #define INSTANTIATE_SUBDIVISION_FE                                      \
+  template FE<2,SUBDIVISION>::FE(const FEType & fet);                     \
   template unsigned int FE<2,SUBDIVISION>::n_shape_functions () const;  \
   template void         FE<2,SUBDIVISION>::attach_quadrature_rule (QBase *); \
   template unsigned int FE<2,SUBDIVISION>::n_quadrature_points () const; \

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -24,7 +24,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/point.h"
 #include "libmesh/vector_value.h"
-#include "libmesh/enum_elem_type.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/auto_ptr.h" // deprecated
 

--- a/src/fe/fe.C
+++ b/src/fe/fe.C
@@ -25,6 +25,7 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/tensor_value.h"
+#include "libmesh/enum_elem_type.h"
 
 namespace libMesh
 {
@@ -32,6 +33,19 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // FE class members
+template <unsigned int Dim, FEFamily T>
+FE<Dim,T>::FE (const FEType & fet) :
+  FEGenericBase<typename FEOutputType<T>::type> (Dim,fet),
+  last_side(INVALID_ELEM),
+  last_edge(libMesh::invalid_uint)
+{
+  // Sanity check.  Make sure the
+  // Family specified in the template instantiation
+  // matches the one in the FEType object
+  libmesh_assert_equal_to (T, this->get_family());
+}
+
+
 template <unsigned int Dim, FEFamily T>
 unsigned int FE<Dim,T>::n_shape_functions () const
 {

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -37,9 +37,35 @@
 #include "libmesh/remote_elem.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/threads.h"
+#include "libmesh/enum_elem_type.h"
 
 namespace libMesh
 {
+
+FEAbstract::FEAbstract(const unsigned int d,
+                       const FEType & fet) :
+  _fe_map( FEMap::build(fet) ),
+  dim(d),
+  calculations_started(false),
+  calculate_phi(false),
+  calculate_dphi(false),
+  calculate_d2phi(false),
+  calculate_curl_phi(false),
+  calculate_div_phi(false),
+  calculate_dphiref(false),
+  fe_type(fet),
+  elem_type(INVALID_ELEM),
+  _p_level(0),
+  qrule(libmesh_nullptr),
+  shapes_on_quadrature(false)
+{
+}
+
+
+FEAbstract::~FEAbstract()
+{
+}
+
 
 std::unique_ptr<FEAbstract> FEAbstract::build(const unsigned int dim,
                                               const FEType & fet)

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -34,6 +34,7 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_elem_type.h"
 
 namespace libMesh
 {


### PR DESCRIPTION
This removes these header files' dependencies on enum_elem_type.h.  In
order to do this, we had to explicitly instantiate the `FESubdivision`
constructor.  This was the only class affected since the others can
all apparently use the full class instantiation macro while
`FESubdivision` is only instantiated for 2D...