### PR TITLE
Make QBase-derived classes explicitly default copy/move constructible…

### DIFF
--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -67,15 +67,20 @@ protected:
    * Constructor. Protected to prevent instantiation of this base
    * class.  Use the build() method instead.
    */
-  QBase (const unsigned int _dim,
-         const Order _order=INVALID_ORDER);
+  QBase (unsigned int dim,
+         Order order=INVALID_ORDER);
 
 public:
 
   /**
-   * Destructor.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  virtual ~QBase() {}
+  QBase (const QBase &) = default;
+  QBase (QBase &&) = default;
+  QBase & operator= (const QBase &) = default;
+  QBase & operator= (QBase &&) = default;
+  virtual ~QBase() = default;
 
   /**
    * \returns The quadrature type in derived classes.
@@ -317,13 +322,13 @@ protected:
   /**
    * The spatial dimension of the quadrature rule.
    */
-  const unsigned int _dim;
+  unsigned int _dim;
 
   /**
    * The polynomial order which the quadrature rule is capable of
    * integrating exactly.
    */
-  const Order _order;
+  Order _order;
 
   /**
    * The type of element for which the current values have been
@@ -356,8 +361,8 @@ protected:
 // QBase class members
 
 inline
-QBase::QBase(const unsigned int d,
-             const Order o) :
+QBase::QBase(unsigned int d,
+             Order o) :
   allow_rules_with_negative_weights(true),
   _dim(d),
   _order(o),

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -41,15 +41,20 @@ public:
   /**
    * Constructor.  Declares the order of the quadrature rule.
    */
-  QClough (const unsigned int _dim,
-           const Order _order=INVALID_ORDER) :
-    QBase(_dim, _order)
+  QClough (unsigned int dim,
+           Order order=INVALID_ORDER) :
+    QBase(dim, order)
   {}
 
   /**
-   * Destructor.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QClough() {}
+  QClough (const QClough &) = default;
+  QClough (QClough &&) = default;
+  QClough & operator= (const QClough &) = default;
+  QClough & operator= (QClough &&) = default;
+  virtual ~QClough() = default;
 
   /**
    * \returns \p QCLOUGH.

--- a/include/quadrature/quadrature_composite.h
+++ b/include/quadrature/quadrature_composite.h
@@ -64,13 +64,18 @@ public:
   /**
    * Constructor.  Declares the order of the quadrature rule.
    */
-  QComposite (const unsigned int _dim,
-              const Order _order=INVALID_ORDER);
+  QComposite (unsigned int dim,
+              Order order=INVALID_ORDER);
 
   /**
-   * Destructor.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QComposite();
+  QComposite (const QComposite &) = default;
+  QComposite (QComposite &&) = default;
+  QComposite & operator= (const QComposite &) = default;
+  QComposite & operator= (QComposite &&) = default;
+  virtual ~QComposite() = default;
 
   /**
    * \returns \p QCOMPOSITE.

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -47,13 +47,20 @@ public:
   /**
    * Constructor.  Declares the order of the quadrature rule.
    */
-  QConical (const unsigned int _dim,
-            const Order _order=INVALID_ORDER);
+  QConical (unsigned int d,
+            Order o=INVALID_ORDER) :
+    QBase(d,o)
+  {}
 
   /**
-   * Destructor.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QConical();
+  QConical (const QConical &) = default;
+  QConical (QConical &&) = default;
+  QConical & operator= (const QConical &) = default;
+  QConical & operator= (QConical &&) = default;
+  virtual ~QConical() = default;
 
   /**
    * \returns The QuadratureType for this class.

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -49,8 +49,8 @@ public:
    * however if we called the function with INVALID_ELEM it would try
    * to be smart and return, thinking it had already done the work.
    */
-  QGauss (const unsigned int _dim,
-          const Order _order=INVALID_ORDER) :
+  QGauss (unsigned int _dim,
+          Order _order=INVALID_ORDER) :
     QBase(_dim, _order)
   {
     if (_dim == 1)
@@ -58,9 +58,14 @@ public:
   }
 
   /**
-   * Destructor.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QGauss() {}
+  QGauss (const QGauss &) = default;
+  QGauss (QGauss &&) = default;
+  QGauss & operator= (const QGauss &) = default;
+  QGauss & operator= (QGauss &&) = default;
+  virtual ~QGauss() = default;
 
   /**
    * \returns \p QGAUSS.

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -45,13 +45,18 @@ public:
   /**
    * Constructor.  Declares the order of the quadrature rule.
    */
