### PR TITLE
Avoid modifying solution vector in TaoOptimizationSolver callbacks.

### DIFF
--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -594,6 +594,12 @@ void TaoOptimizationSolver<T>::solve ()
   ierr = TaoSolve(_tao);
   LIBMESH_CHKERR(ierr);
 
+  // Enforce constraints exactly now that the solve is done.  We have
+  // been enforcing them on the current_local_solution during the
+  // solve, but now need to be sure they are enforced on the parallel
+  // solution vector as well.
+  this->system().get_dof_map().enforce_constraints_exactly(this->system());
+
   // Store the convergence/divergence reason
   ierr = TaoGetConvergedReason(_tao, &_reason);
   LIBMESH_CHKERR(ierr);

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -67,14 +67,19 @@ extern "C"
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X(x, sys.comm());
 
-    // Perform a swap so that sys.solution points to X
+    // Perform a swap so that sys.solution points to the input vector
+    // "x", update sys.current_local_solution based on "x", then swap
+    // back.
     X.swap(X_sys);
-    // Impose constraints on X
-    sys.get_dof_map().enforce_constraints_exactly(sys);
-    // Update sys.current_local_solution based on X
     sys.update();
-    // Swap back
     X.swap(X_sys);
+
+    // Enforce constraints (if any) exactly on the
+    // current_local_solution.  This is the solution vector that is
+    // actually used in the computation of the objective function
+    // below, and is not locked by debug-enabled PETSc the way that
+    // the solution vector is.
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     if (solver->objective_object != nullptr)
       (*objective) = solver->objective_object->objective(*(sys.current_local_solution), sys);
@@ -110,13 +115,11 @@ extern "C"
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X(x, sys.comm());
 
-    // Perform a swap so that sys.solution points to X
+    // Perform a swap so that sys.solution points to the input vector
+    // "x", update sys.current_local_solution based on "x", then swap
+    // back.
     X.swap(X_sys);
-    // Impose constraints on X
-    sys.get_dof_map().enforce_constraints_exactly(sys);
-    // Update sys.current_local_solution based on X
     sys.update();
-    // Swap back
     X.swap(X_sys);
 
     // We'll also pass the gradient in to the assembly routine
@@ -125,6 +128,9 @@ extern "C"
 
     // Clear the gradient prior to assembly
     gradient.zero();
+
+    // Enforce constraints exactly on the current_local_solution.
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     if (solver->gradient_object != nullptr)
       solver->gradient_object->gradient(*(sys.current_local_solution), gradient, sys);
@@ -161,13 +167,11 @@ extern "C"
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X(x, sys.comm());
 
-    // Perform a swap so that sys.solution points to X
+    // Perform a swap so that sys.solution points to the input vector
+    // "x", update sys.current_local_solution based on "x", then swap
+    // back.
     X.swap(X_sys);
-    // Impose constraints on X
-    sys.get_dof_map().enforce_constraints_exactly(sys);
-    // Update sys.current_local_solution based on X
     sys.update();
-    // Swap back
     X.swap(X_sys);
 
     // Let's also wrap pc and h in PetscMatrix objects for convenience
@@ -175,6 +179,9 @@ extern "C"
     PetscMatrix<Number> hessian(h, sys.comm());
     PC.attach_dof_map(sys.get_dof_map());
     hessian.attach_dof_map(sys.get_dof_map());
