### PR TITLE
Respect the hide_output() flag in various EquationSystems::build_xyz() functions.

### DIFF
--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -484,6 +484,8 @@ void EquationSystems::build_variable_names (std::vector<std::string> & var_names
           use_current_system = system_names->count(pos->first);
         if (!use_current_system)
           continue;
+        if (pos->second->hide_output())
+          continue;
 
         for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
           {
@@ -518,6 +520,8 @@ void EquationSystems::build_variable_names (std::vector<std::string> & var_names
       if (!use_current_system)
         use_current_system = system_names->count(pos->first);
       if (!use_current_system)
+        continue;
+      if (pos->second->hide_output())
         continue;
 
       for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
@@ -612,6 +616,8 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
           use_current_system = system_names->count(pos->first);
         if (!use_current_system)
           continue;
+        if (pos->second->hide_output())
+          continue;
 
         for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
           {
@@ -676,6 +682,8 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
         use_current_system = system_names->count(pos->first);
       if (!use_current_system)
         continue;
+      if (pos->second->hide_output())
+          continue;
 
       const System & system  = *(pos->second);
       const unsigned int nv_sys = system.n_vars();
@@ -1054,6 +1062,8 @@ void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> &
           use_current_system = system_names->count(pos->first);
         if (!use_current_system)
           continue;
+        if (pos->second->hide_output())
+          continue;
 
         const System & system  = *(pos->second);
         nv += system.n_vars();
@@ -1092,6 +1102,8 @@ void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> &
         if (!use_current_system)
           use_current_system = system_names->count(pos->first);
         if (!use_current_system)
+          continue;
+        if (pos->second->hide_output())
           continue;
 
         const System & system  = *(pos->second);

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -482,9 +482,7 @@ void EquationSystems::build_variable_names (std::vector<std::string> & var_names
         bool use_current_system = (system_names == nullptr);
         if (!use_current_system)
           use_current_system = system_names->count(pos->first);
-        if (!use_current_system)
-          continue;
-        if (pos->second->hide_output())
+        if (!use_current_system || pos->second->hide_output())
           continue;
 
         for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
@@ -519,9 +517,7 @@ void EquationSystems::build_variable_names (std::vector<std::string> & var_names
       bool use_current_system = (system_names == nullptr);
       if (!use_current_system)
         use_current_system = system_names->count(pos->first);
-      if (!use_current_system)
-        continue;
-      if (pos->second->hide_output())
+      if (!use_current_system || pos->second->hide_output())
         continue;
 
       for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
@@ -614,9 +610,7 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
         bool use_current_system = (system_names == nullptr);
         if (!use_current_system)
           use_current_system = system_names->count(pos->first);
-        if (!use_current_system)
-          continue;
-        if (pos->second->hide_output())
+        if (!use_current_system || pos->second->hide_output())
           continue;
 
         for (unsigned int vn=0; vn<pos->second->n_vars(); vn++)
@@ -680,10 +674,8 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
       bool use_current_system = (system_names == nullptr);
       if (!use_current_system)
         use_current_system = system_names->count(pos->first);
-      if (!use_current_system)
+      if (!use_current_system || pos->second->hide_output())
         continue;
-      if (pos->second->hide_output())
-          continue;
 
       const System & system  = *(pos->second);
       const unsigned int nv_sys = system.n_vars();
@@ -1060,9 +1052,7 @@ void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> &
         bool use_current_system = (system_names == nullptr);
         if (!use_current_system)
           use_current_system = system_names->count(pos->first);
-        if (!use_current_system)
-          continue;
-        if (pos->second->hide_output())
+        if (!use_current_system || pos->second->hide_output())
           continue;
 
         const System & system  = *(pos->second);
@@ -1101,9 +1091,7 @@ void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> &
         bool use_current_system = (system_names == nullptr);
         if (!use_current_system)
           use_current_system = system_names->count(pos->first);
-        if (!use_current_system)
-          continue;
-        if (pos->second->hide_output())
+        if (!use_current_system || pos->second->hide_output())
           continue;
 
         const System & system  = *(pos->second);


### PR DESCRIPTION
Patch originally came from the email thread:
https://sourceforge.net/p/libmesh/mailman/message/36415390/