### PR TITLE
Laspack fixes

### DIFF
--- a/contrib/laspack/matrix.C
+++ b/contrib/laspack/matrix.C
@@ -118,7 +118,7 @@ void M_SetName(Matrix *M, const char *Name)
     }
 }
 
-const char *M_GetName(Matrix *M)
+const char *M_GetName(const Matrix *M)
 /* returns the name of the matrix M */
 {
     if (LASResult() == LASOK)
@@ -127,7 +127,7 @@ const char *M_GetName(Matrix *M)
         return("");
 }
 
-size_t M_GetRowDim(Matrix *M)
+size_t M_GetRowDim(const Matrix *M)
 /* returns the row dimension of the matrix M */
 {
     size_t Dim;
@@ -139,7 +139,7 @@ size_t M_GetRowDim(Matrix *M)
     return(Dim);
 }
 
-size_t M_GetClmDim(Matrix *M)
+size_t M_GetClmDim(const Matrix *M)
 /* returns the column dimension of the matrix M */
 {
     size_t Dim;
@@ -151,7 +151,7 @@ size_t M_GetClmDim(Matrix *M)
     return(Dim);
 }
 
-ElOrderType M_GetElOrder(Matrix *M)
+ElOrderType M_GetElOrder(const Matrix *M)
 /* returns the element order */
 {
     ElOrderType ElOrder;
@@ -207,7 +207,7 @@ void M_SetLen(Matrix *M, size_t RoC, size_t Len)
     }
 }
 
-size_t M_GetLen(Matrix *M, size_t RoC)
+size_t M_GetLen(const Matrix *M, size_t RoC)
 /* returns the length of a row or column of the matrix M */
 {
     size_t Len;
@@ -241,7 +241,7 @@ void M_SetEntry(Matrix *M, size_t RoC, size_t Entry, size_t Pos, _LPNumber Val)
     }
 }
 
-size_t M_GetPos(Matrix *M, size_t RoC, size_t Entry)
+size_t M_GetPos(const Matrix *M, size_t RoC, size_t Entry)
 /* returns the position of a matrix entry */
 {
     size_t Pos;

--- a/contrib/laspack/matrix.h
+++ b/contrib/laspack/matrix.h
@@ -46,15 +46,15 @@ void M_Constr(Matrix *M, const char *Name, size_t RowDim, size_t ClmDim,
               ElOrderType ElOrder, InstanceType Instance, _LPBoolean OwnData);
 void M_Destr(Matrix *M);
 void M_SetName(Matrix *M, const char *Name);
-const char *M_GetName(Matrix *M);
-size_t M_GetRowDim(Matrix *M);
-size_t M_GetClmDim(Matrix *M);
-ElOrderType M_GetElOrder(Matrix *M);
+const char *M_GetName(const Matrix *M);
+size_t M_GetRowDim(const Matrix *M);
+size_t M_GetClmDim(const Matrix *M);
+ElOrderType M_GetElOrder(const Matrix *M);
 void M_SetLen(Matrix *M, size_t RoC, size_t Len);
-size_t M_GetLen(Matrix *M, size_t RoC);
+size_t M_GetLen(const Matrix *M, size_t RoC);
 void M_SetEntry(Matrix *M, size_t RoC, size_t Entry, size_t Pos, _LPNumber Val);
-size_t M_GetPos(Matrix *M, size_t RoC, size_t Entry);
-_LPNumber M_GetVal(Matrix *M, size_t RoC, size_t Entry);
+size_t M_GetPos(const Matrix *M, size_t RoC, size_t Entry);
+_LPNumber M_GetVal(const Matrix *M, size_t RoC, size_t Entry);
 void M_AddVal(Matrix *M, size_t RoC, size_t Entry, _LPNumber Val);
 
 /* macros for fast access */

--- a/contrib/laspack/qmatrix.C
+++ b/contrib/laspack/qmatrix.C
@@ -177,7 +177,7 @@ void Q_SetName(QMatrix *Q, const char *Name)
     }
 }
 
