### PR TITLE
PetscDMWrapper: Fieldsplit Capabilities (Replaces #1568)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -457,7 +457,7 @@ am__libmesh_dbg_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -863,6 +863,7 @@ am__objects_1 = src/base/libmesh_dbg_la-default_coupling.lo \
 	src/solvers/libmesh_dbg_la-optimization_solver.lo \
 	src/solvers/libmesh_dbg_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_dbg_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_dbg_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_dbg_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_dbg_la-petscdmlibmesh.lo \
@@ -1183,7 +1184,7 @@ am__libmesh_devel_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -1588,6 +1589,7 @@ am__objects_2 = src/base/libmesh_devel_la-default_coupling.lo \
 	src/solvers/libmesh_devel_la-optimization_solver.lo \
 	src/solvers/libmesh_devel_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_devel_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_devel_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_devel_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_devel_la-petscdmlibmesh.lo \
@@ -1905,7 +1907,7 @@ am__libmesh_oprof_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -2310,6 +2312,7 @@ am__objects_3 = src/base/libmesh_oprof_la-default_coupling.lo \
 	src/solvers/libmesh_oprof_la-optimization_solver.lo \
 	src/solvers/libmesh_oprof_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_oprof_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_oprof_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_oprof_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_oprof_la-petscdmlibmesh.lo \
@@ -2627,7 +2630,7 @@ am__libmesh_opt_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -3032,6 +3035,7 @@ am__objects_4 = src/base/libmesh_opt_la-default_coupling.lo \
 	src/solvers/libmesh_opt_la-optimization_solver.lo \
 	src/solvers/libmesh_opt_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_opt_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_opt_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_opt_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_opt_la-petscdmlibmesh.lo \
@@ -3348,7 +3352,7 @@ am__libmesh_prof_la_SOURCES_DIST = src/base/default_coupling.C \
 	src/solvers/nonlinear_solver.C \
 	src/solvers/optimization_solver.C \
 	src/solvers/petsc_auto_fieldsplit.C \
-	src/solvers/petsc_diff_solver.C \
+	src/solvers/petsc_diff_solver.C src/solvers/petsc_dm_wrapper.C \
 	src/solvers/petsc_linear_solver.C \
 	src/solvers/petsc_nonlinear_solver.C \
 	src/solvers/petscdmlibmesh.C src/solvers/petscdmlibmeshimpl.C \
@@ -3753,6 +3757,7 @@ am__objects_5 = src/base/libmesh_prof_la-default_coupling.lo \
 	src/solvers/libmesh_prof_la-optimization_solver.lo \
 	src/solvers/libmesh_prof_la-petsc_auto_fieldsplit.lo \
 	src/solvers/libmesh_prof_la-petsc_diff_solver.lo \
+	src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo \
 	src/solvers/libmesh_prof_la-petsc_linear_solver.lo \
 	src/solvers/libmesh_prof_la-petsc_nonlinear_solver.lo \
 	src/solvers/libmesh_prof_la-petscdmlibmesh.lo \
@@ -5188,6 +5193,7 @@ libmesh_SOURCES = \
         src/solvers/optimization_solver.C \
         src/solvers/petsc_auto_fieldsplit.C \
         src/solvers/petsc_diff_solver.C \
+        src/solvers/petsc_dm_wrapper.C \
         src/solvers/petsc_linear_solver.C \
         src/solvers/petsc_nonlinear_solver.C \
         src/solvers/petscdmlibmesh.C \
@@ -6589,6 +6595,9 @@ src/solvers/libmesh_dbg_la-petsc_auto_fieldsplit.lo:  \
 src/solvers/libmesh_dbg_la-petsc_diff_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_dbg_la-petsc_linear_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -7643,6 +7652,9 @@ src/solvers/libmesh_devel_la-petsc_auto_fieldsplit.lo:  \
 src/solvers/libmesh_devel_la-petsc_diff_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_devel_la-petsc_linear_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -8687,6 +8699,9 @@ src/solvers/libmesh_oprof_la-petsc_auto_fieldsplit.lo:  \
 src/solvers/libmesh_oprof_la-petsc_diff_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_oprof_la-petsc_linear_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -9729,6 +9744,9 @@ src/solvers/libmesh_opt_la-petsc_auto_fieldsplit.lo:  \
 src/solvers/libmesh_opt_la-petsc_diff_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_opt_la-petsc_linear_solver.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
@@ -10767,6 +10785,9 @@ src/solvers/libmesh_prof_la-petsc_auto_fieldsplit.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_prof_la-petsc_diff_solver.lo:  \
+	src/solvers/$(am__dirstamp) \
+	src/solvers/$(DEPDIR)/$(am__dirstamp)
+src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo:  \
 	src/solvers/$(am__dirstamp) \
 	src/solvers/$(DEPDIR)/$(am__dirstamp)
 src/solvers/libmesh_prof_la-petsc_linear_solver.lo:  \
@@ -13227,6 +13248,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_dbg_la-petscdmlibmesh.Plo@am__quote@
@@ -13259,6 +13281,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_devel_la-petscdmlibmesh.Plo@am__quote@
@@ -13291,6 +13314,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_oprof_la-petscdmlibmesh.Plo@am__quote@
@@ -13323,6 +13347,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_opt_la-petscdmlibmesh.Plo@am__quote@
@@ -13355,6 +13380,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-optimization_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_auto_fieldsplit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_diff_solver.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_dm_wrapper.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_linear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_nonlinear_solver.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/solvers/$(DEPDIR)/libmesh_prof_la-petscdmlibmesh.Plo@am__quote@
@@ -16179,6 +16205,13 @@ src/solvers/libmesh_dbg_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_diff_solver.C' object='src/solvers/libmesh_dbg_la-petsc_diff_solver.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_dbg_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
+
+src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_dbg_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
 
 src/solvers/libmesh_dbg_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_dbg_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_dbg_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_dbg_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_dbg_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_dbg_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C
@@ -19148,6 +19181,13 @@ src/solvers/libmesh_devel_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_devel_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
 
+src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_devel_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+
 src/solvers/libmesh_devel_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_devel_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_devel_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_devel_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_devel_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_linear_solver.Tpo src/solvers/$(DEPDIR)/libmesh_devel_la-petsc_linear_solver.Plo
@@ -22115,6 +22155,13 @@ src/solvers/libmesh_oprof_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_diff_solver.C' object='src/solvers/libmesh_oprof_la-petsc_diff_solver.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_oprof_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
+
+src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_oprof_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
 
 src/solvers/libmesh_oprof_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_oprof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_oprof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_oprof_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_oprof_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_oprof_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C
@@ -25084,6 +25131,13 @@ src/solvers/libmesh_opt_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_opt_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
 
+src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_opt_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+
 src/solvers/libmesh_opt_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_opt_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_opt_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_opt_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_opt_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_linear_solver.Tpo src/solvers/$(DEPDIR)/libmesh_opt_la-petsc_linear_solver.Plo
@@ -28051,6 +28105,13 @@ src/solvers/libmesh_prof_la-petsc_diff_solver.lo: src/solvers/petsc_diff_solver.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_diff_solver.C' object='src/solvers/libmesh_prof_la-petsc_diff_solver.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_prof_la-petsc_diff_solver.lo `test -f 'src/solvers/petsc_diff_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_diff_solver.C
+
+src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo: src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_dm_wrapper.Tpo -c -o src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_dm_wrapper.Tpo src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_dm_wrapper.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='src/solvers/petsc_dm_wrapper.C' object='src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -c -o src/solvers/libmesh_prof_la-petsc_dm_wrapper.lo `test -f 'src/solvers/petsc_dm_wrapper.C' || echo '$(srcdir)/'`src/solvers/petsc_dm_wrapper.C
 
 src/solvers/libmesh_prof_la-petsc_linear_solver.lo: src/solvers/petsc_linear_solver.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libmesh_prof_la_CPPFLAGS) $(CPPFLAGS) $(libmesh_prof_la_CXXFLAGS) $(CXXFLAGS) -MT src/solvers/libmesh_prof_la-petsc_linear_solver.lo -MD -MP -MF src/solvers/$(DEPDIR)/libmesh_prof_la-petsc_linear_solver.Tpo -c -o src/solvers/libmesh_prof_la-petsc_linear_solver.lo `test -f 'src/solvers/petsc_linear_solver.C' || echo '$(srcdir)/'`src/solvers/petsc_linear_solver.C

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -949,6 +949,7 @@ include_HEADERS = \
         solvers/optimization_solver.h \
         solvers/petsc_auto_fieldsplit.h \
         solvers/petsc_diff_solver.h \
+        solvers/petsc_dm_wrapper.h \
         solvers/petsc_linear_solver.h \
         solvers/petsc_nonlinear_solver.h \
         solvers/petscdmlibmesh.h \

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -685,6 +685,13 @@ public:
   bool all_semilocal_indices (const std::vector<dof_id_type> & dof_indices) const;
 
   /**
+   * \returns \p true if degree of freedom index \p dof_index
+   * is a local index.
+   */
+  bool local_index (dof_id_type dof_index) const
+  { return (dof_index >= this->first_dof()) && (dof_index < this->end_dof()); }
+
+  /**
    * \returns \p true iff our solutions can be locally evaluated on
    * \p obj (which should be an Elem or a Node) for variable number \p
    * var_num (for all variables, if \p var_num is invalid_uint)

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -374,6 +374,7 @@ include_HEADERS =  \
         solvers/optimization_solver.h \
         solvers/petsc_auto_fieldsplit.h \
         solvers/petsc_diff_solver.h \
+        solvers/petsc_dm_wrapper.h \
         solvers/petsc_linear_solver.h \
         solvers/petsc_nonlinear_solver.h \
         solvers/petscdmlibmesh.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -370,6 +370,7 @@ BUILT_SOURCES = \
         optimization_solver.h \
         petsc_auto_fieldsplit.h \
         petsc_diff_solver.h \
+        petsc_dm_wrapper.h \
         petsc_linear_solver.h \
         petsc_nonlinear_solver.h \
         petscdmlibmesh.h \
@@ -1633,6 +1634,9 @@ petsc_auto_fieldsplit.h: $(top_srcdir)/include/solvers/petsc_auto_fieldsplit.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_diff_solver.h: $(top_srcdir)/include/solvers/petsc_diff_solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_dm_wrapper.h: $(top_srcdir)/include/solvers/petsc_dm_wrapper.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_linear_solver.h: $(top_srcdir)/include/solvers/petsc_linear_solver.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -615,7 +615,7 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	memory_solution_history.h newmark_solver.h newton_solver.h \
 	nlopt_optimization_solver.h no_solution_history.h \
 	nonlinear_solver.h optimization_solver.h \
-	petsc_auto_fieldsplit.h petsc_diff_solver.h \
+	petsc_auto_fieldsplit.h petsc_diff_solver.h petsc_dm_wrapper.h \
 	petsc_linear_solver.h petsc_nonlinear_solver.h \
 	petscdmlibmesh.h second_order_unsteady_solver.h \
 	slepc_eigen_solver.h slepc_macro.h solution_history.h \
@@ -1975,6 +1975,9 @@ petsc_auto_fieldsplit.h: $(top_srcdir)/include/solvers/petsc_auto_fieldsplit.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_diff_solver.h: $(top_srcdir)/include/solvers/petsc_diff_solver.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+petsc_dm_wrapper.h: $(top_srcdir)/include/solvers/petsc_dm_wrapper.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 petsc_linear_solver.h: $(top_srcdir)/include/solvers/petsc_linear_solver.h

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -27,6 +27,7 @@
 // Local includes
 #include "libmesh/diff_solver.h"
 #include "libmesh/petsc_macro.h"
+#include "libmesh/petsc_dm_wrapper.h"
 
 // PETSc includes
 # include <petscsnes.h>
@@ -91,6 +92,11 @@ protected:
    * Nonlinear solver context
    */
   SNES _snes;
+
+  /**
+   * Wrapper object for interacting with PetscDM
+   */
+  PetscDMWrapper _dm_wrapper;
 
 private:
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -105,6 +105,14 @@ private:
                                    PetscSection & section,
                                    std::unordered_map<dof_id_type,dof_id_type> & node_map);
 
+  //! Helper function for build_section.
+  /**
+   * This function will set the DoF info for each "point" in the PetscSection.
+   */
+  void add_dofs_to_section (const System & system,
+                            PetscSection & section,
+                            const std::unordered_map<dof_id_type,dof_id_type> & node_map);
+
 };
 
 }

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -106,6 +106,20 @@ private:
    */
   void build_section(const System & system, PetscSection & section);
 
+  //! Takes System, empty PetscSF and populates the PetscSF
+  /**
+   * The PetscSF (star forest) is a cousin of PetscSection. PetscSection
+   * has the DoF info, and PetscSF gives the parallel distribution of the
+   * DoF info. So PetscSF should only be necessary when we have more than
+   * one MPI rank. Essentially, we are copying the DofMap.send_list(): we
+   * are specifying the local dofs, what rank communicates that dof info
+   * (for off-processor dofs that are communicated) and the dofs local
+   * index on that rank.
+   *
+   * https://jedbrown.org/files/StarForest.pdf
+   */
+  void build_sf( const System & system, PetscSF & star_forest );
+
   //! Helper function for build_section.
   /**
    * This function will count how many "points" on the current processor have

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -101,9 +101,6 @@ private:
    * face, or element. Then, we also add the DoF numbering for each variable
    * for each of the "points". The PetscSection, together the with PetscSF
    * will allow for recursive fieldsplits from the command line using PETSc.
-   *
-   * TODO: Currently only populates nodal DoF data. Need to generalize
-   *       elem DoFs as well.
    */
   void build_section(const System & system, PetscSection & section);
 
@@ -117,7 +114,8 @@ private:
    */
   void set_point_range_in_section( const System & system,
                                    PetscSection & section,
-                                   std::unordered_map<dof_id_type,dof_id_type> & node_map);
+                                   std::unordered_map<dof_id_type,dof_id_type> & node_map,
+                                   std::unordered_map<dof_id_type,dof_id_type> & elem_map);
 
   //! Helper function for build_section.
   /**
@@ -125,7 +123,8 @@ private:
    */
   void add_dofs_to_section (const System & system,
                             PetscSection & section,
-                            const std::unordered_map<dof_id_type,dof_id_type> & node_map);
+                            const std::unordered_map<dof_id_type,dof_id_type> & node_map,
+                            const std::unordered_map<dof_id_type,dof_id_type> & elem_map);
 
 };
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -22,6 +22,12 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+#include <vector>
+#include <memory>
+
+// PETSc includes
+#include <petsc.h>
+
 namespace libMesh
 {
 
@@ -42,6 +48,44 @@ public:
   PetscDMWrapper() = default;
 
   ~PetscDMWrapper(){};
+
+private:
+
+  //! Vector of DMs for all grid levels
+  std::vector<std::unique_ptr<DM>> _dms;
+
+  //! Vector of PETScSections for all grid levels
+  std::vector<std::unique_ptr<PetscSection>> _sections;
+
+  //! Vector of star forests for all grid levels
+  std::vector<std::unique_ptr<PetscSF>> _star_forests;
+
+  //! Init all the n_mesh_level dependent data structures
+  void init_dm_data(unsigned int n_levels);
+
+  //! Get reference to DM for the given mesh level
+  /**
+   * init_dm_data() should be called before this function.
+   */
+  DM & get_dm(unsigned int level)
+  { libmesh_assert(level < _dms.size());
+    return *(_dms[level].get()); }
+
+  //! Get reference to PetscSection for the given mesh level
+  /**
+   * init_dm_data() should be called before this function.
+   */
+  PetscSection & get_section(unsigned int level)
+  { libmesh_assert(level < _sections.size());
+    return *(_sections[level].get()); }
+
+  //! Get reference to PetscSF for the given mesh level
+  /**
+   * init_dm_data() should be called before this function.
+   */
+  PetscSF & get_star_forest(unsigned int level)
+  { libmesh_assert(level < _star_forests.size());
+    return *(_star_forests[level].get()); }
 
 };
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -93,6 +93,20 @@ private:
   { libmesh_assert(level < _star_forests.size());
     return *(_star_forests[level].get()); }
 
+  //! Takes System, empty PetscSection and populates the PetscSection
+  /**
+   * Take the System in its current state and an empty PetscSection and then
+   * populate the PetscSection. The PetscSection is comprised of global "point"
+   * numbers, where a "point" in PetscDM parlance is a geometric entity: node, edge,
+   * face, or element. Then, we also add the DoF numbering for each variable
+   * for each of the "points". The PetscSection, together the with PetscSF
+   * will allow for recursive fieldsplits from the command line using PETSc.
+   *
+   * TODO: Currently only populates nodal DoF data. Need to generalize
+   *       elem DoFs as well.
+   */
+  void build_section(const System & system, PetscSection & section);
+
   //! Helper function for build_section.
   /**
    * This function will count how many "points" on the current processor have

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -1,0 +1,52 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2018 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_PETSC_DM_WRAPPER_H
+#define LIBMESH_PETSC_DM_WRAPPER_H
+
+#include "libmesh/libmesh_common.h"
+
+#ifdef LIBMESH_HAVE_PETSC
+
+namespace libMesh
+{
+
+/**
+ * This class defines a wrapper around the PETSc DM infrastructure.
+ * By coordinating DM data structures with libMesh, we can use libMesh
+ * mesh hierarchies for geometric multigrid. Additionally, by setting the
+ * DM data, we can additionally (with or without multigrid) define recursive
+ * fieldsplits of our variables.
+ *
+ * \author Paul T. Bauman, Boris Boutkov
+ * \date 2018
+ */
+class PetscDMWrapper
+{
+public:
+
+  PetscDMWrapper() = default;
+
+  ~PetscDMWrapper(){};
+
+};
+
+}
+
+#endif // #ifdef LIBMESH_HAVE_PETSC
+
+#endif // LIBMESH_PETSC_DM_WRAPPER_H

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -47,7 +47,10 @@ public:
 
   PetscDMWrapper() = default;
 
-  ~PetscDMWrapper(){};
+  ~PetscDMWrapper();
+
+  //! Destroys and clears all build DM-related data
+  void clear();
 
 private:
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <memory>
 #include <unordered_map>
+#include <map>
 
 // PETSc includes
 #include <petsc.h>
@@ -115,7 +116,8 @@ private:
   void set_point_range_in_section( const System & system,
                                    PetscSection & section,
                                    std::unordered_map<dof_id_type,dof_id_type> & node_map,
-                                   std::unordered_map<dof_id_type,dof_id_type> & elem_map);
+                                   std::unordered_map<dof_id_type,dof_id_type> & elem_map,
+                                   std::map<dof_id_type,unsigned int> & scalar_map);
 
   //! Helper function for build_section.
   /**
@@ -124,7 +126,8 @@ private:
   void add_dofs_to_section (const System & system,
                             PetscSection & section,
                             const std::unordered_map<dof_id_type,dof_id_type> & node_map,
-                            const std::unordered_map<dof_id_type,dof_id_type> & elem_map);
+                            const std::unordered_map<dof_id_type,dof_id_type> & elem_map,
+                            const std::map<dof_id_type,unsigned int> & scalar_map);
 
 };
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -129,6 +129,13 @@ private:
                             const std::unordered_map<dof_id_type,dof_id_type> & elem_map,
                             const std::map<dof_id_type,unsigned int> & scalar_map);
 
+  //! Helper function to sanity check PetscSection construction
+  /**
+   * The PetscSection contains local dof information. This helper function just facilitates
+   * sanity checking that in fact it only has n_local_dofs.
+   */
+  dof_id_type check_section_n_dofs( const System & system, PetscSection & section );
+
 };
 
 }

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -34,6 +34,7 @@ namespace libMesh
 {
   // Forward declarations
   class System;
+  class DofObject;
 
 /**
  * This class defines a wrapper around the PETSc DM infrastructure.
@@ -135,6 +136,12 @@ private:
    * sanity checking that in fact it only has n_local_dofs.
    */
   dof_id_type check_section_n_dofs( const System & system, PetscSection & section );
+
+  //! Helper function to reduce code duplication when setting dofs in section
+  void add_dofs_helper (const System & system,
+                        const DofObject & dof_object,
+                        dof_id_type local_id,
+                        PetscSection & section);
 
 };
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -57,6 +57,8 @@ public:
   //! Destroys and clears all build DM-related data
   void clear();
 
+  void init_and_attach_petscdm(System & system, SNES & snes);
+
 private:
 
   //! Vector of DMs for all grid levels

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -24,12 +24,15 @@
 
 #include <vector>
 #include <memory>
+#include <unordered_map>
 
 // PETSc includes
 #include <petsc.h>
 
 namespace libMesh
 {
+  // Forward declarations
+  class System;
 
 /**
  * This class defines a wrapper around the PETSc DM infrastructure.
@@ -89,6 +92,18 @@ private:
   PetscSF & get_star_forest(unsigned int level)
   { libmesh_assert(level < _star_forests.size());
     return *(_star_forests[level].get()); }
+
+  //! Helper function for build_section.
+  /**
+   * This function will count how many "points" on the current processor have
+   * DoFs associated with them and give that count to PETSc. We need to cache
+   * a mapping between the global node id and our local count that we do in this
+   * function because we will need the local number again in the add_dofs_to_section
+   * function.
+   */
+  void set_point_range_in_section( const System & system,
+                                   PetscSection & section,
+                                   std::unordered_map<dof_id_type,dof_id_type> & node_map);
 
 };
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2322,8 +2322,7 @@ void DofMap::SCALAR_dof_indices (std::vector<dof_id_type> & di,
 bool DofMap::semilocal_index (dof_id_type dof_index) const
 {
   // If it's not in the local indices
-  if (dof_index < this->first_dof() ||
-      dof_index >= this->end_dof())
+  if (!this->local_index(dof_index))
     {
       // and if it's not in the ghost indices, then we're not
       // semilocal

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1098,8 +1098,7 @@ void DofMap::local_variable_indices(std::vector<dof_id_type> & idx,
               for(unsigned int i=0; i<n_comp; i++)
                 {
                   const dof_id_type index = node.dof_number(sys_num,var_num,i);
-                  libmesh_assert_greater_equal (index, this->first_dof());
-                  libmesh_assert_less (index, this->end_dof());
+                  libmesh_assert (this->local_index(index));
 
                   if (idx.empty() || index > idx.back())
                     idx.push_back(index);
@@ -1582,8 +1581,7 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
 
               // Insert the remote DOF indices into the send list
               for (std::size_t j=0; j != di.size(); ++j)
-                if (di[j] < this->first_dof() ||
-                    di[j] >= this->end_dof())
+                if (!this->local_index(di[j]))
                   _send_list.push_back(di[j]);
             }
         }
@@ -1594,8 +1592,7 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
 
           // Insert the remote DOF indices into the send list
           for (std::size_t j=0; j != di.size(); ++j)
-            if (di[j] < this->first_dof() ||
-                di[j] >= this->end_dof())
+            if (!this->local_index(di[j]))
               _send_list.push_back(di[j]);
         }
 
@@ -1622,8 +1619,7 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
 
       // Insert the remote DOF indices into the send list
       for (std::size_t j=0; j != di.size(); ++j)
-        if (di[j] < this->first_dof() ||
-            di[j] >= this->end_dof())
+        if (!this->local_index(di[j]))
           _send_list.push_back(di[j]);
     }
 }
@@ -2706,8 +2702,7 @@ std::string DofMap::get_info() const
     {
       // Only count local constraints, then sum later
       const dof_id_type constrained_dof = pr.first;
-      if (constrained_dof < this->first_dof() ||
-          constrained_dof >= this->end_dof())
+      if (!this->local_index(constrained_dof))
         continue;
 
       const DofConstraintRow & row = pr.second;

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1477,9 +1477,7 @@ std::string DofMap::get_local_constraints(bool print_nonlocal) const
       const dof_id_type i = pr.first;
 
       // Skip non-local dofs if requested
-      if (!print_nonlocal &&
-          ((i < this->first_dof()) ||
-           (i >= this->end_dof())))
+      if (!print_nonlocal && !this->local_index(i))
         continue;
 
       const DofConstraintRow & row = pr.second;
@@ -1514,9 +1512,7 @@ std::string DofMap::get_local_constraints(bool print_nonlocal) const
             const dof_id_type i = pr.first;
 
             // Skip non-local dofs if requested
-            if (!print_nonlocal &&
-                ((i < this->first_dof()) ||
-                 (i >= this->end_dof())))
+            if (!print_nonlocal && !this->local_index(i))
               continue;
 
             const Number rhs = pr.second;
@@ -2109,8 +2105,7 @@ void DofMap::enforce_constraints_exactly (const System & system,
   for (const auto & pr : _dof_constraints)
     {
       dof_id_type constrained_dof = pr.first;
-      if (constrained_dof < this->first_dof() ||
-          constrained_dof >= this->end_dof())
+      if (!this->local_index(constrained_dof))
         continue;
 
       const DofConstraintRow constraint_row = pr.second;
@@ -2205,8 +2200,7 @@ void DofMap::enforce_adjoint_constraints_exactly (NumericVector<Number> & v,
   for (const auto & pr : _dof_constraints)
     {
       dof_id_type constrained_dof = pr.first;
-      if (constrained_dof < this->first_dof() ||
-          constrained_dof >= this->end_dof())
+      if (!this->local_index(constrained_dof))
         continue;
 
       const DofConstraintRow constraint_row = pr.second;
@@ -3888,9 +3882,8 @@ void DofMap::gather_constraints (MeshBase & /*mesh*/,
           // constraint for it, then we need to check for one.
           if (pos == _dof_constraints.end())
             {
-              if (((unexpanded_dof < this->first_dof()) ||
-                   (unexpanded_dof >= this->end_dof())) &&
-                  !_dof_constraints.count(unexpanded_dof))
+              if (!this->local_index(unexpanded_dof) &&
+                  !_dof_constraints.count(unexpanded_dof) )
                 dof_request_set.insert(unexpanded_dof);
             }
           // If we were asked for a DoF and we already have a
@@ -3905,8 +3898,7 @@ void DofMap::gather_constraints (MeshBase & /*mesh*/,
 
                   // If it's non-local and we haven't already got a
                   // constraint for it, we might need to ask for one
-                  if (((constraining_dof < this->first_dof()) ||
-                       (constraining_dof >= this->end_dof())) &&
+                  if (!this->local_index(constraining_dof) &&
                       !_dof_constraints.count(constraining_dof))
                     dof_request_set.insert(constraining_dof);
                 }
@@ -4155,8 +4147,7 @@ void DofMap::add_constraints_to_send_list()
       dof_id_type constrained_dof = i.first;
 
       // We only need the dependencies of our own constrained dofs
-      if (constrained_dof < this->first_dof() ||
-          constrained_dof >= this->end_dof())
+      if (!this->local_index(constrained_dof))
         continue;
 
       const DofConstraintRow & constraint_row = i.second;
@@ -4165,8 +4156,7 @@ void DofMap::add_constraints_to_send_list()
           dof_id_type constraint_dependency = j.first;
 
           // No point in adding one of our own dofs to the send_list
-          if (constraint_dependency >= this->first_dof() &&
-              constraint_dependency < this->end_dof())
+          if (this->local_index(constraint_dependency))
             continue;
 
           _send_list.push_back(constraint_dependency);

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -368,6 +368,7 @@ libmesh_SOURCES =  \
         src/solvers/optimization_solver.C \
         src/solvers/petsc_auto_fieldsplit.C \
         src/solvers/petsc_diff_solver.C \
+        src/solvers/petsc_dm_wrapper.C \
         src/solvers/petsc_linear_solver.C \
         src/solvers/petsc_nonlinear_solver.C \
         src/solvers/petscdmlibmesh.C \

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -318,6 +318,9 @@ unsigned int PetscDiffSolver::solve()
                           __libmesh_petsc_diff_solver_jacobian, this);
   LIBMESH_CHKERR(ierr);
 
+  ierr = SNESSetFromOptions(_snes);
+  LIBMESH_CHKERR(ierr);
+
   ierr = SNESSolve (_snes, PETSC_NULL, x.vec());
   LIBMESH_CHKERR(ierr);
 
@@ -354,13 +357,13 @@ void PetscDiffSolver::setup_petsc_data()
   if (use_petsc_dm)
     this->_dm_wrapper.init_and_attach_petscdm(_system, _snes);
 
-  ierr = SNESSetFromOptions(_snes);
-  LIBMESH_CHKERR(ierr);
-
   // If we're not using PETSc DM, let's keep around
   // the old style for fieldsplit
   if (!use_petsc_dm)
     {
+      ierr = SNESSetFromOptions(_snes);
+      LIBMESH_CHKERR(ierr);
+
       KSP my_ksp;
       ierr = SNESGetKSP(_snes, &my_ksp);
       LIBMESH_CHKERR(ierr);

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -1,0 +1,22 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2018 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/libmesh_common.h"
+
+#ifdef LIBMESH_HAVE_PETSC
+
+#endif // LIBMESH_HAVE_PETSC

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -19,4 +19,28 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+#include <petscsf.h>
+
+#include "libmesh/petsc_dm_wrapper.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
+
+namespace libMesh
+{
+
+void PetscDMWrapper::init_dm_data(unsigned int n_levels)
+{
+  _dms.resize(n_levels);
+  _sections.resize(n_levels);
+  _star_forests.resize(n_levels);
+
+  for( unsigned int i = 0; i < n_levels; i++ )
+    {
+      _dms[i] = libmesh_make_unique<DM>();
+      _sections[i] = libmesh_make_unique<PetscSection>();
+      _star_forests[i] = libmesh_make_unique<PetscSF>();
+    }
+}
+
+} // end namespace libMesh
+
 #endif // LIBMESH_HAVE_PETSC

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -27,6 +27,24 @@
 namespace libMesh
 {
 
+PetscDMWrapper::~PetscDMWrapper()
+{
+  this->clear();
+}
+
+void PetscDMWrapper::clear()
+{
+  // This will also Destroy the attached PetscSection and PetscSF as well
+  // Destroy doesn't free the memory, but just resets points internally
+  // in the struct, so we'd still need to wipe out the memory on our side
+  for( auto dm_it = _dms.begin(); dm_it < _dms.end(); ++dm_it )
+    DMDestroy( dm_it->get() );
+
+  _dms.clear();
+  _sections.clear();
+  _star_forests.clear();
+}
+
 void PetscDMWrapper::init_dm_data(unsigned int n_levels)
 {
   _dms.resize(n_levels);

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -49,6 +49,50 @@ void PetscDMWrapper::clear()
   _star_forests.clear();
 }
 
+void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
+{
+  START_LOG ("init_and_attach_petscdm()", "PetscDMWrapper");
+
+  PetscErrorCode ierr;
+
+  // Eventually, we'll traverse the mesh hierarchy and cache
+  // for each grid level, but for now, we're just using the
+  // finest level
+  unsigned int n_levels = 1;
+  this->init_dm_data(n_levels);
+
+  for(unsigned int level = 0; level < n_levels; level++)
+    {
+      DM & dm = this->get_dm(level);
+      PetscSection & section = this->get_section(level);
+      PetscSF & star_forest = this->get_star_forest(level);
+
+      ierr = DMShellCreate(system.comm().get(), &dm);
+      CHKERRABORT(system.comm().get(),ierr);
+
+      // Build the PetscSection and attach it to the DM
+      this->build_section(system, section);
+      ierr = DMSetDefaultSection(dm, section);
+      CHKERRABORT(system.comm().get(),ierr);
+
+      // We only need to build the star forest if we're in a parallel environment
+      if (system.n_processors() > 1)
+        {
+          // Build the PetscSF and attach it to the DM
+          this->build_sf(system, star_forest);
+          ierr = DMSetDefaultSF(dm, star_forest);
+          CHKERRABORT(system.comm().get(),ierr);
+        }
+    }
+
+  // We need to set only the finest level DM in the SNES
+  DM & dm = this->get_dm(0);
+  ierr = SNESSetDM(snes, dm);
+  CHKERRABORT(system.comm().get(),ierr);
+
+  STOP_LOG ("init_and_attach_petscdm()", "PetscDMWrapper");
+}
+
 void PetscDMWrapper::build_section( const System & system, PetscSection & section )
 {
   START_LOG ("build_section()", "PetscDMWrapper");

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -133,6 +133,23 @@ void PetscDMWrapper::build_section( const System & system, PetscSection & sectio
   this->add_dofs_to_section(system, section, node_map, elem_map, scalar_map);
 
   // Final setup of PetscSection
+  // Until Matt Knepley finishes implementing the commented out function
+  // below, the PetscSection will be assuming node-major ordering
+  // so let's throw and error if the user tries to use this without
+  // node-major order
+  if (!libMesh::on_command_line("--node-major-dofs"))
+    libmesh_error_msg("ERROR: Must use --node-major-dofs with PetscSection!");
+
+  //else if (!system.identify_variable_groups())
+  //  ierr = PetscSectionSetUseFieldOffsets(section,PETSC_TRUE);CHKERRABORT(system.comm().get(),ierr);
+  //else
+  //  {
+  //    std::string msg = "ERROR: Only node-major or var-major ordering supported for PetscSection!\n";
+  //    msg += "       var-group-major ordering not supported!\n";
+  //    msg += "       Must use --node-major-dofs or set System::identify_variable_groups() = false!\n";
+  //    libmesh_error_msg(msg);
+  //  }
+
   ierr = PetscSectionSetUp(section);CHKERRABORT(system.comm().get(),ierr);
 
   // Sanity checking at least that local_n_dofs match


### PR DESCRIPTION
I guess if you force push to a branch you can't reopen the pull request. This replaces #1568. 

I believe I've addressed all the comments from the previous version, in particular, this should support all the finite element types, including SCALARs. I've tested this on both `ReplicatedMesh` and `DistributedMesh`, both in serial and parallel, including cases with more processors than elements. I've tried Lagrange and Hierarchic elements and can reproduce the same convergence behavior as using the "old style" libMesh field split interface for Stokes and Navier-Stokes problems. I think I got it right, but would appreciate a look to see if I did anything obviously stupid. The only assumption that I'm not asserting here (I think) and for which I don't know how to assert within this code is that Node::n_dofs() and Elem::n_dofs() will not both count the same dof for the same variable. Originally I was thinking that elements were only nodal or elemental dof-oriented, but looks like Hierarchic elements associates dofs at the nodes for low order and then the interior for higher order.

The only catch, as described in 814081f, is that this currently will only do the correct thing for fieldsplit when using node-major ordering. @knepley is updating the PETSc side to support var-major ordering automatically at which point we can use this for both var-major and node-major orderings. We'll simply need to uncomment the currently commented petsc function call.

@bboutkov should rebase on this branch; that branch will add geometric multigrid. At that point, we'll want to open the discussion on integration with `PetscNonlinearSolver` (beyond the current `PetscDiffSolver`). 