### PR TITLE
Assert that PetscVector is closed before calling _get_array().

### DIFF
--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -1345,6 +1345,7 @@ template <typename T>
 void PetscVector<T>::_get_array(bool read_only) const
 {
   libmesh_assert (this->initialized());
+  libmesh_assert (this->closed());
 
 #ifdef LIBMESH_HAVE_CXX11_THREAD
   std::atomic_thread_fence(std::memory_order_acquire);


### PR DESCRIPTION
@fdkong ran into an issue with this recently that was fixed by
ensuring the vector was closed before trying to get values from it,
but it originally looked like some kind of threading issue even in
debug mode. This assert should let us figure out the same problem
faster in the future.