### PR TITLE
Added option to specify the order of variables on subdomains.

### DIFF
--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -87,6 +87,44 @@ public:
   {}
 
   /**
+   * Constructor.  Takes a map which specifies variable orders on subdomains.
+   */
+  Variable (System * sys,
+            const std::string & var_name,
+            const unsigned int var_number,
+            const unsigned int first_scalar_num,
+            const FEType & var_type,
+            const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders) :
+    _sys(sys),
+    _name(var_name),
+    _subdomain_var_orders(subdomain_var_orders),
+    _number(var_number),
+    _first_scalar_number(first_scalar_num),
+    _type(var_type)
+  {}
+
+  /**
+   * Constructor.  Takes a set which contains the subdomain
+   * indices for which this variable is active, and a map
+   * which specifies variable orders on subdomains.
+   */
+  Variable (System * sys,
+            const std::string & var_name,
+            const unsigned int var_number,
+            const unsigned int first_scalar_num,
+            const FEType & var_type,
+            const std::set<subdomain_id_type> & var_active_subdomains,
+            const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders) :
+    _sys(sys),
+    _name(var_name),
+    _active_subdomains(var_active_subdomains),
+    _subdomain_var_orders(subdomain_var_orders),
+    _number(var_number),
+    _first_scalar_number(first_scalar_num),
+    _type(var_type)
+  {}
+
+  /**
    * \returns A pointer to the System this Variable is part of.
    */
   System * system() const
@@ -150,10 +188,25 @@ public:
   const std::set<subdomain_id_type> & active_subdomains() const
   { return _active_subdomains; }
 
+  /**
+   * \returns \p true if this variable has the same order on all
+   * subdomains because it has no specified subdomain-variable-order
+   * map.
+   */
+  bool implicitly_same_order () const
+  { return _subdomain_var_orders.empty(); }
+
+  /**
+   * \returns The map of variable orders on subdomains for this variable.
+   */
+  const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders() const
+  { return _subdomain_var_orders; }
+
 protected:
   System *                _sys;
   std::string             _name;
   std::set<subdomain_id_type> _active_subdomains;
+  std::map<subdomain_id_type, unsigned char> _subdomain_var_orders;
   unsigned int            _number;
   unsigned int            _first_scalar_number;
   FEType                  _type;
@@ -212,6 +265,50 @@ public:
   {}
 
   /**
+   * Constructor.  Takes a set which contains the subdomain
+   * indices for which this variable is active, and a map which
+   * contains the variable orders on subdomains.
+   */
+  VariableGroup (System * sys,
+                 const std::vector<std::string> & var_names,
+                 const unsigned int var_number,
+                 const unsigned int first_scalar_num,
+                 const FEType & var_type,
+                 const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders) :
+
+    Variable (sys,
+              "var_group",
+              var_number,
+              first_scalar_num,
+              var_type,
+              subdomain_var_orders),
+    _names(var_names)
+  {}
+
+  /**
+   * Constructor.  Takes a set which contains the subdomain
+   * indices for which this variable is active, and a map which
+   * contains the variable orders on subdomains.
+   */
+  VariableGroup (System * sys,
+                 const std::vector<std::string> & var_names,
+                 const unsigned int var_number,
+                 const unsigned int first_scalar_num,
+                 const FEType & var_type,
+                 const std::set<subdomain_id_type> & var_active_subdomains,
+                 const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders) :
+
+    Variable (sys,
+              "var_group",
+              var_number,
+              first_scalar_num,
+              var_type,
+              var_active_subdomains,
+              subdomain_var_orders),
+    _names(var_names)
+  {}
+
+  /**
    * \returns The number of variables in this \p VariableGroup
    */
   unsigned int n_variables () const
@@ -229,7 +326,8 @@ public:
                      this->number(v),
                      this->first_scalar_number(v),
                      this->type(),
