### PR TITLE
Default/delete special functions in Partitioner classes

### DIFF
--- a/include/partitioning/centroid_partitioner.h
+++ b/include/partitioning/centroid_partitioner.h
@@ -68,6 +68,16 @@ public:
   CentroidPartitioner (const CentroidSortMethod sm=X) : _sort_method(sm) {}
 
   /**
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this class.
+   */
+  CentroidPartitioner (const CentroidPartitioner &) = default;
+  CentroidPartitioner (CentroidPartitioner &&) = default;
+  CentroidPartitioner & operator= (const CentroidPartitioner &) = default;
+  CentroidPartitioner & operator= (CentroidPartitioner &&) = default;
+  virtual ~CentroidPartitioner() = default;
+
+  /**
    * \returns A copy of this partitioner wrapped in a smart pointer.
    */
   virtual std::unique_ptr<Partitioner> clone () const override

--- a/include/partitioning/centroid_partitioner.h
+++ b/include/partitioning/centroid_partitioner.h
@@ -82,7 +82,7 @@ public:
    */
   virtual std::unique_ptr<Partitioner> clone () const override
   {
-    return libmesh_make_unique<CentroidPartitioner>(sort_method());
+    return libmesh_make_unique<CentroidPartitioner>(*this);
   }
 
   /**

--- a/include/partitioning/hilbert_sfc_partitioner.h
+++ b/include/partitioning/hilbert_sfc_partitioner.h
@@ -47,6 +47,16 @@ public:
   }
 
   /**
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this class.
+   */
+  HilbertSFCPartitioner (const HilbertSFCPartitioner &) = default;
+  HilbertSFCPartitioner (HilbertSFCPartitioner &&) = default;
+  HilbertSFCPartitioner & operator= (const HilbertSFCPartitioner &) = default;
+  HilbertSFCPartitioner & operator= (HilbertSFCPartitioner &&) = default;
+  virtual ~HilbertSFCPartitioner() = default;
+
+  /**
    * \returns A copy of this partitioner wrapped in a smart pointer.
    */
   virtual std::unique_ptr<Partitioner> clone () const override

--- a/include/partitioning/hilbert_sfc_partitioner.h
+++ b/include/partitioning/hilbert_sfc_partitioner.h
@@ -61,7 +61,7 @@ public:
    */
   virtual std::unique_ptr<Partitioner> clone () const override
   {
-    return libmesh_make_unique<HilbertSFCPartitioner>();
+    return libmesh_make_unique<HilbertSFCPartitioner>(*this);
   }
 
 protected:

--- a/include/partitioning/linear_partitioner.h
+++ b/include/partitioning/linear_partitioner.h
@@ -61,7 +61,7 @@ public:
    */
   virtual std::unique_ptr<Partitioner> clone () const override
   {
-    return libmesh_make_unique<LinearPartitioner>();
+    return libmesh_make_unique<LinearPartitioner>(*this);
   }
 
   /**

--- a/include/partitioning/linear_partitioner.h
+++ b/include/partitioning/linear_partitioner.h
@@ -42,14 +42,10 @@ class LinearPartitioner : public Partitioner
 public:
 
   /**
-   * Constructor.
-   */
-  LinearPartitioner () = default;
-
-  /**
-   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * Ctors, assignment operators, and destructor are
    * all explicitly defaulted for this class.
    */
+  LinearPartitioner () = default;
   LinearPartitioner (const LinearPartitioner &) = default;
   LinearPartitioner (LinearPartitioner &&) = default;
   LinearPartitioner & operator= (const LinearPartitioner &) = default;

--- a/include/partitioning/linear_partitioner.h
+++ b/include/partitioning/linear_partitioner.h
@@ -44,7 +44,17 @@ public:
   /**
    * Constructor.
    */
