### PR TITLE
Acquire BC lists outside the CheckPointIO id loop

### DIFF
--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -214,13 +214,15 @@ private:
    * Write the side boundary conditions for part of a mesh
    */
   void write_bcs (Xdr & io,
-                  const std::set<const Elem *, CompareElemIdsByLevel> & elements) const;
+                  const std::set<const Elem *, CompareElemIdsByLevel> & elements,
+                  const std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> & bc_triples) const;
 
   /**
    * Write the nodal boundary conditions for part of a mesh
    */
   void write_nodesets (Xdr & io,
-                       const std::set<const Node *> & nodeset) const;
+                       const std::set<const Node *> & nodeset,
+                       const std::vector<std::tuple<dof_id_type, boundary_id_type>> & bc_tuples) const;
 
   /**
    * Write boundary names information (sideset and nodeset)


### PR DESCRIPTION
This should be just as fast for restarts and O(Nsplits/Nprocs) times
faster for mesh splitting.  Thanks to @friedmud for the idea.

I'm about to head home so I haven't yet made 100% sure this optimizes things.  Or works correctly.  Or compiles.  Hopefully @friedmud can check up on the first question and Civet will scream at me if I've flubbed the latter two.