### PR TITLE
Add enum header to rb_scm_construction

### DIFF
--- a/src/reduced_basis/rb_scm_construction.C
+++ b/src/reduced_basis/rb_scm_construction.C
@@ -35,6 +35,8 @@
 #include "libmesh/getpot.h"
 #include "libmesh/parallel.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/enum_eigen_solver_type.h"
+
 // For creating a directory
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
This fixes a regression (presumably due to #1721 not being tested with
SLEPc?) in my configuration.