### PR TITLE
Datatype leak fix, again

### DIFF
--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -216,6 +216,9 @@ public:
 
     libmesh_call_mpi
       (MPI_Type_commit (&_datatype));
+
+    libmesh_call_mpi
+      (MPI_Type_free(&tmptype));
 #endif // #ifdef LIBMESH_HAVE_MPI
   }
 

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -41,12 +41,6 @@ namespace Parallel {
 // StandardType<> specializations to return a derived MPI datatype
 // to handle communication of LIBMESH_DIM-vectors.
 //
-// We use static variables to minimize the number of MPI datatype
-// construction calls executed over the course of the program.
-//
-// We use a singleton pattern because a global variable would
-// have tried to call MPI functions before MPI got initialized.
-//
 // We use MPI_Create_struct here because our vector classes might
 // have vptrs, and I'd rather not have the datatype break in those
 // cases.
@@ -67,49 +61,42 @@ public:
         ex = temp.get();
       }
 
-    // _static_type never gets freed, but it only gets committed once
-    // per T, so it's not a *huge* memory leak...
-    static data_type _static_type;
-    static bool _is_initialized = false;
-    if (!_is_initialized)
-      {
 #ifdef LIBMESH_HAVE_MPI
-        StandardType<T> T_type(&((*ex)(0)));
+    StandardType<T> T_type(&((*ex)(0)));
 
-        // We require MPI-2 here:
-        int blocklength = LIBMESH_DIM;
-        MPI_Aint displs, start;
-        MPI_Datatype tmptype, type = T_type;
+    // We require MPI-2 here:
+    int blocklength = LIBMESH_DIM;
+    MPI_Aint displs, start;
+    MPI_Datatype tmptype, type = T_type;
 
-        libmesh_call_mpi
-          (MPI_Get_address (ex, &start));
-        libmesh_call_mpi
-          (MPI_Get_address (&((*ex)(0)), &displs));
+    libmesh_call_mpi
+      (MPI_Get_address (ex, &start));
+    libmesh_call_mpi
+      (MPI_Get_address (&((*ex)(0)), &displs));
 
-        // subtract off offset to first value from the beginning of the structure
-        displs -= start;
+    // subtract off offset to first value from the beginning of the structure
+    displs -= start;
 
-        // create a prototype structure
-        libmesh_call_mpi
-          (MPI_Type_create_struct (1, &blocklength, &displs, &type,
-                                   &tmptype));
-        libmesh_call_mpi
-          (MPI_Type_commit (&tmptype));
+    // create a prototype structure
+    libmesh_call_mpi
+      (MPI_Type_create_struct (1, &blocklength, &displs, &type,
+                               &tmptype));
+    libmesh_call_mpi
+      (MPI_Type_commit (&tmptype));
 
-        // resize the structure type to account for padding, if any
-        libmesh_call_mpi
-          (MPI_Type_create_resized (tmptype, 0, sizeof(TypeVector<T>),
-                                    &_static_type));
+    // resize the structure type to account for padding, if any
+    libmesh_call_mpi
+      (MPI_Type_create_resized (tmptype, 0, sizeof(TypeVector<T>),
+                                &_datatype));
 
-        libmesh_call_mpi
-          (MPI_Type_commit (&_static_type));
+    libmesh_call_mpi
+      (MPI_Type_commit (&_datatype));
 #endif // #ifdef LIBMESH_HAVE_MPI
-
-        _is_initialized = true;
-      }
-    _datatype = _static_type;
   }
+
+  ~StandardType() { this->free(); }
 };
+
 
 template <typename T>
 class StandardType<VectorValue<T>> : public DataType
@@ -128,49 +115,42 @@ public:
         ex = temp.get();
       }
 
