### PR TITLE
Stop using libmesh_final workaround in library and examples

### DIFF
--- a/configure
+++ b/configure
@@ -902,8 +902,6 @@ HAVE_CXX17_FALLTHROUGH_ATTRIBUTE_FALSE
 HAVE_CXX17_FALLTHROUGH_ATTRIBUTE_TRUE
 HAVE_CXX11_TO_STRING_FALSE
 HAVE_CXX11_TO_STRING_TRUE
-HAVE_CXX11_FINAL_FALSE
-HAVE_CXX11_FINAL_TRUE
 HAVE_CXX11_ERF_FALSE
 HAVE_CXX11_ERF_TRUE
 HAVE_CXX11_INVERSE_HYPERBOLIC_TANGENT_COMPLEX_FALSE
@@ -940,6 +938,8 @@ HAVE_CXX11_RVALUE_REFERENCES_FALSE
 HAVE_CXX11_RVALUE_REFERENCES_TRUE
 HAVE_CXX11_DECLTYPE_FALSE
 HAVE_CXX11_DECLTYPE_TRUE
+HAVE_CXX11_FINAL_FALSE
+HAVE_CXX11_FINAL_TRUE
 HAVE_CXX11_NULLPTR_FALSE
 HAVE_CXX11_NULLPTR_TRUE
 HAVE_CXX11_DEFAULTED_FUNCTIONS_FALSE
@@ -9331,24 +9331,12 @@ main ()
 _ACEOF
 if ac_fn_cxx_try_compile "$LINENO"; then :
 
-      if test "x$enablecxx11" = "xyes"; then :
-
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
 $as_echo "#define HAVE_CXX11_NULLPTR 1" >>confdefs.h
 
-              have_cxx11_nullptr=yes
-
-else
-
-              { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, but disabled." >&5
-$as_echo "yes, but disabled." >&6; }
-
-$as_echo "#define HAVE_CXX11_NULLPTR_BUT_DISABLED 1" >>confdefs.h
-
-
-fi
+      have_cxx11_nullptr=yes
 
 else
 
@@ -9378,6 +9366,206 @@ fi
 
 if test "x$have_cxx11_nullptr" != "xyes"; then :
   as_fn_error $? "libMesh requires the C++11 nullptr keyword" "$LINENO" 5
