### PR TITLE
 Be more explicit about some defaulted/deleted functions

### DIFF
--- a/configure
+++ b/configure
@@ -901,8 +901,6 @@ HAVE_DOUBLE_UNDERSCORE_ATTRIBUTE_FALLTHROUGH_FALSE
 HAVE_DOUBLE_UNDERSCORE_ATTRIBUTE_FALLTHROUGH_TRUE
 HAVE_CXX17_FALLTHROUGH_ATTRIBUTE_FALSE
 HAVE_CXX17_FALLTHROUGH_ATTRIBUTE_TRUE
-HAVE_CXX11_NOEXCEPT_FALSE
-HAVE_CXX11_NOEXCEPT_TRUE
 HAVE_CXX11_TO_STRING_FALSE
 HAVE_CXX11_TO_STRING_TRUE
 HAVE_CXX11_NULLPTR_WORKAROUND_FALSE
@@ -911,8 +909,6 @@ HAVE_CXX11_NULLPTR_FALSE
 HAVE_CXX11_NULLPTR_TRUE
 HAVE_CXX11_FINAL_FALSE
 HAVE_CXX11_FINAL_TRUE
-HAVE_CXX11_DELETED_FUNCTIONS_FALSE
-HAVE_CXX11_DELETED_FUNCTIONS_TRUE
 HAVE_CXX11_ERF_FALSE
 HAVE_CXX11_ERF_TRUE
 HAVE_CXX11_INVERSE_HYPERBOLIC_TANGENT_COMPLEX_FALSE
@@ -949,10 +945,12 @@ HAVE_CXX11_RVALUE_REFERENCES_FALSE
 HAVE_CXX11_RVALUE_REFERENCES_TRUE
 HAVE_CXX11_DECLTYPE_FALSE
 HAVE_CXX11_DECLTYPE_TRUE
+HAVE_CXX11_DEFAULTED_FUNCTIONS_FALSE
+HAVE_CXX11_DEFAULTED_FUNCTIONS_TRUE
+HAVE_CXX11_DELETED_FUNCTIONS_FALSE
+HAVE_CXX11_DELETED_FUNCTIONS_TRUE
 HAVE_CXX11_MOVE_CONSTRUCTORS_FALSE
 HAVE_CXX11_MOVE_CONSTRUCTORS_TRUE
-HAVE_CXX11_MOVE_FALSE
-HAVE_CXX11_MOVE_TRUE
 HAVE_CXX11_OVERRIDE_FALSE
 HAVE_CXX11_OVERRIDE_TRUE
 HAVE_CXX11_FIXED_TYPE_ENUM_FWD_FALSE
@@ -8506,88 +8504,6 @@ if test "x$have_cxx11_override" != "xyes"; then :
   as_fn_error $? "libMesh requires C++11 compiler support the override keyword" "$LINENO" 5
 fi
 
