### PR TITLE
Skip partitioning in copy_nodes_and_elems if we should

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -239,7 +239,8 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
     }
 
   // Partition the mesh.
-  this->partition();
+  if (!skip_partitioning())
+    this->partition();
 
   // If we're using DistributedMesh, we'll probably want it
   // parallelized.


### PR DESCRIPTION
Huge optimization for stitching meshes...

`MeshTools::correct_node_proc_ids()` was taking a HUGE amount of time... and is completely unnecessary in this situation.