### PR TITLE
Disable HDF5 detection by default

### DIFF
--- a/configure
+++ b/configure
@@ -2030,7 +2030,8 @@ Optional Features:
   --disable-glpk          build without GLPK support
   --disable-nlopt         build without NLOPT support
   --disable-capnproto     build without Cap'n Proto support
-  --disable-hdf5          build without HDF5 support
+  --enable-hdf5           build libmesh with HDF5 support, the selected HDF5
+                          must be compatible with contrib/netcdf
   --disable-netcdf        build without netCDF binary I/O
   --disable-exodus        build without ExodusII API support
   --enable-exodus-fortran build with ExodusII Fortran API support
@@ -39830,7 +39831,7 @@ if test "${enable_hdf5+set}" = set; then :
     as_fn_error $? "bad value ${enableval} for --enable-hdf5" "$LINENO" 5 ;;
 esac
 else
-  enablehdf5=$enableoptional
+  enablehdf5=no
 fi
 
 

--- a/m4/hdf5.m4
+++ b/m4/hdf5.m4
@@ -4,13 +4,13 @@
 AC_DEFUN([CONFIGURE_HDF5],
 [
   AC_ARG_ENABLE(hdf5,
-                AS_HELP_STRING([--disable-hdf5],
-                               [build without HDF5 support]),
+                AS_HELP_STRING([--enable-hdf5],
+                               [build libmesh with HDF5 support, the selected HDF5 must be compatible with contrib/netcdf]),
                 [AS_CASE("${enableval}",
                          [yes], [enablehdf5=yes],
                          [no],  [enablehdf5=no],
                          [AC_MSG_ERROR(bad value ${enableval} for --enable-hdf5)])],
-                [enablehdf5=$enableoptional])
+                [enablehdf5=no])
 
   AS_IF([test "x$enablehdf5" = "xyes"],
         [


### PR DESCRIPTION
We require an HDF5 which is compatible with our bundled NetCDF, but I don't want to maintain a sophisticated configure test for this since HDF5 is still an optional dependency.

Closes #1585.
