### PR TITLE
Homepage: mention Github issues and pull requests

### DIFF
--- a/doc/html/src/index.html
+++ b/doc/html/src/index.html
@@ -37,7 +37,16 @@ Computational Frameworks Group</a> at
 and <a href="http://augustine.mit.edu">MIT</a>.
 The <code>libMesh</code> <a href="http://libmesh.github.io/developers.html">developers</a> welcome contributions
 in the form of patches and bug reports (preferably with a minimal test case that reliably reproduces the error)
-to the official <a href="http://sourceforge.net/mail/?group_id=71130">mailing lists</a>.
+to the official
+<a href="http://sourceforge.net/mail/?group_id=71130">mailing
+lists</a>, or via
+<a href="https://github.com/libMesh/libmesh/issues">Github issues</a>
+and <a href="https://github.com/libMesh/libmesh/pulls">pull
+requests</a>.
+
+
+<br>
+<br>
 Many thanks to <a href="http://github.com">GitHub</a> for
 <a href="http://github.com/libMesh">hosting the
 project</a>.  You can find out what is currently happening in the


### PR DESCRIPTION
The Github tracker system is both more accessible to users and more
convenient to developers than the old mailing lists, so we shouldn't
only be recommending the latter.