### PR TITLE
Fix new unit test failures with --enable-parmesh

### DIFF
--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -347,6 +347,10 @@ public:
     ZeroFunction<> zf;
     sys.boundary_project_solution(boundary_ids, variables, &zf);
 
+    // On a distributed mesh we may not have every node on every
+    // processor
+    TestCommWorld->set_union(projected_nodes_set);
+
     // We set the solution to be 1 everywhere and then zero on specific boundary
     // nodes, so the final l1 norm of the solution is the difference between the
     // number of nodes in the mesh and the number of nodes we zero on.


### PR DESCRIPTION
The test @dknez added in #1792 was breaking for me on distributed meshes, but the fix is simple.

@pbauman, should we switch the GRINS-devel CI to use --enable-parmesh, so we get regular coverage of that?  We definitely don't want to change GRINS-dbg or MOOSE Test Debug (there are some stupidly slow dbg-mode-only tests on large distributed problems), but changing GRINS-devel should give us pretty full coverage at little to negative net cost.