### PR TITLE
Use unordered_map instead of map in BoundaryInfo

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -29,8 +29,9 @@
 #include <cstddef>
 #include <map>
 #include <set>
-#include <vector>
 #include <tuple>
+#include <unordered_map>
+#include <vector>
 
 namespace libMesh
 {
@@ -898,31 +899,31 @@ private:
    * Data structure that maps nodes in the mesh
    * to boundary ids.
    */
-  std::multimap<const Node *,
-                boundary_id_type> _boundary_node_id;
+  std::unordered_multimap<const Node *,
+                          boundary_id_type> _boundary_node_id;
 
   /**
    * Data structure that maps edges of elements
    * to boundary ids. This is only relevant in 3D.
    */
-  std::multimap<const Elem *,
-                std::pair<unsigned short int, boundary_id_type>>
+  std::unordered_multimap<const Elem *,
+                          std::pair<unsigned short int, boundary_id_type>>
   _boundary_edge_id;
 
   /**
    * Data structure that maps faces of shell elements
    * to boundary ids. This is only relevant for shell elements.
    */
-  std::multimap<const Elem *,
-                std::pair<unsigned short int, boundary_id_type>>
+  std::unordered_multimap<const Elem *,
+                          std::pair<unsigned short int, boundary_id_type>>
   _boundary_shellface_id;
 
   /**
    * Data structure that maps sides of elements
    * to boundary ids.
    */
-  std::multimap<const Elem *,
-                std::pair<unsigned short int, boundary_id_type>>
+  std::unordered_multimap<const Elem *,
+                          std::pair<unsigned short int, boundary_id_type>>
   _boundary_side_id;
 
   /**


### PR DESCRIPTION
We don't use the useless order-by-pointer-address behavior of maps of
pointers, and O(1) average lookup time may be more efficient than
just using a saner ordering.

Hopefully this will eat into the 14% of #1821 runtime currently spent
in equal_range calls from BoundaryInfo

This would make #1787 moot