### PR TITLE
NumericVector::operator/= argument should be const

### DIFF
--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -161,7 +161,7 @@ public:
 
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) override;
 
-  virtual NumericVector<T> & operator /= (NumericVector<T> & v) override;
+  virtual NumericVector<T> & operator /= (const NumericVector<T> & v) override;
 
   virtual void reciprocal() override;
 

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -165,7 +165,7 @@ public:
 
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) override;
 
-  virtual NumericVector<T> & operator /= (NumericVector<T> & v_in) override;
+  virtual NumericVector<T> & operator /= (const NumericVector<T> & v_in) override;
 
   virtual void reciprocal() override;
 

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -165,7 +165,7 @@ public:
 
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) override;
 
-  virtual NumericVector<T> & operator /= (NumericVector<T> & v) override;
+  virtual NumericVector<T> & operator /= (const NumericVector<T> & v) override;
 
   virtual void reciprocal() override;
 

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -393,7 +393,7 @@ public:
    *
    * \returns A reference to *this.
    */
-  virtual NumericVector<T> & operator /= (NumericVector<T> & /*v*/) = 0;
+  virtual NumericVector<T> & operator /= (const NumericVector<T> & /*v*/) = 0;
 
   /**
    * Computes the pointwise reciprocal,

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -270,7 +270,7 @@ public:
 
   virtual void scale (const T factor) override;
 
-  virtual NumericVector<T> & operator /= (NumericVector<T> & v) override;
+  virtual NumericVector<T> & operator /= (const NumericVector<T> & v) override;
 
   virtual void abs() override;
 

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -181,7 +181,7 @@ public:
 
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) override;
 
-  virtual NumericVector<T> & operator /= (NumericVector<T> & v) override;
+  virtual NumericVector<T> & operator /= (const NumericVector<T> & v) override;
 
   virtual void reciprocal() override;
 

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -162,11 +162,11 @@ NumericVector<T> & DistributedVector<T>::operator -= (const NumericVector<T> & v
 
 
 template <typename T>
-NumericVector<T> & DistributedVector<T>::operator /= (NumericVector<T> & v)
+NumericVector<T> & DistributedVector<T>::operator /= (const NumericVector<T> & v)
 {
   libmesh_assert_equal_to(size(), v.size());
 
-  DistributedVector<T> & v_vec = cast_ref<DistributedVector<T> &>(v);
+  const DistributedVector<T> & v_vec = cast_ref<const DistributedVector<T> &>(v);
 
   std::size_t val_size = _values.size();
 

--- a/src/numerics/eigen_sparse_vector.C
+++ b/src/numerics/eigen_sparse_vector.C
@@ -107,7 +107,7 @@ NumericVector<T> & EigenSparseVector<T>::operator -= (const NumericVector<T> & v
 
 
 template <typename T>
-NumericVector<T> & EigenSparseVector<T>::operator /= (NumericVector<T> & v_in)
+NumericVector<T> & EigenSparseVector<T>::operator /= (const NumericVector<T> & v_in)
 {
   libmesh_assert (this->closed());
   libmesh_assert_equal_to(size(), v_in.size());

--- a/src/numerics/laspack_vector.C
+++ b/src/numerics/laspack_vector.C
@@ -106,7 +106,7 @@ NumericVector<T> & LaspackVector<T>::operator -= (const NumericVector<T> & v)
 
 
 template <typename T>
-NumericVector<T> & LaspackVector<T>::operator /= (NumericVector<T> & v)
+NumericVector<T> & LaspackVector<T>::operator /= (const NumericVector<T> & v)
 {
   libmesh_assert_equal_to(size(), v.size());
 

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -423,7 +423,7 @@ void PetscVector<T>::scale (const T factor_in)
 }
 
 template <typename T>
-NumericVector<T> & PetscVector<T>::operator /= (NumericVector<T> & v)
+NumericVector<T> & PetscVector<T>::operator /= (const NumericVector<T> & v)
 {
   PetscErrorCode ierr = 0;
 

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -128,12 +128,12 @@ EpetraVector<T>::operator -= (const NumericVector<T> & v)
 
 template <typename T>
 NumericVector<T> &
-EpetraVector<T>::operator /= (NumericVector<T> & v)
+EpetraVector<T>::operator /= (const NumericVector<T> & v)
 {
   libmesh_assert(this->closed());
   libmesh_assert_equal_to(size(), v.size());
 
-  EpetraVector<T> & v_vec = cast_ref<EpetraVector<T> &>(v);
+  const EpetraVector<T> & v_vec = cast_ref<const EpetraVector<T> &>(v);
 
   _vec->ReciprocalMultiply(1.0, *v_vec._vec, *_vec, 0.0);
 


### PR DESCRIPTION
We never modify it.  Perhaps at some point we had a shim to a
non-const-correct numerics library?  But even if that were the case we
should have used const_cast rather than inheriting the incorrectness.

Thanks to @dmcdougall for pointing this out.