### PR TITLE
reconnect_nodes with an unordered_set

### DIFF
--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -28,7 +28,9 @@
 #include "libmesh/parallel_object.h"
 
 // C++ includes
+#include <set>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace libMesh
@@ -217,7 +219,7 @@ private:
    * Write the nodal locations for part of a mesh
    */
   void write_nodes (Xdr & io,
-                    const std::set<const Node *> & nodeset) const;
+                    const std::unordered_set<const Node *> & nodeset) const;
 
   /**
    * Write the side boundary conditions for part of a mesh
@@ -230,7 +232,7 @@ private:
    * Write the nodal boundary conditions for part of a mesh
    */
   void write_nodesets (Xdr & io,
-                       const std::set<const Node *> & nodeset,
+                       const std::unordered_set<const Node *> & nodeset,
                        const std::vector<std::tuple<dof_id_type, boundary_id_type>> & bc_tuples) const;
 
   /**

--- a/include/mesh/mesh_communication.h
+++ b/include/mesh/mesh_communication.h
@@ -26,7 +26,10 @@
 #include "libmesh/mesh_tools.h"
 
 // C++ Includes
+#include <set>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace libMesh
 {
@@ -273,7 +276,7 @@ void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_
 
 // Take a set of elements and create a set of connected nodes.
 void reconnect_nodes (const std::set<const Elem *, CompareElemIdsByLevel> & connected_elements,
-                      std::set<const Node *> & connected_nodes);
+                      std::unordered_set<const Node *> & connected_nodes);
 
 
 

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -478,7 +478,7 @@ void CheckpointIO::write (const std::string & name)
             }
         }
 
-      std::set<const Node *> connected_nodes;
+      std::unordered_set<const Node *> connected_nodes;
       reconnect_nodes(elements, connected_nodes);
 
       // write the nodal locations
@@ -538,7 +538,7 @@ void CheckpointIO::write_subdomain_names(Xdr & io) const
 
 
 void CheckpointIO::write_nodes (Xdr & io,
-                                const std::set<const Node *> & nodeset) const
+                                const std::unordered_set<const Node *> & nodeset) const
 {
   largest_id_type n_nodes_here = nodeset.size();
 
@@ -749,7 +749,7 @@ void CheckpointIO::write_bcs (Xdr & io,
 
 
 void CheckpointIO::write_nodesets (Xdr & io,
-                                   const std::set<const Node *> & nodeset,
+                                   const std::unordered_set<const Node *> & nodeset,
                                    const std::vector<std::tuple<dof_id_type, boundary_id_type>> & bc_tuples) const
 {
   libmesh_assert (io.writing());

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -310,7 +310,7 @@ void connect_families(std::set<const Elem *, CompareElemIdsByLevel> & connected_
 
 
 void reconnect_nodes (const std::set<const Elem *, CompareElemIdsByLevel> & connected_elements,
-                      std::set<const Node *> & connected_nodes)
+                      std::unordered_set<const Node *> & connected_nodes)
 {
   // We're done using the nodes list for element decisions; now
   // let's reuse it for nodes of the elements we've decided on.
@@ -473,7 +473,7 @@ void MeshCommunication::redistribute (DistributedMesh & mesh,
       // elements with constraining nodes to remain present.
       connect_families(elements_to_send, &mesh);
 
-      std::set<const Node *> connected_nodes;
+      std::unordered_set<const Node *> connected_nodes;
       reconnect_nodes(elements_to_send, connected_nodes);
 
       // the number of nodes we will ship to pid
@@ -2113,7 +2113,7 @@ MeshCommunication::delete_remote_elements (DistributedMesh & mesh,
   connect_families(elements_to_keep, &mesh);
 
   // Don't delete nodes that our semilocal elements need
-  std::set<const Node *> connected_nodes;
+  std::unordered_set<const Node *> connected_nodes;
   reconnect_nodes(elements_to_keep, connected_nodes);
 
   // Delete all the elements we have no reason to save,


### PR DESCRIPTION
We don't actually need an ordering here, and count/insert/etc
operations in O(1) instead of O(log(N)) might be nice.

@friedmud, try this on the case from #1859 and see if it chops anything off the write_nodesets time?

This might be another pessimization instead but it's an easy enough change to be worth trying.