### PR TITLE
Make C++11 decltype required, as it is now used in the library

### DIFF
--- a/configure
+++ b/configure
@@ -9569,10 +9569,6 @@ if test "x$have_cxx11_final" != "xyes"; then :
   as_fn_error $? "libMesh requires the C++11 final keyword" "$LINENO" 5
 fi
 
-# --------------------------------------------------------------
-# Test for optional modern C++ features, which libMesh offers shims
-# for and/or which libMesh applications may want to selectively use.
-# --------------------------------------------------------------
 
     have_cxx11_decltype=no
 
@@ -9591,6 +9587,7 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
+        #include <vector>
 
 int
 main ()
@@ -9598,6 +9595,9 @@ main ()
 
         int a;
         decltype(a) b;
+        std::vector<int> vec(10);
+        for (auto i = decltype(vec.size())(0); i < vec.size(); ++i)
+          vec[i] += i;
 
   ;
   return 0;
@@ -9638,6 +9638,14 @@ else
 fi
 
 
+if test "x$have_cxx11_decltype" != "xyes"; then :
+  as_fn_error $? "libMesh requires the C++11 decltype keyword" "$LINENO" 5
+fi
+
+# --------------------------------------------------------------
+# Test for optional modern C++ features, which libMesh offers shims
+# for and/or which libMesh applications may want to selectively use.
+# --------------------------------------------------------------
 
     have_cxx11_rvalue_references=no
 

--- a/configure.ac
+++ b/configure.ac
@@ -291,11 +291,14 @@ LIBMESH_TEST_CXX11_FINAL
 AS_IF([test "x$have_cxx11_final" != "xyes"],
       [AC_MSG_ERROR([libMesh requires the C++11 final keyword])])
 
+LIBMESH_TEST_CXX11_DECLTYPE
+AS_IF([test "x$have_cxx11_decltype" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires the C++11 decltype keyword])])
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.
 # --------------------------------------------------------------
-LIBMESH_TEST_CXX11_DECLTYPE
 LIBMESH_TEST_CXX11_RVALUE_REFERENCES
 LIBMESH_TEST_CXX11_CONSTEXPR
 LIBMESH_TEST_CXX11_ALIAS_DECLARATIONS

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -221,9 +221,13 @@ AC_DEFUN([LIBMESH_TEST_CXX11_DECLTYPE],
     CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
 
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+        @%:@include <vector>
     ]], [[
         int a;
         decltype(a) b;
+        std::vector<int> vec(10);
+        for (auto i = decltype(vec.size())(0); i < vec.size(); ++i)
+          vec[i] += i;
     ]])],[
         AC_MSG_RESULT(yes)
         AC_DEFINE(HAVE_CXX11_DECLTYPE, 1, [Flag indicating whether compiler supports decltype])


### PR DESCRIPTION

Refs #1751.
