### PR TITLE
Explicitly delete copy/move constructors and assignment operators in Elem hierarchy

### DIFF
--- a/include/geom/cell.h
+++ b/include/geom/cell.h
@@ -49,6 +49,12 @@ public:
         Node ** nodelinkdata) :
     Elem (nn, ns, p, elemlinkdata, nodelinkdata) {}
 
+  Cell (Cell &&) = delete;
+  Cell (const Cell &) = delete;
+  Cell & operator= (const Cell &) = delete;
+  Cell & operator= (Cell &&) = delete;
+  virtual ~Cell() = default;
+
   /**
    * \returns 3, the dimensionality of the object.
    */

--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -49,6 +49,11 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  Hex (Hex &&) = delete;
+  Hex (const Hex &) = delete;
+  Hex & operator= (const Hex &) = delete;
+  Hex & operator= (Hex &&) = delete;
+  virtual ~Hex() = default;
 
   /**
    * \returns The \p Point associated with local \p Node \p i,

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -77,6 +77,12 @@ public:
     Hex(Hex20::n_nodes(), p, _nodelinks_data)
   {}
 
+  Hex20 (Hex20 &&) = delete;
+  Hex20 (const Hex20 &) = delete;
+  Hex20 & operator= (const Hex20 &) = delete;
+  Hex20 & operator= (Hex20 &&) = delete;
+  virtual ~Hex20() = default;
+
   /**
    * \returns \p HEX20.
    */

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -77,6 +77,12 @@ public:
     Hex(Hex27::n_nodes(), p, _nodelinks_data)
   {}
 
+  Hex27 (Hex27 &&) = delete;
+  Hex27 (const Hex27 &) = delete;
+  Hex27 & operator= (const Hex27 &) = delete;
+  Hex27 & operator= (Hex27 &&) = delete;
+  virtual ~Hex27() = default;
+
   /**
    * \returns \p HEX27.
    */

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -62,6 +62,12 @@ public:
     Hex(Hex8::n_nodes(), p, _nodelinks_data)
   {}
 
+  Hex8 (Hex8 &&) = delete;
+  Hex8 (const Hex8 &) = delete;
+  Hex8 & operator= (const Hex8 &) = delete;
+  Hex8 & operator= (Hex8 &&) = delete;
+  virtual ~Hex8() = default;
+
   /**
    * \returns \p HEX8.
    */

--- a/include/geom/cell_inf.h
+++ b/include/geom/cell_inf.h
@@ -54,6 +54,12 @@ public:
     Elem (nn, ns, p, elemlinkdata, nodelinkdata)
   {}
 
+  InfCell (InfCell &&) = delete;
+  InfCell (const InfCell &) = delete;
+  InfCell & operator= (const InfCell &) = delete;
+  InfCell & operator= (InfCell &&) = delete;
+  virtual ~InfCell() = default;
+
   /**
    * \returns 3, the dimensionality of the object.
    */

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -59,6 +59,12 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  InfHex (InfHex &&) = delete;
+  InfHex (const InfHex &) = delete;
+  InfHex & operator= (const InfHex &) = delete;
+  InfHex & operator= (InfHex &&) = delete;
+  virtual ~InfHex() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -79,6 +79,12 @@ public:
     InfHex(InfHex16::n_nodes(), p, _nodelinks_data)
   {}
 
+  InfHex16 (InfHex16 &&) = delete;
+  InfHex16 (const InfHex16 &) = delete;
+  InfHex16 & operator= (const InfHex16 &) = delete;
+  InfHex16 & operator= (InfHex16 &&) = delete;
+  virtual ~InfHex16() = default;
+
   /**
    * \returns 16.  The \p InfHex16 has 16 nodes.
    */

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -79,6 +79,12 @@ public:
     InfHex(InfHex18::n_nodes(), p, _nodelinks_data)
   {}
 
+  InfHex18 (InfHex18 &&) = delete;
+  InfHex18 (const InfHex18 &) = delete;
+  InfHex18 & operator= (const InfHex18 &) = delete;
+  InfHex18 & operator= (InfHex18 &&) = delete;
+  virtual ~InfHex18() = default;
+
   /**
    * \returns 18.  The \p InfHex18 has 18 nodes.
    */

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -64,6 +64,12 @@ public:
     InfHex(InfHex8::n_nodes(), p, _nodelinks_data)
   {}
 
+  InfHex8 (InfHex8 &&) = delete;
+  InfHex8 (const InfHex8 &) = delete;
+  InfHex8 & operator= (const InfHex8 &) = delete;
+  InfHex8 & operator= (InfHex8 &&) = delete;
+  virtual ~InfHex8() = default;
+
   /**
    * \returns 8.  The \p InfHex8 has 8 nodes.
    */

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -55,6 +55,12 @@ public:
     InfCell(nn, InfPrism::n_sides(), p, _elemlinks_data, nodelinkdata)
   {}
 