-                     this->active_subdomains());
+                     this->active_subdomains(),
+                     this->subdomain_var_orders());
   }
 
   /**

--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -153,10 +153,30 @@ public:
   { return _first_scalar_number; }
 
   /**
-   * \returns The \p FEType for this variable.
+   * \returns The "base" \p FEType for this variable. The variable order
+   * may change depending on subdomain, so to access the per-subdomain
+   * type, use the overloaded Variable::type(subdomain_id_type) method.
    */
   const FEType & type() const
   { return _type; }
+
+  /**
+   * \returns The \p FEType for this variable for subdomain \p sbd_id.
+   */
+  FEType type(subdomain_id_type sbd_id) const
+  {
+    auto it = _subdomain_var_orders.find(sbd_id);
+    if(it == _subdomain_var_orders.end())
+    {
+      return _type;
+    }
+    else
+    {
+      FEType type_with_modified_order = _type;
+      type_with_modified_order.order = it->second;
+      return type_with_modified_order;
+    }
+  }
 
   /**
    * \returns The number of components of this variable.
@@ -202,6 +222,20 @@ public:
    */
   const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders() const
   { return _subdomain_var_orders; }
+
+  /**
+   * \returns a set of all orders on all subdomains for this variable.
+   */
+  std::set<unsigned char> get_all_variable_orders() const
+  {
+    std::set<unsigned char> all_orders;
+    all_orders.insert(_type.order);
+    for (auto it : _subdomain_var_orders)
+      {
+        all_orders.insert(it.second);
+      }
+    return all_orders;
+  }
 
 protected:
   System *                _sys;

--- a/include/base/variable.h
+++ b/include/base/variable.h
@@ -27,6 +27,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <map>
 
 namespace libMesh
 {

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1084,7 +1084,8 @@ public:
    */
   unsigned int add_variable (const std::string & var,
                              const FEType & type,
-                             const std::set<subdomain_id_type> * const active_subdomains = nullptr);
+                             const std::set<subdomain_id_type> * const active_subdomains = nullptr,
+                             const std::map<subdomain_id_type, unsigned char> * const subdomain_var_orders = nullptr);
 
   /**
    * Adds the variable \p var to the list of variables
@@ -1094,7 +1095,8 @@ public:
   unsigned int add_variable (const std::string & var,
                              const Order order = FIRST,
                              const FEFamily = LAGRANGE,
-                             const std::set<subdomain_id_type> * const active_subdomains = nullptr);
+                             const std::set<subdomain_id_type> * const active_subdomains = nullptr,
+                             const std::map<subdomain_id_type, unsigned char> * const subdomain_var_orders = nullptr);
 
   /**
    * Adds the variable \p var to the list of variables
@@ -1104,7 +1106,8 @@ public:
    */
   unsigned int add_variables (const std::vector<std::string> & vars,
                               const FEType & type,
-                              const std::set<subdomain_id_type> * const active_subdomains = nullptr);
+                              const std::set<subdomain_id_type> * const active_subdomains = nullptr,
+                              const std::map<subdomain_id_type, unsigned char> * const subdomain_var_orders = nullptr);
 
   /**
    * Adds the variable \p var to the list of variables
@@ -1114,7 +1117,8 @@ public:
   unsigned int add_variables (const std::vector<std::string> & vars,
                               const Order order = FIRST,
                               const FEFamily = LAGRANGE,
-                              const std::set<subdomain_id_type> * const active_subdomains = nullptr);
+                              const std::set<subdomain_id_type> * const active_subdomains = nullptr,
+                              const std::map<subdomain_id_type, unsigned char> * const subdomain_var_orders = nullptr);
 
   /**
    * Return a constant reference to \p Variable \p var.

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1180,12 +1180,18 @@ public:
 
 
   /**
-   * \returns The finite element type variable number \p i.
+   * \returns The "base" finite element type variable number \p i.
+   * If you want the subdomain-dependent variable type, which has
+   * order that may change depending on the subdomain, then use
+   * variable(i).type(sbdid) instead.
    */
   const FEType & variable_type (const unsigned int i) const;
 
   /**
    * \returns The finite element type for variable \p var.
+  * If you want the subdomain-dependent variable type, which has
+   * order that may change depending on the subdomain, then use
+   * variable(var).type(sbdid) instead.
    */
   const FEType & variable_type (const std::string & var) const;
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -691,7 +691,6 @@ void DofMap::reinit(MeshBase & mesh)
           const unsigned int dim = elem->dim();
 
           FEType fe_type = vg_description.type(elem->subdomain_id());
