### PR TITLE
std container erase() test

### DIFF
--- a/configure
+++ b/configure
@@ -9874,6 +9874,82 @@ if test "x$have_cxx11_begin_end" != "xyes"; then :
   as_fn_error $? "libMesh requires C++11 std::begin/end support" "$LINENO" 5
 fi
 
+
+    have_cxx11_container_erase=no
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 std container erase() functions returning iterators" >&5
+$as_echo_n "checking for C++11 std container erase() functions returning iterators... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <map>
+    #include <set>
+
+int
+main ()
+{
+
+    {
+      std::map<int, int> m;
+      m.insert(std::make_pair(1,2));
+      std::map<int, int>::iterator it = m.erase(m.begin());
+    }
+    {
+      std::set<int> s;
+      s.insert(1);
+      std::set<int>::iterator it = s.erase(s.begin());
+    }
+    {
+      std::multimap<int, int> m;
+      m.insert(std::make_pair(1,2));
+      std::multimap<int, int>::iterator it = m.erase(m.begin());
+    }
+    {
+      std::multiset<int> s;
+      s.insert(1);
+      std::multiset<int>::iterator it = s.erase(s.begin());
+    }
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+        have_cxx11_container_erase=yes
+
+else
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+        CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+if test "x$have_cxx11_container_erase" != "xyes"; then :
+  as_fn_error $? "libMesh requires C++11 support for std container erase() functions returning iterators" "$LINENO" 5
+fi
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.

--- a/configure
+++ b/configure
@@ -30069,6 +30069,7 @@ main ()
   m.insert(std::make_pair(1, 2));
   m.insert(std::make_pair(1, 3));
   if (m.size() != 2) return 1;
+  std::unordered_multimap<int, int>::iterator it = m.erase(m.begin());
 
   ;
   return 0;
@@ -30130,6 +30131,7 @@ main ()
 
   std::unordered_map<int, int> m;
   m.insert(std::make_pair(1, 2));
+  std::unordered_map<int, int>::iterator it = m.erase(m.begin());
 
   ;
   return 0;
@@ -30193,6 +30195,7 @@ main ()
   s.insert(1);
   s.insert(1);
   if (s.size() != 2) return 1;
+  std::unordered_multiset<int>::iterator it = s.erase(s.begin());
 
   ;
   return 0;
@@ -30252,9 +30255,10 @@ int
 main ()
 {
 
-  std::unordered_set<int> m;
-  m.insert(1);
-  m.insert(2);
+  std::unordered_set<int> s;
+  s.insert(1);
+  s.insert(2);
+  std::unordered_set<int>::iterator it = s.erase(s.begin());
 
   ;
   return 0;

--- a/configure.ac
+++ b/configure.ac
@@ -353,6 +353,10 @@ LIBMESH_TEST_CXX11_BEGIN_END
 AS_IF([test "x$have_cxx11_begin_end" != "xyes"],
       [AC_MSG_ERROR([libMesh requires C++11 std::begin/end support])])
 
+LIBMESH_TEST_CXX11_CONTAINER_ERASE
+AS_IF([test "x$have_cxx11_container_erase" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires C++11 support for std container erase() functions returning iterators])])
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -3,6 +3,53 @@ dnl Tests for various C++11 features.  These will probably only work
 dnl if they are run after the autoconf test that sets -std=c++11.
 dnl ----------------------------------------------------------------
 
+dnl Test C++11 std::map,set,multimap,multiset iterator-returning erase() APIs.
+AC_DEFUN([LIBMESH_TEST_CXX11_CONTAINER_ERASE],
+  [
+    have_cxx11_container_erase=no
+
+    AC_MSG_CHECKING(for C++11 std container erase() functions returning iterators)
+    AC_LANG_PUSH([C++])
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include <map>
+    @%:@include <set>
+    ]], [[
+    {
+      std::map<int, int> m;
+      m.insert(std::make_pair(1,2));
+      std::map<int, int>::iterator it = m.erase(m.begin());
+    }
+    {
+      std::set<int> s;
+      s.insert(1);
+      std::set<int>::iterator it = s.erase(s.begin());
+    }
+    {
+      std::multimap<int, int> m;
+      m.insert(std::make_pair(1,2));
+      std::multimap<int, int>::iterator it = m.erase(m.begin());
+    }
+    {
+      std::multiset<int> s;
+      s.insert(1);
+      std::multiset<int>::iterator it = s.erase(s.begin());
+    }
+    ]])],[
+        AC_MSG_RESULT(yes)
+        have_cxx11_container_erase=yes
+    ],[
+        AC_MSG_RESULT(no)
+    ])
+
+    dnl Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    AC_LANG_POP([C++])
+  ])
+
 dnl Test C++11 std::tuple and several related helper functions.
 AC_DEFUN([LIBMESH_TEST_CXX11_BEGIN_END],
   [

--- a/m4/unordered.m4
+++ b/m4/unordered.m4
@@ -11,6 +11,7 @@ ac_cv_cxx_unordered_map,
 [
   std::unordered_map<int, int> m;
   m.insert(std::make_pair(1, 2));
+  std::unordered_map<int, int>::iterator it = m.erase(m.begin());
 ],
  ac_cv_cxx_unordered_map=yes, ac_cv_cxx_unordered_map=no)
  AC_LANG_RESTORE
@@ -42,6 +43,7 @@ ac_cv_cxx_unordered_multimap,
   m.insert(std::make_pair(1, 2));
   m.insert(std::make_pair(1, 3));
   if (m.size() != 2) return 1;
+  std::unordered_multimap<int, int>::iterator it = m.erase(m.begin());
 ],
  ac_cv_cxx_unordered_multimap=yes, ac_cv_cxx_unordered_multimap=no)
  AC_LANG_RESTORE
@@ -73,6 +75,7 @@ ac_cv_cxx_unordered_multiset,
   s.insert(1);
   s.insert(1);
   if (s.size() != 2) return 1;
+  std::unordered_multiset<int>::iterator it = s.erase(s.begin());
 ],
  ac_cv_cxx_unordered_multiset=yes,
  ac_cv_cxx_unordered_multiset=no)
@@ -101,9 +104,10 @@ ac_cv_cxx_unordered_set,
  AC_LANG_CPLUSPLUS
  AC_TRY_COMPILE([@%:@include <unordered_set>],
 [
-  std::unordered_set<int> m;
-  m.insert(1);
-  m.insert(2);
+  std::unordered_set<int> s;
+  s.insert(1);
+  s.insert(2);
+  std::unordered_set<int>::iterator it = s.erase(s.begin());
 ],
  ac_cv_cxx_unordered_set=yes, ac_cv_cxx_unordered_set=no)
  AC_LANG_RESTORE


### PR DESCRIPTION
In 9872b8b I inadvertently introduced a C++11-ism by calling the version of `std::set::erase()` that returns an iterator to the next element. I don't think we'll run into compiler issues with this, but just to be on the safe side, add a configure test while I'm thinking about it.