+  InfPrism (InfPrism &&) = delete;
+  InfPrism (const InfPrism &) = delete;
+  InfPrism & operator= (const InfPrism &) = delete;
+  InfPrism & operator= (InfPrism &&) = delete;
+  virtual ~InfPrism() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -70,6 +70,12 @@ public:
     InfPrism(InfPrism12::n_nodes(), p, _nodelinks_data)
   {}
 
+  InfPrism12 (InfPrism12 &&) = delete;
+  InfPrism12 (const InfPrism12 &) = delete;
+  InfPrism12 & operator= (const InfPrism12 &) = delete;
+  InfPrism12 & operator= (InfPrism12 &&) = delete;
+  virtual ~InfPrism12() = default;
+
   /**
    * \returns 12.  The \p InfPrism12 has 12 nodes.
    */

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -66,6 +66,12 @@ public:
     InfPrism(InfPrism6::n_nodes(), p, _nodelinks_data)
   {}
 
+  InfPrism6 (InfPrism6 &&) = delete;
+  InfPrism6 (const InfPrism6 &) = delete;
+  InfPrism6 & operator= (const InfPrism6 &) = delete;
+  InfPrism6 & operator= (InfPrism6 &&) = delete;
+  virtual ~InfPrism6() = default;
+
   /**
    * \returns 6.  The \p InfPrism6 has 6 nodes.
    */

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -49,6 +49,12 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  Prism (Prism &&) = delete;
+  Prism (const Prism &) = delete;
+  Prism & operator= (const Prism &) = delete;
+  Prism & operator= (Prism &&) = delete;
+  virtual ~Prism() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -78,6 +78,12 @@ public:
     Prism(Prism15::n_nodes(), p, _nodelinks_data)
   {}
 
+  Prism15 (Prism15 &&) = delete;
+  Prism15 (const Prism15 &) = delete;
+  Prism15 & operator= (const Prism15 &) = delete;
+  Prism15 & operator= (Prism15 &&) = delete;
+  virtual ~Prism15() = default;
+
   /**
    * \returns \p PRISM15.
    */

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -78,6 +78,12 @@ public:
     Prism(Prism18::n_nodes(), p, _nodelinks_data)
   {}
 
+  Prism18 (Prism18 &&) = delete;
+  Prism18 (const Prism18 &) = delete;
+  Prism18 & operator= (const Prism18 &) = delete;
+  Prism18 & operator= (Prism18 &&) = delete;
+  virtual ~Prism18() = default;
+
   /**
    * \returns \p PRISM18.
    */

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -61,6 +61,12 @@ public:
     Prism(Prism6::n_nodes(), p, _nodelinks_data)
   {}
 
+  Prism6 (Prism6 &&) = delete;
+  Prism6 (const Prism6 &) = delete;
+  Prism6 & operator= (const Prism6 &) = delete;
+  Prism6 & operator= (Prism6 &&) = delete;
+  virtual ~Prism6() = default;
+
   /**
    * \returns \p PRISM6.
    */

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -53,6 +53,12 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  Pyramid (Pyramid &&) = delete;
+  Pyramid (const Pyramid &) = delete;
+  Pyramid & operator= (const Pyramid &) = delete;
+  Pyramid & operator= (Pyramid &&) = delete;
+  virtual ~Pyramid() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -77,6 +77,12 @@ public:
     Pyramid(Pyramid13::n_nodes(), p, _nodelinks_data)
   {}
 
+  Pyramid13 (Pyramid13 &&) = delete;
+  Pyramid13 (const Pyramid13 &) = delete;
+  Pyramid13 & operator= (const Pyramid13 &) = delete;
+  Pyramid13 & operator= (Pyramid13 &&) = delete;
+  virtual ~Pyramid13() = default;
+
   /**
    * \returns 13.
    */

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -80,6 +80,12 @@ public:
     Pyramid(Pyramid14::n_nodes(), p, _nodelinks_data)
   {}
 
+  Pyramid14 (Pyramid14 &&) = delete;
+  Pyramid14 (const Pyramid14 &) = delete;
+  Pyramid14 & operator= (const Pyramid14 &) = delete;
+  Pyramid14 & operator= (Pyramid14 &&) = delete;
+  virtual ~Pyramid14() = default;
+
   /**
    * \returns 14.
    */

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -61,6 +61,12 @@ public:
     Pyramid(Pyramid5::n_nodes(), p, _nodelinks_data)
   {}
 