-# --------------------------------------------------------------
-# Test for optional modern C++ features, which libMesh offers shims
-# for and/or which libMesh applications may want to selectively use.
-# --------------------------------------------------------------
-
-    have_cxx11_move=no
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 std::move support" >&5
-$as_echo_n "checking for C++11 std::move support... " >&6; }
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-    # For this and all of the C++ standards tests: Save the original
-    # CXXFLAGS (if any) before appending the $switch determined by
-    # AX_CXX_COMPILE_STDCXX_11, and any compiler flags specified by
-    # the user in the libmesh_CXXFLAGS environment variable, letting
-    # that override everything else.
-    old_CXXFLAGS="$CXXFLAGS"
-    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-    #include <utility>
-    template <class T>
-    void move_swap(T& a, T& b)
-    {
-      T tmp(std::move(a));
-      a = std::move(b);
-      b = std::move(tmp);
-    }
-
-int
-main ()
-{
-
-        int one = 1, two = 2;
-        move_swap(one,two);
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-$as_echo "#define HAVE_CXX11_MOVE 1" >>confdefs.h
-
-        have_cxx11_move=yes
-
-else
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-    # Reset the flags
-    CXXFLAGS="$old_CXXFLAGS"
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-     if test x$have_cxx11_move == xyes; then
-  HAVE_CXX11_MOVE_TRUE=
-  HAVE_CXX11_MOVE_FALSE='#'
-else
-  HAVE_CXX11_MOVE_TRUE='#'
-  HAVE_CXX11_MOVE_FALSE=
-fi
-
-
 
     have_cxx11_move_constructors=no
 
@@ -8666,6 +8582,158 @@ else
 fi
 
 
+if test "x$have_cxx11_move_constructors" != "xyes"; then :
+  as_fn_error $? "libMesh requires C++11 move constructor support" "$LINENO" 5
+fi
+
+
+    have_cxx11_deleted_functions=no
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 deleted functions support" >&5
+$as_echo_n "checking for C++11 deleted functions support... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    class Foo
+    {
+      Foo(const Foo &) = delete;
+    };
+
+int
+main ()
+{
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_CXX11_DELETED_FUNCTIONS 1" >>confdefs.h
+
+        have_cxx11_deleted_functions=yes
+
+else
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+    # Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+     if test x$have_cxx11_deleted_functions == xyes; then
+  HAVE_CXX11_DELETED_FUNCTIONS_TRUE=
+  HAVE_CXX11_DELETED_FUNCTIONS_FALSE='#'
+else
+  HAVE_CXX11_DELETED_FUNCTIONS_TRUE='#'
+  HAVE_CXX11_DELETED_FUNCTIONS_FALSE=
+fi
+
+
+if test "x$have_cxx11_deleted_functions" != "xyes"; then :
+  as_fn_error $? "libMesh requires C++11 deleted function support" "$LINENO" 5
+fi
+
+
+    have_cxx11_defaulted_functions=no
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 defaulted functions support" >&5
+$as_echo_n "checking for C++11 defaulted functions support... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    class Foo
+    {
+      Foo(const Foo &) = default;
+      ~Foo();
+    };
+    Foo::~Foo() = default;
+
+int
+main ()
+{
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_CXX11_DEFAULTED_FUNCTIONS 1" >>confdefs.h
+
+        have_cxx11_defaulted_functions=yes
+
+else
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+    # Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+     if test x$have_cxx11_defaulted_functions == xyes; then
+  HAVE_CXX11_DEFAULTED_FUNCTIONS_TRUE=
+  HAVE_CXX11_DEFAULTED_FUNCTIONS_FALSE='#'
+else
+  HAVE_CXX11_DEFAULTED_FUNCTIONS_TRUE='#'
+  HAVE_CXX11_DEFAULTED_FUNCTIONS_FALSE=
+fi
+
+
+if test "x$have_cxx11_defaulted_functions" != "xyes"; then :
+  as_fn_error $? "libMesh requires C++11 defaulted function support" "$LINENO" 5
+fi
+
+# --------------------------------------------------------------
+# Test for optional modern C++ features, which libMesh offers shims
+# for and/or which libMesh applications may want to selectively use.
+# --------------------------------------------------------------
 
     have_cxx11_decltype=no
 
@@ -9963,73 +10031,6 @@ fi
 
 
 
-    have_cxx11_deleted_functions=no
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 deleted functions support" >&5
-$as_echo_n "checking for C++11 deleted functions support... " >&6; }
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-    old_CXXFLAGS="$CXXFLAGS"
-    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-    class Foo
-    {
-      Foo(const Foo &) = delete;
-    };
-
-int
-main ()
-{
-
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-$as_echo "#define HAVE_CXX11_DELETED_FUNCTIONS 1" >>confdefs.h
-
-        have_cxx11_deleted_functions=yes
-
-else
-
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-    # Reset the flags
-    CXXFLAGS="$old_CXXFLAGS"
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-     if test x$have_cxx11_deleted_functions == xyes; then
-  HAVE_CXX11_DELETED_FUNCTIONS_TRUE=
-  HAVE_CXX11_DELETED_FUNCTIONS_FALSE='#'
-else
-  HAVE_CXX11_DELETED_FUNCTIONS_TRUE='#'
-  HAVE_CXX11_DELETED_FUNCTIONS_FALSE=
-fi
-
-
-
     have_cxx11_final=no
     have_cxx11_final_but_disabled=no
 
@@ -10485,81 +10486,6 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 else
   HAVE_CXX11_TO_STRING_TRUE='#'
   HAVE_CXX11_TO_STRING_FALSE=
-fi
-
-
-
-    have_cxx11_noexcept=no
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 noexcept support" >&5
-$as_echo_n "checking for C++11 noexcept support... " >&6; }
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-    old_CXXFLAGS="$CXXFLAGS"
-    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-      #include <stdexcept>
-
-      class MyException : public std::exception
-      {
-      public:
-        virtual const char * what() const noexcept
-        {
-          return "MyException description";
-        }
-      };
-
-int
-main ()
-{
-
-      throw MyException();
-      return 0;
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-$as_echo "#define HAVE_CXX11_NOEXCEPT 1" >>confdefs.h
-
-        have_cxx11_noexcept=yes
-
-else
-
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-    # Reset the flags
-    CXXFLAGS="$old_CXXFLAGS"
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-     if test x$have_cxx11_noexcept == xyes; then
-  HAVE_CXX11_NOEXCEPT_TRUE=
-  HAVE_CXX11_NOEXCEPT_FALSE='#'
-else
-  HAVE_CXX11_NOEXCEPT_TRUE='#'
-  HAVE_CXX11_NOEXCEPT_FALSE=
 fi
 
 
@@ -41558,12 +41484,16 @@ if test -z "${HAVE_CXX11_OVERRIDE_TRUE}" && test -z "${HAVE_CXX11_OVERRIDE_FALSE
   as_fn_error $? "conditional \"HAVE_CXX11_OVERRIDE\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
-if test -z "${HAVE_CXX11_MOVE_TRUE}" && test -z "${HAVE_CXX11_MOVE_FALSE}"; then
-  as_fn_error $? "conditional \"HAVE_CXX11_MOVE\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
 if test -z "${HAVE_CXX11_MOVE_CONSTRUCTORS_TRUE}" && test -z "${HAVE_CXX11_MOVE_CONSTRUCTORS_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_MOVE_CONSTRUCTORS\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${HAVE_CXX11_DELETED_FUNCTIONS_TRUE}" && test -z "${HAVE_CXX11_DELETED_FUNCTIONS_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_CXX11_DELETED_FUNCTIONS\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${HAVE_CXX11_DEFAULTED_FUNCTIONS_TRUE}" && test -z "${HAVE_CXX11_DEFAULTED_FUNCTIONS_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_CXX11_DEFAULTED_FUNCTIONS\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX11_DECLTYPE_TRUE}" && test -z "${HAVE_CXX11_DECLTYPE_FALSE}"; then
@@ -41638,10 +41568,6 @@ if test -z "${HAVE_CXX11_ERF_TRUE}" && test -z "${HAVE_CXX11_ERF_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_ERF\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
-if test -z "${HAVE_CXX11_DELETED_FUNCTIONS_TRUE}" && test -z "${HAVE_CXX11_DELETED_FUNCTIONS_FALSE}"; then
-  as_fn_error $? "conditional \"HAVE_CXX11_DELETED_FUNCTIONS\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
 if test -z "${HAVE_CXX11_FINAL_TRUE}" && test -z "${HAVE_CXX11_FINAL_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_FINAL\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
@@ -41656,10 +41582,6 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX11_TO_STRING_TRUE}" && test -z "${HAVE_CXX11_TO_STRING_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_TO_STRING\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${HAVE_CXX11_NOEXCEPT_TRUE}" && test -z "${HAVE_CXX11_NOEXCEPT_FALSE}"; then
-  as_fn_error $? "conditional \"HAVE_CXX11_NOEXCEPT\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX17_FALLTHROUGH_ATTRIBUTE_TRUE}" && test -z "${HAVE_CXX17_FALLTHROUGH_ATTRIBUTE_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -240,12 +240,22 @@ LIBMESH_TEST_CXX11_OVERRIDE
 AS_IF([test "x$have_cxx11_override" != "xyes"],
       [AC_MSG_ERROR([libMesh requires C++11 compiler support the override keyword])])
 
+LIBMESH_TEST_CXX11_MOVE_CONSTRUCTORS
+AS_IF([test "x$have_cxx11_move_constructors" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires C++11 move constructor support])])
+
+LIBMESH_TEST_CXX11_DELETED_FUNCTIONS
+AS_IF([test "x$have_cxx11_deleted_functions" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires C++11 deleted function support])])
+
+LIBMESH_TEST_CXX11_DEFAULTED_FUNCTIONS
+AS_IF([test "x$have_cxx11_defaulted_functions" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires C++11 defaulted function support])])
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.
 # --------------------------------------------------------------
