### PR TITLE
Forward declare enumerations instead of including headers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4655,6 +4655,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/configure
+++ b/configure
@@ -855,6 +855,7 @@ LIBMESH_ENABLE_COMPLEX_TRUE
 LIBMESH_ENABLE_INFINITE_ELEMENTS_FALSE
 LIBMESH_ENABLE_INFINITE_ELEMENTS_TRUE
 enablelegacyincludepaths
+enablefwdenums
 enabledeprecated
 enablewarnings
 enableuniqueptr
@@ -1163,6 +1164,7 @@ with_gdb_command
 enable_unique_ptr
 enable_warnings
 enable_deprecated
+enable_forward_declare_enums
 enable_blocked_storage
 enable_legacy_include_paths
 enable_legacy_using_namespace
@@ -1959,6 +1961,9 @@ Optional Features:
                           questionable code
   --disable-deprecated    Deprecated code use gives errors rather than
                           warnings
+  --disable-forward-declare-enums
+                          Directly include enumeration headers rather than
+                          forward declaring them
   --enable-blocked-storage
                           Support for blocked matrix/vector storage
   --enable-legacy-include-paths
@@ -30393,6 +30398,41 @@ else
 $as_echo "<<< Configuring library with deprecated code support >>>" >&6; }
 
 $as_echo "#define ENABLE_DEPRECATED 1" >>confdefs.h
+
+
+fi
+# --------------------------------------------------------------
+
+
+# --------------------------------------------------------------
+# forward declared enumerations - enable by default
+# We want to prevent new library code from being added that
+# depends on including enum headers, but still give downstream
+# apps the ability to compile with the old headers for a
+# period of deprecation.
+# --------------------------------------------------------------
+# Check whether --enable-forward-declare-enums was given.
+if test "${enable_forward_declare_enums+set}" = set; then :
+  enableval=$enable_forward_declare_enums; enablefwdenums=$enableval
+else
+  enablefwdenums=yes
+fi
+
+
+
+if test "$enablefwdenums" != yes; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> INFO: Forward declared enumerations are disabled <<<" >&5
+$as_echo ">>> INFO: Forward declared enumerations are disabled <<<" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> Enumeration headers will be included directly <<<" >&5
+$as_echo ">>> Enumeration headers will be included directly <<<" >&6; }
+
+else
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with forward declared enumerations >>>" >&5
+$as_echo "<<< Configuring library with forward declared enumerations >>>" >&6; }
+
+$as_echo "#define FORWARD_DECLARE_ENUMS 1" >>confdefs.h
 
 
 fi

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -694,6 +694,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/boost/include/Makefile.in
+++ b/contrib/boost/include/Makefile.in
@@ -2072,6 +2072,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/capnproto/Makefile.in
+++ b/contrib/capnproto/Makefile.in
@@ -569,6 +569,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/eigen/3.2.9/Makefile.in
+++ b/contrib/eigen/3.2.9/Makefile.in
@@ -458,6 +458,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/exodusii/5.22b/exodus/Makefile.in
+++ b/contrib/exodusii/5.22b/exodus/Makefile.in
@@ -2346,6 +2346,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/exodusii/5.22b/nemesis/Makefile.in
+++ b/contrib/exodusii/5.22b/nemesis/Makefile.in
@@ -514,6 +514,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/exodusii/Lib/Makefile.in
+++ b/contrib/exodusii/Lib/Makefile.in
@@ -1201,6 +1201,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/fparser/Makefile.in
+++ b/contrib/fparser/Makefile.in
@@ -868,6 +868,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/fparser/extrasrc/Makefile.in
+++ b/contrib/fparser/extrasrc/Makefile.in
@@ -411,6 +411,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/gmv/Makefile.in
+++ b/contrib/gmv/Makefile.in
@@ -509,6 +509,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/gzstream/Makefile.in
+++ b/contrib/gzstream/Makefile.in
@@ -562,6 +562,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/laspack/Makefile.in
+++ b/contrib/laspack/Makefile.in
@@ -569,6 +569,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/libHilbert/Makefile.in
+++ b/contrib/libHilbert/Makefile.in
@@ -577,6 +577,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/metis/Makefile.in
+++ b/contrib/metis/Makefile.in
@@ -806,6 +806,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/nanoflann/Makefile.in
+++ b/contrib/nanoflann/Makefile.in
@@ -558,6 +558,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/nemesis/Lib/Makefile.in
+++ b/contrib/nemesis/Lib/Makefile.in
@@ -669,6 +669,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/netcdf/Lib/Makefile.in
+++ b/contrib/netcdf/Lib/Makefile.in
@@ -573,6 +573,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/parmetis/Makefile.in
+++ b/contrib/parmetis/Makefile.in
@@ -780,6 +780,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/qhull/2012.1/Makefile.in
+++ b/contrib/qhull/2012.1/Makefile.in
@@ -1025,6 +1025,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/sfcurves/Makefile.in
+++ b/contrib/sfcurves/Makefile.in
@@ -519,6 +519,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/tecplot/binary/Makefile.in
+++ b/contrib/tecplot/binary/Makefile.in
@@ -504,6 +504,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/tecplot/tecio/Makefile.in
+++ b/contrib/tecplot/tecio/Makefile.in
@@ -653,6 +653,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/tetgen/Makefile.in
+++ b/contrib/tetgen/Makefile.in
@@ -540,6 +540,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/contrib/triangle/Makefile.in
+++ b/contrib/triangle/Makefile.in
@@ -540,6 +540,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -467,6 +467,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/doc/html/Makefile.in
+++ b/doc/html/Makefile.in
@@ -427,6 +427,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/Makefile.in
+++ b/examples/Makefile.in
@@ -499,6 +499,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex1/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex1/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
+++ b/examples/adaptivity/adaptivity_ex1/adaptivity_ex1.C
@@ -49,6 +49,7 @@
 #include "libmesh/error_vector.h"
 #include "libmesh/kelly_error_estimator.h"
 #include "libmesh/mesh_refinement.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/adaptivity/adaptivity_ex2/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex2/Makefile.in
@@ -588,6 +588,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
+++ b/examples/adaptivity/adaptivity_ex2/adaptivity_ex2.C
@@ -51,8 +51,10 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
-
 #include "libmesh/getpot.h"
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_xdr_mode.h"
+#include "libmesh/enum_norm_type.h"
 
 // This example will solve a linear transient system,
 // so we need to include the TransientLinearImplicitSystem definition.

--- a/examples/adaptivity/adaptivity_ex3/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex3/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -75,6 +75,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/elem.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/adaptivity/adaptivity_ex4/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex4/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
+++ b/examples/adaptivity/adaptivity_ex4/adaptivity_ex4.C
@@ -57,6 +57,7 @@
 #include "libmesh/tensor_value.h"
 #include "libmesh/perf_log.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/adaptivity/adaptivity_ex5/Makefile.in
+++ b/examples/adaptivity/adaptivity_ex5/Makefile.in
@@ -584,6 +584,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
+++ b/examples/adaptivity/adaptivity_ex5/adaptivity_ex5.C
@@ -54,6 +54,9 @@
 #include "libmesh/parsed_function.h"
 #include "libmesh/getpot.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_xdr_mode.h"
+#include "libmesh/enum_norm_type.h"
 
 // This example will solve a linear transient system,
 // so we need to include the TransientLinearImplicitSystem definition.

--- a/examples/adjoints/adjoints_ex1/Makefile.in
+++ b/examples/adjoints/adjoints_ex1/Makefile.in
@@ -638,6 +638,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex1/adjoints_ex1.C
+++ b/examples/adjoints/adjoints_ex1/adjoints_ex1.C
@@ -69,6 +69,7 @@
 #include "libmesh/steady_solver.h"
 #include "libmesh/system_norm.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 // Error Estimator includes
 #include "libmesh/kelly_error_estimator.h"

--- a/examples/adjoints/adjoints_ex2/Makefile.in
+++ b/examples/adjoints/adjoints_ex2/Makefile.in
@@ -621,6 +621,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex2/adjoints_ex2.C
+++ b/examples/adjoints/adjoints_ex2/adjoints_ex2.C
@@ -71,6 +71,7 @@
 #include "libmesh/steady_solver.h"
 #include "libmesh/system_norm.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 // Sensitivity Calculation related includes
 #include "libmesh/parameter_vector.h"

--- a/examples/adjoints/adjoints_ex3/Makefile.in
+++ b/examples/adjoints/adjoints_ex3/Makefile.in
@@ -641,6 +641,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex3/adjoints_ex3.C
+++ b/examples/adjoints/adjoints_ex3/adjoints_ex3.C
@@ -67,24 +67,19 @@
 // Libmesh includes
 #include "libmesh/equation_systems.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
-
 #include "libmesh/twostep_time_solver.h"
 #include "libmesh/euler_solver.h"
 #include "libmesh/euler2_solver.h"
 #include "libmesh/steady_solver.h"
-
 #include "libmesh/newton_solver.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/petsc_diff_solver.h"
-
 #include "libmesh/mesh.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_refinement.h"
-
 #include "libmesh/system.h"
 #include "libmesh/system_norm.h"
-
 #include "libmesh/adjoint_residual_error_estimator.h"
 #include "libmesh/const_fem_function.h"
 #include "libmesh/error_vector.h"
@@ -101,6 +96,8 @@
 #include "libmesh/uniform_refinement_estimator.h"
 #include "libmesh/qoi_set.h"
 #include "libmesh/weighted_patch_recovery_error_estimator.h"
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_xdr_mode.h"
 
 // Local includes
 #include "coupled_system.h"

--- a/examples/adjoints/adjoints_ex4/Makefile.in
+++ b/examples/adjoints/adjoints_ex4/Makefile.in
@@ -641,6 +641,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex4/adjoints_ex4.C
+++ b/examples/adjoints/adjoints_ex4/adjoints_ex4.C
@@ -67,6 +67,7 @@
 #include "libmesh/steady_solver.h"
 #include "libmesh/system_norm.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 // Adjoint Related includes
 #include "libmesh/qoi_set.h"

--- a/examples/adjoints/adjoints_ex5/Makefile.in
+++ b/examples/adjoints/adjoints_ex5/Makefile.in
@@ -641,6 +641,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -83,6 +83,7 @@
 #include "libmesh/system_norm.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 #include "libmesh/mesh.h"
 #include "libmesh/mesh_generation.h"

--- a/examples/adjoints/adjoints_ex6/Makefile.in
+++ b/examples/adjoints/adjoints_ex6/Makefile.in
@@ -621,6 +621,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/adjoints/adjoints_ex6/adjoints_ex6.C
+++ b/examples/adjoints/adjoints_ex6/adjoints_ex6.C
@@ -71,6 +71,7 @@
 #include "libmesh/system_norm.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 // Adjoint Related includes
 #include "libmesh/qoi_set.h"

--- a/examples/eigenproblems/eigenproblems_ex1/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex1/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/eigenproblems/eigenproblems_ex2/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex2/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -48,6 +48,7 @@
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/enum_eigen_solver_type.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/eigenproblems/eigenproblems_ex3/Makefile.in
+++ b/examples/eigenproblems/eigenproblems_ex3/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -68,6 +68,7 @@
 #include "libmesh/zero_function.h"
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/slepc_macro.h"
+#include "libmesh/enum_eigen_solver_type.h"
 
 #define BOUNDARY_ID 100
 

--- a/examples/fem_system/fem_system_ex1/Makefile.in
+++ b/examples/fem_system/fem_system_ex1/Makefile.in
@@ -603,6 +603,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -40,6 +40,8 @@
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/uniform_refinement_estimator.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_norm_type.h"
 
 // The systems and solvers we may use
 #include "naviersystem.h"

--- a/examples/fem_system/fem_system_ex2/Makefile.in
+++ b/examples/fem_system/fem_system_ex2/Makefile.in
@@ -613,6 +613,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/fem_system/fem_system_ex2/fem_system_ex2.C
+++ b/examples/fem_system/fem_system_ex2/fem_system_ex2.C
@@ -32,6 +32,7 @@
 #include "libmesh/transient_system.h"
 #include "libmesh/vtk_io.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 #include <cstdio>
 #include <ctime>

--- a/examples/fem_system/fem_system_ex3/Makefile.in
+++ b/examples/fem_system/fem_system_ex3/Makefile.in
@@ -603,6 +603,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -37,6 +37,8 @@
 #include "libmesh/kelly_error_estimator.h"
 #include "libmesh/mesh.h"
 #include "libmesh/mesh_generation.h"
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_solver_type.h"
 
 // The systems and solvers we may use
 #include "elasticity_system.h"

--- a/examples/fem_system/fem_system_ex4/Makefile.in
+++ b/examples/fem_system/fem_system_ex4/Makefile.in
@@ -603,6 +603,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.C
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.C
@@ -44,6 +44,8 @@
 #include "libmesh/parsed_function.h"
 #include "libmesh/uniform_refinement_estimator.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_norm_type.h"
 
 // The systems and solvers we may use
 #include "heatsystem.h"

--- a/examples/introduction/introduction_ex1/Makefile.in
+++ b/examples/introduction/introduction_ex1/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/introduction/introduction_ex2/Makefile.in
+++ b/examples/introduction/introduction_ex2/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/introduction/introduction_ex2/introduction_ex2.C
+++ b/examples/introduction/introduction_ex2/introduction_ex2.C
@@ -50,6 +50,7 @@
 //Basic include file needed for the mesh functionality.
 #include "libmesh/libmesh.h"
 #include "libmesh/mesh.h"
+#include "libmesh/enum_xdr_mode.h"
 // Include file that defines various mesh generation utilities
 #include "libmesh/mesh_generation.h"
 // Include file that defines (possibly multiple) systems of equations.
@@ -58,6 +59,7 @@
 #include "libmesh/linear_implicit_system.h"
 #include "libmesh/transient_system.h"
 #include "libmesh/explicit_system.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/introduction/introduction_ex3/Makefile.in
+++ b/examples/introduction/introduction_ex3/Makefile.in
@@ -584,6 +584,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/introduction/introduction_ex3/introduction_ex3.C
+++ b/examples/introduction/introduction_ex3/introduction_ex3.C
@@ -54,6 +54,7 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_solver_package.h"
 
 // Define the DofMap, which handles degree of freedom
 // indexing.

--- a/examples/introduction/introduction_ex4/Makefile.in
+++ b/examples/introduction/introduction_ex4/Makefile.in
@@ -584,6 +584,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/introduction/introduction_ex4/introduction_ex4.C
+++ b/examples/introduction/introduction_ex4/introduction_ex4.C
@@ -82,6 +82,7 @@
 
 #include "libmesh/string_to_enum.h"
 #include "libmesh/getpot.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/introduction/introduction_ex5/Makefile.in
+++ b/examples/introduction/introduction_ex5/Makefile.in
@@ -584,6 +584,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/introduction/introduction_ex5/introduction_ex5.C
+++ b/examples/introduction/introduction_ex5/introduction_ex5.C
@@ -65,6 +65,8 @@
 
 // The definition of a geometric element
 #include "libmesh/elem.h"
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_quadrature_type.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/miscellaneous/miscellaneous_ex1/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex1/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -45,6 +45,7 @@
 #include "libmesh/mesh_generation.h"
 #include "libmesh/linear_implicit_system.h"
 #include "libmesh/equation_systems.h"
+#include "libmesh/enum_xdr_mode.h"
 
 // Define the Finite and Infinite Element object.
 #include "libmesh/fe.h"

--- a/examples/miscellaneous/miscellaneous_ex10/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex10/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
+++ b/examples/miscellaneous/miscellaneous_ex10/miscellaneous_ex10.C
@@ -58,6 +58,7 @@
 #include "libmesh/error_vector.h"
 #include "libmesh/kelly_error_estimator.h"
 #include "libmesh/mesh_refinement.h"
+#include "libmesh/enum_solver_package.h"
 
 using namespace libMesh;
 

--- a/examples/miscellaneous/miscellaneous_ex11/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex11/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -57,6 +57,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/vtk_io.h"
 #include "libmesh/exodusII_io.h"
+#include "libmesh/enum_solver_package.h"
 
 // These are the include files typically needed for subdivision elements.
 #include "libmesh/face_tri3_subdivision.h"

--- a/examples/miscellaneous/miscellaneous_ex12/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex12/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -55,6 +55,8 @@
 #include "libmesh/linear_solver.h"
 #include "libmesh/libmesh_nullptr.h"
 #include "libmesh/getpot.h"
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_solver_type.h"
 
 // Eigen includes
 #ifdef LIBMESH_HAVE_EIGEN

