### PR TITLE
Warn if user tries to add a boundary id for a non-existent node.

### DIFF
--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -579,10 +579,17 @@ void BoundaryInfo::add_elements(const std::set<boundary_id_type> & requested_bou
 
 
 
-void BoundaryInfo::add_node(const dof_id_type node,
+void BoundaryInfo::add_node(const dof_id_type node_id,
                             const boundary_id_type id)
 {
-  this->add_node (_mesh.node_ptr(node), id);
+  const Node * node_ptr = _mesh.query_node_ptr(node_id);
+
+  // The user could easily ask for an invalid node id, so let's warn
+  // them (but not die) when this happens.
+  if (!node_ptr)
+    libmesh_warning("BoundaryInfo::add_node(): Could not retrieve pointer for node " << node_id << ", no boundary id was added.");
+  else
+    this->add_node (node_ptr, id);
 }
 
 

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -584,12 +584,12 @@ void BoundaryInfo::add_node(const dof_id_type node_id,
 {
   const Node * node_ptr = _mesh.query_node_ptr(node_id);
 
-  // The user could easily ask for an invalid node id, so let's warn
-  // them (but not die) when this happens.
+  // The user could easily ask for an invalid node id, so let's throw
+  // an easy-to-understand error message when this happens.
   if (!node_ptr)
-    libmesh_warning("BoundaryInfo::add_node(): Could not retrieve pointer for node " << node_id << ", no boundary id was added.");
-  else
-    this->add_node (node_ptr, id);
+    libmesh_error_msg("BoundaryInfo::add_node(): Could not retrieve pointer for node " << node_id << ", no boundary id was added.");
+
+  this->add_node (node_ptr, id);
 }
 
 


### PR DESCRIPTION
We could also make this a fatal error if people think that would be
safer... previously the code would just segfault in opt mode and
assert in dbg mode.

Refs #1883.