### PR TITLE
Add more paranoid warnings

### DIFF
--- a/configure
+++ b/configure
@@ -7843,12 +7843,12 @@ fi
           CFLAGS_DBG="-g -Wimplicit"
           ASSEMBLY_FLAGS="$ASSEMBLY_FLAGS -fverbose-asm"
 
-                              PARANOID_FLAGS="-Wall -Wextra -Wcast-align -Wdisabled-optimization -Wformat=2"
+                              PARANOID_FLAGS="-Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2"
           PARANOID_FLAGS="$PARANOID_FLAGS -Wformat-nonliteral -Wformat-security -Wformat-y2k"
-          PARANOID_FLAGS="$PARANOID_FLAGS -Winvalid-pch -Wmissing-field-initializers"
-          PARANOID_FLAGS="$PARANOID_FLAGS -Wmissing-include-dirs -Wpacked"
-          PARANOID_FLAGS="$PARANOID_FLAGS -Wstack-protector -Wtrigraphs"
-          PARANOID_FLAGS="$PARANOID_FLAGS -Wunreachable-code -Wunused-label"
+          PARANOID_FLAGS="$PARANOID_FLAGS -Winvalid-pch -Wlogical-op -Wmissing-field-initializers"
+          PARANOID_FLAGS="$PARANOID_FLAGS -Wmissing-include-dirs -Wpacked -Wredundant-decls"
+          PARANOID_FLAGS="$PARANOID_FLAGS -Wshadow -Wstack-protector -Wstrict-aliasing -Wswitch-default"
+          PARANOID_FLAGS="$PARANOID_FLAGS -Wtrigraphs -Wunreachable-code -Wunused-label"
           PARANOID_FLAGS="$PARANOID_FLAGS -Wunused-parameter -Wunused-value -Wvariadic-macros"
           PARANOID_FLAGS="$PARANOID_FLAGS -Wvolatile-register-var -Wwrite-strings"
 

--- a/examples/adjoints/adjoints_ex1/femparameters.C
+++ b/examples/adjoints/adjoints_ex1/femparameters.C
@@ -388,22 +388,22 @@ void FEMParameters::read(GetPot & input,
       libmesh_error();
     }
 