-  QGaussLobatto (const unsigned int _dim,
-                 const Order _order=INVALID_ORDER);
+  QGaussLobatto (unsigned int dim,
+                 Order order=INVALID_ORDER);
 
   /**
-   * Destructor.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QGaussLobatto();
+  QGaussLobatto (const QGaussLobatto &) = default;
+  QGaussLobatto (QGaussLobatto &&) = default;
+  QGaussLobatto & operator= (const QGaussLobatto &) = default;
+  QGaussLobatto & operator= (QGaussLobatto &&) = default;
+  virtual ~QGaussLobatto() = default;
 
   /**
    * \returns \p QGAUSS_LOBATTO.

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -100,13 +100,20 @@ public:
   /**
    * Constructor.  Declares the order of the quadrature rule.
    */
-  QGrundmann_Moller (const unsigned int _dim,
-                     const Order _order=INVALID_ORDER);
+  QGrundmann_Moller (unsigned int dim,
+                     Order order=INVALID_ORDER) :
+    QBase(dim,order)
+  {}
 
   /**
-   * Destructor.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QGrundmann_Moller();
+  QGrundmann_Moller (const QGrundmann_Moller &) = default;
+  QGrundmann_Moller (QGrundmann_Moller &&) = default;
+  QGrundmann_Moller & operator= (const QGrundmann_Moller &) = default;
+  QGrundmann_Moller & operator= (QGrundmann_Moller &&) = default;
+  virtual ~QGrundmann_Moller() = default;
 
   /**
    * \returns \p QGRUNDMANN_MOLLER.

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -51,15 +51,20 @@ public:
   /**
    * Constructor.  Declares the order of the quadrature rule.
    */
-  QGrid (const unsigned int _dim,
-         const Order _order=INVALID_ORDER) :
-    QBase(_dim, _order)
+  QGrid (unsigned int dim,
+         Order order=INVALID_ORDER) :
+    QBase(dim, order)
   {}
 
   /**
-   * Destructor.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QGrid() {}
+  QGrid (const QGrid &) = default;
+  QGrid (QGrid &&) = default;
+  QGrid & operator= (const QGrid &) = default;
+  QGrid & operator= (QGrid &&) = default;
+  virtual ~QGrid() = default;
 
   /**
    * \returns \p QGRID.

--- a/include/quadrature/quadrature_jacobi.h
+++ b/include/quadrature/quadrature_jacobi.h
@@ -53,11 +53,11 @@ public:
   /**
    * Constructor.  Currently, only one-dimensional rules provided.
    */
-  QJacobi (const unsigned int _dim,
-           const Order _order=INVALID_ORDER,
-           const unsigned int a=1,
-           const unsigned int b=0) :
-    QBase(_dim, _order),
+  QJacobi (unsigned int dim,
+           Order order=INVALID_ORDER,
+           unsigned int a=1,
+           unsigned int b=0) :
+    QBase(dim, order),
     _alpha(a),
     _beta(b)
   {
@@ -66,9 +66,14 @@ public:
   }
 
   /**
-   * Destructor. Empty.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QJacobi() {}
+  QJacobi (const QJacobi &) = default;
+  QJacobi (QJacobi &&) = default;
+  QJacobi & operator= (const QJacobi &) = default;
+  QJacobi & operator= (QJacobi &&) = default;
+  virtual ~QJacobi() = default;
 
   /**
    * \returns The \p QuadratureType, either \p QJACOBI_1_0 or \p

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -62,13 +62,20 @@ public:
   /**
    * Constructor.  Declares the order of the quadrature rule.
    */
-  QMonomial (const unsigned int _dim,
-             const Order _order=INVALID_ORDER);
+  QMonomial (unsigned int dim,
+             Order order=INVALID_ORDER) :
+    QBase(dim,order)
+  {}
 
   /**
-   * Destructor.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QMonomial();
+  QMonomial (const QMonomial &) = default;
+  QMonomial (QMonomial &&) = default;
+  QMonomial & operator= (const QMonomial &) = default;
+  QMonomial & operator= (QMonomial &&) = default;
+  virtual ~QMonomial() = default;
 
   /**
    * \returns \p QMONOMIAL.

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -49,18 +49,23 @@ public:
    * to be smart and return, thinking it had already done the work.
    */
   explicit