--- a/examples/miscellaneous/miscellaneous_ex13/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex13/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
+++ b/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
@@ -57,6 +57,8 @@
 #include "libmesh/linear_solver.h"
 #include "libmesh/libmesh_nullptr.h"
 #include "libmesh/getpot.h"
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_solver_type.h"
 
 // Eigen includes
 #ifdef LIBMESH_HAVE_EIGEN

--- a/examples/miscellaneous/miscellaneous_ex14/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex14/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
+++ b/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
@@ -58,6 +58,7 @@
 // for the SlepcSolverConfiguration
 #include "libmesh/solver_configuration.h"
 #include "libmesh/slepc_eigen_solver.h"
+#include "libmesh/enum_eigen_solver_type.h"
 
 #ifdef LIBMESH_HAVE_SLEPC
 EXTERN_C_FOR_SLEPC_BEGIN

--- a/examples/miscellaneous/miscellaneous_ex2/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex2/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
+++ b/examples/miscellaneous/miscellaneous_ex2/miscellaneous_ex2.C
@@ -50,6 +50,7 @@
 #include "libmesh/unv_io.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_xdr_mode.h"
 
 // Include FrequencySystem.  This class offers added functionality for
 // the solution of frequency-dependent systems.

--- a/examples/miscellaneous/miscellaneous_ex3/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex3/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex4/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex4/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -72,6 +72,7 @@
 
 // The definition of a geometric element
 #include "libmesh/elem.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/miscellaneous/miscellaneous_ex5/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex5/Makefile.in
@@ -588,6 +588,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -52,8 +52,8 @@
 #include "libmesh/kelly_error_estimator.h"
 #include "libmesh/discontinuity_measure.h"
 #include "libmesh/string_to_enum.h"
-
 #include "libmesh/exact_solution.h"
+#include "libmesh/enum_solver_package.h"
 //#define QORDER TWENTYSIXTH
 
 // Bring in everything from the libMesh namespace

--- a/examples/miscellaneous/miscellaneous_ex6/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex6/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex7/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex7/Makefile.in
@@ -607,6 +607,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex7/miscellaneous_ex7.C
+++ b/examples/miscellaneous/miscellaneous_ex7/miscellaneous_ex7.C
@@ -26,6 +26,9 @@
 // variational inequality solver through PetscDMNonlinearSolver
 // (available in PETSc-3.3.0 or above).
 
+// libmesh includes
+#include "libmesh/enum_solver_package.h"
+
 // Example include files
 #include "biharmonic.h"
 

--- a/examples/miscellaneous/miscellaneous_ex8/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex8/Makefile.in
@@ -603,6 +603,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex9/Makefile.in
+++ b/examples/miscellaneous/miscellaneous_ex9/Makefile.in
@@ -608,6 +608,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -74,8 +74,9 @@
 #include "libmesh/linear_implicit_system.h"
 #include "libmesh/zero_function.h"
 #include "libmesh/dirichlet_boundaries.h"
+#include "libmesh/enum_solver_package.h"
 
-// local includes
+// example includes
 #include "augment_sparsity_on_interface.h"
 
 // define the boundary IDs in the mesh

--- a/examples/optimization/optimization_ex1/Makefile.in
+++ b/examples/optimization/optimization_ex1/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/optimization/optimization_ex2/Makefile.in
+++ b/examples/optimization/optimization_ex2/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex1/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex1/Makefile.in
@@ -598,6 +598,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
+++ b/examples/reduced_basis/reduced_basis_ex1/reduced_basis_ex1.C
@@ -64,6 +64,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/rb_data_serialization.h"
 #include "libmesh/rb_data_deserialization.h"
+#include "libmesh/enum_solver_package.h"
 
 // local includes
 #include "rb_classes.h"

--- a/examples/reduced_basis/reduced_basis_ex2/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex2/Makefile.in
@@ -598,6 +598,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex2/reduced_basis_ex2.C
+++ b/examples/reduced_basis/reduced_basis_ex2/reduced_basis_ex2.C
@@ -65,6 +65,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/rb_data_serialization.h"
 #include "libmesh/rb_data_deserialization.h"
+#include "libmesh/enum_solver_package.h"
 
 // local includes
 #include "rb_classes.h"

--- a/examples/reduced_basis/reduced_basis_ex3/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex3/Makefile.in
@@ -598,6 +598,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex3/reduced_basis_ex3.C
+++ b/examples/reduced_basis/reduced_basis_ex3/reduced_basis_ex3.C
@@ -41,6 +41,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/rb_data_serialization.h"
 #include "libmesh/rb_data_deserialization.h"
+#include "libmesh/enum_solver_package.h"
 
 // local includes
 #include "rb_classes.h"

--- a/examples/reduced_basis/reduced_basis_ex4/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex4/Makefile.in
@@ -603,6 +603,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
+++ b/examples/reduced_basis/reduced_basis_ex4/reduced_basis_ex4.C
@@ -47,6 +47,7 @@
 #include "libmesh/getpot.h"
 #include "libmesh/rb_data_serialization.h"
 #include "libmesh/rb_data_deserialization.h"
+#include "libmesh/enum_solver_package.h"
 
 #include "eim_classes.h"
 #include "rb_classes.h"

--- a/examples/reduced_basis/reduced_basis_ex5/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex5/Makefile.in
@@ -603,6 +603,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
+++ b/examples/reduced_basis/reduced_basis_ex5/reduced_basis_ex5.C
@@ -53,6 +53,8 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/rb_data_serialization.h"
 #include "libmesh/rb_data_deserialization.h"
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_solver_type.h"
 
 // local includes
 #include "rb_classes.h"

--- a/examples/reduced_basis/reduced_basis_ex6/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex6/Makefile.in
@@ -603,6 +603,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
+++ b/examples/reduced_basis/reduced_basis_ex6/reduced_basis_ex6.C
@@ -92,6 +92,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/rb_data_serialization.h"
 #include "libmesh/rb_data_deserialization.h"
+#include "libmesh/enum_solver_package.h"
 
 // local includes
 #include "rb_classes.h"

--- a/examples/reduced_basis/reduced_basis_ex7/Makefile.in
+++ b/examples/reduced_basis/reduced_basis_ex7/Makefile.in
@@ -598,6 +598,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
+++ b/examples/reduced_basis/reduced_basis_ex7/reduced_basis_ex7.C
@@ -51,6 +51,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/rb_data_serialization.h"
 #include "libmesh/rb_data_deserialization.h"
+#include "libmesh/enum_solver_package.h"
 
 // local includes
 #include "rb_classes.h"

--- a/examples/solution_transfer/solution_transfer_ex1/Makefile.in
+++ b/examples/solution_transfer/solution_transfer_ex1/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/subdomains/subdomains_ex1/Makefile.in
+++ b/examples/subdomains/subdomains_ex1/Makefile.in
@@ -584,6 +584,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/subdomains/subdomains_ex1/subdomains_ex1.C
+++ b/examples/subdomains/subdomains_ex1/subdomains_ex1.C
@@ -72,6 +72,7 @@
 
 #include "libmesh/string_to_enum.h"
 #include "libmesh/getpot.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/subdomains/subdomains_ex2/Makefile.in
+++ b/examples/subdomains/subdomains_ex2/Makefile.in
@@ -584,6 +584,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/subdomains/subdomains_ex2/subdomains_ex2.C
+++ b/examples/subdomains/subdomains_ex2/subdomains_ex2.C
@@ -67,6 +67,7 @@
 
 #include "libmesh/string_to_enum.h"
 #include "libmesh/getpot.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/subdomains/subdomains_ex3/Makefile.in
+++ b/examples/subdomains/subdomains_ex3/Makefile.in
@@ -583,6 +583,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex1/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex1/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
+++ b/examples/systems_of_equations/systems_of_equations_ex1/systems_of_equations_ex1.C
@@ -44,6 +44,7 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/linear_implicit_system.h"
+#include "libmesh/enum_solver_package.h"
 
 // For systems of equations the DenseSubMatrix
 // and DenseSubVector provide convenient ways for

--- a/examples/systems_of_equations/systems_of_equations_ex2/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex2/Makefile.in
@@ -579,6 +579,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -63,6 +63,7 @@
 #include "libmesh/zero_function.h"
 #include "libmesh/const_function.h"
 #include "libmesh/parsed_function.h"
+#include "libmesh/enum_solver_package.h"
 
 // For systems of equations the DenseSubMatrix
 // and DenseSubVector provide convenient ways for

--- a/examples/systems_of_equations/systems_of_equations_ex3/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex3/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -53,6 +53,7 @@
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/zero_function.h"
 #include "libmesh/const_function.h"
+#include "libmesh/enum_solver_package.h"
 
 // For systems of equations the DenseSubMatrix
 // and DenseSubVector provide convenient ways for

--- a/examples/systems_of_equations/systems_of_equations_ex4/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex4/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
+++ b/examples/systems_of_equations/systems_of_equations_ex4/systems_of_equations_ex4.C
@@ -56,6 +56,7 @@
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/getpot.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/systems_of_equations/systems_of_equations_ex5/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex5/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
+++ b/examples/systems_of_equations/systems_of_equations_ex5/systems_of_equations_ex5.C
@@ -60,6 +60,7 @@
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/getpot.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/systems_of_equations/systems_of_equations_ex6/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex6/Makefile.in
@@ -574,6 +574,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -66,6 +66,7 @@
 #include "libmesh/solver_configuration.h"
 #include "libmesh/petsc_linear_solver.h"
 #include "libmesh/petsc_macro.h"
+#include "libmesh/enum_solver_package.h"
 
 #define x_scaling 1.3
 

--- a/examples/systems_of_equations/systems_of_equations_ex7/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex7/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
+++ b/examples/systems_of_equations/systems_of_equations_ex7/systems_of_equations_ex7.C
@@ -65,6 +65,7 @@
 #include "libmesh/mesh_generation.h"
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/zero_function.h"
+#include "libmesh/enum_solver_package.h"
 
 // The nonlinear solver and system we will be using
 #include "libmesh/nonlinear_solver.h"

--- a/examples/systems_of_equations/systems_of_equations_ex8/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex8/Makefile.in
@@ -613,6 +613,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
+++ b/examples/systems_of_equations/systems_of_equations_ex8/systems_of_equations_ex8.C
@@ -55,6 +55,7 @@
 #include "libmesh/nonlinear_solver.h"
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/petsc_macro.h"
+#include "libmesh/enum_solver_package.h"
 
 // Local includes
 #include "linear_elasticity_with_contact.h"

--- a/examples/systems_of_equations/systems_of_equations_ex9/Makefile.in
+++ b/examples/systems_of_equations/systems_of_equations_ex9/Makefile.in
@@ -580,6 +580,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
+++ b/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
@@ -63,6 +63,7 @@
 #include "libmesh/petsc_macro.h"
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/periodic_boundary.h"
+#include "libmesh/enum_solver_package.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/transient/transient_ex1/Makefile.in
+++ b/examples/transient/transient_ex1/Makefile.in
@@ -584,6 +584,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/transient/transient_ex1/transient_ex1.C
+++ b/examples/transient/transient_ex1/transient_ex1.C
@@ -48,6 +48,7 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/exodusII_io.h"
+#include "libmesh/enum_solver_package.h"
 
 // This example will solve a linear transient system,
 // so we need to include the TransientLinearImplicitSystem definition.

--- a/examples/transient/transient_ex2/Makefile.in
+++ b/examples/transient/transient_ex2/Makefile.in
@@ -575,6 +575,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/transient/transient_ex2/transient_ex2.C
+++ b/examples/transient/transient_ex2/transient_ex2.C
@@ -46,6 +46,7 @@
 #include "libmesh/vtk_io.h"
 #include "libmesh/newmark_system.h"
 #include "libmesh/equation_systems.h"
+#include "libmesh/enum_solver_package.h"
 
 // Define the Finite Element object.
 #include "libmesh/fe.h"

--- a/examples/vector_fe/vector_fe_ex1/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex1/Makefile.in
@@ -582,6 +582,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
+++ b/examples/vector_fe/vector_fe_ex1/vector_fe_ex1.C
@@ -38,6 +38,7 @@
 #include "libmesh/equation_systems.h"
 #include "libmesh/exodusII_io.h"
 #include "libmesh/gmv_io.h"
+#include "libmesh/enum_solver_package.h"
 
 // Define the Finite Element object.
 #include "libmesh/fe.h"

--- a/examples/vector_fe/vector_fe_ex2/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex2/Makefile.in
@@ -608,6 +608,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
+++ b/examples/vector_fe/vector_fe_ex2/vector_fe_ex2.C
@@ -35,6 +35,7 @@
 #include "libmesh/exact_solution.h"
 #include "libmesh/ucd_io.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 // The systems and solvers we may use
 #include "laplace_system.h"

--- a/examples/vector_fe/vector_fe_ex3/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex3/Makefile.in
@@ -608,6 +608,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
+++ b/examples/vector_fe/vector_fe_ex3/vector_fe_ex3.C
@@ -32,13 +32,15 @@
 #include "libmesh/mesh_generation.h"
 #include "libmesh/exact_solution.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_norm_type.h"
 
 // The systems and solvers we may use
 #include "curl_curl_system.h"
 #include "libmesh/diff_solver.h"
 #include "libmesh/steady_solver.h"
-
 #include "solution_function.h"
+
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/examples/vector_fe/vector_fe_ex4/Makefile.in
+++ b/examples/vector_fe/vector_fe_ex4/Makefile.in
@@ -608,6 +608,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
+++ b/examples/vector_fe/vector_fe_ex4/vector_fe_ex4.C
@@ -33,12 +33,13 @@
 #include "libmesh/exact_solution.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_norm_type.h"
 
 // The systems and solvers we may use
 #include "curl_curl_system.h"
 #include "libmesh/diff_solver.h"
 #include "libmesh/steady_solver.h"
-
 #include "solution_function.h"
 
 // Bring in everything from the libMesh namespace

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -501,6 +501,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -34,6 +34,15 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/point.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum Order : int;
+}
+#else
+#include "libmesh/enum_order.h"
+#endif
+
 // C++ Includes
 #include <algorithm>
 #include <cstddef>
@@ -64,7 +73,6 @@ template <typename T> class DenseVector;
 template <typename T> class DenseMatrix;
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
-enum Order : int;
 
 
 

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -23,7 +23,6 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/auto_ptr.h" // deprecated
-#include "libmesh/enum_order.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h" // libMesh::invalid_uint
 #include "libmesh/variable.h"
@@ -65,6 +64,7 @@ template <typename T> class DenseVector;
 template <typename T> class DenseMatrix;
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
+enum Order : int;
 
 
 

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -24,7 +24,6 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh_base.h"
-#include "libmesh/enum_solver_package.h"
 #include "libmesh/parallel.h"
 
 // C++ includes