+
+    // Enforce constraints exactly on the current_local_solution.
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     if (solver->hessian_object != nullptr)
       {
@@ -216,13 +223,11 @@ extern "C"
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X(x, sys.comm());
 
-    // Perform a swap so that sys.solution points to X
+    // Perform a swap so that sys.solution points to the input vector
+    // "x", update sys.current_local_solution based on "x", then swap
+    // back.
     X.swap(X_sys);
-    // Impose constraints on X
-    sys.get_dof_map().enforce_constraints_exactly(sys);
-    // Update sys.current_local_solution based on X
     sys.update();
-    // Swap back
     X.swap(X_sys);
 
     // We'll also pass the constraints vector ce into the assembly routine
@@ -231,6 +236,9 @@ extern "C"
 
     // Clear the gradient prior to assembly
     eq_constraints.zero();
+
+    // Enforce constraints exactly on the current_local_solution.
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     if (solver->equality_constraints_object != nullptr)
       solver->equality_constraints_object->equality_constraints(*(sys.current_local_solution), eq_constraints, sys);
@@ -267,18 +275,19 @@ extern "C"
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X(x, sys.comm());
 
-    // Perform a swap so that sys.solution points to X
+    // Perform a swap so that sys.solution points to the input vector
+    // "x", update sys.current_local_solution based on "x", then swap
+    // back.
     X.swap(X_sys);
-    // Impose constraints on X
-    sys.get_dof_map().enforce_constraints_exactly(sys);
-    // Update sys.current_local_solution based on X
     sys.update();
-    // Swap back
     X.swap(X_sys);
 
     // Let's also wrap J and Jpre in PetscMatrix objects for convenience
     PetscMatrix<Number> J_petsc(J, sys.comm());
     PetscMatrix<Number> Jpre_petsc(Jpre, sys.comm());
+
+    // Enforce constraints exactly on the current_local_solution.
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     if (solver->equality_constraints_jacobian_object != nullptr)
       solver->equality_constraints_jacobian_object->equality_constraints_jacobian(*(sys.current_local_solution), J_petsc, sys);
@@ -315,13 +324,11 @@ extern "C"
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X(x, sys.comm());
 
-    // Perform a swap so that sys.solution points to X
+    // Perform a swap so that sys.solution points to the input vector
+    // "x", update sys.current_local_solution based on "x", then swap
+    // back.
     X.swap(X_sys);
-    // Impose constraints on X
-    sys.get_dof_map().enforce_constraints_exactly(sys);
-    // Update sys.current_local_solution based on X
     sys.update();
-    // Swap back
     X.swap(X_sys);
 
     // We'll also pass the constraints vector ce into the assembly routine
@@ -330,6 +337,9 @@ extern "C"
 
     // Clear the gradient prior to assembly
     ineq_constraints.zero();
+
+    // Enforce constraints exactly on the current_local_solution.
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     if (solver->inequality_constraints_object != nullptr)
       solver->inequality_constraints_object->inequality_constraints(*(sys.current_local_solution), ineq_constraints, sys);
@@ -366,18 +376,19 @@ extern "C"
     PetscVector<Number> & X_sys = *cast_ptr<PetscVector<Number> *>(sys.solution.get());
     PetscVector<Number> X(x, sys.comm());
 
-    // Perform a swap so that sys.solution points to X
+    // Perform a swap so that sys.solution points to the input vector
+    // "x", update sys.current_local_solution based on "x", then swap
+    // back.
     X.swap(X_sys);
-    // Impose constraints on X
-    sys.get_dof_map().enforce_constraints_exactly(sys);
-    // Update sys.current_local_solution based on X
     sys.update();
-    // Swap back
     X.swap(X_sys);
 
     // Let's also wrap J and Jpre in PetscMatrix objects for convenience
     PetscMatrix<Number> J_petsc(J, sys.comm());
     PetscMatrix<Number> Jpre_petsc(Jpre, sys.comm());
+
+    // Enforce constraints exactly on the current_local_solution.
+    sys.get_dof_map().enforce_constraints_exactly(sys, sys.current_local_solution.get());
 
     if (solver->inequality_constraints_jacobian_object != nullptr)
       solver->inequality_constraints_jacobian_object->inequality_constraints_jacobian(*(sys.current_local_solution), J_petsc, sys);


### PR DESCRIPTION
As discussed in #1889 (and previously in #630 and #1294) we cannot modify the solution vector by enforcing constraints in the PETSc callback functions but we can enforce the constraints on `current_local_solution`, which is not locked read only.

cc: @andfranklin
  