### PR TITLE
Add local_id_to_elem to Partitioners

### DIFF
--- a/include/partitioning/partitioner.h
+++ b/include/partitioning/partitioner.h
@@ -259,6 +259,9 @@ protected:
    * element neighbors.
    */
   std::vector<std::vector<dof_id_type>> _dual_graph;
+
+
+  std::vector<Elem *> _local_id_to_elem;
 };
 
 } // namespace libMesh

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -706,6 +706,7 @@ void Partitioner::build_graph (const MeshBase & mesh)
 
   _dual_graph.clear();
   _dual_graph.resize(n_active_local_elem);
+  _local_id_to_elem.resize(n_active_local_elem);
 
   for (const auto & elem : mesh.active_local_element_ptr_range())
     {
@@ -718,6 +719,9 @@ void Partitioner::build_graph (const MeshBase & mesh)
       libmesh_assert_less (local_index, n_active_local_elem);
 
       std::vector<dof_id_type> & graph_row = _dual_graph[local_index];
+
+      // Save this off to make it easy to index later
+      _local_id_to_elem[local_index] = elem;
 
       // Loop over the element's neighbors.  An element
       // adjacency corresponds to a face neighbor


### PR DESCRIPTION
The partitioning system goes through a fairly complicated set of reorderings (which can even differ with distributed mesh) in order to come up with local IDs.  However, sometimes a Partitioner will want to be able to get access to the original element by its `local_id`.

My use-cases here involve setting the element/adjancency weights using things like element volume, surface area, etc.  But you could imagine many other uses including getting solution values or querying counters.

Adding this one simple vector makes all of that infinitely easier.

Worked this up with @fdkong 