-  LinearPartitioner () {}
+  LinearPartitioner () = default;
+
+  /**
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this class.
+   */
+  LinearPartitioner (const LinearPartitioner &) = default;
+  LinearPartitioner (LinearPartitioner &&) = default;
+  LinearPartitioner & operator= (const LinearPartitioner &) = default;
+  LinearPartitioner & operator= (LinearPartitioner &&) = default;
+  virtual ~LinearPartitioner() = default;
 
   /**
    * \returns A copy of this partitioner wrapped in a smart pointer.

--- a/include/partitioning/mapped_subdomain_partitioner.h
+++ b/include/partitioning/mapped_subdomain_partitioner.h
@@ -63,7 +63,7 @@ public:
    */
   virtual std::unique_ptr<Partitioner> clone () const override
   {
-    return libmesh_make_unique<MappedSubdomainPartitioner>();
+    return libmesh_make_unique<MappedSubdomainPartitioner>(*this);
   }
 
   /**

--- a/include/partitioning/mapped_subdomain_partitioner.h
+++ b/include/partitioning/mapped_subdomain_partitioner.h
@@ -44,14 +44,10 @@ class MappedSubdomainPartitioner : public Partitioner
 public:
 
   /**
-   * Constructor.
+   * Ctors, assignment operators, and destructor are all explicitly
+   * defaulted for this class.
    */
   MappedSubdomainPartitioner () = default;
-
-  /**
-   * Copy/move ctor, copy/move assignment operator, and destructor are
-   * all explicitly defaulted for this class.
-   */
   MappedSubdomainPartitioner (const MappedSubdomainPartitioner &) = default;
   MappedSubdomainPartitioner (MappedSubdomainPartitioner &&) = default;
   MappedSubdomainPartitioner & operator= (const MappedSubdomainPartitioner &) = default;

--- a/include/partitioning/mapped_subdomain_partitioner.h
+++ b/include/partitioning/mapped_subdomain_partitioner.h
@@ -46,7 +46,17 @@ public:
   /**
    * Constructor.
    */
-  MappedSubdomainPartitioner () {}
+  MappedSubdomainPartitioner () = default;
+
+  /**
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this class.
+   */
+  MappedSubdomainPartitioner (const MappedSubdomainPartitioner &) = default;
+  MappedSubdomainPartitioner (MappedSubdomainPartitioner &&) = default;
+  MappedSubdomainPartitioner & operator= (const MappedSubdomainPartitioner &) = default;
+  MappedSubdomainPartitioner & operator= (MappedSubdomainPartitioner &&) = default;
+  virtual ~MappedSubdomainPartitioner() = default;
 
   /**
    * \returns A copy of this partitioner wrapped in a smart pointer.

--- a/include/partitioning/metis_partitioner.h
+++ b/include/partitioning/metis_partitioner.h
@@ -40,14 +40,10 @@ class MetisPartitioner : public Partitioner
 public:
 
   /**
-   * Constructor.
+   * Ctors, assignment operators, and destructor are all explicitly
+   * defaulted for this class.
    */
   MetisPartitioner () = default;
-
-  /**
-   * Copy/move ctor, copy/move assignment operator, and destructor are
-   * all explicitly defaulted for this class.
-   */
   MetisPartitioner (const MetisPartitioner &) = default;
   MetisPartitioner (MetisPartitioner &&) = default;
   MetisPartitioner & operator= (const MetisPartitioner &) = default;

--- a/include/partitioning/metis_partitioner.h
+++ b/include/partitioning/metis_partitioner.h
@@ -59,7 +59,7 @@ public:
    */
   virtual std::unique_ptr<Partitioner> clone () const override
   {
-    return libmesh_make_unique<MetisPartitioner>();
+    return libmesh_make_unique<MetisPartitioner>(*this);
   }
 
   virtual void attach_weights(ErrorVector * weights) override { _weights = weights; }

--- a/include/partitioning/metis_partitioner.h
+++ b/include/partitioning/metis_partitioner.h
@@ -42,7 +42,17 @@ public:
   /**
    * Constructor.
    */
-  MetisPartitioner () {}
+  MetisPartitioner () = default;
+
+  /**
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this class.
+   */
+  MetisPartitioner (const MetisPartitioner &) = default;
+  MetisPartitioner (MetisPartitioner &&) = default;
+  MetisPartitioner & operator= (const MetisPartitioner &) = default;
+  MetisPartitioner & operator= (MetisPartitioner &&) = default;
+  virtual ~MetisPartitioner() = default;
 
   /**
    * \returns A copy of this partitioner wrapped in a smart pointer.

--- a/include/partitioning/morton_sfc_partitioner.h
+++ b/include/partitioning/morton_sfc_partitioner.h
@@ -61,7 +61,7 @@ public:
    */
   virtual std::unique_ptr<Partitioner> clone () const override
   {
-    return libmesh_make_unique<MortonSFCPartitioner>();
+    return libmesh_make_unique<MortonSFCPartitioner>(*this);
   }
 
 protected:

