### PR TITLE
Change return type of TypeTensor::operator *

### DIFF
--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -240,10 +240,10 @@ public:
    * \returns A copy of the result, this tensor is unchanged.
    */
   template <typename Scalar>
-  typename boostcopy::enable_if_c<
+  auto
+  operator * (const Scalar scalar) const -> typename boostcopy::enable_if_c<
     ScalarTraits<Scalar>::value,
-    TypeTensor<typename CompareTypes<T, Scalar>::supertype>>::type
-  operator * (const Scalar) const;
+    TypeTensor<decltype(this->operator()(0, 0) * scalar)>>::type;
 
   /**
    * Multiply this tensor by a scalar value in place.
@@ -889,12 +889,12 @@ TypeTensor<T> TypeTensor<T>::operator - () const
 template <typename T>
 template <typename Scalar>
 inline
-typename boostcopy::enable_if_c<
+auto
+TypeTensor<T>::operator * (const Scalar factor) const -> typename boostcopy::enable_if_c<
   ScalarTraits<Scalar>::value,
-  TypeTensor<typename CompareTypes<T, Scalar>::supertype>>::type
-TypeTensor<T>::operator * (const Scalar factor) const
+  TypeTensor<decltype(this->operator()(0, 0) * factor)>>::type
 {
-  typedef typename CompareTypes<T, Scalar>::supertype TS;
+  typedef decltype((*this)(0, 0) * factor) TS;
 
 
 #if LIBMESH_DIM == 1


### PR DESCRIPTION
Currently if I multiply something like `TypeTensor<DualNumber<Real, D>>` and `Real` the multiplication will fail because we have not defined a `CompareTypes<DualNumber<Real, D>, Real>` specialization in libMesh. However, we can automatically deduce the return type using information we already have without creating that specialization. If folks are amenable to this change, I could also spread this to more places.