### PR TITLE
DofObject::dof_number alternative

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1279,19 +1279,24 @@ private:
 
   /**
    * Helper function that gets the dof indices on the current element
-   * for a non-SCALAR type variable.
+   * for a non-SCALAR type variable, where the variable is identified
+   * by its variable group number \p vg and its offset \p vig from the
+   * first variable in that group.
    *
    * In DEBUG mode, the tot_size parameter will add up the total
-   * number of dof indices that should have been added to di.
+   * number of dof indices that should have been added to di, and v
+   * will be the variable number corresponding to vg and vig.
    */
   void _dof_indices (const Elem & elem,
                      int p_level,
                      std::vector<dof_id_type> & di,
-                     const unsigned int v,
+                     const unsigned int vg,
+                     const unsigned int vig,
                      const Node * const * nodes,
                      unsigned int       n_nodes
 #ifdef DEBUG
                      ,
+                     const unsigned int v,
                      std::size_t & tot_size
 #endif
                      ) const;
@@ -1445,9 +1450,14 @@ private:
   std::vector<Variable> _variables;
 
   /**
-   * The finite element type for each variable.
+   * The finite element type for each variable group.
    */
   std::vector<VariableGroup> _variable_groups;
+
+  /**
+   * The variable group number for each variable.
+   */
+  std::vector<unsigned int> _variable_group_numbers;
 
   /**
    * The number of the system we manage DOFs for.

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -287,6 +287,20 @@ public:
                          const unsigned int comp) const;
 
   /**
+   * \returns The global degree of freedom number for variable group
+   * \p vg, variable index \p vig within the group, component \p comp
+   * out of \p n_comp, for system \p s on this \p DofObject
+   *
+   * Even users who need to call dof_number from user code probably
+   * don't want to call this overload.
+   */
+  dof_id_type dof_number(const unsigned int s,
+                         const unsigned int vg,
+                         const unsigned int vig,
+                         const unsigned int comp,
+                         const unsigned int n_comp) const;
+
+  /**
    * \returns A pair consisting of the variable group number and the
    * offset index from the start of that group for variable \p var on
    * system \p s associated with this \p DofObject
@@ -824,8 +838,30 @@ dof_id_type DofObject::dof_number(const unsigned int s,
   libmesh_assert_less (var,  this->n_vars(s));
   libmesh_assert_less (comp, this->n_comp(s,var));
 
+  const std::pair<unsigned int, unsigned int>
+    vg_vig = this->var_to_vg_and_offset(s,var);
+
   const unsigned int
-    vg            = this->var_to_vg(s,var),
+    n_comp = this->n_comp_group(s,vg_vig.first);
+
+  return this->dof_number(s, vg_vig.first, vg_vig.second,
+                          comp, n_comp);
+}
+
+
+
+inline
+dof_id_type DofObject::dof_number(const unsigned int s,
+                                  const unsigned int vg,
+                                  const unsigned int vig,
+                                  const unsigned int comp,
+                                  const unsigned int n_comp) const
+{
+  libmesh_assert_less (s,   this->n_systems());
+  libmesh_assert_less (vg,  this->n_var_groups(s));
+  libmesh_assert_less (vig, this->n_vars(s,vg));
+
+  const unsigned int
     start_idx_sys = this->start_idx(s);
 
   libmesh_assert_less ((start_idx_sys + 2*vg + 1), _idx_buf.size());
@@ -841,21 +877,7 @@ dof_id_type DofObject::dof_number(const unsigned int s,
   // otherwise the index is the first component
   // index augmented by the component number
   else
-    {
-      const unsigned int
-        ncg = this->n_comp_group(s,vg),
-        vig = this->system_var_to_vg_var(s,vg,var);
-
-      // std::cout << "base_idx, var, vg, vig, ncg, comp="
-      // << base_idx << " "
-      // << var << " "
-      // << vg << " "
-      // << vig << " "
-      // << ncg << " "
-      // << comp << '\n';
-
-      return cast_int<dof_id_type>(base_idx + vig*ncg + comp);
-    }
+    return cast_int<dof_id_type>(base_idx + vig*n_comp + comp);
 }
 
 

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -287,6 +287,15 @@ public:
                          const unsigned int comp) const;
 
   /**
+   * \returns A pair consisting of the variable group number and the
+   * offset index from the start of that group for variable \p var on
+   * system \p s associated with this \p DofObject
+   */
+  std::pair<unsigned int, unsigned int>
+  var_to_vg_and_offset(const unsigned int s,
+                       const unsigned int var) const;
+
+  /**
    * Sets the global degree of freedom number for variable \p var,
    * component \p comp for system \p s associated with this \p DofObject
    */
