### PR TITLE
ErrorVector::plot_error Nemesis support

### DIFF
--- a/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
+++ b/examples/adaptivity/adaptivity_ex3/adaptivity_ex3.C
@@ -407,7 +407,11 @@ int main(int argc, char ** argv)
               std::ostringstream ss;
               ss << r_step;
 #ifdef LIBMESH_HAVE_EXODUS_API
+#  ifdef LIBMESH_HAVE_NEMESIS_API
+              std::string error_output = "error_" + ss.str() + ".n";
+#  else
               std::string error_output = "error_" + ss.str() + ".e";
+#  endif
 #else
               std::string error_output = "error_" + ss.str() + ".gmv";
 #endif

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1890,18 +1890,10 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
 
     // The number of node communication maps is the number of other processors
     // with which we share nodes. (I think.) This is just the size of the map we just
-    // created, minus 1.
+    // created, minus 1 unless this processor has no nodes of its own.
     this->num_node_cmaps =
-      cast_int<int>(proc_nodes_touched.size() - 1);
-
-    // If we've got no elements on this processor and haven't touched
-    // any nodes, however, then that's 0 other processors with which
-    // we share nodes, not -1.
-    if (this->num_node_cmaps == -1)
-      {
-        libmesh_assert (pmesh.active_elements_begin() == pmesh.active_elements_end());
-        this->num_node_cmaps = 0;
-      }
+      cast_int<int>(proc_nodes_touched.size() -
+                    proc_nodes_touched.count(this->processor_id()));
 
     // We can't be connecting to more processors than exist outside
     // ourselves

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -574,18 +574,18 @@ void Nemesis_IO_Helper::put_cmap_params(std::vector<int> & node_cmap_ids_in,
                                         std::vector<int> & elem_cmap_ids_in,
                                         std::vector<int> & elem_cmap_elem_cnts_in)
 {
-  // We might not have cmaps on every processor in some corner
-  // cases
-  if (node_cmap_ids.size())
-    {
-      nemesis_err_flag =
-        Nemesis::ne_put_cmap_params(ex_id,
-                                    &node_cmap_ids_in[0],
-                                    &node_cmap_node_cnts_in[0],
-                                    &elem_cmap_ids_in[0],
-                                    &elem_cmap_elem_cnts_in[0],
-                                    this->processor_id());
-    }
+  libmesh_assert(!node_cmap_ids_in.empty());
+  libmesh_assert(!node_cmap_node_cnts_in.empty());
+  libmesh_assert(!elem_cmap_ids_in.empty());
+  libmesh_assert(!elem_cmap_elem_cnts_in.empty());
+
+  nemesis_err_flag =
+    Nemesis::ne_put_cmap_params(ex_id,
+                                &node_cmap_ids_in[0],
+                                &node_cmap_node_cnts_in[0],
+                                &elem_cmap_ids_in[0],
+                                &elem_cmap_elem_cnts_in[0],
+                                this->processor_id());
 
   EX_CHECK_ERR(nemesis_err_flag, "Error writing cmap parameters!");
 }