-const char *Q_GetName(QMatrix *Q)
+const char *Q_GetName(const QMatrix *Q)
 /* returns the name of the matrix Q */
 {
     if (LASResult() == LASOK)
@@ -186,7 +186,7 @@ const char *Q_GetName(QMatrix *Q)
         return("");
 }
 
-size_t Q_GetDim(QMatrix *Q)
+size_t Q_GetDim(const QMatrix *Q)
 /* returns the dimension of the matrix Q */
 {
     size_t Dim;
@@ -198,7 +198,7 @@ size_t Q_GetDim(QMatrix *Q)
     return(Dim);
 }
 
-_LPBoolean Q_GetSymmetry(QMatrix *Q)
+_LPBoolean Q_GetSymmetry(const QMatrix *Q)
 /* returns _LPTrue if Q is symmetric otherwise _LPFalse */
 {
     _LPBoolean Symmetry;
@@ -211,7 +211,7 @@ _LPBoolean Q_GetSymmetry(QMatrix *Q)
     return(Symmetry);
 }
 
-ElOrderType Q_GetElOrder(QMatrix *Q)
+ElOrderType Q_GetElOrder(const QMatrix *Q)
 /* returns element order of the matrix Q */
 {
     ElOrderType ElOrder;
@@ -265,7 +265,7 @@ void Q_SetLen(QMatrix *Q, size_t RoC, size_t Len)
     }
 }
 
-size_t Q_GetLen(QMatrix *Q, size_t RoC)
+size_t Q_GetLen(const QMatrix *Q, size_t RoC)
 /* returns the lenght of a row or column of the matrix Q */
 {
     size_t Len;
@@ -297,7 +297,7 @@ void Q_SetEntry(QMatrix *Q, size_t RoC, size_t Entry, size_t Pos, _LPNumber Val)
     }
 }
 
-size_t Q_GetPos(QMatrix *Q, size_t RoC, size_t Entry)
+size_t Q_GetPos(const QMatrix *Q, size_t RoC, size_t Entry)
 /* returns the position of a matrix element */
 {
     size_t Pos;
@@ -314,7 +314,7 @@ size_t Q_GetPos(QMatrix *Q, size_t RoC, size_t Entry)
     return(Pos);
 }
 
-_LPNumber Q_GetVal(QMatrix *Q, size_t RoC, size_t Entry)
+_LPNumber Q_GetVal(const QMatrix *Q, size_t RoC, size_t Entry)
 /* returns the value of a matrix element */
 {
     _LPNumber Val;

--- a/contrib/laspack/qmatrix.h
+++ b/contrib/laspack/qmatrix.h
@@ -60,15 +60,15 @@ void Q_Constr(QMatrix *Q, const char *Name, size_t Dim, _LPBoolean Symmetry,
               ElOrderType ElOrder, InstanceType Instance, _LPBoolean OwnData);
 void Q_Destr(QMatrix *Q);
 void Q_SetName(QMatrix *Q, const char *Name);
-const char *Q_GetName(QMatrix *Q);
-size_t Q_GetDim(QMatrix *Q);
-_LPBoolean Q_GetSymmetry(QMatrix *Q);
-ElOrderType Q_GetElOrder(QMatrix *Q);
+const char *Q_GetName(const QMatrix *Q);
+size_t Q_GetDim(const QMatrix *Q);
+_LPBoolean Q_GetSymmetry(const QMatrix *Q);
+ElOrderType Q_GetElOrder(const QMatrix *Q);
 void Q_SetLen(QMatrix *Q, size_t RoC, size_t Len);
-size_t Q_GetLen(QMatrix *Q, size_t RoC);
+size_t Q_GetLen(const QMatrix *Q, size_t RoC);
 void Q_SetEntry(QMatrix *Q, size_t RoC, size_t Entry, size_t Pos, _LPNumber Val);
-size_t Q_GetPos(QMatrix *Q, size_t RoC, size_t Entry);
-_LPNumber Q_GetVal(QMatrix *Q, size_t RoC, size_t Entry);
+size_t Q_GetPos(const QMatrix *Q, size_t RoC, size_t Entry);
+_LPNumber Q_GetVal(const QMatrix *Q, size_t RoC, size_t Entry);
 void Q_AddVal(QMatrix *Q, size_t RoC, size_t Entry, _LPNumber Val);
 
 /* macros for fast access */

--- a/contrib/laspack/qvector.C
+++ b/contrib/laspack/qvector.C
@@ -75,7 +75,7 @@ void V_SetName(QVector *V, const char *Name)
     }
 }
 