@@ -48,6 +47,8 @@ class vtkMPIController;
 namespace libMesh
 {
 
+// Forward Declarations
+enum SolverPackage : int;
 
 /**
  * The \p LibMeshInit class, when constructed, initializes

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -26,6 +26,15 @@
 #include "libmesh/libmesh_base.h"
 #include "libmesh/parallel.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum SolverPackage : int;
+}
+#else
+#include "libmesh/enum_solver_package.h"
+#endif
+
 // C++ includes
 #include <string>
 #include <vector>
@@ -46,9 +55,6 @@ class vtkMPIController;
  */
 namespace libMesh
 {
-
-// Forward Declarations
-enum SolverPackage : int;
 
 /**
  * The \p LibMeshInit class, when constructed, initializes

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -21,7 +21,6 @@
 // Local includes
 #include <cstddef>         // for NULL with gcc 4.6.2 - I'm serious!
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_elem_type.h"
 #include "libmesh/id_types.h"
 
 // C++ includes
@@ -34,7 +33,7 @@ namespace libMesh
 // Forward declarations
 class BoundaryInfo;
 class DofMap;
-
+enum ElemType : int;
 
 /**
  * This file declares several predicates in the Predicates namespace.  They

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -23,6 +23,15 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/id_types.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 // C++ includes
 #include <vector>
 #include <set>
@@ -33,7 +42,6 @@ namespace libMesh
 // Forward declarations
 class BoundaryInfo;
 class DofMap;
-enum ElemType : int;
 
 /**
  * This file declares several predicates in the Predicates namespace.  They

--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -54,17 +54,7 @@ public:
   /**
    * Constructor.  Sets the most common default parameter values.
    */
-  AdjointRefinementEstimator() :
-    ErrorEstimator(),
-    number_h_refinements(1),
-    number_p_refinements(0),
-    _residual_evaluation_physics(libmesh_nullptr),
-    _qoi_set(QoISet())
-  {
-    // We're not actually going to use error_norm; our norms are
-    // absolute values of QoI error.
-    error_norm = INVALID_NORM;
-  }
+  AdjointRefinementEstimator();
 
   /**
    * Destructor.
@@ -113,8 +103,7 @@ public:
     return computed_global_QoI_errors[qoi_index];
   }
 
-  virtual ErrorEstimatorType type() const
-  { return ADJOINT_REFINEMENT;}
+  virtual ErrorEstimatorType type() const;
 
   /**
    * How many h refinements to perform to get the fine grid

--- a/include/error_estimation/adjoint_residual_error_estimator.h
+++ b/include/error_estimation/adjoint_residual_error_estimator.h
@@ -109,8 +109,7 @@ public:
                                const NumericVector<Number> * solution_vector = libmesh_nullptr,
                                bool estimate_parent_error = false) libmesh_override;
 
-  virtual ErrorEstimatorType type() const libmesh_override
-  { return ADJOINT_RESIDUAL;}
+  virtual ErrorEstimatorType type() const libmesh_override;
 
 protected:
 

--- a/include/error_estimation/discontinuity_measure.h
+++ b/include/error_estimation/discontinuity_measure.h
@@ -55,10 +55,7 @@ public:
    * pointer to libmesh_nullptr.  Defaults to L2 norm; changes to system norm are
    * ignored.
    */
-  DiscontinuityMeasure() :
-    JumpErrorEstimator(),
-    _bc_function(libmesh_nullptr)
-  { error_norm = L2; }
+  DiscontinuityMeasure();
 
   /**
    * Destructor.
@@ -72,8 +69,7 @@ public:
                                                                const Point & p,
                                                                const std::string & var_name));
 
-  virtual ErrorEstimatorType type() const libmesh_override
-  { return DISCONTINUITY_MEASURE;}
+  virtual ErrorEstimatorType type() const libmesh_override;
 
 protected:
 

--- a/include/error_estimation/error_estimator.h
+++ b/include/error_estimation/error_estimator.h
@@ -24,7 +24,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parallel.h"
 #include "libmesh/system_norm.h"
-#include "libmesh/enum_error_estimator_type.h"
 
 // C++ includes
 #include <cstddef>
@@ -40,6 +39,7 @@ class ErrorVector;
 class EquationSystems;
 class System;
 template <typename T> class NumericVector;
+enum ErrorEstimatorType : int;
 
 /**
  * This class holds functions that will estimate the error

--- a/include/error_estimation/error_estimator.h
+++ b/include/error_estimation/error_estimator.h
@@ -25,6 +25,15 @@
 #include "libmesh/parallel.h"
 #include "libmesh/system_norm.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ErrorEstimatorType : int;
+}
+#else
+#include "libmesh/enum_error_estimator_type.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <map>
@@ -39,7 +48,6 @@ class ErrorVector;
 class EquationSystems;
 class System;
 template <typename T> class NumericVector;
-enum ErrorEstimatorType : int;
 
 /**
  * This class holds functions that will estimate the error

--- a/include/error_estimation/exact_error_estimator.h
+++ b/include/error_estimation/exact_error_estimator.h
@@ -62,14 +62,7 @@ public:
    * Constructor.  Responsible for initializing the _bc_function function
    * pointer to libmesh_nullptr, and defaulting the norm type to H1.
    */
-  ExactErrorEstimator() :
-    ErrorEstimator(),
-    _exact_value(libmesh_nullptr),
-    _exact_deriv(libmesh_nullptr),
-    _exact_hessian(libmesh_nullptr),
-    _equation_systems_fine(libmesh_nullptr),
-    _extra_order(0)
-  { error_norm = H1; }
+  ExactErrorEstimator();
 
   /**
    * Destructor.
@@ -179,8 +172,7 @@ public:
                                const NumericVector<Number> * solution_vector = libmesh_nullptr,
                                bool estimate_parent_error = false) libmesh_override;
 
-  virtual ErrorEstimatorType type() const libmesh_override
-  { return EXACT;}
+  virtual ErrorEstimatorType type() const libmesh_override;
 
 private:
 

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -21,7 +21,6 @@
 
 // Local Includes
 #include "libmesh/libmesh_common.h" // for Number
-#include "libmesh/enum_norm_type.h"
 
 // C++ includes
 #include <map>
@@ -47,6 +46,7 @@ typedef TensorValue<Number> NumberTensorValue;
 typedef NumberTensorValue   Tensor;
 typedef VectorValue<Number> NumberVectorValue;
 typedef NumberVectorValue   Gradient;
+enum FEMNormType : int;
 
 /**
  * This class handles the computation of the L2 and/or H1 error for

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -22,6 +22,15 @@
 // Local Includes
 #include "libmesh/libmesh_common.h" // for Number
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum FEMNormType : int;
+}
+#else
+#include "libmesh/enum_norm_type.h"
+#endif
+
 // C++ includes
 #include <map>
 #include <vector>
@@ -46,7 +55,6 @@ typedef TensorValue<Number> NumberTensorValue;
 typedef NumberTensorValue   Tensor;
 typedef VectorValue<Number> NumberVectorValue;
 typedef NumberVectorValue   Gradient;
-enum FEMNormType : int;
 
 /**
  * This class handles the computation of the L2 and/or H1 error for

--- a/include/error_estimation/fourth_error_estimators.h
+++ b/include/error_estimation/fourth_error_estimators.h
@@ -46,17 +46,14 @@ public:
    * Constructor.  Defaults to H2 seminorm; changes to error_norm are
    * ignored.
    */
-  LaplacianErrorEstimator() :
-    JumpErrorEstimator()
-  { error_norm = H2_SEMINORM; }
+  LaplacianErrorEstimator();
 
   /**
    * Destructor.
    */
   ~LaplacianErrorEstimator() {}
 
-  virtual ErrorEstimatorType type() const libmesh_override
-  { return LAPLACIAN;}
+  virtual ErrorEstimatorType type() const libmesh_override;
 
 protected:
 

--- a/include/error_estimation/kelly_error_estimator.h
+++ b/include/error_estimation/kelly_error_estimator.h
@@ -34,10 +34,6 @@ namespace libMesh
 // Forward Declarations
 class Point;
 
-
-
-
-
 /**
  * This class implements the Kelly error indicator
  * which is based on the flux jumps between elements.
@@ -69,10 +65,7 @@ public:
    * pointer to libmesh_nullptr.  Defaults to H1 seminorm; changes to system norm
    * are ignored.
    */
-  KellyErrorEstimator() :
-    JumpErrorEstimator(),
-    _bc_function(libmesh_nullptr)
-  { error_norm = H1_SEMINORM; }
+  KellyErrorEstimator();
 
   /**
    * Destructor.
@@ -86,8 +79,7 @@ public:
                                                           const Point & p,
                                                           const std::string & var_name));
 
-  virtual ErrorEstimatorType type() const libmesh_override
-  { return KELLY;}
+  virtual ErrorEstimatorType type() const libmesh_override;
 
 protected:
 

--- a/include/error_estimation/patch_recovery_error_estimator.h
+++ b/include/error_estimation/patch_recovery_error_estimator.h
@@ -22,7 +22,6 @@
 
 // Local Includes
 #include "libmesh/error_estimator.h"
-#include "libmesh/enum_order.h"
 #include "libmesh/patch.h"
 #include "libmesh/point.h"
 #include "libmesh/elem_range.h"
@@ -36,7 +35,7 @@ namespace libMesh
 
 // Forward Declarations
 class Elem;
-
+enum Order : int;
 
 /**
  * This class implements the Patch Recovery error indicator.
@@ -54,12 +53,7 @@ public:
    * seminorms should be supported now.  W1,p and W2,p norms would
    * be natural to support if any contributors make the effort.
    */
-  PatchRecoveryErrorEstimator() :
-    ErrorEstimator(),
-    target_patch_size(20),
-    patch_growth_strategy(&Patch::add_local_face_neighbors),
-    patch_reuse(true)
-  { error_norm = H1_SEMINORM; }
+  PatchRecoveryErrorEstimator();
 
   /**
    * Destructor.
@@ -94,8 +88,7 @@ public:
 
   void set_patch_reuse (bool);
 
-  virtual ErrorEstimatorType type() const libmesh_override
-  { return PATCH_RECOVERY;}
+  virtual ErrorEstimatorType type() const libmesh_override;
 
 protected:
 

--- a/include/error_estimation/patch_recovery_error_estimator.h
+++ b/include/error_estimation/patch_recovery_error_estimator.h
@@ -26,6 +26,15 @@
 #include "libmesh/point.h"
 #include "libmesh/elem_range.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum Order : int;
+}
+#else
+#include "libmesh/enum_order.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <vector>
@@ -35,7 +44,6 @@ namespace libMesh
 
 // Forward Declarations
 class Elem;
-enum Order : int;
 
 /**
  * This class implements the Patch Recovery error indicator.

--- a/include/error_estimation/uniform_refinement_estimator.h
+++ b/include/error_estimation/uniform_refinement_estimator.h
@@ -49,11 +49,7 @@ public:
   /**
    * Constructor.  Sets the most common default parameter values.
    */
-  UniformRefinementEstimator() :
-    ErrorEstimator(),
-    number_h_refinements(1),
-    number_p_refinements(0)
-  { error_norm = H1; }
+  UniformRefinementEstimator();
 
   /**
    * Destructor.
@@ -108,8 +104,7 @@ public:
                                 const std::map<const System *, const NumericVector<Number> *> * solution_vectors = libmesh_nullptr,
                                 bool estimate_parent_error = false) libmesh_override;
 
-  virtual ErrorEstimatorType type() const libmesh_override
-  { return UNIFORM_REFINEMENT;}
+  virtual ErrorEstimatorType type() const libmesh_override;
 
   /**
    * How many h refinements to perform to get the fine grid

--- a/include/error_estimation/weighted_patch_recovery_error_estimator.h
+++ b/include/error_estimation/weighted_patch_recovery_error_estimator.h
@@ -25,7 +25,6 @@
 
 // Local Includes
 #include "libmesh/elem_range.h"
-#include "libmesh/enum_order.h"
 #include "libmesh/error_estimator.h"
 #include "libmesh/fem_function_base.h"
 #include "libmesh/patch_recovery_error_estimator.h"
@@ -81,8 +80,7 @@ public:
   */
   std::vector<FEMFunctionBase<Number> *> weight_functions;
 
-  virtual ErrorEstimatorType type() const libmesh_override
-  { return WEIGHTED_PATCH_RECOVERY;}
+  virtual ErrorEstimatorType type() const libmesh_override;
 
 private:
 

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -31,6 +31,15 @@
 #include "libmesh/tensor_value.h"
 #endif
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <vector>
@@ -50,7 +59,6 @@ class Elem;
 class MeshBase;
 template <typename T> class NumericVector;
 class QBase;
-enum ElemType : int;
 
 #ifdef LIBMESH_ENABLE_NODE_CONSTRAINTS
 class NodeConstraints;

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -24,7 +24,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/point.h"
 #include "libmesh/vector_value.h"
-#include "libmesh/enum_elem_type.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/fe_map.h"
@@ -51,6 +50,7 @@ class Elem;
 class MeshBase;
 template <typename T> class NumericVector;
 class QBase;
+enum ElemType : int;
 
 #ifdef LIBMESH_ENABLE_NODE_CONSTRAINTS
 class NodeConstraints;

--- a/include/fe/fe_base.h
+++ b/include/fe/fe_base.h
@@ -24,7 +24,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/compare_types.h"
-#include "libmesh/enum_elem_type.h"
 #include "libmesh/fe_abstract.h"
 #include "libmesh/fe_transformation_base.h"
 #include "libmesh/point.h"

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -22,10 +22,7 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_elem_type.h"
 #include "libmesh/vector_value.h"
-#include "libmesh/enum_fe_family.h"
-#include "libmesh/enum_order.h"
 
 // C++ includes
 #include <map>
@@ -44,6 +41,10 @@ class FEType;
 class FEComputeData;
 class Point;
 class MeshBase;
+enum FEFamily : int;
+enum Order : int;
+enum FEFieldType : int;
+enum ElemType : int;
 
 #ifdef LIBMESH_ENABLE_PERIODIC
 class PeriodicBoundaries;
@@ -457,52 +458,6 @@ private:
 
 };
 
-
-
-
-
-// ------------------------------------------------------------
-// FEInterface class inline members
-#ifndef LIBMESH_ENABLE_INFINITE_ELEMENTS
-
-inline bool FEInterface::is_InfFE_elem(const ElemType)
-{
-  return false;
-}
-
-#else
-
-inline bool FEInterface::is_InfFE_elem(const ElemType et)
-{
-
-  switch (et)
-    {
-    case INFEDGE2:
-    case INFQUAD4:
-    case INFQUAD6:
-    case INFHEX8:
-    case INFHEX16:
-    case INFHEX18:
-    case INFPRISM6:
-    case INFPRISM12:
-      {
-        return true;
-      }
-
-    default:
-      {
-        return false;
-      }
-    }
-}
-
-#endif //ifndef LIBMESH_ENABLE_INFINITE_ELEMENTS
-
-
-
 } // namespace libMesh
-
-
-
 
 #endif // LIBMESH_FE_INTERFACE_H

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -25,8 +25,8 @@
 #include "libmesh/compare_types.h"
 #include "libmesh/libmesh_config.h"
 #include "libmesh/enum_order.h"
-#include "libmesh/enum_fe_family.h"
-#include "libmesh/enum_inf_map_type.h"
+#include "libmesh/enum_fe_family.h" // LAGRANGE
+#include "libmesh/enum_inf_map_type.h" // CARTESIAN
 
 // C++ includes
 #include <memory>

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -130,7 +130,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns \p Hex20::side_nodes_map[side][side_node] after doing some range checking.

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -130,7 +130,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Don't hide Elem::key() defined in the base class.

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -115,7 +115,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Builds a QUAD4 built coincident with face i.

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -126,7 +126,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns \p InfHex16::side_nodes_map[side][side_node] after doing some range checking.

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -97,7 +97,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns \p true if the specified (local) node number is a vertex.

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -111,7 +111,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns A \p QUAD4 built coincident with face 0, or an \p INFQUAD4

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -117,7 +117,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns \p InfPrism12::side_nodes_map[side][side_node] after doing some range checking.

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -113,7 +113,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns A \p TRI3 built coincident with face 0, or an \p INFQUAD4

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -131,7 +131,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns \p Prism15::side_nodes_map[side][side_node] after doing some range checking.

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -131,7 +131,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Don't hide Elem::key() defined in the base class.

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -109,7 +109,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Builds a \p QUAD4 or \p TRI3 built coincident with face i.

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -131,7 +131,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns \p Pyramid13::side_nodes_map[side][side_node] after doing some range checking.

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -134,7 +134,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Don't hide Pyramid::key() defined in the base class.

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -109,7 +109,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Builds a \p QUAD4 or \p TRI3 built coincident with face i.

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -129,7 +129,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns \p Tet10::side_nodes_map[side][side_node] after doing some range checking.

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -128,7 +128,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Builds a \p TRI3 built coincident with face i.

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -115,7 +115,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -116,7 +116,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -117,7 +117,7 @@ public:
   /**
    * \returns THIRD.
    */
