### PR TITLE
Disable Trilinos when libmesh is configured with --with-dof-id-bytes=8.

### DIFF
--- a/configure
+++ b/configure
@@ -35718,6 +35718,14 @@ else
 fi
 
 
+        if test "$enabletrilinos" = yes && test "$dof_bytes" != "4"; then :
+
+          enabletrilinos=no
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Trilinos disabled, requires --with-dof-id-bytes=4 >>>" >&5
+$as_echo "<<< Trilinos disabled, requires --with-dof-id-bytes=4 >>>" >&6; }
+
+fi
+
   if test "x$enabletrilinos" = xyes; then :
 
                     { $as_echo "$as_me:${as_lineno-$LINENO}: checking Whether MPI is available for Trilinos" >&5

--- a/m4/trilinos.m4
+++ b/m4/trilinos.m4
@@ -489,6 +489,15 @@ AC_DEFUN([CONFIGURE_TRILINOS],
                                  [AC_MSG_ERROR(bad value ${enableval} for --enable-trilinos)])],
                                [enabletrilinos=$enableoptional])
 
+  dnl Our Trilinos interfaces currently only support 32-bit dof/numeric
+  dnl indices, so effectively --disable-trilinos when libmesh is configured
+  dnl with 64-bit indices.
+  AS_IF([test "$enabletrilinos" = yes && test "$dof_bytes" != "4"],
+        [
+          enabletrilinos=no
+          AC_MSG_RESULT([<<< Trilinos disabled, requires --with-dof-id-bytes=4 >>>])
+        ])
+
   AS_IF([test "x$enabletrilinos" = xyes],
         [
           dnl Trump --enable-trilinos with --disable-mpi


### PR DESCRIPTION
I decided to handle this by disabling Trilinos and printing a status message, rather than throwing an error during configure (as we do with PETSc when those index sizes mismatch). If people want a Trilinos index size mismatch to trigger a configure error as well, we could always change it, but I think disabling is more appropriate since it is currently not possible for us to use a Trilinos which is compiled with 64-bit indices.

Refs #1851.
