### PR TITLE
Test for and use C++11 std::iota 

### DIFF
--- a/configure
+++ b/configure
@@ -9950,6 +9950,64 @@ if test "x$have_cxx11_container_erase" != "xyes"; then :
   as_fn_error $? "libMesh requires C++11 support for std container erase() functions returning iterators" "$LINENO" 5
 fi
 
+
+    have_cxx11_iota=no
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C++11 std::iota algorithm" >&5
+$as_echo_n "checking for C++11 std::iota algorithm... " >&6; }
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <vector>
+    #include <numeric>
+
+int
+main ()
+{
+
+    std::vector<int> v(10);
+    std::iota(v.begin(), v.end(), 0);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+        have_cxx11_iota=yes
+
+else
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+        CXXFLAGS="$old_CXXFLAGS"
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+
+if test "x$have_cxx11_iota" != "xyes"; then :
+  as_fn_error $? "libMesh requires C++11 support for std::iota" "$LINENO" 5
+fi
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.

--- a/configure.ac
+++ b/configure.ac
@@ -357,6 +357,10 @@ LIBMESH_TEST_CXX11_CONTAINER_ERASE
 AS_IF([test "x$have_cxx11_container_erase" != "xyes"],
       [AC_MSG_ERROR([libMesh requires C++11 support for std container erase() functions returning iterators])])
 
+LIBMESH_TEST_CXX11_IOTA
+AS_IF([test "x$have_cxx11_iota" != "xyes"],
+      [AC_MSG_ERROR([libMesh requires C++11 support for std::iota])])
+
 # --------------------------------------------------------------
 # Test for optional modern C++ features, which libMesh offers shims
 # for and/or which libMesh applications may want to selectively use.

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -56,6 +56,9 @@ std::string system_info();
 template <typename ForwardIter, typename T>
 void iota (ForwardIter first, ForwardIter last, T value)
 {
+  // Use std::iota instead!
+  libmesh_deprecated();
+
   while (first != last)
     {
       *first = value++;

--- a/m4/cxx11.m4
+++ b/m4/cxx11.m4
@@ -3,6 +3,35 @@ dnl Tests for various C++11 features.  These will probably only work
 dnl if they are run after the autoconf test that sets -std=c++11.
 dnl ----------------------------------------------------------------
 
+dnl Test C++11 std::iota
+AC_DEFUN([LIBMESH_TEST_CXX11_IOTA],
+  [
+    have_cxx11_iota=no
+
+    AC_MSG_CHECKING(for C++11 std::iota algorithm)
+    AC_LANG_PUSH([C++])
+
+    old_CXXFLAGS="$CXXFLAGS"
+    CXXFLAGS="$CXXFLAGS $switch $libmesh_CXXFLAGS"
+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include <vector>
+    @%:@include <numeric>
+    ]], [[
+    std::vector<int> v(10);
+    std::iota(v.begin(), v.end(), 0);
+    ]])],[
+        AC_MSG_RESULT(yes)
+        have_cxx11_iota=yes
+    ],[
+        AC_MSG_RESULT(no)
+    ])
+
+    dnl Reset the flags
+    CXXFLAGS="$old_CXXFLAGS"
+    AC_LANG_POP([C++])
+  ])
+
 dnl Test C++11 std::map,set,multimap,multiset iterator-returning erase() APIs.
 AC_DEFUN([LIBMESH_TEST_CXX11_CONTAINER_ERASE],
   [

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -47,7 +47,6 @@
 #include "libmesh/system.h" // needed by enforce_constraints_exactly()
 #include "libmesh/threads.h"
 #include "libmesh/tensor_tools.h"
-#include "libmesh/utility.h" // Utility::iota()
 
 // C++ Includes
 #include <set>
@@ -55,7 +54,7 @@
 #include <sstream>
 #include <cstdlib> // *must* precede <cmath> for proper std:abs() on PGI, Sun Studio CC
 #include <cmath>
-
+#include <numeric>
 
 // Anonymous namespace to hold helper classes
 namespace {
@@ -965,7 +964,7 @@ private:
 
               // A shellface has the same dof indices as the element itself
               std::vector<unsigned int> shellface_dofs(n_dofs);
-              Utility::iota(shellface_dofs.begin(), shellface_dofs.end(), 0);
+              std::iota(shellface_dofs.begin(), shellface_dofs.end(), 0);
 
               // Some shellface dofs are on nodes/edges and already
               // fixed, others are free to calculate

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -18,6 +18,7 @@
 
 
 // C++ includes
+#include <numeric> // std::iota
 
 // Local Includes
 #include "libmesh/petsc_vector.h"
@@ -29,7 +30,6 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/parallel.h"
 #include "libmesh/petsc_macro.h"
-#include "libmesh/utility.h"
 
 namespace libMesh
 {
@@ -674,7 +674,8 @@ void PetscVector<T>::localize (NumericVector<T> & v_local_in) const
   VecScatter scatter;
 
   // Create idx, idx[i] = i;
-  std::vector<PetscInt> idx(n); Utility::iota (idx.begin(), idx.end(), 0);
+  std::vector<PetscInt> idx(n);
+  std::iota (idx.begin(), idx.end(), 0);
 
   // Create the index set & scatter object
   ierr = ISCreateLibMesh(this->comm().get(), n, &idx[0], PETSC_USE_POINTER, &is);
@@ -885,7 +886,7 @@ void PetscVector<T>::localize (const numeric_index_type first_local_idx,
 
     // Create idx, idx[i] = i+first_local_idx;
     std::vector<PetscInt> idx(my_local_size);
-    Utility::iota (idx.begin(), idx.end(), first_local_idx);
+    std::iota (idx.begin(), idx.end(), first_local_idx);
 
     // Create the index set & scatter object
     ierr = ISCreateLibMesh(this->comm().get(), my_local_size,
@@ -1296,7 +1297,7 @@ void PetscVector<T>::create_subvector(NumericVector<T> & subvector,
 
   // Use iota to fill an array with entries [0,1,2,3,4,...rows.size()]
   std::vector<PetscInt> idx(rows.size());
-  Utility::iota (idx.begin(), idx.end(), 0);
+  std::iota (idx.begin(), idx.end(), 0);
 
   // Construct index sets
   ierr = ISCreateLibMesh(this->comm().get(),

--- a/src/solution_transfer/dtk_adapter.C
+++ b/src/solution_transfer/dtk_adapter.C
@@ -21,20 +21,23 @@
 
 #ifdef LIBMESH_TRILINOS_HAVE_DTK
 
+// libMesh includes
 #include "libmesh/dtk_adapter.h"
-
 #include "libmesh/dtk_evaluator.h"
 #include "libmesh/mesh.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/elem.h"
 #include "libmesh/equation_systems.h"
 
+// Trilinos includes
 #include "libmesh/ignore_warnings.h"
 #include <DTK_MeshTypes.hpp>
 #include <Teuchos_Comm.hpp>
 #include "libmesh/restore_warnings.h"
 
+// C++ includes
 #include <vector>
+#include <numeric>
 
 namespace libMesh
 {
@@ -96,8 +99,7 @@ DTKAdapter::DTKAdapter(Teuchos::RCP<const Teuchos::Comm<int>> in_comm, EquationS
   }
 
   Teuchos::ArrayRCP<int> permutation_list(n_nodes_per_elem);
-  for (unsigned int i = 0; i < n_nodes_per_elem; ++i )
-    permutation_list[i] = i;
+  std::iota(permutation_list.begin(), permutation_list.end(), 0);
 
   /*
     if (this->processor_id() == 1)

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -19,6 +19,7 @@
 
 // C++ includes
 #include <vector>
+#include <numeric> // std::iota
 
 // Local includes
 #include "libmesh/libmesh_config.h"
@@ -328,8 +329,7 @@ void System::project_vector (const NumericVector<Number> & old_v,
   if (n_variables)
     {
       std::vector<unsigned int> vars(n_variables);
-      for (unsigned int i=0; i != n_variables; ++i)
-        vars[i] = i;
+      std::iota(vars.begin(), vars.end(), 0);
 
       // Use a typedef to make the calling sequence for parallel_for() a bit more readable
       typedef
@@ -748,8 +748,7 @@ void System::projection_matrix (SparseMatrix<Number> & proj_mat) const
          this->get_mesh().active_local_elements_end());
 
       std::vector<unsigned int> vars(n_variables);
-      for (unsigned int i=0; i != n_variables; ++i)
-        vars[i] = i;
+      std::iota(vars.begin(), vars.end(), 0);
 
       // Use a typedef to make the calling sequence for parallel_for() a bit more readable
       typedef OldSolutionCoefs<Real, &FEMContext::point_value> OldSolutionValueCoefs;
@@ -901,8 +900,7 @@ void System::project_vector (NumericVector<Number> & new_vector,
   const unsigned int n_variables = this->n_vars();
 
   std::vector<unsigned int> vars(n_variables);
-  for (unsigned int i=0; i != n_variables; ++i)
-    vars[i] = i;
+  std::iota(vars.begin(), vars.end(), 0);
 
   // Use a typedef to make the calling sequence for parallel_for() a bit more readable
   typedef

--- a/tests/quadrature/quadrature_test.C
+++ b/tests/quadrature/quadrature_test.C
@@ -10,6 +10,7 @@
 #include <libmesh/enum_quadrature_type.h>
 
 #include <iomanip>
+#include <numeric> // std::iota
 
 // THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
 // std::auto_ptr, which in turn produces -Wdeprecated-declarations
@@ -250,9 +251,9 @@ public:
                       denominator(3 + sorted_powers[0] + sorted_powers[1]);
 
                     // Fill up the vectors with sequences starting at the right values.
-                    Utility::iota(numerator_1.begin(), numerator_1.end(), 2);
-                    Utility::iota(numerator_2.begin(), numerator_2.end(), 2);
-                    Utility::iota(denominator.begin(), denominator.end(), sorted_powers[2]+1);
+                    std::iota(numerator_1.begin(), numerator_1.end(), 2);
+                    std::iota(numerator_2.begin(), numerator_2.end(), 2);
+                    std::iota(denominator.begin(), denominator.end(), sorted_powers[2]+1);
 
                     // The denominator is guaranteed to have the most terms...
                     for (std::size_t i=0; i<denominator.size(); ++i)
@@ -328,8 +329,8 @@ public:
                     denominator(2+smaller_power);
 
                   // Fill up the vectors with sequences starting at the right values.
-                  Utility::iota(numerator.begin(), numerator.end(), 2);
-                  Utility::iota(denominator.begin(), denominator.end(), larger_power+1);
+                  std::iota(numerator.begin(), numerator.end(), 2);
+                  std::iota(denominator.begin(), denominator.end(), larger_power+1);
 
                   // The denominator is guaranteed to have more terms...
                   for (std::size_t i=0; i<denominator.size(); ++i)


### PR DESCRIPTION
Been meaning to do this for a while. This PR also deprecates our hand-coded version, `Utility::iota()`.
