### PR TITLE
Conversion warning fixes

### DIFF
--- a/examples/adjoints/adjoints_ex1/L-shaped.C
+++ b/examples/adjoints/adjoints_ex1/L-shaped.C
@@ -75,8 +75,7 @@ bool LaplaceSystem::element_time_derivative (bool request_jacobian,
   const std::vector<std::vector<RealGradient>> & dphi = elem_fe->get_dphi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(0).size());
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(0, 0);
@@ -132,8 +131,7 @@ bool LaplaceSystem::side_constraint (bool request_jacobian,
   const std::vector<Point > & qside_point = side_fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(0).size());
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(0, 0);

--- a/examples/adjoints/adjoints_ex1/element_qoi_derivative.C
+++ b/examples/adjoints/adjoints_ex1/element_qoi_derivative.C
@@ -34,8 +34,7 @@ void LaplaceSystem::element_qoi_derivative (DiffContext & context,
   const std::vector<Point > & q_point = elem_fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(0).size());
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
   unsigned int n_qpoints = c.get_element_qrule().n_points();
 
   // Fill the QoI RHS corresponding to this QoI. Since this is the 0th QoI

--- a/examples/adjoints/adjoints_ex1/side_qoi_derivative.C
+++ b/examples/adjoints/adjoints_ex1/side_qoi_derivative.C
@@ -37,8 +37,7 @@ void LaplaceSystem::side_qoi_derivative (DiffContext & context,
   const std::vector<Point> & face_normals = side_fe->get_normals();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(0).size());
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
   unsigned int n_qpoints = c.get_side_qrule().n_points();
 
   // Fill the QoI RHS corresponding to this QoI. Since this is QoI 1

--- a/examples/adjoints/adjoints_ex2/L-qoi.C
+++ b/examples/adjoints/adjoints_ex2/L-qoi.C
@@ -85,8 +85,7 @@ void LaplaceQoI::element_qoi_derivative (DiffContext & context,
   const std::vector<Point > & q_point = elem_fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(0).size());
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
   unsigned int n_qpoints = c.get_element_qrule().n_points();
 
   // Fill the QoI RHS corresponding to this QoI. Since this is the 0th QoI

--- a/examples/adjoints/adjoints_ex2/L-shaped.C
+++ b/examples/adjoints/adjoints_ex2/L-shaped.C
@@ -72,8 +72,7 @@ bool LaplaceSystem::element_time_derivative (bool request_jacobian,
   const std::vector<std::vector<RealGradient>> & dphi = elem_fe->get_dphi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(0).size());
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(0, 0);
@@ -129,8 +128,7 @@ bool LaplaceSystem::side_constraint (bool request_jacobian,
   const std::vector<Point > & qside_point = side_fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(0).size());
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(0, 0);

--- a/examples/adjoints/adjoints_ex3/H-qoi.C
+++ b/examples/adjoints/adjoints_ex3/H-qoi.C
@@ -30,8 +30,7 @@ void CoupledSystemQoI::side_qoi_derivative (DiffContext & context,
   const std::vector<Point > & q_point = side_fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(1).size());
+  const unsigned int n_u_dofs = c.n_dof_indices(1);
 
   DenseSubVector<Number> & Qu = c.get_qoi_derivatives(0, 0);
   DenseSubVector<Number> & QC = c.get_qoi_derivatives(0, 3);

--- a/examples/adjoints/adjoints_ex3/coupled_system.C
+++ b/examples/adjoints/adjoints_ex3/coupled_system.C
@@ -230,11 +230,9 @@ bool CoupledSystem::element_time_derivative (bool request_jacobian,
   const std::vector<std::vector<Real>> & psi = p_elem_fe->get_phi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_p_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(p_var).size());
-  const unsigned int n_u_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(u_var).size());
-  libmesh_assert_equal_to (n_u_dofs, c.get_dof_indices(v_var).size());
+  const unsigned int n_p_dofs = c.n_dof_indices(p_var);
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
+  libmesh_assert_equal_to (n_u_dofs, c.n_dof_indices(v_var));
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & Kuu = c.get_elem_jacobian(u_var, u_var);
@@ -355,10 +353,8 @@ bool CoupledSystem::element_constraint (bool request_jacobian,
   const std::vector<std::vector<Real>> & psi = p_elem_fe->get_phi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(u_var).size());
