### PR TITLE
Don't set "I_duped_it" to true for undefined

### DIFF
--- a/src/parallel/communicator.C
+++ b/src/parallel/communicator.C
@@ -94,7 +94,7 @@ void Communicator::split(int color, int key, Communicator & target) const
     (MPI_Comm_split(this->get(), color, key, &newcomm));
 
   target.assign(newcomm);
-  target._I_duped_it = true;
+  target._I_duped_it = (color != MPI_UNDEFINED);
   target.send_mode(this->send_mode());
 }
 #else


### PR DESCRIPTION
When using MPI_UNDEFINED, you don't expect to get a new communicator
object so when deleting the Communicator you end up tripping an assertion.