-LIBMESH_TEST_CXX11_MOVE
-LIBMESH_TEST_CXX11_MOVE_CONSTRUCTORS
 LIBMESH_TEST_CXX11_DECLTYPE
 LIBMESH_TEST_CXX11_RVALUE_REFERENCES
 LIBMESH_TEST_CXX11_CONSTEXPR
@@ -258,11 +268,9 @@ LIBMESH_TEST_CXX11_THREAD
 LIBMESH_TEST_CXX11_CONDITION_VARIABLE
 LIBMESH_TEST_CXX11_TYPE_TRAITS
 LIBMESH_TEST_CXX11_MATH_FUNCS
-LIBMESH_TEST_CXX11_DELETED_FUNCTIONS
 LIBMESH_TEST_CXX11_FINAL
 LIBMESH_TEST_CXX11_NULLPTR
 LIBMESH_TEST_CXX11_TO_STRING
-LIBMESH_TEST_CXX11_NOEXCEPT
 LIBMESH_TEST_CXX17_FALLTHROUGH_ATTRIBUTE
 
 #-----------------------------------------------------

--- a/contrib/fparser/Makefile.am
+++ b/contrib/fparser/Makefile.am
@@ -24,10 +24,8 @@ if FPARSER_SUPPORT_DEBUGGING
   FEATURE_FLAGS += -DFUNCTIONPARSER_SUPPORT_DEBUGGING
 endif
 
