### PR TITLE
Default/delete special functions in some numerics classes

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -62,10 +62,14 @@ public:
               const unsigned int new_n=0);
 
   /**
-   * Destructor.  Empty.
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
    */
-  virtual ~DenseMatrix() {}
-
+  DenseMatrix (DenseMatrix &&) = default;
+  DenseMatrix (const DenseMatrix &) = default;
+  DenseMatrix & operator= (const DenseMatrix &) = default;
+  DenseMatrix & operator= (DenseMatrix &&) = default;
+  virtual ~DenseMatrix() = default;
 
   virtual void zero() override;
 
@@ -183,13 +187,6 @@ public:
    * \param[in] b   Vector whose entries correspond to columns in the product matrix.
    */
   void outer_product(const DenseVector<T> & a, const DenseVector<T> & b);
-
-  /**
-   * Assignment operator.
-   *
-   * \returns A reference to *this.
-   */
-  DenseMatrix<T> & operator = (const DenseMatrix<T> & other_matrix);
 
   /**
    * Assignment-from-other-matrix-type operator.
@@ -813,21 +810,6 @@ void DenseMatrix<T>::zero()
   _decomposition_type = NONE;
 
   std::fill (_val.begin(), _val.end(), static_cast<T>(0));
-}
-
-
-
-template<typename T>
-inline
-DenseMatrix<T> & DenseMatrix<T>::operator = (const DenseMatrix<T> & other_matrix)
-{
-  this->_m = other_matrix._m;
-  this->_n = other_matrix._n;
-
-  _val                = other_matrix._val;
-  _decomposition_type = other_matrix._decomposition_type;
-
-  return *this;
 }
 
 

--- a/include/numerics/dense_matrix_base.h
+++ b/include/numerics/dense_matrix_base.h
@@ -54,9 +54,14 @@ protected:
 
 public:
   /**
-   * Destructor. Empty.
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
    */
-  virtual ~DenseMatrixBase() {}
+  DenseMatrixBase (DenseMatrixBase &&) = default;
+  DenseMatrixBase (const DenseMatrixBase &) = default;
+  DenseMatrixBase & operator= (const DenseMatrixBase &) = default;
+  DenseMatrixBase & operator= (DenseMatrixBase &&) = default;
+  virtual ~DenseMatrixBase() = default;
 
   /**
    * Set every element in the matrix to 0.  You must redefine

--- a/include/numerics/dense_submatrix.h
+++ b/include/numerics/dense_submatrix.h
@@ -58,14 +58,14 @@ public:
                  const unsigned int n=0);
 
   /**
-   * Copy Constructor.
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
    */
-  DenseSubMatrix (const DenseSubMatrix<T> & other_matrix);
-
-  /**
-   * Destructor.  Empty.
-   */
-  virtual ~DenseSubMatrix() {}
+  DenseSubMatrix (DenseSubMatrix &&) = default;
+  DenseSubMatrix (const DenseSubMatrix &) = default;
+  DenseSubMatrix & operator= (const DenseSubMatrix &) = default;
+  DenseSubMatrix & operator= (DenseSubMatrix &&) = default;
+  virtual ~DenseSubMatrix() = default;
 
   /**
    * \returns A reference to the parent matrix.
@@ -164,18 +164,6 @@ DenseSubMatrix<T>::DenseSubMatrix(DenseMatrix<T> & new_parent,
   _parent_matrix(new_parent)
 {
   this->reposition (ioff, joff, new_m, new_n);
-}
-
-
-// Copy Constructor
-template<typename T>
-inline
-DenseSubMatrix<T>::DenseSubMatrix(const DenseSubMatrix<T> & other_matrix) :
-  DenseMatrixBase<T>(other_matrix._m, other_matrix._n),
-  _parent_matrix(other_matrix._parent_matrix)
-{
-  _i_off = other_matrix._i_off;
-  _j_off = other_matrix._j_off;
 }
 
 

--- a/include/numerics/dense_subvector.h
+++ b/include/numerics/dense_subvector.h
@@ -53,9 +53,14 @@ public:
                  const unsigned int n=0);
 
   /**
-   * Destructor.  Does nothing.
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
    */
