### PR TITLE
Partitioner unit tests

### DIFF
--- a/src/partitioning/centroid_partitioner.C
+++ b/src/partitioning/centroid_partitioner.C
@@ -31,12 +31,19 @@ void CentroidPartitioner::partition_range(MeshBase & mesh,
                                           MeshBase::element_iterator end,
                                           unsigned int n)
 {
-  // Check for an easy return
+  // Check for easy returns
+  if (it == end)
+    return;
+
   if (n == 1)
     {
       this->single_partition_range (it, end);
       return;
     }
+
+  // Make sure the user has not handed us an
+  // invalid number of partitions.
+  libmesh_assert_greater (n, 0);
 
   // We don't yet support distributed meshes with this Partitioner
   if (!mesh.is_serial())
@@ -92,10 +99,6 @@ void CentroidPartitioner::partition_range(MeshBase & mesh,
     default:
       libmesh_error_msg("Unknown sort method: " << this->sort_method());
     }
-
-  // Make sure the user has not handed us an
-  // invalid number of partitions.
-  libmesh_assert_greater (n, 0);
 
   // Compute target_size, the approximate number of elements on each processor.
   const dof_id_type target_size = cast_int<dof_id_type>

--- a/src/partitioning/linear_partitioner.C
+++ b/src/partitioning/linear_partitioner.C
@@ -30,14 +30,17 @@ void LinearPartitioner::partition_range(MeshBase & mesh,
                                         MeshBase::element_iterator end,
                                         const unsigned int n)
 {
-  libmesh_assert_greater (n, 0);
+  // Check for easy returns
+  if (it == end)
+    return;
 
-  // Check for an easy return
   if (n == 1)
     {
       this->single_partition_range (it, end);
       return;
     }
+
+  libmesh_assert_greater (n, 0);
 
   // Create a simple linear partitioning
   LOG_SCOPE ("partition_range()", "LinearPartitioner");

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -58,18 +58,21 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                                        MeshBase::element_iterator end,
                                        unsigned int n_pieces)
 {
-  libmesh_assert_greater (n_pieces, 0);
+  // Check for easy returns
+  if (beg == end)
+    return;
 
-  // We don't yet support distributed meshes with this Partitioner
-  if (!mesh.is_serial())
-    libmesh_not_implemented();
-
-  // Check for an easy return
   if (n_pieces == 1)
     {
       this->single_partition_range (beg, end);
       return;
     }
+
+  libmesh_assert_greater (n_pieces, 0);
+
+  // We don't yet support distributed meshes with this Partitioner
+  if (!mesh.is_serial())
+    libmesh_not_implemented();
 
   // What to do if the Metis library IS NOT present
 #ifndef LIBMESH_HAVE_METIS

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -72,7 +72,10 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
 
   // We don't yet support distributed meshes with this Partitioner
   if (!mesh.is_serial())
-    libmesh_not_implemented();
+    {
+      libMesh::out << "WARNING: Forced to gather a distributed mesh for METIS" << std::endl;
+      mesh.allgather();
+    }
 
   // What to do if the Metis library IS NOT present
 #ifndef LIBMESH_HAVE_METIS

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -80,10 +80,10 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
   // What to do if the Metis library IS NOT present
 #ifndef LIBMESH_HAVE_METIS
 
-  libmesh_here();
-  libMesh::err << "ERROR: The library has been built without"    << std::endl
+  libmesh_do_once(
+  libMesh::out << "ERROR: The library has been built without"    << std::endl
                << "Metis support.  Using a space-filling curve"  << std::endl
-               << "partitioner instead!"                         << std::endl;
+               << "partitioner instead!"                         << std::endl;);
 
   SFCPartitioner sfcp;
   sfcp.partition_range (mesh, beg, end, n_pieces);

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -118,7 +118,11 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
 
   MetisPartitioner mp;
 
-  mp.partition (mesh, n_sbdmns);
+  // Don't just call partition() here; that would end up calling
+  // post-element-partitioning work redundantly (and at the moment
+  // incorrectly)
+  mp.partition_range (mesh, mesh.active_elements_begin(),
+                      mesh.active_elements_end(), n_sbdmns);
 
   // What to do if the Parmetis library IS present
 #else

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -93,17 +93,20 @@ void ParmetisPartitioner::_do_partition (MeshBase & mesh,
 void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
                                            const unsigned int n_sbdmns)
 {
-  libmesh_assert_greater (n_sbdmns, 0);
+  // This function must be run on all processors at once
+  libmesh_parallel_only(mesh.comm());
 
-  // Check for an easy return
+  // Check for easy returns
+  if (!mesh.n_elem())
+    return;
+
   if (n_sbdmns == 1)
     {
       this->single_partition(mesh);
       return;
     }
 
-  // This function must be run on all processors at once
-  libmesh_parallel_only(mesh.comm());
+  libmesh_assert_greater (n_sbdmns, 0);
 
   // What to do if the Parmetis library IS NOT present
 #ifndef LIBMESH_HAVE_PARMETIS

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -130,7 +130,11 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
       mesh.allgather();
 
       MetisPartitioner mp;
-      mp.partition (mesh, n_sbdmns);
+      // Don't just call partition() here; that would end up calling
+      // post-element-partitioning work redundantly (and at the moment
+      // incorrectly)
+      mp.partition_range (mesh, mesh.active_elements_begin(),
+                          mesh.active_elements_end(), n_sbdmns);
       return;
     }
 

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -111,10 +111,10 @@ void ParmetisPartitioner::_do_repartition (MeshBase & mesh,
   // What to do if the Parmetis library IS NOT present
 #ifndef LIBMESH_HAVE_PARMETIS
 
-  libmesh_here();
-  libMesh::err << "ERROR: The library has been built without" << std::endl
+  libmesh_do_once(
+  libMesh::out << "ERROR: The library has been built without" << std::endl
                << "Parmetis support.  Using a Metis"          << std::endl
-               << "partitioner instead!"                      << std::endl;
+               << "partitioner instead!"                      << std::endl;);
 
   MetisPartitioner mp;
 

--- a/src/partitioning/sfc_partitioner.C
+++ b/src/partitioning/sfc_partitioner.C
@@ -58,10 +58,10 @@ void SFCPartitioner::partition_range(MeshBase & mesh,
   // What to do if the sfcurves library IS NOT present
 #ifndef LIBMESH_HAVE_SFCURVES
 
-  libmesh_here();
-  libMesh::err << "ERROR: The library has been built without"    << std::endl
-               << "Space Filling Curve support.  Using a linear" << std::endl
-               << "partitioner instead!" << std::endl;
+  libmesh_do_once(
+    libMesh::out << "ERROR: The library has been built without"    << std::endl
+                 << "Space Filling Curve support.  Using a linear" << std::endl
+                 << "partitioner instead!" << std::endl;);
 
   LinearPartitioner lp;
   lp.partition_range (mesh, beg, end, n);
@@ -129,13 +129,12 @@ void SFCPartitioner::partition_range(MeshBase & mesh,
 
   else
     {
-      libmesh_here();
-      libMesh::err << "ERROR: Unknown type: " << _sfc_type << std::endl
+      libMesh::out << "ERROR: Unknown type: " << _sfc_type << std::endl
                    << " Valid types are"                   << std::endl
                    << "  \"Hilbert\""                      << std::endl
                    << "  \"Morton\""                       << std::endl
                    << " "                                  << std::endl
-                   << "Proceeding with a Hilbert curve."   << std::endl;
+                   << "Partitioning with a Hilbert curve." << std::endl;
 
       Sfc::hilbert (&x[0], &y[0], &z[0], &size, &table[0]);
     }

--- a/src/partitioning/sfc_partitioner.C
+++ b/src/partitioning/sfc_partitioner.C
@@ -43,14 +43,17 @@ void SFCPartitioner::partition_range(MeshBase & mesh,
                                      MeshBase::element_iterator end,
                                      unsigned int n)
 {
-  libmesh_assert_greater (n, 0);
+  // Check for easy returns
+  if (beg == end)
+    return;
 
-  // Check for an easy return
   if (n == 1)
     {
       this->single_partition_range (beg, end);
       return;
     }
+
+  libmesh_assert_greater (n, 0);
 
   // What to do if the sfcurves library IS NOT present
 #ifndef LIBMESH_HAVE_SFCURVES

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -73,6 +73,14 @@ unit_tests_sources = \
   parallel/parallel_sort_test.C \
   parallel/parallel_test.C \
   parallel/parallel_point_test.C \
+  partitioning/partitioner_test.h \
+  partitioning/centroid_partitioner_test.C \
+  partitioning/hilbert_sfc_partitioner_test.C \
+  partitioning/linear_partitioner_test.C \
+  partitioning/metis_partitioner_test.C \
+  partitioning/morton_sfc_partitioner_test.C \
+  partitioning/parmetis_partitioner_test.C \
+  partitioning/sfc_partitioner_test.C \
   quadrature/quadrature_test.C \
   solvers/time_solver_test_common.h \
   solvers/first_order_unsteady_solver_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -212,6 +212,14 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
+	partitioning/partitioner_test.h \
+	partitioning/centroid_partitioner_test.C \
+	partitioning/hilbert_sfc_partitioner_test.C \
+	partitioning/linear_partitioner_test.C \
+	partitioning/metis_partitioner_test.C \
+	partitioning/morton_sfc_partitioner_test.C \
+	partitioning/parmetis_partitioner_test.C \
+	partitioning/sfc_partitioner_test.C \
 	quadrature/quadrature_test.C solvers/time_solver_test_common.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
@@ -270,6 +278,13 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_sort_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_point_test.$(OBJEXT) \
+	partitioning/unit_tests_dbg-centroid_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_dbg-linear_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_dbg-metis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_dbg-morton_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_dbg-parmetis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_dbg-sfc_partitioner_test.$(OBJEXT) \
 	quadrature/unit_tests_dbg-quadrature_test.$(OBJEXT) \
 	solvers/unit_tests_dbg-first_order_unsteady_solver_test.$(OBJEXT) \
 	solvers/unit_tests_dbg-second_order_unsteady_solver_test.$(OBJEXT) \
@@ -318,6 +333,14 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
+	partitioning/partitioner_test.h \
+	partitioning/centroid_partitioner_test.C \
+	partitioning/hilbert_sfc_partitioner_test.C \
+	partitioning/linear_partitioner_test.C \
+	partitioning/metis_partitioner_test.C \
+	partitioning/morton_sfc_partitioner_test.C \
+	partitioning/parmetis_partitioner_test.C \
+	partitioning/sfc_partitioner_test.C \
 	quadrature/quadrature_test.C solvers/time_solver_test_common.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
@@ -375,6 +398,13 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_sort_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_point_test.$(OBJEXT) \
+	partitioning/unit_tests_devel-centroid_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_devel-linear_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_devel-metis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_devel-morton_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_devel-parmetis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_devel-sfc_partitioner_test.$(OBJEXT) \
 	quadrature/unit_tests_devel-quadrature_test.$(OBJEXT) \
 	solvers/unit_tests_devel-first_order_unsteady_solver_test.$(OBJEXT) \
 	solvers/unit_tests_devel-second_order_unsteady_solver_test.$(OBJEXT) \
@@ -420,6 +450,14 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
+	partitioning/partitioner_test.h \
+	partitioning/centroid_partitioner_test.C \
+	partitioning/hilbert_sfc_partitioner_test.C \
+	partitioning/linear_partitioner_test.C \
+	partitioning/metis_partitioner_test.C \
+	partitioning/morton_sfc_partitioner_test.C \
+	partitioning/parmetis_partitioner_test.C \
+	partitioning/sfc_partitioner_test.C \
 	quadrature/quadrature_test.C solvers/time_solver_test_common.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
@@ -477,6 +515,13 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_sort_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_point_test.$(OBJEXT) \
+	partitioning/unit_tests_oprof-centroid_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_oprof-linear_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_oprof-metis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_oprof-morton_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_oprof-parmetis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_oprof-sfc_partitioner_test.$(OBJEXT) \
 	quadrature/unit_tests_oprof-quadrature_test.$(OBJEXT) \
 	solvers/unit_tests_oprof-first_order_unsteady_solver_test.$(OBJEXT) \
 	solvers/unit_tests_oprof-second_order_unsteady_solver_test.$(OBJEXT) \
@@ -522,6 +567,14 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
+	partitioning/partitioner_test.h \
+	partitioning/centroid_partitioner_test.C \
+	partitioning/hilbert_sfc_partitioner_test.C \
+	partitioning/linear_partitioner_test.C \
+	partitioning/metis_partitioner_test.C \
+	partitioning/morton_sfc_partitioner_test.C \
+	partitioning/parmetis_partitioner_test.C \
+	partitioning/sfc_partitioner_test.C \
 	quadrature/quadrature_test.C solvers/time_solver_test_common.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
@@ -579,6 +632,13 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_sort_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_point_test.$(OBJEXT) \
+	partitioning/unit_tests_opt-centroid_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_opt-linear_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_opt-metis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_opt-morton_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_opt-parmetis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_opt-sfc_partitioner_test.$(OBJEXT) \
 	quadrature/unit_tests_opt-quadrature_test.$(OBJEXT) \
 	solvers/unit_tests_opt-first_order_unsteady_solver_test.$(OBJEXT) \
 	solvers/unit_tests_opt-second_order_unsteady_solver_test.$(OBJEXT) \
@@ -623,6 +683,14 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
+	partitioning/partitioner_test.h \
+	partitioning/centroid_partitioner_test.C \
+	partitioning/hilbert_sfc_partitioner_test.C \
+	partitioning/linear_partitioner_test.C \
+	partitioning/metis_partitioner_test.C \
+	partitioning/morton_sfc_partitioner_test.C \
+	partitioning/parmetis_partitioner_test.C \
+	partitioning/sfc_partitioner_test.C \
 	quadrature/quadrature_test.C solvers/time_solver_test_common.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
@@ -680,6 +748,13 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_sort_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_point_test.$(OBJEXT) \
+	partitioning/unit_tests_prof-centroid_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_prof-linear_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_prof-metis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_prof-morton_sfc_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_prof-parmetis_partitioner_test.$(OBJEXT) \
+	partitioning/unit_tests_prof-sfc_partitioner_test.$(OBJEXT) \
 	quadrature/unit_tests_prof-quadrature_test.$(OBJEXT) \
 	solvers/unit_tests_prof-first_order_unsteady_solver_test.$(OBJEXT) \
 	solvers/unit_tests_prof-second_order_unsteady_solver_test.$(OBJEXT) \
@@ -1151,6 +1226,14 @@ unit_tests_sources = driver.C test_comm.h stream_redirector.h \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
 	parallel/packed_range_test.C parallel/parallel_sort_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
+	partitioning/partitioner_test.h \
+	partitioning/centroid_partitioner_test.C \
+	partitioning/hilbert_sfc_partitioner_test.C \
+	partitioning/linear_partitioner_test.C \
+	partitioning/metis_partitioner_test.C \
+	partitioning/morton_sfc_partitioner_test.C \
+	partitioning/parmetis_partitioner_test.C \
+	partitioning/sfc_partitioner_test.C \
 	quadrature/quadrature_test.C solvers/time_solver_test_common.h \
 	solvers/first_order_unsteady_solver_test.C \
 	solvers/second_order_unsteady_solver_test.C \
@@ -1367,6 +1450,33 @@ parallel/unit_tests_dbg-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_dbg-parallel_point_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+partitioning/$(am__dirstamp):
+	@$(MKDIR_P) partitioning
+	@: > partitioning/$(am__dirstamp)
+partitioning/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) partitioning/$(DEPDIR)
+	@: > partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_dbg-centroid_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_dbg-linear_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_dbg-metis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_dbg-morton_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_dbg-parmetis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_dbg-sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
 quadrature/$(am__dirstamp):
 	@$(MKDIR_P) quadrature
 	@: > quadrature/$(am__dirstamp)
@@ -1516,6 +1626,27 @@ parallel/unit_tests_devel-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-parallel_point_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_devel-centroid_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_devel-linear_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_devel-metis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_devel-morton_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_devel-parmetis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_devel-sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
 quadrature/unit_tests_devel-quadrature_test.$(OBJEXT):  \
 	quadrature/$(am__dirstamp) \
 	quadrature/$(DEPDIR)/$(am__dirstamp)
@@ -1635,6 +1766,27 @@ parallel/unit_tests_oprof-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_oprof-parallel_point_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_oprof-centroid_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_oprof-linear_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_oprof-metis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_oprof-morton_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_oprof-parmetis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_oprof-sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
 quadrature/unit_tests_oprof-quadrature_test.$(OBJEXT):  \
 	quadrature/$(am__dirstamp) \
 	quadrature/$(DEPDIR)/$(am__dirstamp)
@@ -1754,6 +1906,27 @@ parallel/unit_tests_opt-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-parallel_point_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_opt-centroid_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_opt-linear_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_opt-metis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_opt-morton_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_opt-parmetis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_opt-sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
 quadrature/unit_tests_opt-quadrature_test.$(OBJEXT):  \
 	quadrature/$(am__dirstamp) \
 	quadrature/$(DEPDIR)/$(am__dirstamp)
@@ -1873,6 +2046,27 @@ parallel/unit_tests_prof-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_prof-parallel_point_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_prof-centroid_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_prof-linear_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_prof-metis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_prof-morton_sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_prof-parmetis_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
+partitioning/unit_tests_prof-sfc_partitioner_test.$(OBJEXT):  \
+	partitioning/$(am__dirstamp) \
+	partitioning/$(DEPDIR)/$(am__dirstamp)
 quadrature/unit_tests_prof-quadrature_test.$(OBJEXT):  \
 	quadrature/$(am__dirstamp) \
 	quadrature/$(DEPDIR)/$(am__dirstamp)
@@ -1904,6 +2098,7 @@ mostlyclean-compile:
 	-rm -f mesh/*.$(OBJEXT)
 	-rm -f numerics/*.$(OBJEXT)
 	-rm -f parallel/*.$(OBJEXT)
+	-rm -f partitioning/*.$(OBJEXT)
 	-rm -f quadrature/*.$(OBJEXT)
 	-rm -f solvers/*.$(OBJEXT)
 	-rm -f systems/*.$(OBJEXT)
@@ -2167,6 +2362,41 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-parallel_point_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-parallel_sort_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-parallel_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_dbg-linear_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_dbg-metis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_dbg-morton_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_dbg-parmetis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_dbg-sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_devel-centroid_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_devel-hilbert_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_devel-linear_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_devel-metis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_devel-morton_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_devel-parmetis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_devel-sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_oprof-centroid_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_oprof-hilbert_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_oprof-linear_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_oprof-metis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_oprof-morton_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_oprof-parmetis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_oprof-sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_opt-centroid_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_opt-hilbert_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_opt-linear_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_opt-metis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_opt-morton_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_opt-parmetis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_opt-sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_prof-centroid_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_prof-hilbert_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_prof-linear_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_prof-metis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_prof-morton_sfc_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_prof-parmetis_partitioner_test.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_prof-sfc_partitioner_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@quadrature/$(DEPDIR)/unit_tests_dbg-quadrature_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@quadrature/$(DEPDIR)/unit_tests_devel-quadrature_test.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@quadrature/$(DEPDIR)/unit_tests_oprof-quadrature_test.Po@am__quote@
@@ -2926,6 +3156,104 @@ parallel/unit_tests_dbg-parallel_point_test.obj: parallel/parallel_point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_point_test.C' object='parallel/unit_tests_dbg-parallel_point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_dbg-parallel_point_test.obj `if test -f 'parallel/parallel_point_test.C'; then $(CYGPATH_W) 'parallel/parallel_point_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_point_test.C'; fi`
+
+partitioning/unit_tests_dbg-centroid_partitioner_test.o: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-centroid_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_dbg-centroid_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+
+partitioning/unit_tests_dbg-centroid_partitioner_test.obj: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-centroid_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_dbg-centroid_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+
+partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.o: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+
+partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.obj: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_dbg-linear_partitioner_test.o: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-linear_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_dbg-linear_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+
+partitioning/unit_tests_dbg-linear_partitioner_test.obj: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-linear_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_dbg-linear_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+
+partitioning/unit_tests_dbg-metis_partitioner_test.o: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-metis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_dbg-metis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+
+partitioning/unit_tests_dbg-metis_partitioner_test.obj: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-metis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_dbg-metis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_dbg-morton_sfc_partitioner_test.o: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-morton_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_dbg-morton_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+
+partitioning/unit_tests_dbg-morton_sfc_partitioner_test.obj: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-morton_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_dbg-morton_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_dbg-parmetis_partitioner_test.o: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-parmetis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_dbg-parmetis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+
+partitioning/unit_tests_dbg-parmetis_partitioner_test.obj: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-parmetis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_dbg-parmetis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_dbg-sfc_partitioner_test.o: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_dbg-sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+
+partitioning/unit_tests_dbg-sfc_partitioner_test.obj: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_dbg-sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_dbg-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_dbg-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_dbg-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_dbg-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_dbg-sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_dbg-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
 
 quadrature/unit_tests_dbg-quadrature_test.o: quadrature/quadrature_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT quadrature/unit_tests_dbg-quadrature_test.o -MD -MP -MF quadrature/$(DEPDIR)/unit_tests_dbg-quadrature_test.Tpo -c -o quadrature/unit_tests_dbg-quadrature_test.o `test -f 'quadrature/quadrature_test.C' || echo '$(srcdir)/'`quadrature/quadrature_test.C
@@ -3739,6 +4067,104 @@ parallel/unit_tests_devel-parallel_point_test.obj: parallel/parallel_point_test.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_devel-parallel_point_test.obj `if test -f 'parallel/parallel_point_test.C'; then $(CYGPATH_W) 'parallel/parallel_point_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_point_test.C'; fi`
 
+partitioning/unit_tests_devel-centroid_partitioner_test.o: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-centroid_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_devel-centroid_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+
+partitioning/unit_tests_devel-centroid_partitioner_test.obj: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-centroid_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_devel-centroid_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+
+partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.o: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+
+partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.obj: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_devel-linear_partitioner_test.o: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-linear_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_devel-linear_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+
+partitioning/unit_tests_devel-linear_partitioner_test.obj: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-linear_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_devel-linear_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+
+partitioning/unit_tests_devel-metis_partitioner_test.o: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-metis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_devel-metis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+
+partitioning/unit_tests_devel-metis_partitioner_test.obj: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-metis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_devel-metis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_devel-morton_sfc_partitioner_test.o: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-morton_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_devel-morton_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+
+partitioning/unit_tests_devel-morton_sfc_partitioner_test.obj: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-morton_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_devel-morton_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_devel-parmetis_partitioner_test.o: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-parmetis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_devel-parmetis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+
+partitioning/unit_tests_devel-parmetis_partitioner_test.obj: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-parmetis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_devel-parmetis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_devel-sfc_partitioner_test.o: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_devel-sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+
+partitioning/unit_tests_devel-sfc_partitioner_test.obj: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_devel-sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_devel-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_devel-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_devel-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_devel-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_devel-sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_devel-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
+
 quadrature/unit_tests_devel-quadrature_test.o: quadrature/quadrature_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT quadrature/unit_tests_devel-quadrature_test.o -MD -MP -MF quadrature/$(DEPDIR)/unit_tests_devel-quadrature_test.Tpo -c -o quadrature/unit_tests_devel-quadrature_test.o `test -f 'quadrature/quadrature_test.C' || echo '$(srcdir)/'`quadrature/quadrature_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) quadrature/$(DEPDIR)/unit_tests_devel-quadrature_test.Tpo quadrature/$(DEPDIR)/unit_tests_devel-quadrature_test.Po
@@ -4550,6 +4976,104 @@ parallel/unit_tests_oprof-parallel_point_test.obj: parallel/parallel_point_test.
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_point_test.C' object='parallel/unit_tests_oprof-parallel_point_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_oprof-parallel_point_test.obj `if test -f 'parallel/parallel_point_test.C'; then $(CYGPATH_W) 'parallel/parallel_point_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_point_test.C'; fi`
+
+partitioning/unit_tests_oprof-centroid_partitioner_test.o: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-centroid_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_oprof-centroid_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+
+partitioning/unit_tests_oprof-centroid_partitioner_test.obj: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-centroid_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_oprof-centroid_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+
+partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.o: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+
+partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.obj: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_oprof-linear_partitioner_test.o: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-linear_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_oprof-linear_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+
+partitioning/unit_tests_oprof-linear_partitioner_test.obj: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-linear_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_oprof-linear_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+
+partitioning/unit_tests_oprof-metis_partitioner_test.o: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-metis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_oprof-metis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+
+partitioning/unit_tests_oprof-metis_partitioner_test.obj: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-metis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_oprof-metis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_oprof-morton_sfc_partitioner_test.o: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-morton_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_oprof-morton_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+
+partitioning/unit_tests_oprof-morton_sfc_partitioner_test.obj: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-morton_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_oprof-morton_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_oprof-parmetis_partitioner_test.o: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-parmetis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_oprof-parmetis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+
+partitioning/unit_tests_oprof-parmetis_partitioner_test.obj: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-parmetis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_oprof-parmetis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_oprof-sfc_partitioner_test.o: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_oprof-sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+
+partitioning/unit_tests_oprof-sfc_partitioner_test.obj: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_oprof-sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_oprof-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_oprof-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_oprof-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_oprof-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_oprof-sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_oprof-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
 
 quadrature/unit_tests_oprof-quadrature_test.o: quadrature/quadrature_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT quadrature/unit_tests_oprof-quadrature_test.o -MD -MP -MF quadrature/$(DEPDIR)/unit_tests_oprof-quadrature_test.Tpo -c -o quadrature/unit_tests_oprof-quadrature_test.o `test -f 'quadrature/quadrature_test.C' || echo '$(srcdir)/'`quadrature/quadrature_test.C
@@ -5363,6 +5887,104 @@ parallel/unit_tests_opt-parallel_point_test.obj: parallel/parallel_point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_opt-parallel_point_test.obj `if test -f 'parallel/parallel_point_test.C'; then $(CYGPATH_W) 'parallel/parallel_point_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_point_test.C'; fi`
 
+partitioning/unit_tests_opt-centroid_partitioner_test.o: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-centroid_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_opt-centroid_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+
+partitioning/unit_tests_opt-centroid_partitioner_test.obj: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-centroid_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_opt-centroid_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+
+partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.o: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+
+partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.obj: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_opt-linear_partitioner_test.o: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-linear_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_opt-linear_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+
+partitioning/unit_tests_opt-linear_partitioner_test.obj: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-linear_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_opt-linear_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+
+partitioning/unit_tests_opt-metis_partitioner_test.o: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-metis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_opt-metis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+
+partitioning/unit_tests_opt-metis_partitioner_test.obj: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-metis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_opt-metis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_opt-morton_sfc_partitioner_test.o: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-morton_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_opt-morton_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+
+partitioning/unit_tests_opt-morton_sfc_partitioner_test.obj: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-morton_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_opt-morton_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_opt-parmetis_partitioner_test.o: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-parmetis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_opt-parmetis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+
+partitioning/unit_tests_opt-parmetis_partitioner_test.obj: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-parmetis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_opt-parmetis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_opt-sfc_partitioner_test.o: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_opt-sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+
+partitioning/unit_tests_opt-sfc_partitioner_test.obj: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_opt-sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_opt-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_opt-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_opt-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_opt-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_opt-sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_opt-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
+
 quadrature/unit_tests_opt-quadrature_test.o: quadrature/quadrature_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT quadrature/unit_tests_opt-quadrature_test.o -MD -MP -MF quadrature/$(DEPDIR)/unit_tests_opt-quadrature_test.Tpo -c -o quadrature/unit_tests_opt-quadrature_test.o `test -f 'quadrature/quadrature_test.C' || echo '$(srcdir)/'`quadrature/quadrature_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) quadrature/$(DEPDIR)/unit_tests_opt-quadrature_test.Tpo quadrature/$(DEPDIR)/unit_tests_opt-quadrature_test.Po
@@ -6175,6 +6797,104 @@ parallel/unit_tests_prof-parallel_point_test.obj: parallel/parallel_point_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_prof-parallel_point_test.obj `if test -f 'parallel/parallel_point_test.C'; then $(CYGPATH_W) 'parallel/parallel_point_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_point_test.C'; fi`
 
+partitioning/unit_tests_prof-centroid_partitioner_test.o: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-centroid_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_prof-centroid_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-centroid_partitioner_test.o `test -f 'partitioning/centroid_partitioner_test.C' || echo '$(srcdir)/'`partitioning/centroid_partitioner_test.C
+
+partitioning/unit_tests_prof-centroid_partitioner_test.obj: partitioning/centroid_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-centroid_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-centroid_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-centroid_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-centroid_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/centroid_partitioner_test.C' object='partitioning/unit_tests_prof-centroid_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-centroid_partitioner_test.obj `if test -f 'partitioning/centroid_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/centroid_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/centroid_partitioner_test.C'; fi`
+
+partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.o: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.o `test -f 'partitioning/hilbert_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/hilbert_sfc_partitioner_test.C
+
+partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.obj: partitioning/hilbert_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-hilbert_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-hilbert_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-hilbert_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/hilbert_sfc_partitioner_test.C' object='partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-hilbert_sfc_partitioner_test.obj `if test -f 'partitioning/hilbert_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/hilbert_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/hilbert_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_prof-linear_partitioner_test.o: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-linear_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_prof-linear_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-linear_partitioner_test.o `test -f 'partitioning/linear_partitioner_test.C' || echo '$(srcdir)/'`partitioning/linear_partitioner_test.C
+
+partitioning/unit_tests_prof-linear_partitioner_test.obj: partitioning/linear_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-linear_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-linear_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-linear_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-linear_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/linear_partitioner_test.C' object='partitioning/unit_tests_prof-linear_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-linear_partitioner_test.obj `if test -f 'partitioning/linear_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/linear_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/linear_partitioner_test.C'; fi`
+
+partitioning/unit_tests_prof-metis_partitioner_test.o: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-metis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_prof-metis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-metis_partitioner_test.o `test -f 'partitioning/metis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/metis_partitioner_test.C
+
+partitioning/unit_tests_prof-metis_partitioner_test.obj: partitioning/metis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-metis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-metis_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-metis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-metis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/metis_partitioner_test.C' object='partitioning/unit_tests_prof-metis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-metis_partitioner_test.obj `if test -f 'partitioning/metis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/metis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/metis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_prof-morton_sfc_partitioner_test.o: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-morton_sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_prof-morton_sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-morton_sfc_partitioner_test.o `test -f 'partitioning/morton_sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/morton_sfc_partitioner_test.C
+
+partitioning/unit_tests_prof-morton_sfc_partitioner_test.obj: partitioning/morton_sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-morton_sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-morton_sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-morton_sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-morton_sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/morton_sfc_partitioner_test.C' object='partitioning/unit_tests_prof-morton_sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-morton_sfc_partitioner_test.obj `if test -f 'partitioning/morton_sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/morton_sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/morton_sfc_partitioner_test.C'; fi`
+
+partitioning/unit_tests_prof-parmetis_partitioner_test.o: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-parmetis_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_prof-parmetis_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-parmetis_partitioner_test.o `test -f 'partitioning/parmetis_partitioner_test.C' || echo '$(srcdir)/'`partitioning/parmetis_partitioner_test.C
+
+partitioning/unit_tests_prof-parmetis_partitioner_test.obj: partitioning/parmetis_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-parmetis_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-parmetis_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-parmetis_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-parmetis_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/parmetis_partitioner_test.C' object='partitioning/unit_tests_prof-parmetis_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-parmetis_partitioner_test.obj `if test -f 'partitioning/parmetis_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/parmetis_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/parmetis_partitioner_test.C'; fi`
+
+partitioning/unit_tests_prof-sfc_partitioner_test.o: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-sfc_partitioner_test.o -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_prof-sfc_partitioner_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-sfc_partitioner_test.o `test -f 'partitioning/sfc_partitioner_test.C' || echo '$(srcdir)/'`partitioning/sfc_partitioner_test.C
+
+partitioning/unit_tests_prof-sfc_partitioner_test.obj: partitioning/sfc_partitioner_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT partitioning/unit_tests_prof-sfc_partitioner_test.obj -MD -MP -MF partitioning/$(DEPDIR)/unit_tests_prof-sfc_partitioner_test.Tpo -c -o partitioning/unit_tests_prof-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) partitioning/$(DEPDIR)/unit_tests_prof-sfc_partitioner_test.Tpo partitioning/$(DEPDIR)/unit_tests_prof-sfc_partitioner_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='partitioning/sfc_partitioner_test.C' object='partitioning/unit_tests_prof-sfc_partitioner_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o partitioning/unit_tests_prof-sfc_partitioner_test.obj `if test -f 'partitioning/sfc_partitioner_test.C'; then $(CYGPATH_W) 'partitioning/sfc_partitioner_test.C'; else $(CYGPATH_W) '$(srcdir)/partitioning/sfc_partitioner_test.C'; fi`
+
 quadrature/unit_tests_prof-quadrature_test.o: quadrature/quadrature_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT quadrature/unit_tests_prof-quadrature_test.o -MD -MP -MF quadrature/$(DEPDIR)/unit_tests_prof-quadrature_test.Tpo -c -o quadrature/unit_tests_prof-quadrature_test.o `test -f 'quadrature/quadrature_test.C' || echo '$(srcdir)/'`quadrature/quadrature_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) quadrature/$(DEPDIR)/unit_tests_prof-quadrature_test.Tpo quadrature/$(DEPDIR)/unit_tests_prof-quadrature_test.Po
@@ -6515,6 +7235,8 @@ distclean-generic:
 	-rm -f numerics/$(am__dirstamp)
 	-rm -f parallel/$(DEPDIR)/$(am__dirstamp)
 	-rm -f parallel/$(am__dirstamp)
+	-rm -f partitioning/$(DEPDIR)/$(am__dirstamp)
+	-rm -f partitioning/$(am__dirstamp)
 	-rm -f quadrature/$(DEPDIR)/$(am__dirstamp)
 	-rm -f quadrature/$(am__dirstamp)
 	-rm -f solvers/$(DEPDIR)/$(am__dirstamp)
@@ -6533,7 +7255,7 @@ clean-am: clean-checkPROGRAMS clean-generic clean-libtool clean-local \
 	clean-noinstPROGRAMS mostlyclean-am
 
 distclean: distclean-am
-	-rm -rf ./$(DEPDIR) base/$(DEPDIR) fe/$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) solvers/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) base/$(DEPDIR) fe/$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) partitioning/$(DEPDIR) quadrature/$(DEPDIR) solvers/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -6579,7 +7301,7 @@ install-ps-am:
 installcheck-am:
 
 maintainer-clean: maintainer-clean-am
-	-rm -rf ./$(DEPDIR) base/$(DEPDIR) fe/$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) quadrature/$(DEPDIR) solvers/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
+	-rm -rf ./$(DEPDIR) base/$(DEPDIR) fe/$(DEPDIR) fparser/$(DEPDIR) geom/$(DEPDIR) mesh/$(DEPDIR) numerics/$(DEPDIR) parallel/$(DEPDIR) partitioning/$(DEPDIR) quadrature/$(DEPDIR) solvers/$(DEPDIR) systems/$(DEPDIR) utils/$(DEPDIR)
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/tests/partitioning/centroid_partitioner_test.C
+++ b/tests/partitioning/centroid_partitioner_test.C
@@ -1,0 +1,6 @@
+
+#include "partitioner_test.h"
+
+#include <libmesh/centroid_partitioner.h>
+
+INSTANTIATE_PARTITIONER_TEST(CentroidPartitioner,ReplicatedMesh);

--- a/tests/partitioning/hilbert_sfc_partitioner_test.C
+++ b/tests/partitioning/hilbert_sfc_partitioner_test.C
@@ -1,0 +1,8 @@
+
+#include "partitioner_test.h"
+
+// If we don't have SFC this should fall back on Linear so we'll test
+// heedless of configuration
+#include <libmesh/hilbert_sfc_partitioner.h>
+
+INSTANTIATE_PARTITIONER_TEST(HilbertSFCPartitioner,ReplicatedMesh);

--- a/tests/partitioning/linear_partitioner_test.C
+++ b/tests/partitioning/linear_partitioner_test.C
@@ -1,0 +1,6 @@
+
+#include "partitioner_test.h"
+
+#include <libmesh/linear_partitioner.h>
+
+INSTANTIATE_PARTITIONER_TEST(LinearPartitioner,ReplicatedMesh);

--- a/tests/partitioning/metis_partitioner_test.C
+++ b/tests/partitioning/metis_partitioner_test.C
@@ -1,0 +1,8 @@
+
+#include "partitioner_test.h"
+
+// If we don't have METIS this should fall back on SFC or Linear so
+// we'll test heedless of configuration
+#include <libmesh/metis_partitioner.h>
+
+INSTANTIATE_PARTITIONER_TEST(MetisPartitioner,ReplicatedMesh);

--- a/tests/partitioning/morton_sfc_partitioner_test.C
+++ b/tests/partitioning/morton_sfc_partitioner_test.C
@@ -1,0 +1,8 @@
+
+#include "partitioner_test.h"
+
+// If we don't have SFC this should fall back on Linear so we'll test
+// heedless of configuration
+#include <libmesh/morton_sfc_partitioner.h>
+
+INSTANTIATE_PARTITIONER_TEST(MortonSFCPartitioner,ReplicatedMesh);

--- a/tests/partitioning/parmetis_partitioner_test.C
+++ b/tests/partitioning/parmetis_partitioner_test.C
@@ -1,0 +1,9 @@
+
+#include "partitioner_test.h"
+
+// If we don't have ParMETIS this should fall back on Metis or SFC or
+// Linear so we'll test heedless of configuration
+#include <libmesh/parmetis_partitioner.h>
+
+INSTANTIATE_PARTITIONER_TEST(ParmetisPartitioner,ReplicatedMesh);
+INSTANTIATE_PARTITIONER_TEST(ParmetisPartitioner,DistributedMesh);

--- a/tests/partitioning/partitioner_test.h
+++ b/tests/partitioning/partitioner_test.h
@@ -1,0 +1,121 @@
+#ifndef __fe_test_h__
+#define __fe_test_h__
+
+#include "test_comm.h"
+
+#include <libmesh/distributed_mesh.h>
+#include <libmesh/elem.h>
+#include <libmesh/partitioner.h>
+#include <libmesh/replicated_mesh.h>
+#include <libmesh/mesh_generation.h>
+
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#define PARTITIONERTEST                         \
+  CPPUNIT_TEST( testPartitionEmpty );           \
+  CPPUNIT_TEST( testPartition1 );               \
+  CPPUNIT_TEST( testPartition2 );               \
+  CPPUNIT_TEST( testPartitionNProc );           \
+
+using namespace libMesh;
+
+template <typename PartitionerSubclass, typename MeshClass>
+class PartitionerTest : public CppUnit::TestCase {
+public:
+  void setUp()
+  {}
+
+  void tearDown()
+  {}
+
+  void testPartition(processor_id_type n_parts)
+  {
+    MeshClass mesh(*TestCommWorld);
+
+    MeshTools::Generation::build_cube (mesh,
+                                       3, 3, 3,
+                                       0., 1., 0., 1., 0., 1.,
+                                       HEX8);
+
+    // FIXME: Splitting meshes into more than n_proc parts currently
+    // requires us to start with a mesh entirely assigned to proc 0
+    PartitionerSubclass newpart;
+    newpart.partition(mesh, 1);
+
+    for (auto elem : mesh.element_ptr_range())
+      CPPUNIT_ASSERT_EQUAL(elem->processor_id(), processor_id_type(0));
+
+    for (auto node : mesh.node_ptr_range())
+      CPPUNIT_ASSERT_EQUAL(node->processor_id(), processor_id_type(0));
+
+    // But then we can manually partition, into at most many parts as
+    // were requested.
+    newpart.partition(mesh, n_parts);
+
+    // And we expect the partitioner not to suck - every processor
+    // rank (up to n_elem()) ought to have at least one element on it.
+    const processor_id_type n_nonempty =
+      std::min(n_parts, processor_id_type(3*3*3));
+
+    // Let's make sure we can see them all even on a DistributedMesh
+    mesh.allgather();
+
+    for (processor_id_type p=0; p != n_nonempty; ++p)
+      {
+        const std::size_t n_elem_on_p =
+          std::distance(mesh.pid_elements_begin(p),
+                        mesh.pid_elements_end(p));
+        CPPUNIT_ASSERT(n_elem_on_p);
+      }
+  }
+
+  void testPartitionEmpty()
+  {
+    MeshClass mesh(*TestCommWorld);
+    PartitionerSubclass newpart;
+
+    // With a 0 element mesh this should just give us 0 subpartitions
+    // regardless of n_procs
+    newpart.partition(mesh, TestCommWorld->size());
+  }
+
+  void testPartition1()
+  {
+    this->testPartition(1);
+  }
+
+  void testPartition2()
+  {
+    this->testPartition(2);
+  }
+
+  void testPartitionNProc()
+  {
+    this->testPartition(TestCommWorld->size());
+  }
+};
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We'll put an
+// ignore_warnings at the end of this file so it's the last warnings
+// related header that our including code sees.
+#include <libmesh/ignore_warnings.h>
+
+#define INSTANTIATE_PARTITIONER_TEST(partitionersubclass, meshclass)        \
+  class PartitionerTest_##partitionersubclass##_##meshclass :               \
+    public PartitionerTest<partitionersubclass, meshclass> {                \
+  public:                                                                   \
+  CPPUNIT_TEST_SUITE( PartitionerTest_##partitionersubclass##_##meshclass); \
+  PARTITIONERTEST                                                           \
+  CPPUNIT_TEST_SUITE_END();                                                 \
+  };                                                                        \
+                                                                            \
+  CPPUNIT_TEST_SUITE_REGISTRATION( PartitionerTest_##partitionersubclass##_##meshclass );
+
+#endif // #ifdef __fe_test_h__

--- a/tests/partitioning/sfc_partitioner_test.C
+++ b/tests/partitioning/sfc_partitioner_test.C
@@ -1,0 +1,8 @@
+
+#include "partitioner_test.h"
+
+// If we don't have SFC this should fall back on Linear so we'll test
+// heedless of configuration
+#include <libmesh/sfc_partitioner.h>
+
+INSTANTIATE_PARTITIONER_TEST(SFCPartitioner,ReplicatedMesh);


### PR DESCRIPTION
IIRC we have an open ticket for "METIS sucks", but I didn't realize how bad it was until I was futzing around to fix #1905.  What kind of partitioners can't figure out how to put 27 elements into even 14 nonempty groups?  Is there something wrong with our shims??

Anyway, this PR fixes a couple easier minor bugs, and adds unit tests for at least the level of capability that we *can* expect.