-# Wrap code that uses std::move in fparser for compilers that don't support it
-if HAVE_CXX11_MOVE
-  FEATURE_FLAGS += -DFP_SUPPORT_CXX11_MOVE
-endif
+# We now explicitly require compiler support for std::move
+FEATURE_FLAGS += -DFP_SUPPORT_CXX11_MOVE
 
 EXTRA_DIST      = # none, append below
 BUILT_SOURCES   = # none, append below

--- a/contrib/fparser/Makefile.in
+++ b/contrib/fparser/Makefile.in
@@ -93,22 +93,19 @@ host_triplet = @host@
 target_triplet = @target@
 #FEATURE_FLAGS += -DFP_USE_STRTOLD
 @FPARSER_SUPPORT_DEBUGGING_TRUE@am__append_1 = -DFUNCTIONPARSER_SUPPORT_DEBUGGING
-
-# Wrap code that uses std::move in fparser for compilers that don't support it
-@HAVE_CXX11_MOVE_TRUE@am__append_2 = -DFP_SUPPORT_CXX11_MOVE
 noinst_PROGRAMS = $(am__EXEEXT_1)
-@FPARSER_SUPPORT_JIT_TRUE@am__append_3 = -DFPARSER_JIT_COMPILER="\"$(CXX) $(CXXFLAGS)\""
-@FPARSER_DEVEL_TRUE@am__append_4 = fpoptimizer/grammar_data.cc
-@FPARSER_DEVEL_TRUE@am__append_5 = util/tree_grammar_parser \
+@FPARSER_SUPPORT_JIT_TRUE@am__append_2 = -DFPARSER_JIT_COMPILER="\"$(CXX) $(CXXFLAGS)\""
+@FPARSER_DEVEL_TRUE@am__append_3 = fpoptimizer/grammar_data.cc
+@FPARSER_DEVEL_TRUE@am__append_4 = util/tree_grammar_parser \
 @FPARSER_DEVEL_TRUE@	util/bytecoderules_parser
-@FPARSER_DEVEL_TRUE@am__append_6 = $(FPOPTIMIZER_CC_FILES)
-@FPARSER_DEVEL_TRUE@am__append_7 = $(BUILT_SOURCES)
-@FPARSER_DEVEL_FALSE@am__append_8 = fpoptimizer.cc
-@LIBMESH_DBG_MODE_TRUE@am__append_9 = libdbg.la
-@LIBMESH_DEVEL_MODE_TRUE@am__append_10 = libdevel.la
-@LIBMESH_OPT_MODE_TRUE@am__append_11 = libopt.la
-@LIBMESH_PROF_MODE_TRUE@am__append_12 = libprof.la
-@LIBMESH_OPROF_MODE_TRUE@am__append_13 = liboprof.la
+@FPARSER_DEVEL_TRUE@am__append_5 = $(FPOPTIMIZER_CC_FILES)
+@FPARSER_DEVEL_TRUE@am__append_6 = $(BUILT_SOURCES)
+@FPARSER_DEVEL_FALSE@am__append_7 = fpoptimizer.cc
+@LIBMESH_DBG_MODE_TRUE@am__append_8 = libdbg.la
+@LIBMESH_DEVEL_MODE_TRUE@am__append_9 = libdevel.la
+@LIBMESH_OPT_MODE_TRUE@am__append_10 = libopt.la
+@LIBMESH_PROF_MODE_TRUE@am__append_11 = libprof.la
+@LIBMESH_OPROF_MODE_TRUE@am__append_12 = liboprof.la
 subdir = contrib/fparser
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ac_cxx_rtti.m4 \
@@ -928,7 +925,7 @@ top_srcdir = @top_srcdir@
 vtkbuild = @vtkbuild@
 vtkmajor = @vtkmajor@
 vtkversion = @vtkversion@
-pkg_cppflags = -I$(srcdir)/fpoptimizer $(am__append_3) \
+pkg_cppflags = -I$(srcdir)/fpoptimizer $(am__append_2) \
 	$(FEATURE_FLAGS)
 #FEATURE_FLAGS += -DFP_SUPPORT_TR1_MATH_FUNCS
 
@@ -939,23 +936,25 @@ pkg_cppflags = -I$(srcdir)/fpoptimizer $(am__append_3) \
 #FEATURE_FLAGS += -DFP_DISABLE_SHORTCUT_LOGICAL_EVALUATION
 #FEATURE_FLAGS += -DFP_SUPPORT_MPFR_FLOAT_TYPE
 #FEATURE_FLAGS += -DFP_SUPPORT_GMP_INT_TYPE
+
+# We now explicitly require compiler support for std::move
 FEATURE_FLAGS = -DFP_ENABLE_EVAL -DFP_SUPPORT_FLOAT_TYPE \
 	-DFP_SUPPORT_LONG_DOUBLE_TYPE -DFP_SUPPORT_LONG_INT_TYPE \
 	-DFP_SUPPORT_COMPLEX_DOUBLE_TYPE \
 	-DFP_SUPPORT_COMPLEX_FLOAT_TYPE \
 	-DFP_SUPPORT_COMPLEX_LONG_DOUBLE_TYPE $(am__append_1) \
