### PR TITLE
Avoid [-Wunused-private-field] warnings.

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -738,11 +738,11 @@ public:
   {
     // libmesh_ignore variables that are only used in asserts to avoid
     // compiler warnings.
-    libmesh_ignore(node_map_size);
-    libmesh_ignore(inverse_node_map_size);
-    libmesh_ignore(inverse_side_map_size);
-    libmesh_ignore(shellface_map_size);
-    libmesh_ignore(inverse_shellface_map_size);
+    libmesh_ignore(node_map_size,
+                   inverse_node_map_size,
+                   inverse_side_map_size,
+                   shellface_map_size,
+                   inverse_shellface_map_size);
   }
 
   /**

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -745,6 +745,7 @@ public:
    */
   int get_node_map(int i) const
   {
+    libmesh_ignore(node_map_size);
     libmesh_assert_less (static_cast<size_t>(i), node_map_size);
     return node_map[i];
   }
@@ -761,6 +762,7 @@ public:
    */
   int get_inverse_node_map(int i) const
   {
+    libmesh_ignore(inverse_node_map_size);
     libmesh_assert_less (static_cast<size_t>(i), inverse_node_map_size);
     return inverse_node_map[i];
   }
@@ -781,6 +783,7 @@ public:
    */
   int get_inverse_side_map(int i) const
   {
+    libmesh_ignore(inverse_side_map_size);
     libmesh_assert_less (static_cast<size_t>(i), inverse_side_map_size);
     return inverse_side_map[i];
   }
@@ -790,6 +793,9 @@ public:
    */
   int get_inverse_shellface_map(int i) const
   {
+    libmesh_ignore(shellface_map);
+    libmesh_ignore(shellface_map_size);
+    libmesh_ignore(inverse_shellface_map_size);
     libmesh_assert_less (static_cast<size_t>(i), inverse_shellface_map_size);
     return inverse_shellface_map[i];
   }
@@ -825,7 +831,9 @@ private:
   const int * node_map;
 
   /**
-   * The size of the node map array, this helps with bounds checking...
+   * The size of the node map array, this helps with bounds checking
+   * and is only used in asserts so we also libmesh_ignore() to avoid
+   * compiler warnings.
    */
   size_t node_map_size;
 
@@ -837,7 +845,9 @@ private:
   const int * inverse_node_map;
 
   /**
-   * The size of the inverse node map array, this helps with bounds checking...
+   * The size of the inverse node map array, this helps with bounds
+   * checking and is only used in asserts so we also libmesh_ignore()
+   * to avoid compiler warnings.
    */
   size_t inverse_node_map_size;
 
@@ -857,17 +867,22 @@ private:
   const int * inverse_side_map;
 
   /**
-   * The size of the inverse side map array, this helps with bounds checking...
+   * The size of the inverse side map array, this helps with bounds
+   * checking and is only used in asserts so we also libmesh_ignore()
+   * to avoid compiler warnings.
    */
   size_t inverse_side_map_size;
 
   /**
-   * Pointer to the shellface map for this element.
+   * Pointer to the shellface map for this element. Only the inverse
+   * is actually used currently, this one is provided for completeness
+   * and libmesh_ingore()d to avoid warnings.
    */
   const int * shellface_map;
 
   /**
-   * The size of the shellface map array, this helps with bounds checking...
+   * The size of the shellface map array, this helps with bounds
+   * checking, but is not currently used by anything.
    */
   size_t shellface_map_size;
 
@@ -877,7 +892,9 @@ private:
   const int * inverse_shellface_map;
 
   /**
-   * The size of the inverse shellface map array, this helps with bounds checking...
+   * The size of the inverse shellface map array, this helps with
+   * bounds checking and is only used in asserts so we also
+   * libmesh_ignore() to avoid compiler warnings.
    */
   size_t inverse_shellface_map_size;
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -675,27 +675,35 @@ public:
    * variables.
    */
   Conversion(const int * nm,       // node_map
-             size_t nm_size,
+             size_t libmesh_dbg_var(nm_size),
              const int * inm,      // inverse_node_map
-             size_t inm_size,
+             size_t libmesh_dbg_var(inm_size),
              const int * sm,       // side_map
              size_t sm_size,
              const int * ism,      // inverse_side_map
-             size_t ism_size,
+             size_t libmesh_dbg_var(ism_size),
              const ElemType ct,   // "canonical" aka libmesh element type
              std::string ex_type) // string representing the Exodus element type
     : node_map(nm),
