### PR TITLE
Fix Intel warnings

### DIFF
--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -51,37 +51,37 @@
 
 
 // Anonymous namespace for helper functions
-namespace {
-
-using namespace libMesh;
-
-struct SyncCoarsenInactive
-{
-  bool operator() (const Elem * elem) const {
-    // If we're not an ancestor, there's no chance our coarsening
-    // settings need to be changed.
-    if (!elem->ancestor())
-      return false;
-
-    // If we don't have any remote children, we already know enough to
-    // determine the correct refinement flag ourselves.
-    //
-    // If we know we have a child that isn't being coarsened, that
-    // also forces a specific flag.
-    //
-    // Either way there's nothing we need to communicate.
-    bool found_remote_child = false;
-    for (auto & child : elem->child_ref_range())
-      {
-        if (child.refinement_flag() != Elem::COARSEN)
-          return false;
-        if (&child == remote_elem)
-          found_remote_child = true;
-      }
-    return found_remote_child;
-  }
-};
-}
+// namespace {
+//
+// using namespace libMesh;
+//
+// struct SyncCoarsenInactive
+// {
+//   bool operator() (const Elem * elem) const {
+//     // If we're not an ancestor, there's no chance our coarsening
+//     // settings need to be changed.
+//     if (!elem->ancestor())
+//       return false;
+//
+//     // If we don't have any remote children, we already know enough to
+//     // determine the correct refinement flag ourselves.
+//     //
+//     // If we know we have a child that isn't being coarsened, that
+//     // also forces a specific flag.
+//     //
+//     // Either way there's nothing we need to communicate.
+//     bool found_remote_child = false;
+//     for (auto & child : elem->child_ref_range())
+//       {
+//         if (child.refinement_flag() != Elem::COARSEN)
+//           return false;
+//         if (&child == remote_elem)
+//           found_remote_child = true;
+//       }
+//     return found_remote_child;
+//   }
+// };
+// }
 
 
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -124,11 +124,7 @@ public:
       }
   }
 
-  const Point & min() const { return _bbox.min(); }
-
   Point & min() { return _bbox.min(); }
-
-  const Point & max() const { return _bbox.max(); }
 
   Point & max() { return _bbox.max(); }
 
@@ -140,11 +136,6 @@ public:
     _bbox.union_with(other._bbox);
   }
 #endif
-
-  const libMesh::BoundingBox & bbox () const
-  {
-    return _bbox;
-  }
 
   libMesh::BoundingBox & bbox ()
   {


### PR DESCRIPTION
Intel 18 seems to be more strict on warning about "declared but never referenced" functions, this PR cleans up the handful that we had in anonymous namespaces, etc.
