### PR TITLE
Make default constructors public for TypeVector and TypeTensor

### DIFF
--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -38,9 +38,7 @@ template <unsigned int N, typename T> class TypeNTensor;
 
 /**
  * This class defines a tensor in \p LIBMESH_DIM dimensional space of
- * type T.  T may either be Real or Complex.  The default constructor
- * for this class is protected, suggesting that you should not
- * instantiate one of these directly.
+ * type T.  T may either be Real or Complex.
  *
  * \author Roy Stogner
  * \date 2004
@@ -51,14 +49,14 @@ class TypeTensor
   template <typename T2>
   friend class TypeTensor;
 
-protected:
-
+public:
   /**
    * Empty constructor. Gives the tensor 0 in \p LIBMESH_DIM
    * dimensions.
    */
   TypeTensor  ();
 
+protected:
   /**
    * Constructor-from-T.  By default sets higher dimensional entries
    * to 0.  This is a poor constructor for 2D tensors - if the default

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -40,9 +40,7 @@ template <typename T> class TensorValue;
 
 /**
  * This class defines a vector in \p LIBMESH_DIM dimensional space of
- * type T.  T may either be Real or Complex.  The default constructor
- * for this class is protected, suggesting that you should not
- * instantiate one of these directly.  Instead use one of the derived
+ * type T.  T may either be Real or Complex. Instead use one of the derived
  * types such as \p Point or \p Node.
  *
  * \author Benjamin S. Kirk
@@ -56,14 +54,14 @@ class TypeVector
 
   friend class TypeTensor<T>;
 
-protected:
-
+public:
   /**
    * Empty constructor.  Gives the vector 0 in \p LIBMESH_DIM
    * dimensions.
    */
   TypeVector  ();
 
+protected:
   /**
    * Constructor-from-T.  By default sets higher dimensional
    * entries to 0.


### PR DESCRIPTION
In the course of trying to get automatic differentiation into MOOSE, I've found it advantageous and perhaps necessary to modify some of the operator overloads in `MetaPhysicL` as shown for example in the `NumberArray` code starting [here](https://github.com/lindsayad/moose/blob/ad-moose-wip/framework/contrib/metaphysicl/include/metaphysicl/numberarray.h#L335). The default construction of a `NumberArray` has some consequences, specifically it leads to default construction of its data of type `T`. An operation like `NumberArray<N, TensorValue<Real>> * Real` yields a resulting type `NumberArray<N, TypeVector<Real>`, which means that in my overloaded `operator *` I  want to default construct `TypeVector`. I would like to be able to do this...