-  virtual Order default_order() const libmesh_override { return THIRD; }
+  virtual Order default_order() const libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/edge_inf_edge2.h
+++ b/include/geom/edge_inf_edge2.h
@@ -112,7 +112,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   virtual void connectivity(const unsigned int se,
                             const IOPackage iop,

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -27,10 +27,7 @@
 #include "libmesh/id_types.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/node.h"
-#include "libmesh/enum_elem_type.h"
-#include "libmesh/enum_elem_quality.h"
-#include "libmesh/enum_order.h"
-#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_elem_type.h" // INVALID_ELEM
 #include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/multi_predicates.h"
 #include "libmesh/pointer_to_pointer_iter.h"
@@ -59,6 +56,9 @@ class Elem;
 class PeriodicBoundaries;
 class PointLocatorBase;
 #endif
+enum ElemQuality : int;
+enum IOPackage : int;
+enum Order : int;
 
 /**
  * This is the base class from which all geometric element types are

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -36,6 +36,19 @@
 #include "libmesh/variant_filter_iterator.h"
 #include "libmesh/hashword.h" // Used in compute_key() functions
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemQuality : int;
+enum IOPackage : int;
+enum Order : int;
+}
+#else
+#include "libmesh/enum_elem_quality.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
+#endif
+
 // C++ includes
 #include <algorithm>
 #include <cstddef>
@@ -56,9 +69,6 @@ class Elem;
 class PeriodicBoundaries;
 class PointLocatorBase;
 #endif
-enum ElemQuality : int;
-enum IOPackage : int;
-enum Order : int;
 
 /**
  * This is the base class from which all geometric element types are

--- a/include/geom/elem_quality.h
+++ b/include/geom/elem_quality.h
@@ -20,16 +20,23 @@
 #ifndef LIBMESH_ELEM_QUALITY_H
 #define LIBMESH_ELEM_QUALITY_H
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+enum ElemQuality : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#include "libmesh/enum_elem_quality.h"
+#endif
+
 // C++ includes
 #include <vector>
 #include <string>
 
 namespace libMesh
 {
-
-// Forward declarations
-enum ElemType : int;
-enum ElemQuality : int;
 
 /**
  * A namespace for quality utility functions.

--- a/include/geom/elem_quality.h
+++ b/include/geom/elem_quality.h
@@ -20,16 +20,16 @@
 #ifndef LIBMESH_ELEM_QUALITY_H
 #define LIBMESH_ELEM_QUALITY_H
 
-// Local includes
-#include "libmesh/enum_elem_type.h"
-#include "libmesh/enum_elem_quality.h"
-
 // C++ includes
 #include <vector>
 #include <string>
 
 namespace libMesh
 {
+
+// Forward declarations
+enum ElemType : int;
+enum ElemQuality : int;
 
 /**
  * A namespace for quality utility functions.

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -108,7 +108,7 @@ public:
   /**
    * \returns \p FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * \returns An \p Edge2 for the base side, or an \p InfEdge2 for

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -109,7 +109,7 @@ public:
   /**
    * \returns \p SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Don't hide Elem::key() defined in the base class.

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -108,7 +108,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) libmesh_override;

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -113,7 +113,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Don't hide Elem::key() defined in the base class.

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -113,7 +113,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Don't hide Elem::key() defined in the base class.

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -119,7 +119,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) libmesh_override;

--- a/include/geom/face_tri3_subdivision.h
+++ b/include/geom/face_tri3_subdivision.h
@@ -72,7 +72,7 @@ public:
   /**
    * \returns FOURTH.
    */
-  virtual Order default_order() const libmesh_override { return FOURTH; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Prepares the element for use by reordering the nodes such that

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -118,7 +118,7 @@ public:
   /**
    * \returns SECOND.
    */
-  virtual Order default_order() const libmesh_override { return SECOND; }
+  virtual Order default_order() const libmesh_override;
 
   /**
    * Don't hide Elem::key() defined in the base class.

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -185,7 +185,7 @@ public:
   /**
    * \returns FIRST.
    */
-  virtual Order default_order() const libmesh_override { return FIRST; }
+  virtual Order default_order() const libmesh_override;
 
   virtual void connectivity(const unsigned int sc,
                             const IOPackage iop,

--- a/include/geom/reference_elem.h
+++ b/include/geom/reference_elem.h
@@ -22,13 +22,13 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_elem_type.h"
 
 namespace libMesh
 {
 
 // forward declarations
 class Elem;
+enum ElemType : int;
 
 /**
  * This namespace implements singleton reference elements for each

--- a/include/geom/reference_elem.h
+++ b/include/geom/reference_elem.h
@@ -23,12 +23,20 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 namespace libMesh
 {
 
 // forward declarations
 class Elem;
-enum ElemType : int;
 
 /**
  * This namespace implements singleton reference elements for each

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -163,7 +163,7 @@ public:
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }
 
   virtual Order default_order () const libmesh_override
-  { libmesh_not_implemented(); return FIRST; }
+  { libmesh_not_implemented(); return static_cast<Order>(1); }
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -425,6 +425,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -186,6 +186,9 @@
 /* Flag indicating if the library should have warnings enabled */
 #undef ENABLE_WARNINGS
 
+/* Flag indicating if the library uses forward declared enumerations */
+#undef FORWARD_DECLARE_ENUMS
+
 /* Enable fparser debugging functions */
 #undef FPARSER_SUPPORT_DEBUGGING
 

--- a/include/mesh/ensight_io.h
+++ b/include/mesh/ensight_io.h
@@ -24,6 +24,15 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_output.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 // C++ includes
 #include <map>
 #include <string>
@@ -34,7 +43,6 @@ namespace libMesh
 
 // Forward declarations
 class EquationSystems;
-enum ElemType : int;
 
 /**
  * This class implements writing meshes and solutions in Ensight's Gold format.

--- a/include/mesh/ensight_io.h
+++ b/include/mesh/ensight_io.h
@@ -21,7 +21,6 @@
 
 // libMesh includes
 #include "libmesh/libmesh.h"
-#include "libmesh/enum_elem_type.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_output.h"
 
@@ -35,6 +34,7 @@ namespace libMesh
 
 // Forward declarations
 class EquationSystems;
+enum ElemType : int;
 
 /**
  * This class implements writing meshes and solutions in Ensight's Gold format.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -25,7 +25,6 @@
 // Local includes
 #include "libmesh/parallel_object.h"
 #include "libmesh/point.h"
-#include "libmesh/enum_elem_type.h"
 
 // C++ includes
 #include <iostream>
@@ -74,6 +73,7 @@ namespace libMesh
 
 // Forward declarations
 class MeshBase;
+enum ElemType : int;
 
 /**
  * This is the \p ExodusII_IO_Helper class.  This class hides the

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -26,6 +26,15 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/point.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 // C++ includes
 #include <iostream>
 #include <string>
@@ -73,7 +82,6 @@ namespace libMesh
 
 // Forward declarations
 class MeshBase;
-enum ElemType : int;
 
 /**
  * This is the \p ExodusII_IO_Helper class.  This class hides the

--- a/include/mesh/gmv_io.h
+++ b/include/mesh/gmv_io.h
@@ -24,7 +24,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/mesh_output.h"
 #include "libmesh/mesh_input.h"
-#include "libmesh/enum_elem_type.h"
 
 // C++ includes
 #include <map>
@@ -34,6 +33,7 @@ namespace libMesh
 
 // Forward declarations
 class MeshBase;
+enum ElemType : int;
 
 /**
  * This class implements writing meshes in the GMV format.

--- a/include/mesh/gmv_io.h
+++ b/include/mesh/gmv_io.h
@@ -25,6 +25,15 @@
 #include "libmesh/mesh_output.h"
 #include "libmesh/mesh_input.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 // C++ includes
 #include <map>
 
@@ -33,7 +42,6 @@ namespace libMesh
 
 // Forward declarations
 class MeshBase;
-enum ElemType : int;
 
 /**
  * This class implements writing meshes in the GMV format.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -31,6 +31,15 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/simple_range.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 // C++ Includes
 #include <cstddef>
 #include <string>
@@ -45,7 +54,6 @@ class GhostingFunctor;
 class Node;
 class Point;
 class Partitioner;
-enum ElemType : int;
 
 template <class MT>
 class MeshInput;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -24,7 +24,6 @@
 #include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/boundary_info.h"
 #include "libmesh/dof_object.h" // for invalid_processor_id
-#include "libmesh/enum_elem_type.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/multi_predicates.h"
 #include "libmesh/point_locator_base.h"
@@ -46,6 +45,7 @@ class GhostingFunctor;
 class Node;
 class Point;
 class Partitioner;
+enum ElemType : int;
 
 template <class MT>
 class MeshInput;

--- a/include/mesh/mesh_generation.h
+++ b/include/mesh/mesh_generation.h
@@ -22,7 +22,7 @@
 
 // Local Includes
 #include "libmesh/libmesh.h"
-#include "libmesh/enum_elem_type.h"
+#include "libmesh/enum_elem_type.h" // INVALID_ELEM
 #include "libmesh/vector_value.h"
 #ifdef LIBMESH_HAVE_TRIANGLE
 #include "libmesh/mesh_triangle_interface.h"

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -23,7 +23,6 @@
 // Local Includes
 #include "libmesh/libmesh.h"
 #include "libmesh/bounding_box.h"
-#include "libmesh/enum_elem_type.h"
 #include "libmesh/id_types.h"
 #include "libmesh/mesh_base.h"
 
@@ -38,6 +37,7 @@ namespace libMesh
 // forward declarations
 class Sphere;
 class Elem;
+enum ElemType : int;
 
 /**
  * Utility functions for operations on a \p Mesh object.  Here is where

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -26,6 +26,15 @@
 #include "libmesh/id_types.h"
 #include "libmesh/mesh_base.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 // C++ Includes
 #include <vector>
 #include <set>
@@ -37,7 +46,6 @@ namespace libMesh
 // forward declarations
 class Sphere;
 class Elem;
-enum ElemType : int;
 
 /**
  * Utility functions for operations on a \p Mesh object.  Here is where

--- a/include/mesh/mesh_triangle_interface.h
+++ b/include/mesh/mesh_triangle_interface.h
@@ -28,6 +28,15 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/mesh_serializer.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <vector>
@@ -37,7 +46,6 @@ namespace libMesh
 
 // Forward Declarations
 class UnstructuredMesh;
-enum ElemType : int;
 
 /**
  * A C++ interface between LibMesh and the Triangle library written by

--- a/include/mesh/mesh_triangle_interface.h
+++ b/include/mesh/mesh_triangle_interface.h
@@ -25,7 +25,6 @@
 #ifdef LIBMESH_HAVE_TRIANGLE
 
 // Local Includes
-#include "libmesh/enum_elem_type.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/mesh_serializer.h"
 
@@ -37,8 +36,8 @@ namespace libMesh
 {
 
 // Forward Declarations
-
 class UnstructuredMesh;
+enum ElemType : int;
 
 /**
  * A C++ interface between LibMesh and the Triangle library written by

--- a/include/mesh/mesh_triangle_wrapper.h
+++ b/include/mesh/mesh_triangle_wrapper.h
@@ -25,7 +25,6 @@
 
 // Local Includes
 #include "libmesh/libmesh_common.h" // Real
-#include "libmesh/enum_elem_type.h" // For ElemType declaration below
 
 // C++ includes
 #include <cstddef>
@@ -34,6 +33,7 @@ namespace libMesh
 {
 // Forward declarations
 class UnstructuredMesh;
+enum ElemType : int;
 
 // Make sure Triangle uses our "Real" as its "REAL"
 typedef Real REAL;

--- a/include/mesh/mesh_triangle_wrapper.h
+++ b/include/mesh/mesh_triangle_wrapper.h
@@ -26,6 +26,15 @@
 // Local Includes
 #include "libmesh/libmesh_common.h" // Real
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 
@@ -33,7 +42,6 @@ namespace libMesh
 {
 // Forward declarations
 class UnstructuredMesh;
-enum ElemType : int;
 
 // Make sure Triangle uses our "Real" as its "REAL"
 typedef Real REAL;

--- a/include/mesh/ucd_io.h
+++ b/include/mesh/ucd_io.h
@@ -27,13 +27,13 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/mesh_input.h"
 #include "libmesh/mesh_output.h"
-#include "libmesh/enum_elem_type.h"
 
 namespace libMesh
 {
 
 // Forward declarations
 class MeshBase;
+enum ElemType : int;
 
 /**
  * This class implements reading & writing meshes in the AVS's UCD format.

--- a/include/mesh/ucd_io.h
+++ b/include/mesh/ucd_io.h
@@ -28,12 +28,20 @@
 #include "libmesh/mesh_input.h"
 #include "libmesh/mesh_output.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum ElemType : int;
+}
+#else
+#include "libmesh/enum_elem_type.h"
+#endif
+
 namespace libMesh
 {
 
 // Forward declarations
 class MeshBase;
-enum ElemType : int;
 
 /**
  * This class implements reading & writing meshes in the AVS's UCD format.

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -24,7 +24,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/enum_parallel_type.h"
-#include "libmesh/enum_solver_package.h"
 #include "libmesh/id_types.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
@@ -48,7 +47,7 @@ template <typename T> class DenseVector;
 template <typename T> class DenseSubVector;
 template <typename T> class SparseMatrix;
 template <typename T> class ShellMatrix;
-
+enum SolverPackage : int;
 
 /**
  * Numeric vector. Provides a uniform interface

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -31,6 +31,15 @@
 #include "libmesh/dense_subvector.h"
 #include "libmesh/dense_vector.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum SolverPackage : int;
+}
+#else
+#include "libmesh/enum_solver_package.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <set>
@@ -47,7 +56,6 @@ template <typename T> class DenseVector;
 template <typename T> class DenseSubVector;
 template <typename T> class SparseMatrix;
 template <typename T> class ShellMatrix;
-enum SolverPackage : int;
 
 /**
  * Numeric vector. Provides a uniform interface

--- a/include/numerics/petsc_preconditioner.h
+++ b/include/numerics/petsc_preconditioner.h
@@ -31,6 +31,15 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/petsc_macro.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum PreconditionerType : int;
+}
+#else
+#include "libmesh/enum_preconditioner_type.h"
+#endif
+
 // Petsc includes
 #include "petscpc.h"
 
@@ -41,7 +50,6 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
-enum PreconditionerType : int;
 
 /**
  * This class provides an interface to the suite of preconditioners

--- a/include/numerics/petsc_preconditioner.h
+++ b/include/numerics/petsc_preconditioner.h
@@ -27,8 +27,6 @@
 // Local includes
 #include "libmesh/preconditioner.h"
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_solver_package.h"
-#include "libmesh/enum_preconditioner_type.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/petsc_macro.h"
@@ -43,6 +41,7 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
+enum PreconditionerType : int;
 
 /**
  * This class provides an interface to the suite of preconditioners

--- a/include/numerics/preconditioner.h
+++ b/include/numerics/preconditioner.h
@@ -23,9 +23,6 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_solver_package.h"
-#include "libmesh/enum_solver_type.h"
-#include "libmesh/enum_preconditioner_type.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
@@ -40,6 +37,8 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
+enum SolverPackage : int;
+enum PreconditionerType : int;
 
 /**
  * This class provides a uniform interface for preconditioners.  This base
@@ -160,18 +159,6 @@ protected:
 
 
 /*----------------------- inline functions ----------------------------------*/
-template <typename T>
-inline
-Preconditioner<T>::Preconditioner (const libMesh::Parallel::Communicator & comm_in) :
-  ParallelObject(comm_in),
-  _matrix(libmesh_nullptr),
-  _preconditioner_type (ILU_PRECOND),
-  _is_initialized      (false)
-{
-}
-
-
-
 template <typename T>
 inline
 Preconditioner<T>::~Preconditioner ()

--- a/include/numerics/preconditioner.h
+++ b/include/numerics/preconditioner.h
@@ -27,6 +27,18 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum SolverPackage : int;
+enum PreconditionerType : int;
+}
+#else
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_preconditioner_type.h"
+#endif
+
+
 // C++ includes
 #include <cstddef>
 
@@ -37,8 +49,6 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
-enum SolverPackage : int;
-enum PreconditionerType : int;
 
 /**
  * This class provides a uniform interface for preconditioners.  This base

--- a/include/numerics/trilinos_preconditioner.h
+++ b/include/numerics/trilinos_preconditioner.h
@@ -39,6 +39,15 @@
 #include "Teuchos_ParameterList.hpp"
 #include "libmesh/restore_warnings.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum PreconditionerType : int;
+}
+#else
+#include "libmesh/enum_preconditioner_type.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 
@@ -49,7 +58,6 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
-enum PreconditionerType : int;
 
 /**
  * This class provides an interface to the suite of preconditioners

--- a/include/numerics/trilinos_preconditioner.h
+++ b/include/numerics/trilinos_preconditioner.h
@@ -27,8 +27,6 @@
 // Local includes
 #include "libmesh/preconditioner.h"
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_solver_package.h"
-#include "libmesh/enum_preconditioner_type.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/auto_ptr.h" // deprecated
@@ -51,6 +49,7 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class ShellMatrix;
+enum PreconditionerType : int;
 
 /**
  * This class provides an interface to the suite of preconditioners

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -28,6 +28,15 @@
 #include "libmesh/enum_order.h" // INVALID_ORDER
 #include "libmesh/auto_ptr.h" // deprecated
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum QuadratureType : int;
+}
+#else
+#include "libmesh/enum_quadrature_type.h"
+#endif
+
 // C++ includes
 #include <vector>
 #include <string>
@@ -39,7 +48,6 @@ namespace libMesh
 
 // forward declarations
 class Elem;
-enum QuadratureType : int;
 
 /**
  * The \p QBase class provides the basic functionality from which

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -24,9 +24,8 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/point.h"
-#include "libmesh/enum_elem_type.h"
-#include "libmesh/enum_order.h"
-#include "libmesh/enum_quadrature_type.h"
+#include "libmesh/enum_elem_type.h" // INVALID_ELEM
+#include "libmesh/enum_order.h" // INVALID_ORDER
 #include "libmesh/auto_ptr.h" // deprecated
 
 // C++ includes
@@ -40,6 +39,7 @@ namespace libMesh
 
 // forward declarations
 class Elem;
+enum QuadratureType : int;
 
 /**
  * The \p QBase class provides the basic functionality from which

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -54,7 +54,7 @@ public:
   /**
    * \returns \p QCLOUGH.
    */
-  virtual QuadratureType type() const libmesh_override { return QCLOUGH; }
+  virtual QuadratureType type() const libmesh_override;
 
 
 private:

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -58,7 +58,7 @@ public:
   /**
    * \returns The QuadratureType for this class.
    */
-  virtual QuadratureType type() const libmesh_override { return QCONICAL; }
+  virtual QuadratureType type() const libmesh_override;
 
 private:
 

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -65,7 +65,7 @@ public:
   /**
    * \returns \p QGAUSS.
    */
-  virtual QuadratureType type() const libmesh_override { return QGAUSS; }
+  virtual QuadratureType type() const libmesh_override;
 
 
 private:

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -56,7 +56,7 @@ public:
   /**
    * \returns \p QGAUSS_LOBATTO.
    */
-  virtual QuadratureType type() const libmesh_override { return QGAUSS_LOBATTO; }
+  virtual QuadratureType type() const libmesh_override;
 
 private:
 

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -111,7 +111,7 @@ public:
   /**
    * \returns \p QGRUNDMANN_MOLLER.
    */
-  virtual QuadratureType type() const libmesh_override { return QGRUNDMANN_MOLLER; }
+  virtual QuadratureType type() const libmesh_override;
 
 
 private:

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -64,7 +64,7 @@ public:
   /**
    * \returns \p QGRID.
    */
-  virtual QuadratureType type() const libmesh_override { return QGRID; }
+  virtual QuadratureType type() const libmesh_override;
 
 
 private:

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -73,7 +73,7 @@ public:
   /**
    * \returns \p QMONOMIAL.
    */
-  virtual QuadratureType type() const libmesh_override { return QMONOMIAL; }
+  virtual QuadratureType type() const libmesh_override;
 
 
 private:

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -65,7 +65,7 @@ public:
   /**
    * \returns \p QSIMPSON.
    */
-  virtual QuadratureType type() const libmesh_override { return QSIMPSON; }
+  virtual QuadratureType type() const libmesh_override;
 
 
 private:

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -65,7 +65,7 @@ public:
   /**
    * \returns \p QTRAP.
    */
-  virtual QuadratureType type() const libmesh_override { return QTRAP; }
+  virtual QuadratureType type() const libmesh_override;
 
 private:
 

--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -32,6 +32,18 @@
 #include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/enum_solver_package.h" // SLEPC_SOLVERS
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum EigenSolverType : int;
+enum EigenProblemType : int;
+enum PositionOfSpectrum : int;
+}
+#else
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_eigen_solver_type.h"
+#endif
+
 // C++ includes
 #include <memory>
 
@@ -43,9 +55,6 @@ template <typename T> class SparseMatrix;
 template <typename T> class ShellMatrix;
 template <typename T> class NumericVector;
 class SolverConfiguration;
-enum EigenSolverType : int;
-enum EigenProblemType : int;
-enum PositionOfSpectrum : int;
 
 /**
  * This class provides an interface to solvers for eigenvalue

--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -26,12 +26,11 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_solver_package.h"
-#include "libmesh/enum_eigen_solver_type.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
 #include "libmesh/auto_ptr.h" // deprecated
+#include "libmesh/enum_solver_package.h" // SLEPC_SOLVERS
 
 // C++ includes
 #include <memory>
@@ -44,6 +43,9 @@ template <typename T> class SparseMatrix;
 template <typename T> class ShellMatrix;
 template <typename T> class NumericVector;
 class SolverConfiguration;
+enum EigenSolverType : int;
+enum EigenProblemType : int;
+enum PositionOfSpectrum : int;
 
 /**
  * This class provides an interface to solvers for eigenvalue
@@ -293,32 +295,6 @@ protected:
 
   bool _close_matrix_before_solve;
 };
-
-
-
-
-/*----------------------- inline functions ----------------------------------*/
-template <typename T>
-inline
-EigenSolver<T>::EigenSolver (const Parallel::Communicator & comm_in) :
-  ParallelObject(comm_in),
-  _eigen_solver_type    (ARNOLDI),
-  _eigen_problem_type   (NHEP),
-  _position_of_spectrum (LARGEST_MAGNITUDE),
-  _is_initialized       (false),
-  _solver_configuration(libmesh_nullptr),
-  _close_matrix_before_solve(true)
-{
-}
-
-
-
-template <typename T>
-inline
-EigenSolver<T>::~EigenSolver ()
-{
-  this->clear ();
-}
 
 } // namespace libMesh
 

--- a/include/solvers/eigen_sparse_linear_solver.h
+++ b/include/solvers/eigen_sparse_linear_solver.h
@@ -30,8 +30,8 @@
 #include "libmesh/linear_solver.h"
 #include "libmesh/eigen_sparse_vector.h"
 #include "libmesh/eigen_sparse_matrix.h"
+#include "libmesh/enum_convergence_flags.h" // The build_map() function uses these.
 
-// C++ includes
 
 namespace libMesh
 {

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -22,11 +22,7 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_convergence_flags.h"
-#include "libmesh/enum_solver_package.h"
-#include "libmesh/enum_solver_type.h"
-#include "libmesh/enum_preconditioner_type.h"
-#include "libmesh/enum_subset_solve_mode.h"
+#include "libmesh/enum_subset_solve_mode.h" // SUBSET_ZERO
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
@@ -47,6 +43,10 @@ template <typename T> class ShellMatrix;
 template <typename T> class Preconditioner;
 class System;
 class SolverConfiguration;
+enum SolverPackage : int;
+enum PreconditionerType : int;
+enum SolverType : int;
+enum LinearConvergenceReason : int;
 
 /**
  * This base class can be inherited from to provide interfaces to
@@ -299,21 +299,6 @@ protected:
 
 
 /*----------------------- inline functions ----------------------------------*/
-template <typename T>
-inline
-LinearSolver<T>::LinearSolver (const libMesh::Parallel::Communicator & comm_in) :
-  ParallelObject       (comm_in),
-  _solver_type         (GMRES),
-  _preconditioner_type (ILU_PRECOND),
-  _is_initialized      (false),
-  _preconditioner      (libmesh_nullptr),
-  same_preconditioner  (false),
-  _solver_configuration(libmesh_nullptr)
-{
-}
-
-
-
 template <typename T>
 inline
 LinearSolver<T>::~LinearSolver ()

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -28,6 +28,21 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/auto_ptr.h" // deprecated
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum SolverPackage : int;
+enum PreconditionerType : int;
+enum SolverType : int;
+enum LinearConvergenceReason : int;
+}
+#else
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_preconditioner_type.h"
+#include "libmesh/enum_solver_type.h"
+#include "libmesh/enum_convergence_flags.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <vector>
@@ -43,10 +58,6 @@ template <typename T> class ShellMatrix;
 template <typename T> class Preconditioner;
 class System;
 class SolverConfiguration;
-enum SolverPackage : int;
-enum PreconditionerType : int;
-enum SolverType : int;
-enum LinearConvergenceReason : int;
 
 /**
  * This base class can be inherited from to provide interfaces to

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -28,6 +28,15 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/auto_ptr.h" // deprecated
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum SolverPackage : int;
+}
+#else
+#include "libmesh/enum_solver_package.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <memory>
@@ -40,7 +49,6 @@ template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class Preconditioner;
 class SolverConfiguration;
-enum SolverPackage : int;
 
 /**
  * This base class can be inherited from to provide interfaces to

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -22,7 +22,6 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_solver_package.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/libmesh.h"
@@ -41,6 +40,7 @@ template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class Preconditioner;
 class SolverConfiguration;
+enum SolverPackage : int;
 
 /**
  * This base class can be inherited from to provide interfaces to

--- a/include/solvers/optimization_solver.h
+++ b/include/solvers/optimization_solver.h
@@ -22,7 +22,6 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/enum_solver_package.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
@@ -40,6 +39,7 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class Preconditioner;
+enum SolverPackage : int;
 
 /**
  * This base class can be inherited from to provide interfaces to

--- a/include/solvers/optimization_solver.h
+++ b/include/solvers/optimization_solver.h
@@ -28,6 +28,15 @@
 #include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/optimization_system.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum SolverPackage : int;
+}
+#else
+#include "libmesh/enum_solver_package.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <memory>
@@ -39,7 +48,6 @@ namespace libMesh
 template <typename T> class SparseMatrix;
 template <typename T> class NumericVector;
 template <typename T> class Preconditioner;
-enum SolverPackage : int;
 
 /**
  * This base class can be inherited from to provide interfaces to

--- a/include/solvers/petsc_linear_solver.h
+++ b/include/solvers/petsc_linear_solver.h
@@ -328,22 +328,6 @@ private:
 /*----------------------- functions ----------------------------------*/
 template <typename T>
 inline
-PetscLinearSolver<T>::PetscLinearSolver(const libMesh::Parallel::Communicator & comm_in) :
-  LinearSolver<T>(comm_in),
-  _restrict_solve_to_is(libmesh_nullptr),
-  _restrict_solve_to_is_complement(libmesh_nullptr),
-  _subset_solve_mode(SUBSET_ZERO)
-{
-  if (this->n_processors() == 1)
-    this->_preconditioner_type = ILU_PRECOND;
-  else
-    this->_preconditioner_type = BLOCK_JACOBI_PRECOND;
-}
-
-
-
-template <typename T>
-inline
 PetscLinearSolver<T>::~PetscLinearSolver ()
 {
   this->clear ();

--- a/include/solvers/slepc_eigen_solver.h
+++ b/include/solvers/slepc_eigen_solver.h
@@ -271,26 +271,6 @@ private:
 
 };
 
-
-/*----------------------- inline functions ----------------------------------*/
-template <typename T>
-inline
-SlepcEigenSolver<T>::SlepcEigenSolver (const Parallel::Communicator & comm_in) :
-  EigenSolver<T>(comm_in)
-{
-  this->_eigen_solver_type  = ARNOLDI;
-  this->_eigen_problem_type = NHEP;
-}
-
-
-
-template <typename T>
-inline
-SlepcEigenSolver<T>::~SlepcEigenSolver ()
-{
-  this->clear ();
-}
-
 } // namespace libMesh
 
 

