### PR TITLE
Possibly exit train_reduced_basis() before calling update_residual_terms()

### DIFF
--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -159,6 +159,13 @@ public:
   virtual Real train_reduced_basis(const bool resize_rb_eval_data=true);
 
   /**
+   * This function computes one basis function for each rhs term. This is
+   * useful in some cases since we can avoid doing a full greedy if we know
+   * that we do not have any "left-hand side" parameters, for example.
+   */
+  void enrich_basis_from_rhs_terms(const bool resize_rb_eval_data=true);
+
+  /**
    * (i) Compute the a posteriori error bound for each set of parameters
    * in the training set, (ii) set current_parameters to the parameters that
    * maximize the error bound, and (iii) return the maximum error bound.

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -1005,7 +1005,7 @@ Real RBConstruction::train_reduced_basis(const bool resize_rb_eval_data)
 
   get_rb_evaluation().greedy_param_list.clear();
 
-  Real training_greedy_error;
+  Real training_greedy_error = 0.;
 
 
   // If we are continuing from a previous training run,

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -1068,6 +1068,18 @@ Real RBConstruction::train_reduced_basis(const bool resize_rb_eval_data)
 
       update_system();
 
+      // Check if we've reached Nmax now. We do this before calling
+      // update_residual_terms() since we can skip that step if we've
+      // already reached Nmax.
+      if (get_rb_evaluation().get_n_basis_functions() >= this->get_Nmax())
+      {
+        libMesh::out << "Maximum number of basis functions reached: Nmax = "
+                     << get_Nmax() << std::endl;
+        break;
+      }
+
+      update_residual_terms();
+
       // Increment counter
       count++;
     }
@@ -1241,10 +1253,6 @@ void RBConstruction::update_system()
 {
   libMesh::out << "Updating RB matrices" << std::endl;
   update_RB_system_matrices();
-
-  libMesh::out << "Updating RB residual terms" << std::endl;
-
-  update_residual_terms();
 }
 
 Real RBConstruction::get_RB_error_bound()
@@ -1429,6 +1437,8 @@ void RBConstruction::update_RB_system_matrices()
 void RBConstruction::update_residual_terms(bool compute_inner_products)
 {
   LOG_SCOPE("update_residual_terms()", "RBConstruction");
+
+  libMesh::out << "Updating RB residual terms" << std::endl;
 
   unsigned int RB_size = get_rb_evaluation().get_n_basis_functions();
 


### PR DESCRIPTION
Reduced Basis change: Small optimization in reduced basis training if we hit maximum number of basis functions.