-  QSimpson (const unsigned int _dim,
-            const Order o=THIRD) :
-    QBase(_dim, o)
+  QSimpson (unsigned int dim,
+            Order order=THIRD) :
+    QBase(dim, order)
   {
     if (_dim == 1)
       init(EDGE2);
   }
 
   /**
-   * Destructor. Empty.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QSimpson() {}
+  QSimpson (const QSimpson &) = default;
+  QSimpson (QSimpson &&) = default;
+  QSimpson & operator= (const QSimpson &) = default;
+  QSimpson & operator= (QSimpson &&) = default;
+  virtual ~QSimpson() = default;
 
   /**
    * \returns \p QSIMPSON.

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -49,18 +49,23 @@ public:
    * to be smart and return, thinking it had already done the work.
    */
   explicit
-  QTrap (const unsigned int _dim,
-         const Order o=FIRST) :
-    QBase(_dim,o)
+  QTrap (unsigned int dim,
+         Order order=FIRST) :
+    QBase(dim,order)
   {
     if (_dim == 1)
       init(EDGE2);
   }
 
   /**
-   * Destructor. Empty.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
    */
-  ~QTrap() {}
+  QTrap (const QTrap &) = default;
+  QTrap (QTrap &&) = default;
+  QTrap & operator= (const QTrap &) = default;
+  QTrap & operator= (QTrap &&) = default;
+  virtual ~QTrap() = default;
 
   /**
    * \returns \p QTRAP.

--- a/src/quadrature/quadrature_composite.C
+++ b/src/quadrature/quadrature_composite.C
@@ -33,8 +33,8 @@ namespace libMesh
 
 
 template <class QSubCell>
-QComposite<QSubCell>::QComposite(const unsigned int d,
-                                 const Order o) :
+QComposite<QSubCell>::QComposite(unsigned int d,
+                                 Order o) :
   QSubCell(d,o), // explicitly call base class constructor
   _q_subcell(d,o),
   _lagrange_fe(FEBase::build (d, FEType (FIRST, LAGRANGE)))
@@ -51,12 +51,6 @@ QComposite<QSubCell>::QComposite(const unsigned int d,
 
   _lagrange_fe->attach_quadrature_rule (&_q_subcell);
 }
-
-
-
-template <class QSubCell>
-QComposite<QSubCell>::~QComposite()
-{}
 
 
 

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -30,24 +30,6 @@ namespace libMesh
 // quadrature_conical_3D.C
 // for additional implementation.
 
-
-
-
-// Constructor
-QConical::QConical(const unsigned int d,
-                   const Order o) : QBase(d,o)
-{
-}
-
-
-
-// Destructor
-QConical::~QConical()
-{
-}
-
-
-
 QuadratureType QConical::type() const
 {
   return QCONICAL;

--- a/src/quadrature/quadrature_gauss_lobatto.C
+++ b/src/quadrature/quadrature_gauss_lobatto.C
@@ -43,12 +43,6 @@ QGaussLobatto::QGaussLobatto(const unsigned int d,
 }
 
 
-
-QGaussLobatto::~QGaussLobatto()
-{
-}
-
-
 QuadratureType QGaussLobatto::type() const
 {
   return QGAUSS_LOBATTO;

--- a/src/quadrature/quadrature_gm.C
+++ b/src/quadrature/quadrature_gm.C
@@ -28,20 +28,6 @@ namespace libMesh
 // quadrature_gm_3D.C
 // for additional implementation.
 
-// Constructor
-QGrundmann_Moller::QGrundmann_Moller(const unsigned int d,
-                                     const Order o) : QBase(d,o)
-{
-}
-
-
-// Destructor
-QGrundmann_Moller::~QGrundmann_Moller()
-{
-}
-
-
-
 QuadratureType QGrundmann_Moller::type() const
 {
   return QGRUNDMANN_MOLLER;

--- a/src/quadrature/quadrature_monomial.C
+++ b/src/quadrature/quadrature_monomial.C
@@ -29,18 +29,6 @@ namespace libMesh
 // quadrature_monomial_3D.C
 // for implementation of specific element types.
 
-// Constructor
-QMonomial::QMonomial(const unsigned int d,
-                     const Order o) : QBase(d,o)
-{
-}
-
-
-// Destructor
-QMonomial::~QMonomial()
-{
-}
-
 QuadratureType QMonomial::type() const
 {
   return QMONOMIAL;


### PR DESCRIPTION
… and assignable.

For these super simple classes, there is no reason they should not
be. One small change required was to make the protected _dim and
_order members non-const.  I don't think there's a compelling reason
for these to be const, other than we did not really understand all the
ramifications of making things const when this class was written.