+fi
+
+
+    have_cxx11_final=no
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 'final' keyword support" >&5
+$as_echo_n "checking for C++11 'final' keyword support... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    // Test that a function can be declared final.
+    struct A
+    {
+      virtual void foo() final;
+    };
+
+    // Test that a struct can be declared final.
+    struct B final : A
+    {
+    };
+
+int
+main ()
+{
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+      have_cxx11_final=yes
+
+else
+
+      have_cxx11_final=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+    # Confirm that you cannot declare a non-virtual function 'final'.
+    if test "x$have_cxx11_final" != "xno"; then :
+
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+            struct A
+            {
+              // Error: non-virtual function cannot be final
+              void bar() final;
+            };
+
+int
+main ()
+{
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+              # If this code compiles, 'final' is not working correctly.
+              have_cxx11_final=no
+
+else
+
+              have_cxx11_final=yes
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+
+        if test "x$have_cxx11_final" != "xno"; then :
+
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+            struct A
+            {
+              virtual void foo() final;
+            };
+            struct B : A
+            {
+              // Error: foo cannot be overridden as it's final in A
+              void foo();
+            };
+
+int
+main ()
+{
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+              # If this code compiles, 'final' is not working correctly.
+              have_cxx11_final=no
+
+else
+
+              have_cxx11_final=yes
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+
+        if test "x$have_cxx11_final" != "xno"; then :
+
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+            struct A
+            {
+            };
+
+            // struct B is final
+            struct B final : A
+            {
+            };
+
+            // Error: B is final
+            struct C : B
+            {
+            };
+
+int
+main ()
+{
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+              # If this code compiles, 'final' is not working correctly.
+              have_cxx11_final=no
+
+else
+
+              have_cxx11_final=yes
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+
+    # If the flag is still 'yes' after all the tests, set the #define.
+    if test "x$have_cxx11_final" = "xyes"; then :
+
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+$as_echo "#define HAVE_CXX11_FINAL 1" >>confdefs.h
+
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+    # Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+     if test x$have_cxx11_final == xyes; then
+  HAVE_CXX11_FINAL_TRUE=
+  HAVE_CXX11_FINAL_FALSE='#'
+else
+  HAVE_CXX11_FINAL_TRUE='#'
+  HAVE_CXX11_FINAL_FALSE=
+fi
+
+
+if test "x$have_cxx11_final" != "xyes"; then :
+  as_fn_error $? "libMesh requires the C++11 final keyword" "$LINENO" 5
 fi
 
 # --------------------------------------------------------------
@@ -9657,7 +9845,6 @@ fi
 
 
     have_cxx11_shared_ptr=init
-    have_cxx11_shared_ptr_but_disabled=init
 
     ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
@@ -9737,12 +9924,6 @@ fi
         if test "x$have_cxx11_shared_ptr" = "xyes"; then :
 
 $as_echo "#define HAVE_CXX11_SHARED_PTR 1" >>confdefs.h
-
-fi
-
-        if test "x$have_cxx11_shared_ptr_but_disabled" = "xyes"; then :
-
-$as_echo "#define HAVE_CXX11_SHARED_PTR_BUT_DISABLED 1" >>confdefs.h
 
 fi
 
@@ -10677,227 +10858,6 @@ fi
 else
   HAVE_CXX11_ERF_TRUE='#'
   HAVE_CXX11_ERF_FALSE=
-fi
-
-
-
-    have_cxx11_final=no
-    have_cxx11_final_but_disabled=no
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 'final' keyword support" >&5
-$as_echo_n "checking for C++11 'final' keyword support... " >&6; }
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-    old_CXXFLAGS="$CXXFLAGS"
-    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-    // Test that a function can be declared final.
-    struct A
-    {
-      virtual void foo() final;
-    };
-
-    // Test that a struct can be declared final.
-    struct B final : A
-    {
-    };
-
-int
-main ()
-{
-
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-      if test "x$enablecxx11" = "xyes"; then :
-  have_cxx11_final=yes
-else
-  have_cxx11_final_but_disabled=yes
-fi
-
-else
-
-      have_cxx11_final=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-    # Confirm that you cannot declare a non-virtual function 'final'.
-    if test "x$have_cxx11_final" != "xno"; then :
-
-            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-            struct A
-            {
-              // Error: non-virtual function cannot be final
-              void bar() final;
-            };
-
-int
-main ()
-{
-
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-              # If this code compiles, 'final' is not working correctly.
-              have_cxx11_final=no
-
-else
-
-              if test "x$enablecxx11" = "xyes"; then :
-  have_cxx11_final=yes
-else
-  have_cxx11_final_but_disabled=yes
-fi
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-fi
-
-        if test "x$have_cxx11_final" != "xno"; then :
-
-            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-            struct A
-            {
-              virtual void foo() final;
-            };
-            struct B : A
-            {
-              // Error: foo cannot be overridden as it's final in A
-              void foo();
-            };
-
-int
-main ()
-{
-
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-              # If this code compiles, 'final' is not working correctly.
-              have_cxx11_final=no
-
-else
-
-              if test "x$enablecxx11" = "xyes"; then :
-  have_cxx11_final=yes
-else
-  have_cxx11_final_but_disabled=yes
-fi
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-fi
-
-        if test "x$have_cxx11_final" != "xno"; then :
-
-            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-            struct A
-            {
-            };
-
-            // struct B is final
-            struct B final : A
-            {
-            };
-
-            // Error: B is final
-            struct C : B
-            {
-            };
-
-int
-main ()
-{
-
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_cxx_try_compile "$LINENO"; then :
-
-              # If this code compiles, 'final' is not working correctly.
-              have_cxx11_final=no
-
-else
-
-              if test "x$enablecxx11" = "xyes"; then :
-  have_cxx11_final=yes
-else
-  have_cxx11_final_but_disabled=yes
-fi
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-fi
-
-    # If the flag is still 'yes' after all the tests, set the #define.
-    if test "x$have_cxx11_final" = "xyes"; then :
-
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-
-$as_echo "#define HAVE_CXX11_FINAL 1" >>confdefs.h
-
-
-elif test "x$have_cxx11_final_but_disabled" = "xyes"; then :
-
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, but disabled." >&5
-$as_echo "yes, but disabled." >&6; }
-
-$as_echo "#define HAVE_CXX11_FINAL_BUT_DISABLED 1" >>confdefs.h
-
-
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-    # Reset the flags
-    CXXFLAGS="$old_CXXFLAGS"
-    ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-
-     if test x$have_cxx11_final == xyes; then
-  HAVE_CXX11_FINAL_TRUE=
-  HAVE_CXX11_FINAL_FALSE='#'
-else
-  HAVE_CXX11_FINAL_TRUE='#'
-  HAVE_CXX11_FINAL_FALSE=
 fi
 
 
@@ -42010,6 +41970,10 @@ if test -z "${HAVE_CXX11_NULLPTR_TRUE}" && test -z "${HAVE_CXX11_NULLPTR_FALSE}"
   as_fn_error $? "conditional \"HAVE_CXX11_NULLPTR\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
+if test -z "${HAVE_CXX11_FINAL_TRUE}" && test -z "${HAVE_CXX11_FINAL_FALSE}"; then
+  as_fn_error $? "conditional \"HAVE_CXX11_FINAL\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
 if test -z "${HAVE_CXX11_DECLTYPE_TRUE}" && test -z "${HAVE_CXX11_DECLTYPE_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_DECLTYPE\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
@@ -42080,10 +42044,6 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX11_ERF_TRUE}" && test -z "${HAVE_CXX11_ERF_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_CXX11_ERF\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${HAVE_CXX11_FINAL_TRUE}" && test -z "${HAVE_CXX11_FINAL_FALSE}"; then
-  as_fn_error $? "conditional \"HAVE_CXX11_FINAL\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${HAVE_CXX11_TO_STRING_TRUE}" && test -z "${HAVE_CXX11_TO_STRING_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,10 @@ LIBMESH_TEST_CXX11_NULLPTR
 AS_IF([test "x$have_cxx11_nullptr" != "xyes"],
       [AC_MSG_ERROR([libMesh requires the C++11 nullptr keyword])])
 
+LIBMESH_TEST_CXX11_FINAL
+AS_IF([test "x$have_cxx11_final" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires the C++11 final keyword])])
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.
@@ -303,7 +307,6 @@ LIBMESH_TEST_CXX11_THREAD
 LIBMESH_TEST_CXX11_CONDITION_VARIABLE
 LIBMESH_TEST_CXX11_TYPE_TRAITS
 LIBMESH_TEST_CXX11_MATH_FUNCS
-LIBMESH_TEST_CXX11_FINAL
 LIBMESH_TEST_CXX11_TO_STRING
 LIBMESH_TEST_CXX17_FALLTHROUGH_ATTRIBUTE
 

--- a/contrib/bin/reindent.sh
+++ b/contrib/bin/reindent.sh
@@ -20,15 +20,6 @@ if [ -z $EMACS ]; then
 fi
 
 for i in $*; do
-  # Even the most recent version of Emacs (25.1.50.1 at the time of this
-  # writing) fails to properly indent classes which have been marked
-  # "libmesh_final", presumably because this is our own macro which is
-  # not valid C++.  It does, however, properly indent classes marked as
-  # "final".  So, a possible workaround is to text-replace
-  # "libmesh_final" with "final" before doing the indentation, and then
-  # swap it back again afterward.
-  perl -pli -e 's/ libmesh_final : / \/\*\*\/ : /g' $i
-
   # Print name of file we are working on
   echo "Indenting $i"
 
@@ -44,8 +35,6 @@ for i in $*; do
     --eval="(c-set-offset 'innamespace 0)" \
     --eval="(indent-region (point-min) (point-max) nil)" \
     -f save-buffer &> /dev/null
-
-  perl -pli -e 's/ \/\*\*\/ : / libmesh_final : /g' $i
 done
 
 

--- a/doc/html/Makefile.am
+++ b/doc/html/Makefile.am
@@ -49,14 +49,10 @@ support.html: src/$@ src/simple_header.html src/simple_footer.html
 
 #
 # doxygen documentation - be sure to generate symlinks in include/libmesh!
-# doxygen does not correctly handle 'libmesh_final' directives in class declarations,
-# so we do a pre/postprocessing step with perl to temporarily remove these.
 doc html: doxygen
 doxygen:
 	@cd $(top_builddir)/include/libmesh && $(MAKE)
-	perl -pli -e 's/ libmesh_final : / \/\*\*\/ : /g' $(top_srcdir)/include/*/*.h
 	$(DOXYGEN) $(top_builddir)/doc/Doxyfile
-	perl -pli -e 's/ \/\*\*\/ : / libmesh_final : /g' $(top_srcdir)/include/*/*.h
 
 #  need to link files for VPATH builds
 if LIBMESH_VPATH_BUILD

--- a/doc/html/Makefile.in
+++ b/doc/html/Makefile.in
@@ -773,14 +773,10 @@ support.html: src/$@ src/simple_header.html src/simple_footer.html
 
 #
 # doxygen documentation - be sure to generate symlinks in include/libmesh!
-# doxygen does not correctly handle 'libmesh_final' directives in class declarations,
-# so we do a pre/postprocessing step with perl to temporarily remove these.
 doc html: doxygen
 doxygen:
 	@cd $(top_builddir)/include/libmesh && $(MAKE)
-	perl -pli -e 's/ libmesh_final : / \/\*\*\/ : /g' $(top_srcdir)/include/*/*.h
 	$(DOXYGEN) $(top_builddir)/doc/Doxyfile
-	perl -pli -e 's/ \/\*\*\/ : / libmesh_final : /g' $(top_srcdir)/include/*/*.h
 @LIBMESH_VPATH_BUILD_TRUE@.linkstamp:
 @LIBMESH_VPATH_BUILD_TRUE@	-rm -rf examples              && cp -r $(srcdir)/examples . && chmod -R u+rw examples
 @LIBMESH_VPATH_BUILD_TRUE@	-rm -rf images                && cp -r $(srcdir)/images .   && chmod -R u+rw images

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -567,19 +567,13 @@ inline Tnew libmesh_cast_int (Told oldvar)
 // a C++11 compiler that supports this keyword.
 #define libmesh_override override
 
-// Define C++03 backwards-compatible function deletion keyword.
-#ifdef LIBMESH_HAVE_CXX11_DELETED_FUNCTIONS
+// libmesh_delete is simply a synonym for '=delete' as we now require
+// a C++11 compiler that supports this keyword.
 #define libmesh_delete =delete
-#else
-#define libmesh_delete
-#endif
 
-// Define C++03 backwards-compatible final keyword.
-#ifdef LIBMESH_HAVE_CXX11_FINAL
+// libmesh_final is simply a synonym for 'final' as we now require
+// a C++11 compiler that supports this keyword.
 #define libmesh_final final
-#else
-#define libmesh_final
-#endif
 
 // Define backwards-compatible fallthrough attribute.  We could
 // eventually also add support for other compiler-specific fallthrough

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -65,7 +65,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D hexahedral element with 20 nodes.
  */
-class Hex20 libmesh_final : public Hex
+class Hex20 final : public Hex
 {
 public:
 

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -65,7 +65,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D hexahedral element with 27 nodes.
  */
-class Hex27 libmesh_final : public Hex
+class Hex27 final : public Hex
 {
 public:
 

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -50,7 +50,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D hexahedral element with 8 nodes.
  */
-class Hex8 libmesh_final : public Hex
+class Hex8 final : public Hex
 {
 public:
 

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -67,7 +67,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D infinite hexahedral element with 16 nodes.
  */
-class InfHex16 libmesh_final : public InfHex
+class InfHex16 final : public InfHex
 {
 public:
 

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -67,7 +67,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D infinite hexahedral element with 18 nodes.
  */
-class InfHex18 libmesh_final : public InfHex
+class InfHex18 final : public InfHex
 {
 public:
 

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -52,7 +52,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D infinite hexahedral element with 8 nodes.
  */
-class InfHex8 libmesh_final : public InfHex
+class InfHex8 final : public InfHex
 {
 public:
 

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -58,7 +58,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D infinite prismatic element with 12 nodes.
  */
-class InfPrism12 libmesh_final : public InfPrism
+class InfPrism12 final : public InfPrism
 {
 public:
 

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -54,7 +54,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D infinite prismatic element with 6 nodes.
  */
-class InfPrism6 libmesh_final : public InfPrism
+class InfPrism6 final : public InfPrism
 {
 public:
 

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -66,7 +66,7 @@ namespace libMesh
  * \date 2003
  * \brief A 3D prismatic element with 15 nodes.
  */
-class Prism15 libmesh_final : public Prism
+class Prism15 final : public Prism
 {
 public:
 

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -66,7 +66,7 @@ namespace libMesh
  * \date 2003
  * \brief A 3D prismatic element with 18 nodes.
  */
-class Prism18 libmesh_final : public Prism
+class Prism18 final : public Prism
 {
 public:
 

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -49,7 +49,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D prismatic element with 6 nodes.
  */
-class Prism6 libmesh_final : public Prism
+class Prism6 final : public Prism
 {
 public:
 

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -65,7 +65,7 @@ namespace libMesh
  * \date 2014
  * \brief A 3D pyramid element with 13 nodes.
  */
-class Pyramid13 libmesh_final : public Pyramid
+class Pyramid13 final : public Pyramid
 {
 public:
 

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -68,7 +68,7 @@ namespace libMesh
  * \date 2013
  * \brief A 3D pyramid element with 14 nodes.
  */
-class Pyramid14 libmesh_final : public Pyramid
+class Pyramid14 final : public Pyramid
 {
 public:
 

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -49,7 +49,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D pyramid element with 5 nodes.
  */
-class Pyramid5 libmesh_final : public Pyramid
+class Pyramid5 final : public Pyramid
 {
 public:
 

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -57,7 +57,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D tetrahedral element with 10 nodes.
  */
-class Tet10 libmesh_final : public Tet
+class Tet10 final : public Tet
 {
 public:
 

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -50,7 +50,7 @@ namespace libMesh
  * \date 2002
  * \brief A 3D tetrahedral element with 4 nodes.
  */
-class Tet4 libmesh_final : public Tet
+class Tet4 final : public Tet
 {
 public:
 

--- a/include/geom/edge_edge4.h
+++ b/include/geom/edge_edge4.h
@@ -41,7 +41,7 @@ namespace libMesh
  * \date 2005
  * \brief A 1D geometric element with 4 nodes.
  */
-class Edge4 libmesh_final : public Edge
+class Edge4 final : public Edge
 {
 public:
 

--- a/include/geom/face_tri3_subdivision.h
+++ b/include/geom/face_tri3_subdivision.h
@@ -37,7 +37,7 @@ namespace libMesh
  * \date 2014
  * \brief A surface shell element used in mechanics calculations.
  */
-class Tri3Subdivision libmesh_final : public Tri3
+class Tri3Subdivision final : public Tri3
 {
 public:
 

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -246,9 +246,6 @@
 /* Flag indicating whether compiler supports f() final; */
 #undef HAVE_CXX11_FINAL
 
-/* Compiler supports final keyword, but it is disabled in libmesh */
-#undef HAVE_CXX11_FINAL_BUT_DISABLED
-
 /* Flag indicating whether compiler supports fixed type enumerations */
 #undef HAVE_CXX11_FIXED_TYPE_ENUM
 
@@ -289,9 +286,6 @@
 /* Flag indicating whether compiler supports nullptr */
 #undef HAVE_CXX11_NULLPTR
 
-/* Compiler supports nullptr, but it is disabled in libmesh */
-#undef HAVE_CXX11_NULLPTR_BUT_DISABLED
-
 /* Flag indicating whether compiler supports the override keyword */
 #undef HAVE_CXX11_OVERRIDE
 
@@ -306,9 +300,6 @@
 
 /* Flag indicating whether compiler supports std::shared_ptr */
 #undef HAVE_CXX11_SHARED_PTR
-
-/* Compiler supports std::shared_ptr, but it is disabled in libmesh */
-#undef HAVE_CXX11_SHARED_PTR_BUT_DISABLED
 
 /* Flag indicating whether compiler supports std::thread */
 #undef HAVE_CXX11_THREAD

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -49,7 +49,7 @@ namespace libMesh
  * \date 2003
  */
 template <typename T>
-class DistributedVector libmesh_final : public NumericVector<T>
+class DistributedVector final : public NumericVector<T>
 {
 public:
 

--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -51,7 +51,7 @@ template <typename T> class EigenSparseLinearSolver;
  * \date 2013
  */
 template <typename T>
-class EigenSparseMatrix libmesh_final : public SparseMatrix<T>
+class EigenSparseMatrix final : public SparseMatrix<T>
 {
 
 public:

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -48,7 +48,7 @@ template <typename T> class SparseMatrix;
  * \date 2002
  */
 template <typename T>
-class EigenSparseVector libmesh_final : public NumericVector<T>
+class EigenSparseVector final : public NumericVector<T>
 {
 public:
 

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -53,7 +53,7 @@ template <typename T> class LaspackLinearSolver;
  * \date 2003
  */
 template <typename T>
-class LaspackMatrix libmesh_final : public SparseMatrix<T>
+class LaspackMatrix final : public SparseMatrix<T>
 {
 
 public:

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -53,7 +53,7 @@ template <typename T> class SparseMatrix;
  * \date 2002
  */
 template <typename T>
-class LaspackVector libmesh_final : public NumericVector<T>
+class LaspackVector final : public NumericVector<T>
 {
 public:
 

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -71,7 +71,7 @@ template <typename T> class DenseMatrix;
  * \brief SparseMatrix interface to PETSc Mat.
  */
 template <typename T>
-class PetscMatrix libmesh_final : public SparseMatrix<T>
+class PetscMatrix final : public SparseMatrix<T>
 {
 public:
   /**

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -61,7 +61,7 @@ template <typename T> class SparseMatrix;
  * \brief NumericVector interface to PETSc Vec.
  */
 template <typename T>
-class PetscVector libmesh_final : public NumericVector<T>
+class PetscVector final : public NumericVector<T>
 {
 public:
 

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -60,7 +60,7 @@ template <typename T> class DenseMatrix;
  * \date 2008
  */
 template <typename T>
-class EpetraMatrix libmesh_final : public SparseMatrix<T>
+class EpetraMatrix final : public SparseMatrix<T>
 {
 public:
   /**

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -59,7 +59,7 @@ template <typename T> class SparseMatrix;
  * \date 2008
  */
 template <typename T>
-class EpetraVector libmesh_final : public NumericVector<T>
+class EpetraVector final : public NumericVector<T>
 {
 public:
 

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -34,7 +34,7 @@ namespace libMesh
  * \date 2005
  * \brief Implements quadrature rules for Clough-Tocher macroelements.
  */
-class QClough libmesh_final : public QBase
+class QClough final : public QBase
 {
 public:
 

--- a/include/quadrature/quadrature_composite.h
+++ b/include/quadrature/quadrature_composite.h
@@ -49,7 +49,7 @@ namespace libMesh
  * \brief A quadrature rule for subdivided elements.
  */
 template <class QSubCell>
-class QComposite libmesh_final : public QSubCell
+class QComposite final : public QSubCell
 {
 public:
 

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -40,7 +40,7 @@ namespace libMesh
  * \date 2008
  * \brief Conical product quadrature rules for Tri and Tet elements.
  */
-class QConical libmesh_final : public QBase
+class QConical final : public QBase
 {
 public:
 

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -38,7 +38,7 @@ namespace libMesh
  * \date 2014
  * \brief Implements 1D and 2/3D tensor product Gauss-Lobatto quadrature rules.
  */
-class QGaussLobatto libmesh_final : public QBase
+class QGaussLobatto final : public QBase
 {
 public:
 

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -93,7 +93,7 @@ namespace libMesh
  * \date 2008
  * \brief Implements the quadrature rules of Grundmann and Moller in 2D and 3D.
  */
-class QGrundmann_Moller libmesh_final : public QBase
+class QGrundmann_Moller final : public QBase
 {
 public:
 

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -44,7 +44,7 @@ namespace libMesh
  * \date 2005
  * \brief Implements grid-based quadrature rules suitable for non-smooth functions.
  */
-class QGrid libmesh_final : public QBase
+class QGrid final : public QBase
 {
 public:
 

--- a/include/quadrature/quadrature_jacobi.h
+++ b/include/quadrature/quadrature_jacobi.h
@@ -46,7 +46,7 @@ namespace libMesh
  * \date 2003
  * \brief Implements 1D Gauss-Jacobi quadrature rules of various orders.
  */
-class QJacobi libmesh_final : public QBase
+class QJacobi final : public QBase
 {
 public:
 

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -55,7 +55,7 @@ namespace libMesh
  * \date 2008
  * \brief Implements quadrature rules for non-tensor polynomials.
  */
-class QMonomial libmesh_final : public QBase
+class QMonomial final : public QBase
 {
 public:
 

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -411,7 +411,6 @@ AC_DEFUN([LIBMESH_TEST_CXX11_ALIAS_DECLARATIONS],
 AC_DEFUN([LIBMESH_TEST_CXX11_SHARED_PTR],
   [
     have_cxx11_shared_ptr=init
-    have_cxx11_shared_ptr_but_disabled=init
 
     AC_LANG_PUSH([C++])
 
@@ -459,10 +458,6 @@ AC_DEFUN([LIBMESH_TEST_CXX11_SHARED_PTR],
     dnl Only set the header file variable if our flag was set to 'yes'.
     AS_IF([test "x$have_cxx11_shared_ptr" = "xyes"],
           [AC_DEFINE(HAVE_CXX11_SHARED_PTR, 1, [Flag indicating whether compiler supports std::shared_ptr])])
-
-    dnl If the test compilation succeeded, but we have disabled C++11, set a different #define.
-    AS_IF([test "x$have_cxx11_shared_ptr_but_disabled" = "xyes"],
-          [AC_DEFINE(HAVE_CXX11_SHARED_PTR_BUT_DISABLED, 1, [Compiler supports std::shared_ptr, but it is disabled in libmesh])])
 
     AC_LANG_POP([C++])
 
@@ -1201,7 +1196,6 @@ AC_DEFUN([LIBMESH_TEST_CXX11_DEFAULTED_FUNCTIONS],
 AC_DEFUN([LIBMESH_TEST_CXX11_FINAL],
   [
     have_cxx11_final=no
-    have_cxx11_final_but_disabled=no
 
     AC_MSG_CHECKING(for C++11 'final' keyword support)
     AC_LANG_PUSH([C++])
@@ -1222,9 +1216,7 @@ AC_DEFUN([LIBMESH_TEST_CXX11_FINAL],
     };
     ]], [[
     ]])],[
-      AS_IF([test "x$enablecxx11" = "xyes"],
-            [have_cxx11_final=yes],
-            [have_cxx11_final_but_disabled=yes])
+      have_cxx11_final=yes
     ],[
       have_cxx11_final=no
     ])
@@ -1243,9 +1235,7 @@ AC_DEFUN([LIBMESH_TEST_CXX11_FINAL],
               # If this code compiles, 'final' is not working correctly.
               have_cxx11_final=no
             ],[
-              AS_IF([test "x$enablecxx11" = "xyes"],
-                    [have_cxx11_final=yes],
-                    [have_cxx11_final_but_disabled=yes])
+              have_cxx11_final=yes
             ])
           ])
 
@@ -1267,9 +1257,7 @@ AC_DEFUN([LIBMESH_TEST_CXX11_FINAL],
               # If this code compiles, 'final' is not working correctly.
               have_cxx11_final=no
             ],[
-              AS_IF([test "x$enablecxx11" = "xyes"],
-                    [have_cxx11_final=yes],
-                    [have_cxx11_final_but_disabled=yes])
+              have_cxx11_final=yes
             ])
           ])
 
@@ -1295,9 +1283,7 @@ AC_DEFUN([LIBMESH_TEST_CXX11_FINAL],
               # If this code compiles, 'final' is not working correctly.
               have_cxx11_final=no
             ],[
-              AS_IF([test "x$enablecxx11" = "xyes"],
-                    [have_cxx11_final=yes],
-                    [have_cxx11_final_but_disabled=yes])
+              have_cxx11_final=yes
             ])
           ])
 
@@ -1306,11 +1292,6 @@ AC_DEFUN([LIBMESH_TEST_CXX11_FINAL],
           [
             AC_MSG_RESULT(yes)
             AC_DEFINE(HAVE_CXX11_FINAL, 1, [Flag indicating whether compiler supports f() final;])
-          ],
-          [test "x$have_cxx11_final_but_disabled" = "xyes"],
-          [
-            AC_MSG_RESULT([yes, but disabled.])
-            AC_DEFINE(HAVE_CXX11_FINAL_BUT_DISABLED, 1, [Compiler supports final keyword, but it is disabled in libmesh])
           ],
           [AC_MSG_RESULT(no)])
 
@@ -1341,16 +1322,9 @@ AC_DEFUN([LIBMESH_TEST_CXX11_NULLPTR],
     // would be ambiguous without void f(nullptr_t)
     f(nullptr);
     ]])],[
-      AS_IF([test "x$enablecxx11" = "xyes"],
-            [
-              AC_MSG_RESULT(yes)
-              AC_DEFINE(HAVE_CXX11_NULLPTR, 1, [Flag indicating whether compiler supports nullptr])
-              have_cxx11_nullptr=yes
-            ],
-            [
-              AC_MSG_RESULT([yes, but disabled.])
-              AC_DEFINE(HAVE_CXX11_NULLPTR_BUT_DISABLED, 1, [Compiler supports nullptr, but it is disabled in libmesh])
-            ])
+      AC_MSG_RESULT(yes)
+      AC_DEFINE(HAVE_CXX11_NULLPTR, 1, [Flag indicating whether compiler supports nullptr])
+      have_cxx11_nullptr=yes
     ],[
       AC_MSG_RESULT(no)
     ])


### PR DESCRIPTION
As usual, the `libmesh_final` macro will still hang around for backwards compatibility.