--- a/include/partitioning/morton_sfc_partitioner.h
+++ b/include/partitioning/morton_sfc_partitioner.h
@@ -47,6 +47,16 @@ public:
   }
 
   /**
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this class.
+   */
+  MortonSFCPartitioner (const MortonSFCPartitioner &) = default;
+  MortonSFCPartitioner (MortonSFCPartitioner &&) = default;
+  MortonSFCPartitioner & operator= (const MortonSFCPartitioner &) = default;
+  MortonSFCPartitioner & operator= (MortonSFCPartitioner &&) = default;
+  virtual ~MortonSFCPartitioner() = default;
+
+  /**
    * \returns A copy of this partitioner wrapped in a smart pointer.
    */
   virtual std::unique_ptr<Partitioner> clone () const override

--- a/include/partitioning/parmetis_helper.h
+++ b/include/partitioning/parmetis_helper.h
@@ -55,9 +55,14 @@ class ParmetisHelper
 {
 public:
   /**
-   * Constructor.
+   * Defaulted constructors, assignment operators, and destructor.
    */
-  ParmetisHelper () {}
+  ParmetisHelper () = default;
+  ParmetisHelper (const ParmetisHelper &) = default;
+  ParmetisHelper (ParmetisHelper &&) = default;
+  ParmetisHelper & operator= (const ParmetisHelper &) = default;
+  ParmetisHelper & operator= (ParmetisHelper &&) = default;
+  ~ParmetisHelper () = default;
 
 #ifdef LIBMESH_HAVE_PARMETIS
 

--- a/include/partitioning/parmetis_partitioner.h
+++ b/include/partitioning/parmetis_partitioner.h
@@ -49,15 +49,15 @@ class ParmetisPartitioner : public Partitioner
 public:
 
   /**
-   * Constructor.
+   * Default and copy ctors.
    */
   ParmetisPartitioner ();
+  ParmetisPartitioner (const ParmetisPartitioner & other);
 
   /**
    * This class contains a unique_ptr member, so it can't be default
-   * copy constructed or assigned.
+   * copy assigned.
    */
-  ParmetisPartitioner (const ParmetisPartitioner &) = delete;
   ParmetisPartitioner & operator= (const ParmetisPartitioner &) = delete;
 
   /**
@@ -78,7 +78,7 @@ public:
    */
   virtual std::unique_ptr<Partitioner> clone () const override
   {
-    return libmesh_make_unique<ParmetisPartitioner>();
+    return libmesh_make_unique<ParmetisPartitioner>(*this);
   }
 
 

--- a/include/partitioning/parmetis_partitioner.h
+++ b/include/partitioning/parmetis_partitioner.h
@@ -54,9 +54,24 @@ public:
   ParmetisPartitioner ();
 
   /**
-   * Destructor.
+   * This class contains a unique_ptr member, so it can't be default
+   * copy constructed or assigned.
    */
-  ~ParmetisPartitioner ();
+  ParmetisPartitioner (const ParmetisPartitioner &) = delete;
+  ParmetisPartitioner & operator= (const ParmetisPartitioner &) = delete;
+
+  /**
+   * Move ctor, move assignment operator, and destructor are
+   * all explicitly inline-defaulted for this class.
+   */
+  ParmetisPartitioner (ParmetisPartitioner &&) = default;
+  ParmetisPartitioner & operator= (ParmetisPartitioner &&) = default;
+
+  /**
+   * The destructor is out-of-line-defaulted to play nice with forward
+   * declarations.
+   */
+  virtual ~ParmetisPartitioner();
 
   /**
    * \returns A copy of this partitioner wrapped in a smart pointer.

--- a/include/partitioning/partitioner.h
+++ b/include/partitioning/partitioner.h
@@ -56,9 +56,14 @@ public:
   Partitioner () : _weights(libmesh_nullptr) {}
 
   /**
-   * Destructor. Virtual so that we can derive from this class.
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this class.
    */
-  virtual ~Partitioner() {}
+  Partitioner (const Partitioner &) = default;
+  Partitioner (Partitioner &&) = default;
+  Partitioner & operator= (const Partitioner &) = default;
+  Partitioner & operator= (Partitioner &&) = default;
+  virtual ~Partitioner() = default;
 
   /**
    * \returns A copy of this partitioner wrapped in a smart pointer.

--- a/include/partitioning/sfc_partitioner.h
+++ b/include/partitioning/sfc_partitioner.h
@@ -65,7 +65,7 @@ public:
    */
   virtual std::unique_ptr<Partitioner> clone () const override
   {
-    return libmesh_make_unique<SFCPartitioner>();
+    return libmesh_make_unique<SFCPartitioner>(*this);
   }
 
   /**

--- a/include/partitioning/sfc_partitioner.h
+++ b/include/partitioning/sfc_partitioner.h
@@ -51,6 +51,16 @@ public:
   {}
 
   /**
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this class.
+   */
+  SFCPartitioner (const SFCPartitioner &) = default;
+  SFCPartitioner (SFCPartitioner &&) = default;
+  SFCPartitioner & operator= (const SFCPartitioner &) = default;
+  SFCPartitioner & operator= (SFCPartitioner &&) = default;
+  virtual ~SFCPartitioner() = default;
+
+  /**
    * \returns A copy of this partitioner wrapped in a smart pointer.
    */
   virtual std::unique_ptr<Partitioner> clone () const override

--- a/include/partitioning/subdomain_partitioner.h
+++ b/include/partitioning/subdomain_partitioner.h
@@ -57,17 +57,17 @@ class SubdomainPartitioner : public Partitioner
 public:
 
   /**
-   * Constructor, default initializes the internal Partitioner object
-   * to a MetisPartitioner so the class is usable, although this type
-   * can be customized later.
+   * Constructors. The default ctor initializes the internal
+   * Partitioner object to a MetisPartitioner so the class is usable,
+   * although this type can be customized later.
    */
   SubdomainPartitioner ();
+  SubdomainPartitioner (const SubdomainPartitioner & other);
 
   /**
    * This class contains a unique_ptr member, so it can't be default
-   * copy constructed or assigned.
+   * copy assigned.
    */
-  SubdomainPartitioner (const SubdomainPartitioner &) = delete;
   SubdomainPartitioner & operator= (const SubdomainPartitioner &) = delete;
 
   /**
@@ -83,7 +83,7 @@ public:
    */
   virtual std::unique_ptr<Partitioner> clone () const override
   {
-    return libmesh_make_unique<SubdomainPartitioner>();
+    return libmesh_make_unique<SubdomainPartitioner>(*this);
   }
 
   /**

--- a/include/partitioning/subdomain_partitioner.h
+++ b/include/partitioning/subdomain_partitioner.h
@@ -64,6 +64,21 @@ public:
   SubdomainPartitioner ();
 
   /**
+   * This class contains a unique_ptr member, so it can't be default
+   * copy constructed or assigned.
+   */
+  SubdomainPartitioner (const SubdomainPartitioner &) = delete;
+  SubdomainPartitioner & operator= (const SubdomainPartitioner &) = delete;
+
+  /**
+   * Move ctor, move assignment operator, and destructor are
+   * all explicitly defaulted for this class.
+   */
+  SubdomainPartitioner (SubdomainPartitioner &&) = default;
+  SubdomainPartitioner & operator= (SubdomainPartitioner &&) = default;
+  virtual ~SubdomainPartitioner() = default;
+
+  /**
    * \returns A copy of this partitioner wrapped in a smart pointer.
    */
   virtual std::unique_ptr<Partitioner> clone () const override

--- a/include/quadrature/quadrature_composite.h
+++ b/include/quadrature/quadrature_composite.h
@@ -68,19 +68,24 @@ public:
               Order order=INVALID_ORDER);
 
   /**
+   * This class contains a unique_ptr member, so it can't be default
+   * copy constructed or assigned.
+   */
+  QComposite (const QComposite &) = delete;
+  QComposite & operator= (const QComposite &) = delete;
+
+  /**
    * Copy/move ctor, copy/move assignment operator, and destructor are
    * all explicitly defaulted for this simple class.
    */
