### PR TITLE
Avoid unused lambda capture warnings.

### DIFF
--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1085,7 +1085,6 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
   auto action_functor =
     [
 #ifndef NDEBUG
-     this,
      &first_object_on_proc,
      &objects_on_proc,
 #endif

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -833,8 +833,8 @@ void MeshCommunication::find_global_indices (const Parallel::Communicator & comm
 #ifndef NDEBUG
      & upper_bounds,
      & communicator,
-#endif
      & bbox,
+#endif
      & my_bin,
        my_offset
     ]


### PR DESCRIPTION
I see these on newer versions of clang (3.5) but not older (3.9) ones.