-	$(am__append_2)
+	-DFP_SUPPORT_CXX11_MOVE
 EXTRA_DIST = util/bytecoderules.dat util/bytecoderules_header.txt \
 	fpoptimizer/treerules.dat $(FPOPTIMIZER_CC_FILES) \
 	fpoptimizer/fpoptimizer_header.txt \
 	fpoptimizer/fpoptimizer_footer.txt
-BUILT_SOURCES = extrasrc/fp_opcode_add.inc $(am__append_4)
+BUILT_SOURCES = extrasrc/fp_opcode_add.inc $(am__append_3)
 
 #  util_cpp_compress_CXXFLAGS = # nothing fancy - don't use our compile flags for this utility code lest it be horribly slow
 #  util_cpp_compress_SOURCES  = util/cpp_compress.hh util/cpp_compress.cc util/cpp_compress_main.cc
 
 # when doing 'make clean' we need to remove the generated sources
-CLEANFILES = fpoptimizer/grammar_data.cc $(am__append_7)
+CLEANFILES = fpoptimizer/grammar_data.cc $(am__append_6)
 # in case they weren't conditionally cleaned:
 # DISTCLEANFILES += util/cpp_compress
 DISTCLEANFILES = util/bytecoderules_parser util/tree_grammar_parser
@@ -1000,7 +999,7 @@ FPOPTIMIZER_CC_FILES = \
 	    fpoptimizer/optimize_main.cc
 
 pkg_sources = fparser.cc fparser_ad.cc Faddeeva.cc Faddeeva.hh \
-	lib/sha1.cpp $(am__append_6) $(am__append_8)
+	lib/sha1.cpp $(am__append_5) $(am__append_7)
 
 # util/tree_grammar_parser is a utility which is required to build
 # fpoptimizer/grammar_data.cc.  But this file itself is only needed
@@ -1064,8 +1063,8 @@ AM_LDFLAGS = $(libmesh_LDFLAGS)
 #
 # Building the flavors
 #
-noinst_LTLIBRARIES = $(am__append_9) $(am__append_10) $(am__append_11) \
-	$(am__append_12) $(am__append_13)
+noinst_LTLIBRARIES = $(am__append_8) $(am__append_9) $(am__append_10) \
+	$(am__append_11) $(am__append_12)
 @LIBMESH_DBG_MODE_TRUE@libdbg_la_SOURCES = $(pkg_sources)
 @LIBMESH_DBG_MODE_TRUE@libdbg_la_CPPFLAGS = $(CPPFLAGS_DBG) $(AM_CPPFLAGS)
 @LIBMESH_DBG_MODE_TRUE@libdbg_la_CXXFLAGS = $(CXXFLAGS_DBG)

--- a/include/base/libmesh_exceptions.h
+++ b/include/base/libmesh_exceptions.h
@@ -27,11 +27,7 @@
 #include <string>
 #include <sstream>
 
-#ifdef LIBMESH_HAVE_CXX11_NOEXCEPT
 #define libmesh_noexcept noexcept
-#else
-#define libmesh_noexcept throw()
-#endif
 
 namespace libMesh {
 
@@ -123,12 +119,12 @@ public:
   /**
    * Virtual destructor, gotta have one of those.
    */
-  virtual ~SolverException() libmesh_noexcept {};
+  virtual ~SolverException() noexcept {};
 
   /**
    * Override the what() function to provide a generic error message.
    */
-  virtual const char * what() const libmesh_noexcept
+  virtual const char * what() const noexcept
   {
     // std::string::c_str() is noexcept in C++11, so it's safe to call
     // in what() because it can't throw.

--- a/include/base/reference_counted_object.h
+++ b/include/base/reference_counted_object.h
@@ -93,7 +93,6 @@ protected:
 #endif
   }
 
-#ifdef LIBMESH_HAVE_CXX11_MOVE_CONSTRUCTORS
   /**
    * Move constructor, must be declared noexcept.
    */
@@ -106,7 +105,6 @@ protected:
 
 #endif
   }
-#endif
 
   /**
    * Copy assignment operator does nothing - we're copying an

--- a/include/base/reference_counter.h
+++ b/include/base/reference_counter.h
@@ -54,12 +54,10 @@ protected:
   ReferenceCounter (const ReferenceCounter &);
 
 
-#ifdef LIBMESH_HAVE_CXX11_MOVE_CONSTRUCTORS
   /**
    * Move constructor, must be declared noexcept.
    */
   ReferenceCounter(ReferenceCounter && other) noexcept;
-#endif
 
 public:
 