-
           fe_type.order = static_cast<Order>(fe_type.order +
                                              elem->p_level());
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -603,13 +603,24 @@ void DofMap::reinit(MeshBase & mesh)
 
           FEType fe_type = base_fe_type;
 
+          unsigned char extra_order_on_subdomain = 0;
+            {
+              const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders = vg_description.subdomain_var_orders();
+              auto var_order_it = subdomain_var_orders.find(elem->subdomain_id());
+              if (var_order_it != subdomain_var_orders.end())
+                {
+                  extra_order_on_subdomain = var_order_it->second;
+                }
+            }
+          int base_order = base_fe_type.order.get_order() + extra_order_on_subdomain;
+
 #ifdef LIBMESH_ENABLE_AMR
           // Make sure we haven't done more p refinement than we can
           // handle
           if (elem->p_level() + base_fe_type.order >
               FEInterface::max_order(base_fe_type, type))
             {
-              libmesh_assert_less_msg(static_cast<unsigned int>(base_fe_type.order.get_order()),
+              libmesh_assert_less_msg(static_cast<unsigned int>(base_order),
                                       FEInterface::max_order(base_fe_type,type),
                                       "ERROR: Finite element "
                                       << Utility::enum_to_string(base_fe_type.family)
@@ -618,7 +629,7 @@ void DofMap::reinit(MeshBase & mesh)
                                       << "\nonly supports FEInterface::max_order = "
                                       << FEInterface::max_order(base_fe_type,type)
                                       << ", not fe_type.order = "
-                                      << base_fe_type.order);
+                                      << base_order);
 
 #  ifdef DEBUG
               libMesh::err << "WARNING: Finite element "
@@ -634,7 +645,7 @@ void DofMap::reinit(MeshBase & mesh)
             }
 #endif
 
