### PR TITLE
Finer ghosting control

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -266,10 +266,16 @@ public:
    * for codes where no evaluations on neighbor cells (e.g. no jump
    * error estimators) are done.
    *
-   * Default ghosting can be restored manually, or is restored
+   * Defaults can be restored manually via add_default_ghosting(), or
    * automatically if clear() returns the DofMap to a default state.
    */
   void remove_default_ghosting();
+
+  /**
+   * Add the default functor(s) for coupling and algebraic ghosting.
+   * User-added ghosting functors will be unaffected.
+   */
+  void add_default_ghosting();
 
   /**
    * Adds a functor which can specify coupling requirements for

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -257,6 +257,21 @@ public:
   void clear_sparsity();
 
   /**
+   * Remove any default ghosting functor(s).  User-added ghosting
+   * functors will be unaffected.
+   *
+   * Unless user-added equivalent ghosting functors exist, removing
+   * the default coupling functor is only safe for explicit solves,
+   * and removing the default algebraic ghosting functor is only safe
+   * for codes where no evaluations on neighbor cells (e.g. no jump
+   * error estimators) are done.
+   *
+   * Default ghosting can be restored manually, or is restored
+   * automatically if clear() returns the DofMap to a default state.
+   */
+  void remove_default_ghosting();
+
+  /**
    * Adds a functor which can specify coupling requirements for
    * creation of sparse matrices.
    * Degree of freedom pairs which match the elements and variables

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -1262,7 +1262,8 @@ public:
   void reinit (MeshBase & mesh);
 
   /**
-   * Free all memory associated with the object, but keep the mesh pointer.
+   * Free all new memory associated with the object, but restore its
+   * original state, with the mesh pointer and any default ghosting.
    */
   void clear ();
 

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -306,7 +306,8 @@ public:
 
   /**
    * Removes a functor which was previously added to the set of
-   * coupling functors.
+   * coupling functors, from both this DofMap and from the underlying
+   * mesh.
    */
   void remove_coupling_functor(GhostingFunctor & coupling_functor);
 
@@ -355,7 +356,8 @@ public:
 
   /**
    * Removes a functor which was previously added to the set of
-   * algebraic ghosting functors.
+   * algebraic ghosting functors, from both this DofMap and from the
+   * underlying mesh.
    */
   void remove_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor);
 

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -290,8 +290,19 @@ public:
    * GhostingFunctor memory must be managed by the code which calls
    * this function; the GhostingFunctor lifetime is expected to extend
    * until either the functor is removed or the DofMap is destructed.
+   *
+   * When \p to_mesh is true, the \p coupling_functor is also added to
+   * our associated mesh, to ensure that coupled elements do not get
+   * lost during mesh distribution.  (if coupled elements were
+   * *already* lost there's no getting them back after the fact,
+   * sorry)
+   *
+   * If \p to_mesh is false, no change to mesh ghosting is made;
+   * the Mesh must already have ghosting functor(s) specifying a
+   * superset of \p coupling_functor or this is a horrible bug.
    */
-  void add_coupling_functor(GhostingFunctor & coupling_functor);
+  void add_coupling_functor(GhostingFunctor & coupling_functor,
+                            bool to_mesh = true);
 
   /**
    * Removes a functor which was previously added to the set of
@@ -321,19 +332,32 @@ public:
    * for use with distributed vectors.  Degrees of freedom on other
    * processors which match the elements and variables returned by
    * these functors will be added to the send_list, and the elements
-   * on other processors will be ghosted on a distributed mesh.
+   * on other processors will be ghosted on a distributed mesh, so
+   * that the elements can always be found and the solutions on them
+   * will always be evaluable.
    *
    * GhostingFunctor memory must be managed by the code which calls
    * this function; the GhostingFunctor lifetime is expected to extend
    * until either the functor is removed or the DofMap is destructed.
+   *
+   * When \p to_mesh is true, the \p coupling_functor is also added to
+   * our associated mesh, to ensure that evaluable elements do not get
+   * lost during mesh distribution.  (if evaluable elements were
+   * *already* lost there's no getting them back after the fact,
+   * sorry)
+   *
+   * If \p to_mesh is false, no change to mesh ghosting is made;
+   * the Mesh must already have ghosting functor(s) specifying a
+   * superset of \p evaluable_functor or this is a horrible bug.
    */
