### PR TITLE
nodes_to_elem_map should be a map

### DIFF
--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -36,10 +36,11 @@ enum ElemType : int;
 #endif
 
 // C++ Includes
-#include <vector>
-#include <set>
 #include <limits>
+#include <set>
 #include <unordered_set>
+#include <unordered_map>
+#include <vector>
 
 namespace libMesh
 {
@@ -126,6 +127,21 @@ void build_nodes_to_elem_map (const MeshBase & mesh,
  */
 void build_nodes_to_elem_map (const MeshBase & mesh,
                               std::vector<std::vector<const Elem *>> & nodes_to_elem_map);
+
+/**
+ * After calling this function the input map \p nodes_to_elem_map
+ * will contain the node to element connectivity.  That is to say
+ * \p nodes_to_elem_map[i][j] is the global number of \f$ j^{th} \f$
+ * element connected to node \p i.
+ */
+void build_nodes_to_elem_map (const MeshBase & mesh,
+                              std::unordered_map<dof_id_type, std::vector<dof_id_type>> & nodes_to_elem_map);
+
+/**
+ * The same, except element pointers are returned instead of indices.
+ */
+void build_nodes_to_elem_map (const MeshBase & mesh,
+                              std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map);
 
 
 //   /**
@@ -378,7 +394,6 @@ dof_id_type n_nodes (const MeshBase::const_node_iterator & begin,
  * Find the maximum h-refinement level in a mesh.
  */
 unsigned int max_level (const MeshBase & mesh);
-
 
 /**
  * Given a mesh and a node in the mesh, the vector will be filled with

--- a/include/mesh/mesh_tools.h
+++ b/include/mesh/mesh_tools.h
@@ -405,6 +405,15 @@ void find_nodal_neighbors(const MeshBase & mesh,
                           std::vector<const Node *> & neighbors);
 
 /**
+ * Given a mesh and a node in the mesh, the vector will be filled with
+ * every node directly attached to the given one.
+ */
+void find_nodal_neighbors(const MeshBase & mesh,
+                          const Node & n,
+                          const std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map,
+                          std::vector<const Node *> & neighbors);
+
+/**
  * Given a mesh hanging_nodes will be filled with an associative array keyed off the
  * global id of all the hanging nodes in the mesh.  It will hold an array of the
  * parents of the node (meaning the two nodes to either side of it that make up

--- a/include/utils/tree_node.h
+++ b/include/utils/tree_node.h
@@ -27,8 +27,9 @@
 
 // C++ includes
 #include <cstddef>
-#include <vector>
 #include <set>
+#include <unordered_map>
+#include <vector>
 
 namespace libMesh
 {
@@ -140,6 +141,11 @@ public:
    * Transforms node numbers to element pointers.
    */
   void transform_nodes_to_elements (std::vector<std::vector<const Elem *>> & nodes_to_elem);
+
+  /**
+   * Transforms node numbers to element pointers.
+   */
+  void transform_nodes_to_elements (std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem);
 
   /**
    * \returns The number of active bins below

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -18,19 +18,19 @@
 #include "libmesh/libmesh_config.h"
 #ifdef LIBMESH_ENABLE_VSMOOTHER
 
-// C++ includes
-#include <time.h> // for clock_t, clock()
-#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
-#include <cmath>
-#include <iomanip>
-#include <limits>
-
 // Local includes
 #include "libmesh/mesh_smoother_vsmoother.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/elem.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/utility.h"
+
+// C++ includes
+#include <time.h> // for clock_t, clock()
+#include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
+#include <cmath>
+#include <iomanip>
+#include <limits>
 
 namespace libMesh
 {
@@ -283,7 +283,7 @@ int VariationalMeshSmoother::readgr(Array2D<double> & R,
   // Grab node coordinates and set mask
   {
     // Only compute the node to elem map once
-    std::vector<std::vector<const Elem *>> nodes_to_elem_map;
+    std::unordered_map<dof_id_type, std::vector<const Elem *>> nodes_to_elem_map;
     MeshTools::build_nodes_to_elem_map(_mesh, nodes_to_elem_map);
 
     int i = 0;

--- a/src/mesh/mesh_subdivision_support.C
+++ b/src/mesh/mesh_subdivision_support.C
@@ -177,7 +177,7 @@ void MeshTools::Subdivision::prepare_subdivision_mesh(MeshBase & mesh, bool ghos
 
   mesh.prepare_for_use();
 
-  std::vector<std::vector<const Elem *>> nodes_to_elem_map;
+  std::unordered_map<dof_id_type, std::vector<const Elem *>> nodes_to_elem_map;
   MeshTools::build_nodes_to_elem_map(mesh, nodes_to_elem_map);
 
   // compute the node valences

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -284,6 +284,30 @@ void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
 
 
 
+void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
+                                         std::unordered_map<dof_id_type, std::vector<dof_id_type>> & nodes_to_elem_map)
+{
+  nodes_to_elem_map.clear();
+
+  for (const auto & elem : mesh.element_ptr_range())
+    for (auto & node : elem->node_ref_range())
+      nodes_to_elem_map[node.id()].push_back(elem->id());
+}
+
+
+
+void MeshTools::build_nodes_to_elem_map (const MeshBase & mesh,
+                                         std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem_map)
+{
+  nodes_to_elem_map.clear();
+
+  for (const auto & elem : mesh.element_ptr_range())
+    for (auto & node : elem->node_ref_range())
+      nodes_to_elem_map[node.id()].push_back(elem);
+}
+
+
+
 #ifdef LIBMESH_ENABLE_DEPRECATED
 void MeshTools::find_boundary_nodes (const MeshBase & mesh,
                                      std::vector<bool> & on_boundary)

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -504,7 +504,7 @@ void Partitioner::set_interface_node_processor_ids_BFS(MeshBase & mesh)
 
   processor_pairs_to_interface_nodes(mesh, processor_pair_to_nodes);
 
-  std::vector<std::vector<const Elem *>> nodes_to_elem_map;
+  std::unordered_map<dof_id_type, std::vector<const Elem *>> nodes_to_elem_map;
 
   MeshTools::build_nodes_to_elem_map(mesh, nodes_to_elem_map);
 

--- a/src/utils/tree.C
+++ b/src/utils/tree.C
@@ -61,7 +61,7 @@ Tree<N>::Tree (const MeshBase & m,
       // Now the tree contains the nodes.
       // However, we want element pointers, so here we
       // convert between the two.
-      std::vector<std::vector<const Elem *>> nodes_to_elem;
+      std::unordered_map<dof_id_type, std::vector<const Elem *>> nodes_to_elem;
 
       MeshTools::build_nodes_to_elem_map (mesh, nodes_to_elem);
       root.transform_nodes_to_elements (nodes_to_elem);

--- a/src/utils/tree_node.C
+++ b/src/utils/tree_node.C
@@ -443,6 +443,63 @@ void TreeNode<N>::transform_nodes_to_elements (std::vector<std::vector<const Ele
 
 
 template <unsigned int N>
+void TreeNode<N>::transform_nodes_to_elements (std::unordered_map<dof_id_type, std::vector<const Elem *>> & nodes_to_elem)
+{
+  if (this->active())
+    {
+      elements.clear();
+
+      // Temporarily use a set. Since multiple nodes
+      // will likely map to the same element we use a
+      // set to eliminate the duplication.
+      std::set<const Elem *> elements_set;
+
+      for (std::size_t n=0; n<nodes.size(); n++)
+        {
+          // the actual global node number we are replacing
+          // with the connected elements
+          const dof_id_type node_number = nodes[n]->id();
+
+          libmesh_assert_less (node_number, mesh.n_nodes());
+
+          auto & my_elems = nodes_to_elem[node_number];
+          elements_set.insert(my_elems.begin(), my_elems.end());
+        }
+
+      // Done with the nodes.
+      std::vector<const Node *>().swap(nodes);
+
+      // Now the set is built.  We can copy this to the
+      // vector.  Note that the resulting vector will
+      // already be sorted, and will require less memory
+      // than the set.
+      elements.reserve(elements_set.size());
+
+      for (const auto & elem : elements_set)
+        {
+          elements.push_back(elem);
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+          // flag indicating this node contains
+          // infinite elements
+          if (elem->infinite())
+            this->contains_ifems = true;
+
+#endif
+        }
+    }
+  else
+    {
+      for (std::size_t child=0; child<children.size(); child++)
+        children[child]->transform_nodes_to_elements (nodes_to_elem);
+    }
+
+}
+
+
+
+template <unsigned int N>
 unsigned int TreeNode<N>::n_active_bins() const
 {
   if (this->active())


### PR DESCRIPTION
Probably unordered_map; let's give that a try.

The memory usage of this ought to scale much better than our previous build_nodes_to_elem_vector_pretending_to_be_a_map overload.  Thanks to @friedmud for pointing that out.

We'll leave the old method overloads in for now but switch to use the new ones internally.