--- a/include/solvers/trilinos_aztec_linear_solver.h
+++ b/include/solvers/trilinos_aztec_linear_solver.h
@@ -172,19 +172,6 @@ private:
 /*----------------------- functions ----------------------------------*/
 template <typename T>
 inline
-AztecLinearSolver<T>::AztecLinearSolver (const libMesh::Parallel::Communicator & comm) :
-  LinearSolver<T>(comm)
-{
-  if (this->n_processors() == 1)
-    this->_preconditioner_type = ILU_PRECOND;
-  else
-    this->_preconditioner_type = BLOCK_JACOBI_PRECOND;
-}
-
-
-
-template <typename T>
-inline
 AztecLinearSolver<T>::~AztecLinearSolver ()
 {
   this->clear ();

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -24,7 +24,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parameters.h"
 #include "libmesh/system.h"
-#include "libmesh/enum_xdr_mode.h"
 #include "libmesh/parallel_object.h"
 
 // HP aCC needs these for some reason
@@ -48,6 +47,7 @@ namespace libMesh
 // Forward Declarations
 class Elem;
 class MeshBase;
+enum XdrMODE : int;
 
 /**
  * This is the \p EquationSystems class.  It is in charge

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -26,6 +26,15 @@
 #include "libmesh/system.h"
 #include "libmesh/parallel_object.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum XdrMODE : int;
+}
+#else
+#include "libmesh/enum_xdr_mode.h"
+#endif
+
 // HP aCC needs these for some reason
 #ifdef __HP_aCC
 # include "libmesh/frequency_system.h"
@@ -47,7 +56,6 @@ namespace libMesh
 // Forward Declarations
 class Elem;
 class MeshBase;
-enum XdrMODE : int;
 
 /**
  * This is the \p EquationSystems class.  It is in charge

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -33,6 +33,15 @@
 #include "libmesh/tensor_value.h" // For point_hessian
 #include "libmesh/variable.h"
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum FEMNormType : int;
+}
+#else
+#include "libmesh/enum_norm_type.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <set>
@@ -61,7 +70,6 @@ typedef NumberVectorValue Gradient;
 class SystemSubset;
 class FEType;
 class SystemNorm;
-enum FEMNormType : int;
 
 /**
  * This is the base class for classes which contain

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -23,10 +23,8 @@
 // Local Includes
 #include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/elem_range.h"
-#include "libmesh/enum_norm_type.h"
-#include "libmesh/enum_xdr_mode.h"
-#include "libmesh/enum_subset_solve_mode.h"
-#include "libmesh/enum_parallel_type.h"
+#include "libmesh/enum_subset_solve_mode.h" // SUBSET_ZERO
+#include "libmesh/enum_parallel_type.h" // PARALLEL
 #include "libmesh/fem_function_base.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parallel_object.h"
@@ -63,6 +61,7 @@ typedef NumberVectorValue Gradient;
 class SystemSubset;
 class FEType;
 class SystemNorm;
+enum FEMNormType : int;
 
 /**
  * This is the base class for classes which contain

--- a/include/systems/system_norm.h
+++ b/include/systems/system_norm.h
@@ -22,13 +22,15 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h" // for Real
-#include "libmesh/enum_norm_type.h"
 
 // C++ includes
 #include <vector>
 
 namespace libMesh
 {
+
+// Forward Declarations
+enum FEMNormType : int;
 
 /**
  * This class defines a norm/seminorm to be applied to a NumericVector which

--- a/include/systems/system_norm.h
+++ b/include/systems/system_norm.h
@@ -23,14 +23,20 @@
 // Local includes
 #include "libmesh/libmesh_common.h" // for Real
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum FEMNormType : int;
+}
+#else
+#include "libmesh/enum_norm_type.h"
+#endif
+
 // C++ includes
 #include <vector>
 
 namespace libMesh
 {
-
-// Forward Declarations
-enum FEMNormType : int;
 
 /**
  * This class defines a norm/seminorm to be applied to a NumericVector which

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -25,6 +25,15 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/auto_ptr.h" // deprecated
 
+#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
+namespace libMesh
+{
+enum PointLocatorType : int;
+}
+#else
+#include "libmesh/enum_point_locator_type.h"
+#endif
+
 // C++ includes
 #include <cstddef>
 #include <vector>
@@ -40,7 +49,6 @@ class Point;
 class TreeBase;
 class Elem;
 class Node;
-enum PointLocatorType : int;
 
 
 /**

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -24,7 +24,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/auto_ptr.h" // deprecated
-#include "libmesh/enum_point_locator_type.h"
 
 // C++ includes
 #include <cstddef>
@@ -41,7 +40,7 @@ class Point;
 class TreeBase;
 class Elem;
 class Node;
-
+enum PointLocatorType : int;
 
 
 /**

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -23,7 +23,7 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh.h"
-#include "libmesh/enum_xdr_mode.h"
+#include "libmesh/enum_xdr_mode.h" // READ, WRITE, etc.
 #include "libmesh/auto_ptr.h" // deprecated
 
 // C++ includes

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -89,6 +89,31 @@ AS_IF([test "$enabledeprecated" != yes],
 
 
 # --------------------------------------------------------------
+# forward declared enumerations - enable by default
+# We want to prevent new library code from being added that
+# depends on including enum headers, but still give downstream
+# apps the ability to compile with the old headers for a
+# period of deprecation.
+# --------------------------------------------------------------
+AC_ARG_ENABLE(forward-declare-enums,
+              [AS_HELP_STRING([--disable-forward-declare-enums],[Directly include enumeration headers rather than forward declaring them])],
+              enablefwdenums=$enableval,
+              enablefwdenums=yes)
+
+AC_SUBST(enablefwdenums)
+AS_IF([test "$enablefwdenums" != yes],
+      [
+        AC_MSG_RESULT([>>> INFO: Forward declared enumerations are disabled <<<])
+        AC_MSG_RESULT([>>> Enumeration headers will be included directly <<<])
+      ],
+      [
+        AC_MSG_RESULT([<<< Configuring library with forward declared enumerations >>>])
+        AC_DEFINE(FORWARD_DECLARE_ENUMS, 1, [Flag indicating if the library uses forward declared enumerations])
+      ])
+# --------------------------------------------------------------
+
+
+# --------------------------------------------------------------
 # blocked matrix/vector storage - disabled by default.
 #   See http://sourceforge.net/mailarchive/forum.php?thread_name=B4613A7D-0033-43C7-A9DF-5A801217A097%40nasa.gov&forum_name=libmesh-devel
 # --------------------------------------------------------------

--- a/src/apps/calculator.C
+++ b/src/apps/calculator.C
@@ -20,13 +20,13 @@
 // arguments, parse the function specified in a command line argument,
 // L2-project its value onto the mesh, and output the new solution.
 
+// C++ includes
 #include <map>
 #include <string>
 
+// libMesh includes
 #include "L2system.h"
-
 #include "libmesh/libmesh.h"
-
 #include "libmesh/dof_map.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/getpot.h"
@@ -36,6 +36,7 @@
 #include "libmesh/parsed_fem_function.h"
 #include "libmesh/point.h"
 #include "libmesh/steady_solver.h"
+#include "libmesh/enum_xdr_mode.h"
 
 
 using namespace libMesh;

--- a/src/apps/meshdiff.C
+++ b/src/apps/meshdiff.C
@@ -21,13 +21,13 @@
 // differences between them.
 
 #include "libmesh/libmesh.h"
-
 #include "libmesh/mesh.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/exact_solution.h"
 #include "libmesh/mesh_function.h"
 #include "libmesh/namebased_io.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/enum_norm_type.h"
 
 using namespace libMesh;
 

--- a/src/apps/meshnorm.C
+++ b/src/apps/meshnorm.C
@@ -20,9 +20,9 @@
 // Open the mesh and solution file named on standard input, find all
 // variables therein, and output their norms and seminorms.
 #include "libmesh/libmesh.h"
-
 #include "libmesh/mesh.h"
 #include "libmesh/equation_systems.h"
+#include "libmesh/enum_norm_type.h"
 
 using namespace libMesh;
 

--- a/src/apps/meshtool.C
+++ b/src/apps/meshtool.C
@@ -50,7 +50,7 @@
 #include "libmesh/perfmon.h"
 #include "libmesh/statistics.h"
 #include "libmesh/string_to_enum.h"
-
+#include "libmesh/enum_elem_quality.h"
 
 using namespace libMesh;
 

--- a/src/apps/projection.C
+++ b/src/apps/projection.C
@@ -20,11 +20,12 @@
 // arguments, open the output mesh, project that solution onto the
 // output mesh, and write a corresponding output solution file.
 
+// C++ includes
 #include <map>
 #include <string>
 
+// libMesh includes
 #include "libmesh/libmesh.h"
-
 #include "libmesh/dof_map.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/getpot.h"
@@ -33,6 +34,7 @@
 #include "libmesh/numeric_vector.h"
 #include "libmesh/point.h"
 #include "libmesh/replicated_mesh.h"
+#include "libmesh/enum_xdr_mode.h"
 
 
 using namespace libMesh;

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -25,7 +25,7 @@
 #include "libmesh/remote_elem.h"
 #include "libmesh/threads.h"
 #include "libmesh/print_trace.h"
-
+#include "libmesh/enum_solver_package.h"
 
 // C/C++ includes
 #include <iostream>

--- a/src/base/single_predicates.C
+++ b/src/base/single_predicates.C
@@ -17,7 +17,7 @@
 
 // Local includes
 #include "libmesh/single_predicates.h"
-
+#include "libmesh/enum_elem_type.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/mapvector.h"

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -43,6 +43,8 @@
 #include "libmesh/implicit_system.h"
 #include "libmesh/partitioner.h"
 #include "libmesh/adjoint_refinement_estimator.h"
+#include "libmesh/enum_error_estimator_type.h"
+#include "libmesh/enum_norm_type.h"
 
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -67,6 +69,23 @@ namespace libMesh
 // Both a global QoI error estimate and element wise error indicators are included
 // Note that the element wise error indicators slightly over estimate the error in
 // each element
+
+AdjointRefinementEstimator::AdjointRefinementEstimator() :
+  ErrorEstimator(),
+  number_h_refinements(1),
+  number_p_refinements(0),
+  _residual_evaluation_physics(libmesh_nullptr),
+  _qoi_set(QoISet())
+{
+  // We're not actually going to use error_norm; our norms are
+  // absolute values of QoI error.
+  error_norm = INVALID_NORM;
+}
+
+ErrorEstimatorType AdjointRefinementEstimator::type() const
+{
+  return ADJOINT_REFINEMENT;
+}
 
 void AdjointRefinementEstimator::estimate_error (const System & _system,
                                                  ErrorVector & error_per_cell,

--- a/src/error_estimation/adjoint_residual_error_estimator.C
+++ b/src/error_estimation/adjoint_residual_error_estimator.C
@@ -25,6 +25,7 @@
 #include "libmesh/system.h"
 #include "libmesh/system_norm.h"
 #include "libmesh/qoi_set.h"
+#include "libmesh/enum_error_estimator_type.h"
 
 // C++ includes
 #include <iostream>
@@ -43,6 +44,14 @@ AdjointResidualErrorEstimator::AdjointResidualErrorEstimator () :
   _dual_error_estimator(new PatchRecoveryErrorEstimator()),
   _qoi_set(QoISet())
 {
+}
+
+
+
+ErrorEstimatorType
+AdjointResidualErrorEstimator::type() const
+{
+  return ADJOINT_RESIDUAL;
 }
 
 

--- a/src/error_estimation/discontinuity_measure.C
+++ b/src/error_estimation/discontinuity_measure.C
@@ -30,13 +30,30 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/elem.h"
 #include "libmesh/system.h"
-
 #include "libmesh/dense_vector.h"
 #include "libmesh/tensor_tools.h"
-
+#include "libmesh/enum_error_estimator_type.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace libMesh
 {
+
+DiscontinuityMeasure::DiscontinuityMeasure() :
+  JumpErrorEstimator(),
+  _bc_function(libmesh_nullptr)
+{
+  error_norm = L2;
+}
+
+
+
+ErrorEstimatorType
+DiscontinuityMeasure::type() const
+{
+  return DISCONTINUITY_MEASURE;
+}
+
+
 
 void
 DiscontinuityMeasure::init_context(FEMContext & c)

--- a/src/error_estimation/error_estimator.C
+++ b/src/error_estimation/error_estimator.C
@@ -22,7 +22,7 @@
 #include "libmesh/error_vector.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/parallel.h"
-
+#include "libmesh/enum_error_estimator_type.h"
 
 
 

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -37,12 +37,32 @@
 #include "libmesh/quadrature.h"
 #include "libmesh/system.h"
 #include "libmesh/tensor_tools.h"
+#include "libmesh/enum_error_estimator_type.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace libMesh
 {
 
 //-----------------------------------------------------------------
 // ErrorEstimator implementations
+ExactErrorEstimator::ExactErrorEstimator() :
+    ErrorEstimator(),
+    _exact_value(libmesh_nullptr),
+    _exact_deriv(libmesh_nullptr),
+    _exact_hessian(libmesh_nullptr),
+    _equation_systems_fine(libmesh_nullptr),
+    _extra_order(0)
+{
+  error_norm = H1;
+}
+
+
+ErrorEstimatorType ExactErrorEstimator::type() const
+{
+  return EXACT;
+}
+
+
 void ExactErrorEstimator::attach_exact_value (ValueFunctionPointer fptr)
 {
   libmesh_assert(fptr);

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -15,9 +15,6 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-
-
 // Local includes
 #include "libmesh/dof_map.h"
 #include "libmesh/elem.h"
@@ -34,6 +31,7 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/raw_accessor.h"
 #include "libmesh/tensor_tools.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace libMesh
 {

--- a/src/error_estimation/fourth_error_estimators.C
+++ b/src/error_estimation/fourth_error_estimators.C
@@ -34,13 +34,29 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/elem.h"
 #include "libmesh/system.h"
-
 #include "libmesh/dense_vector.h"
 #include "libmesh/tensor_tools.h"
-
+#include "libmesh/enum_error_estimator_type.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace libMesh
 {
+
+
+LaplacianErrorEstimator::LaplacianErrorEstimator() :
+  JumpErrorEstimator()
+{
+  error_norm = H2_SEMINORM;
+}
+
+
+
+ErrorEstimatorType
+LaplacianErrorEstimator::type() const
+{
+  return LAPLACIAN;
+}
+
 
 
 void

--- a/src/error_estimation/kelly_error_estimator.C
+++ b/src/error_estimation/kelly_error_estimator.C
@@ -30,12 +30,28 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/elem.h"
 #include "libmesh/system.h"
-
 #include "libmesh/dense_vector.h"
 #include "libmesh/tensor_tools.h"
+#include "libmesh/enum_error_estimator_type.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace libMesh
 {
+
+KellyErrorEstimator::KellyErrorEstimator() :
+  JumpErrorEstimator(),
+  _bc_function(libmesh_nullptr)
+{
+  error_norm = H1_SEMINORM;
+}
+
+
+
+ErrorEstimatorType
+KellyErrorEstimator::type() const
+{
+  return KELLY;
+}
 
 
 

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -40,9 +40,19 @@
 #include "libmesh/tensor_value.h"
 #include "libmesh/threads.h"
 #include "libmesh/tensor_tools.h"
+#include "libmesh/enum_error_estimator_type.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace libMesh
 {
+
+ErrorEstimatorType PatchRecoveryErrorEstimator::type() const
+{
+  return PATCH_RECOVERY;
+}
+
+
+
 // Setter function for the patch_reuse flag
 void PatchRecoveryErrorEstimator::set_patch_reuse(bool patch_reuse_flag)
 {
@@ -51,6 +61,17 @@ void PatchRecoveryErrorEstimator::set_patch_reuse(bool patch_reuse_flag)
 
 //-----------------------------------------------------------------
 // PatchRecoveryErrorEstimator implementations
+PatchRecoveryErrorEstimator::PatchRecoveryErrorEstimator() :
+    ErrorEstimator(),
+    target_patch_size(20),
+    patch_growth_strategy(&Patch::add_local_face_neighbors),
+    patch_reuse(true)
+{
+  error_norm = H1_SEMINORM;
+}
+
+
+
 std::vector<Real> PatchRecoveryErrorEstimator::specpoly(const unsigned int dim,
                                                         const Order order,
                                                         const Point p,

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -38,6 +38,8 @@
 #include "libmesh/uniform_refinement_estimator.h"
 #include "libmesh/partitioner.h"
 #include "libmesh/tensor_tools.h"
+#include "libmesh/enum_error_estimator_type.h"
+#include "libmesh/enum_norm_type.h"
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -46,6 +48,23 @@ namespace libMesh
 
 //-----------------------------------------------------------------
 // ErrorEstimator implementations
+
+UniformRefinementEstimator::UniformRefinementEstimator() :
+    ErrorEstimator(),
+    number_h_refinements(1),
+    number_p_refinements(0)
+{
+  error_norm = H1;
+}
+
+
+
+ErrorEstimatorType UniformRefinementEstimator::type() const
+{
+  return UNIFORM_REFINEMENT;
+}
+
+
 void UniformRefinementEstimator::estimate_error (const System & _system,
                                                  ErrorVector & error_per_cell,
                                                  const NumericVector<Number> * solution_vector,

--- a/src/error_estimation/weighted_patch_recovery_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_estimator.C
@@ -38,9 +38,20 @@
 #include "libmesh/tensor_value.h"
 #include "libmesh/threads.h"
 #include "libmesh/weighted_patch_recovery_error_estimator.h"
+#include "libmesh/enum_error_estimator_type.h"
+#include "libmesh/enum_order.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace libMesh
 {
+
+ErrorEstimatorType WeightedPatchRecoveryErrorEstimator::type() const
+{
+  return WEIGHTED_PATCH_RECOVERY;
+}
+
+
+
 void WeightedPatchRecoveryErrorEstimator::estimate_error (const System & system,
                                                           ErrorVector & error_per_cell,
                                                           const NumericVector<Number> * solution_vector,

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -20,6 +20,7 @@
 // Local includes
 #include "libmesh/fe.h"
 #include "libmesh/libmesh_logging.h"
+#include "libmesh/enum_elem_type.h"
 
 // For projection code:
 #include "libmesh/boundary_info.h"

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -23,6 +23,9 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_compute_data.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/enum_fe_family.h"
+#include "libmesh/enum_order.h"
+#include "libmesh/enum_elem_type.h"
 
 namespace libMesh
 {
@@ -33,6 +36,46 @@ FEInterface::FEInterface()
 {
   libmesh_error_msg("ERROR: Do not define an object of this type.");
 }
+
+
+
+#ifndef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+bool
+FEInterface::is_InfFE_elem(const ElemType)
+{
+  return false;
+}
+
+#else
+
+bool
+FEInterface::is_InfFE_elem(const ElemType et)
+{
+
+  switch (et)
+    {
+    case INFEDGE2:
+    case INFQUAD4:
+    case INFQUAD6:
+    case INFHEX8:
+    case INFHEX16:
+    case INFHEX18:
+    case INFPRISM6:
+    case INFPRISM12:
+      {
+        return true;
+      }
+
+    default:
+      {
+        return false;
+      }
+    }
+}
+
+#endif //ifndef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
 
 
 #ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -23,7 +23,7 @@
 #include "libmesh/cell_hex.h"
 #include "libmesh/cell_hex8.h"
 #include "libmesh/face_quad4.h"
-
+#include "libmesh/enum_elem_quality.h"
 
 
 namespace libMesh

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -16,13 +16,13 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_hex20.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_quad8.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -138,6 +138,13 @@ bool Hex20::has_affine_map() const
     return false;
   // If all the above checks out, the map is affine
   return true;
+}
+
+
+
+Order Hex20::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -16,13 +16,13 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_hex27.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_quad9.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -151,6 +151,13 @@ bool Hex27::has_affine_map() const
     return false;
   // If all the above checks out, the map is affine
   return true;
+}
+
+
+
+Order Hex27::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -16,13 +16,13 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_hex8.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/face_quad4.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -113,6 +113,13 @@ bool Hex8::has_affine_map() const
     return false;
   // If all the above checks out, the map is affine
   return true;
+}
+
+
+
+Order Hex8::default_order() const
+{
+  return FIRST;
 }
 
 

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -31,6 +31,7 @@
 #include "libmesh/face_inf_quad4.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/enum_elem_quality.h"
 
 namespace libMesh
 {

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -20,8 +20,6 @@
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-// C++ includes
-
 // Local includes cont'd
 #include "libmesh/cell_inf_hex16.h"
 #include "libmesh/edge_edge3.h"
@@ -29,6 +27,8 @@
 #include "libmesh/face_quad8.h"
 #include "libmesh/face_inf_quad6.h"
 #include "libmesh/side.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -102,6 +102,13 @@ bool InfHex16::is_node_on_edge(const unsigned int n,
     if (edge_nodes_map[e][i] == n)
       return true;
   return false;
+}
+
+
+
+Order InfHex16::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -20,8 +20,6 @@
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-// C++ includes
-
 // Local includes cont'd
 #include "libmesh/cell_inf_hex18.h"
 #include "libmesh/edge_edge3.h"
@@ -29,6 +27,8 @@
 #include "libmesh/face_quad9.h"
 #include "libmesh/face_inf_quad6.h"
 #include "libmesh/side.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -59,6 +59,11 @@ const unsigned int InfHex18::edge_nodes_map[8][3] =
 
 // ------------------------------------------------------------
 // InfHex18 class member functions
+
+Order InfHex18::default_order() const
+{
+  return SECOND;
+}
 
 bool InfHex18::is_vertex(const unsigned int i) const
 {

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -20,8 +20,6 @@
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-// C++ includes
-
 // Local includes cont'd
 #include "libmesh/cell_inf_hex8.h"
 #include "libmesh/edge_edge2.h"
@@ -29,6 +27,8 @@
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_inf_quad4.h"
 #include "libmesh/side.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -99,6 +99,15 @@ bool InfHex8::is_node_on_edge(const unsigned int n,
       return true;
   return false;
 }
+
+
+
+Order InfHex8::default_order() const
+{
+  return FIRST;
+}
+
+
 
 std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
                                                bool proxy)

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -15,21 +15,18 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-
-// C++ includes
-// include <algorithm>
-
-// Local includes cont'd
+// Local includes
 #include "libmesh/cell_inf_prism.h"
 #include "libmesh/cell_inf_prism6.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/face_inf_quad4.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -15,20 +15,19 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// Local includes
 #include "libmesh/libmesh_config.h"
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-// C++ includes
-
-// Local includes cont'd
+// Local includes
 #include "libmesh/cell_inf_prism12.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/edge_inf_edge2.h"
 #include "libmesh/face_tri6.h"
 #include "libmesh/face_inf_quad6.h"
 #include "libmesh/side.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -101,7 +100,10 @@ bool InfPrism12::is_node_on_edge(const unsigned int n,
   return false;
 }
 
-
+Order InfPrism12::default_order() const
+{
+  return SECOND;
+}
 
 unsigned int InfPrism12::which_node_am_i(unsigned int side,
                                          unsigned int side_node) const

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -20,8 +20,6 @@
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-// C++ includes
-
 // Local includes cont'd
 #include "libmesh/cell_inf_prism6.h"
 #include "libmesh/edge_edge2.h"
@@ -30,6 +28,8 @@
 #include "libmesh/side.h"
 #include "libmesh/face_inf_quad4.h"
 #include "libmesh/face_tri3.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -97,6 +97,14 @@ bool InfPrism6::is_node_on_edge(const unsigned int n,
       return true;
   return false;
 }
+
+
+
+Order InfPrism6::default_order() const
+{
+  return FIRST;
+}
+
 
 
 std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -16,14 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_prism15.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_quad8.h"
 #include "libmesh/face_tri6.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -125,6 +125,13 @@ bool Prism15::has_affine_map() const
       !v.relative_fuzzy_equals(this->point(13) - this->point(4)))
     return false;
   return true;
+}
+
+
+
+Order Prism15::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -16,14 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_prism18.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_quad9.h"
 #include "libmesh/face_tri6.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -135,6 +135,11 @@ bool Prism18::has_affine_map() const
 }
 
 
+
+Order Prism18::default_order() const
+{
+  return SECOND;
+}
 
 dof_id_type Prism18::key (const unsigned int s) const
 {

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -16,14 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_prism6.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_tri3.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -112,6 +112,13 @@ bool Prism6::has_affine_map() const
       !v.relative_fuzzy_equals(this->point(5) - this->point(2)))
     return false;
   return true;
+}
+
+
+
+Order Prism6::default_order() const
+{
+  return FIRST;
 }
 
 

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -16,14 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_pyramid13.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_tri6.h"
 #include "libmesh/face_quad8.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -111,6 +111,13 @@ bool Pyramid13::has_affine_map() const
   // TODO: If the base is a parallelogram and all the triangular faces are planar,
   // the map should be linear, but I need to test this theory...
   return false;
+}
+
+
+
+Order Pyramid13::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -16,14 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_pyramid14.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_tri6.h"
 #include "libmesh/face_quad9.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -115,6 +115,13 @@ bool Pyramid14::has_affine_map() const
   // TODO: If the base is a parallelogram and all the triangular faces are planar,
   // the map should be linear, but I need to test this theory...
   return false;
+}
+
+
+
+Order Pyramid14::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -16,14 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_pyramid5.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/face_quad4.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -101,6 +101,13 @@ bool Pyramid5::has_affine_map() const
   //  Point v = this->point(3) - this->point(0);
   //  return (v.relative_fuzzy_equals(this->point(2) - this->point(1)));
   return false;
+}
+
+
+
+Order Pyramid5::default_order() const
+{
+  return FIRST;
 }
 
 

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -16,12 +16,11 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/cell_tet.h"
 #include "libmesh/cell_tet4.h"
 #include "libmesh/face_tri3.h"
+#include "libmesh/enum_elem_quality.h"
 
 namespace libMesh
 {

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -16,13 +16,13 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_tet10.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_tri6.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -149,6 +149,13 @@ bool Tet10::has_affine_map() const
       ((this->point(3) + this->point(2))/2))
     return false;
   return true;
+}
+
+
+
+Order Tet10::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -16,14 +16,14 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/cell_tet4.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/tensor_value.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -125,6 +125,11 @@ bool Tet4::is_node_on_side(const unsigned int n,
     if (side_nodes_map[s][i] == n)
       return true;
   return false;
+}
+
+Order Tet4::default_order() const
+{
+  return FIRST;
 }
 
 std::unique_ptr<Elem> Tet4::build_side_ptr (const unsigned int i,

--- a/src/geom/edge_edge2.C
+++ b/src/geom/edge_edge2.C
@@ -19,6 +19,8 @@
 
 // Local includes
 #include "libmesh/edge_edge2.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -73,6 +75,15 @@ bool Edge2::is_node_on_edge(const unsigned int,
   libmesh_assert_equal_to (e, 0);
   return true;
 }
+
+
+
+Order Edge2::default_order() const
+{
+  return FIRST;
+}
+
+
 
 void Edge2::connectivity(const unsigned int libmesh_dbg_var(sc),
                          const IOPackage iop,

--- a/src/geom/edge_edge3.C
+++ b/src/geom/edge_edge3.C
@@ -19,6 +19,8 @@
 
 // Local includes
 #include "libmesh/edge_edge3.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -86,6 +88,13 @@ bool Edge3::has_affine_map() const
 {
   return (this->point(2).relative_fuzzy_equals
           ((this->point(0) + this->point(1))/2));
+}
+
+
+
+Order Edge3::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/edge_edge4.C
+++ b/src/geom/edge_edge4.C
@@ -19,6 +19,8 @@
 
 // Local includes
 #include "libmesh/edge_edge4.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -90,6 +92,13 @@ bool Edge4::has_affine_map() const
       ((this->point(0) + this->point(1)*2.)/3.))
     return false;
   return true;
+}
+
+
+
+Order Edge4::default_order() const
+{
+  return THIRD;
 }
 
 

--- a/src/geom/edge_inf_edge2.C
+++ b/src/geom/edge_inf_edge2.C
@@ -17,11 +17,14 @@
 
 
 
-// Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
+// Local includes
 #include "libmesh/edge_inf_edge2.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -61,6 +64,11 @@ bool InfEdge2::is_node_on_edge(const unsigned int,
 {
   libmesh_assert_equal_to (e, 0);
   return true;
+}
+
+Order InfEdge2::default_order() const
+{
+  return FIRST;
 }
 
 void InfEdge2::connectivity(const unsigned int libmesh_dbg_var(se),

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -68,6 +68,9 @@
 #include "libmesh/reference_elem.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/threads.h"
+#include "libmesh/enum_elem_quality.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 #ifdef LIBMESH_ENABLE_PERIODIC
 #include "libmesh/mesh.h"

--- a/src/geom/elem_quality.C
+++ b/src/geom/elem_quality.C
@@ -22,6 +22,9 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/elem_quality.h"
+#include "libmesh/enum_elem_type.h"
+#include "libmesh/enum_elem_quality.h"
+
 
 namespace libMesh
 {

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -20,13 +20,12 @@
 #include "libmesh/libmesh_config.h"
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-// C++ includes
-
 // Local includes cont'd
 #include "libmesh/face_inf_quad.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/edge_inf_edge2.h"
 #include "libmesh/face_inf_quad4.h"
+#include "libmesh/enum_elem_quality.h"
 
 namespace libMesh
 {

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -17,18 +17,19 @@
 
 
 
-// Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-
-// Local includes cont'd
+// Local includes
 #include "libmesh/face_inf_quad4.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/side.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/edge_inf_edge2.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -160,6 +161,13 @@ bool InfQuad4::contains_point (const Point & p, Real tol) const
     }
 }
 
+
+
+
+Order InfQuad4::default_order() const
+{
+  return FIRST;
+}
 
 
 

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -17,16 +17,17 @@
 
 
 
-// Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 
-
-// Local includes cont'd
+// Local includes
 #include "libmesh/face_inf_quad6.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/side.h"
 #include "libmesh/edge_inf_edge2.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -105,6 +106,13 @@ const float InfQuad6::_embedding_matrix[2][6][6] =
 
 #endif
 
+
+
+
+Order InfQuad6::default_order() const
+{
+  return SECOND;
+}
 
 
 

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -19,6 +19,7 @@
 #include "libmesh/face_quad.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/face_quad4.h"
+#include "libmesh/enum_elem_quality.h"
 
 // C++ includes
 #include <array>

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -15,12 +15,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/face_quad4.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -120,6 +120,13 @@ bool Quad4::has_affine_map() const
 {
   Point v = this->point(3) - this->point(0);
   return (v.relative_fuzzy_equals(this->point(2) - this->point(1)));
+}
+
+
+
+Order Quad4::default_order() const
+{
+  return FIRST;
 }
 
 

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -15,12 +15,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_quad8.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -150,6 +150,13 @@ bool Quad8::has_affine_map() const
       !v.relative_fuzzy_equals(this->point(5) - this->point(1)))
     return false;
   return true;
+}
+
+
+
+Order Quad8::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -15,12 +15,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_quad9.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -161,6 +161,13 @@ bool Quad9::has_affine_map() const
       !v.relative_fuzzy_equals(this->point(8) - this->point(4)))
     return false;
   return true;
+}
+
+
+
+Order Quad9::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -15,12 +15,11 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-
 // Local includes
 #include "libmesh/face_tri.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/face_tri3.h"
+#include "libmesh/enum_elem_quality.h"
 
 namespace libMesh
 {

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -15,12 +15,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/face_tri3.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -104,6 +104,11 @@ bool Tri3::is_node_on_side(const unsigned int n,
     if (side_nodes_map[s][i] == n)
       return true;
   return false;
+}
+
+Order Tri3::default_order() const
+{
+  return FIRST;
 }
 
 std::unique_ptr<Elem> Tri3::build_side_ptr (const unsigned int i,

--- a/src/geom/face_tri3_subdivision.C
+++ b/src/geom/face_tri3_subdivision.C
@@ -15,11 +15,10 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-
 // Local includes
 #include "libmesh/face_tri3_subdivision.h"
 #include "libmesh/mesh_subdivision_support.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -45,6 +44,14 @@ Tri3Subdivision::Tri3Subdivision(Elem * p) : Tri3(p), _subdivision_updated(true)
         }
     }
 }
+
+
+
+Order Tri3Subdivision::default_order() const
+{
+  return FOURTH;
+}
+
 
 
 void Tri3Subdivision::prepare_subdivision_properties()

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -15,12 +15,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-// C++ includes
-
 // Local includes
 #include "libmesh/side.h"
 #include "libmesh/edge_edge3.h"
 #include "libmesh/face_tri6.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
@@ -139,6 +139,13 @@ bool Tri6::has_affine_map() const
     return false;
 
   return true;
+}
+
+
+
+Order Tri6::default_order() const
+{
+  return SECOND;
 }
 
 

--- a/src/geom/node_elem.C
+++ b/src/geom/node_elem.C
@@ -17,16 +17,19 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/node_elem.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {
 
 
-// Forward declarations
+Order NodeElem::default_order() const
+{
+  return FIRST;
+}
+
 
 
 void NodeElem::connectivity(const unsigned int,

--- a/src/geom/reference_elem.C
+++ b/src/geom/reference_elem.C
@@ -24,6 +24,7 @@
 #include "libmesh/libmesh_singleton.h"
 #include "libmesh/threads.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_elem_type.h"
 
 // C++ includes
 #include <map>

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -17,11 +17,7 @@
 
 
 
-#include <sstream>
-#include <fstream>
-#include <string>
-#include <iomanip>
-
+// libMesh includes
 #include "libmesh/dof_map.h"
 #include "libmesh/ensight_io.h"
 #include "libmesh/equation_systems.h"
@@ -29,6 +25,13 @@
 #include "libmesh/libmesh.h"
 #include "libmesh/system.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_elem_type.h"
+
+// C++ includes
+#include <sstream>
+#include <fstream>
+#include <string>
+#include <iomanip>
 
 namespace libMesh
 {

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -32,6 +32,7 @@
 #include "libmesh/system.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_elem_type.h"
 
 #ifdef DEBUG
 #include "libmesh/mesh_tools.h"  // for elem_types warning

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -30,6 +30,8 @@
 #include "libmesh/equation_systems.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_elem_type.h"
 
 // Wrap everything in a GMVLib namespace and
 // use extern "C" to avoid name mangling.

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -37,6 +37,8 @@
 #include "libmesh/partitioner.h"
 #include "libmesh/point_locator_base.h"
 #include "libmesh/threads.h"
+#include "libmesh/enum_elem_type.h"
+#include "libmesh/enum_point_locator_type.h"
 
 
 namespace libMesh

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -51,6 +51,7 @@
 #include "libmesh/node_elem.h"
 #include "libmesh/vector_value.h"
 #include "libmesh/function_base.h"
+#include "libmesh/enum_order.h"
 
 namespace libMesh
 {

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -40,6 +40,7 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/partitioner.h"
+#include "libmesh/enum_order.h"
 
 namespace
 {

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -30,6 +30,7 @@
 #include "libmesh/sphere.h"
 #include "libmesh/threads.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_elem_type.h"
 
 #ifdef DEBUG
 #  include "libmesh/remote_elem.h"

--- a/src/mesh/mesh_triangle_interface.C
+++ b/src/mesh/mesh_triangle_interface.C
@@ -32,6 +32,7 @@
 #include "libmesh/boundary_info.h"
 #include "libmesh/mesh_triangle_holes.h"
 #include "libmesh/mesh_triangle_wrapper.h"
+#include "libmesh/enum_elem_type.h"
 
 namespace libMesh
 {

--- a/src/mesh/mesh_triangle_wrapper.C
+++ b/src/mesh/mesh_triangle_wrapper.C
@@ -26,6 +26,7 @@
 #include "libmesh/point.h"
 #include "libmesh/face_tri3.h"
 #include "libmesh/face_tri6.h"
+#include "libmesh/enum_elem_type.h"
 
 namespace libMesh
 {

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -28,9 +28,7 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_communication.h"
-
 #include "libmesh/namebased_io.h"
-
 #include "libmesh/exodusII_io.h"
 #include "libmesh/gmv_io.h"
 #include "libmesh/tecplot_io.h"
@@ -47,9 +45,8 @@
 #include "libmesh/vtk_io.h"
 #include "libmesh/abaqus_io.h"
 #include "libmesh/checkpoint_io.h"
-
 #include "libmesh/equation_systems.h"
-
+#include "libmesh/enum_xdr_mode.h"
 
 
 namespace libMesh

--- a/src/mesh/tecplot_io.C
+++ b/src/mesh/tecplot_io.C
@@ -29,6 +29,7 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/elem.h"
 #include "libmesh/parallel.h"
+#include "libmesh/enum_io_package.h"
 
 #ifdef LIBMESH_HAVE_TECPLOT_API
 extern "C" {

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -29,6 +29,8 @@
 #include "libmesh/cell_tet4.h"
 #include "libmesh/cell_hex8.h"
 #include "libmesh/cell_prism6.h"
+#include "libmesh/enum_io_package.h"
+#include "libmesh/enum_elem_type.h"
 
 #ifdef LIBMESH_HAVE_GZSTREAM
 # include "gzstream.h" // For reading/writing compressed streams

--- a/src/mesh/vtk_io.C
+++ b/src/mesh/vtk_io.C
@@ -28,6 +28,7 @@
 #include "libmesh/system.h"
 #include "libmesh/node.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_io_package.h"
 
 #ifdef LIBMESH_HAVE_VTK
 

--- a/src/numerics/numeric_vector.C
+++ b/src/numerics/numeric_vector.C
@@ -32,6 +32,7 @@
 #include "libmesh/shell_matrix.h"
 #include "libmesh/tensor_tools.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 namespace libMesh
 {

--- a/src/numerics/petsc_preconditioner.C
+++ b/src/numerics/petsc_preconditioner.C
@@ -27,6 +27,7 @@
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/libmesh_common.h"
+#include "libmesh/enum_preconditioner_type.h"
 
 // PCBJacobiGetSubKSP was defined in petscksp.h in PETSc 2.3.3, 3.1.0
 #if PETSC_VERSION_LESS_THAN(3,1,0)

--- a/src/numerics/preconditioner.C
+++ b/src/numerics/preconditioner.C
@@ -19,16 +19,27 @@
 
 // Local Includes
 #include "libmesh/preconditioner.h"
-
 #include "libmesh/auto_ptr.h"
 #include "libmesh/eigen_preconditioner.h"
 #include "libmesh/petsc_preconditioner.h"
 #include "libmesh/trilinos_preconditioner.h"
-
-
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_preconditioner_type.h"
 
 namespace libMesh
 {
+
+template <typename T>
+inline
+Preconditioner<T>::Preconditioner (const libMesh::Parallel::Communicator & comm_in) :
+  ParallelObject(comm_in),
+  _matrix(libmesh_nullptr),
+  _preconditioner_type (ILU_PRECOND),
+  _is_initialized      (false)
+{
+}
+
+
 
 template <typename T>
 std::unique_ptr<Preconditioner<T>>

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -30,6 +30,7 @@
 #include "libmesh/trilinos_epetra_matrix.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 namespace libMesh
 {

--- a/src/numerics/trilinos_preconditioner.C
+++ b/src/numerics/trilinos_preconditioner.C
@@ -24,6 +24,7 @@
 #include "libmesh/trilinos_epetra_matrix.h"
 #include "libmesh/trilinos_epetra_vector.h"
 #include "libmesh/libmesh_common.h"
+#include "libmesh/enum_preconditioner_type.h"
 
 #include "libmesh/ignore_warnings.h"
 #ifdef LIBMESH_TRILINOS_HAVE_IFPACK

--- a/src/quadrature/quadrature_build.C
+++ b/src/quadrature/quadrature_build.C
@@ -29,6 +29,7 @@
 #include "libmesh/quadrature_conical.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_quadrature_type.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_clough.C
+++ b/src/quadrature/quadrature_clough.C
@@ -16,10 +16,22 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// See the files:
+// libMesh includes
+#include "libmesh/quadrature_clough.h"
+#include "libmesh/enum_quadrature_type.h"
 
+namespace libMesh
+{
+
+QuadratureType QClough::type() const
+{
+  return QCLOUGH;
+}
+
+// See the files:
 // quadrature_clough_1D.C
 // quadrature_clough_2D.C
 // quadrature_clough_3D.C
-
 // for implementation.
+
+}

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -16,9 +16,11 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
+// libMesh includes
 #include "libmesh/quadrature_conical.h"
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/quadrature_jacobi.h"
+#include "libmesh/enum_quadrature_type.h"
 
 namespace libMesh
 {
@@ -45,6 +47,11 @@ QConical::~QConical()
 }
 
 
+
+QuadratureType QConical::type() const
+{
+  return QCONICAL;
+}
 
 void QConical::init_1D(const ElemType /*type_in*/,
                        unsigned int p)

