### PR TITLE
infinite improvements

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -837,6 +837,7 @@ public:
   /**
    * Explicitly call base class method.  This prevents some
    * compilers being confused by partially overriding this virtual function.
+   * \note: pts need to be in reference space coordinates, not physical ones.
    */
   virtual void reinit (const Elem * elem,
                        const std::vector<Point> * const pts = nullptr,

--- a/include/fe/fe_compute_data.h
+++ b/include/fe/fe_compute_data.h
@@ -79,21 +79,17 @@ public:
   std::vector<Number> shape;
 
 
-#if defined(LIBMESH_ENABLE_INFINITE_ELEMENTS) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   /**
    * Storage for the computed phase lag
    */
   Real phase;
-#endif
 
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   /**
    * The wave speed.
    */
   Real speed;
-#endif
 
-#if defined LIBMESH_ENABLE_INFINITE_ELEMENTS && defined(LIBMESH_USE_COMPLEX_NUMBERS)
   /**
    * The frequency to evaluate shape functions
    * including the wave number depending terms.

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -399,6 +399,7 @@ public:
    * new element in the mesh.  Reinitializes all the physical
    * element-dependent data based on the current element
    * \p elem.
+   * \note: pts need to be in reference space coordinates, not physical ones.
    */
   virtual void reinit (const Elem * elem,
                        const std::vector<Point> * const pts = nullptr,

--- a/src/fe/fe_compute_data.C
+++ b/src/fe/fe_compute_data.C
@@ -25,13 +25,8 @@ namespace libMesh
 void FEComputeData::clear ()
 {
   this->shape.clear();
-#if defined(LIBMESH_ENABLE_INFINITE_ELEMENTS) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   this->phase = 0.;
-  this->speed = 1.;
-#endif
-
-#if defined (LIBMESH_ENABLE_INFINITE_ELEMENTS) && defined(LIBMESH_USE_COMPLEX_NUMBERS)
-  //lets default speed and frequency to 1; 0 leads to troubles with the wavenumber.
   this->speed = 1.;
   this->frequency = 1.;
 
@@ -45,37 +40,32 @@ void FEComputeData::init ()
   if (!(this->shape.empty()))
     std::fill (this->shape.begin(),   this->shape.end(),   0.);
 
-#if defined(LIBMESH_ENABLE_INFINITE_ELEMENTS) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
-  this->phase = 0.;
-
-  if (equation_systems.parameters.have_parameter<Real>("speed"))
-    this->speed = this->equation_systems.parameters.get<Real>("speed");
-#endif
-
-#if defined (LIBMESH_ENABLE_INFINITE_ELEMENTS) && defined(LIBMESH_USE_COMPLEX_NUMBERS)
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (equation_systems.parameters.have_parameter<Real>("speed"))
     this->speed = this->equation_systems.parameters.get<Real>("speed");
 
-  if (equation_systems.parameters.have_parameter<Real>("current frequency"))
+  libmesh_assert_not_equal_to(this->speed, 0);
+
+  if (equation_systems.parameters.have_parameter<Number>("current frequency"))
+    this->frequency = this->equation_systems.parameters.get<Number>("current frequency");
+
+#if LIBMESH_USE_COMPLEX_NUMBERS
+  else if (equation_systems.parameters.have_parameter<Real>("current frequency"))
     {
       // please use the type Number instead.
       libmesh_deprecated();
       this->frequency = static_cast<Number> (this->equation_systems.parameters.get<Real>("current frequency"));
     }
-
-  else if (equation_systems.parameters.have_parameter<Number>("current frequency"))
-    this->frequency = this->equation_systems.parameters.get<Number>("current frequency");
-
 #endif
+
   // ensure that the wavenumber k=2. * libMesh::pi * this->frequency / this->speed
   // in src/fe/inf_fe_static.C: 310
   // is well-defined. 0 as well as NaN will lead to problems here.
-#if defined(LIBMESH_ENABLE_INFINITE_ELEMENTS) && defined(LIBMESH_USE_COMPLEX_NUMBERS)
   libmesh_assert_not_equal_to(this->frequency, 0.);
-#endif
-#if defined(LIBMESH_ENABLE_INFINITE_ELEMENTS)
-  libmesh_assert_not_equal_to(this->speed, 0);
-#endif
+
+  this->phase = 0.;
+
+#endif //LIBMESH_ENABLE_INFINITE_ELEMENTS
 
 }
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -73,6 +73,15 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
   // We're calculating now!
   this->determine_calculations();
 
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (elem->infinite())
+    {
+      //This mainly requires to change the FE<>-calls
+      // to FEInterface in this function.
+      libmesh_not_implemented();
+    }
+#endif
+
   // The number of quadrature points.
   const std::size_t n_qp = qp.size();
 

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -217,6 +217,9 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
       for (std::size_t p=0; p != pts->size(); ++p)
         {
           Real radius = (*pts)[p](Dim-1);
+          //IMHO this is a dangerous check:
+          // 1) it is not guaranteed that two points have numerically equal radii
+          // 2) if there several radii but not sorted/regular, this breaks
           if (radial_pts.size() && radial_pts[0](0) == radius)
             break;
           radial_pts.push_back(Point(radius));
@@ -226,6 +229,19 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
       // If we're a tensor product we should have no remainder
       libmesh_assert_equal_to
         (base_pts_size * radial_pts_size, pts->size());
+
+      if (pts->size() > 1)
+        {
+           // lets inform the user about our assumptions.
+           // If this warning appears very often, this should be taken as a reason
+           // for rewriting this.
+           libmesh_experimental();
+           libmesh_warning("We assume that the "<<pts->size()
+                           <<" points are of tensor-product type with "
+                           <<radial_pts_size<<" radial points and "
+                           <<base_pts_size<< " angular points.");
+        }
+
 
       std::vector<Point> base_pts;
       base_pts.reserve(base_pts_size);

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -2514,10 +2514,17 @@ std::string Elem::get_info () const
         oss << "nullptr\n";
     }
 
-  oss << "   hmin()=" << this->hmin()
-      << ", hmax()=" << this->hmax()                               << '\n'
-      << "   volume()=" << this->volume()                          << '\n'
-      << "   active()=" << this->active()
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+  if (!this->infinite())
+    {
+#endif
+    oss << "   hmin()=" << this->hmin()
+        << ", hmax()=" << this->hmax()                             << '\n'
+        << "   volume()=" << this->volume()                        << '\n';
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+    }
+#endif
+    oss << "   active()=" << this->active()
       << ", ancestor()=" << this->ancestor()
       << ", subactive()=" << this->subactive()
       << ", has_children()=" << this->has_children()               << '\n'


### PR DESCRIPTION
Dear all,
I'd like to suggest some changes related to infinite elements:
There are three main issues I try to address in this PR:

- [b86d346, 45478c0,  8b8556f ]: added some documentation and assertions where infinite elements cannot be assumed (I just ran into these cases and think it might be nice to inform the user) 

- [dac368c ]: Change in the infFE:inverse_map(): I realized that the implemented newton iteration fails for v=0 (2* the radius of the FEM-region).
  So I removed the iterative scheme completely, as it anyway was a fallback for the analytical case only, which I think might be not needed (the analytic expression is quite stable, I guess).
  Also, I removed the search within the base-element as it just resembled the inverse_map of the respective 2D-elements; now this function is called directly.

- [commit  d70c659 ] Finally, I think it is convenient to have both the frequency and the phase available when dealing with infinite elements; independent of the use of complex numbers; so I removed the respective clauses.

Best, 
Hubert