@@ -161,12 +159,10 @@ inline ReferenceCounter::ReferenceCounter(const ReferenceCounter & /*other*/)
 
 
 
-#ifdef LIBMESH_HAVE_CXX11_MOVE_CONSTRUCTORS
 inline ReferenceCounter::ReferenceCounter(ReferenceCounter && /*other*/) noexcept
 {
   ++_n_objects;
 }
-#endif
 
 
 

--- a/include/error_estimation/exact_solution.h
+++ b/include/error_estimation/exact_solution.h
@@ -82,10 +82,21 @@ public:
   ExactSolution (const EquationSystems & es);
 
   /**
-   * Destructor.
+   * The copy constructor and copy/move assignment operators are
+   * deleted.  This class has containers of unique_ptrs so it can't be
+   * default (shallow) copied, and it has a const reference so it
+   * can't be assigned to after creation.
    */
-  ~ExactSolution();
+  ExactSolution(const ExactSolution &) = delete;
+  ExactSolution & operator= (const ExactSolution &) = delete;
+  ExactSolution & operator= (ExactSolution &&) = delete;
 
+  /**
+   * Move constructor and destructor are defaulted out-of-line (in the
+   * C file) to play nicely with our forward declarations.
+   */
+  ExactSolution(ExactSolution &&);
+  ~ExactSolution();
 
   /**
    * Attach function similar to system.h which

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -234,6 +234,9 @@
 /* Flag indicating whether compiler supports decltype */
 #undef HAVE_CXX11_DECLTYPE
 
+/* Flag indicating whether compiler supports defaulted functions */
+#undef HAVE_CXX11_DEFAULTED_FUNCTIONS
+
 /* Flag indicating whether compiler supports f() = delete; */
 #undef HAVE_CXX11_DELETED_FUNCTIONS
 
@@ -280,14 +283,8 @@
    */
 #undef HAVE_CXX11_MAKE_UNIQUE_WORKAROUND
 
-/* Flag indicating whether compiler supports std::move */
-#undef HAVE_CXX11_MOVE
-
 /* Flag indicating whether compiler supports move construction */
 #undef HAVE_CXX11_MOVE_CONSTRUCTORS
-
-/* Flag indicating whether compiler supports noexcept */
-#undef HAVE_CXX11_NOEXCEPT
 
 /* Flag indicating whether compiler supports nullptr */
 #undef HAVE_CXX11_NULLPTR

--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -73,6 +73,17 @@ public:
   DistributedMesh (const DistributedMesh & other_mesh);
 
   /**
+   * Move-constructor.
+   */
+  DistributedMesh(DistributedMesh &&) = default;
+
+  /**
+   * Copy and move assignment are not allowed.
+   */
+  DistributedMesh & operator= (const DistributedMesh &) = delete;
+  DistributedMesh & operator= (DistributedMesh &&) = delete;
+
+  /**
    * Virtual copy-constructor, creates a copy of this mesh
    */
   virtual std::unique_ptr<MeshBase> clone () const override

--- a/include/mesh/mesh.h
+++ b/include/mesh/mesh.h
@@ -69,9 +69,17 @@ public:
   Mesh (const UnstructuredMesh & other_mesh) : DefaultMesh(other_mesh) {}
 
   /**
-   * Destructor.
+   * Default copy/move constructors and destructor.
    */
-  ~Mesh() {}
+  Mesh(const Mesh &) = default;
+  Mesh(Mesh &&) = default;
+  ~Mesh() = default;
+
+  /**
+   * Copy and move assignment are not allowed.
+   */
+  Mesh & operator= (const Mesh &) = delete;
+  Mesh & operator= (Mesh &&) = delete;
 };
 
 

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -92,6 +92,25 @@ public:
   MeshBase (const MeshBase & other_mesh);
 
   /**
+   * Move-constructor - this function is defaulted out-of-line (in the
+   * C file) to play nicely with our forward declarations.
+   */
+  MeshBase(MeshBase &&);
+
+  /**
+   * Copy and move assignment are not allowed because MeshBase
+   * subclasses manually manage memory (Elems and Nodes) and therefore
+   * the default versions of these operators would leak memory.  Since
+   * we don't want to maintain non-default copy and move assignment
+   * operators at this time, the safest and most self-documenting
+   * approach is to delete them.
+   *
+   * If you need to copy a Mesh, use the clone() method.
+   */
+  MeshBase & operator= (const MeshBase &) = delete;
+  MeshBase & operator= (MeshBase &&) = delete;
+
+  /**
    * Virtual "copy constructor"
    */
   virtual std::unique_ptr<MeshBase> clone() const = 0;
@@ -1467,15 +1486,6 @@ protected:
    * it can create and interact with \p BoundaryMesh.
    */
   friend class BoundaryInfo;
