### PR TITLE
Heap vectors of local node data can instead be stack arrays

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -594,6 +594,12 @@ public:
   virtual unsigned int n_nodes () const = 0;
 
   /**
+   * The maximum number of nodes *any* element can contain.
+   * This is useful for replacing heap vectors with stack arrays.
+   */
+  static const unsigned int max_n_nodes = 27;
+
+  /**
    * \returns An integer range from 0 up to (but not including)
    * the number of nodes this element contains.
    */
@@ -1777,6 +1783,9 @@ Elem::Elem(const unsigned int nn,
 #endif
 {
   this->processor_id() = DofObject::invalid_processor_id;
+
+  // If this ever legitimately fails we need to increase max_n_nodes
+  libmesh_assert_less_equal(nn, max_n_nodes);
 
   // Initialize the nodes data structure
   if (_nodes)

--- a/include/utils/hashword.h
+++ b/include/utils/hashword.h
@@ -254,15 +254,6 @@ uint64_t hashword(const uint64_t * k, size_t length)
 
 
 /**
- * Calls function above with slightly more convenient std::vector interface.
- */
-inline
-uint64_t hashword(const std::vector<uint64_t> & keys)
-{
-  return hashword(&keys[0], keys.size());
-}
-
-/**
  * In a personal communication from Bob Jenkins, he recommended using
  * "Probably final() from lookup3.c... You could hash up to 6 16-bit
  * integers that way.  The output is c, or the top or bottom 16 bits
@@ -305,12 +296,14 @@ uint16_t hashword(const uint16_t * k, size_t length)
 
 
 /**
- * Calls function above with slightly more convenient std::vector interface.
+ * Calls functions above with slightly more convenient
+ * std::vector/array compatible interface.
  */
+template <typename Container>
 inline
-uint16_t hashword(const std::vector<uint16_t> & keys)
+typename Container::value_type hashword(const Container & keys)
 {
-  return hashword(&keys[0], keys.size());
+  return hashword(keys.data(), keys.size());
 }
 
 

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -87,6 +87,8 @@ Threads::spin_mutex parent_bracketing_nodes_mutex;
 const subdomain_id_type Elem::invalid_subdomain_id = std::numeric_limits<subdomain_id_type>::max();
 
 // Initialize static member variables
+const unsigned int Elem::max_n_nodes;
+
 const unsigned int Elem::type_to_n_nodes_map [] =
   {
     2,  // EDGE2

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -19,6 +19,7 @@
 
 // C++ includes
 #include <algorithm> // for std::sort
+#include <array>
 #include <iterator>  // for std::ostream_iterator
 #include <sstream>
 #include <limits>    // for std::numeric_limits<>
@@ -401,16 +402,16 @@ dof_id_type Elem::key () const
 {
   const unsigned short n_n = this->n_nodes();
 
-  std::vector<dof_id_type> node_ids(n_n);
+  std::array<dof_id_type, Elem::max_n_nodes> node_ids;
 
   for (unsigned short n=0; n != n_n; ++n)
     node_ids[n] = this->node_id(n);
 
   // Always sort, so that different local node numberings hash to the
   // same value.
-  std::sort (node_ids.begin(), node_ids.end());
+  std::sort (node_ids.begin(), node_ids.begin()+n_n);
 
-  return Utility::hashword(node_ids);
+  return Utility::hashword(node_ids.data(), n_n);
 }
 
 
@@ -424,11 +425,9 @@ bool Elem::operator == (const Elem & rhs) const
   const unsigned short n_n = this->n_nodes();
   libmesh_assert_equal_to(n_n, rhs.n_nodes());
 
-  // Make two sorted vectors of global node ids and compare them for
+  // Make two sorted arrays of global node ids and compare them for
   // equality.
-  std::vector<dof_id_type>
-    this_ids(n_n),
-    rhs_ids(n_n);
+  std::array<dof_id_type, Elem::max_n_nodes> this_ids, rhs_ids;
 
   for (unsigned short n = 0; n != n_n; n++)
     {
@@ -437,11 +436,14 @@ bool Elem::operator == (const Elem & rhs) const
     }
 
   // Sort the vectors to rule out different local node numberings.
-  std::sort(this_ids.begin(), this_ids.end());
-  std::sort(rhs_ids.begin(), rhs_ids.end());
+  std::sort(this_ids.begin(), this_ids.begin()+n_n);
+  std::sort(rhs_ids.begin(), rhs_ids.begin()+n_n);
 
   // If the node ids match, the elements are equal!
-  return this_ids == rhs_ids;
+  for (unsigned short n = 0; n != n_n; ++n)
+    if (this_ids[n] != rhs_ids[n])
+      return false;
+  return true;
 }
 
 


### PR DESCRIPTION
This ought to shave 4 or 5 seconds off of the results @friedmud shared
in #1821 

I was kind of hoping to find more than a couple spots where this trick would be useful.