+#ifndef NDEBUG
       node_map_size(nm_size),
+#endif
       inverse_node_map(inm),
+#ifndef NDEBUG
       inverse_node_map_size(inm_size),
+#endif
       side_map(sm),
       side_map_size(sm_size),
       inverse_side_map(ism),
+#ifndef NDEBUG
       inverse_side_map_size(ism_size),
+#endif
       shellface_map(nullptr),
       shellface_map_size(0),
       inverse_shellface_map(nullptr),
+#ifndef NDEBUG
       inverse_shellface_map_size(0),
+#endif
       shellface_index_offset(0),
       canonical_type(ct),
       exodus_type(ex_type)
@@ -706,32 +714,40 @@ public:
    * variables.  In this case we also initialize shellface data.
    */
   Conversion(const int * nm,       // node_map
-             size_t nm_size,
+             size_t libmesh_dbg_var(nm_size),
              const int * inm,      // inverse_node_map
-             size_t inm_size,
+             size_t libmesh_dbg_var(inm_size),
              const int * sm,       // side_map
              size_t sm_size,
              const int * ism,      // inverse_side_map
-             size_t ism_size,
+             size_t libmesh_dbg_var(ism_size),
              const int * sfm,      // shellface_map
              size_t sfm_size,
              const int * isfm,     // inverse_shellface_map
-             size_t isfm_size,
+             size_t libmesh_dbg_var(isfm_size),
              size_t sfi_offset,
              const ElemType ct,   // "canonical" aka libmesh element type
              std::string ex_type) // string representing the Exodus element type
     : node_map(nm),
+#ifndef NDEBUG
       node_map_size(nm_size),
+#endif
       inverse_node_map(inm),
+#ifndef NDEBUG
       inverse_node_map_size(inm_size),
+#endif
       side_map(sm),
       side_map_size(sm_size),
       inverse_side_map(ism),
+#ifndef NDEBUG
       inverse_side_map_size(ism_size),
+#endif
       shellface_map(sfm),
       shellface_map_size(sfm_size),
       inverse_shellface_map(isfm),
+#ifndef NDEBUG
       inverse_shellface_map_size(isfm_size),
+#endif
       shellface_index_offset(sfi_offset),
       canonical_type(ct),
       exodus_type(ex_type)
@@ -745,7 +761,6 @@ public:
    */
   int get_node_map(int i) const
   {
-    libmesh_ignore(node_map_size);
     libmesh_assert_less (static_cast<size_t>(i), node_map_size);
     return node_map[i];
   }
@@ -762,7 +777,6 @@ public:
    */
   int get_inverse_node_map(int i) const
   {
-    libmesh_ignore(inverse_node_map_size);
     libmesh_assert_less (static_cast<size_t>(i), inverse_node_map_size);
     return inverse_node_map[i];
   }
@@ -783,7 +797,6 @@ public:
    */
   int get_inverse_side_map(int i) const
   {
-    libmesh_ignore(inverse_side_map_size);
     libmesh_assert_less (static_cast<size_t>(i), inverse_side_map_size);
     return inverse_side_map[i];
   }
@@ -795,7 +808,6 @@ public:
   {
     libmesh_ignore(shellface_map);
     libmesh_ignore(shellface_map_size);
-    libmesh_ignore(inverse_shellface_map_size);
     libmesh_assert_less (static_cast<size_t>(i), inverse_shellface_map_size);
     return inverse_shellface_map[i];
   }
@@ -832,10 +844,11 @@ private:
 
   /**
    * The size of the node map array, this helps with bounds checking
-   * and is only used in asserts so we also libmesh_ignore() to avoid
-   * compiler warnings.
+   * and is only used in asserts.
    */
+#ifndef NDEBUG
   size_t node_map_size;
+#endif
 
   /**
    * Pointer to the inverse node map for this element.
@@ -846,10 +859,11 @@ private:
 
   /**
    * The size of the inverse node map array, this helps with bounds
-   * checking and is only used in asserts so we also libmesh_ignore()
-   * to avoid compiler warnings.
+   * checking and is only used in asserts.
    */
+#ifndef NDEBUG
   size_t inverse_node_map_size;