-  void add_algebraic_ghosting_functor(GhostingFunctor & ghosting_functor);
+  void add_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor,
+                                      bool to_mesh = true);
 
   /**
    * Removes a functor which was previously added to the set of
    * algebraic ghosting functors.
    */
-  void remove_algebraic_ghosting_functor(GhostingFunctor & ghosting_functor);
+  void remove_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor);
 
   /**
    * Beginning of range of algebraic ghosting functors

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -842,6 +842,11 @@ public:
   { return _ghosting_functors.end(); }
 
   /**
+   * Default ghosting functor
+   */
+  GhostingFunctor & default_ghosting() { return *_default_ghosting; }
+
+  /**
    * Constructs a list of all subdomain identifiers in the global mesh.
    * Subdomains correspond to separate subsets of the mesh which could correspond
    * e.g. to different materials in a solid mechanics application,

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1803,6 +1803,14 @@ void DofMap::remove_default_ghosting()
 
 
 
+void DofMap::add_default_ghosting()
+{
+  this->add_coupling_functor(this->default_coupling());
+  this->add_algebraic_ghosting_functor(this->default_algebraic_ghosting());
+}
+
+
+
 void
 DofMap::add_coupling_functor(GhostingFunctor & coupling_functor)
 {

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1795,6 +1795,14 @@ void DofMap::clear_sparsity()
 
 
 
+void DofMap::remove_default_ghosting()
+{
+  this->remove_coupling_functor(this->default_coupling());
+  this->remove_algebraic_ghosting_functor(this->default_algebraic_ghosting());
+}
+
+
+
 void
 DofMap::add_coupling_functor(GhostingFunctor & coupling_functor)
 {

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1812,10 +1812,12 @@ void DofMap::add_default_ghosting()
 
 
 void
-DofMap::add_coupling_functor(GhostingFunctor & coupling_functor)
+DofMap::add_coupling_functor(GhostingFunctor & coupling_functor,
+                             bool to_mesh)
 {
   _coupling_functors.insert(&coupling_functor);
-  _mesh.add_ghosting_functor(coupling_functor);
+  if (to_mesh)
+    _mesh.add_ghosting_functor(coupling_functor);
 }
 
 
@@ -1830,19 +1832,21 @@ DofMap::remove_coupling_functor(GhostingFunctor & coupling_functor)
 
 
 void
-DofMap::add_algebraic_ghosting_functor(GhostingFunctor & algebraic_ghosting_functor)
+DofMap::add_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor,
+                                       bool to_mesh)
 {
-  _algebraic_ghosting_functors.insert(&algebraic_ghosting_functor);
-  _mesh.add_ghosting_functor(algebraic_ghosting_functor);
+  _algebraic_ghosting_functors.insert(&evaluable_functor);
+  if (to_mesh)
+    _mesh.add_ghosting_functor(evaluable_functor);
 }
 
 
 
 void
-DofMap::remove_algebraic_ghosting_functor(GhostingFunctor & algebraic_ghosting_functor)
+DofMap::remove_algebraic_ghosting_functor(GhostingFunctor & evaluable_functor)
 {
-  _algebraic_ghosting_functors.erase(&algebraic_ghosting_functor);
-  _mesh.remove_ghosting_functor(algebraic_ghosting_functor);
+  _algebraic_ghosting_functors.erase(&evaluable_functor);
+  _mesh.remove_ghosting_functor(evaluable_functor);
 }
 
 


### PR DESCRIPTION
EquationSystems::enable_default_ghosting(false/true) will now remove/restore default ghosting functors created by Mesh and DofMap objects, and will disable/reenable the creation of default ghosting functors by the creations of new add_system calls.

@friedmud you can take a look at these first 5 commits and see if enable_default_ghosting(false) is a start for your codes; the finer DofMap method control will come in later commits and the unit testing to see if any of this is actually working will be later still.