-
-private:
-  /**
-   *  The default shallow assignment operator is a very bad idea, so
-   *  we'll make it a compile-time error to try and do it from other
-   *  classes and a link-time error to try and do it from this class.
-   *  Use clone() if necessary.
-   */
-  MeshBase & operator= (const MeshBase & other);
 };
 
 

--- a/include/mesh/replicated_mesh.h
+++ b/include/mesh/replicated_mesh.h
@@ -69,6 +69,17 @@ public:
   ReplicatedMesh (const ReplicatedMesh & other_mesh);
 
   /**
+   * Move-constructor.
+   */
+  ReplicatedMesh(ReplicatedMesh &&) = default;
+
+  /**
+   * Copy and move assignment are not allowed.
+   */
+  ReplicatedMesh & operator= (const ReplicatedMesh &) = delete;
+  ReplicatedMesh & operator= (ReplicatedMesh &&) = delete;
+
+  /**
    * Virtual copy-constructor, creates a copy of this mesh
    */
   virtual std::unique_ptr<MeshBase> clone () const override

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -59,6 +59,22 @@ public:
                     unsigned char dim=1);
 
   /**
+   * UnstructuredMesh uses a defaulted copy constructor.
+   */
+  UnstructuredMesh(const UnstructuredMesh &) = default;
+
+  /**
+   * Move-constructor.
+   */
+  UnstructuredMesh(UnstructuredMesh &&) = default;
+
+  /**
+   * Copy and move assignment are not allowed.
+   */
+  UnstructuredMesh & operator= (const UnstructuredMesh &) = delete;
+  UnstructuredMesh & operator= (UnstructuredMesh &&) = delete;
+
+  /**
    * Destructor.
    */
   virtual ~UnstructuredMesh();

--- a/include/reduced_basis/rb_theta.h
+++ b/include/reduced_basis/rb_theta.h
@@ -53,14 +53,12 @@ public:
    */
   RBTheta () {}
 
-#ifdef LIBMESH_HAVE_CXX11_MOVE_CONSTRUCTORS
   /**
    * Move constructor, must be declared noexcept.
    */
   RBTheta (RBTheta && other) noexcept
     : ReferenceCountedObject<RBTheta>(std::move(other))
   {}
