### PR TITLE
Detect when PETSc is built with ParMETIS.

### DIFF
--- a/configure
+++ b/configure
@@ -32746,6 +32746,7 @@ fi
             petsc_have_chaco=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_CHACO`
             petsc_have_party=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_PARTY`
             petsc_have_ptscotch=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_PTSCOTCH`
+            petsc_have_parmetis=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_PARMETIS`
 
 else
   enablepetsc=no
@@ -35114,6 +35115,13 @@ fi
           if test $petsc_have_ptscotch -gt 0; then :
 
 $as_echo "#define PETSC_HAVE_PTSCOTCH 1" >>confdefs.h
+
+fi
+
+          # Set a #define if PETSc was built with ParMETIS support
+          if test $petsc_have_parmetis -gt 0; then :
+
+$as_echo "#define PETSC_HAVE_PARMETIS 1" >>confdefs.h
 
 fi
 

--- a/include/libmesh_config.h.in
+++ b/include/libmesh_config.h.in
@@ -646,6 +646,10 @@
 /* Flag indicating whether or not PETSc was configured with MUMPS support */
 #undef PETSC_HAVE_MUMPS
 
+/* Flag indicating whether or not PETSc was configured with ParMETIS support
+   */
+#undef PETSC_HAVE_PARMETIS
+
 /* Flag indicating whether or not PETSc was configured with PARTY support */
 #undef PETSC_HAVE_PARTY
 

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -99,6 +99,7 @@ AC_DEFUN([CONFIGURE_PETSC],
             petsc_have_chaco=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_CHACO`
             petsc_have_party=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_PARTY`
             petsc_have_ptscotch=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_PTSCOTCH`
+            petsc_have_parmetis=`cat ${PETSC_DIR}/include/petscconf.h ${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h 2>/dev/null | grep -c PETSC_HAVE_PARMETIS`
           ],
           [enablepetsc=no])
 
@@ -373,6 +374,10 @@ AC_DEFUN([CONFIGURE_PETSC],
           # Set a #define if PETSc was built with PTScotch support
           AS_IF([test $petsc_have_ptscotch -gt 0],
                 [AC_DEFINE(PETSC_HAVE_PTSCOTCH, 1, [Flag indicating whether or not PETSc was configured with PTSCOTCH support])])
+
+          # Set a #define if PETSc was built with ParMETIS support
+          AS_IF([test $petsc_have_parmetis -gt 0],
+                [AC_DEFINE(PETSC_HAVE_PARMETIS, 1, [Flag indicating whether or not PETSc was configured with ParMETIS support])])
 
           AC_SUBST(PETSC_ARCH) # Note: may be empty...
           AC_SUBST(PETSC_DIR)


### PR DESCRIPTION
Fixes #1762.

cc: @fdkong 