+#endif
 
   /**
    * Pointer to the side map for this element.
@@ -868,10 +882,11 @@ private:
 
   /**
    * The size of the inverse side map array, this helps with bounds
-   * checking and is only used in asserts so we also libmesh_ignore()
-   * to avoid compiler warnings.
+   * checking and is only used in asserts.
    */
+#ifndef NDEBUG
   size_t inverse_side_map_size;
+#endif
 
   /**
    * Pointer to the shellface map for this element. Only the inverse
@@ -893,10 +908,11 @@ private:
 
   /**
    * The size of the inverse shellface map array, this helps with
-   * bounds checking and is only used in asserts so we also
-   * libmesh_ignore() to avoid compiler warnings.
+   * bounds checking and is only used in asserts.
    */
+#ifndef NDEBUG
   size_t inverse_shellface_map_size;
+#endif
 
   /**
    * The shellface index offset defines the offset due to a difference between libMesh

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -679,7 +679,7 @@ public:
              const int * inm,      // inverse_node_map
              size_t libmesh_dbg_var(inm_size),
              const int * sm,       // side_map
-             size_t sm_size,
+             size_t libmesh_dbg_var(sm_size),
              const int * ism,      // inverse_side_map
              size_t libmesh_dbg_var(ism_size),
              const ElemType ct,   // "canonical" aka libmesh element type
@@ -693,13 +693,17 @@ public:
       inverse_node_map_size(inm_size),
 #endif
       side_map(sm),
+#ifndef NDEBUG
       side_map_size(sm_size),
+#endif
       inverse_side_map(ism),
 #ifndef NDEBUG
       inverse_side_map_size(ism_size),
 #endif
       shellface_map(nullptr),
+#ifndef NDEBUG
       shellface_map_size(0),
+#endif
       inverse_shellface_map(nullptr),
 #ifndef NDEBUG
       inverse_shellface_map_size(0),
@@ -722,7 +726,7 @@ public:
              const int * ism,      // inverse_side_map
              size_t libmesh_dbg_var(ism_size),
              const int * sfm,      // shellface_map
-             size_t sfm_size,
+             size_t libmesh_dbg_var(sfm_size),
              const int * isfm,     // inverse_shellface_map
              size_t libmesh_dbg_var(isfm_size),
              size_t sfi_offset,
@@ -743,7 +747,9 @@ public:
       inverse_side_map_size(ism_size),
 #endif
       shellface_map(sfm),
+#ifndef NDEBUG
       shellface_map_size(sfm_size),
+#endif
       inverse_shellface_map(isfm),
 #ifndef NDEBUG
       inverse_shellface_map_size(isfm_size),
@@ -803,11 +809,19 @@ public:
 
   /**
    * \returns The ith component of the shellface map for this element.
+   * \note Nothing is currently using this.
+   */
+  int get_shellface_map(int i) const
+  {
+    libmesh_assert_less (static_cast<size_t>(i), shellface_map_size);
+    return shellface_map[i];
+  }
+
+  /**
+   * \returns The ith component of the inverse shellface map for this element.
    */
   int get_inverse_shellface_map(int i) const
   {
-    libmesh_ignore(shellface_map);
-    libmesh_ignore(shellface_map_size);
     libmesh_assert_less (static_cast<size_t>(i), inverse_shellface_map_size);
     return inverse_shellface_map[i];
   }

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -675,39 +675,27 @@ public:
    * variables.
    */
   Conversion(const int * nm,       // node_map
-             size_t libmesh_dbg_var(nm_size),
+             size_t nm_size,
              const int * inm,      // inverse_node_map
-             size_t libmesh_dbg_var(inm_size),
+             size_t inm_size,
              const int * sm,       // side_map
-             size_t libmesh_dbg_var(sm_size),
+             size_t sm_size,
              const int * ism,      // inverse_side_map
-             size_t libmesh_dbg_var(ism_size),
+             size_t ism_size,
              const ElemType ct,   // "canonical" aka libmesh element type
              std::string ex_type) // string representing the Exodus element type
     : node_map(nm),
-#ifndef NDEBUG
       node_map_size(nm_size),
-#endif
       inverse_node_map(inm),
-#ifndef NDEBUG
       inverse_node_map_size(inm_size),
-#endif
       side_map(sm),
