### PR TITLE
Remove remaining uses of deprecated find_boundary_nodes() function.

### DIFF
--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -74,12 +74,11 @@ void MeshTools::Modification::distort (MeshBase & mesh,
 
   LOG_SCOPE("distort()", "MeshTools::Modification");
 
-  // First find nodes on the boundary and flag them
-  // so that we don't move them
-  // on_boundary holds false (not on boundary) and true (on boundary)
-  std::vector<bool> on_boundary (mesh.max_node_id(), false);
-
-  if (!perturb_boundary) MeshTools::find_boundary_nodes (mesh, on_boundary);
+  // If we are not perturbing boundary nodes, make a
+  // quickly-searchable list of node ids we can check against.
+  std::unordered_set<dof_id_type> boundary_node_ids;
+  if (!perturb_boundary)
+    boundary_node_ids = MeshTools::find_boundary_nodes (mesh);
 
   // Now calculate the minimum distance to
   // neighboring nodes for each node.
@@ -91,7 +90,6 @@ void MeshTools::Modification::distort (MeshBase & mesh,
     for (auto & n : elem->node_ref_range())
       hmin[n.id()] = std::min(hmin[n.id()],
                               static_cast<float>(elem->hmin()));
-
 
   // Now actually move the nodes
   {
@@ -109,18 +107,12 @@ void MeshTools::Modification::distort (MeshBase & mesh,
     // [Note: Testing for (in)equality might be wrong
     // (different types, namely float and double)]
     for (unsigned int n=0; n<mesh.max_node_id(); n++)
-      if (!on_boundary[n] && (hmin[n] < 1.e20) )
+      if ((perturb_boundary || !boundary_node_ids.count(n)) && hmin[n] < 1.e20)
         {
           // the direction, random but unit normalized
-
-          Point dir( static_cast<Real>(std::rand())/static_cast<Real>(RAND_MAX),
-                     (mesh.mesh_dimension() > 1) ?
-                     static_cast<Real>(std::rand())/static_cast<Real>(RAND_MAX)
-                     : 0.,
-                     ((mesh.mesh_dimension() == 3) ?
-                      static_cast<Real>(std::rand())/static_cast<Real>(RAND_MAX)
-                      : 0.)
-                     );
+          Point dir (static_cast<Real>(std::rand())/static_cast<Real>(RAND_MAX),
+                     (mesh.mesh_dimension() > 1) ? static_cast<Real>(std::rand())/static_cast<Real>(RAND_MAX) : 0.,
+                     ((mesh.mesh_dimension() == 3) ? static_cast<Real>(std::rand())/static_cast<Real>(RAND_MAX) : 0.));
 
           dir(0) = (dir(0)-.5)*2.;
           if (mesh.mesh_dimension() > 1)

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -1576,13 +1576,12 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
   libmesh_assert_equal_to (mesh.mesh_dimension(), 2);
 
   /*
-   * find the boundary nodes
+   * Create a quickly-searchable list of boundary nodes.
    */
-  std::vector<bool>  on_boundary;
-  MeshTools::find_boundary_nodes(mesh, on_boundary);
+  std::unordered_set<dof_id_type> boundary_node_ids =
+    MeshTools::find_boundary_nodes (mesh);
 
   for (unsigned int iter=0; iter<n_iterations; iter++)
-
     {
       /*
        * loop over the mesh refinement level
@@ -1689,7 +1688,7 @@ void MeshTools::Modification::smooth (MeshBase & mesh,
              * finally reposition the vertex nodes
              */
             for (unsigned int nid=0; nid<mesh.n_nodes(); ++nid)
-              if (!on_boundary[nid] && weight[nid] > 0.)
+              if (!boundary_node_ids.count(nid) && weight[nid] > 0.)
                 mesh.node_ref(nid) = new_positions[nid]/weight[nid];
           }
 

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -275,9 +275,9 @@ int VariationalMeshSmoother::readgr(Array2D<double> & R,
   libMesh::out << "Starting readgr" << std::endl;
   // add error messages where format can be inconsistent
 
-  // Find the boundary nodes
-  std::vector<bool> on_boundary;
-  MeshTools::find_boundary_nodes(_mesh, on_boundary);
+  // Create a quickly-searchable list of boundary nodes.
+  std::unordered_set<dof_id_type> boundary_node_ids =
+    MeshTools::find_boundary_nodes (_mesh);
 
   // Grab node coordinates and set mask
   {
@@ -299,7 +299,7 @@ int VariationalMeshSmoother::readgr(Array2D<double> & R,
         // Internal nodes are 0
         // Immovable boundary nodes are 1
         // Movable boundary nodes are 2
-        if (on_boundary[i])
+        if (boundary_node_ids.count(i))
           {
             // Only look for sliding edge nodes in 2D
             if (_dim == 2)
@@ -346,8 +346,8 @@ int VariationalMeshSmoother::readgr(Array2D<double> & R,
                         // Find if the two neighbor nodes angles are 180 degrees (pi) off of each other (withing a tolerance)
                         // In order to make this a true movable boundary node... the two that forma  straight line with
                         // it must also be on the boundary
-                        if (on_boundary[neighbors[a]->id()] &&
-                            on_boundary[neighbors[b]->id()] &&
+                        if (boundary_node_ids.count(neighbors[a]->id()) &&
+                            boundary_node_ids.count(neighbors[b]->id()) &&
                             (
                              (std::abs(thetas[a] - (thetas[b] + (libMesh::pi))) < .001) ||
                              (std::abs(thetas[a] - (thetas[b] - (libMesh::pi))) < .001)

--- a/src/solution_transfer/dtk_adapter.C
+++ b/src/solution_transfer/dtk_adapter.C
@@ -71,8 +71,8 @@ DTKAdapter::DTKAdapter(Teuchos::RCP<const Teuchos::Comm<int>> in_comm, EquationS
   }
 
   // Currently assuming all elements are the same!
-  DataTransferKit::DTK_ElementTopology element_topology = get_element_topology(mesh.elem(0));
-  unsigned int n_nodes_per_elem = mesh.elem(0)->n_nodes();
+  DataTransferKit::DTK_ElementTopology element_topology = get_element_topology(mesh.elem_ptr(0));
+  unsigned int n_nodes_per_elem = mesh.elem_ptr(0)->n_nodes();
 
   unsigned int n_local_elem = mesh.n_local_elem();
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,7 @@ unit_tests_sources = \
   geom/point_test.h \
   geom/which_node_am_i_test.C \
   mesh/all_tri.C \
+  mesh/distort.C \
   mesh/boundary_mesh.C \
   mesh/boundary_info.C \
   mesh/checkpoint.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -192,8 +192,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/point_test.C \
 	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C \
+	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/checkpoint.C mesh/contains_point.C mesh/mesh_input.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -238,6 +238,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	geom/unit_tests_dbg-point_test.$(OBJEXT) \
 	geom/unit_tests_dbg-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-all_tri.$(OBJEXT) \
+	mesh/unit_tests_dbg-distort.$(OBJEXT) \
 	mesh/unit_tests_dbg-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_dbg-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_dbg-checkpoint.$(OBJEXT) \
@@ -295,8 +296,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/point_test.C \
 	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C \
+	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/checkpoint.C mesh/contains_point.C mesh/mesh_input.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -340,6 +341,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	geom/unit_tests_devel-point_test.$(OBJEXT) \
 	geom/unit_tests_devel-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_devel-all_tri.$(OBJEXT) \
+	mesh/unit_tests_devel-distort.$(OBJEXT) \
 	mesh/unit_tests_devel-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_devel-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_devel-checkpoint.$(OBJEXT) \
@@ -394,8 +396,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/point_test.C \
 	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C \
+	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/checkpoint.C mesh/contains_point.C mesh/mesh_input.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -439,6 +441,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	geom/unit_tests_oprof-point_test.$(OBJEXT) \
 	geom/unit_tests_oprof-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-all_tri.$(OBJEXT) \
+	mesh/unit_tests_oprof-distort.$(OBJEXT) \
 	mesh/unit_tests_oprof-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_oprof-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_oprof-checkpoint.$(OBJEXT) \
@@ -493,8 +496,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/point_test.C \
 	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C \
+	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/checkpoint.C mesh/contains_point.C mesh/mesh_input.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -538,6 +541,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	geom/unit_tests_opt-point_test.$(OBJEXT) \
 	geom/unit_tests_opt-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_opt-all_tri.$(OBJEXT) \
+	mesh/unit_tests_opt-distort.$(OBJEXT) \
 	mesh/unit_tests_opt-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_opt-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_opt-checkpoint.$(OBJEXT) \
@@ -591,8 +595,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/point_test.C \
 	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C \
+	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/checkpoint.C mesh/contains_point.C mesh/mesh_input.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -636,6 +640,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	geom/unit_tests_prof-point_test.$(OBJEXT) \
 	geom/unit_tests_prof-which_node_am_i_test.$(OBJEXT) \
 	mesh/unit_tests_prof-all_tri.$(OBJEXT) \
+	mesh/unit_tests_prof-distort.$(OBJEXT) \
 	mesh/unit_tests_prof-boundary_mesh.$(OBJEXT) \
 	mesh/unit_tests_prof-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_prof-checkpoint.$(OBJEXT) \
@@ -1116,8 +1121,8 @@ unit_tests_sources = driver.C test_comm.h stream_redirector.h \
 	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
 	fe/fe_xyz_test.C geom/elem_test.C geom/point_test.C \
 	geom/point_test.h geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C \
+	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	mesh/checkpoint.C mesh/contains_point.C mesh/mesh_input.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
@@ -1277,6 +1282,8 @@ mesh/$(DEPDIR)/$(am__dirstamp):
 	@: > mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-distort.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1434,6 +1441,8 @@ geom/unit_tests_devel-which_node_am_i_test.$(OBJEXT):  \
 	geom/$(am__dirstamp) geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-distort.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1548,6 +1557,8 @@ geom/unit_tests_oprof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 geom/unit_tests_oprof-which_node_am_i_test.$(OBJEXT):  \
 	geom/$(am__dirstamp) geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-distort.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1664,6 +1675,8 @@ geom/unit_tests_opt-which_node_am_i_test.$(OBJEXT):  \
 	geom/$(am__dirstamp) geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-distort.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -1778,6 +1791,8 @@ geom/unit_tests_prof-point_test.$(OBJEXT): geom/$(am__dirstamp) \
 geom/unit_tests_prof-which_node_am_i_test.$(OBJEXT):  \
 	geom/$(am__dirstamp) geom/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-all_tri.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-distort.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-boundary_mesh.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1976,6 +1991,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-distort.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po@am__quote@
@@ -1990,6 +2006,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-distort.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po@am__quote@
@@ -2004,6 +2021,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-distort.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po@am__quote@
@@ -2018,6 +2036,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-distort.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po@am__quote@
@@ -2032,6 +2051,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_mesh.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-checkpoint.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-contains_point.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-distort.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po@am__quote@
@@ -2446,6 +2466,20 @@ mesh/unit_tests_dbg-all_tri.obj: mesh/all_tri.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_dbg-all_tri.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+
+mesh/unit_tests_dbg-distort.o: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-distort.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-distort.Tpo -c -o mesh/unit_tests_dbg-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-distort.Tpo mesh/$(DEPDIR)/unit_tests_dbg-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_dbg-distort.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+
+mesh/unit_tests_dbg-distort.obj: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-distort.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-distort.Tpo -c -o mesh/unit_tests_dbg-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-distort.Tpo mesh/$(DEPDIR)/unit_tests_dbg-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_dbg-distort.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
 
 mesh/unit_tests_dbg-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-boundary_mesh.Tpo -c -o mesh/unit_tests_dbg-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C
@@ -3231,6 +3265,20 @@ mesh/unit_tests_devel-all_tri.obj: mesh/all_tri.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
 
+mesh/unit_tests_devel-distort.o: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-distort.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-distort.Tpo -c -o mesh/unit_tests_devel-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-distort.Tpo mesh/$(DEPDIR)/unit_tests_devel-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_devel-distort.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+
+mesh/unit_tests_devel-distort.obj: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-distort.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-distort.Tpo -c -o mesh/unit_tests_devel-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-distort.Tpo mesh/$(DEPDIR)/unit_tests_devel-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_devel-distort.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
+
 mesh/unit_tests_devel-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Tpo -c -o mesh/unit_tests_devel-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Tpo mesh/$(DEPDIR)/unit_tests_devel-boundary_mesh.Po
@@ -4014,6 +4062,20 @@ mesh/unit_tests_oprof-all_tri.obj: mesh/all_tri.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_oprof-all_tri.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+
+mesh/unit_tests_oprof-distort.o: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-distort.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-distort.Tpo -c -o mesh/unit_tests_oprof-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-distort.Tpo mesh/$(DEPDIR)/unit_tests_oprof-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_oprof-distort.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+
+mesh/unit_tests_oprof-distort.obj: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-distort.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-distort.Tpo -c -o mesh/unit_tests_oprof-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-distort.Tpo mesh/$(DEPDIR)/unit_tests_oprof-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_oprof-distort.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
 
 mesh/unit_tests_oprof-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-boundary_mesh.Tpo -c -o mesh/unit_tests_oprof-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C
@@ -4799,6 +4861,20 @@ mesh/unit_tests_opt-all_tri.obj: mesh/all_tri.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
 
+mesh/unit_tests_opt-distort.o: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-distort.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-distort.Tpo -c -o mesh/unit_tests_opt-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-distort.Tpo mesh/$(DEPDIR)/unit_tests_opt-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_opt-distort.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+
+mesh/unit_tests_opt-distort.obj: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-distort.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-distort.Tpo -c -o mesh/unit_tests_opt-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-distort.Tpo mesh/$(DEPDIR)/unit_tests_opt-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_opt-distort.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
+
 mesh/unit_tests_opt-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Tpo -c -o mesh/unit_tests_opt-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Tpo mesh/$(DEPDIR)/unit_tests_opt-boundary_mesh.Po
@@ -5582,6 +5658,20 @@ mesh/unit_tests_prof-all_tri.obj: mesh/all_tri.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/all_tri.C' object='mesh/unit_tests_prof-all_tri.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-all_tri.obj `if test -f 'mesh/all_tri.C'; then $(CYGPATH_W) 'mesh/all_tri.C'; else $(CYGPATH_W) '$(srcdir)/mesh/all_tri.C'; fi`
+
+mesh/unit_tests_prof-distort.o: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-distort.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-distort.Tpo -c -o mesh/unit_tests_prof-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-distort.Tpo mesh/$(DEPDIR)/unit_tests_prof-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_prof-distort.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-distort.o `test -f 'mesh/distort.C' || echo '$(srcdir)/'`mesh/distort.C
+
+mesh/unit_tests_prof-distort.obj: mesh/distort.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-distort.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-distort.Tpo -c -o mesh/unit_tests_prof-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-distort.Tpo mesh/$(DEPDIR)/unit_tests_prof-distort.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/distort.C' object='mesh/unit_tests_prof-distort.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-distort.obj `if test -f 'mesh/distort.C'; then $(CYGPATH_W) 'mesh/distort.C'; else $(CYGPATH_W) '$(srcdir)/mesh/distort.C'; fi`
 
 mesh/unit_tests_prof-boundary_mesh.o: mesh/boundary_mesh.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-boundary_mesh.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-boundary_mesh.Tpo -c -o mesh/unit_tests_prof-boundary_mesh.o `test -f 'mesh/boundary_mesh.C' || echo '$(srcdir)/'`mesh/boundary_mesh.C

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -65,9 +65,11 @@ public:
     BoundaryInfo & bi = mesh.get_boundary_info();
 
     // Side lists should be cleared and refilled by each call
+#ifdef LIBMESH_ENABLE_DEPRECATED
     std::vector<dof_id_type> element_id_list;
     std::vector<unsigned short int> side_list;
     std::vector<boundary_id_type> bc_id_list;
+#endif
 
     // build_square adds boundary_ids 0,1,2,3 for the bottom, right,
     // top, and left sides, respectively.
@@ -88,7 +90,9 @@ public:
     }
 
     // Build the side list
+#ifdef LIBMESH_ENABLE_DEPRECATED
     bi.build_side_list (element_id_list, side_list, bc_id_list);
+#endif
 
     // Test that the new vector-of-tuples API works equivalently.
     auto bc_triples = bi.build_side_list();
@@ -97,7 +101,9 @@ public:
     // replicated mesh
     if (mesh.is_serial())
       {
+#ifdef LIBMESH_ENABLE_DEPRECATED
         CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(8), element_id_list.size());
+#endif
         CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(8), bc_triples.size());
       }
 
@@ -120,19 +126,25 @@ public:
     }
 
     // Build the side list again
+#ifdef LIBMESH_ENABLE_DEPRECATED
     bi.build_side_list (element_id_list, side_list, bc_id_list);
+#endif
     bc_triples = bi.build_side_list();
 
     // Check that there are now exactly 6 sides left in the
     // BoundaryInfo on a replicated mesh
     if (mesh.is_serial())
       {
+#ifdef LIBMESH_ENABLE_DEPRECATED
         CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(6), element_id_list.size());
+#endif
         CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(6), bc_triples.size());
       }
 
     // Check that the removed ID is really removed
+#ifdef LIBMESH_ENABLE_DEPRECATED
     CPPUNIT_ASSERT(std::find(bc_id_list.begin(), bc_id_list.end(), 0) == bc_id_list.end());
+#endif
     typedef std::tuple<dof_id_type, unsigned short int, boundary_id_type> Tuple;
     CPPUNIT_ASSERT(std::find_if(bc_triples.begin(), bc_triples.end(),
                                 [](const Tuple & t)->bool { return std::get<2>(t) == 0; }) == bc_triples.end());
@@ -148,11 +160,15 @@ public:
     bi.remove_id(1);
     bi.remove_id(2);
     bi.remove_id(3);
+#ifdef LIBMESH_ENABLE_DEPRECATED
     bi.build_side_list (element_id_list, side_list, bc_id_list);
+#endif
     bc_triples = bi.build_side_list();
 
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(0), bi.n_boundary_ids());
+#ifdef LIBMESH_ENABLE_DEPRECATED
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(0), element_id_list.size());
+#endif
     CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(0), bc_triples.size());
   }
 

--- a/tests/mesh/distort.C
+++ b/tests/mesh/distort.C
@@ -1,0 +1,111 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/libmesh.h>
+#include <libmesh/replicated_mesh.h>
+#include <libmesh/elem.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/mesh_modification.h>
+#include <libmesh/mesh_tools.h>
+
+#include "test_comm.h"
+
+// C++ includes
+#include <unordered_set>
+#include <unordered_map>
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+using namespace libMesh;
+
+class DistortTest : public CppUnit::TestCase
+{
+  /**
+   * The goal of this test is to make sure that boundary nodes are not
+   * restricted during distortion.
+   */
+public:
+  CPPUNIT_TEST_SUITE( DistortTest );
+
+  // 2D tests
+  CPPUNIT_TEST( testDistortQuad );
+
+  // 3D tests
+  CPPUNIT_TEST( testDistortHex );
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+  // Helper function called by the test implementations, saves a few lines of code.
+  void test_helper_2D(ElemType elem_type)
+  {
+    ReplicatedMesh mesh(*TestCommWorld, /*dim=*/2);
+
+    MeshTools::Generation::build_square(mesh,
+                                        /*nx=*/2, /*ny=*/2,
+                                        /*xmin=*/0., /*xmax=*/1.,
+                                        /*ymin=*/0., /*ymax=*/1.,
+                                        elem_type);
+
+    perturb_and_check(mesh);
+  }
+
+  // Helper function called by the test implementations in 3D, saves a few lines of code.
+  void test_helper_3D(ElemType elem_type)
+  {
+    ReplicatedMesh mesh(*TestCommWorld, /*dim=*/3);
+
+    MeshTools::Generation::build_cube(mesh,
+                                      /*nx=*/2, /*ny=*/2, /*nz=*/2,
+                                      /*xmin=*/0., /*xmax=*/1.,
+                                      /*ymin=*/0., /*ymax=*/1.,
+                                      /*zmin=*/0., /*zmax=*/1.,
+                                      elem_type);
+    perturb_and_check(mesh);
+  }
+
+  // Code to save node positions, perturb the mesh, and ensure the correct nodes moved.
+  void perturb_and_check(ReplicatedMesh & mesh)
+  {
+    // Record node positions ahead of time to make sure the correct
+    // ones are moved by distort.
+    std::unordered_map<dof_id_type, Point> pts_before;
+    for (const auto & node : mesh.node_ptr_range())
+      pts_before[node->id()] = *node;
+
+    std::unordered_set<dof_id_type> boundary_node_ids =
+      MeshTools::find_boundary_nodes (mesh);
+
+    MeshTools::Modification::distort(mesh,
+                                     /*factor=*/0.1,
+                                     /*perturb_boundary=*/false);
+
+    // Make sure the boundary nodes are not perturbed, and the
+    // other nodes are.
+    for (const auto & node : mesh.node_ptr_range())
+      {
+        bool equal = node->absolute_fuzzy_equals(pts_before[node->id()]);
+        CPPUNIT_ASSERT(boundary_node_ids.count(node->id()) ? equal : !equal);
+      }
+  }
+
+public:
+  void setUp() {}
+  void tearDown() {}
+  void testDistortQuad() { test_helper_2D(QUAD4); }
+  void testDistortHex() { test_helper_3D(HEX8); }
+};
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION( DistortTest );


### PR DESCRIPTION
I will also attach a `--disable-deprecated` test to this PR.
