### PR TITLE
Fix missing base class initialization in constructors.

### DIFF
--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -69,8 +69,9 @@ ParmetisPartitioner::ParmetisPartitioner()
 
 
 ParmetisPartitioner::ParmetisPartitioner (const ParmetisPartitioner & other)
+  : Partitioner(other)
 #ifdef LIBMESH_HAVE_PARMETIS
-  : _pmetis(libmesh_make_unique<ParmetisHelper>(*(other._pmetis)))
+  , _pmetis(libmesh_make_unique<ParmetisHelper>(*(other._pmetis)))
 #endif
 {
 }

--- a/src/partitioning/subdomain_partitioner.C
+++ b/src/partitioning/subdomain_partitioner.C
@@ -31,9 +31,10 @@ SubdomainPartitioner::SubdomainPartitioner () :
 {}
 
 
-SubdomainPartitioner::SubdomainPartitioner (const SubdomainPartitioner & other) :
-  chunks(other.chunks),
-  _internal_partitioner(other._internal_partitioner->clone())
+SubdomainPartitioner::SubdomainPartitioner (const SubdomainPartitioner & other)
+  : Partitioner(other),
+    chunks(other.chunks),
+    _internal_partitioner(other._internal_partitioner->clone())
 {}
 
 


### PR DESCRIPTION
Not sure why clang allowed this, GCC warns:

../src/partitioning/parmetis_partitioner.C: In copy constructor ‘libMesh::ParmetisPartitioner::ParmetisPartitioner(const libMesh::ParmetisPartitioner&)’:
../src/partitioning/parmetis_partitioner.C:71:1: warning: base class ‘class libMesh::Partitioner’ should be explicitly initialized in the copy constructor [-Wextra]