-#ifndef NDEBUG
       side_map_size(sm_size),
-#endif
       inverse_side_map(ism),
-#ifndef NDEBUG
       inverse_side_map_size(ism_size),
-#endif
       shellface_map(nullptr),
-#ifndef NDEBUG
       shellface_map_size(0),
-#endif
       inverse_shellface_map(nullptr),
-#ifndef NDEBUG
       inverse_shellface_map_size(0),
-#endif
       shellface_index_offset(0),
       canonical_type(ct),
       exodus_type(ex_type)
@@ -718,46 +706,44 @@ public:
    * variables.  In this case we also initialize shellface data.
    */
   Conversion(const int * nm,       // node_map
-             size_t libmesh_dbg_var(nm_size),
+             size_t nm_size,
              const int * inm,      // inverse_node_map
-             size_t libmesh_dbg_var(inm_size),
+             size_t inm_size,
              const int * sm,       // side_map
              size_t sm_size,
              const int * ism,      // inverse_side_map
-             size_t libmesh_dbg_var(ism_size),
+             size_t ism_size,
              const int * sfm,      // shellface_map
-             size_t libmesh_dbg_var(sfm_size),
+             size_t sfm_size,
              const int * isfm,     // inverse_shellface_map
-             size_t libmesh_dbg_var(isfm_size),
+             size_t isfm_size,
              size_t sfi_offset,
              const ElemType ct,   // "canonical" aka libmesh element type
              std::string ex_type) // string representing the Exodus element type
     : node_map(nm),
-#ifndef NDEBUG
       node_map_size(nm_size),
-#endif
       inverse_node_map(inm),
-#ifndef NDEBUG
       inverse_node_map_size(inm_size),
-#endif
       side_map(sm),
       side_map_size(sm_size),
       inverse_side_map(ism),
-#ifndef NDEBUG
       inverse_side_map_size(ism_size),
-#endif
       shellface_map(sfm),
-#ifndef NDEBUG
       shellface_map_size(sfm_size),
-#endif
       inverse_shellface_map(isfm),
-#ifndef NDEBUG
       inverse_shellface_map_size(isfm_size),
-#endif
       shellface_index_offset(sfi_offset),
       canonical_type(ct),
       exodus_type(ex_type)
-  {}
+  {
+    // libmesh_ignore variables that are only used in asserts to avoid
+    // compiler warnings.
+    libmesh_ignore(node_map_size);
+    libmesh_ignore(inverse_node_map_size);
+    libmesh_ignore(inverse_side_map_size);
+    libmesh_ignore(shellface_map_size);
+    libmesh_ignore(inverse_shellface_map_size);
+  }
 
   /**
    * \returns The ith component of the node map for this element.
@@ -860,9 +846,7 @@ private:
    * The size of the node map array, this helps with bounds checking
    * and is only used in asserts.
    */
-#ifndef NDEBUG
   size_t node_map_size;
-#endif
 
   /**
    * Pointer to the inverse node map for this element.
@@ -875,9 +859,7 @@ private:
    * The size of the inverse node map array, this helps with bounds
    * checking and is only used in asserts.
    */
-#ifndef NDEBUG
   size_t inverse_node_map_size;
-#endif
 
   /**
    * Pointer to the side map for this element.
@@ -898,9 +880,7 @@ private:
    * The size of the inverse side map array, this helps with bounds
    * checking and is only used in asserts.
    */
-#ifndef NDEBUG
   size_t inverse_side_map_size;
-#endif
 
   /**
    * Pointer to the shellface map for this element. Only the inverse
@@ -911,7 +891,7 @@ private:
 
   /**
    * The size of the shellface map array, this helps with bounds
-   * checking, but is not currently used by anything.
+   * checking and is only used in asserts.
    */
   size_t shellface_map_size;
 
@@ -924,9 +904,7 @@ private:
    * The size of the inverse shellface map array, this helps with
    * bounds checking and is only used in asserts.
    */
-#ifndef NDEBUG
   size_t inverse_shellface_map_size;
-#endif
 
   /**
    * The shellface index offset defines the offset due to a difference between libMesh


### PR DESCRIPTION
Several private members of the ExodusII_IO_Helper class are only used
in asserts, so libmesh_ignore() them to silence the compiler. Newer
versions of clang (6.0.1) started to warn about these.