-    // _static_type never gets freed, but it only gets committed once
-    // per T, so it's not a *huge* memory leak...
-    static data_type _static_type;
-    static bool _is_initialized = false;
-    if (!_is_initialized)
-      {
 #ifdef LIBMESH_HAVE_MPI
-        StandardType<T> T_type(&((*ex)(0)));
+    StandardType<T> T_type(&((*ex)(0)));
 
-        int blocklength = LIBMESH_DIM;
-        MPI_Aint displs, start;
-        MPI_Datatype tmptype, type = T_type;
+    int blocklength = LIBMESH_DIM;
+    MPI_Aint displs, start;
+    MPI_Datatype tmptype, type = T_type;
 
-        libmesh_call_mpi
-          (MPI_Get_address (ex, &start));
-        libmesh_call_mpi
-          (MPI_Get_address (&((*ex)(0)), &displs));
+    libmesh_call_mpi
+      (MPI_Get_address (ex, &start));
+    libmesh_call_mpi
+      (MPI_Get_address (&((*ex)(0)), &displs));
 
-        // subtract off offset to first value from the beginning of the structure
-        displs -= start;
+    // subtract off offset to first value from the beginning of the structure
+    displs -= start;
 
-        // create a prototype structure
-        libmesh_call_mpi
-          (MPI_Type_create_struct (1, &blocklength, &displs, &type,
-                                   &tmptype));
-        libmesh_call_mpi
-          (MPI_Type_commit (&tmptype));
+    // create a prototype structure
+    libmesh_call_mpi
+      (MPI_Type_create_struct (1, &blocklength, &displs, &type,
+                               &tmptype));
+    libmesh_call_mpi
+      (MPI_Type_commit (&tmptype));
 
-        // resize the structure type to account for padding, if any
-        libmesh_call_mpi
-          (MPI_Type_create_resized (tmptype, 0,
-                                    sizeof(VectorValue<T>),
-                                    &_static_type));
+    // resize the structure type to account for padding, if any
+    libmesh_call_mpi
+      (MPI_Type_create_resized (tmptype, 0,
+                                sizeof(VectorValue<T>),
+                                &_datatype));
 
-        libmesh_call_mpi
-          (MPI_Type_commit (&_static_type));
+    libmesh_call_mpi
+      (MPI_Type_commit (&_datatype));
 #endif // #ifdef LIBMESH_HAVE_MPI
-
-        _is_initialized = true;
-      }
-    _datatype = _static_type;
   }
+
+  ~StandardType() { this->free(); }
 };
+
 
 template <>
 class StandardType<Point> : public DataType
@@ -182,61 +162,54 @@ public:
     // Prevent unused variable warnings when !LIBMESH_HAVE_MPI
     libmesh_ignore(example);
 
-    // _static_type never gets freed, but it only gets committed once
-    // per T, so it's not a *huge* memory leak...
-    static data_type _static_type;
-    static bool _is_initialized = false;
-    if (!_is_initialized)
-      {
 #ifdef LIBMESH_HAVE_MPI
 
-        // We need an example for MPI_Address to use
-        Point * ex;
+    // We need an example for MPI_Address to use
+    Point * ex;
 
-        std::unique_ptr<Point> temp;
-        if (example)
-          ex = const_cast<Point *>(example);
-        else
-          {
-            temp.reset(new Point());
-            ex = temp.get();
-          }
-
-        StandardType<Real> T_type(&((*ex)(0)));
-
-        int blocklength = LIBMESH_DIM;
-        MPI_Aint displs, start;
-        MPI_Datatype tmptype, type = T_type;
-
-        libmesh_call_mpi
-          (MPI_Get_address (ex, &start));
-        libmesh_call_mpi
-          (MPI_Get_address (&((*ex)(0)), &displs));
-
-        // subtract off offset to first value from the beginning of the structure
-        displs -= start;
-
-        // create a prototype structure
-        libmesh_call_mpi
-          (MPI_Type_create_struct (1, &blocklength, &displs, &type,
-                                   &tmptype));
-        libmesh_call_mpi
-          (MPI_Type_commit (&tmptype));
-
-        // resize the structure type to account for padding, if any
-        libmesh_call_mpi
-          (MPI_Type_create_resized (tmptype, 0, sizeof(Point),
-                                    &_static_type));
-
-        libmesh_call_mpi
-          (MPI_Type_commit (&_static_type));
-#endif // #ifdef LIBMESH_HAVE_MPI
-
-        _is_initialized = true;
+    std::unique_ptr<Point> temp;
+    if (example)
+      ex = const_cast<Point *>(example);
+    else
+      {
+        temp.reset(new Point());
+        ex = temp.get();
       }
-    _datatype = _static_type;
+
+    StandardType<Real> T_type(&((*ex)(0)));
+
+    int blocklength = LIBMESH_DIM;
+    MPI_Aint displs, start;
+    MPI_Datatype tmptype, type = T_type;
+
+    libmesh_call_mpi
+      (MPI_Get_address (ex, &start));
+    libmesh_call_mpi
+      (MPI_Get_address (&((*ex)(0)), &displs));
+
+    // subtract off offset to first value from the beginning of the structure
+    displs -= start;
+
+    // create a prototype structure
+    libmesh_call_mpi
+      (MPI_Type_create_struct (1, &blocklength, &displs, &type,
+                               &tmptype));
+    libmesh_call_mpi
+      (MPI_Type_commit (&tmptype));
+
+    // resize the structure type to account for padding, if any
+    libmesh_call_mpi
+      (MPI_Type_create_resized (tmptype, 0, sizeof(Point),
+                                &_datatype));
+
+    libmesh_call_mpi
+      (MPI_Type_commit (&_datatype));
+#endif // #ifdef LIBMESH_HAVE_MPI
   }