-          fe_type.order = static_cast<Order>(fe_type.order +
+          fe_type.order = static_cast<Order>(base_order +
                                              elem->p_level());
 
           // Allocate the vertex DOFs
@@ -691,7 +702,19 @@ void DofMap::reinit(MeshBase & mesh)
           const unsigned int dim = elem->dim();
 
           FEType fe_type = base_fe_type;
-          fe_type.order = static_cast<Order>(fe_type.order +
+
+          unsigned char extra_order_on_subdomain = 0;
+            {
+              const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders = vg_description.subdomain_var_orders();
+              auto var_order_it = subdomain_var_orders.find(elem->subdomain_id());
+              if (var_order_it != subdomain_var_orders.end())
+                {
+                  extra_order_on_subdomain = var_order_it->second;
+                }
+            }
+          int base_order = base_fe_type.order.get_order() + extra_order_on_subdomain;
+
+          fe_type.order = static_cast<Order>(base_order +
                                              elem->p_level());
 
           // Allocate the edge and face DOFs
@@ -2221,7 +2244,18 @@ void DofMap::_dof_indices (const Elem & elem,
 
       // Increase the polynomial order on p refined elements
       FEType fe_type = var.type();
-      fe_type.order = static_cast<Order>(fe_type.order + p_level);
+
+      unsigned char extra_order_on_subdomain = 0;
+        {
+          const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders = var.subdomain_var_orders();
+          auto var_order_it = subdomain_var_orders.find(elem.subdomain_id());
+          if (var_order_it != subdomain_var_orders.end())
+            {
+              extra_order_on_subdomain = var_order_it->second;
+            }
+        }
+      int base_order = fe_type.order.get_order() + extra_order_on_subdomain;
+      fe_type.order = static_cast<Order>(base_order + p_level);
 
       const bool extra_hanging_dofs =
         FEInterface::extra_hanging_dofs(fe_type);
@@ -2506,7 +2540,19 @@ void DofMap::old_dof_indices (const Elem * const elem,
                         p_adjustment = 1;
                       }
                     FEType fe_type = var.type();
-                    fe_type.order = static_cast<Order>(fe_type.order +
+
+                    unsigned char extra_order_on_subdomain = 0;
+                      {
+                        const std::map<subdomain_id_type, unsigned char> & subdomain_var_orders = var.subdomain_var_orders();
+                        auto var_order_it = subdomain_var_orders.find(elem->subdomain_id());
+                        if (var_order_it != subdomain_var_orders.end())
+                          {
+                            extra_order_on_subdomain = var_order_it->second;
+                          }
+                      }
+                    int base_order = fe_type.order.get_order() + extra_order_on_subdomain;
+
+                    fe_type.order = static_cast<Order>(base_order +
                                                        elem->p_level() +
                                                        p_adjustment);
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1119,45 +1119,45 @@ unsigned int System::add_variable (const std::string & var,
       if (vg.type() != type)
         should_be_in_vg = false;
 
-        {
-          // get a pointer to their subdomain restriction, if any.
-          const std::set<subdomain_id_type> * const
-            their_active_subdomains (vg.implicitly_active() ?
-                                     nullptr : &vg.active_subdomains());
+      {
+        // get a pointer to their subdomain restriction, if any.
+        const std::set<subdomain_id_type> * const
+          their_active_subdomains (vg.implicitly_active() ?
+                                    nullptr : &vg.active_subdomains());
 
-          // they are restricted, we aren't?
-          if (their_active_subdomains && !active_subdomains)
+        // they are restricted, we aren't?
+        if (their_active_subdomains && !active_subdomains)
+          should_be_in_vg = false;
+
+        // they aren't restricted, we are?
+        if (!their_active_subdomains && active_subdomains)
+          should_be_in_vg = false;
+
+        if (their_active_subdomains && active_subdomains)
+          // restricted to different sets?
+          if (*their_active_subdomains != *active_subdomains)
             should_be_in_vg = false;
+      }
 
-          // they aren't restricted, we are?
-          if (!their_active_subdomains && active_subdomains)
+      {
+        // get a pointer to their sudomain variable order, if any.
+        const std::map<subdomain_id_type, unsigned char> * const
+          their_subdomain_var_orders (vg.implicitly_same_order() ?
+                                      nullptr : &vg.subdomain_var_orders());
+
+        // they have subdomain variable orders, we aren't?
+        if (their_subdomain_var_orders && !subdomain_var_orders)
+          should_be_in_vg = false;
+
+        // they don't have subdomain variable orders, we do?
+        if (!their_subdomain_var_orders && subdomain_var_orders)
+          should_be_in_vg = false;
+
+        if (their_subdomain_var_orders && subdomain_var_orders)
+          // subdomain variable orders don't match
+          if (*their_subdomain_var_orders != *subdomain_var_orders)
             should_be_in_vg = false;
-
-          if (their_active_subdomains && active_subdomains)
-            // restricted to different sets?
-            if (*their_active_subdomains != *active_subdomains)
-              should_be_in_vg = false;
-        }
-
-        {
-          // get a pointer to their sudomain variable order, if any.
-          const std::map<subdomain_id_type, unsigned char> * const
-            their_subdomain_var_orders (vg.implicitly_same_order() ?
-                                        nullptr : &vg.subdomain_var_orders());
-
-          // they have subdomain variable orders, we aren't?
-          if (their_subdomain_var_orders && !subdomain_var_orders)
-            should_be_in_vg = false;
-
-          // they don't have subdomain variable orders, we do?
-          if (!their_subdomain_var_orders && subdomain_var_orders)
-            should_be_in_vg = false;
-
-          if (their_subdomain_var_orders && subdomain_var_orders)
-            // subdomain variable orders don't match
-            if (*their_subdomain_var_orders != *subdomain_var_orders)
-              should_be_in_vg = false;
-        }
+      }
 
       // OK, after all that, append the variable to the vg if none of the conditions
       // were violated


### PR DESCRIPTION
When a variable is added to a System we can now specify extra variable order to include on subdomains so that we can increase the variable order in specific regions of a mesh.