### PR TITLE
Add configure option to require PETSc with builtin Hypre

### DIFF
--- a/configure
+++ b/configure
@@ -1201,6 +1201,7 @@ with_boost
 with_boost_libdir
 enable_petsc
 enable_petsc_required
+enable_petsc_hypre_required
 with_mpi
 with_gm
 enable_slepc
@@ -2001,6 +2002,9 @@ Optional Features:
                           support
   --disable-petsc         build without PETSc iterative solver support
   --enable-petsc-required Error if PETSc is not detected by configure
+  --enable-petsc-hypre-required
+                          Error if a PETSc with Hypre is not detected by
+                          configure
   --disable-slepc         build without SLEPc eigen solver support
   --disable-trilinos      build without Trilinos support
   --disable-pthreads      build without POSIX threading (pthreads) support
@@ -32618,6 +32622,27 @@ else
 fi
 
 
+  # Setting --enable-petsc-hypre-required causes an error to be
+  # emitted during configure if PETSc with builtin Hypre is not
+  # detected successfully.  This is useful for app codes which require
+  # both PETSc and Hypre (like MOOSE-based apps), since it prevents
+  # libmesh from being accidentally built without PETSc and Hypre
+  # support.
+  # Check whether --enable-petsc-hypre-required was given.
+if test "${enable_petsc_hypre_required+set}" = set; then :
+  enableval=$enable_petsc_hypre_required; case "${enableval}" in #(
+  yes) :
+    petschyprerequired=yes ;; #(
+  no) :
+    petschyprerequired=no ;; #(
+  *) :
+    as_fn_error $? "bad value ${enableval} for --enable-petsc-hypre-required" "$LINENO" 5 ;;
+esac
+else
+  petschyprerequired=no
+fi
+
+
   # Trump --enable-petsc with --disable-mpi
   if test "x$enablempi" = xno; then :
   enablepetsc=no
@@ -33359,6 +33384,7 @@ fi
           PETSCINCLUDEDIRS="$PETSCINCLUDEDIRS $PETSC_CC_INCLUDES"
 
           # Check for Hypre
+          petsc_have_hypre=no
           if test -r $PETSC_DIR/bmake/$PETSC_ARCH/petscconf; then :
                   HYPRE_LIB=`grep "HYPRE_LIB" $PETSC_DIR/bmake/$PETSC_ARCH/petscconf`
 elif test -r $PETSC_DIR/$PETSC_ARCH/conf/petscvariables; then :
@@ -33370,7 +33396,8 @@ elif test -r $PETSC_DIR/lib/petsc/conf/petscvariables; then :
 fi
 
           if test "x$HYPRE_LIB" != x; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with Hypre support >>>" >&5
+  petsc_have_hypre=yes
+                 { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Configuring library with Hypre support >>>" >&5
 $as_echo "<<< Configuring library with Hypre support >>>" >&6; }
 fi
 
@@ -35141,7 +35168,7 @@ $as_echo "#define HAVE_MPI 1" >>confdefs.h
 
 fi
 
-          if test "x$HYPRE_LIB" != x; then :
+          if test "x$petsc_have_hypre" = "xyes"; then :
 
 $as_echo "#define HAVE_PETSC_HYPRE 1" >>confdefs.h
 
@@ -35163,6 +35190,11 @@ fi
   # instead of compiling libmesh in an invalid configuration.
   if test "$enablepetsc" = "no" && test "$petscrequired" = "yes"; then :
                                   as_fn_error 3 "*** PETSc was not found, but --enable-petsc-required was specified." "$LINENO" 5
+fi
+
+  # If PETSc + Hypre is required, throw an error if we don't have it.
+  if test "x$petschyprerequired" = "xyes" && test "x$petsc_have_hypre" != "xyes"; then :
+  as_fn_error 4 "*** PETSc with Hypre was not found, but --enable-petsc-hypre-required was specified." "$LINENO" 5
 fi
 
 if test $enablempi != no; then :


### PR DESCRIPTION
This will prevent MOOSE users from accidentally building all of libMesh and MOOSE with an incorrect/unsuitable PETSc that does not have Hypre built-in.