@@ -862,49 +862,48 @@ void Nemesis_IO_Helper::initialize(std::string title_in, const MeshBase & mesh, 
   // when the mesh file is read back in.
   this->compute_communication_map_parameters();
 
-  // Write communication map parameters to file.
-  this->put_cmap_params(this->node_cmap_ids,
-                        this->node_cmap_node_cnts,
-                        this->elem_cmap_ids,
-                        this->elem_cmap_elem_cnts);
+  // Do we have communication maps to write?  Note that
+  // ne_put_cmap_params expects us to have either *both* node and elem
+  // cmaps or *neither*
+  if (!this->node_cmap_ids.empty() &&
+      !this->node_cmap_node_cnts.empty() &&
+      !this->elem_cmap_ids.empty() &&
+      !this->elem_cmap_elem_cnts.empty())
+    {
+      // Write communication map parameters to file.
+      this->put_cmap_params(this->node_cmap_ids,
+                            this->node_cmap_node_cnts,
+                            this->elem_cmap_ids,
+                            this->elem_cmap_elem_cnts);
 
+      // Ready the node communication maps.  The node IDs which
+      // are communicated are the ones currently stored in
+      // proc_nodes_touched_intersections.
+      this->compute_node_communication_maps();
 
-  // Ready the node communication maps.  The node IDs which
-  // are communicated are the ones currently stored in
-  // proc_nodes_touched_intersections.
-  this->compute_node_communication_maps();
+      // Write the packed node communication vectors to file.
+      this->put_node_cmap(this->node_cmap_node_ids,
+                          this->node_cmap_proc_ids);
 
-  // Write the packed node communication vectors to file.
-  this->put_node_cmap(this->node_cmap_node_ids,
-                      this->node_cmap_proc_ids);
+      // Ready the node maps.  These have nothing to do with communication, they map
+      // the nodes to internal, border, and external nodes in the file.
+      this->compute_node_maps();
 
+      // Call the Nemesis API to write the node maps to file.
+      this->put_node_map(this->node_mapi,
+                         this->node_mapb,
+                         this->node_mape);
 
-  // Ready the node maps.  These have nothing to do with communication, they map
-  // the nodes to internal, border, and external nodes in the file.
-  this->compute_node_maps();
+      // Ready the element communication maps.  This includes border
+      // element IDs, sides which are on the border, and the processors to which
+      // they are to be communicated...
+      this->compute_elem_communication_maps();
 
-  // Call the Nemesis API to write the node maps to file.
-  this->put_node_map(this->node_mapi,
-                     this->node_mapb,
-                     this->node_mape);
-
-
-
-  // Ready the element communication maps.  This includes border
-  // element IDs, sides which are on the border, and the processors to which
-  // they are to be communicated...
-  this->compute_elem_communication_maps();
-
-
-
-  // Call the Nemesis API to write the packed element communication maps vectors to file
-  this->put_elem_cmap(this->elem_cmap_elem_ids,
-                      this->elem_cmap_side_ids,
-                      this->elem_cmap_proc_ids);
-
-
-
-
+      // Call the Nemesis API to write the packed element communication maps vectors to file
+      this->put_elem_cmap(this->elem_cmap_elem_ids,
+                          this->elem_cmap_side_ids,
+                          this->elem_cmap_proc_ids);
+    }
 
 
   // Ready the Nemesis element maps (internal and border) for writing to file.
@@ -913,7 +912,6 @@ void Nemesis_IO_Helper::initialize(std::string title_in, const MeshBase & mesh, 
   // Call the Nemesis API to write the internal and border element IDs.
   this->put_elem_map(this->elem_mapi,
                      this->elem_mapb);
-
 
   // Now write Exodus-specific initialization information, some of which is
   // different when you are using Nemesis.

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1113,6 +1113,10 @@ void Nemesis_IO_Helper::compute_node_communication_maps()
   this->node_cmap_node_ids.clear();
   this->node_cmap_proc_ids.clear();
 
+  libmesh_assert_less_equal
+    (this->proc_nodes_touched_intersections.size(),
+     std::size_t(this->num_node_cmaps));
+
   // Allocate enough space for all our node maps
   this->node_cmap_node_ids.resize(this->num_node_cmaps);
   this->node_cmap_proc_ids.resize(this->num_node_cmaps);
@@ -1962,6 +1966,10 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
         // Swap our intermediate result into the final set
         this->border_node_ids.swap(intermediate_result);
       }
+
+    libmesh_assert_less_equal
+      (this->proc_nodes_touched_intersections.size(),
+       std::size_t(this->num_node_cmaps));
 
     if (verbose)
       {

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -621,11 +621,14 @@ void Nemesis_IO_Helper::put_node_cmap(std::vector<std::vector<int>> & node_cmap_
 
   for (std::size_t i=0; i<node_cmap_node_ids_in.size(); ++i)
     {
+      int * node_ids_ptr = node_cmap_node_ids_in[i].empty() ?
+        nullptr : &node_cmap_node_ids_in[i][0];
+      int * proc_ids_ptr = node_cmap_proc_ids_in[i].empty() ?
+        nullptr : &node_cmap_proc_ids_in[i][0];
+
       nemesis_err_flag =
-        Nemesis::ne_put_node_cmap(ex_id,
-                                  this->node_cmap_ids[i],
-                                  &node_cmap_node_ids_in[i][0],
-                                  &node_cmap_proc_ids_in[i][0],
+        Nemesis::ne_put_node_cmap(ex_id, this->node_cmap_ids[i],
+                                  node_ids_ptr, proc_ids_ptr,
                                   this->processor_id());
 
       EX_CHECK_ERR(nemesis_err_flag, "Error writing node communication map to file!");

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -796,12 +796,11 @@ void PetscVector<T>::localize (std::vector<T> & v_local,
   // Create an IS using the libmesh routine.  PETSc does not own the
   // IS memory in this case, it is automatically cleaned up by the
   // std::vector destructor.
+  PetscInt * idxptr =
+    indices.empty() ? nullptr : numeric_petsc_cast(&indices[0]);
   IS is;
-  ierr = ISCreateLibMesh(this->comm().get(),
-                         indices.size(),
-                         numeric_petsc_cast(&indices[0]),
-                         PETSC_USE_POINTER,
-                         &is);
+  ierr = ISCreateLibMesh(this->comm().get(), indices.size(), idxptr,
+                         PETSC_USE_POINTER, &is);
   LIBMESH_CHKERR(ierr);
 
   // Create the VecScatter object. "PETSC_NULL" means "use the identity IS".

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -747,12 +747,9 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in,
     idx[n_sl+i] = i + this->first_local_index();
 
   // Create the index set & scatter object
-  if (idx.empty())
-    ierr = ISCreateLibMesh(this->comm().get(),
-                           n_sl+this->local_size(), PETSC_NULL, PETSC_USE_POINTER, &is);
-  else
-    ierr = ISCreateLibMesh(this->comm().get(),
-                           n_sl+this->local_size(), &idx[0], PETSC_USE_POINTER, &is);
+  PetscInt * idxptr = idx.empty() ? nullptr : &idx[0];
+  ierr = ISCreateLibMesh(this->comm().get(), n_sl+this->local_size(),
+                         idxptr, PETSC_USE_POINTER, &is);
   LIBMESH_CHKERR(ierr);
 
   ierr = VecScatterCreate(_vec,          is,

--- a/src/utils/error_vector.C
+++ b/src/utils/error_vector.C
@@ -20,19 +20,21 @@
 #include <limits>
 
 // Local includes
-#include "libmesh/elem.h"
-#include "libmesh/error_vector.h"
-#include "libmesh/libmesh_logging.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/elem.h"
+#include "libmesh/enum_xdr_mode.h"
+#include "libmesh/error_vector.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/explicit_system.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/gmv_io.h"
-#include "libmesh/tecplot_io.h"
+
 #include "libmesh/exodusII_io.h"
+#include "libmesh/gmv_io.h"
+#include "libmesh/nemesis_io.h"
+#include "libmesh/tecplot_io.h"
 #include "libmesh/xdr_io.h"
-#include "libmesh/enum_xdr_mode.h"
 
 namespace libMesh
 {
@@ -274,6 +276,15 @@ void ErrorVector::plot_error(const std::string & filename,
       TecplotIO (mesh).write_equation_systems
         (filename, temp_es);
     }
+#if defined(LIBMESH_HAVE_EXODUS_API) && defined(LIBMESH_HAVE_NEMESIS_API)
+  else if ((filename.rfind(".nem") < filename.size()) ||
+           (filename.rfind(".n") < filename.size()))
+    {
+      Nemesis_IO io(mesh);
+      io.write(filename);
+      io.write_element_data(temp_es);
+    }
+#endif
 #ifdef LIBMESH_HAVE_EXODUS_API
   else if ((filename.rfind(".exo") < filename.size()) ||
            (filename.rfind(".e") < filename.size()))


### PR DESCRIPTION
Plotting error indicator output is often nice.  Plotting it to a
standard format that viz tools can read is nice.  Being unable to do
that on a distributed mesh without serializing first is not nice, so
let's fix that.