+
+  ~StandardType() { this->free(); }
 };
+
 
 // OpFunction<> specializations to return an MPI_Op version of the
 // reduction operations on LIBMESH_DIM-vectors.

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -91,6 +91,9 @@ public:
 
     libmesh_call_mpi
       (MPI_Type_commit (&_datatype));
+
+    libmesh_call_mpi
+      (MPI_Type_free (&tmptype));
 #endif // #ifdef LIBMESH_HAVE_MPI
   }
 
@@ -151,6 +154,9 @@ public:
 
     libmesh_call_mpi
       (MPI_Type_commit (&_datatype));
+
+    libmesh_call_mpi
+      (MPI_Type_free (&tmptype));
 #endif // #ifdef LIBMESH_HAVE_MPI
   }
 
@@ -218,7 +224,7 @@ public:
       (MPI_Type_commit (&_datatype));
 
     libmesh_call_mpi
-      (MPI_Type_free(&tmptype));
+      (MPI_Type_free (&tmptype));
 #endif // #ifdef LIBMESH_HAVE_MPI
   }
 

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -94,6 +94,12 @@ public:
 #endif // #ifdef LIBMESH_HAVE_MPI
   }
 
+  StandardType(const StandardType<TypeVector<T>> & t)
+    : DataType()
+  {
+    libmesh_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
+  }
+
   ~StandardType() { this->free(); }
 };
 
@@ -146,6 +152,12 @@ public:
     libmesh_call_mpi
       (MPI_Type_commit (&_datatype));
 #endif // #ifdef LIBMESH_HAVE_MPI
+  }
+
+  StandardType(const StandardType<VectorValue<T>> & t)
+    : DataType()
+  {
+    libmesh_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
   }
 
   ~StandardType() { this->free(); }
@@ -205,6 +217,12 @@ public:
     libmesh_call_mpi
       (MPI_Type_commit (&_datatype));
 #endif // #ifdef LIBMESH_HAVE_MPI
+  }
+
+  StandardType(const StandardType<Point> & t)
+    : DataType()
+  {
+    libmesh_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
   }
 
   ~StandardType() { this->free(); }

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -51,17 +51,18 @@ class StandardType<Hilbert::HilbertIndices> : public DataType
 public:
   explicit
   StandardType(const Hilbert::HilbertIndices * =nullptr) {
-    // _static_type never gets freed, but it only gets committed once
-    // so it's not a *huge* memory leak...
-    static DataType _static_type;
-    static bool _is_initialized = false;
-    if (!_is_initialized)
-      {
-        _static_type = DataType(Parallel::StandardType<Hilbert::inttype>(), 3);
-        _is_initialized = true;
-      }
-    _datatype = _static_type;
+    _datatype = DataType(Parallel::StandardType<Hilbert::inttype>(), 3);
   }
+
+  StandardType(const StandardType<Hilbert::HilbertIndices> & t)
+  {
+#ifdef LIBMESH_HAVE_MPI
+    libmesh_call_mpi
+      (MPI_Type_dup (t._datatype, &_datatype));
+#endif
+  }
+
+  ~StandardType() { this->free(); }
 };
 
 #endif // LIBMESH_HAVE_MPI

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -56,10 +56,8 @@ public:
 
   StandardType(const StandardType<Hilbert::HilbertIndices> & t)
   {
-#ifdef LIBMESH_HAVE_MPI
     libmesh_call_mpi
       (MPI_Type_dup (t._datatype, &_datatype));
-#endif
   }
 
   ~StandardType() { this->free(); }

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -55,9 +55,9 @@ public:
   }
 
   StandardType(const StandardType<Hilbert::HilbertIndices> & t)
+    : DataType()
   {
-    libmesh_call_mpi
-      (MPI_Type_dup (t._datatype, &_datatype));
+    libmesh_call_mpi (MPI_Type_dup (t._datatype, &_datatype));
   }
 
   ~StandardType() { this->free(); }


### PR DESCRIPTION
This will hopefully fix a valgrind error discovered in #1857, as well
as preemptively fix the same problem with all our other remaining MPI
types.  I have no idea why I didn't do all these when I was putting
together #1616, and I'm completely baffled that the valgrind output
there didn't catch the HilbertIndices case.

@lindsayad, could you give this a try?