-  virtual ~DenseSubVector() {}
+  DenseSubVector (DenseSubVector &&) = default;
+  DenseSubVector (const DenseSubVector &) = default;
+  DenseSubVector & operator= (const DenseSubVector &) = default;
+  DenseSubVector & operator= (DenseSubVector &&) = default;
+  virtual ~DenseSubVector() = default;
 
   /**
    * \returns A reference to the parent vector.

--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -80,9 +80,14 @@ public:
   DenseVector (const std::vector<T2> & other_vector);
 
   /**
-   * Destructor.  Does nothing.
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
    */
-  ~DenseVector() {}
+  DenseVector (DenseVector &&) = default;
+  DenseVector (const DenseVector &) = default;
+  DenseVector & operator= (const DenseVector &) = default;
+  DenseVector & operator= (DenseVector &&) = default;
+  virtual ~DenseVector() = default;
 
   virtual unsigned int size() const override
   {

--- a/include/numerics/dense_vector_base.h
+++ b/include/numerics/dense_vector_base.h
@@ -42,14 +42,19 @@ class DenseVectorBase
 {
 public:
   /**
-   * Constructor.  Empty.
+   * Constructor.
    */
-  DenseVectorBase() {}
+  DenseVectorBase() = default;
 
   /**
-   * Destructor.  Does nothing.
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
    */
-  virtual ~DenseVectorBase() {}
+  DenseVectorBase (DenseVectorBase &&) = default;
+  DenseVectorBase (const DenseVectorBase &) = default;
+  DenseVectorBase & operator= (const DenseVectorBase &) = default;
+  DenseVectorBase & operator= (DenseVectorBase &&) = default;
+  virtual ~DenseVectorBase() = default;
 
   /**
    * Set every element in the vector to 0.  Needs to
@@ -98,7 +103,6 @@ public:
    * decimal places in scientific notation.
    */
   void print_scientific(std::ostream & os, unsigned precision=8) const;
-
 };
 
 } // namespace libMesh

--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -89,10 +89,22 @@ public:
                      const ParallelType ptype = AUTOMATIC);
 
   /**
-   * Destructor, deallocates memory. Made virtual to allow
-   * for derived classes to behave properly.
+   * Copy assignment operator. We cannot default this (although it
+   * essentially implements the default behavior) because the
+   * compiler-generated default attempts to automatically call the
+   * base class (NumericVector) copy assignment operator, which we
+   * have chosen to make pure virtual for other design reasons.
    */
-  ~DistributedVector ();
+  DistributedVector & operator= (const DistributedVector &);
+
+  /**
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
+   */
+  DistributedVector (DistributedVector &&) = default;
+  DistributedVector (const DistributedVector &) = default;
+  DistributedVector & operator= (DistributedVector &&) = default;
+  virtual ~DistributedVector () = default;
 
   virtual void close () override;
 
@@ -125,13 +137,6 @@ public:
   virtual NumericVector<T> & operator= (const T s) override;
 
   virtual NumericVector<T> & operator= (const NumericVector<T> & v) override;
-
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the derived type.
-   */
-  DistributedVector<T> & operator= (const DistributedVector<T> & v);
 
   virtual NumericVector<T> & operator= (const std::vector<T> & v) override;
 