+  Pyramid5 (Pyramid5 &&) = delete;
+  Pyramid5 (const Pyramid5 &) = delete;
+  Pyramid5 & operator= (const Pyramid5 &) = delete;
+  Pyramid5 & operator= (Pyramid5 &&) = delete;
+  virtual ~Pyramid5() = default;
+
   /**
    * \returns \p PRYAMID.
    */

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -50,6 +50,12 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  Tet (Tet &&) = delete;
+  Tet (const Tet &) = delete;
+  Tet & operator= (const Tet &) = delete;
+  Tet & operator= (Tet &&) = delete;
+  virtual ~Tet() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -69,6 +69,12 @@ public:
     Tet(Tet10::n_nodes(), p, _nodelinks_data)
   {}
 
+  Tet10 (Tet10 &&) = delete;
+  Tet10 (const Tet10 &) = delete;
+  Tet10 & operator= (const Tet10 &) = delete;
+  Tet10 & operator= (Tet10 &&) = delete;
+  virtual ~Tet10() = default;
+
   /**
    * \returns \p TET10.
    */

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -62,6 +62,12 @@ public:
     Tet(Tet4::n_nodes(), p, _nodelinks_data)
   {}
 
+  Tet4 (Tet4 &&) = delete;
+  Tet4 (const Tet4 &) = delete;
+  Tet4 & operator= (const Tet4 &) = delete;
+  Tet4 & operator= (Tet4 &&) = delete;
+  virtual ~Tet4() = default;
+
   /**
    * \returns \p TET4.
    */

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -52,6 +52,12 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  Edge (Edge &&) = delete;
+  Edge (const Edge &) = delete;
+  Edge & operator= (const Edge &) = delete;
+  Edge & operator= (Edge &&) = delete;
+  virtual ~Edge() = default;
+
   /**
    * \returns 1, the dimensionality of the object.
    */

--- a/include/geom/edge_edge2.h
+++ b/include/geom/edge_edge2.h
@@ -51,6 +51,12 @@ public:
   Edge2 (Elem * p=libmesh_nullptr) :
     Edge(Edge2::n_nodes(), p, _nodelinks_data) {}
 
+  Edge2 (Edge2 &&) = delete;
+  Edge2 (const Edge2 &) = delete;
+  Edge2 & operator= (const Edge2 &) = delete;
+  Edge2 & operator= (Edge2 &&) = delete;
+  virtual ~Edge2() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/edge_edge3.h
+++ b/include/geom/edge_edge3.h
@@ -51,6 +51,12 @@ public:
   Edge3 (Elem * p=libmesh_nullptr) :
     Edge(Edge3::n_nodes(), p, _nodelinks_data) {}
 
+  Edge3 (Edge3 &&) = delete;
+  Edge3 (const Edge3 &) = delete;
+  Edge3 & operator= (const Edge3 &) = delete;
+  Edge3 & operator= (Edge3 &&) = delete;
+  virtual ~Edge3() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -52,6 +52,12 @@ public:
   Edge4 (Elem * p=libmesh_nullptr) :
     Edge(Edge4::n_nodes(), p, _nodelinks_data) {}
 
+  Edge4 (Edge4 &&) = delete;
+  Edge4 (const Edge4 &) = delete;
+  Edge4 & operator= (const Edge4 &) = delete;
+  Edge4 & operator= (Edge4 &&) = delete;
+  virtual ~Edge4() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/edge_inf_edge2.h
+++ b/include/geom/edge_inf_edge2.h
@@ -60,6 +60,12 @@ public:
   InfEdge2 (Elem * p=libmesh_nullptr) :
     Edge(InfEdge2::n_nodes(), p, _nodelinks_data) {}
 
+  InfEdge2 (InfEdge2 &&) = delete;
+  InfEdge2 (const InfEdge2 &) = delete;
+  InfEdge2 & operator= (const InfEdge2 &) = delete;
+  InfEdge2 & operator= (InfEdge2 &&) = delete;
+  virtual ~InfEdge2() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -117,6 +117,20 @@ protected:
 public:
 
   /**
+   * Elems are responsible for allocating and deleting their children
+   * during refinement, so they cannot be (default) copied or
+   * assigned. We therefore explicitly delete these operations.  Note
+   * that because _children is a C-style array, an Elem cannot even be
+   * safely default move-constructed (we would have to maintain a
+   * custom move constructor that explicitly sets _children to nullptr
+   * to do this safely).
+   */
+  Elem (Elem &&) = delete;
+  Elem (const Elem &) = delete;
+  Elem & operator= (const Elem &) = delete;
+  Elem & operator= (Elem &&) = delete;
+
+  /**
    * Destructor.  Frees all the memory associated with the element.
    */
   virtual ~Elem();

