### PR TITLE
GCC 8 warning fixes

### DIFF
--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -1718,8 +1718,9 @@ GetPot::_internal_managed_copy(const std::string& Arg) const
     return *it;
 
   // Otherwise, create a new one
-  char* newcopy = new char[strlen(arg)+1];
-  strncpy(newcopy, arg, strlen(arg)+1);
+  const std::size_t bufsize = strlen(arg)+1;
+  char* newcopy = new char[bufsize];
+  strncpy(newcopy, arg, bufsize);
   _internal_string_container.insert(newcopy);
   return newcopy;
 }

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -477,7 +477,7 @@ inline Tnew cast_ref(Told & oldvar)
       Tnew newvar = dynamic_cast<Tnew>(oldvar);
       return newvar;
     }
-  catch (std::bad_cast)
+  catch (std::bad_cast &)
     {
       libMesh::err << "Failed to convert " << typeid(Told).name()
                    << " reference to " << typeid(Tnew).name()

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -549,8 +549,8 @@ void Build::parallel_sync ()
     comm.receive(proc_id, in_dofs, dof_tag);
     comm.receive(proc_id, in_rows, row_tag);
 
-    const auto n_rows = in_dofs.size();
-    for (auto i = decltype(n_rows)(0); i != n_rows; ++i)
+    const std::size_t n_rows = in_dofs.size();
+    for (std::size_t i = 0; i != n_rows; ++i)
     {
       const auto r = in_dofs[i];
       const auto my_r = r - local_first_dof;


### PR DESCRIPTION
This is the dark side to ```configure --enable-werror``` - just because we've fixed all the warnings that one compiler found doesn't mean we'll have fixed all the warnings that the very next version of the very same compiler will find with the very same compiler arguments.

On the bright side, now that I'm building with --enable-error I can actually notice these things and fix them right away.