-  QComposite (const QComposite &) = default;
   QComposite (QComposite &&) = default;
-  QComposite & operator= (const QComposite &) = default;
   QComposite & operator= (QComposite &&) = default;
   virtual ~QComposite() = default;
 
   /**
    * \returns \p QCOMPOSITE.
    */
-  virtual QuadratureType type() const override { return QCOMPOSITE; }
+  virtual QuadratureType type() const override;
 
   /**
    * Overrides the base class init() function, and uses the ElemCutter to

--- a/include/solvers/laspack_linear_solver.h
+++ b/include/solvers/laspack_linear_solver.h
@@ -35,8 +35,6 @@
 #include "libmesh/laspack_vector.h"
 #include "libmesh/laspack_matrix.h"
 
-// C++ includes
-
 namespace libMesh
 {
 

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -62,7 +62,7 @@ const unsigned int MIN_ELEM_PER_PROC = 4;
 // ParmetisPartitioner implementation
 ParmetisPartitioner::ParmetisPartitioner()
 #ifdef LIBMESH_HAVE_PARMETIS
-  :  _pmetis(new ParmetisHelper)
+  :  _pmetis(libmesh_make_unique<ParmetisHelper>())
 #endif
 {}
 

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -68,9 +68,7 @@ ParmetisPartitioner::ParmetisPartitioner()
 
 
 
-ParmetisPartitioner::~ParmetisPartitioner()
-{
-}
+ParmetisPartitioner::~ParmetisPartitioner() = default;
 
 
 

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -68,6 +68,15 @@ ParmetisPartitioner::ParmetisPartitioner()
 
 
 
+ParmetisPartitioner::ParmetisPartitioner (const ParmetisPartitioner & other)
+#ifdef LIBMESH_HAVE_PARMETIS
+  : _pmetis(libmesh_make_unique<ParmetisHelper>(*(other._pmetis)))
+#endif
+{
+}
+
+
+
 ParmetisPartitioner::~ParmetisPartitioner() = default;
 
 

--- a/src/partitioning/subdomain_partitioner.C
+++ b/src/partitioning/subdomain_partitioner.C
@@ -27,7 +27,7 @@ namespace libMesh
 {
 
 SubdomainPartitioner::SubdomainPartitioner () :
-  _internal_partitioner(new MetisPartitioner)
+  _internal_partitioner(libmesh_make_unique<MetisPartitioner>())
 {}
 
 

--- a/src/partitioning/subdomain_partitioner.C
+++ b/src/partitioning/subdomain_partitioner.C
@@ -31,6 +31,12 @@ SubdomainPartitioner::SubdomainPartitioner () :
 {}
 
 
+SubdomainPartitioner::SubdomainPartitioner (const SubdomainPartitioner & other) :
+  chunks(other.chunks),
+  _internal_partitioner(other._internal_partitioner->clone())
+{}
+
+
 void SubdomainPartitioner::_do_partition (MeshBase & mesh,
                                           const unsigned int n)
 {

--- a/src/quadrature/quadrature_composite.C
+++ b/src/quadrature/quadrature_composite.C
@@ -25,11 +25,20 @@
 #include "libmesh/quadrature_simpson.h"
 #include "libmesh/quadrature_composite.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_quadrature_type.h"
 
 
 
 namespace libMesh
 {
+
+
+template <class QSubCell>
+QuadratureType QComposite<QSubCell>::type() const
+{
+  return QCOMPOSITE;
+}
+
 
 
 template <class QSubCell>

--- a/src/solvers/laspack_linear_solver.C
+++ b/src/solvers/laspack_linear_solver.C
@@ -22,12 +22,13 @@
 #if defined(LIBMESH_HAVE_LASPACK)
 
 
-// C++ includes
-
 // Local Includes
 #include "libmesh/laspack_linear_solver.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_solver_type.h"
+#include "libmesh/enum_preconditioner_type.h"
+#include "libmesh/enum_convergence_flags.h"
 
 namespace libMesh
 {


### PR DESCRIPTION
Also fix the `Partitioner::clone()` method implementations which were not calling the copy constructors. This also includes the separate fixes from #1739 but should not conflict with that PR.