### PR TITLE
ignore/restore gzstream.h warnings

### DIFF
--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -33,7 +33,9 @@
 #include "libmesh/enum_elem_type.h"
 
 #ifdef LIBMESH_HAVE_GZSTREAM
+# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h" // For reading/writing compressed streams
+# include "libmesh/restore_warnings.h"
 #endif
 
 

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -42,7 +42,9 @@
 #include <unordered_map>
 
 #ifdef LIBMESH_HAVE_GZSTREAM
+# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
 # include "gzstream.h" // For reading/writing compressed streams
+# include "libmesh/restore_warnings.h"
 #endif
 
 

--- a/src/utils/xdr_cxx.C
+++ b/src/utils/xdr_cxx.C
@@ -29,7 +29,9 @@
 #include "libmesh/xdr_cxx.h"
 #include "libmesh/libmesh_logging.h"
 #ifdef LIBMESH_HAVE_GZSTREAM
-# include "gzstream.h"
+# include "libmesh/ignore_warnings.h" // shadowing in gzstream.h
+# include "gzstream.h" // For reading/writing compressed streams
+# include "libmesh/restore_warnings.h"
 #endif
 
 


### PR DESCRIPTION
My gcc 8.1 install thinks that open_mode there shadows std::ios_base::open_mode
somehow?

This sort of thing is why --enable-werror will never ever ever be on by default...