### PR TITLE
Create partial class specialization for DenseMatrix<DualNumber>

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -30,6 +30,10 @@
 # include <petscsys.h>
 #endif
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
+#include "metaphysicl/dualnumber.h"
+#endif
+
 // C++ includes
 #include <vector>
 #include <algorithm>
@@ -701,9 +705,39 @@ private:
                     bool trans=false) const;
 };
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
+/**
+ * Partial specialization for dual numbers
+ * We don't do anything for these at this point. This is provided for compilation purposes
+ */
+template<typename T, typename D>
+class DenseMatrix<MetaPhysicL::DualNumber<T, D>> : public DenseMatrixBase<MetaPhysicL::DualNumber<T, D>>
+{
+  virtual void zero() override { libmesh_not_implemented(); }
+
+  virtual MetaPhysicL::DualNumber<T, D> el(const unsigned int, const unsigned int) const override
+    {
+      libmesh_not_implemented();
+      return MetaPhysicL::DualNumber<T, D>{};
+    }
+
+  virtual MetaPhysicL::DualNumber<T, D> & el(const unsigned int, const unsigned int) override
+    {
+      libmesh_not_implemented();
+      return _dummy;
+    }
+
+  virtual void left_multiply (const DenseMatrixBase<MetaPhysicL::DualNumber<T, D>> &) override
+    { libmesh_not_implemented(); }
+
+  virtual void right_multiply (const DenseMatrixBase<MetaPhysicL::DualNumber<T, D>> &) override
+    { libmesh_not_implemented(); }
 
 
-
+private:
+  MetaPhysicL::DualNumber<T, D> _dummy;
+};
+#endif
 
 // ------------------------------------------------------------
 /**

--- a/tests/numerics/dense_matrix_test.C
+++ b/tests/numerics/dense_matrix_test.C
@@ -38,11 +38,21 @@ public:
   CPPUNIT_TEST(testEVDreal);
   CPPUNIT_TEST(testEVDcomplex);
   CPPUNIT_TEST(testComplexSVD);
+#ifdef LIBMESH_HAVE_METAPHYSICL
+  CPPUNIT_TEST(testDualNumberInstantiation);
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 
 
 private:
+
+#ifdef LIBMESH_HAVE_METAPHYSICL
+  void testDualNumberInstantiation()
+  {
+    DenseMatrix<MetaPhysicL::DualNumber<Real>> test;
+  }
+#endif
 
   void testOuterProduct()
   {


### PR DESCRIPTION
Any instantiation of a `DenseMatrix<DualNumber>` currently fails because of missing symbols. We could fix this by explicitly instantiating in `dense_matrix.C`, but this will fail because we can't call through to PETSc routines with dual numbers. We cannot partially specialize a template class method to work with all possible `DualNumbers` so my solution at this point is to partially specialize the template class.