-  for (unsigned int i=0; i != n_dirichlet_conditions; ++i)
+  for (unsigned int dc=0; dc != n_dirichlet_conditions; ++dc)
     {
       const std::string func_type =
-        input("dirichlet_condition_types", zero_string, i);
+        input("dirichlet_condition_types", zero_string, dc);
 
       const std::string func_value =
-        input("dirichlet_condition_values", empty_string, i);
+        input("dirichlet_condition_values", empty_string, dc);
 
       const boundary_id_type func_boundary =
-        input("dirichlet_condition_boundaries", boundary_id_type(0), i);
+        input("dirichlet_condition_boundaries", boundary_id_type(0), dc);
 
       dirichlet_conditions[func_boundary] =
         (new_function_base(func_type, func_value).release());
 
       const std::string variable_set =
-        input("dirichlet_condition_variables", empty_string, i);
+        input("dirichlet_condition_variables", empty_string, dc);
 
       for (std::size_t i=0; i != variable_set.size(); ++i)
         {
@@ -459,22 +459,22 @@ void FEMParameters::read(GetPot & input,
       libmesh_error();
     }
 
-  for (unsigned int i=0; i != n_neumann_conditions; ++i)
+  for (unsigned int nc=0; nc != n_neumann_conditions; ++nc)
     {
       const std::string func_type =
-        input("neumann_condition_types", zero_string, i);
+        input("neumann_condition_types", zero_string, nc);
 
       const std::string func_value =
-        input("neumann_condition_values", empty_string, i);
+        input("neumann_condition_values", empty_string, nc);
 
       const boundary_id_type func_boundary =
-        input("neumann_condition_boundaries", boundary_id_type(0), i);
+        input("neumann_condition_boundaries", boundary_id_type(0), nc);
 
       neumann_conditions[func_boundary] =
         (new_function_base(func_type, func_value).release());
 
       const std::string variable_set =
-        input("neumann_condition_variables", empty_string, i);
+        input("neumann_condition_variables", empty_string, nc);
 
       for (std::size_t i=0; i != variable_set.size(); ++i)
         {

--- a/include/base/getpot.h
+++ b/include/base/getpot.h
@@ -2595,12 +2595,12 @@ GetPot::get_section_names() const
 
 
 inline STRING_VECTOR
-GetPot::get_subsection_names(const std::string & prefix) const
+GetPot::get_subsection_names(const std::string & sec_prefix) const
 {
   // GetPot functions should understand user-provided section names
   // either with or without a trailing slash.
   const std::string full_prefix =
-    *prefix.rbegin() == '/' ? prefix : prefix + '/';
+    *sec_prefix.rbegin() == '/' ? sec_prefix : sec_prefix + '/';
 
   const std::size_t full_prefix_len = full_prefix.size();
 

--- a/include/base/single_predicates.h
+++ b/include/base/single_predicates.h
@@ -207,9 +207,9 @@ protected:
 template <typename T>
 struct bid : predicate<T>
 {
-  bid(boundary_id_type bid,
+  bid(boundary_id_type b_id,
       const BoundaryInfo & bndry_info) :
-    _bid(bid),
+    _bid(b_id),
     _bndry_info(bndry_info)
   {}
   virtual ~bid() {}

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -908,7 +908,7 @@ private:
   /**
    * Work vector for compute_affine_map()
    */
-  std::vector<const Node *> elem_nodes;
+  std::vector<const Node *> _elem_nodes;
 };
 
 }

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -44,7 +44,7 @@ class CheckpointIO;
  * equal to the number of chunks.  This function supports MPI parallelism and can be used with
  * several MPI procs to speed up splitting.
  */
-std::unique_ptr<CheckpointIO> split_mesh(MeshBase & mesh, unsigned int nsplits);
+std::unique_ptr<CheckpointIO> split_mesh(MeshBase & mesh, processor_id_type nsplits);
 
 /**
  * The CheckpointIO class can be used to write simplified restart

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -810,7 +810,7 @@ public:
   /**
    * \returns The shellface index offset.
    */
-  int get_shellface_index_offset() const { return shellface_index_offset; }
+  std::size_t get_shellface_index_offset() const { return shellface_index_offset; }
 
   /**
    * An invalid_id that can be returned to signal failure in case

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -71,11 +71,13 @@ enum ElemType : int;
 #endif
 
 
+#include <libmesh/ignore_warnings.h>
 namespace exII {
 extern "C" {
 #include "exodusII.h" // defines MAX_LINE_LENGTH, MAX_STR_LENGTH used later
 }
 }
+#include <libmesh/restore_warnings.h>
 
 namespace libMesh
 {

--- a/include/numerics/coupling_matrix.h
+++ b/include/numerics/coupling_matrix.h
@@ -236,13 +236,15 @@ public:
         libmesh_assert_less_equal(firstloc, _location);
 
 #ifdef DEBUG
-        CouplingMatrix::rc_type::const_iterator next = lb;
-        next++;
-        if (next != _my_mat._ranges.end())
-          {
-            // Ranges should be sorted and should not touch
-            libmesh_assert_greater(next->first, lastloc+1);
-          }
+        {
+          CouplingMatrix::rc_type::const_iterator next = lb;
+          next++;
+          if (next != _my_mat._ranges.end())
+            {
+              // Ranges should be sorted and should not touch
+              libmesh_assert_greater(next->first, lastloc+1);
+            }
+        }
 #endif
 
         // If we're in this range, we might need to shorten or remove

--- a/include/numerics/petsc_macro.h
+++ b/include/numerics/petsc_macro.h
@@ -58,7 +58,10 @@
 #define EXTERN_C_FOR_PETSC_END
 
 // Petsc include files
+// Wrapped to avoid triggering our more paranoid warnings
+#include <libmesh/ignore_warnings.h>
 #include <petsc.h>
+#include <libmesh/restore_warnings.h>
 
 #if PETSC_RELEASE_LESS_THAN(3,1,1)
 typedef PetscTruth PetscBool;

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -825,6 +825,14 @@ void EpetraVector<T>::swap (NumericVector<T> & other)
   std::swap(ignoreNonLocalEntries_, v.ignoreNonLocalEntries_);
 }
 
+
+// Trilinos only got serious about const in version 10.4
+inline
+int * numeric_trilinos_cast(const numeric_index_type * p)
+{
+  return reinterpret_cast<int *>(const_cast<numeric_index_type *>(p));
+}
+
 } // namespace libMesh
 
 

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -1145,7 +1145,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
 
 template <typename T, typename A1, typename A2>
 inline void Communicator::send (const unsigned int dest_processor_id,
-                                const std::vector<std::vector<T,A1>,A2> & send,
+                                const std::vector<std::vector<T,A1>,A2> & send_vecs,
                                 const DataType & type,
                                 Request & req,
                                 const MessageTag & tag) const
@@ -1166,7 +1166,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
 
   int sendsize = packedsize;
 
-  const std::size_t n_vecs = send.size();
+  const std::size_t n_vecs = send_vecs.size();
 
   for (std::size_t i = 0; i != n_vecs; ++i)
     {
@@ -1181,7 +1181,7 @@ inline void Communicator::send (const unsigned int dest_processor_id,
 
       // The data for each inner buffer
       libmesh_call_mpi
-        (MPI_Pack_size (libMesh::cast_int<int>(send[i].size()), type,
+        (MPI_Pack_size (libMesh::cast_int<int>(send_vecs[i].size()), type,
                         this->get(), &packedsize));
 
       sendsize += packedsize;
@@ -1204,16 +1204,16 @@ inline void Communicator::send (const unsigned int dest_processor_id,
   for (std::size_t i = 0; i != n_vecs; ++i)
     {
       // ... the size of the ith inner buffer
-      const int subvec_size = libMesh::cast_int<int>(send[i].size());
+      const int subvec_size = libMesh::cast_int<int>(send_vecs[i].size());
 
       libmesh_call_mpi
         (MPI_Pack (&subvec_size, 1, libMesh::Parallel::StandardType<unsigned int>(),
                    &(*sendbuf)[0], sendsize, &pos, this->get()));
 
       // ... the contents of the ith inner buffer
-      if (!send[i].empty())
+      if (!send_vecs[i].empty())
         libmesh_call_mpi
-          (MPI_Pack (const_cast<T*>(&send[i][0]),
+          (MPI_Pack (const_cast<T*>(&send_vecs[i][0]),
                      libMesh::cast_int<int>(subvec_size), type,
                      &(*sendbuf)[0], sendsize, &pos, this->get()));
     }

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -400,13 +400,13 @@ void parallel_reduce (const Range & range, Body & body)
     bodies[i] = new Body(body, Threads::split());
 
   // Create the ranges for each thread
-  unsigned int range_size = range.size() / n_threads;
+  std::size_t range_size = range.size() / n_threads;
 
   typename Range::const_iterator current_beginning = range.begin();
 
   for (unsigned int i=0; i<n_threads; i++)
     {
-      unsigned int this_range_size = range_size;
+      std::size_t this_range_size = range_size;
 
       if (i+1 == n_threads)
         this_range_size += range.size() % n_threads; // Give the last one the remaining work to do

--- a/include/parallel/threads_pthread.h
+++ b/include/parallel/threads_pthread.h
@@ -291,13 +291,13 @@ void parallel_for (const Range & range, const Body & body)
   std::vector<pthread_t> threads(n_threads);
 
   // Create the ranges for each thread
-  unsigned int range_size = range.size() / n_threads;
+  std::size_t range_size = range.size() / n_threads;
 
   typename Range::const_iterator current_beginning = range.begin();
 
   for (unsigned int i=0; i<n_threads; i++)
     {
-      unsigned int this_range_size = range_size;
+      std::size_t this_range_size = range_size;
 
       if (i+1 == n_threads)
         this_range_size += range.size() % n_threads; // Give the last one the remaining work to do

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -49,11 +49,11 @@ public:
    * however if we called the function with INVALID_ELEM it would try
    * to be smart and return, thinking it had already done the work.
    */
-  QGauss (unsigned int _dim,
-          Order _order=INVALID_ORDER) :
-    QBase(_dim, _order)
+  QGauss (unsigned int dim,
+          Order order=INVALID_ORDER) :
+    QBase(dim, order)
   {
-    if (_dim == 1)
+    if (dim == 1)
       init(EDGE2);
   }
 

--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -195,8 +195,8 @@ public:
   /**
    * Get/set the boolean to indicate if we normalize the RB error in the greedy.
    */
-  void set_normalize_rb_bound_in_greedy(bool normalize_rb_bound_in_greedy)
-  {this->normalize_rb_bound_in_greedy = normalize_rb_bound_in_greedy; }
+  void set_normalize_rb_bound_in_greedy(bool normalize_rb_bound_in_greedy_in)
+  {this->normalize_rb_bound_in_greedy = normalize_rb_bound_in_greedy_in; }
   bool get_normalize_rb_bound_in_greedy() { return normalize_rb_bound_in_greedy; }
 
   /**

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -28,7 +28,9 @@
 #include <map>
 
 // PETSc includes
+#include "libmesh/ignore_warnings.h"
 #include <petsc.h>
+#include "libmesh/restore_warnings.h"
 
 namespace libMesh
 {

--- a/include/solvers/slepc_eigen_solver.h
+++ b/include/solvers/slepc_eigen_solver.h
@@ -30,7 +30,9 @@
 
 // SLEPc include files.
 EXTERN_C_FOR_SLEPC_BEGIN
+# include "libmesh/ignore_warnings.h"
 # include <slepceps.h>
+# include "libmesh/restore_warnings.h"
 EXTERN_C_FOR_SLEPC_END
 
 namespace libMesh

--- a/include/solvers/trilinos_aztec_linear_solver.h
+++ b/include/solvers/trilinos_aztec_linear_solver.h
@@ -30,8 +30,10 @@
 
 // Trilinos include files.  AztecOO requires Epetra, so there's no
 // need to check for both.
+#include "libmesh/ignore_warnings.h"
 #include <Epetra_LinearProblem.h>
 #include <AztecOO.h>
+#include "libmesh/restore_warnings.h"
 
 // C++ includes
 #include <vector>

--- a/include/systems/qoi_set.h
+++ b/include/systems/qoi_set.h
@@ -48,13 +48,13 @@ public:
   class iterator
   {
   public:
-    iterator(unsigned int i, const std::vector<bool> & v) : _i(i), _vecbool(v)
+    iterator(std::size_t i, const std::vector<bool> & v) : _i(i), _vecbool(v)
     {
       while (_i < _vecbool.size() && !_vecbool[_i])
         _i++;
     }
 
-    unsigned int operator*() const { return _i; }
+    std::size_t operator*() const { return _i; }
 
     iterator & operator++()
     {
@@ -82,7 +82,7 @@ public:
 
   private:
 
-    unsigned int _i;
+    std::size_t _i;
 
     const std::vector<bool> & _vecbool;
   };
@@ -127,7 +127,7 @@ public:
    * \returns The number of QoIs that would be computed for the
    * System \p sys
    */
-  unsigned int size(const System & sys) const;
+  std::size_t size(const System & sys) const;
 
   /**
    * Add this indices to the set to be calculated
@@ -137,7 +137,7 @@ public:
   /**
    * Add this index to the set to be calculated
    */
-  void add_index(unsigned int);
+  void add_index(std::size_t);
 
   /**
    * Remove these indices from the set to be calculated
@@ -147,22 +147,22 @@ public:
   /**
    * Remove this index from the set to be calculated
    */
-  void remove_index(unsigned int);
+  void remove_index(std::size_t);
 
   /**
    * Set the weight for this index
    */
-  void set_weight(unsigned int, Real);
+  void set_weight(std::size_t, Real);
 
   /**
    * Get the weight for this index (default 1.0)
    */
-  Real weight(unsigned int) const;
+  Real weight(std::size_t) const;
 
   /**
    * Return whether or not this index is in the set to be calculated
    */
-  bool has_index(unsigned int) const;
+  bool has_index(std::size_t) const;
 
   /**
    * Return an iterator pointing to the first index in the set
@@ -198,7 +198,7 @@ QoISet::QoISet(const std::vector<unsigned int> & indices) :
 
 
 inline
-void QoISet::add_index(unsigned int i)
+void QoISet::add_index(std::size_t i)
 {
   if (i >= _indices.size())
     _indices.resize(i+1, true);
@@ -208,7 +208,7 @@ void QoISet::add_index(unsigned int i)
 
 
 inline
-void QoISet::remove_index(unsigned int i)
+void QoISet::remove_index(std::size_t i)
 {
   if (i >= _indices.size())
     _indices.resize(i+1, true);
@@ -218,7 +218,7 @@ void QoISet::remove_index(unsigned int i)
 
 
 inline
-bool QoISet::has_index(unsigned int i) const
+bool QoISet::has_index(std::size_t i) const
 {
   return (_indices.size() <= i || _indices[i]);
 }
@@ -226,7 +226,7 @@ bool QoISet::has_index(unsigned int i) const
 
 
 inline
-void QoISet::set_weight(unsigned int i, Real w)
+void QoISet::set_weight(std::size_t i, Real w)
 {
   if (_weights.size() <= i)
     _weights.resize(i+1, 1.0);
@@ -237,7 +237,7 @@ void QoISet::set_weight(unsigned int i, Real w)
 
 
 inline
-Real QoISet::weight(unsigned int i) const
+Real QoISet::weight(std::size_t i) const
 {
   if (_weights.size() <= i)
     return 1.0;

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1538,6 +1538,11 @@ public:
   Real time;
 
   /**
+   * Number of currently active quantities of interest.
+   */
+  unsigned int n_qois() const;
+
+  /**
    * Values of the quantities of interest.  This vector needs
    * to be both resized and filled by the user before any quantity of
    * interest assembly is done and before any sensitivities are
@@ -2261,6 +2266,12 @@ void System::assemble_residual_derivatives (const ParameterVector &)
 
 inline
 void System::disable_cache () { assemble_before_solve = true; }
+
+inline
+unsigned int System::n_qois() const
+{
+  return cast_int<unsigned int>(this->qoi.size());
+}
 
 inline
 std::pair<unsigned int, Real>

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -64,6 +64,8 @@
 #pragma GCC diagnostic ignored "-Wswitch-default"
 // And this for Eigen
 #pragma GCC diagnostic ignored "-Wconversion"
+// And this for VTK
+#pragma GCC diagnostic ignored "-Wlogical-op"
 // Ignore warnings from code that uses deprecated members of std, like std::auto_ptr.
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #if (__GNUC__ > 5)

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -32,6 +32,10 @@
 #pragma clang diagnostic ignored "-Wnested-anon-types"
 #pragma clang diagnostic ignored "-Wsign-compare"
 #pragma clang diagnostic ignored "-Wunused-private-field"
+#pragma clang diagnostic ignored "-Wextra"
+#pragma clang diagnostic ignored "-Wredundant-decls"
+#pragma clang diagnostic ignored "-Wcast-qual"
+#pragma clang diagnostic ignored "-Wswitch-default"
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #if (__clang_major__ > 3) || (__clang_major__ == 3 && __clang_minor__ > 5)
 // This was introduced in 3.6
@@ -48,10 +52,18 @@
 #pragma GCC diagnostic ignored "-Wdeprecated"
 // But this is helpful with some MPI stacks
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-// And this is for cppunit
+// And these are for cppunit
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
-// And this is for Trilinos
+#pragma GCC diagnostic ignored "-Wundef"
+// And these are for Trilinos
 #pragma GCC diagnostic ignored "-Wextra"
+#pragma GCC diagnostic ignored "-Wshadow"
+// And these are for PETSc
+#pragma GCC diagnostic ignored "-Wredundant-decls"
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+// And this for Eigen
+#pragma GCC diagnostic ignored "-Wconversion"
 // Ignore warnings from code that uses deprecated members of std, like std::auto_ptr.
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #if (__GNUC__ > 5)

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -468,12 +468,12 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
 
           dnl Tested on gcc 4.8.5; hopefully the other 4.8.x and all
           dnl later versions support these too:
-          PARANOID_FLAGS="-Wall -Wextra -Wcast-align -Wdisabled-optimization -Wformat=2"
+          PARANOID_FLAGS="-Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2"
           PARANOID_FLAGS="$PARANOID_FLAGS -Wformat-nonliteral -Wformat-security -Wformat-y2k"
-          PARANOID_FLAGS="$PARANOID_FLAGS -Winvalid-pch -Wmissing-field-initializers"
-          PARANOID_FLAGS="$PARANOID_FLAGS -Wmissing-include-dirs -Wpacked"
-          PARANOID_FLAGS="$PARANOID_FLAGS -Wstack-protector -Wtrigraphs"
-          PARANOID_FLAGS="$PARANOID_FLAGS -Wunreachable-code -Wunused-label"
+          PARANOID_FLAGS="$PARANOID_FLAGS -Winvalid-pch -Wlogical-op -Wmissing-field-initializers"
+          PARANOID_FLAGS="$PARANOID_FLAGS -Wmissing-include-dirs -Wpacked -Wredundant-decls"
+          PARANOID_FLAGS="$PARANOID_FLAGS -Wshadow -Wstack-protector -Wstrict-aliasing -Wswitch-default"
+          PARANOID_FLAGS="$PARANOID_FLAGS -Wtrigraphs -Wunreachable-code -Wunused-label"
           PARANOID_FLAGS="$PARANOID_FLAGS -Wunused-parameter -Wunused-value -Wvariadic-macros"
           PARANOID_FLAGS="$PARANOID_FLAGS -Wvolatile-register-var -Wwrite-strings"
 

--- a/src/apps/meshid.C
+++ b/src/apps/meshid.C
@@ -29,8 +29,11 @@
 
 #ifdef LIBMESH_HAVE_EXODUS_API
 
+#include "libmesh/ignore_warnings.h"
 #include "exodusII.h"
 #include "exodusII_int.h"
+#include "libmesh/restore_warnings.h"
+
 #include "libmesh/getpot.h"
 
 #define EXODUS_DIM 0x8

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1580,9 +1580,9 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
               this->dof_indices (partner, di, vj);
 
               // Insert the remote DOF indices into the send list
-              for (std::size_t j=0; j != di.size(); ++j)
-                if (!this->local_index(di[j]))
-                  _send_list.push_back(di[j]);
+              for (auto d : di)
+                if (!this->local_index(d))
+                  _send_list.push_back(d);
             }
         }
       else

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2692,12 +2692,12 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
                 const DofConstraintValueMap & constraint_map =
                   adjoint_map_it->second;
 
-                DofConstraintValueMap::const_iterator rhsit =
+                DofConstraintValueMap::const_iterator adj_rhsit =
                   constraint_map.find(pushed_id);
 
                 rhs[q] =
-                  (rhsit == constraint_map.end()) ?
-                  0 : rhsit->second;
+                  (adj_rhsit == constraint_map.end()) ?
+                  0 : adj_rhsit->second;
               }
           }
       }
@@ -4016,11 +4016,11 @@ void DofMap::gather_constraints (MeshBase & /*mesh*/,
                       const DofConstraintValueMap & constraint_map =
                         adjoint_map_it->second;
 
-                      DofConstraintValueMap::const_iterator rhsit =
+                      DofConstraintValueMap::const_iterator adj_rhsit =
                         constraint_map.find(constrained);
                       data[i].push_back
-                        ((rhsit == constraint_map.end()) ?
-                         0 : rhsit->second);
+                        ((adj_rhsit == constraint_map.end()) ?
+                         0 : adj_rhsit->second);
                     }
                 }
             }

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3775,7 +3775,7 @@ void DofMap::scatter_constraints(MeshBase & mesh)
                   while (constrained >= _end_df[the_constrained_proc_id])
                     the_constrained_proc_id++;
 
-                  const dof_id_type elemproc = elem->processor_id();
+                  const processor_id_type elemproc = elem->processor_id();
                   if (elemproc != the_constrained_proc_id)
                     pushed_ids[elemproc].insert(constrained);
                 }

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -284,7 +284,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
           if (var > 0)
             {
               // We can't mix L_inf and L_2 norms
-              bool is_valid_norm_type =
+              bool is_valid_norm_combo =
                 ((error_estimator.error_norm.type(var) == L2 ||
                   error_estimator.error_norm.type(var) == H1_SEMINORM ||
                   error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
@@ -303,7 +303,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                  (error_estimator.error_norm.type(var-1) == L_INF ||
                   error_estimator.error_norm.type(var-1) == W1_INF_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == W2_INF_SEMINORM));
-              libmesh_assert (is_valid_norm_type);
+              libmesh_assert (is_valid_norm_combo);
             }
 #endif // DEBUG
 

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -186,7 +186,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
           if (var > 0)
             {
               // We can't mix L_inf and L_2 norms
-              bool is_valid_norm_type =
+              bool is_valid_norm_combo =
                 ((error_estimator.error_norm.type(var) == L2 ||
                   error_estimator.error_norm.type(var) == H1_SEMINORM ||
                   error_estimator.error_norm.type(var) == H1_X_SEMINORM ||
@@ -205,7 +205,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                  (error_estimator.error_norm.type(var-1) == L_INF ||
                   error_estimator.error_norm.type(var-1) == W1_INF_SEMINORM ||
                   error_estimator.error_norm.type(var-1) == W2_INF_SEMINORM));
-              libmesh_assert (is_valid_norm_type);
+              libmesh_assert (is_valid_norm_combo);
             }
 #endif // DEBUG
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -1235,12 +1235,12 @@ void FEMap::compute_affine_map(const unsigned int dim,
 
   // Determine the nodes contributing to element elem
   unsigned int n_nodes = elem->n_nodes();
-  elem_nodes.resize(elem->n_nodes());
+  _elem_nodes.resize(elem->n_nodes());
   for (unsigned int i=0; i<n_nodes; i++)
-    elem_nodes[i] = elem->node_ptr(i);
+    _elem_nodes[i] = elem->node_ptr(i);
 
   // Compute map at quadrature point 0
-  this->compute_single_point_map(dim, qw, elem, 0, elem_nodes, /*compute_second_derivatives=*/false);
+  this->compute_single_point_map(dim, qw, elem, 0, _elem_nodes, /*compute_second_derivatives=*/false);
 
   // Compute xyz at all other quadrature points
   if (calculate_xyz)
@@ -1248,7 +1248,7 @@ void FEMap::compute_affine_map(const unsigned int dim,
       {
         xyz[p].zero();
         for (std::size_t i=0; i<phi_map.size(); i++) // sum over the nodes
-          xyz[p].add_scaled        (*elem_nodes[i], phi_map[i][p]    );
+          xyz[p].add_scaled        (*_elem_nodes[i], phi_map[i][p]    );
       }
 
   // Copy other map data from quadrature point 0

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -1403,25 +1403,24 @@ void FEMap::compute_map(const unsigned int dim,
   this->resize_quadrature_map_vectors(dim, n_qp);
 
   // Determine the nodes contributing to element elem
-  std::vector<const Node *> elem_nodes;
   if (elem->type() == TRI3SUBDIVISION)
     {
       // Subdivision surface FE require the 1-ring around elem
       libmesh_assert_equal_to (dim, 2);
       const Tri3Subdivision * sd_elem = static_cast<const Tri3Subdivision *>(elem);
-      MeshTools::Subdivision::find_one_ring(sd_elem, elem_nodes);
+      MeshTools::Subdivision::find_one_ring(sd_elem, _elem_nodes);
     }
   else
     {
       // All other FE use only the nodes of elem itself
-      elem_nodes.resize(elem->n_nodes(), nullptr);
+      _elem_nodes.resize(elem->n_nodes(), nullptr);
       for (unsigned int i=0; i<elem->n_nodes(); i++)
-        elem_nodes[i] = elem->node_ptr(i);
+        _elem_nodes[i] = elem->node_ptr(i);
     }
 
   // Compute map at all quadrature points
   for (unsigned int p=0; p!=n_qp; p++)
-    this->compute_single_point_map(dim, qw, elem, p, elem_nodes, calculate_d2phi);
+    this->compute_single_point_map(dim, qw, elem, p, _elem_nodes, calculate_d2phi);
 }
 
 

--- a/src/fe/inf_fe_map.C
+++ b/src/fe/inf_fe_map.C
@@ -61,10 +61,11 @@ Point InfFE<Dim,T_radial,T_map>::map (const Elem * inf_elem,
     case 3:
       base_point = FE<2,LAGRANGE>::map (base_elem.get(), reference_point);
       break;
-#ifdef DEBUG
     default:
+#ifdef DEBUG
       libmesh_error_msg("Unknown Dim = " << Dim);
 #endif
+      break;
     }
 
 

--- a/src/geom/elem_refinement.C
+++ b/src/geom/elem_refinement.C
@@ -60,13 +60,13 @@ void Elem::refine (MeshRefinement & mesh_refinement)
           current_child->set_p_level(parent_p_level);
           current_child->set_p_refinement_flag(this->p_refinement_flag());
 
-          for (unsigned int nc=0; nc<current_child->n_nodes(); nc++)
+          for (unsigned int cnode=0; cnode != current_child->n_nodes(); ++cnode)
             {
               Node * node =
-                mesh_refinement.add_node(*this, c, nc,
+                mesh_refinement.add_node(*this, c, cnode,
                                          current_child->processor_id());
               node->set_n_systems (this->n_systems());
-              current_child->set_node(nc) = node;
+              current_child->set_node(cnode) = node;
             }
 
           mesh_refinement.add_elem (current_child);
@@ -120,7 +120,7 @@ void Elem::coarsen()
       Elem * mychild = this->child_ptr(c);
       if (mychild == remote_elem)
         continue;
-      for (unsigned int nc=0; nc != mychild->n_nodes(); nc++)
+      for (unsigned int cnode=0; cnode != mychild->n_nodes(); ++cnode)
         {
           Point new_pos;
           bool calculated_new_pos = false;
@@ -128,7 +128,7 @@ void Elem::coarsen()
           for (unsigned int n=0; n<this->n_nodes(); n++)
             {
               // The value from the embedding matrix
-              const float em_val = this->embedding_matrix(c,nc,n);
+              const float em_val = this->embedding_matrix(c,cnode,n);
 
               // The node location is somewhere between existing vertices
               if ((em_val != 0.) && (em_val != 1.))
@@ -143,7 +143,7 @@ void Elem::coarsen()
               //Move the existing node back into it's original location
               for (unsigned int i=0; i<LIBMESH_DIM; i++)
                 {
-                  Point & child_node = mychild->point(nc);
+                  Point & child_node = mychild->point(cnode);
                   child_node(i)=new_pos(i);
                 }
             }

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -127,7 +127,7 @@ void make_dir(const std::string & input_name, libMesh::processor_id_type n_procs
 namespace libMesh
 {
 
-std::unique_ptr<CheckpointIO> split_mesh(MeshBase & mesh, unsigned int nsplits)
+std::unique_ptr<CheckpointIO> split_mesh(MeshBase & mesh, processor_id_type nsplits)
 {
   // There is currently an issue with DofObjects not being properly
   // reset if the mesh is not first repartitioned onto 1 processor

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -195,8 +195,8 @@ processor_id_type CheckpointIO::select_split_config(const std::string & input_na
           {
             // otherwise fall back to a serial/single-split mesh
             header_name = header_file(input_name, 1);
-            std::ifstream in (header_name.c_str());
-            if (!in.good())
+            std::ifstream in2 (header_name.c_str());
+            if (!in2.good())
               {
                 libmesh_error_msg("ERROR: cannot locate header file for input '" << input_name << "'");
               }
@@ -248,7 +248,7 @@ void CheckpointIO::cleanup(const std::string & input_name, processor_id_type n_p
   for (processor_id_type i = 0; i < n_procs; i++)
     {
       auto split = split_file(input_name, n_procs, i);
-      auto ret = std::remove(split.c_str());
+      ret = std::remove(split.c_str());
       if (ret != 0)
         libmesh_warning("Failed to clean up checkpoint split file '" << split << "': " << std::strerror(ret));
     }

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1869,7 +1869,7 @@ void ExodusII_IO_Helper::write_element_values(const MeshBase & mesh,
     return;
 
   // Loop over the element blocks and write the data one block at a time
-  std::map<unsigned int, std::vector<unsigned int>> subdomain_map;
+  std::map<subdomain_id_type, std::vector<unsigned int>> subdomain_map;
 
   // Ask the file how many element vars it has, store it in the num_elem_vars variable.
   ex_err = exII::ex_get_var_param(ex_id, "e", &num_elem_vars);
@@ -1891,7 +1891,7 @@ void ExodusII_IO_Helper::write_element_values(const MeshBase & mesh,
   for (unsigned int i=0; i<static_cast<unsigned>(num_elem_vars); ++i)
     {
       // The size of the subdomain map is the number of blocks.
-      std::map<unsigned int, std::vector<unsigned int>>::iterator it = subdomain_map.begin();
+      std::map<subdomain_id_type, std::vector<unsigned int>>::iterator it = subdomain_map.begin();
 
       const std::set<subdomain_id_type> & active_subdomains = vars_active_subdomains[i];
       for (unsigned int j=0; it!=subdomain_map.end(); ++it, ++j)

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -978,24 +978,24 @@ void ExodusII_IO_Helper::write_var_names_impl(const char * var_type, int & count
   ex_err = exII::ex_put_var_param(ex_id, var_type, count);
   EX_CHECK_ERR(ex_err, "Error setting number of vars.");
 
-  if (names.size() > 0)
+  if (count > 0)
     {
-      NamesData names_table(names.size(), MAX_STR_LENGTH);
+      NamesData names_table(count, MAX_STR_LENGTH);
 
       // Store the input names in the format required by Exodus.
-      for (std::size_t i=0; i<names.size(); ++i)
+      for (int i=0; i != count; ++i)
         names_table.push_back_entry(names[i]);
 
       if (verbose)
         {
           libMesh::out << "Writing variable name(s) to file: " << std::endl;
-          for (std::size_t i=0; i<names.size(); ++i)
+          for (int i=0; i != count; ++i)
             libMesh::out << names_table.get_char_star(i) << std::endl;
         }
 
       ex_err = exII::ex_put_var_names(ex_id,
                                       var_type,
-                                      cast_int<int>(names.size()),
+                                      count,
                                       names_table.get_char_star_star()
                                       );
 

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -651,7 +651,7 @@ void GmshIO::write_mesh (std::ostream & out_stream)
 
   // If requested, write out lower-dimensional elements for
   // element-side-based boundary conditions.
-  unsigned int n_boundary_faces = 0;
+  std::size_t n_boundary_faces = 0;
   if (this->write_lower_dimensional_elements())
     n_boundary_faces = mesh.get_boundary_info().n_boundary_conds();
 

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -489,7 +489,7 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
 
   // Likewise with our unique_ids
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
-  dof_id_type old_max_unique_id = _mesh.parallel_max_unique_id();
+  unique_id_type old_max_unique_id = _mesh.parallel_max_unique_id();
 #endif
 
   // for each boundary node, add an outer_node with

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -931,7 +931,7 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
   // to all processors which own any of the coarsened-away-element's
   // siblings.
   typedef std::unordered_map<processor_id_type, std::vector<Elem *>> ghost_map;
-  ghost_map elements_to_ghost;
+  ghost_map coarsening_elements_to_ghost;
 
   const processor_id_type proc_id = mesh.processor_id();
   // Look for just-coarsened elements
@@ -947,7 +947,7 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
       // the parent's owner needs us to send them.
       const processor_id_type their_proc_id = elem->parent()->processor_id();
       if (their_proc_id != proc_id)
-        elements_to_ghost[their_proc_id].push_back(elem);
+        coarsening_elements_to_ghost[their_proc_id].push_back(elem);
     }
 
   const processor_id_type n_proc = mesh.n_processors();
@@ -976,8 +976,8 @@ void MeshCommunication::send_coarse_ghosts(MeshBase & mesh) const
       std::set<const Node *> nodes_to_send;
 
       const ghost_map::const_iterator it =
-        elements_to_ghost.find(p);
-      if (it != elements_to_ghost.end())
+        coarsening_elements_to_ghost.find(p);
+      if (it != coarsening_elements_to_ghost.end())
         {
           const std::vector<Elem *> & elems = it->second;
           libmesh_assert(elems.size());

--- a/src/mesh/mesh_communication_global_indices.C
+++ b/src/mesh/mesh_communication_global_indices.C
@@ -334,7 +334,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
     // Nodes first -- all nodes, not just local ones
     {
       // Request sets to send to each processor
-      std::map<dof_id_type, std::vector<Parallel::DofObjectKey>>
+      std::map<processor_id_type, std::vector<Parallel::DofObjectKey>>
         requested_ids;
       // Results to gather from each processor - kept in a map so we
       // do only one loop over nodes after all receives are done.
@@ -451,7 +451,7 @@ void MeshCommunication::assign_global_indices (MeshBase & mesh) const
     // elements next -- all elements, not just local ones
     {
       // Request sets to send to each processor
-      std::map<dof_id_type, std::vector<Parallel::DofObjectKey>>
+      std::map<processor_id_type, std::vector<Parallel::DofObjectKey>>
         requested_ids;
       // Results to gather from each processor - kept in a map so we
       // do only one loop over elements after all receives are done.

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -1380,6 +1380,8 @@ double VariationalMeshSmoother::maxE(Array2D<double> & R,
                                 K[1] = 1./3.;
                                 K[2] = 1;
                                 break;
+                              default:
+                                break;
                               }
 
                             switch (j)
@@ -1404,6 +1406,8 @@ double VariationalMeshSmoother::maxE(Array2D<double> & R,
                                 K[4] = 1./3.;
                                 K[5] = 1;
                                 break;
+                              default:
+                                break;
                               }
 
                             switch (k)
@@ -1427,6 +1431,8 @@ double VariationalMeshSmoother::maxE(Array2D<double> & R,
                                 K[6] = 0.5;
                                 K[7] = 1./3.;
                                 K[8] = 1;
+                                break;
+                              default:
                                 break;
                               }
 
@@ -1770,6 +1776,8 @@ double VariationalMeshSmoother::minq(const Array2D<double> & R,
                                 K[2] = 1;
                                 break;
 
+                              default:
+                                break;
                               }
                             switch (j)
                               {
@@ -1797,6 +1805,8 @@ double VariationalMeshSmoother::minq(const Array2D<double> & R,
                                 K[5] = 1;
                                 break;
 
+                              default:
+                                break;
                               }
                             switch (k)
                               {
@@ -1822,6 +1832,9 @@ double VariationalMeshSmoother::minq(const Array2D<double> & R,
                                 K[6] = 0.5;
                                 K[7] = 1./3.;
                                 K[8] = 1;
+                                break;
+
+                              default:
                                 break;
                               }
 
@@ -3190,6 +3203,9 @@ double VariationalMeshSmoother::localP(Array3D<double> & W,
                           K[1] = 1./3.;
                           K[2] = 1;
                           break;
+
+                        default:
+                          break;
                         }
 
                       switch (j)
@@ -3218,6 +3234,8 @@ double VariationalMeshSmoother::localP(Array3D<double> & W,
                           K[5] = 1;
                           break;
 
+                        default:
+                          break;
                         }
 
                       switch (k)
@@ -3246,6 +3264,8 @@ double VariationalMeshSmoother::localP(Array3D<double> & W,
                           K[8] = 1;
                           break;
 
+                        default:
+                          break;
                         }
 
                       if ((i==j) && (j==k))

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -1178,11 +1178,11 @@ double VariationalMeshSmoother::maxE(Array2D<double> & R,
                         basisA(Q, 6, K, H[ii], me);
 
                         std::vector<double> a1(3), a2(3);
-                        for (int k=0; k<2; k++)
+                        for (int k2=0; k2<2; k2++)
                           for (int l=0; l<6; l++)
                             {
-                              a1[k] += Q[k][l]*R[cells[ii][l]][0];
-                              a2[k] += Q[k][l]*R[cells[ii][l]][1];
+                              a1[k2] += Q[k2][l]*R[cells[ii][l]][0];
+                              a2[k2] += Q[k2][l]*R[cells[ii][l]][1];
                             }
 
                         double det = jac2(a1[0],a1[1],a2[0],a2[1]);
@@ -1571,11 +1571,11 @@ double VariationalMeshSmoother::minq(const Array2D<double> & R,
                         basisA(Q, 6, K, H[ii], me);
 
                         std::vector<double> a1(3), a2(3);
-                        for (int k=0; k<2; k++)
+                        for (int k2=0; k2<2; k2++)
                           for (int l=0; l<6; l++)
                             {
-                              a1[k] += Q[k][l]*R[cells[ii][l]][0];
-                              a2[k] += Q[k][l]*R[cells[ii][l]][1];
+                              a1[k2] += Q[k2][l]*R[cells[ii][l]][0];
+                              a2[k2] += Q[k2][l]*R[cells[ii][l]][1];
                             }
 
                         double det = jac2(a1[0], a1[1], a2[0], a2[1]);

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -2343,11 +2343,11 @@ double VariationalMeshSmoother::minJ(Array2D<double> & R,
     }
 
   nonzero = 0;
-  for (dof_id_type j=0; j<_n_nodes; j++)
+  for (dof_id_type j2=0; j2<_n_nodes; j2++)
     for (unsigned k=0; k<_dim; k++)
       {
-        R[j][k] = R[j][k] + T*P[j][k];
-        nonzero += T*P[j][k]*T*P[j][k];
+        R[j2][k] = R[j2][k] + T*P[j2][k];
+        nonzero += T*P[j2][k]*T*P[j2][k];
       }
 
   if (msglev >= 2)

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -23,6 +23,7 @@
 #include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
 #include <cmath>
 #include <iomanip>
+#include <limits>
 
 // Local includes
 #include "libmesh/mesh_smoother_vsmoother.h"
@@ -515,7 +516,7 @@ int VariationalMeshSmoother::readmetr(std::string name,
 // Stolen from ErrorVector!
 float VariationalMeshSmoother::adapt_minimum() const
 {
-  float min = 1.e30;
+  float min = std::numeric_limits<float>::max();
 
   for (std::size_t i=0; i<_adapt_data->size(); i++)
     {

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1183,11 +1183,11 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
   // Then we iterate over node_to_node_map and delete the
   // duplicate nodes that came from other_mesh.
 
-  // Container to catch boundary IDs passed back from BoundaryInfo.
-  std::vector<boundary_id_type> bc_ids;
-
   {
     LOG_SCOPE("stitch_meshes node updates", "ReplicatedMesh");
+
+    // Container to catch boundary IDs passed back from BoundaryInfo.
+    std::vector<boundary_id_type> bc_ids;
 
     for (const auto & pr : node_to_elems_map)
       {

--- a/src/numerics/dense_matrix_blas_lapack.C
+++ b/src/numerics/dense_matrix_blas_lapack.C
@@ -23,7 +23,9 @@
 
 #if (LIBMESH_HAVE_PETSC)
 # include "libmesh/petsc_macro.h"
+# include "libmesh/ignore_warnings.h"
 # include <petscblaslapack.h>
+# include "libmesh/restore_warnings.h"
 #endif
 
 namespace libMesh

--- a/src/numerics/trilinos_epetra_matrix.C
+++ b/src/numerics/trilinos_epetra_matrix.C
@@ -251,7 +251,9 @@ void EpetraMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
   libmesh_assert_equal_to (rows.size(), m);
   libmesh_assert_equal_to (cols.size(), n);
 
-  _mat->SumIntoGlobalValues(m, (int *)&rows[0], n, (int *)&cols[0], &dm.get_values()[0]);
+  _mat->SumIntoGlobalValues(m, numeric_trilinos_cast(&rows[0]),
+                            n, numeric_trilinos_cast(&cols[0]),
+                            &dm.get_values()[0]);
 }
 
 

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -215,8 +215,8 @@ void EpetraVector<T>::add_vector (const T * v,
 {
   libmesh_assert_equal_to (sizeof(numeric_index_type), sizeof(int));
 
-  SumIntoGlobalValues (dof_indices.size(),
-                       (int *) &dof_indices[0],
+  SumIntoGlobalValues (cast_int<numeric_index_type>(dof_indices.size()),
+                       numeric_trilinos_cast(&dof_indices[0]),
                        const_cast<T *>(v));
 }
 
@@ -288,8 +288,8 @@ void EpetraVector<T>::insert (const T * v,
 {
   libmesh_assert_equal_to (sizeof(numeric_index_type), sizeof(int));
 
-  ReplaceGlobalValues (dof_indices.size(),
-                       (int *) &dof_indices[0],
+  ReplaceGlobalValues (cast_int<numeric_index_type>(dof_indices.size()),
+                       numeric_trilinos_cast(&dof_indices[0]),
                        const_cast<T *>(v));
 }
 

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -282,16 +282,16 @@ void Partitioner::set_parent_processor_ids(MeshBase & mesh)
   // of its active ancestor.
   if (mesh.is_serial())
     {
-      for (auto & child : mesh.active_element_ptr_range())
+      for (auto & elem : mesh.active_element_ptr_range())
         {
           // First set descendents
           std::vector<const Elem *> subactive_family;
-          child->total_family_tree(subactive_family);
+          elem->total_family_tree(subactive_family);
           for (std::size_t i = 0; i != subactive_family.size(); ++i)
-            const_cast<Elem *>(subactive_family[i])->processor_id() = child->processor_id();
+            const_cast<Elem *>(subactive_family[i])->processor_id() = elem->processor_id();
 
           // Then set ancestors
-          Elem * parent = child->parent();
+          Elem * parent = elem->parent();
 
           while (parent)
             {
@@ -551,11 +551,11 @@ void Partitioner::set_interface_node_processor_ids_BFS(MeshBase & mesh)
                                     neighbors_order.begin(), neighbors_order.end(),
                                     std::back_inserter(common_nodes));
 
-              for (auto node : common_nodes)
-                if (visted_nodes.find(node) == visted_nodes.end())
+              for (auto c_node : common_nodes)
+                if (visted_nodes.find(c_node) == visted_nodes.end())
                   {
-                    nodes_queue.push(node);
-                    visted_nodes.insert(node);
+                    nodes_queue.push(c_node);
+                    visted_nodes.insert(c_node);
                     if (visted_nodes.size() >= n_own_nodes)
                       goto queue_done;
                   }
@@ -618,10 +618,10 @@ void Partitioner::set_interface_node_processor_ids_petscpartitioner(MeshBase & m
                                 neighbors_order.begin(), neighbors_order.end(),
                                 std::back_inserter(common_nodes));
 
-          rows[i+1] = rows[i] +  common_nodes.size();
+          rows[i+1] = rows[i] + cast_int<dof_id_type>(common_nodes.size());
 
-          for (auto node : common_nodes)
-            cols.push_back(global_to_local[node]);
+          for (auto c_node : common_nodes)
+            cols.push_back(global_to_local[c_node]);
         }
 
       Mat adj;

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -29,7 +29,9 @@
 #include "libmesh/parallel_ghost_sync.h"
 
 #ifdef LIBMESH_HAVE_PETSC
+#include "libmesh/ignore_warnings.h"
 #include "petscmat.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 namespace libMesh

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -206,9 +206,8 @@ void RBConstruction::process_parameters_file (const std::string & parameters_fil
                                                 abs_training_tolerance);
 
   // Initialize value to false, let the input file value override.
-  bool normalize_rb_bound_in_greedy = false;
   const bool normalize_rb_bound_in_greedy_in = infile("normalize_rb_bound_in_greedy",
-                                                      normalize_rb_bound_in_greedy);
+                                                      false);
 
   // Read in the parameters from the input file too
   unsigned int n_continuous_parameters = infile.vector_variable_size("parameter_names");

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -47,8 +47,10 @@
 // Need SLEPc to get the POD eigenvalues
 #if defined(LIBMESH_HAVE_SLEPC)
 // LAPACK include (via SLEPc)
+#include "libmesh/ignore_warnings.h"
 #include <petscsys.h>
 #include <slepcblaslapack.h>
+#include "libmesh/restore_warnings.h"
 #endif // LIBMESH_HAVE_SLEPC
 
 namespace libMesh

--- a/src/solution_transfer/radial_basis_interpolation.C
+++ b/src/solution_transfer/radial_basis_interpolation.C
@@ -28,7 +28,9 @@
 #include "libmesh/eigen_core_support.h"
 
 #ifdef LIBMESH_HAVE_EIGEN
-#include <Eigen/Dense>
+# include "libmesh/ignore_warnings.h"
+# include <Eigen/Dense>
+# include "libmesh/restore_warnings.h"
 #endif
 
 

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -31,7 +31,9 @@
 #include "libmesh/enum_solver_type.h"
 
 // GMRES is an "unsupported" iterative solver in Eigen.
+#include "libmesh/ignore_warnings.h"
 #include <unsupported/Eigen/IterativeSolvers>
+#include "libmesh/restore_warnings.h"
 
 namespace libMesh
 {

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -19,7 +19,9 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 
+#include "libmesh/ignore_warnings.h"
 #include <petscsf.h>
+#include "libmesh/restore_warnings.h"
 
 #include "libmesh/petsc_dm_wrapper.h"
 #include "libmesh/system.h"

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -412,8 +412,6 @@ void PetscDMWrapper::add_dofs_helper (const System & system,
 {
   unsigned int total_n_dofs_at_dofobject = 0;
 
-  PetscErrorCode ierr;
-
   // We are assuming variables are also numbered 0 to n_vars()-1
   for( unsigned int v = 0; v < system.n_vars(); v++ )
     {
@@ -434,7 +432,8 @@ void PetscDMWrapper::add_dofs_helper (const System & system,
 
   libmesh_assert_equal_to(total_n_dofs_at_dofobject, dof_object.n_dofs(system.number()));
 
-  ierr = PetscSectionSetDof( section, local_id, total_n_dofs_at_dofobject );
+  PetscErrorCode ierr =
+    PetscSectionSetDof( section, local_id, total_n_dofs_at_dofobject );
   CHKERRABORT(system.comm().get(),ierr);
 }
 

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -598,17 +598,17 @@ void SlepcEigenSolver<T>::set_slepc_solver_type()
   switch (this->_eigen_solver_type)
     {
     case POWER:
-      ierr = EPSSetType (_eps, (char *) EPSPOWER);    LIBMESH_CHKERR(ierr); return;
+      ierr = EPSSetType (_eps, EPSPOWER);    LIBMESH_CHKERR(ierr); return;
     case SUBSPACE:
-      ierr = EPSSetType (_eps, (char *) EPSSUBSPACE); LIBMESH_CHKERR(ierr); return;
+      ierr = EPSSetType (_eps, EPSSUBSPACE); LIBMESH_CHKERR(ierr); return;
     case LAPACK:
-      ierr = EPSSetType (_eps, (char *) EPSLAPACK);   LIBMESH_CHKERR(ierr); return;
+      ierr = EPSSetType (_eps, EPSLAPACK);   LIBMESH_CHKERR(ierr); return;
     case ARNOLDI:
-      ierr = EPSSetType (_eps, (char *) EPSARNOLDI);  LIBMESH_CHKERR(ierr); return;
+      ierr = EPSSetType (_eps, EPSARNOLDI);  LIBMESH_CHKERR(ierr); return;
     case LANCZOS:
-      ierr = EPSSetType (_eps, (char *) EPSLANCZOS);  LIBMESH_CHKERR(ierr); return;
+      ierr = EPSSetType (_eps, EPSLANCZOS);  LIBMESH_CHKERR(ierr); return;
     case KRYLOVSCHUR:
-      ierr = EPSSetType (_eps, (char *) EPSKRYLOVSCHUR);  LIBMESH_CHKERR(ierr); return;
+      ierr = EPSSetType (_eps, EPSKRYLOVSCHUR);  LIBMESH_CHKERR(ierr); return;
       // case ARPACK:
       // ierr = EPSSetType (_eps, (char *) EPSARPACK);   LIBMESH_CHKERR(ierr); return;
 

--- a/src/solvers/trilinos_aztec_linear_solver.C
+++ b/src/solvers/trilinos_aztec_linear_solver.C
@@ -239,6 +239,8 @@ LinearConvergenceReason AztecLinearSolver<T>::get_converged_reason() const
       return CONVERGED_RTOL_NORMAL;
     case AZ_maxits :
       return DIVERGED_ITS;
+    default :
+      break;
     }
   return DIVERGED_NULL;
 }

--- a/src/solvers/trilinos_nox_nonlinear_solver.C
+++ b/src/solvers/trilinos_nox_nonlinear_solver.C
@@ -157,12 +157,12 @@ bool Problem_Interface::computeJacobian(const Epetra_Vector & x,
 
   NonlinearImplicitSystem & sys = _solver->system();
 
-  EpetraMatrix<Number> Jac(&dynamic_cast<Epetra_FECrsMatrix &>(jac), sys.comm());
+  EpetraMatrix<Number> J(&dynamic_cast<Epetra_FECrsMatrix &>(jac), sys.comm());
   EpetraVector<Number> & X_sys = *cast_ptr<EpetraVector<Number> *>(sys.solution.get());
   EpetraVector<Number> X_global(*const_cast<Epetra_Vector *>(&x), sys.comm());
 
   // Set the dof maps
-  Jac.attach_dof_map(sys.get_dof_map());
+  J.attach_dof_map(sys.get_dof_map());
 
   // Use the systems update() to get a good local version of the parallel solution
   X_global.swap(X_sys);
@@ -182,21 +182,21 @@ bool Problem_Interface::computeJacobian(const Epetra_Vector & x,
     libmesh_error_msg("ERROR: cannot specify both a function and object to compute the combined Residual & Jacobian!");
 
   if (_solver->jacobian != nullptr)
-    _solver->jacobian(*sys.current_local_solution.get(), Jac, sys);
+    _solver->jacobian(*sys.current_local_solution.get(), J, sys);
 
   else if (_solver->jacobian_object != nullptr)
-    _solver->jacobian_object->jacobian(*sys.current_local_solution.get(), Jac, sys);
+    _solver->jacobian_object->jacobian(*sys.current_local_solution.get(), J, sys);
 
   else if (_solver->matvec != nullptr)
-    _solver->matvec(*sys.current_local_solution.get(), nullptr, &Jac, sys);
+    _solver->matvec(*sys.current_local_solution.get(), nullptr, &J, sys);
 
   else if (_solver->residual_and_jacobian_object != nullptr)
-    _solver->residual_and_jacobian_object->residual_and_jacobian (*sys.current_local_solution.get(), nullptr, &Jac, sys);
+    _solver->residual_and_jacobian_object->residual_and_jacobian (*sys.current_local_solution.get(), nullptr, &J, sys);
 
   else
     libmesh_error_msg("Error! Unable to compute residual and/or Jacobian!");
 
-  Jac.close();
+  J.close();
   X_global.close();
 
   return true;
@@ -221,12 +221,12 @@ bool Problem_Interface::computePreconditioner(const Epetra_Vector & x,
   NonlinearImplicitSystem & sys = _solver->system();
   TrilinosPreconditioner<Number> & tpc = dynamic_cast<TrilinosPreconditioner<Number> &>(prec);
 
-  EpetraMatrix<Number> Jac(dynamic_cast<Epetra_FECrsMatrix *>(tpc.mat()),sys.comm());
+  EpetraMatrix<Number> J(dynamic_cast<Epetra_FECrsMatrix *>(tpc.mat()),sys.comm());
   EpetraVector<Number> & X_sys = *cast_ptr<EpetraVector<Number> *>(sys.solution.get());
   EpetraVector<Number> X_global(*const_cast<Epetra_Vector *>(&x), sys.comm());
 
   // Set the dof maps
-  Jac.attach_dof_map(sys.get_dof_map());
+  J.attach_dof_map(sys.get_dof_map());
 
   // Use the systems update() to get a good local version of the parallel solution
   X_global.swap(X_sys);
@@ -246,21 +246,21 @@ bool Problem_Interface::computePreconditioner(const Epetra_Vector & x,
     libmesh_error_msg("ERROR: cannot specify both a function and object to compute the combined Residual & Jacobian!");
 
   if (_solver->jacobian != nullptr)
-    _solver->jacobian(*sys.current_local_solution.get(), Jac, sys);
+    _solver->jacobian(*sys.current_local_solution.get(), J, sys);
 
   else if (_solver->jacobian_object != nullptr)
-    _solver->jacobian_object->jacobian(*sys.current_local_solution.get(), Jac, sys);
+    _solver->jacobian_object->jacobian(*sys.current_local_solution.get(), J, sys);
 
   else if (_solver->matvec != nullptr)
-    _solver->matvec(*sys.current_local_solution.get(), nullptr, &Jac, sys);
+    _solver->matvec(*sys.current_local_solution.get(), nullptr, &J, sys);
 
   else if (_solver->residual_and_jacobian_object != nullptr)
-    _solver->residual_and_jacobian_object->residual_and_jacobian (*sys.current_local_solution.get(), nullptr, &Jac, sys);
+    _solver->residual_and_jacobian_object->residual_and_jacobian (*sys.current_local_solution.get(), nullptr, &J, sys);
 
   else
     libmesh_error_msg("Error! Unable to compute residual and/or Jacobian!");
 
-  Jac.close();
+  J.close();
   X_global.close();
 
   tpc.compute();

--- a/src/systems/qoi_set.C
+++ b/src/systems/qoi_set.C
@@ -32,9 +32,9 @@ QoISet::QoISet(const System & sys) : _indices(sys.qoi.size(), true) {}
 
 
 
-unsigned int QoISet::size (const System & sys) const
+std::size_t QoISet::size (const System & sys) const
 {
-  unsigned int qoi_count = 0;
+  std::size_t qoi_count = 0;
   for (std::size_t i=0; i != sys.qoi.size(); ++i)
     if (this->has_index(i))
       qoi_count++;

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -692,8 +692,8 @@ void System::read_parallel_data (Xdr & io,
                           std::vector<dof_id_type> SCALAR_dofs;
                           dof_map.SCALAR_dof_indices(SCALAR_dofs, var);
 
-                          for (std::size_t i=0; i<SCALAR_dofs.size(); i++)
-                            pos->second->set(SCALAR_dofs[i], io_buffer[cnt++]);
+                          for (std::size_t sd=0; sd<SCALAR_dofs.size(); sd++)
+                            pos->second->set(SCALAR_dofs[sd], io_buffer[cnt++]);
                         }
                     }
                 }

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -527,10 +527,10 @@ eval_at_point(const FEMContext & c,
   DynamicSparseNumberArray<Real, dof_id_type> returnval;
   returnval.resize(n_dofs);
 
-  for (std::size_t i = 0; i != n_dofs; ++i)
+  for (std::size_t j = 0; j != n_dofs; ++j)
     {
-      returnval.raw_at(i) = phi[i][0];
-      returnval.raw_index(i) = dof_indices[i];
+      returnval.raw_at(j) = phi[j][0];
+      returnval.raw_index(j) = dof_indices[j];
     }
 
   return returnval;
@@ -574,12 +574,12 @@ eval_at_point(const FEMContext & c,
   for (unsigned int d = 0; d != LIBMESH_DIM; ++d)
     returnval(d).resize(n_dofs);
 
-  for (std::size_t i = 0; i != n_dofs; ++i)
+  for (std::size_t j = 0; j != n_dofs; ++j)
     {
       for (unsigned int d = 0; d != LIBMESH_DIM; ++d)
         {
-          returnval(d).raw_at(i) = dphi[i][0](d);
-          returnval(d).raw_index(i) = dof_indices[i];
+          returnval(d).raw_at(j) = dphi[j][0](d);
+          returnval(d).raw_index(j) = dof_indices[j];
         }
     }
 
@@ -707,8 +707,8 @@ public:
           if ((dof_i >= begin_dof) && (dof_i < end_dof))
             {
               const DynamicSparseNumberArray<ValIn,dof_id_type> & dnsa = Ue(i);
-              const std::size_t size = dnsa.size();
-              for (unsigned int j = 0; j != size; ++j)
+              const std::size_t dnsa_size = dnsa.size();
+              for (unsigned int j = 0; j != dnsa_size; ++j)
                 {
                   const dof_id_type dof_j = dnsa.raw_index(j);
                   const ValIn dof_val = dnsa.raw_at(j);


### PR DESCRIPTION
These commits include fixes (at least on my system; we'll see if femputer agrees) for many instances of warning triggers for:
```
-Wcast-qual -Wredundant-decls -Wshadow -Wstrict-aliasing -Wswitch-default -Wlogical-op
```
(as well as for a few conversion issues, but I started separating those out after realizing how vastly more prevalent they were)

And the last fix adds those warnings to our ```--enable-paranoid-warnings``` option, so that Paul's CI can scream at us if we backslide in the future.

I'm also wrapping more of our third-party headers in ignore_warnings/restore_warnings; the goal here is to keep our own stuff cleaner, not fix the world.