### PR TITLE
Add BoundingBox::signed_distance().

### DIFF
--- a/include/geom/bounding_box.h
+++ b/include/geom/bounding_box.h
@@ -58,7 +58,7 @@ public:
     this->invalidate();
   }
 
-  /*
+  /**
    * Sets the bounding box to encompass the universe.
    */
   void invalidate ()
@@ -70,7 +70,7 @@ public:
       }
   }
 
-  /*
+  /**
    * \returns A point at the minimum x,y,z coordinates of the box.
    */
   const Point & min() const
@@ -79,7 +79,7 @@ public:
   Point & min()
   { return this->first; }
 
-  /*
+  /**
    * \returns A point at the maximum x,y,z coordinates of the box.
    */
   const Point & max() const
@@ -88,14 +88,14 @@ public:
   Point & max()
   { return this->second; }
 
-  /*
+  /**
    * \returns \p true if the other bounding box has a non-empty
    * intersection with this bounding box. Exact floating point <=
    * comparisons are performed.
    */
   bool intersects (const BoundingBox &) const;
 
-  /*
+  /**
    * \returns \p true if the other bounding box has a non-empty
    * intersection with this bounding box. abstol is an absolute
    * tolerance used to make "fuzzy" comparisons. abstol must be
@@ -122,29 +122,35 @@ public:
   { libmesh_deprecated(); return this->intersects(b); }
 #endif
 
-  /*
+  /**
    * \returns \p true if the bounding box contains the given point.
    */
   bool contains_point (const Point &) const;
 
-  /*
+  /**
    * Sets this bounding box to be the intersection with the other
    * bounding box.
    */
   void intersect_with (const BoundingBox &);
 
-  /*
+  /**
    * Enlarges this bounding box to include the given point
    */
   void union_with (const Point & p);
 
-  /*
+  /**
    * Sets this bounding box to be the union with the other
    * bounding box.
    */
   void union_with (const BoundingBox &);
 
-private:
+  /**
+   * Computes the signed distance, d, from a given Point p to this
+   * BoundingBox.  The sign convention is:
+   * d > 0 if the point is outside the BoundingBox
+   * d <= 0 if the point is inside the Bounding Box
+   */
+  Real signed_distance(const Point & p) const;
 };
 
 

--- a/src/geom/bounding_box.C
+++ b/src/geom/bounding_box.C
@@ -204,11 +204,15 @@ Real BoundingBox::signed_distance(const Point & p) const
       // Sign convention: if Point is inside the bbox, the distance is
       // negative. We then find the smallest distance to the different
       // sides of the box and return that.
-      std::array<Real, 6> dists = {std::abs(p(0) - second(0)), std::abs(p(0) - first(0)),
-                                   std::abs(p(1) - second(1)), std::abs(p(1) - first(1)),
-                                   std::abs(p(2) - second(2)), std::abs(p(2) - first(2))};
+      Real min_dist = std::numeric_limits<Real>::max();
 
-      return -1. * (*std::min_element(dists.begin(), dists.end()));
+      for (unsigned int dir=0; dir<LIBMESH_DIM; ++dir)
+        {
+          min_dist = std::min(min_dist, std::abs(p(dir) - second(dir)));
+          min_dist = std::min(min_dist, std::abs(p(dir) - first(dir)));
+        }
+
+      return -min_dist;
     }
   else // p is outside the box
     {

--- a/tests/geom/bbox_test.C
+++ b/tests/geom/bbox_test.C
@@ -26,6 +26,7 @@ public:
   CPPUNIT_TEST( test_one_degenerate );
   CPPUNIT_TEST( test_two_degenerate );
   CPPUNIT_TEST( test_no_degenerate );
+  CPPUNIT_TEST( test_signed_distance );
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -220,6 +221,36 @@ public:
         std::rotate(mins.rbegin(), mins.rbegin()+1, mins.rend());
         std::rotate(maxs.rbegin(), maxs.rbegin()+1, maxs.rend());
       }
