### PR TITLE
Add --enable-metaphysicl-required configure option.

### DIFF
--- a/configure
+++ b/configure
@@ -41621,6 +41621,10 @@ else
 fi
 
 
+        if test "x$enablemetaphysicl" = "xno" && test "x$metaphysiclrequired" = "xyes"; then :
+  enablemetaphysicl=yes
+fi
+
     if test "x$enablemetaphysicl" = "xyes" && test -r $top_srcdir/contrib/metaphysicl/README; then :
   enablemetaphysicl=yes
 else

--- a/configure
+++ b/configure
@@ -1264,6 +1264,7 @@ with_cppunit_prefix
 with_cppunit_exec_prefix
 enable_nanoflann
 enable_metaphysicl
+enable_metaphysicl_required
 enable_curl
 with_curl_include
 with_curl_lib
@@ -2054,6 +2055,8 @@ Optional Features:
   --disable-cppunit       Build without cppunit C++ unit testing support
   --disable-nanoflann     build without nanoflann KD-tree support
   --disable-metaphysicl   build without MetaPhysicL suppport
+  --enable-metaphysicl-required
+                          Error if MetaPhysicL is not detected by configure
   --enable-curl           link against libcurl, for using the cURL API
 
 Optional Packages:
@@ -41603,6 +41606,21 @@ else
 fi
 
 
+                # Check whether --enable-metaphysicl-required was given.
+if test "${enable_metaphysicl_required+set}" = set; then :
+  enableval=$enable_metaphysicl_required; case "${enableval}" in #(
+  yes) :
+    metaphysiclrequired=yes ;; #(
+  no) :
+    metaphysiclrequired=no ;; #(
+  *) :
+    as_fn_error $? "bad value ${enableval} for --enable-metaphysicl-required" "$LINENO" 5 ;;
+esac
+else
+  metaphysiclrequired=no
+fi
+
+
     if test "x$enablemetaphysicl" = "xyes" && test -r $top_srcdir/contrib/metaphysicl/README; then :
   enablemetaphysicl=yes
 else
@@ -41611,6 +41629,10 @@ else
 $as_echo ">>> Configuring metaphysicl failed, you may need to run 'git submodule update --init' first <<<" >&6; }
           enablemetaphysicl=no
 
+fi
+
+            if test "x$enablemetaphysicl" = "xno" && test "x$metaphysiclrequired" = "xyes"; then :
+  as_fn_error 5 "*** MetaPhysicL was not found, but --enable-metaphysicl-required was specified." "$LINENO" 5
 fi
 
         if test "x$enablemetaphysicl" = "xyes"; then :

--- a/m4/libmesh_metaphysicl.m4
+++ b/m4/libmesh_metaphysicl.m4
@@ -28,6 +28,12 @@ AC_DEFUN([CONFIGURE_METAPHYSICL],
                          [AC_MSG_ERROR(bad value ${enableval} for --enable-metaphysicl-required)])],
                      [metaphysiclrequired=no])
 
+  dnl Let --enable-metaphysicl-required override the value of $enablenested. Also, if the user
+  dnl provides the nonsensical combination "--disable-metaphysicl --enable-metaphysicl-required"
+  dnl we'll set $enablemetaphysicl to yes instead.
+  AS_IF([test "x$enablemetaphysicl" = "xno" && test "x$metaphysiclrequired" = "xyes"],
+        [enablemetaphysicl=yes])
+
   dnl Check for existence of a file that should always be in metaphysicl
   AS_IF([test "x$enablemetaphysicl" = "xyes" && test -r $top_srcdir/contrib/metaphysicl/README],
         [enablemetaphysicl=yes],

--- a/m4/libmesh_metaphysicl.m4
+++ b/m4/libmesh_metaphysicl.m4
@@ -12,6 +12,22 @@ AC_DEFUN([CONFIGURE_METAPHYSICL],
                          [AC_MSG_ERROR(bad value ${enableval} for --enable-metaphysicl)])],
                 [enablemetaphysicl=$enablenested])
 
+  dnl Setting --enable-metaphysicl-required causes an error to be
+  dnl emitted during configure if the MetaPhysicL library is not
+  dnl detected successfully.  This is useful for app codes which require
+  dnl MetaPhysicL (like MOOSE-based apps), since it prevents situations
+  dnl where libmesh is accidentally built without MetaPhysicL support
+  dnl (which may take a very long time), and then the app fails to
+  dnl compile, requiring you to redo everything.
+  AC_ARG_ENABLE(metaphysicl-required,
+                AC_HELP_STRING([--enable-metaphysicl-required],
+                               [Error if MetaPhysicL is not detected by configure]),
+                [AS_CASE("${enableval}",
+                         [yes], [metaphysiclrequired=yes],
+                         [no],  [metaphysiclrequired=no],
+                         [AC_MSG_ERROR(bad value ${enableval} for --enable-metaphysicl-required)])],
+                     [metaphysiclrequired=no])
+
   dnl Check for existence of a file that should always be in metaphysicl
   AS_IF([test "x$enablemetaphysicl" = "xyes" && test -r $top_srcdir/contrib/metaphysicl/README],
         [enablemetaphysicl=yes],
@@ -19,6 +35,14 @@ AC_DEFUN([CONFIGURE_METAPHYSICL],
           AC_MSG_RESULT([>>> Configuring metaphysicl failed, you may need to run 'git submodule update --init' first <<<])
           enablemetaphysicl=no
         ])
+
+  dnl If metaphysicl was required but isn't available, throw an error.
+  dnl We return a non-unity error code here, since 0 means success and 1 is
+  dnl indistinguishable from other errors.  Ideally, all of the
+  dnl AC_MSG_ERROR calls in our m4 files would return a different
+  dnl error code, but currently this is not implemented.
+  AS_IF([test "x$enablemetaphysicl" = "xno" && test "x$metaphysiclrequired" = "xyes"],
+        [AC_MSG_ERROR([*** MetaPhysicL was not found, but --enable-metaphysicl-required was specified.], 5)])
 
   dnl The MetaPhysicL API is distributed with libmesh, so we don't have
   dnl to guess where it might be installed.  This needs to be replaced


### PR DESCRIPTION
Now that idaholab/moose#12111 has been merged, we are going to start requiring libmesh+metaphysicl in MOOSE, and this configure option allows us to enforce that at configure time, rather than waiting until all of libmesh is built in an invalid state.
