### PR TITLE
PGI compiler identification and flags (revision 3)

### DIFF
--- a/configure
+++ b/configure
@@ -5625,7 +5625,7 @@ fi
 
     if test "x$compiler_brand_detected" = "xno"; then :
 
-          is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group'`"
+          is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group\|PGI'`"
           if test "x$is_pgcc" != "x"; then :
 
             { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< C++ compiler is Portland Group C++ >>>" >&5
@@ -7885,14 +7885,14 @@ esac
                         ;; #(
   portland_group) :
 
-                                CXXFLAGS_DBG="-g --no_using_std"
-                                CXXFLAGS_OPT="-O2 --no_using_std -fast -Minform=severe"
+                                CXXFLAGS_DBG="$CXXFLAGS_DBG -g --no_using_std"
+                                CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 --no_using_std -fast -Minform=severe"
                                 CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
 
                                                                 NODEPRECATEDFLAG=""
 
-                                CFLAGS_DBG="-g"
-                                CFLAGS_OPT="-O2"
+                                CFLAGS_DBG="$CFLAGS_DBG -g"
+                                CFLAGS_OPT="$CFLAGS_OPT -O2"
                                 CFLAGS_DEVEL="$CFLAGS_DBG"
 
                                                                 if test "$enableexceptions" = no; then :

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -532,15 +532,15 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
                        ],
 
             [portland_group], [
-                                CXXFLAGS_DBG="-g --no_using_std"
-                                CXXFLAGS_OPT="-O2 --no_using_std -fast -Minform=severe"
+                                CXXFLAGS_DBG="$CXXFLAGS_DBG -g --no_using_std"
+                                CXXFLAGS_OPT="$CXXFLAGS_OPT -O2 --no_using_std -fast -Minform=severe"
                                 CXXFLAGS_DEVEL="$CXXFLAGS_DBG"
 
                                 dnl PG C++ definitely doesnt understand -Wno-deprecated...
                                 NODEPRECATEDFLAG=""
 
-                                CFLAGS_DBG="-g"
-                                CFLAGS_OPT="-O2"
+                                CFLAGS_DBG="$CFLAGS_DBG -g"
+                                CFLAGS_OPT="$CFLAGS_OPT -O2"
                                 CFLAGS_DEVEL="$CFLAGS_DBG"
 
                                 dnl Disable exception handling if we dont use it

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -274,7 +274,7 @@ AC_DEFUN([DETERMINE_CXX_BRAND],
   dnl Portland Group C++?
   AS_IF([test "x$compiler_brand_detected" = "xno"],
         [
-          is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group'`"
+          is_pgcc="`($CXX -V 2>&1) | grep 'Portland Group\|PGI'`"
           AS_IF([test "x$is_pgcc" != "x"],
           [
             AC_MSG_RESULT(<<< C++ compiler is Portland Group C++ >>>)


### PR DESCRIPTION
This addresses problems with the PGI compiler from Issue #1730. With respect to my previous, unmerged PRs:
* It is a much more lightweight solution than PR #1731.  
* It has a separate commit for bootstrapping, as requested by @roystgnr  in PR #1745 

There are still some linker issues that I discovered in libtool itself. After I reported the issue, PGI said they'd follow-up with the libtool team (link). In particular, libtool doesn't identify the PGI compiler correctly when it's discovering the PIC flags. I'd like to wait for libtool to fix that, instead of hacking something into the libtool now. For now, I can complete configure by manually specifying -fpic in CFLAGS, etc.