### PR TITLE
Test repartition-only-then-reinit

### DIFF
--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -154,6 +154,11 @@ void Partitioner::single_partition (MeshBase & mesh)
 {
   this->single_partition_range(mesh.elements_begin(),
                                mesh.elements_end());
+
+  // Redistribute, in case someone (like our unit tests) is doing
+  // something silly (like moving a whole already-distributed mesh
+  // back onto rank 0).
+  mesh.redistribute();
 }
 
 


### PR DESCRIPTION
This actually caught a bug, albeit in a case nobody would use in real life: if you tried to move an already-distributed mesh onto rank 0, it would break.

Sorry to @boyceg for the false alarm on the mailing list.  It looks like, with that bug fixed (or with more realistic cases where that bug wasn't in play) it should be safe to call EquationSystems::reinit() straight away after repartitioning.