### PR TITLE
Fix a unit test I/O race condition

### DIFF
--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -219,6 +219,10 @@ public:
       mesh.write(mesh_filename);
     }
 
+    // Make sure all processors are done writing before we try to
+    // start reading
+    TestCommWorld->barrier();
+
     Mesh mesh(*TestCommWorld);
     mesh.read(mesh_filename);
 


### PR DESCRIPTION
If we don't make sure all processors are done writing before one
starts reading, we can end up seeing a file from a different test.