@@ -846,6 +855,33 @@ dof_id_type DofObject::dof_number(const unsigned int s,
       // << comp << '\n';
 
       return cast_int<dof_id_type>(base_idx + vig*ncg + comp);
+    }
+}
+
+
+
+inline
+std::pair<unsigned int, unsigned int>
+DofObject::var_to_vg_and_offset(const unsigned int s,
+                                const unsigned int var) const
+{
+  std::pair<unsigned int, unsigned int> returnval(0,0);
+
+  unsigned int & vg = returnval.first;
+  unsigned int & offset = returnval.second;
+
+  unsigned int vg_start = 0;
+  for (; ; vg++)
+    {
+      libmesh_assert_less(vg, this->n_var_groups(s));
+
+      const unsigned int vg_end = vg_start + this->n_vars(s,vg);
+      if (var < vg_end)
+        {
+          offset = var - vg_start;
+          return returnval;
+        }
+      vg_start = vg_end;
     }
 }
 

--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -258,6 +258,9 @@ public:
     return _number + v;
   }
 
+  // Don't let number(uint) hide number()
+  using Variable::number;
+
   /**
    * \returns The index of the first scalar component of this variable in the
    * system.

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -28,7 +28,6 @@
 #pragma clang diagnostic ignored "-Wextra-semi"
 #pragma clang diagnostic ignored "-Wvariadic-macros"
 #pragma clang diagnostic ignored "-Wc++11-extensions"
-#pragma clang diagnostic ignored "-Wmacro-redefined"
 #pragma clang diagnostic ignored "-Wnested-anon-types"
 #pragma clang diagnostic ignored "-Wsign-compare"
 #pragma clang diagnostic ignored "-Wunused-private-field"
@@ -37,6 +36,11 @@
 #pragma clang diagnostic ignored "-Wcast-qual"
 #pragma clang diagnostic ignored "-Wswitch-default"
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Woverloaded-virtual"
+// This isn't supported in 3.4.2 at least
+#if (__clang_major__ > 3)
+#pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
 #if (__clang_major__ > 3) || (__clang_major__ == 3 && __clang_minor__ > 5)
 // This was introduced in 3.6
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2170,7 +2170,9 @@ void DofMap::dof_indices (const Node * const node,
   const unsigned int sys_num = this->sys_number();
 
   // Get the dof numbers
-  const Variable & var = this->variable(vn);
+  const unsigned int vg = this->_variable_group_numbers[vn];
+  const VariableGroup & var = this->variable_group(vg);
+
   if (var.type().family == SCALAR)
     {
       std::vector<dof_id_type> di_new;
@@ -2179,13 +2181,15 @@ void DofMap::dof_indices (const Node * const node,
     }
   else
     {
-      const int n_comp = node->n_comp(sys_num,vn);
+      const unsigned int vig = vn - var.number();
+      const int n_comp = node->n_comp_group(sys_num,vg);
       for (int i=0; i != n_comp; ++i)
         {
+          const dof_id_type d =
+            node->dof_number(sys_num, vg, vig, i, n_comp);
           libmesh_assert_not_equal_to
-            (node->dof_number(sys_num,vn,i),
-             DofObject::invalid_id);
-          di.push_back(node->dof_number(sys_num,vn,i));
+            (d, DofObject::invalid_id);
+          di.push_back(d);
         }
     }
 }

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1134,14 +1134,20 @@ void BuildProjectionList::operator()(const ConstElemRange & range)
               if (old_dofs)
                 {
                   const unsigned int sysnum = system.number();
-                  const unsigned int nv = old_dofs->n_vars(sysnum);
-                  for (unsigned int v=0; v != nv; ++v)
+                  const unsigned int nvg = old_dofs->n_var_groups(sysnum);
+
+                  for (unsigned int vg=0; vg != nvg; ++vg)
                     {
-                      const unsigned int nc =
-                        old_dofs->n_comp(sysnum, v);
-                      for (unsigned int c=0; c != nc; ++c)
-                        di.push_back
-                          (old_dofs->dof_number(sysnum, v, c));
+                      const unsigned int nvig =
+                        old_dofs->n_vars(sysnum, vg);
+                      for (unsigned int vig=0; vig != nvig; ++vig)
+                        {
+                          const unsigned int n_comp =
+                            old_dofs->n_comp_group(sysnum, vg);
+                          for (unsigned int c=0; c != n_comp; ++c)
+                            di.push_back
+                              (old_dofs->dof_number(sysnum, vg, vig, c, n_comp));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This still has quite a bit more work incoming, but since it's a major refactoring of one of the most basic and pervasive libMesh functions, I'm thinking we'll test it one optimization step at a time.

The original motivation comes from @friedmud via #1753 but anything with noticeable time spent in dof_indices() (including some of the RELAP-7 cases, IIRC?) ought to benefit from some of the later optimization stages.