-  const unsigned int n_p_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(p_var).size());
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
+  const unsigned int n_p_dofs = c.n_dof_indices(p_var);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & Kpu = c.get_elem_jacobian(p_var, u_var);

--- a/examples/adjoints/adjoints_ex4/L-shaped.C
+++ b/examples/adjoints/adjoints_ex4/L-shaped.C
@@ -76,7 +76,7 @@ bool LaplaceSystem::element_time_derivative (bool request_jacobian,
   const std::vector<std::vector<RealGradient>> & dphi = elem_fe->get_dphi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs = c.get_dof_indices(0).size();
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(0, 0);
@@ -132,7 +132,7 @@ bool LaplaceSystem::side_constraint (bool request_jacobian,
   const std::vector<Point > & qside_point = side_fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs = c.get_dof_indices(0).size();
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(0, 0);

--- a/examples/adjoints/adjoints_ex4/element_qoi_derivative.C
+++ b/examples/adjoints/adjoints_ex4/element_qoi_derivative.C
@@ -34,7 +34,7 @@ void LaplaceSystem::element_qoi_derivative (DiffContext & context,
   const std::vector<Point > & q_point = elem_fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs = c.get_dof_indices(0).size();
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
   unsigned int n_qpoints = c.get_element_qrule().n_points();
 
   // Fill the QoI RHS corresponding to this QoI. Since this is the 0th QoI

--- a/examples/adjoints/adjoints_ex4/side_qoi_derivative.C
+++ b/examples/adjoints/adjoints_ex4/side_qoi_derivative.C
@@ -37,7 +37,7 @@ void LaplaceSystem::side_qoi_derivative (DiffContext & context,
   const std::vector<Point> & face_normals = side_fe->get_normals();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs = c.get_dof_indices(0).size();
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
   unsigned int n_qpoints = c.get_side_qrule().n_points();
 
   // Fill the QoI RHS corresponding to this QoI. Since this is QoI 1

--- a/examples/adjoints/adjoints_ex5/adjoints_ex5.C
+++ b/examples/adjoints/adjoints_ex5/adjoints_ex5.C
@@ -321,7 +321,7 @@ int main (int argc, char ** argv)
 
   // Create a mesh with the given dimension, distributed
   // across the default MPI communicator.
-  Mesh mesh(init.comm(), param.dimension);
+  Mesh mesh(init.comm(), cast_int<unsigned char>(param.dimension));
 
   // And an object to refine it
   auto mesh_refinement = libmesh_make_unique<MeshRefinement>(mesh);

--- a/examples/adjoints/adjoints_ex5/element_qoi_derivative.C
+++ b/examples/adjoints/adjoints_ex5/element_qoi_derivative.C
@@ -50,7 +50,7 @@ void HeatSystem::element_qoi_derivative (DiffContext & context,
   const std::vector<std::vector<Real>> & phi = elem_fe->get_phi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs = c.get_dof_indices(0).size();
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
   unsigned int n_qpoints = c.get_element_qrule().n_points();
 
   // Fill the QoI RHS corresponding to this QoI. Since this is the 0th QoI

--- a/examples/adjoints/adjoints_ex5/heatsystem.C
+++ b/examples/adjoints/adjoints_ex5/heatsystem.C
@@ -125,11 +125,8 @@ bool HeatSystem::element_time_derivative (bool request_jacobian,
   // Element basis functions
   const std::vector<std::vector<RealGradient>> & dphi = elem_fe->get_dphi();
 
-  // Workaround for weird FC6 bug
-  optassert(c.get_dof_indices().size() > 0);
-
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(0).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(0);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(0, 0);

--- a/examples/adjoints/adjoints_ex5/heatsystem.C
+++ b/examples/adjoints/adjoints_ex5/heatsystem.C
@@ -159,11 +159,9 @@ bool HeatSystem::element_time_derivative (bool request_jacobian,
 // Perturb and accumulate dual weighted residuals
 void HeatSystem::perturb_accumulate_residuals(ParameterVector & parameters_in)
 {
-  const unsigned int Np = parameters_in.size();
-
   this->update();
 
-  for (unsigned int j=0; j != Np; ++j)
+  for (std::size_t j=0, Np = parameters_in.size(); j != Np; ++j)
     {
       Number old_parameter = *parameters_in[j];
 

--- a/examples/adjoints/adjoints_ex6/poisson.C
+++ b/examples/adjoints/adjoints_ex6/poisson.C
@@ -143,7 +143,7 @@ bool PoissonSystem::element_time_derivative (bool request_jacobian,
   const std::vector<Point > & q_point = elem_fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs = c.get_dof_indices(0).size();
+  const unsigned int n_T_dofs = c.n_dof_indices(0);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(0,0);

--- a/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
+++ b/examples/eigenproblems/eigenproblems_ex1/eigenproblems_ex1.C
@@ -263,7 +263,9 @@ void assemble_mass(EquationSystems & es,
       // the last element.  Note that this will be the case if the
       // element type is different (i.e. the last element was a
       // triangle, now we are on a quadrilateral).
-      Me.resize (dof_indices.size(), dof_indices.size());
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
+      Me.resize (n_dofs, n_dofs);
 
       // Now loop over the quadrature points.  This handles
       // the numeric integration.
@@ -272,8 +274,8 @@ void assemble_mass(EquationSystems & es,
       // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
-        for (std::size_t i=0; i<phi.size(); i++)
-          for (std::size_t j=0; j<phi.size(); j++)
+        for (unsigned int i=0; i != n_dofs; i++)
+          for (unsigned int j=0; j != n_dofs; j++)
             Me(i,j) += JxW[qp]*phi[i][qp]*phi[j][qp];
 
       // On an unrefined mesh, constrain_element_matrix does

--- a/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
+++ b/examples/eigenproblems/eigenproblems_ex2/eigenproblems_ex2.C
@@ -302,8 +302,10 @@ void assemble_mass(EquationSystems & es,
       // the last element.  Note that this will be the case if the
       // element type is different (i.e. the last element was a
       // triangle, now we are on a quadrilateral).
-      Ke.resize (dof_indices.size(), dof_indices.size());
-      Me.resize (dof_indices.size(), dof_indices.size());
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
+      Ke.resize (n_dofs, n_dofs);
+      Me.resize (n_dofs, n_dofs);
 
       // Now loop over the quadrature points.  This handles
       // the numeric integration.
@@ -312,8 +314,8 @@ void assemble_mass(EquationSystems & es,
       // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
-        for (std::size_t i=0; i<phi.size(); i++)
-          for (std::size_t j=0; j<phi.size(); j++)
+        for (unsigned int i=0; i<n_dofs; i++)
+          for (unsigned int j=0; j<n_dofs; j++)
             {
               Me(i,j) += JxW[qp]*phi[i][qp]*phi[j][qp];
               Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);

--- a/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
+++ b/examples/eigenproblems/eigenproblems_ex3/eigenproblems_ex3.C
@@ -372,8 +372,10 @@ void assemble_matrices(EquationSystems & es,
       // the last element.  Note that this will be the case if the
       // element type is different (i.e. the last element was a
       // triangle, now we are on a quadrilateral).
-      Ke.resize (dof_indices.size(), dof_indices.size());
-      Me.resize (dof_indices.size(), dof_indices.size());
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
+      Ke.resize (n_dofs, n_dofs);
+      Me.resize (n_dofs, n_dofs);
 
       // Now loop over the quadrature points.  This handles
       // the numeric integration.
@@ -382,8 +384,8 @@ void assemble_matrices(EquationSystems & es,
       // a double loop to integrate the test functions (i) against
       // the trial functions (j).
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
-        for (std::size_t i=0; i<phi.size(); i++)
-          for (std::size_t j=0; j<phi.size(); j++)
+        for (unsigned int i=0; i<n_dofs; i++)
+          for (unsigned int j=0; j<n_dofs; j++)
             {
               Me(i,j) += JxW[qp]*phi[i][qp]*phi[j][qp];
               Ke(i,j) += JxW[qp]*(dphi[i][qp]*dphi[j][qp]);

--- a/examples/fem_system/fem_system_ex1/naviersystem.C
+++ b/examples/fem_system/fem_system_ex1/naviersystem.C
@@ -235,9 +235,9 @@ bool NavierSystem::element_time_derivative (bool request_jacobian,
   const std::vector<Point> & qpoint = u_elem_fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_p_dofs = c.get_dof_indices(p_var).size();
-  const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
-  libmesh_assert_equal_to (n_u_dofs, c.get_dof_indices(v_var).size());
+  const unsigned int n_p_dofs = c.n_dof_indices(p_var);
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
+  libmesh_assert_equal_to (n_u_dofs, c.n_dof_indices(v_var));
 
   // The subvectors and submatrices we need to fill:
   const unsigned int dim = this->get_mesh().mesh_dimension();
@@ -413,8 +413,8 @@ bool NavierSystem::element_constraint (bool request_jacobian,
   const std::vector<std::vector<Real>> & psi = p_elem_fe->get_phi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
-  const unsigned int n_p_dofs = c.get_dof_indices(p_var).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
+  const unsigned int n_p_dofs = c.n_dof_indices(p_var);
 
   // The subvectors and submatrices we need to fill:
   const unsigned int dim = this->get_mesh().mesh_dimension();
@@ -485,7 +485,7 @@ bool NavierSystem::side_constraint (bool request_jacobian,
 
       DenseSubMatrix<Number> & Kpp = c.get_elem_jacobian(p_var, p_var);
       DenseSubVector<Number> & Fp = c.get_elem_residual(p_var);
-      const unsigned int n_p_dofs = c.get_dof_indices(p_var).size();
+      const unsigned int n_p_dofs = c.n_dof_indices(p_var);
 
       Number p;
       c.point_value(p_var, zero, p);
@@ -553,7 +553,7 @@ bool NavierSystem::mass_residual (bool request_jacobian,
   DenseSubMatrix<Number> & Kww = c.get_elem_jacobian(w_var, w_var);
 
   // The number of local degrees of freedom in velocity
-  const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
 
   unsigned int n_qpoints = c.get_element_qrule().n_points();
 

--- a/examples/fem_system/fem_system_ex2/fem_system_ex2.C
+++ b/examples/fem_system/fem_system_ex2/fem_system_ex2.C
@@ -185,7 +185,7 @@ int main(int argc, char ** argv)
   libmesh_example_requires(dim <= LIBMESH_DIM, "3D support");
 
   // Create a mesh distributed across the default MPI communicator.
-  Mesh mesh(init.comm(), dim);
+  Mesh mesh(init.comm(), cast_int<unsigned char>(dim));
 
   EquationSystems systems(mesh);
 

--- a/examples/fem_system/fem_system_ex2/solid_system.C
+++ b/examples/fem_system/fem_system_ex2/solid_system.C
@@ -192,10 +192,10 @@ bool SolidSystem::element_time_derivative(bool request_jacobian,
   const unsigned int dim = this->get_mesh().mesh_dimension();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(var[0]).size();
-  libmesh_assert(n_u_dofs == c.get_dof_indices(var[1]).size());
+  const unsigned int n_u_dofs = c.n_dof_indices(var[0]);
+  libmesh_assert(n_u_dofs == c.n_dof_indices(var[1]));
   if (dim == 3)
-    libmesh_assert(n_u_dofs ==  c.get_dof_indices(var[2]).size());
+    libmesh_assert(n_u_dofs ==  c.n_dof_indices(var[2]));
 
   unsigned int n_qpoints = c.get_element_qrule().n_points();
 
@@ -291,16 +291,18 @@ bool SolidSystem::side_time_derivative(bool request_jacobian,
   // side 5 about 1.0 units down the z-axis while leaving all other directions unrestricted
 
   // Get number of BCs to enforce
-  unsigned int num_bc = args.vector_variable_size("bc/displacement");
+  boundary_id_type num_bc =
+    cast_int<boundary_id_type>(args.vector_variable_size("bc/displacement"));
   if (num_bc % 4 != 0)
     libmesh_error_msg("ERROR, Odd number of values in displacement boundary condition.");
   num_bc /= 4;
 
   // Loop over all BCs
-  for (unsigned int nbc = 0; nbc < num_bc; nbc++)
+  for (boundary_id_type nbc = 0; nbc < num_bc; nbc++)
     {
       // Get IDs of the side for this BC
-      short int positive_boundary_id = args("bc/displacement", 1, nbc * 4);
+      boundary_id_type positive_boundary_id =
+        cast_int<boundary_id_type>(args("bc/displacement", 1, nbc * 4));
 
       // The current side may not be on the boundary to be restricted
       if (!this->get_mesh().get_boundary_info().has_boundary_id
@@ -324,7 +326,7 @@ bool SolidSystem::side_time_derivative(bool request_jacobian,
       const std::vector<Real> & JxW = fe->get_JxW();
       const std::vector<Point> & coords = fe->get_xyz();
 
-      unsigned int n_x_dofs = c.get_dof_indices(this->var[0]).size();
+      const unsigned int n_x_dofs = c.n_dof_indices(this->var[0]);
 
       // get mappings for dofs for auxiliary system for original mesh positions
       const System & auxsys = this->get_equation_systems().get_system("auxiliary");

--- a/examples/fem_system/fem_system_ex3/elasticity_system.C
+++ b/examples/fem_system/fem_system_ex3/elasticity_system.C
@@ -102,7 +102,7 @@ bool ElasticitySystem::element_time_derivative(bool request_jacobian,
   c.get_element_fe(_u_var, u_elem_fe);
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(_u_var).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(_u_var);
 
   // Element Jacobian * quadrature weights for interior integration
   const std::vector<Real> & JxW = u_elem_fe->get_JxW();
@@ -218,7 +218,7 @@ bool ElasticitySystem::side_time_derivative (bool request_jacobian,
       c.get_side_fe(_u_var, u_side_fe);
 
       // The number of local degrees of freedom in each variable
-      const unsigned int n_u_dofs = c.get_dof_indices(_u_var).size();
+      const unsigned int n_u_dofs = c.n_dof_indices(_u_var);
 
       DenseSubVector<Number> & Fu = c.get_elem_residual(u_dot_var);
       DenseSubVector<Number> & Fv = c.get_elem_residual(v_dot_var);
@@ -271,7 +271,7 @@ bool ElasticitySystem::mass_residual(bool request_jacobian,
   c.get_element_fe(u_dot_var, u_elem_fe);
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(u_dot_var).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(u_dot_var);
 
   // Element Jacobian * quadrature weights for interior integration
   const std::vector<Real> & JxW = u_elem_fe->get_JxW();

--- a/examples/fem_system/fem_system_ex4/heatsystem.C
+++ b/examples/fem_system/fem_system_ex4/heatsystem.C
@@ -80,7 +80,7 @@ bool HeatSystem::element_time_derivative (bool request_jacobian,
 
   // First we get some references to cell-specific data that
   // will be used to assemble the linear system.
-  const unsigned int dim = c.get_elem().dim();
+  const unsigned short dim = c.get_elem().dim();
   FEBase * fe = nullptr;
   c.get_element_fe(T_var, fe, dim);
 

--- a/examples/fem_system/fem_system_ex4/heatsystem.C
+++ b/examples/fem_system/fem_system_ex4/heatsystem.C
@@ -94,7 +94,7 @@ bool HeatSystem::element_time_derivative (bool request_jacobian,
   const std::vector<std::vector<RealGradient>> & dphi = fe->get_dphi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_T_dofs = c.get_dof_indices(T_var).size();
+  const unsigned int n_T_dofs = c.n_dof_indices(T_var);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(T_var, T_var);

--- a/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
+++ b/examples/miscellaneous/miscellaneous_ex1/miscellaneous_ex1.C
@@ -306,6 +306,9 @@ void assemble_wave(EquationSystems & es,
       // contribute to.
       dof_map.dof_indices (elem, dof_indices);
 
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
+
       // The mesh contains both finite and infinite elements.  These
       // elements are handled through different classes, namely
       // FE and InfFE, respectively.  However, since both
@@ -341,7 +344,7 @@ void assemble_wave(EquationSystems & es,
           // conditions check e.g. previous examples.
           {
             // Zero the RHS for this element.
-            Fe.resize (dof_indices.size());
+            Fe.resize (n_dofs);
 
             system.rhs->add_vector (Fe, dof_indices);
           } // end boundary condition section
@@ -383,9 +386,9 @@ void assemble_wave(EquationSystems & es,
 
       // Zero the element matrices.  Boundary conditions were already
       // processed in the FE-only section, see above.
-      Ke.resize (dof_indices.size(), dof_indices.size());
-      Ce.resize (dof_indices.size(), dof_indices.size());
-      Me.resize (dof_indices.size(), dof_indices.size());
+      Ke.resize (n_dofs, n_dofs);
+      Ce.resize (n_dofs, n_dofs);
+      Me.resize (n_dofs, n_dofs);
 
       // The total number of quadrature points for infinite elements
       // @e has to be determined in a different way, compared to

--- a/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
+++ b/examples/miscellaneous/miscellaneous_ex3/miscellaneous_ex3.C
@@ -388,7 +388,9 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
       // the last element.  Note that this will be the case if the
       // element type is different (i.e. the last element was a
       // triangle, now we are on a quadrilateral).
-      Re.resize (dof_indices.size());
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
+      Re.resize (n_dofs);
 
       // Now we will build the residual. This involves
       // the construction of the matrix K and multiplication of it
@@ -403,7 +405,7 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
           Number u = 0;
           Gradient grad_u;
 
-          for (std::size_t j=0; j<phi.size(); j++)
+          for (unsigned int j=0; j<n_dofs; j++)
             {
               u      += phi[j][qp]*soln(dof_indices[j]);
               grad_u += dphi[j][qp]*soln(dof_indices[j]);
@@ -411,7 +413,7 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
 
           const Number K = 1./std::sqrt(1. + grad_u*grad_u);
 
-          for (std::size_t i=0; i<phi.size(); i++)
+          for (unsigned int i=0; i<n_dofs; i++)
             Re(i) += JxW[qp]*(
                               K*(dphi[i][qp]*grad_u) +
                               _kappa*phi[i][qp]*u
@@ -444,7 +446,7 @@ void LaplaceYoung::residual (const NumericVector<Number> & soln,
               {
                 // This is the right-hand-side contribution (f),
                 // which has to be subtracted from the current residual
-                for (std::size_t i=0; i<phi_face.size(); i++)
+                for (unsigned int i=0; i<n_dofs; i++)
                   Re(i) -= JxW_face[qp]*_sigma*phi_face[i][qp];
               }
           }
@@ -544,8 +546,9 @@ void LaplaceYoung::jacobian (const NumericVector<Number> & soln,
       // the last element.  Note that this will be the case if the
       // element type is different (i.e. the last element was a
       // triangle, now we are on a quadrilateral).
-      Ke.resize (dof_indices.size(),
-                 dof_indices.size());
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
+      Ke.resize (n_dofs, n_dofs);
 
       // Now we will build the element Jacobian.  This involves
       // a double loop to integrate the test functions (i) against
@@ -557,7 +560,7 @@ void LaplaceYoung::jacobian (const NumericVector<Number> & soln,
         {
           Gradient grad_u;
 
-          for (std::size_t i=0; i<phi.size(); i++)
+          for (unsigned int i=0; i<n_dofs; i++)
             grad_u += dphi[i][qp]*soln(dof_indices[i]);
 
           const Number
@@ -565,8 +568,8 @@ void LaplaceYoung::jacobian (const NumericVector<Number> & soln,
             K  = 1. / std::sqrt(sa),
             dK = -K / sa;
 
-          for (std::size_t i=0; i<phi.size(); i++)
-            for (std::size_t j=0; j<phi.size(); j++)
+          for (unsigned int i=0; i<n_dofs; i++)
+            for (unsigned int j=0; j<n_dofs; j++)
               Ke(i,j) += JxW[qp]*(
                                   K * (dphi[i][qp]*dphi[j][qp]) +
                                   dK * (grad_u*dphi[j][qp]) * (grad_u*dphi[i][qp]) +

--- a/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
+++ b/examples/miscellaneous/miscellaneous_ex4/miscellaneous_ex4.C
@@ -337,12 +337,14 @@ void assemble (EquationSystems & es,
       // the last element.  Note that this will be the case if the
       // element type is different (i.e. the last element was a
       // triangle, now we are on a quadrilateral).
-      Ke.resize (dof_indices.size(),
-                 dof_indices.size());
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
 
-      Fe.resize (dof_indices.size());
-      Ve.resize (dof_indices.size());
-      We.resize (dof_indices.size());
+      Ke.resize (n_dofs, n_dofs);
+
+      Fe.resize (n_dofs);
+      Ve.resize (n_dofs);
+      We.resize (n_dofs);
 
       // Now we will build the element matrix and right-hand-side.
       // Constructing the RHS requires the solution and its
@@ -353,12 +355,12 @@ void assemble (EquationSystems & es,
       for (unsigned int qp=0; qp<qrule.n_points(); qp++)
         {
           // Now compute the element matrix and RHS contributions.
-          for (std::size_t i=0; i<phi.size(); i++)
+          for (unsigned int i=0; i<n_dofs; i++)
             {
               // The RHS contribution
               Fe(i) += JxW[qp]*phi[i][qp];
 
-              for (std::size_t j=0; j<phi.size(); j++)
+              for (unsigned int j=0; j<n_dofs; j++)
                 {
                   // The matrix contribution
                   Ke(i,j) += JxW[qp]*(
@@ -397,8 +399,8 @@ void assemble (EquationSystems & es,
               for (unsigned int qp=0; qp<qface.n_points(); qp++)
                 {
                   // Matrix contribution
-                  for (std::size_t i=0; i<psi.size(); i++)
-                    for (std::size_t j=0; j<psi.size(); j++)
+                  for (unsigned int i=0; i<n_dofs; i++)
+                    for (unsigned int j=0; j<n_dofs; j++)
                       Ke(i,j) += penalty*JxW_face[qp]*psi[i][qp]*psi[j][qp];
                 }
             }

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -241,7 +241,8 @@ void assemble_ellipticdg(EquationSystems & es,
       // matrix and right-hand-side this element will
       // contribute to.
       dof_map.dof_indices (elem, dof_indices);
-      const unsigned int n_dofs = dof_indices.size();
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
 
       // Compute the element-specific data for the current
       // element.  This involves computing the location of the
@@ -377,7 +378,8 @@ void assemble_ellipticdg(EquationSystems & es,
                   // matrix this neighbor will contribute to.
                   std::vector<dof_id_type> neighbor_dof_indices;
                   dof_map.dof_indices (neighbor, neighbor_dof_indices);
-                  const unsigned int n_neighbor_dofs = neighbor_dof_indices.size();
+                  const unsigned int n_neighbor_dofs =
+                    cast_int<unsigned int>(neighbor_dof_indices.size());
 
                   // Zero the element and neighbor side matrix before
                   // summing them.  We use the resize member here because

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
@@ -263,6 +263,9 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
       // contribute to.
       dof_map.dof_indices (elem, dof_indices);
 
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
+
       // Compute the element-specific data for the current
       // element.  This involves computing the location of the
       // quadrature points (q_point) and the shape function
@@ -272,12 +275,12 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
       // Zero the element matrix, the right-hand side and the Laplacian matrix
       // before summing them.
       if (J)
-        Je.resize(dof_indices.size(), dof_indices.size());
+        Je.resize(n_dofs, n_dofs);
 
       if (R)
-        Re.resize(dof_indices.size());
+        Re.resize(n_dofs);
 
-      Laplacian_phi_qp.resize(dof_indices.size());
+      Laplacian_phi_qp.resize(n_dofs);
 
       for (unsigned int qp=0; qp<qrule->n_points(); qp++)
         {
@@ -302,7 +305,7 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
             M_prime_qp = 0.0,
             M_prime_old_qp = 0.0;
 
-          for (std::size_t i=0; i<phi.size(); i++)
+          for (unsigned int i=0; i<n_dofs; i++)
             {
               Laplacian_phi_qp[i] = d2phi[i][qp](0, 0);
               grad_u_qp(0) += u(dof_indices[i])*dphi[i][qp](0);
@@ -335,7 +338,7 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
             }
 
           // ELEMENT RESIDUAL AND JACOBIAN
-          for (std::size_t i=0; i<phi.size(); i++)
+          for (unsigned int i=0; i<n_dofs; i++)
             {
               // RESIDUAL
               if (R)
@@ -395,7 +398,7 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
                 {
                   Number M_prime_prime_qp = 0.0;
                   if (_biharmonic._degenerate) M_prime_prime_qp = -2.0;
-                  for (std::size_t j=0; j<phi.size(); j++)
+                  for (unsigned int j=0; j<n_dofs; j++)
                     {
                       Number ri_j = 0.0;
                       ri_j -= Laplacian_phi_qp[i]*M_qp*_biharmonic._kappa*Laplacian_phi_qp[j];
@@ -522,9 +525,12 @@ void Biharmonic::JR::bounds(NumericVector<Number> & XL,
       // and define where in the global vector this element will.
       dof_map.dof_indices (elem, dof_indices);
 
+      const unsigned int n_dofs =
+        cast_int<unsigned int>(dof_indices.size());
+
       // Resize the local bounds vectors (zeroing them out in the process).
-      XLe.resize(dof_indices.size());
-      XUe.resize(dof_indices.size());
+      XLe.resize(n_dofs);
+      XUe.resize(n_dofs);
 
       // Extract the element node coordinates in the reference frame
       std::vector<Point> nodes;
@@ -544,12 +550,12 @@ void Biharmonic::JR::bounds(NumericVector<Number> & XL,
       // Auxiliary variables will need to be introduced to reduce this to a "box" constraint.
       // Additional complications will arise since m might be singular (as is the case for Hermite,
       // which, however, is easily handled by inspection).
-      for (std::size_t i=0; i<phi.size(); ++i)
+      for (unsigned int i=0; i<n_dofs; ++i)
         {
           // FIXME: should be able to define INF and pass it to the solve
           Real infinity = 1.0e20;
           Real bound = infinity;
-          for (std::size_t j = 0; j < nodes.size(); ++j)
+          for (unsigned int j = 0; j < nodes.size(); ++j)
             {
               if (phi[i][j])
                 {

--- a/examples/vector_fe/vector_fe_ex2/laplace_system.C
+++ b/examples/vector_fe/vector_fe_ex2/laplace_system.C
@@ -131,7 +131,7 @@ bool LaplaceSystem::element_time_derivative (bool request_jacobian,
   const std::vector<Point> & qpoint = fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
 
   DenseSubMatrix<Number> & Kuu = c.get_elem_jacobian(u_var, u_var);
 

--- a/examples/vector_fe/vector_fe_ex3/curl_curl_system.C
+++ b/examples/vector_fe/vector_fe_ex3/curl_curl_system.C
@@ -126,7 +126,7 @@ bool CurlCurlSystem::element_time_derivative (bool request_jacobian,
   const std::vector<Point> & qpoint = fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
 
   DenseSubMatrix<Number> & Kuu = c.get_elem_jacobian(u_var, u_var);
 
@@ -189,7 +189,7 @@ bool CurlCurlSystem::side_time_derivative (bool request_jacobian,
   const std::vector<std::vector<RealGradient>> & phi = side_fe->get_phi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
 
   const std::vector<Point> & normals = side_fe->get_normals();
 

--- a/examples/vector_fe/vector_fe_ex4/curl_curl_system.C
+++ b/examples/vector_fe/vector_fe_ex4/curl_curl_system.C
@@ -127,7 +127,7 @@ bool CurlCurlSystem::element_time_derivative (bool request_jacobian,
   const std::vector<Point> & qpoint = fe->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
 
   DenseSubMatrix<Number> & Kuu = c.get_elem_jacobian(u_var, u_var);
 
@@ -190,7 +190,7 @@ bool CurlCurlSystem::side_time_derivative (bool request_jacobian,
   const std::vector<std::vector<RealGradient>> & phi = side_fe->get_phi();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
+  const unsigned int n_u_dofs = c.n_dof_indices(u_var);
 
   const std::vector<Point> & normals = side_fe->get_normals();
 

--- a/include/systems/diff_context.h
+++ b/include/systems/diff_context.h
@@ -394,6 +394,22 @@ public:
   }
 
   /**
+   * Total number of dof indices on the element
+   */
+  unsigned int n_dof_indices() const
+  { return cast_int<unsigned int>(_dof_indices.size()); }
+
+  /**
+   * Total number of dof indices of the particular variable
+   * corresponding to the index argument
+   */
+  unsigned int n_dof_indices( unsigned int var ) const
+  {
+    libmesh_assert_greater(_dof_indices_var.size(), var);
+    return cast_int<unsigned int>(_dof_indices_var[var].size());
+  }
+
+  /**
    * Accessor for the time variable stored in the system class.
    */
   Real get_system_time() const

--- a/src/apps/L2system.C
+++ b/src/apps/L2system.C
@@ -86,8 +86,7 @@ bool L2System::element_time_derivative (bool request_jacobian,
   const std::vector<Point> & xyz = c.get_element_fe(0)->get_xyz();
 
   // The number of local degrees of freedom in each variable
-  const unsigned int n_u_dofs =
-    cast_int<unsigned int>(c.get_dof_indices(0).size());
+  const unsigned int n_u_dofs = c.n_dof_indices(0);
 
   // The subvectors and submatrices we need to fill:
   DenseSubMatrix<Number> & K = c.get_elem_jacobian(0, 0);


### PR DESCRIPTION
This doesn't get us clean w.r.t. -Wconversion (and I'm not sure we're ever going to be at this rate - the easiest way to fix a wide swath of warnings is an API change that breaks MOOSE) but it clears out a lot of them.