-#endif
 
   /**
    * Destructor.

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -3,48 +3,6 @@ dnl Tests for various C++11 features.  These will probably only work
 dnl if they are run after the autoconf test that sets -std=c++11.
 dnl ----------------------------------------------------------------
 
-AC_DEFUN([LIBMESH_TEST_CXX11_MOVE],
-  [
-    have_cxx11_move=no
-
-    AC_MSG_CHECKING(for C++11 std::move support)
-    AC_LANG_PUSH([C++])
-
-    # For this and all of the C++ standards tests: Save the original
-    # CXXFLAGS (if any) before appending the $switch determined by
-    # AX_CXX_COMPILE_STDCXX_11, and any compiler flags specified by
-    # the user in the libmesh_CXXFLAGS environment variable, letting
-    # that override everything else.
-    old_CXXFLAGS="$CXXFLAGS"
-    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
-
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    @%:@include <utility>
-    template <class T>
-    void move_swap(T& a, T& b)
-    {
-      T tmp(std::move(a));
-      a = std::move(b);
-      b = std::move(tmp);
-    }
-    ]], [[
-        int one = 1, two = 2;
-        move_swap(one,two);
-    ]])],[
-        AC_MSG_RESULT(yes)
-        AC_DEFINE(HAVE_CXX11_MOVE, 1, [Flag indicating whether compiler supports std::move])
-        have_cxx11_move=yes
-    ],[
-        AC_MSG_RESULT(no)
-    ])
-
-    # Reset the flags
-    CXXFLAGS="$old_CXXFLAGS"
-    AC_LANG_POP([C++])
-
-    AM_CONDITIONAL(HAVE_CXX11_MOVE, test x$have_cxx11_move == xyes)
-  ])
-
 dnl Test C++11 std::tuple and several related helper functions.
 AC_DEFUN([LIBMESH_TEST_CXX11_TUPLE],
   [
@@ -1206,6 +1164,40 @@ AC_DEFUN([LIBMESH_TEST_CXX11_DELETED_FUNCTIONS],
   ])
 
 
+AC_DEFUN([LIBMESH_TEST_CXX11_DEFAULTED_FUNCTIONS],
+  [
+    have_cxx11_defaulted_functions=no
+
+    AC_MSG_CHECKING(for C++11 defaulted functions support)
+    AC_LANG_PUSH([C++])
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    class Foo
+    {
+      Foo(const Foo &) = default;
+      ~Foo();
+    };
+    Foo::~Foo() = default;
+    ]], [[
+    ]])],[
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_CXX11_DEFAULTED_FUNCTIONS, 1, [Flag indicating whether compiler supports defaulted functions])
+        have_cxx11_defaulted_functions=yes
+    ],[
+      AC_MSG_RESULT(no)
+    ])
+
+    # Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    AC_LANG_POP([C++])
+
+    AM_CONDITIONAL(HAVE_CXX11_DEFAULTED_FUNCTIONS, test x$have_cxx11_defaulted_functions == xyes)
+  ])
+
+
 AC_DEFUN([LIBMESH_TEST_CXX11_FINAL],
   [
     have_cxx11_final=no
@@ -1453,45 +1445,4 @@ AC_DEFUN([LIBMESH_TEST_CXX11_TO_STRING],
     AC_LANG_POP([C++])
 
     AM_CONDITIONAL(HAVE_CXX11_TO_STRING, test x$have_cxx11_to_string == xyes)
-  ])
-
-
-
-AC_DEFUN([LIBMESH_TEST_CXX11_NOEXCEPT],
-  [
-    have_cxx11_noexcept=no
-
-    AC_MSG_CHECKING(for C++11 noexcept support)
-    AC_LANG_PUSH([C++])
-
-    old_CXXFLAGS="$CXXFLAGS"
-    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
-
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-      @%:@include <stdexcept>
-
-      class MyException : public std::exception
-      {
-      public:
-        virtual const char * what() const noexcept
-        {
-          return "MyException description";
-        }
-      };
-    ]], [[
-      throw MyException();
-      return 0;
-    ]])],[
-        AC_MSG_RESULT(yes)
-        AC_DEFINE(HAVE_CXX11_NOEXCEPT, 1, [Flag indicating whether compiler supports noexcept])
-        have_cxx11_noexcept=yes
-    ],[
-      AC_MSG_RESULT(no)
-    ])
-
-    # Reset the flags
-    CXXFLAGS="$old_CXXFLAGS"
-    AC_LANG_POP([C++])
-
-    AM_CONDITIONAL(HAVE_CXX11_NOEXCEPT, test x$have_cxx11_noexcept == xyes)
   ])

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -66,9 +66,8 @@ ExactSolution::ExactSolution(const EquationSystems & es) :
 }
 
 
-ExactSolution::~ExactSolution()
-{
-}
+ExactSolution::ExactSolution(ExactSolution &&) = default;
+ExactSolution::~ExactSolution() = default;
 
 
 void ExactSolution::attach_reference_solution (const EquationSystems * es_fine)

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -53,6 +53,7 @@ DistributedMesh::DistributedMesh (const Parallel::Communicator & comm_in,
 }
 
 
+
 DistributedMesh::~DistributedMesh ()
 {
   this->clear();  // Free nodes and elements

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -110,6 +110,10 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
 
 
 
+MeshBase::MeshBase(MeshBase &&) = default;
+
+
+
 MeshBase::~MeshBase()
 {
   this->clear();
@@ -265,7 +269,8 @@ void MeshBase::clear ()
   _is_prepared = false;
 
   // Clear boundary information
-  this->get_boundary_info().clear();
+  if (boundary_info)
+    boundary_info->clear();
 
   // Clear element dimensions
   _elem_dims.clear();

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -46,6 +46,7 @@ public:
   CPPUNIT_TEST( testExodusCopyElementSolution );
 #endif
 
+  CPPUNIT_TEST( testMeshMoveConstructor );
   CPPUNIT_TEST_SUITE_END();
 
 private:
@@ -123,6 +124,28 @@ public:
   }
 #endif
 
+  void testMeshMoveConstructor ()
+  {
+    Mesh mesh(*TestCommWorld);
+    MeshTools::Generation::build_square (mesh,
+                                         3, 3,
+                                         0., 1., 0., 1.);
+
+    // Construct mesh2, stealing the resources of the original.
+    Mesh mesh2(std::move(mesh));
+
+    // Make sure mesh2 now has the 9 elements.
+    CPPUNIT_ASSERT_EQUAL(mesh2.n_elem(),
+                         static_cast<unsigned int>(9));
+
+    // Verify that the moved-from mesh's Partitioner and BoundaryInfo
+    // objects were successfully stolen.  Note: moved-from unique_ptrs
+    // are guaranteed to compare equal to nullptr, see e.g. Section
+    // 20.8.1/4 of the standard.
+    // https://stackoverflow.com/questions/24061767/is-unique-ptr-guaranteed-to-store-nullptr-after-move
+    CPPUNIT_ASSERT(!mesh.partitioner());
+    CPPUNIT_ASSERT(!mesh.boundary_info);
+  }
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( MeshInputTest );


### PR DESCRIPTION
These changes currently only affect the MeshBase hierarchy and the
ExactSolution class, but eventually every class in the library should
be more specific about which of the 5 "special functions" (copy/move
ctor, copy/move assignment operator, destructor) are deleted or
defaulted.