@@ -300,15 +305,6 @@ DistributedVector<T>::DistributedVector (const Parallel::Communicator & comm_in,
   : NumericVector<T>(comm_in, ptype)
 {
   this->init(n, n_local, ghost, false, ptype);
-}
-
-
-
-template <typename T>
-inline
-DistributedVector<T>::~DistributedVector ()
-{
-  this->clear ();
 }
 
 

--- a/include/numerics/eigen_sparse_matrix.h
+++ b/include/numerics/eigen_sparse_matrix.h
@@ -68,10 +68,14 @@ public:
   EigenSparseMatrix (const Parallel::Communicator & comm);
 
   /**
-   * Destructor. Free all memory, but do not release the memory of the
-   * sparsity structure.
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
    */
-  ~EigenSparseMatrix ();
+  EigenSparseMatrix (EigenSparseMatrix &&) = default;
+  EigenSparseMatrix (const EigenSparseMatrix &) = default;
+  EigenSparseMatrix & operator= (const EigenSparseMatrix &) = default;
+  EigenSparseMatrix & operator= (EigenSparseMatrix &&) = default;
+  virtual ~EigenSparseMatrix () = default;
 
   /**
    * Convenient typedefs

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -88,10 +88,20 @@ public:
                      const ParallelType = AUTOMATIC);
 
   /**
-   * Destructor, deallocates memory. Made virtual to allow
-   * for derived classes to behave properly.
+   * Copy assignment operator. Does some state checks before copying
+   * the underlying Eigen data type.
+   * \returns A reference to *this as the derived type.
    */
-  ~EigenSparseVector ();
+  EigenSparseVector<T> & operator= (const EigenSparseVector<T> & v);
+
+  /**
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
+   */
+  EigenSparseVector (EigenSparseVector &&) = default;
+  EigenSparseVector (const EigenSparseVector &) = default;
+  EigenSparseVector & operator= (EigenSparseVector &&) = default;
+  virtual ~EigenSparseVector () = default;
 
   /**
    * Convenient typedefs
@@ -129,13 +139,6 @@ public:
   virtual NumericVector<T> & operator= (const T s) override;
 
   virtual NumericVector<T> & operator= (const NumericVector<T> & v) override;
-
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the derived type.
-   */
-  EigenSparseVector<T> & operator= (const EigenSparseVector<T> & v);
 
   virtual NumericVector<T> & operator= (const std::vector<T> & v) override;
 
@@ -293,15 +296,6 @@ EigenSparseVector<T>::EigenSparseVector (const Parallel::Communicator & comm_in,
   : NumericVector<T>(comm_in, ptype)
 {
   this->init(N, n_local, ghost, false, ptype);
-}
-
-
-
-template <typename T>
-inline
-EigenSparseVector<T>::~EigenSparseVector ()
-{
-  this->clear ();
 }
 
 

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -70,10 +70,15 @@ public:
   LaspackMatrix (const Parallel::Communicator & comm);
 
   /**
-   * Destructor. Free all memory, but do not release the memory of the
-   * sparsity structure.
+   * This class manages a C-style struct (QMatrix) manually, so we
+   * don't want to allow any automatic copy/move functions to be
+   * generated, and we can't default the destructor.
    */
-  ~LaspackMatrix ();
+  LaspackMatrix (LaspackMatrix &&) = delete;
+  LaspackMatrix (const LaspackMatrix &) = delete;
+  LaspackMatrix & operator= (const LaspackMatrix &) = delete;
+  LaspackMatrix & operator= (LaspackMatrix &&) = delete;
+  virtual ~LaspackMatrix ();
 
   /**
    * The \p LaspackMatrix needs the full sparsity pattern.

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -93,10 +93,21 @@ public:
                  const ParallelType = AUTOMATIC);
 
   /**
-   * Destructor, deallocates memory. Made virtual to allow
-   * for derived classes to behave properly.
+   * Copy assignment operator.
+   * Calls Asgn_VV() to assign the contents of one vector to another.
+   * \returns A reference to *this as the derived type.
    */
-  ~LaspackVector ();
+  LaspackVector<T> & operator= (const LaspackVector<T> & v);
+
+  /**
+   * This class manages a C-style struct (QVector) manually, so we
+   * don't want to allow any automatic copy/move functions to be
+   * generated, and we can't default the destructor.
+   */
+  LaspackVector (LaspackVector &&) = delete;
+  LaspackVector (const LaspackVector &) = delete;
+  LaspackVector & operator= (LaspackVector &&) = delete;
+  virtual ~LaspackVector ();
 
   virtual void close () override;
 
@@ -129,13 +140,6 @@ public:
   virtual NumericVector<T> & operator= (const T s) override;
 
   virtual NumericVector<T> & operator= (const NumericVector<T> & v) override;
-
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the derived type.
-   */
-  LaspackVector<T> & operator= (const LaspackVector<T> & v);
 
   virtual NumericVector<T> & operator= (const std::vector<T> & v) override;
 

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -106,13 +106,26 @@ public:
                  const std::vector<numeric_index_type> & ghost,
                  const ParallelType ptype = AUTOMATIC);
 
-public:
+  /**
+   * This _looks_ like a copy assignment operator, but note that,
+   * unlike normal copy assignment operators, it is pure virtual. This
+   * function should be overridden in derived classes so that they can
+   * be copied correctly via references to the base class. This design
+   * usually isn't a good idea in general, but in this context it
+   * works because we usually don't have a mix of different kinds of
+   * NumericVectors active in the library at a single time.
+   *
+   * \returns A reference to *this as the base type.
+   */
+  virtual NumericVector<T> & operator= (const NumericVector<T> & v) = 0;
 
   /**
-   * Destructor, deallocates memory. Made virtual to allow
-   * for derived classes to behave properly.
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
    */
-  virtual ~NumericVector ();
+  NumericVector (NumericVector &&) = default;
+  NumericVector (const NumericVector &) = default;
+  NumericVector & operator= (NumericVector &&) = default;
 
   /**
    * Builds a \p NumericVector on the processors in communicator
@@ -222,13 +235,6 @@ public:
    * \returns A reference to *this.
    */
   virtual NumericVector<T> & operator= (const T s) = 0;
-
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the base type.
-   */
-  virtual NumericVector<T> & operator= (const NumericVector<T> & v) = 0;
 
   /**
    * Sets (*this)(i) = v(i) for each entry of the vector.
@@ -775,15 +781,6 @@ NumericVector<T>::NumericVector (const Parallel::Communicator & comm_in,
 {
   libmesh_not_implemented(); // Abstract base class!
   // init(n, n_local, ghost, false, ptype);
-}
-
-
-
-template <typename T>
-inline
-NumericVector<T>::~NumericVector ()
-{
-  clear ();
 }
 
 

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -99,10 +99,15 @@ public:
                const Parallel::Communicator & comm_in);
 
   /**
-   * Destructor. Free all memory, but do not release the memory of the
-   * sparsity structure.
+   * This class manages a C-style struct (Mat) manually, so we
+   * don't want to allow any automatic copy/move functions to be
+   * generated, and we can't default the destructor.
    */
-  ~PetscMatrix ();
+  PetscMatrix (PetscMatrix &&) = delete;
+  PetscMatrix (const PetscMatrix &) = delete;
+  PetscMatrix & operator= (const PetscMatrix &) = delete;
+  PetscMatrix & operator= (PetscMatrix &&) = delete;
+  virtual ~PetscMatrix ();
 
   virtual void init (const numeric_index_type m,
                      const numeric_index_type n,

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -111,10 +111,21 @@ public:
               const Parallel::Communicator & comm_in);
 
   /**
-   * Destructor, deallocates memory. Made virtual to allow
-   * for derived classes to behave properly.
+   * Copy assignment operator.
+   * Calls VecCopy after performing various checks.
+   * \returns A reference to *this as the derived type.
    */
-  ~PetscVector ();
+  PetscVector<T> & operator= (const PetscVector<T> & v);
+
+  /**
+   * This class manages a C-style struct (Vec) manually, so we
+   * don't want to allow any automatic copy/move functions to be
+   * generated, and we can't default the destructor.
+   */
+  PetscVector (PetscVector &&) = delete;
+  PetscVector (const PetscVector &) = delete;
+  PetscVector & operator= (PetscVector &&) = delete;
+  virtual ~PetscVector ();
 
   virtual void close () override;
 
@@ -149,13 +160,6 @@ public:
   virtual NumericVector<T> & operator= (const NumericVector<T> & v) override;
 
   virtual NumericVector<T> & operator= (const std::vector<T> & v) override;
-
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the derived type.
-   */
-  PetscVector<T> & operator= (const PetscVector<T> & v);
 
   virtual Real min () const override;
 

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -80,10 +80,14 @@ public:
   SparseMatrix (const Parallel::Communicator & comm);
 
   /**
-   * Destructor. Free all memory, but do not release the memory of the
-   * sparsity structure.
+   * The 5 special functions can be defaulted for this class, as it
+   * does not manage any memory itself.
    */
-  virtual ~SparseMatrix ();
+  SparseMatrix (SparseMatrix &&) = default;
+  SparseMatrix (const SparseMatrix &) = default;
+  SparseMatrix & operator= (const SparseMatrix &) = default;
+  SparseMatrix & operator= (SparseMatrix &&) = default;
+  virtual ~SparseMatrix () = default;
 
   /**
    * Builds a \p SparseMatrix<T> using the linear solver package specified by

--- a/include/numerics/trilinos_epetra_matrix.h
+++ b/include/numerics/trilinos_epetra_matrix.h
@@ -87,9 +87,14 @@ public:
                 const Parallel::Communicator & comm);
 
   /**
-   * Destructor. Free all memory, but do not release the memory of the
-   * sparsity structure.
+   * This class manages the lifetime of an Epetra_FECrsMatrix
+   * manually, so we don't want to allow any automatic copy/move
+   * functions to be generated, and we can't default the destructor.
    */
+  EpetraMatrix (EpetraMatrix &&) = delete;
+  EpetraMatrix (const EpetraMatrix &) = delete;
+  EpetraMatrix & operator= (const EpetraMatrix &) = delete;
+  EpetraMatrix & operator= (EpetraMatrix &&) = delete;
   virtual ~EpetraMatrix ();
 
   /**

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -109,10 +109,15 @@ public:
                const Parallel::Communicator & comm);
 
   /**
-   * Destructor, deallocates memory. Made virtual to allow
-   * for derived classes to behave properly.
+   * This class manages the lifetime of an Epetra_Vector manually, so
+   * we don't want to allow any automatic copy/move functions to be
+   * generated, and we can't default the destructor.
    */
-  ~EpetraVector ();
+  EpetraVector (EpetraVector &&) = delete;
+  EpetraVector (const EpetraVector &) = delete;
+  EpetraVector & operator= (const EpetraVector &) = delete;
+  EpetraVector & operator= (EpetraVector &&) = delete;
+  virtual ~EpetraVector ();
 
   virtual void close () override;
 
@@ -145,13 +150,6 @@ public:
   virtual NumericVector<T> & operator= (const T s) override;
 
   virtual NumericVector<T> & operator= (const NumericVector<T> & v) override;
-
-  /**
-   * Sets (*this)(i) = v(i) for each entry of the vector.
-   *
-   * \returns A reference to *this as the derived type.
-   */
-  EpetraVector<T> & operator= (const EpetraVector<T> & v);
 
   virtual NumericVector<T> & operator= (const std::vector<T> & v) override;
 

--- a/src/numerics/eigen_sparse_matrix.C
+++ b/src/numerics/eigen_sparse_matrix.C
@@ -167,14 +167,6 @@ EigenSparseMatrix<T>::EigenSparseMatrix (const Parallel::Communicator & comm_in)
 
 
 template <typename T>
-EigenSparseMatrix<T>::~EigenSparseMatrix ()
-{
-  this->clear ();
-}
-
-
-
-template <typename T>
 void EigenSparseMatrix<T>::clear ()
 {
   _mat.resize(0,0);

--- a/src/numerics/sparse_matrix.C
+++ b/src/numerics/sparse_matrix.C
@@ -50,13 +50,6 @@ SparseMatrix<T>::SparseMatrix (const Parallel::Communicator & comm_in) :
 
 
 
-// Destructor
-template <typename T>
-SparseMatrix<T>::~SparseMatrix ()
-{}
-
-
-
 
 // default implementation is to fall back to non-blocked method
 template <typename T>

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -277,8 +277,12 @@ void EpetraMatrix<T>::get_transpose (SparseMatrix<T> & dest) const
   // Make sure the SparseMatrix passed in is really a EpetraMatrix
   EpetraMatrix<T> & epetra_dest = cast_ref<EpetraMatrix<T> &>(dest);
 
+  // We currently only support calling get_transpose() with ourself
+  // as the destination. Previously, this called the default copy
+  // constructor which was not safe because this class manually
+  // manages memory.
   if (&epetra_dest != this)
-    epetra_dest = *this;
+    libmesh_not_implemented();
 
   epetra_dest._use_transpose = !epetra_dest._use_transpose;
   epetra_dest._mat->SetUseTranspose(epetra_dest._use_transpose);

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -347,23 +347,12 @@ template <typename T>
 NumericVector<T> &
 EpetraVector<T>::operator = (const NumericVector<T> & v_in)
 {
-  const EpetraVector<T> * v = cast_ptr<const EpetraVector<T> *>(&v_in);
-
-  *this = *v;
-
-  return *this;
-}
-
-
-
-template <typename T>
-EpetraVector<T> &
-EpetraVector<T>::operator = (const EpetraVector<T> & v)
-{
-  (*_vec) = *v._vec;
-
-  // FIXME - what about our communications data?
-
+  // This function could be implemented in terms of the copy
+  // assignment operator (see other NumericVector subclasses) but that
+  // function is currently deleted so calling this function is an error.
+  // const EpetraVector<T> * v = cast_ptr<const EpetraVector<T> *>(&v_in);
+  // *this = *v;
+  libmesh_not_implemented();
   return *this;
 }
 


### PR DESCRIPTION
This PR replaces a hand-coded copy assignment operator and copy constructor with `= default` versions. This is good because the default functions are both self-documenting and don't get out of date when new members are added to classes. 