+  }
+
+  void test_signed_distance()
+  {
+    // Simple tests which we can compare with known values.
+    BoundingBox unit(Point(0.,0.,0.), Point(1.,1.,1.));
+
+    // Test points inside the box
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(0.5, 0.5, 0.5)), -0.5, TOLERANCE * TOLERANCE);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(0.5, 0.6, 0.5)), -0.4, TOLERANCE * TOLERANCE);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(0.4, 0.5, 0.5)), -0.4, TOLERANCE * TOLERANCE);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(0.1, 0.1, 0.1)), -0.1, TOLERANCE * TOLERANCE);
+
+    // Test points on the box
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(1.0, 0.5, 0.5)), 0., TOLERANCE * TOLERANCE);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(1.0, 0., 0.)), 0., TOLERANCE * TOLERANCE);
+
+    // Test points outside the box
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(1.5, 0.5, 0.5)), 0.5, TOLERANCE * TOLERANCE);  // right
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(-0.5, 0.5, 0.5)), 0.5, TOLERANCE * TOLERANCE); // left
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(0.5, 0.5, 1.5)), 0.5, TOLERANCE * TOLERANCE);  // above
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(0.5, 0.5, -0.5)), 0.5, TOLERANCE * TOLERANCE); // below
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(0.5, -0.5, 0.5)), 0.5, TOLERANCE * TOLERANCE); // front
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(0.5, 1.5, 0.5)), 0.5, TOLERANCE * TOLERANCE);  // back
+
+    // Outside the box, closest to a corner.
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(2., 2., 2.)), std::sqrt(3.), TOLERANCE * TOLERANCE);    // Point along line (0,0,0) -> (1,1,1)
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(-1., -1., -1.)), std::sqrt(3.), TOLERANCE * TOLERANCE); // Point along line (0,0,0) -> (1,1,1)
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(1.5, 1.5, -0.5)), std::sqrt(3.)/2., TOLERANCE * TOLERANCE); // Point along line (0.5,0.5,0.5) -> (1,1,0)
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(1.5, -0.5, -0.5)), std::sqrt(3.)/2., TOLERANCE * TOLERANCE); // Point along line (0.5,0.5,0.5) -> (1,0,0)
   }
 };
 

--- a/tests/geom/bbox_test.C
+++ b/tests/geom/bbox_test.C
@@ -225,7 +225,10 @@ public:
 
   void test_signed_distance()
   {
-    // Simple tests which we can compare with known values.
+    // If libMesh is compiled with LIBMESH_DIM!=3, this code should
+    // still compile but all the distances will be different.
+#if LIBMESH_DIM == 3
+    // A "unit" size bounding box for making distance comparisons.
     BoundingBox unit(Point(0.,0.,0.), Point(1.,1.,1.));
 
     // Test points inside the box
@@ -251,6 +254,7 @@ public:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(-1., -1., -1.)), std::sqrt(3.), TOLERANCE * TOLERANCE); // Point along line (0,0,0) -> (1,1,1)
     CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(1.5, 1.5, -0.5)), std::sqrt(3.)/2., TOLERANCE * TOLERANCE); // Point along line (0.5,0.5,0.5) -> (1,1,0)
     CPPUNIT_ASSERT_DOUBLES_EQUAL(unit.signed_distance(Point(1.5, -0.5, -0.5)), std::sqrt(3.)/2., TOLERANCE * TOLERANCE); // Point along line (0.5,0.5,0.5) -> (1,0,0)
+#endif
   }
 };
 


### PR DESCRIPTION
Sign convention:
1. If Point p is inside the BoundingBox B: d(p, B) < 0
1. If Point p is outside the BoundingBox B: d(p, B) > 0
1. If Point p is on the BoundingBox B: d(p, B) = 0

@roystgnr let me know if you think the formulas/approach seem reasonable. We talked about the "point outside" case; the "point inside" case also seems pretty straightforward. Also adds some simple unit tests.