--- a/include/geom/face.h
+++ b/include/geom/face.h
@@ -49,6 +49,12 @@ public:
         Node ** nodelinkdata) :
     Elem(nn, ns, p, elemlinkdata, nodelinkdata) {}
 
+  Face (Face &&) = delete;
+  Face (const Face &) = delete;
+  Face & operator= (const Face &) = delete;
+  Face & operator= (Face &&) = delete;
+  virtual ~Face() = default;
+
   /**
    * \returns 2, the dimensionality of the object.
    */

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -71,6 +71,12 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  InfQuad (InfQuad &&) = delete;
+  InfQuad (const InfQuad &) = delete;
+  InfQuad & operator= (const InfQuad &) = delete;
+  InfQuad & operator= (InfQuad &&) = delete;
+  virtual ~InfQuad() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -60,6 +60,12 @@ public:
   InfQuad4 (Elem * p=libmesh_nullptr) :
     InfQuad(InfQuad4::n_nodes(), p, _nodelinks_data) {}
 
+  InfQuad4 (InfQuad4 &&) = delete;
+  InfQuad4 (const InfQuad4 &) = delete;
+  InfQuad4 & operator= (const InfQuad4 &) = delete;
+  InfQuad4 & operator= (InfQuad4 &&) = delete;
+  virtual ~InfQuad4() = default;
+
   /**
    * \returns 4.
    */

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -61,6 +61,12 @@ public:
   InfQuad6 (Elem * p=libmesh_nullptr):
     InfQuad(InfQuad6::n_nodes(), p, _nodelinks_data) {}
 
+  InfQuad6 (InfQuad6 &&) = delete;
+  InfQuad6 (const InfQuad6 &) = delete;
+  InfQuad6 & operator= (const InfQuad6 &) = delete;
+  InfQuad6 & operator= (InfQuad6 &&) = delete;
+  virtual ~InfQuad6() = default;
+
   /**
    * \returns 6.
    */

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -61,6 +61,12 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  Quad (Quad &&) = delete;
+  Quad (const Quad &) = delete;
+  Quad & operator= (const Quad &) = delete;
+  Quad & operator= (Quad &&) = delete;
+  virtual ~Quad() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -59,6 +59,12 @@ public:
   Quad4 (Elem * p=libmesh_nullptr) :
     Quad(Quad4::n_nodes(), p, _nodelinks_data) {}
 
+  Quad4 (Quad4 &&) = delete;
+  Quad4 (const Quad4 &) = delete;
+  Quad4 & operator= (const Quad4 &) = delete;
+  Quad4 & operator= (Quad4 &&) = delete;
+  virtual ~Quad4() = default;
+
   /**
    * \returns \p QUAD4.
    */

--- a/include/geom/face_quad4_shell.h
+++ b/include/geom/face_quad4_shell.h
@@ -43,6 +43,12 @@ public:
   QuadShell4 (Elem * p=libmesh_nullptr) :
     Quad4(p) {}
 
+  QuadShell4 (QuadShell4 &&) = delete;
+  QuadShell4 (const QuadShell4 &) = delete;
+  QuadShell4 & operator= (const QuadShell4 &) = delete;
+  QuadShell4 & operator= (QuadShell4 &&) = delete;
+  virtual ~QuadShell4() = default;
+
   /**
    * \returns \p QUADSHELL4.
    */

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -59,6 +59,12 @@ public:
   Quad8 (Elem * p=libmesh_nullptr) :
     Quad(Quad8::n_nodes(), p, _nodelinks_data) {}
 
+  Quad8 (Quad8 &&) = delete;
+  Quad8 (const Quad8 &) = delete;
+  Quad8 & operator= (const Quad8 &) = delete;
+  Quad8 & operator= (Quad8 &&) = delete;
+  virtual ~Quad8() = default;
+
   /**
    * \returns \p QUAD8.
    */

--- a/include/geom/face_quad8_shell.h
+++ b/include/geom/face_quad8_shell.h
@@ -43,6 +43,12 @@ public:
   QuadShell8 (Elem * p=libmesh_nullptr) :
     Quad8(p) {}
 
+  QuadShell8 (QuadShell8 &&) = delete;
+  QuadShell8 (const QuadShell8 &) = delete;
+  QuadShell8 & operator= (const QuadShell8 &) = delete;
+  QuadShell8 & operator= (QuadShell8 &&) = delete;
+  virtual ~QuadShell8() = default;
+
   /**
    * \returns \p QUADSHELL8.
    */

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -59,6 +59,12 @@ public:
   Quad9 (Elem * p=libmesh_nullptr) :
     Quad(Quad9::n_nodes(), p, _nodelinks_data) {}
 
