### PR TITLE
More warning fixes

### DIFF
--- a/include/partitioning/parmetis_helper.h
+++ b/include/partitioning/parmetis_helper.h
@@ -73,16 +73,20 @@ public:
   std::vector<Parmetis::idx_t>  vtxdist;
   std::vector<Parmetis::idx_t>  xadj;
   std::vector<Parmetis::idx_t>  adjncy;
+
+  // We use dof_id_type for part so we can pass it directly to
+  // Partitioner:: methods expecting that type.
   std::vector<dof_id_type>  part;
+
+  // But we plan to pass a pointer to part as a buffer to ParMETIS, so
+  // it had better be using a simply reinterpretable type!
+  static_assert(sizeof(Parmetis::idx_t) == sizeof(dof_id_type),
+                "ParMETIS and libMesh ID sizes must match!");
+
   std::vector<Parmetis::real_t> tpwgts;
   std::vector<Parmetis::real_t> ubvec;
   std::vector<Parmetis::idx_t>  options;
   std::vector<Parmetis::idx_t>  vwgt;
-
-  // We plan to pass part as a buffer to ParMETIS, so it had better be
-  // using the same type!
-  static_assert(sizeof(Parmetis::idx_t) == sizeof(dof_id_type),
-                "ParMETIS and libMesh ID sizes must match!");
 
   Parmetis::idx_t wgtflag;
   Parmetis::idx_t ncon;

--- a/include/partitioning/parmetis_helper.h
+++ b/include/partitioning/parmetis_helper.h
@@ -73,11 +73,16 @@ public:
   std::vector<Parmetis::idx_t>  vtxdist;
   std::vector<Parmetis::idx_t>  xadj;
   std::vector<Parmetis::idx_t>  adjncy;
-  std::vector<Parmetis::idx_t>  part;
+  std::vector<dof_id_type>  part;
   std::vector<Parmetis::real_t> tpwgts;
   std::vector<Parmetis::real_t> ubvec;
   std::vector<Parmetis::idx_t>  options;
   std::vector<Parmetis::idx_t>  vwgt;
+
+  // We plan to pass part as a buffer to ParMETIS, so it had better be
+  // using the same type!
+  static_assert(sizeof(Parmetis::idx_t) == sizeof(dof_id_type),
+                "ParMETIS and libMesh ID sizes must match!");
 
   Parmetis::idx_t wgtflag;
   Parmetis::idx_t ncon;

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -48,6 +48,10 @@
 #pragma GCC diagnostic ignored "-Wdeprecated"
 // But this is helpful with some MPI stacks
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+// And this is for cppunit
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+// And this is for Trilinos
+#pragma GCC diagnostic ignored "-Wextra"
 // Ignore warnings from code that uses deprecated members of std, like std::auto_ptr.
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #if (__GNUC__ > 5)

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -189,8 +189,6 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
                                        &mpi_comm);
 
   // Assign the returned processor ids
-  static_assert(sizeof(dof_id_type) == sizeof(Parmetis::idx_t),
-                "libMesh and Parmetis integer sizes must match!");
   this->assign_partitioning (mesh, _pmetis->part);
 
 #endif // #ifndef LIBMESH_HAVE_PARMETIS ... else ...

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -185,13 +185,13 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
                                        &itr,
                                        &_pmetis->options[0],
                                        &_pmetis->edgecut,
-                                       _pmetis->part.empty()    ? nullptr : &_pmetis->part[0],
+                                       _pmetis->part.empty()    ? nullptr : reinterpret_cast<Parmetis::idx_t *>(&_pmetis->part[0]),
                                        &mpi_comm);
 
   // Assign the returned processor ids
   static_assert(sizeof(dof_id_type) == sizeof(Parmetis::idx_t),
                 "libMesh and Parmetis integer sizes must match!");
-  this->assign_partitioning (mesh, reinterpret_cast<std::vector<dof_id_type> &> (_pmetis->part));
+  this->assign_partitioning (mesh, _pmetis->part);
 
 #endif // #ifndef LIBMESH_HAVE_PARMETIS ... else ...
 

--- a/tests/driver.C
+++ b/tests/driver.C
@@ -1,5 +1,8 @@
+// Ignore overloaded-virtual warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
+#include <libmesh/restore_warnings.h>
 
 #include <libmesh/libmesh.h>
 


### PR DESCRIPTION
This cleans up the warning from #1793 as well as a couple others that had been bothering me.  libMesh (except for contrib/) now compiles cleanly for me.