-const char *V_GetName(QVector *V)
+const char *V_GetName(const QVector *V)
 /* returns the name of the vector V */
 {
     if (LASResult() == LASOK)
@@ -84,7 +84,7 @@ const char *V_GetName(QVector *V)
         return("");
 }
 
-size_t V_GetDim(QVector *V)
+size_t V_GetDim(const QVector *V)
 /* returns dimension of the vector V */
 {
     size_t Dim;

--- a/contrib/laspack/qvector.h
+++ b/contrib/laspack/qvector.h
@@ -42,8 +42,8 @@ void V_Constr(QVector *V, const char *Name, size_t Dim, InstanceType Instance,
 	      _LPBoolean OwnData);
 void V_Destr(QVector *V);
 void V_SetName(QVector *V, const char *Name);
-const char *V_GetName(QVector *V);
-size_t V_GetDim(QVector *V);
+const char *V_GetName(const QVector *V);
+size_t V_GetDim(const QVector *V);
 void V_SetCmp(QVector *V, size_t Ind, _LPNumber Val);
 void V_SetAllCmp(QVector *V, _LPNumber Val);
 void V_SetRndCmp(QVector *V);

--- a/include/numerics/laspack_matrix.h
+++ b/include/numerics/laspack_matrix.h
@@ -107,7 +107,7 @@ public:
 
   virtual void zero () override;
 
-  virtual void close () override { this->_closed = true; }
+  virtual void close () override;
 
   virtual numeric_index_type m () const override;
 

--- a/src/numerics/laspack_matrix.C
+++ b/src/numerics/laspack_matrix.C
@@ -289,6 +289,8 @@ void LaspackMatrix<T>::zero ()
           Q_SetEntry (&_QMat, row+1, l, j+1, 0.);
         }
     }
+
+  this->close();
 }
 
 
@@ -466,6 +468,26 @@ numeric_index_type LaspackMatrix<T>::pos (const numeric_index_type i,
 
   // Return the position in the compressed row
   return std::distance (_row_start[i], p.first);
+}
+
+
+
+template <typename T>
+void LaspackMatrix<T>::close()
+{
+  libmesh_assert(this->initialized());
+
+  this->_closed = true;
+
+  // We've probably changed some entries so we need to tell LASPACK
+  // that cached data is now invalid.
+  *_QMat.DiagElAlloc = _LPFalse;
+  *_QMat.ElSorted = _LPFalse;
+  if (*_QMat.ILUExists)
+    {
+      *_QMat.ILUExists = _LPFalse;
+      Q_Destr(_QMat.ILU);
+    }
 }
 
 

--- a/src/numerics/laspack_matrix.C
+++ b/src/numerics/laspack_matrix.C
@@ -386,13 +386,8 @@ void LaspackMatrix<T>::add (const T a_in, const SparseMatrix<T> & X_in)
   libmesh_assert_equal_to (this->m(), X_in.m());
   libmesh_assert_equal_to (this->n(), X_in.n());
 
-  const LaspackMatrix<T> * const_X =
+  const LaspackMatrix<T> * X =
     cast_ptr<const LaspackMatrix<T> *> (&X_in);