--- a/src/quadrature/quadrature_gauss.C
+++ b/src/quadrature/quadrature_gauss.C
@@ -16,19 +16,24 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
+// libMesh includes
 #include "libmesh/quadrature_gauss.h"
+#include "libmesh/enum_quadrature_type.h"
 
 namespace libMesh
 {
 
 // See the files:
-
 // quadrature_gauss_1D.C
 // quadrature_gauss_2D.C
 // quadrature_gauss_3D.C
-
 // for implementation of specific element types.
 
+
+QuadratureType QGauss::type() const
+{
+  return QGAUSS;
+}
 
 void QGauss::keast_rule(const Real rule_data[][4],
                         const unsigned int n_pts)

--- a/src/quadrature/quadrature_gauss_lobatto.C
+++ b/src/quadrature/quadrature_gauss_lobatto.C
@@ -16,17 +16,17 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
+// libMesh includes
 #include "libmesh/quadrature_gauss_lobatto.h"
+#include "libmesh/enum_quadrature_type.h"
 
 namespace libMesh
 {
 
 // See the files:
-
 // quadrature_gauss_lobatto_1D.C
 // quadrature_gauss_lobatto_2D.C
 // quadrature_gauss_lobatto_3D.C
-
 // for implementation of specific element types.
 
 
@@ -48,5 +48,10 @@ QGaussLobatto::~QGaussLobatto()
 {
 }
 
+
+QuadratureType QGaussLobatto::type() const
+{
+  return QGAUSS_LOBATTO;
+}
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_gm.C
+++ b/src/quadrature/quadrature_gm.C
@@ -18,16 +18,15 @@
 
 #include "libmesh/quadrature_gm.h"
 #include "libmesh/quadrature_gauss.h"
+#include "libmesh/enum_quadrature_type.h"
 
 namespace libMesh
 {
 
 // See also the file:
+// quadrature_gm_2D.C
 // quadrature_gm_3D.C
 // for additional implementation.
-
-
-
 
 // Constructor
 QGrundmann_Moller::QGrundmann_Moller(const unsigned int d,
@@ -39,6 +38,13 @@ QGrundmann_Moller::QGrundmann_Moller(const unsigned int d,
 // Destructor
 QGrundmann_Moller::~QGrundmann_Moller()
 {
+}
+
+
+
+QuadratureType QGrundmann_Moller::type() const
+{
+  return QGRUNDMANN_MOLLER;
 }
 
 

--- a/src/quadrature/quadrature_grid.C
+++ b/src/quadrature/quadrature_grid.C
@@ -16,10 +16,22 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// See the files:
+// libMesh includes
+#include "libmesh/quadrature_grid.h"
+#include "libmesh/enum_quadrature_type.h"
 
+namespace libMesh
+{
+
+QuadratureType QGrid::type() const
+{
+  return QGRID;
+}
+
+// See the files:
 // quadrature_grid_1D.C
 // quadrature_grid_2D.C
 // quadrature_grid_3D.C
-
 // for implementation.
+
+}

--- a/src/quadrature/quadrature_jacobi.C
+++ b/src/quadrature/quadrature_jacobi.C
@@ -17,7 +17,9 @@
 
 
 
+// libMesh includes
 #include "libmesh/quadrature_jacobi.h"
+#include "libmesh/enum_quadrature_type.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_monomial.C
+++ b/src/quadrature/quadrature_monomial.C
@@ -16,17 +16,17 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
+// libMesh includes
 #include "libmesh/quadrature_monomial.h"
+#include "libmesh/enum_quadrature_type.h"
 
 namespace libMesh
 {
 
 
 // See the files:
-
 // quadrature_monomial_2D.C
 // quadrature_monomial_3D.C
-
 // for implementation of specific element types.
 
 // Constructor
@@ -39,6 +39,11 @@ QMonomial::QMonomial(const unsigned int d,
 // Destructor
 QMonomial::~QMonomial()
 {
+}
+
+QuadratureType QMonomial::type() const
+{
+  return QMONOMIAL;
 }
 
 void QMonomial::wissmann_rule(const Real rule_data[][3],

--- a/src/quadrature/quadrature_simpson.C
+++ b/src/quadrature/quadrature_simpson.C
@@ -16,11 +16,22 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
+// libMesh includes
+#include "libmesh/quadrature_simpson.h"
+#include "libmesh/enum_quadrature_type.h"
+
+namespace libMesh
+{
+
+QuadratureType QSimpson::type() const
+{
+  return QSIMPSON;
+}
 
 // See the files:
-
 // quadrature_simpson_1D.C
 // quadrature_simpson_2D.C
 // quadrature_simpson_3D.C
-
 // for implementation.
+
+}

--- a/src/quadrature/quadrature_trap.C
+++ b/src/quadrature/quadrature_trap.C
@@ -16,10 +16,22 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// See the files:
+// libMesh includes
+#include "libmesh/quadrature_trap.h"
+#include "libmesh/enum_quadrature_type.h"
 
+namespace libMesh
+{
+
+QuadratureType QTrap::type() const
+{
+  return QTRAP;
+}
+
+// See the files:
 // quadrature_trap_1D.C
 // quadrature_trap_2D.C
 // quadrature_trap_3D.C
-
 // for implementation.
+
+}

--- a/src/solvers/eigen_solver.C
+++ b/src/solvers/eigen_solver.C
@@ -24,6 +24,7 @@
 #include "libmesh/slepc_eigen_solver.h"
 #include "libmesh/solver_configuration.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_eigen_solver_type.h"
 
 namespace libMesh
 {
@@ -31,6 +32,28 @@ namespace libMesh
 
 //------------------------------------------------------------------
 // EigenSolver members
+template <typename T>
+EigenSolver<T>::EigenSolver (const Parallel::Communicator & comm_in) :
+  ParallelObject(comm_in),
+  _eigen_solver_type    (ARNOLDI),
+  _eigen_problem_type   (NHEP),
+  _position_of_spectrum (LARGEST_MAGNITUDE),
+  _is_initialized       (false),
+  _solver_configuration(libmesh_nullptr),
+  _close_matrix_before_solve(true)
+{
+}
+
+
+
+template <typename T>
+EigenSolver<T>::~EigenSolver ()
+{
+  this->clear ();
+}
+
+
+
 template <typename T>
 std::unique_ptr<EigenSolver<T>>
 EigenSolver<T>::build(const Parallel::Communicator & comm,

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -22,13 +22,13 @@
 #ifdef LIBMESH_HAVE_EIGEN
 
 
-// C++ includes
-
 // Local Includes
 #include "libmesh/eigen_sparse_linear_solver.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/solver_configuration.h"
+#include "libmesh/enum_preconditioner_type.h"
+#include "libmesh/enum_solver_type.h"
 
 // GMRES is an "unsupported" iterative solver in Eigen.
 #include <unsupported/Eigen/IterativeSolvers>

--- a/src/solvers/eigen_time_solver.C
+++ b/src/solvers/eigen_time_solver.C
@@ -24,6 +24,7 @@
 #include "libmesh/eigen_time_solver.h"
 #include "libmesh/eigen_solver.h"
 #include "libmesh/sparse_matrix.h"
+#include "libmesh/enum_eigen_solver_type.h"
 
 namespace libMesh
 {

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -29,12 +29,29 @@
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/solver_configuration.h"
+#include "libmesh/enum_solver_package.h"
+#include "libmesh/enum_preconditioner_type.h"
+#include "libmesh/enum_solver_type.h"
 
 namespace libMesh
 {
 
 //------------------------------------------------------------------
 // LinearSolver members
+template <typename T>
+LinearSolver<T>::LinearSolver (const libMesh::Parallel::Communicator & comm_in) :
+  ParallelObject       (comm_in),
+  _solver_type         (GMRES),
+  _preconditioner_type (ILU_PRECOND),
+  _is_initialized      (false),
+  _preconditioner      (libmesh_nullptr),
+  same_preconditioner  (false),
+  _solver_configuration(libmesh_nullptr)
+{
+}
+
+
+
 template <typename T>
 std::unique_ptr<LinearSolver<T>>
 LinearSolver<T>::build(const libMesh::Parallel::Communicator & comm,

--- a/src/solvers/nonlinear_solver.C
+++ b/src/solvers/nonlinear_solver.C
@@ -23,6 +23,7 @@
 #include "libmesh/petsc_nonlinear_solver.h"
 #include "libmesh/trilinos_nox_nonlinear_solver.h"
 #include "libmesh/solver_configuration.h"
+#include "libmesh/enum_solver_package.h"
 
 namespace libMesh
 {

--- a/src/solvers/optimization_solver.C
+++ b/src/solvers/optimization_solver.C
@@ -17,13 +17,12 @@
 
 
 
-// C++ includes
-
 // Local Includes
 #include "libmesh/optimization_solver.h"
 #include "libmesh/tao_optimization_solver.h"
 #include "libmesh/nlopt_optimization_solver.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/enum_solver_package.h"
 
 namespace libMesh
 {

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -35,6 +35,9 @@
 #include "libmesh/system.h"
 #include "libmesh/petsc_auto_fieldsplit.h"
 #include "libmesh/solver_configuration.h"
+#include "libmesh/enum_preconditioner_type.h"
+#include "libmesh/enum_solver_type.h"
+#include "libmesh/enum_convergence_flags.h"
 
 namespace libMesh
 {
@@ -127,6 +130,21 @@ extern "C"
 } // end extern "C"
 
 /*----------------------- functions ----------------------------------*/
+template <typename T>
+PetscLinearSolver<T>::PetscLinearSolver(const libMesh::Parallel::Communicator & comm_in) :
+  LinearSolver<T>(comm_in),
+  _restrict_solve_to_is(libmesh_nullptr),
+  _restrict_solve_to_is_complement(libmesh_nullptr),
+  _subset_solve_mode(SUBSET_ZERO)
+{
+  if (this->n_processors() == 1)
+    this->_preconditioner_type = ILU_PRECOND;
+  else
+    this->_preconditioner_type = BLOCK_JACOBI_PRECOND;
+}
+
+
+
 template <typename T>
 void PetscLinearSolver<T>::clear ()
 {

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -32,9 +32,30 @@
 #include "libmesh/shell_matrix.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/solver_configuration.h"
+#include "libmesh/enum_eigen_solver_type.h"
 
 namespace libMesh
 {
+
+
+
+template <typename T>
+SlepcEigenSolver<T>::SlepcEigenSolver (const Parallel::Communicator & comm_in) :
+  EigenSolver<T>(comm_in)
+{
+  this->_eigen_solver_type  = ARNOLDI;
+  this->_eigen_problem_type = NHEP;
+}
+
+
+
+template <typename T>
+SlepcEigenSolver<T>::~SlepcEigenSolver ()
+{
+  this->clear ();
+}
+
+
 
 template <typename T>
 void SlepcEigenSolver<T>::clear ()

--- a/src/solvers/trilinos_aztec_linear_solver.C
+++ b/src/solvers/trilinos_aztec_linear_solver.C
@@ -22,20 +22,33 @@
 #ifdef LIBMESH_TRILINOS_HAVE_AZTECOO
 
 
-// C++ includes
-
 // Local Includes
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/trilinos_aztec_linear_solver.h"
 #include "libmesh/trilinos_epetra_matrix.h"
 #include "libmesh/trilinos_epetra_vector.h"
+#include "libmesh/enum_preconditioner_type.h"
+#include "libmesh/enum_solver_type.h"
+#include "libmesh/enum_convergence_flags.h"
 
 namespace libMesh
 {
 
 
 /*----------------------- functions ----------------------------------*/
+template <typename T>
+AztecLinearSolver<T>::AztecLinearSolver (const libMesh::Parallel::Communicator & comm) :
+  LinearSolver<T>(comm)
+{
+  if (this->n_processors() == 1)
+    this->_preconditioner_type = ILU_PRECOND;
+  else
+    this->_preconditioner_type = BLOCK_JACOBI_PRECOND;
+}
+
+
+
 template <typename T>
 void AztecLinearSolver<T>::clear ()
 {

--- a/src/systems/eigen_system.C
+++ b/src/systems/eigen_system.C
@@ -22,8 +22,6 @@
 // if SLEPc support is enabled.
 #if defined(LIBMESH_HAVE_SLEPC)
 
-// C++ includes
-
 // Local includes
 #include "libmesh/eigen_system.h"
 #include "libmesh/equation_systems.h"
@@ -31,6 +29,7 @@
 #include "libmesh/eigen_solver.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/enum_eigen_solver_type.h"
 
 namespace libMesh
 {

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -49,6 +49,7 @@
 #include "libmesh/tensor_value.h"
 #include "libmesh/vector_value.h"
 #include "libmesh/tensor_tools.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace libMesh
 {

--- a/src/systems/system_norm.C
+++ b/src/systems/system_norm.C
@@ -18,6 +18,7 @@
 
 // libMesh includes
 #include "libmesh/system_norm.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace libMesh
 {

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -23,7 +23,6 @@
 #include "libmesh/elem.h"
 #include "libmesh/error_vector.h"
 #include "libmesh/libmesh_logging.h"
-
 #include "libmesh/dof_map.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/explicit_system.h"
@@ -33,6 +32,7 @@
 #include "libmesh/tecplot_io.h"
 #include "libmesh/exodusII_io.h"
 #include "libmesh/xdr_io.h"
+#include "libmesh/enum_xdr_mode.h"
 
 namespace libMesh
 {

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -17,14 +17,11 @@
 
 
 
-// C++ includes
-
-
 // Local Includes
 #include "libmesh/point_locator_base.h"
 #include "libmesh/point_locator_tree.h"
-
 #include "libmesh/elem.h"
+#include "libmesh/enum_point_locator_type.h"
 
 namespace libMesh
 {

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -1025,6 +1025,7 @@ datarootdir = @datarootdir@
 docdir = @docdir@
 dvidir = @dvidir@
 enabledeprecated = @enabledeprecated@
+enablefwdenums = @enablefwdenums@
 enablelegacyincludepaths = @enablelegacyincludepaths@
 enablepetsc = @enablepetsc@
 enableuniqueptr = @enableuniqueptr@

--- a/tests/quadrature/quadrature_test.C
+++ b/tests/quadrature/quadrature_test.C
@@ -7,6 +7,7 @@
 #include <libmesh/quadrature.h>
 #include <libmesh/string_to_enum.h>
 #include <libmesh/utility.h>
+#include <libmesh/enum_quadrature_type.h>
 
 #include <iomanip>
 


### PR DESCRIPTION
The forward enumerations are currently enabled by default, but for backwards compatibility, I have also added the `--disable-forward-declare-enums` configure option, which restores the previous enum inclusions and will give downstream apps time to fix up their includes on their own schedule. MOOSE, MOOSE-based apps, and GRINS have already been updated, and even in these relatively large codebases I didn't have to add many new includes. 
