### PR TITLE
Don't assert GhostingFunctor presence before removing.

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1809,7 +1809,6 @@ DofMap::add_coupling_functor(GhostingFunctor & coupling_functor)
 void
 DofMap::remove_coupling_functor(GhostingFunctor & coupling_functor)
 {
-  libmesh_assert(_coupling_functors.count(&coupling_functor));
   _coupling_functors.erase(&coupling_functor);
   _mesh.remove_ghosting_functor(coupling_functor);
 }

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -283,9 +283,6 @@ void MeshBase::clear ()
 
 void MeshBase::remove_ghosting_functor(GhostingFunctor & ghosting_functor)
 {
-  // We should only be trying to remove ghosting functors we actually
-  // have
-  libmesh_assert(_ghosting_functors.count(&ghosting_functor));
   _ghosting_functors.erase(&ghosting_functor);
 }
 


### PR DESCRIPTION
Since the DofMap removes GhostingFunctors from both itself and the
underlying mesh, the asserts make it an error if the user subsequently
tries to remove a GhostingFunctor from the Mesh manually. This assert
seems overzealous, though, if there's no GhostingFunctor there we
should just be able to do nothing.