### PR TITLE
Fix #1862: Uncomment lines which actually do the optimization.

### DIFF
--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -1343,10 +1343,10 @@ inline void Communicator::nonblocking_send_packed_range (const unsigned int dest
 
   if (range_begin != range_end)
     {
-//      if (buffer == nullptr)
+      if (buffer == nullptr)
         buffer = std::make_shared<std::vector<buffer_t>>();
-//      else
-//        buffer->clear();
+      else
+        buffer->clear();
 
       range_begin =
         Parallel::pack_range(context,


### PR DESCRIPTION
According to @friedmud, the original PR should not have been merged
with these lines commented out...