### PR TITLE
Simplify the loose bounding box for 'linear' elements

### DIFF
--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -170,6 +170,11 @@ public:
    */
   virtual Real volume () const override;
 
+  /**
+   * Builds a bounding box out of the nodal positions
+   */
+  virtual BoundingBox loose_bounding_box () const override;
+
 protected:
 
   /**

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -168,6 +168,11 @@ public:
    */
   virtual Real volume () const override;
 
+  /**
+   * Builds a bounding box out of the nodal positions
+   */
+  virtual BoundingBox loose_bounding_box () const override;
+
 protected:
 
   /**

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -163,6 +163,10 @@ public:
    */
   virtual Real volume () const override;
 
+  /**
+   * Builds a bounding box out of the nodal positions
+   */
+  virtual BoundingBox loose_bounding_box () const override;
 
 protected:
 

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -146,6 +146,11 @@ public:
    */
   virtual Real volume () const override;
 
+  /**
+   * Builds a bounding box out of the nodal positions
+   */
+  virtual BoundingBox loose_bounding_box () const override;
+
 protected:
 
   /**

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -168,6 +168,11 @@ public:
    */
   virtual bool contains_point (const Point & p, Real tol) const override;
 
+  /**
+   * Builds a bounding box out of the nodal positions
+   */
+  virtual BoundingBox loose_bounding_box () const override;
+
 protected:
 
   /**

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -368,4 +368,10 @@ Real Hex8::volume () const
     triple_product(q[2], q[4], q[5]) / 64.;
 }
 
+BoundingBox
+Hex8::loose_bounding_box () const
+{
+  return Elem::loose_bounding_box();
+}
+
 } // namespace libMesh

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -439,4 +439,10 @@ Real Prism6::volume () const
   return vol;
 }
 
+BoundingBox
+Prism6::loose_bounding_box () const
+{
+  return Elem::loose_bounding_box();
+}
+
 } // namespace libMesh

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -256,4 +256,10 @@ Real Pyramid5::volume () const
     triple_product(v02, v01, v03) / 12.;
 }
 
+BoundingBox
+Pyramid5::loose_bounding_box () const
+{
+  return Elem::loose_bounding_box();
+}
+
 } // namespace libMesh

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -239,4 +239,11 @@ Real Quad4::volume () const
   return vol;
 }
 
+BoundingBox
+Quad4::loose_bounding_box () const
+{
+  return Elem::loose_bounding_box();
+}
+
+
 } // namespace libMesh

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -246,4 +246,11 @@ bool Tri3::contains_point (const Point & p, Real tol) const
   return (u > -tol) && (v > -tol) && (u + v < 1 + tol);
 }
 
+BoundingBox
+Tri3::loose_bounding_box () const
+{
+  return Elem::loose_bounding_box();
+}
+
+
 } // namespace libMesh


### PR DESCRIPTION
Use the "simple" method for computing loose bounding boxes for all 'linear' elements.  I know that the 3D ones can technically have curved sides - but this is such a huge optimization... I'm interested in discussion about it.

You can see the before and after over here: #1824