-
-  // The Laspack APIs expect non-const pointers; I don't think
-  // X_in should actually be changed by any of the code below.
-  LaspackMatrix<T> * X =
-    const_cast<LaspackMatrix<T> *>(const_X);
 
   _LPNumber a = static_cast<_LPNumber> (a_in);
 

--- a/tests/solvers/time_solver_test_common.h
+++ b/tests/solvers/time_solver_test_common.h
@@ -1,5 +1,8 @@
 #include <libmesh/dof_map.h>
 #include <libmesh/fem_system.h>
+#include <libmesh/newton_solver.h>
+#include <libmesh/enum_solver_type.h>
+#include <libmesh/enum_preconditioner_type.h>
 
 using namespace libMesh;
 
@@ -30,6 +33,13 @@ protected:
     solver.relative_step_tolerance = std::numeric_limits<Real>::epsilon()*10;
     solver.relative_residual_tolerance = std::numeric_limits<Real>::epsilon()*10;
     solver.absolute_residual_tolerance = std::numeric_limits<Real>::epsilon()*10;
+
+    NewtonSolver & newton = cast_ref<NewtonSolver &>(solver);
+
+    // LASPACK GMRES + ILU defaults don't like these problems, so
+    // we'll use a sophisticated "just divide the scalars" solver instead.
+    newton.get_linear_solver().set_solver_type(JACOBI);
+    newton.get_linear_solver().set_preconditioner_type(IDENTITY_PRECOND);
 
     system.deltat = deltat;
 

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -20,8 +20,11 @@
 #include <libmesh/linear_implicit_system.h>
 #include <libmesh/quadrature_gauss.h>
 #include <libmesh/node_elem.h>
-#include "libmesh/edge_edge2.h"
-#include "libmesh/dg_fem_context.h"
+#include <libmesh/edge_edge2.h>
+#include <libmesh/dg_fem_context.h>
+#include <libmesh/enum_solver_type.h>
+#include <libmesh/enum_preconditioner_type.h>
+#include <libmesh/linear_solver.h>
 
 #include "test_comm.h"
 
@@ -707,7 +710,7 @@ public:
 
     // Create an equation systems object.
     EquationSystems equation_systems (mesh);
-    ExplicitSystem& system =
+    LinearImplicitSystem & system =
       equation_systems.add_system<LinearImplicitSystem> ("test");
 
     system.add_variable ("u", libMesh::FIRST);
@@ -724,6 +727,11 @@ public:
 
     AugmentSparsityOnNodes augment_sparsity(mesh);
     system.get_dof_map().add_coupling_functor(augment_sparsity);
+
+    // LASPACK GMRES + ILU defaults don't like this problem, but it's
+    // small enough to just use a simpler iteration.
+    system.get_linear_solver()->set_solver_type(JACOBI);
+    system.get_linear_solver()->set_preconditioner_type(IDENTITY_PRECOND);
 
     equation_systems.init ();
 


### PR DESCRIPTION
It seems to be my year for finding and fixing ancient libMesh bugs.

I got started by trying to fix #1916, but upon testing that fix, found that many of our unit tests' solves were failing to converge.  Ridiculously simple solves, with 1x1 Jacobian matrices, were failing to converge.  Switching from GMRES+ILU to Jacobi fixed a bit of that, but Newmark was *still* failing to converge!

It turns out that, when Laspack does a solve, it attaches internal caches to its matrices for frequently used data - inverses of diagonal values, ILU decompositions, etc.  And when we change the values in a LaspackMatrix to reuse it in a later solve (e.g. the per-timestep solve vs the initial acceleration solve in a Newmark time iteration), the caches were left untouched, still marked valid!

This PR fixes all those bugs, at least.  Some of those unit tests which now pass (using Jacobi iteration) still fail if left using GMRES+ILU, though, so there must be something I'm still missing, but I've used enough time on this last-ditch-fallback solver package already.