+  Quad9 (Quad9 &&) = delete;
+  Quad9 (const Quad9 &) = delete;
+  Quad9 & operator= (const Quad9 &) = delete;
+  Quad9 & operator= (Quad9 &&) = delete;
+  virtual ~Quad9() = default;
+
   /**
    * \returns \p QUAD9.
    */

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -62,6 +62,12 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  Tri (Tri &&) = delete;
+  Tri (const Tri &) = delete;
+  Tri & operator= (const Tri &) = delete;
+  Tri & operator= (Tri &&) = delete;
+  virtual ~Tri() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -64,6 +64,12 @@ public:
   Tri3 (Elem * p=libmesh_nullptr) :
     Tri(Tri3::n_nodes(), p, _nodelinks_data) {}
 
+  Tri3 (Tri3 &&) = delete;
+  Tri3 (const Tri3 &) = delete;
+  Tri3 & operator= (const Tri3 &) = delete;
+  Tri3 & operator= (Tri3 &&) = delete;
+  virtual ~Tri3() = default;
+
   /**
    * \returns \p TRI3.
    */

--- a/include/geom/face_tri3_shell.h
+++ b/include/geom/face_tri3_shell.h
@@ -42,6 +42,12 @@ public:
   TriShell3 (Elem * p=libmesh_nullptr) :
     Tri3(p) {}
 
+  TriShell3 (TriShell3 &&) = delete;
+  TriShell3 (const TriShell3 &) = delete;
+  TriShell3 & operator= (const TriShell3 &) = delete;
+  TriShell3 & operator= (TriShell3 &&) = delete;
+  virtual ~TriShell3() = default;
+
   /**
    * \returns \p TRISHELL3.
    */

--- a/include/geom/face_tri3_subdivision.h
+++ b/include/geom/face_tri3_subdivision.h
@@ -52,6 +52,12 @@ public:
    */
   Tri3Subdivision(Elem * p);
 
+  Tri3Subdivision (Tri3Subdivision &&) = delete;
+  Tri3Subdivision (const Tri3Subdivision &) = delete;
+  Tri3Subdivision & operator= (const Tri3Subdivision &) = delete;
+  Tri3Subdivision & operator= (Tri3Subdivision &&) = delete;
+  virtual ~Tri3Subdivision() = default;
+
   /**
    * \returns \p TRI3SUBDIVISION.
    */

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -64,6 +64,12 @@ public:
   Tri6 (Elem * p=libmesh_nullptr) :
     Tri(Tri6::n_nodes(), p, _nodelinks_data) {}
 
+  Tri6 (Tri6 &&) = delete;
+  Tri6 (const Tri6 &) = delete;
+  Tri6 & operator= (const Tri6 &) = delete;
+  Tri6 & operator= (Tri6 &&) = delete;
+  virtual ~Tri6() = default;
+
   /**
    * \returns \p TRI6.
    */

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -51,6 +51,12 @@ public:
       this->set_interior_parent(libmesh_nullptr);
   }
 
+  NodeElem (NodeElem &&) = delete;
+  NodeElem (const NodeElem &) = delete;
+  NodeElem & operator= (const NodeElem &) = delete;
+  NodeElem & operator= (NodeElem &&) = delete;
+  virtual ~NodeElem() = default;
+
   /**
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -63,8 +63,14 @@ private:
   { this->set_id(remote_elem_id); }
 
 public:
+
+  RemoteElem (RemoteElem &&) = delete;
+  RemoteElem (const RemoteElem &) = delete;
+  RemoteElem & operator= (const RemoteElem &) = delete;
+  RemoteElem & operator= (RemoteElem &&) = delete;
+
   /**
-   * Destructor.
+   * Sets remote_elem to nullptr.
    */
   virtual ~RemoteElem();
 

--- a/include/geom/side.h
+++ b/include/geom/side.h
@@ -67,6 +67,12 @@ public:
         (ParentType::side_nodes_map[_side_number][n]);
   }
 
+  Side (Side &&) = delete;
+  Side (const Side &) = delete;
+  Side & operator= (const Side &) = delete;
+  Side & operator= (Side &&) = delete;
+  virtual ~Side() = default;
+
   /**
    * Setting a side node changes the node on the parent.
    */


### PR DESCRIPTION
It is not possible to default the move ctor for classes which have C
arrays, such as _children in Elem. The default move assignment
operator has the same issue as the copy assignment, so it is also
deleted.