### PR TITLE
Add -Wdeprecated-declarations to the list of warnings ignored on clang.

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -32,6 +32,7 @@
 #pragma clang diagnostic ignored "-Wnested-anon-types"
 #pragma clang diagnostic ignored "-Wsign-compare"
 #pragma clang diagnostic ignored "-Wunused-private-field"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #if (__clang_major__ > 3) || (__clang_major__ == 3 && __clang_minor__ > 5)
 // This was introduced in 3.6
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"


### PR DESCRIPTION
After a bit of Internet detective work, I figured out that the ability
to disable this warning has likely been around since at least April
2012, which corresponds to Clang version 3.1. I've therefore decided
not to guard this line with specific clang versions, but that could be
added later if we decide it's necessary.