### PR TITLE
Fixes for --disable-strict-lgpl builds.

### DIFF
--- a/include/quadrature/quadrature_composite.h
+++ b/include/quadrature/quadrature_composite.h
@@ -68,19 +68,24 @@ public:
               Order order=INVALID_ORDER);
 
   /**
+   * This class contains a unique_ptr member, so it can't be default
+   * copy constructed or assigned.
+   */
+  QComposite (const QComposite &) = delete;
+  QComposite & operator= (const QComposite &) = delete;
+
+  /**
    * Copy/move ctor, copy/move assignment operator, and destructor are
    * all explicitly defaulted for this simple class.
    */
-  QComposite (const QComposite &) = default;
   QComposite (QComposite &&) = default;
-  QComposite & operator= (const QComposite &) = default;
   QComposite & operator= (QComposite &&) = default;
   virtual ~QComposite() = default;
 
   /**
    * \returns \p QCOMPOSITE.
    */
-  virtual QuadratureType type() const override { return QCOMPOSITE; }
+  virtual QuadratureType type() const override;
 
   /**
    * Overrides the base class init() function, and uses the ElemCutter to

--- a/include/solvers/laspack_linear_solver.h
+++ b/include/solvers/laspack_linear_solver.h
@@ -35,8 +35,6 @@
 #include "libmesh/laspack_vector.h"
 #include "libmesh/laspack_matrix.h"
 
-// C++ includes
-
 namespace libMesh
 {
 

--- a/src/quadrature/quadrature_composite.C
+++ b/src/quadrature/quadrature_composite.C
@@ -25,11 +25,20 @@
 #include "libmesh/quadrature_simpson.h"
 #include "libmesh/quadrature_composite.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_quadrature_type.h"
 
 
 
 namespace libMesh
 {
+
+
+template <class QSubCell>
+QuadratureType QComposite<QSubCell>::type() const
+{
+  return QCOMPOSITE;
+}
+
 
 
 template <class QSubCell>

--- a/src/solvers/laspack_linear_solver.C
+++ b/src/solvers/laspack_linear_solver.C
@@ -22,12 +22,13 @@
 #if defined(LIBMESH_HAVE_LASPACK)
 
 
-// C++ includes
-
 // Local Includes
 #include "libmesh/laspack_linear_solver.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_solver_type.h"
+#include "libmesh/enum_preconditioner_type.h"
+#include "libmesh/enum_convergence_flags.h"
 
 namespace libMesh
 {


### PR DESCRIPTION
`QComposite` and `Laspack` are only enabled when libmesh is configured
with `--disable-strict-lgpl`.  Unfortunately I did not test this
configuration when moving around enums.