### PR TITLE
GenericProjector rewrite

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -716,18 +716,40 @@ public:
 
   /**
    * Fills the vector \p di with the global degree of freedom indices
-   * for the node.
+   * for the \p node.
    */
   void dof_indices (const Node * const node,
                     std::vector<dof_id_type> & di) const;
 
   /**
    * Fills the vector \p di with the global degree of freedom indices
-   * for the node.   For one variable \p vn.
+   * for the \p node, for one variable \p vn.
    */
   void dof_indices (const Node * const node,
                     std::vector<dof_id_type> & di,
                     const unsigned int vn) const;
+
+  /**
+   * Appends to the vector \p di the global degree of freedom indices
+   * for \p elem.node_ref(n), for one variable \p vn.  On hanging
+   * nodes with both vertex and non-vertex DoFs, only those indices
+   * which are directly supported on \p elem are included.
+   */
+  void dof_indices (const Elem & elem,
+                    unsigned int n,
+                    std::vector<dof_id_type> & di,
+                    const unsigned int vn) const;
+
+  /**
+   * Appends to the vector \p di the old global degree of freedom
+   * indices for \p elem.node_ref(n), for one variable \p vn.  On
+   * hanging nodes with both vertex and non-vertex DoFs, only those
+   * indices which are directly supported on \p elem are included.
+   */
+  void old_dof_indices (const Elem & elem,
+                        unsigned int n,
+                        std::vector<dof_id_type> & di,
+                        const unsigned int vn) const;
 
   /**
    * Fills the vector \p di with the global degree of freedom indices
@@ -1410,6 +1432,16 @@ private:
                      std::size_t & tot_size
 #endif
                      ) const;
+
+  /**
+   * Helper function that implements the element-nodal versions of
+   * dof_indices and old_dof_indices
+   */
+  void _node_dof_indices (const Elem & elem,
+                          unsigned int n,
+                          const DofObject & obj,
+                          std::vector<dof_id_type> & di,
+                          const unsigned int vn) const;
 
   /**
    * Builds a sparsity pattern

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -31,13 +31,34 @@
 #include "libmesh/fe_base.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/libmesh_logging.h"
+#include "libmesh/mesh_tools.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/parallel_sync.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/system.h"
 #include "libmesh/threads.h"
 
 namespace libMesh
 {
+
+/**
+ * For ease of communication, we allow users to translate their own
+ * value types to a more easily computable (typically a vector of some
+ * fixed-size type) output, by specializing these calls using
+ * different types.
+ */
+template <typename T>
+struct TypeToSend {
+  typedef T type;
+};
+
+template <typename T>
+const typename TypeToSend<T>::type convert_to_send (const T& in)
+{ return in; }
+
+template <typename SendT, typename T>
+void convert_from_receive (SendT & received, T & converted)
+{ converted = received; }
 
 /**
  * The GenericProjector class implements the core of other projection
@@ -60,23 +81,35 @@ private:
   // operator()
   const FFunctor & master_f;
   const GFunctor * master_g;  // Needed for C1 type elements only
-  bool g_was_copied;
+  bool g_was_copied, map_was_created;
   const ProjectionAction & master_action;
   const std::vector<unsigned int> & variables;
+  std::unordered_map<dof_id_type, std::vector<dof_id_type>> * nodes_to_elem;
 
 public:
   GenericProjector (const System & system_in,
                     const FFunctor & f_in,
                     const GFunctor * g_in,
                     const ProjectionAction & act_in,
-                    const std::vector<unsigned int> & variables_in) :
+                    const std::vector<unsigned int> & variables_in,
+                    std::unordered_map<dof_id_type, std::vector<dof_id_type>> *
+                      nodes_to_elem_in = nullptr) :
     system(system_in),
     master_f(f_in),
     master_g(g_in),
     g_was_copied(false),
+    map_was_created(!nodes_to_elem_in),
     master_action(act_in),
-    variables(variables_in)
-  {}
+    variables(variables_in),
+    nodes_to_elem(nodes_to_elem_in)
+  {
+    if (map_was_created) // past tense misnomer here
+      {
+        nodes_to_elem = new
+          std::unordered_map<dof_id_type, std::vector<dof_id_type>>;
+        MeshTools::build_nodes_to_elem_map (system.get_mesh(), *nodes_to_elem);
+      }
+  }
 
   GenericProjector (const GenericProjector & in) :
     system(in.system),
@@ -84,16 +117,41 @@ public:
     master_g(in.master_g ? new GFunctor(*in.master_g) : nullptr),
     g_was_copied(in.master_g),
     master_action(in.master_action),
-    variables(in.variables)
+    variables(in.variables),
+    nodes_to_elem(in.nodes_to_elem)
   {}
 
   ~GenericProjector()
   {
     if (g_was_copied)
       delete master_g;
+    if (map_was_created)
+      delete nodes_to_elem;
   }
 
   void operator() (const ConstElemRange & range) const;
+
+  void find_dofs_to_send
+    (const Node & node,
+     std::unordered_map<dof_id_type, std::pair<FValue, processor_id_type>> & ids_to_push) const;
+
+  void send_and_insert_dof_values
+    (std::unordered_map<dof_id_type, std::pair<FValue, processor_id_type>> & ids_to_push,
+     ProjectionAction & action) const;
+
+  template <typename InsertId>
+  void construct_projection
+    (const std::vector<dof_id_type> & dof_indices_var,
+     const std::vector<unsigned int> & involved_dofs,
+     unsigned int var_component,
+     const FEMContext & context,
+     const Node * node,
+     InsertId & insert_id,
+     const FEBase & fe,
+     FFunctor & f,
+     GFunctor * g,
+     const std::unordered_map<dof_id_type, FValue> & ids_to_save
+     ) const;
 };
 
 
@@ -115,6 +173,17 @@ private:
 public:
   VectorSetAction(NumericVector<Val> & target_vec) :
     target_vector(target_vec) {}
+
+  void insert(dof_id_type id,
+              Val val)
+  {
+    // Lock the new vector since it is shared among threads.
+    {
+      Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+      target_vector.set(id, val);
+    }
+  }
+
 
   void insert(const FEMContext & c,
               unsigned int var_num,
@@ -595,20 +664,10 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
   if (master_g)
     g.reset(new GFunctor(*master_g));
 
-  // The DofMap for this system
-  const DofMap & dof_map = system.get_dof_map();
-
-  // The element matrix and RHS for projections.
-  // Note that Ke is always real-valued, whereas
-  // Fe may be complex valued if complex number
-  // support is enabled
-  DenseMatrix<Real> Ke;
-  DenseVector<FValue> Fe;
-  // The new element degree of freedom coefficients
-  DenseVector<FValue> Ue;
-
   // Context objects to contain all our required FE objects
   FEMContext context( system );
+
+  std::vector<FEContinuity> conts(system.n_vars());
 
   // Loop over all the variables we've been requested to project, to
   // pre-request
@@ -632,16 +691,26 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
           if (dim > 2)
             context.get_edge_fe( var, edge_fe );
 
+          fe->get_JxW();
           fe->get_xyz();
           fe->get_JxW();
 
           fe->get_phi();
           if (dim > 1)
-            side_fe->get_phi();
+            {
+              side_fe->get_JxW();
+              side_fe->get_xyz();
+              side_fe->get_phi();
+            }
           if (dim > 2)
-            edge_fe->get_phi();
+            {
+              edge_fe->get_JxW();
+              edge_fe->get_xyz();
+              edge_fe->get_phi();
+            }
 
           const FEContinuity cont = fe->get_continuity();
+          conts[var] = cont;
           if (cont == C_ONE)
             {
               // Our C1 elements need gradient information
@@ -663,13 +732,27 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
 
   // this->init_context(context);
 
-  // Iterate over all the elements in the range
+  // Look at all the elements in the range.  Determine sets of
+  // vertices, edge nodes, and side nodes to project.
+  //
+  // As per our other weird nomenclature, "sides" means faces in 3D
+  // and edges in 2D, and "edges" gets skipped in 2D
+  //
+  // This gets tricky in the case of subdomain-restricted
+  // variables, for which we might need to do the same projection
+  // from different elements when evaluating different variables.
+  // We'll keep track of which variables can be projected from which
+  // elements.
+
+  typedef std::unordered_set<unsigned int> var_set;
+
+  std::unordered_multimap<const Node *, std::pair<const Elem *, var_set>> vertices;
+  std::unordered_multimap<const Node *, std::tuple<const Elem *, unsigned short, var_set>> edges;
+  std::unordered_multimap<const Node *, std::tuple<const Elem *, unsigned short, var_set>> sides;
+  std::vector<const Elem *> interiors;
+
   for (const auto & elem : range)
     {
-      unsigned char dim = cast_int<unsigned char>(elem->dim());
-
-      context.pre_fe_reinit(system, elem);
-
       // If we're doing AMR, this might be a grid projection with a cheap
       // early exit.
 #ifdef LIBMESH_ENABLE_AMR
@@ -684,13 +767,694 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
         continue;
 #endif // LIBMESH_ENABLE_AMR
 
+      const int dim = elem->dim();
+
+      const unsigned int n_vertices = elem->n_vertices();
+      const unsigned int n_edges = elem->n_edges();
+      const unsigned int n_nodes = elem->n_nodes();
+
+      // In 1-D we already handle our sides as vertices
+      const unsigned int n_sides = (dim > 1) * elem->n_sides();
+
+      // What variables are supported on each kind of node on elem?
+      var_set vertex_vars, edge_vars, side_vars;
+
+      // If we have non-vertex nodes, the first is an edge node, but
+      // if we're in 2D we'll call that a side node
+      const bool has_edge_nodes = (n_nodes > n_vertices && dim > 2);
+
+      // If we have even more nodes, the next is a side node.
+      const bool has_side_nodes =
+        (n_nodes > n_vertices + ((dim > 2) * n_edges));
+
+      // We may be out of DoFs at this point or we may have interior
+      // DoFs to project too
+      const bool has_interior_nodes =
+        (n_nodes > n_vertices + ((dim > 2) * n_edges) + n_sides);
+
+      for (auto v_num : variables)
+        {
+          const Variable & var = system.variable(v_num);
+          if (!var.active_on_subdomain(elem->subdomain_id()))
+            continue;
+          FEType fe_type = var.type();
+          fe_type.order =
+            libMesh::Order (fe_type.order + elem->p_level());
+          const ElemType elem_type = elem->type();
+
+          if (FEInterface::n_dofs_at_node(dim, fe_type, elem_type, 0))
+            vertex_vars.insert(vertex_vars.end(), v_num);
+
+          // The first non-vertex node is always an edge node if those
+          // exist.  All edge nodes have the same number of DoFs
+          if (has_edge_nodes)
+            if (FEInterface::n_dofs_at_node(dim, fe_type, elem_type, n_vertices))
+              edge_vars.insert(edge_vars.end(), v_num);
+
+          if (has_side_nodes)
+            {
+              if (dim != 3)
+                {
+                  if (FEInterface::n_dofs_at_node(dim, fe_type, elem_type, n_vertices))
+                    side_vars.insert(side_vars.end(), v_num);
+                }
+              else
+                // In 3D, not all face nodes always have the same number of
+                // DoFs!  We'll loop over all sides to be safe.
+                for (unsigned int n = 0; n != n_nodes; ++n)
+                  if (elem->is_face(n))
+                    if (FEInterface::n_dofs_at_node(dim, fe_type,
+                                                    elem_type, n))
+                      {
+                        side_vars.insert(side_vars.end(), v_num);
+                        break;
+                      }
+            }
+
+          if (FEInterface::n_dofs_per_elem(dim, fe_type, elem_type) ||
+              (has_interior_nodes &&
+               FEInterface::n_dofs_at_node(dim, fe_type, elem_type, n_nodes-1)))
+            if (interiors.empty() || interiors.back() != elem)
+              interiors.push_back(elem);
+        }
+
+      // We'll use a greedy algorithm in most cases: if another
+      // element has already claimed some of our DoFs, we'll let it do
+      // the work.
+      for (unsigned int v=0; v != n_vertices; ++v)
+        {
+          const Node * node = elem->node_ptr(v);
+
+          auto remaining_vars = vertex_vars;
+
+          auto set_range = vertices.equal_range(node);
+          for (const auto & v_ent : as_range(set_range))
+            for (const unsigned int var_covered :
+                 v_ent.second.second)
+              remaining_vars.erase(var_covered);
+
+          if (!remaining_vars.empty())
+            vertices.emplace
+              (node, std::make_pair(elem, std::move(remaining_vars)));
+        }
+
+      if (has_edge_nodes)
+        {
+          for (unsigned int e=0; e != n_edges; ++e)
+            {
+              const Node * node = elem->node_ptr(n_vertices+e);
+
+              auto remaining_vars = edge_vars;
+
+              auto set_range = edges.equal_range(node);
+              for (const auto & v_ent : as_range(set_range))
+                for (const unsigned int var_covered :
+                     std::get<2>(v_ent.second))
+                  remaining_vars.erase(var_covered);
+
+              if (!remaining_vars.empty())
+                edges.emplace
+                  (node, std::make_tuple(elem, e, std::move(remaining_vars)));
+            }
+        }
+
+      if (has_side_nodes)
+        {
+          for (unsigned int side=0; side != n_sides; ++side)
+            {
+              const Node * node = nullptr;
+              if (dim != 3)
+                node = elem->node_ptr(n_vertices+(dim>2)*n_edges+side);
+              else
+                {
+                  // In 3D only some sides may have nodes
+                  for (unsigned int n = 0; n != n_nodes; ++n)
+                    {
+                      if (!elem->is_face(n))
+                        continue;
+
+                      if (elem->is_node_on_side(n, side))
+                        {
+                          node = elem->node_ptr(n);
+                          break;
+                        }
+                    }
+                }
+
+              if (!node)
+                continue;
+
+              auto remaining_vars = side_vars;
+
+              auto set_range = sides.equal_range(node);
+              for (const auto & v_ent : as_range(set_range))
+                for (const unsigned int var_covered :
+                     std::get<2>(v_ent.second))
+                  remaining_vars.erase(var_covered);
+
+              if (!remaining_vars.empty())
+                sides.emplace
+                  (node, std::make_tuple(elem, side, std::move(remaining_vars)));
+            }
+        }
+    }
+
+  // While we're looping over nodes, also figure out which ghosted
+  // nodes will have data we might need to send to their owners
+  // instead of being acted on by ourselves.
+  //
+  // We keep track of which dof ids we might need to send, and what
+  // values those ids should get (along with a pprocessor_id to leave
+  // invalid in case *we* can't compute those values either).
+  std::unordered_map<dof_id_type, std::pair<FValue, processor_id_type>> ids_to_push;
+
+  // We generally need to hang on to every value we've calculated
+  // until we're all done, because later projection calculations
+  // depend on boundary data from earlier calculations.
+  std::unordered_map<dof_id_type, FValue> ids_to_save;
+  bool done_saving_ids = edges.empty() && sides.empty() && interiors.empty();
+
+  // When we have new data to act on, we may also need to save it
+  // and get ready to push it.
+  auto insert_id = [&ids_to_push, &ids_to_save, &action, &done_saving_ids]
+    (dof_id_type id, const FValue & val, processor_id_type pid)
+    {
+      auto iter = ids_to_push.find(id);
+      if (iter == ids_to_push.end())
+        action.insert(id, val);
+      else
+        {
+          libmesh_assert(pid != DofObject::invalid_processor_id);
+          iter->second = std::make_pair(val, pid);
+        }
+      if (!done_saving_ids)
+        {
+          libmesh_assert(!ids_to_save.count(id));
+          ids_to_save[id] = val;
+        }
+    };
+
+  START_LOG ("project_vertices","GenericProjector");
+  for (const auto & v_pair : vertices)
+    {
+      const Node & vertex = *v_pair.first;
+      const Elem & elem = *v_pair.second.first;
+      context.pre_fe_reinit(system, &elem);
+
+      this->find_dofs_to_send(vertex, ids_to_push);
+
+      // Look at all the variables we're supposed to interpolate from
+      // this element on this vertex
+      for (const auto & var : v_pair.second.second)
+        {
+          const Variable & variable = system.variable(var);
+          const FEType & base_fe_type = variable.type();
+          const unsigned int var_component =
+            system.variable_scalar_number(var, 0);
+
+          if (base_fe_type.family == SCALAR)
+            continue;
+
+          const FEContinuity & cont = conts[var];
+          if (cont == DISCONTINUOUS)
+            {
+              libmesh_assert_equal_to(vertex.n_comp(system.number(), var), 0);
+            }
+          else if (cont == C_ZERO)
+            {
+              libmesh_assert(vertex.n_comp(system.number(), var));
+              const dof_id_type id = vertex.dof_number(system.number(), var, 0);
+              // C_ZERO elements have a single nodal value DoF at vertices
+              const FValue val = f.eval_at_node
+                (context, var_component, /*dim=*/ 0, // Don't care w/C0
+                 vertex, system.time);
+              insert_id(id, val, vertex.processor_id());
+            }
+          else if (cont == C_ONE)
+            {
+              libmesh_assert(vertex.n_comp(system.number(), var));
+              const dof_id_type first_id = vertex.dof_number(system.number(), var, 0);
+
+              // C_ONE elements have a single nodal value and dim
+              // gradient values at vertices, as well as cross
+              // gradients for HERMITE.  We need to have an element in
+              // hand to figure out dim and to have in case this
+              // vertex is a new vertex.
+              const int dim = elem.dim();
+#ifndef NDEBUG
+              // For now all C1 elements at a vertex had better have
+              // the same dimension.  If anyone hits these asserts let
+              // me know; we could probably support a mixed-dimension
+              // mesh IFF the 2D elements were all parallel to xy and
+              // the 1D elements all parallel to x.
+              for (const auto e_id : (*nodes_to_elem)[vertex.id()])
+                {
+                  const Elem & e = system.get_mesh().elem_ref(e_id);
+                  libmesh_assert_equal_to(dim, e.dim());
+                }
+#endif
+#ifdef LIBMESH_ENABLE_AMR
+              bool is_parent_vertex = false;
+              if (elem.parent())
+                {
+                  const int i_am_child =
+                    elem.parent()->which_child_am_i(&elem);
+                  const unsigned int n = elem.get_node_index(&vertex);
+                  is_parent_vertex =
+                    elem.parent()->is_vertex_on_parent(i_am_child, n);
+                }
+#else
+              const bool is_parent_vertex = false;
+#endif
+
+              // The hermite element vertex shape functions are weird
+              if (base_fe_type.family == HERMITE)
+                {
+                  const unsigned int n = elem.get_node_index(&vertex);
+                  const FValue val =
+                    f.eval_at_node(context,
+                                   var_component,
+                                   dim,
+                                   vertex,
+                                   system.time);
+                  insert_id(first_id, val, vertex.processor_id());
+
+                  VectorValue<FValue> grad =
+                    is_parent_vertex ?
+                    g->eval_at_node(context,
+                                    var_component,
+                                    dim,
+                                    vertex,
+                                    system.time) :
+                    g->eval_at_point(context,
+                                     var_component,
+                                     vertex,
+                                     system.time);
+                  // x derivative
+                  insert_id(first_id+1, grad(0),
+                            vertex.processor_id());
+                  if (dim > 1)
+                    {
+                      // We'll finite difference mixed derivatives
+                      Real delta_x = TOLERANCE * elem.hmin();
+
+                      Point nxminus = elem.point(n),
+                            nxplus = elem.point(n);
+                      nxminus(0) -= delta_x;
+                      nxplus(0) += delta_x;
+                      VectorValue<FValue> gxminus =
+                        g->eval_at_point(context,
+                                         var_component,
+                                         nxminus,
+                                         system.time);
+                      VectorValue<FValue> gxplus =
+                        g->eval_at_point(context,
+                                         var_component,
+                                         nxplus,
+                                         system.time);
+                      // y derivative
+                      insert_id(first_id+2, grad(1),
+                                vertex.processor_id());
+                      // xy derivative
+                      insert_id(first_id+3,
+                        (gxplus(1) - gxminus(1)) / 2. / delta_x,
+                        vertex.processor_id());
+
+                      if (dim > 2)
+                        {
+                          // z derivative
+                          insert_id(first_id+4, grad(2),
+                                    vertex.processor_id());
+                          // xz derivative
+                          insert_id(first_id+5,
+                            (gxplus(2) - gxminus(2)) / 2. / delta_x,
+                            vertex.processor_id());
+
+                          // We need new points for yz
+                          Point nyminus = elem.point(n),
+                            nyplus = elem.point(n);
+                          nyminus(1) -= delta_x;
+                          nyplus(1) += delta_x;
+                          VectorValue<FValue> gyminus =
+                            g->eval_at_point(context,
+                                             var_component,
+                                             nyminus,
+                                             system.time);
+                          VectorValue<FValue> gyplus =
+                            g->eval_at_point(context,
+                                             var_component,
+                                             nyplus,
+                                             system.time);
+                          // yz derivative
+                          insert_id(first_id+6,
+                            (gyplus(2) - gyminus(2)) / 2. / delta_x,
+                            vertex.processor_id());
+                          // Getting a 2nd order xyz is more tedious
+                          Point nxmym = elem.point(n),
+                            nxmyp = elem.point(n),
+                            nxpym = elem.point(n),
+                            nxpyp = elem.point(n);
+                          nxmym(0) -= delta_x;
+                          nxmym(1) -= delta_x;
+                          nxmyp(0) -= delta_x;
+                          nxmyp(1) += delta_x;
+                          nxpym(0) += delta_x;
+                          nxpym(1) -= delta_x;
+                          nxpyp(0) += delta_x;
+                          nxpyp(1) += delta_x;
+                          VectorValue<FValue> gxmym =
+                            g->eval_at_point(context,
+                                             var_component,
+                                             nxmym,
+                                             system.time);
+                          VectorValue<FValue> gxmyp =
+                            g->eval_at_point(context,
+                                             var_component,
+                                             nxmyp,
+                                             system.time);
+                          VectorValue<FValue> gxpym =
+                            g->eval_at_point(context,
+                                             var_component,
+                                             nxpym,
+                                             system.time);
+                          VectorValue<FValue> gxpyp =
+                            g->eval_at_point(context,
+                                             var_component,
+                                             nxpyp,
+                                             system.time);
+                          FValue gxzplus = (gxpyp(2) - gxmyp(2))
+                            / 2. / delta_x;
+                          FValue gxzminus = (gxpym(2) - gxmym(2))
+                            / 2. / delta_x;
+                          // xyz derivative
+                          insert_id(first_id+7,
+                            (gxzplus - gxzminus) / 2. / delta_x,
+                            vertex.processor_id());
+                        }
+                    }
+                }
+              else
+                {
+                  // Currently other C_ONE elements have a single nodal
+                  // value shape function and nodal gradient component
+                  // shape functions
+                  libmesh_assert_equal_to
+                    (FEInterface::n_dofs_at_node
+                      (dim, base_fe_type, elem.type(),
+                       elem.get_node_index(&vertex)),
+                    (unsigned int)(1 + dim));
+                  const FValue val =
+                    f.eval_at_node(context, var_component, dim,
+                                   vertex, system.time);
+                  insert_id(first_id, val, vertex.processor_id());
+                  VectorValue<FValue> grad =
+                    is_parent_vertex ?
+                    g->eval_at_node(context, var_component, dim,
+                                    vertex, system.time) :
+                    g->eval_at_point(context, var_component, vertex,
+                                     system.time);
+                  for (int i=0; i!= dim; ++i)
+                    insert_id(first_id + i + 1, grad(i),
+                              vertex.processor_id());
+                }
+            }
+          else
+            libmesh_error_msg("Unknown continuity " << cont);
+        }
+    }
+  STOP_LOG ("project_vertices","GenericProjector");
+
+  done_saving_ids = sides.empty() && interiors.empty();
+
+  this->send_and_insert_dof_values(ids_to_push, action);
+  ids_to_push.clear();
+
+  START_LOG ("project_edges","GenericProjector");
+  for (const auto & e_pair : edges)
+    {
+      const Elem & elem = *std::get<0>(e_pair.second);
+
+      // If this is an unchanged element then we already copied all
+      // its dofs
+#ifdef LIBMESH_ENABLE_AMR
+      if (f.is_grid_projection() &&
+          (elem.refinement_flag() != Elem::JUST_REFINED &&
+           elem.refinement_flag() != Elem::JUST_COARSENED &&
+           elem.p_refinement_flag() != Elem::JUST_REFINED &&
+           elem.p_refinement_flag() != Elem::JUST_COARSENED))
+        continue;
+#endif // LIBMESH_ENABLE_AMR
+
+      const Node & edge_node = *e_pair.first;
+      const int dim = elem.dim();
+
+      context.edge = std::get<1>(e_pair.second);
+      context.pre_fe_reinit(system, &elem);
+
+      this->find_dofs_to_send(edge_node, ids_to_push);
+
+      // Look at all the variables we're supposed to interpolate from
+      // this element on this edge
+      for (const auto & var : std::get<2>(e_pair.second))
+        {
+          const Variable & variable = system.variable(var);
+          const FEType & base_fe_type = variable.type();
+          const unsigned int var_component =
+            system.variable_scalar_number(var, 0);
+
+          if (base_fe_type.family == SCALAR)
+            continue;
+
+          FEType fe_type = base_fe_type;
+
+          // This may be a p refined element
+          fe_type.order =
+            libMesh::Order (fe_type.order + elem.p_level());
+
+          // If this is a low order monomial element which has merely
+          // been h refined then we already copied all its dofs
+          if (fe_type.family == MONOMIAL &&
+              fe_type.order == CONSTANT &&
+              elem.refinement_flag() != Elem::JUST_COARSENED &&
+              elem.p_refinement_flag() != Elem::JUST_COARSENED)
+            continue;
+
+          // FIXME: Need to generalize this to vector-valued elements. [PB]
+          FEBase * fe = nullptr;
+          context.get_element_fe( var, fe, dim );
+          FEBase * edge_fe = nullptr;
+          context.get_edge_fe( var, edge_fe );
+
+          // If we're JUST_COARSENED we'll need a custom
+          // evaluation, not just the standard edge FE
+          const FEBase & proj_fe =
+#ifdef LIBMESH_ENABLE_AMR
+            (elem.refinement_flag() == Elem::JUST_COARSENED) ?
+            *fe :
+#endif
+            *edge_fe;
+
+#ifdef LIBMESH_ENABLE_AMR
+          if (elem.refinement_flag() == Elem::JUST_COARSENED)
+            {
+              std::vector<Point> fine_points;
+
+              std::unique_ptr<FEBase> fine_fe
+                (FEBase::build (dim, base_fe_type));
+
+              std::unique_ptr<QBase> qrule
+                (base_fe_type.default_quadrature_rule(1));
+              fine_fe->attach_quadrature_rule(qrule.get());
+
+              const std::vector<Point> & child_xyz =
+                        fine_fe->get_xyz();
+
+              for (unsigned int c = 0, nc = elem.n_children();
+                   c != nc; ++c)
+                {
+                  if (!elem.is_child_on_edge(c, context.edge))
+                    continue;
+
+                  fine_fe->edge_reinit(elem.child_ptr(c), context.edge);
+                  fine_points.insert(fine_points.end(),
+                                     child_xyz.begin(),
+                                     child_xyz.end());
+                }
+
+              std::vector<Point> fine_qp;
+              FEInterface::inverse_map (dim, base_fe_type, &elem,
+                                        fine_points, fine_qp);
+
+              context.elem_fe_reinit(&fine_qp);
+            }
+          else
+#endif // LIBMESH_ENABLE_AMR
+            context.edge_fe_reinit();
+
+          const std::vector<dof_id_type> & dof_indices =
+            context.get_dof_indices(var);
+
+          std::vector<unsigned int> edge_dofs;
+          FEInterface::dofs_on_edge(&elem, dim, base_fe_type,
+                                    context.edge, edge_dofs);
+
+          this->construct_projection
+            (dof_indices, edge_dofs, var_component, context,
+             &edge_node, insert_id, proj_fe, f, g.get(), ids_to_save);
+        }
+    }
+  STOP_LOG ("project_edges","GenericProjector");
+
+  done_saving_ids = !interiors.empty();
+
+  this->send_and_insert_dof_values(ids_to_push, action);
+  ids_to_push.clear();
+
+  START_LOG ("project_sides","GenericProjector");
+  for (const auto & s_pair : sides)
+    {
+      const Elem & elem = *std::get<0>(s_pair.second);
+
+      // If this is an unchanged element then we already copied all
+      // its dofs
+#ifdef LIBMESH_ENABLE_AMR
+      if (f.is_grid_projection() &&
+          (elem.refinement_flag() != Elem::JUST_REFINED &&
+           elem.refinement_flag() != Elem::JUST_COARSENED &&
+           elem.p_refinement_flag() != Elem::JUST_REFINED &&
+           elem.p_refinement_flag() != Elem::JUST_COARSENED))
+        continue;
+#endif // LIBMESH_ENABLE_AMR
+
+      const Node & side_node = *s_pair.first;
+      const int dim = elem.dim();
+
+      context.side = std::get<1>(s_pair.second);
+      context.pre_fe_reinit(system, &elem);
+
+      this->find_dofs_to_send(side_node, ids_to_push);
+
+      // Look at all the variables we're supposed to interpolate from
+      // this element on this side
+      for (const auto & var : std::get<2>(s_pair.second))
+        {
+          const Variable & variable = system.variable(var);
+          const FEType & base_fe_type = variable.type();
+          const unsigned int var_component =
+            system.variable_scalar_number(var, 0);
+
+          if (base_fe_type.family == SCALAR)
+            continue;
+
+          FEType fe_type = base_fe_type;
+
+          // This may be a p refined element
+          fe_type.order =
+            libMesh::Order (fe_type.order + elem.p_level());
+
+          // If this is a low order monomial element which has merely
+          // been h refined then we already copied all its dofs
+          if (fe_type.family == MONOMIAL &&
+              fe_type.order == CONSTANT &&
+              elem.refinement_flag() != Elem::JUST_COARSENED &&
+              elem.p_refinement_flag() != Elem::JUST_COARSENED)
+            continue;
+
+          // FIXME: Need to generalize this to vector-valued elements. [PB]
+          FEBase * fe = nullptr;
+          context.get_element_fe( var, fe, dim );
+          FEBase * side_fe = nullptr;
+          context.get_side_fe( var, side_fe );
+
+          // If we're JUST_COARSENED we'll need a custom
+          // evaluation, not just the standard side FE
+          const FEBase & proj_fe =
+#ifdef LIBMESH_ENABLE_AMR
+            (elem.refinement_flag() == Elem::JUST_COARSENED) ?
+            *fe :
+#endif
+            *side_fe;
+
+#ifdef LIBMESH_ENABLE_AMR
+          if (elem.refinement_flag() == Elem::JUST_COARSENED)
+            {
+              std::vector<Point> fine_points;
+
+              std::unique_ptr<FEBase> fine_fe
+                (FEBase::build (dim, base_fe_type));
+
+              std::unique_ptr<QBase> qrule
+                (base_fe_type.default_quadrature_rule(1));
+              fine_fe->attach_quadrature_rule(qrule.get());
+
+              const std::vector<Point> & child_xyz =
+                        fine_fe->get_xyz();
+
+              for (unsigned int c = 0, nc = elem.n_children();
+                   c != nc; ++c)
+                {
+                  if (!elem.is_child_on_side(c, context.side))
+                    continue;
+
+                  fine_fe->reinit(elem.child_ptr(c), context.side);
+                  fine_points.insert(fine_points.end(),
+                                     child_xyz.begin(),
+                                     child_xyz.end());
+                }
+
+              std::vector<Point> fine_qp;
+              FEInterface::inverse_map (dim, base_fe_type, &elem,
+                                        fine_points, fine_qp);
+
+              context.elem_fe_reinit(&fine_qp);
+            }
+          else
+#endif // LIBMESH_ENABLE_AMR
+            context.side_fe_reinit();
+
+          const std::vector<dof_id_type> & dof_indices =
+            context.get_dof_indices(var);
+
+          std::vector<unsigned int> side_dofs;
+          FEInterface::dofs_on_side(&elem, dim, base_fe_type,
+                                    context.side, side_dofs);
+
+          this->construct_projection
+            (dof_indices, side_dofs, var_component, context,
+             &side_node, insert_id, proj_fe, f, g.get(), ids_to_save);
+        }
+    }
+  STOP_LOG ("project_sides","GenericProjector");
+
+  done_saving_ids = true;
+
+  this->send_and_insert_dof_values(ids_to_push, action);
+  ids_to_push.clear();
+
+  START_LOG ("project_interiors","GenericProjector");
+  // Iterate over all dof-bearing element interiors in the range
+  for (const auto & elem : interiors)
+    {
+      unsigned char dim = cast_int<unsigned char>(elem->dim());
+
+      context.pre_fe_reinit(system, elem);
+
       // Loop over all the variables we've been requested to project, to
       // do the projection
       for (const auto & var : variables)
         {
-          const Variable & variable = dof_map.variable(var);
+          const Variable & variable = system.variable(var);
+
+          if (!variable.active_on_subdomain(elem->subdomain_id()))
+            continue;
 
           const FEType & base_fe_type = variable.type();
+
+          if (base_fe_type.family == SCALAR)
+            continue;
+
+          FEBase * fe = nullptr;
+          context.get_element_fe( var, fe, dim );
 
           FEType fe_type = base_fe_type;
 
@@ -698,816 +1462,337 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
           fe_type.order =
             libMesh::Order (fe_type.order + elem->p_level());
 
-          if (fe_type.family == SCALAR)
-            continue;
+          const unsigned int var_component =
+            system.variable_scalar_number(var, 0);
 
-          // Per-subdomain variables don't need to be projected on
-          // elements where they're not active
-          if (!variable.active_on_subdomain(elem->subdomain_id()))
-            continue;
+#ifdef LIBMESH_ENABLE_AMR
+          if (elem->refinement_flag() == Elem::JUST_COARSENED)
+            {
+              std::vector<Point> fine_points;
+
+              std::unique_ptr<FEBase> fine_fe
+                (FEBase::build (dim, base_fe_type));
+
+              std::unique_ptr<QBase> qrule
+                (base_fe_type.default_quadrature_rule(dim));
+              fine_fe->attach_quadrature_rule(qrule.get());
+
+              const std::vector<Point> & child_xyz =
+                fine_fe->get_xyz();
+
+              for (auto & child : elem->child_ref_range())
+                {
+                  fine_fe->reinit(&child);
+                  fine_points.insert(fine_points.end(),
+                                     child_xyz.begin(),
+                                     child_xyz.end());
+                }
+
+              std::vector<Point> fine_qp;
+              FEInterface::inverse_map (dim, base_fe_type, elem,
+                                        fine_points, fine_qp);
+
+              context.elem_fe_reinit(&fine_qp);
+            }
+          else
+#endif // LIBMESH_ENABLE_AMR
+            context.elem_fe_reinit();
 
           const std::vector<dof_id_type> & dof_indices =
             context.get_dof_indices(var);
 
-          // The number of DOFs on the element
           const unsigned int n_dofs =
             cast_int<unsigned int>(dof_indices.size());
 
-          const unsigned int var_component =
-            system.variable_scalar_number(var, 0);
-
-          // Zero the interpolated values
-          Ue.resize (n_dofs); Ue.zero();
-
-          // If we're projecting from an old grid
-#ifdef LIBMESH_ENABLE_AMR
-          if (f.is_grid_projection() &&
-              // And either this is an unchanged element
-              ((elem->refinement_flag() != Elem::JUST_REFINED &&
-                elem->refinement_flag() != Elem::JUST_COARSENED &&
-                elem->p_refinement_flag() != Elem::JUST_REFINED &&
-                elem->p_refinement_flag() != Elem::JUST_COARSENED) ||
-               // Or this is a low order monomial element which has merely
-               // been h refined
-               (fe_type.family == MONOMIAL &&
-                fe_type.order == CONSTANT &&
-                elem->p_level() == 0 &&
-                elem->refinement_flag() != Elem::JUST_COARSENED &&
-                elem->p_refinement_flag() != Elem::JUST_COARSENED))
-              )
-            // then we can simply copy its old dof
-            // values to new indices.
-            {
-              LOG_SCOPE ("copy_dofs", "GenericProjector");
-
-              f.eval_old_dofs(context, var, Ue.get_values());
-
-              action.insert(context, var, Ue);
-
-              continue;
-            }
-#endif // LIBMESH_ENABLE_AMR
-
-          FEBase * fe = nullptr;
-          FEBase * side_fe = nullptr;
-          FEBase * edge_fe = nullptr;
-
-          context.get_element_fe( var, fe, dim );
-          if (fe->get_fe_type().family == SCALAR)
-            continue;
-          if (dim > 1)
-            context.get_side_fe( var, side_fe, dim );
-          if (dim > 2)
-            context.get_edge_fe( var, edge_fe );
-
-          const FEContinuity cont = fe->get_continuity();
-
-          std::vector<unsigned int> side_dofs;
-
-          // Fixed vs. free DoFs on edge/face projections
-          std::vector<char> dof_is_fixed(n_dofs, false); // bools
-          std::vector<int> free_dof(n_dofs, 0);
-
-          // The element type
-          const ElemType elem_type = elem->type();
-
-          // The number of nodes on the new element
-          const unsigned int n_nodes = elem->n_nodes();
-
-          START_LOG ("project_nodes","GenericProjector");
-
-          // When interpolating C1 elements we need to know which
-          // vertices were also parent vertices; we'll cache an
-          // intermediate fact outside the nodes loop.
-          int i_am_child = -1;
-#ifdef LIBMESH_ENABLE_AMR
-          if (elem->parent())
-            i_am_child = elem->parent()->which_child_am_i(elem);
-#endif
-          // In general, we need a series of
-          // projections to ensure a unique and continuous
-          // solution.  We start by interpolating nodes, then
-          // hold those fixed and project edges, then
-          // hold those fixed and project faces, then
-          // hold those fixed and project interiors
-          //
-          // In the LAGRANGE case, we will save a lot of solution
-          // evaluations (at a slight cost in accuracy) by simply
-          // interpolating all nodes rather than projecting.
-
-          // Interpolate vertex (or for LAGRANGE, all node) values first.
-          unsigned int current_dof = 0;
-          for (unsigned int n=0; n!= n_nodes; ++n)
-            {
-              // FIXME: this should go through the DofMap,
-              // not duplicate dof_indices code badly!
-              const unsigned int nc =
-                FEInterface::n_dofs_at_node (dim, fe_type, elem_type, n);
-
-              if (!elem->is_vertex(n) &&
-                  fe_type.family != LAGRANGE)
-                {
-                  current_dof += nc;
-                  continue;
-                }
-
-              if (cont == DISCONTINUOUS)
-                {
-                  libmesh_assert_equal_to (nc, 0);
-                }
-              else if (!nc)
-                {
-                  // This should only occur for first-order LAGRANGE
-                  // FE on non-vertices of higher-order elements
-                  libmesh_assert (!elem->is_vertex(n));
-                  libmesh_assert_equal_to(fe_type.family, LAGRANGE);
-                }
-              // Assume that C_ZERO elements have a single nodal
-              // value shape function at vertices
-              else if (cont == C_ZERO)
-                {
-                  Ue(current_dof) = f.eval_at_node(context,
-                                                   var_component,
-                                                   dim,
-                                                   elem->node_ref(n),
-                                                   system.time);
-                  dof_is_fixed[current_dof] = true;
-                  current_dof++;
-                }
-              else if (cont == C_ONE)
-                {
-                  const bool is_parent_vertex = (i_am_child == -1) ||
-                    elem->parent()->is_vertex_on_parent(i_am_child, n);
-
-                  // The hermite element vertex shape functions are weird
-                  if (fe_type.family == HERMITE)
-                    {
-                      Ue(current_dof) =
-                        f.eval_at_node(context,
-                                       var_component,
-                                       dim,
-                                       elem->node_ref(n),
-                                       system.time);
-                      dof_is_fixed[current_dof] = true;
-                      current_dof++;
-                      VectorValue<FValue> grad =
-                        is_parent_vertex ?
-                        g->eval_at_node(context,
-                                        var_component,
-                                        dim,
-                                        elem->node_ref(n),
-                                        system.time) :
-                        g->eval_at_point(context,
-                                         var_component,
-                                         elem->node_ref(n),
-                                         system.time);
-                      // x derivative
-                      Ue(current_dof) = grad(0);
-                      dof_is_fixed[current_dof] = true;
-                      current_dof++;
-                      if (dim > 1)
-                        {
-                          // We'll finite difference mixed derivatives
-                          Real delta_x = TOLERANCE * elem->hmin();
-
-                          Point nxminus = elem->point(n),
-                            nxplus = elem->point(n);
-                          nxminus(0) -= delta_x;
-                          nxplus(0) += delta_x;
-                          VectorValue<FValue> gxminus =
-                            g->eval_at_point(context,
-                                             var_component,
-                                             nxminus,
-                                             system.time);
-                          VectorValue<FValue> gxplus =
-                            g->eval_at_point(context,
-                                             var_component,
-                                             nxplus,
-                                             system.time);
-                          // y derivative
-                          Ue(current_dof) = grad(1);
-                          dof_is_fixed[current_dof] = true;
-                          current_dof++;
-                          // xy derivative
-                          Ue(current_dof) = (gxplus(1) - gxminus(1))
-                            / 2. / delta_x;
-                          dof_is_fixed[current_dof] = true;
-                          current_dof++;
-
-                          if (dim > 2)
-                            {
-                              // z derivative
-                              Ue(current_dof) = grad(2);
-                              dof_is_fixed[current_dof] = true;
-                              current_dof++;
-                              // xz derivative
-                              Ue(current_dof) = (gxplus(2) - gxminus(2))
-                                / 2. / delta_x;
-                              dof_is_fixed[current_dof] = true;
-                              current_dof++;
-                              // We need new points for yz
-                              Point nyminus = elem->point(n),
-                                nyplus = elem->point(n);
-                              nyminus(1) -= delta_x;
-                              nyplus(1) += delta_x;
-                              VectorValue<FValue> gyminus =
-                                g->eval_at_point(context,
-                                                 var_component,
-                                                 nyminus,
-                                                 system.time);
-                              VectorValue<FValue> gyplus =
-                                g->eval_at_point(context,
-                                                 var_component,
-                                                 nyplus,
-                                                 system.time);
-                              // xz derivative
-                              Ue(current_dof) = (gyplus(2) - gyminus(2))
-                                / 2. / delta_x;
-                              dof_is_fixed[current_dof] = true;
-                              current_dof++;
-                              // Getting a 2nd order xyz is more tedious
-                              Point nxmym = elem->point(n),
-                                nxmyp = elem->point(n),
-                                nxpym = elem->point(n),
-                                nxpyp = elem->point(n);
-                              nxmym(0) -= delta_x;
-                              nxmym(1) -= delta_x;
-                              nxmyp(0) -= delta_x;
-                              nxmyp(1) += delta_x;
-                              nxpym(0) += delta_x;
-                              nxpym(1) -= delta_x;
-                              nxpyp(0) += delta_x;
-                              nxpyp(1) += delta_x;
-                              VectorValue<FValue> gxmym =
-                                g->eval_at_point(context,
-                                                 var_component,
-                                                 nxmym,
-                                                 system.time);
-                              VectorValue<FValue> gxmyp =
-                                g->eval_at_point(context,
-                                                 var_component,
-                                                 nxmyp,
-                                                 system.time);
-                              VectorValue<FValue> gxpym =
-                                g->eval_at_point(context,
-                                                 var_component,
-                                                 nxpym,
-                                                 system.time);
-                              VectorValue<FValue> gxpyp =
-                                g->eval_at_point(context,
-                                                 var_component,
-                                                 nxpyp,
-                                                 system.time);
-                              FValue gxzplus = (gxpyp(2) - gxmyp(2))
-                                / 2. / delta_x;
-                              FValue gxzminus = (gxpym(2) - gxmym(2))
-                                / 2. / delta_x;
-                              // xyz derivative
-                              Ue(current_dof) = (gxzplus - gxzminus)
-                                / 2. / delta_x;
-                              dof_is_fixed[current_dof] = true;
-                              current_dof++;
-                            }
-                        }
-                    }
-                  else
-                    {
-                      // Assume that other C_ONE elements have a single nodal
-                      // value shape function and nodal gradient component
-                      // shape functions
-                      libmesh_assert_equal_to (nc, (unsigned int)(1 + dim));
-                      Ue(current_dof) = f.eval_at_node(context,
-                                                       var_component,
-                                                       dim,
-                                                       elem->node_ref(n),
-                                                       system.time);
-                      dof_is_fixed[current_dof] = true;
-                      current_dof++;
-                      VectorValue<FValue> grad =
-                        is_parent_vertex ?
-                        g->eval_at_node(context,
-                                        var_component,
-                                        dim,
-                                        elem->node_ref(n),
-                                        system.time) :
-                        g->eval_at_point(context,
-                                         var_component,
-                                         elem->node_ref(n),
-                                         system.time);
-                      for (unsigned int i=0; i!= dim; ++i)
-                        {
-                          Ue(current_dof) = grad(i);
-                          dof_is_fixed[current_dof] = true;
-                          current_dof++;
-                        }
-                    }
-                }
-              else
-                libmesh_error_msg("Unknown continuity " << cont);
-            }
-
-          STOP_LOG ("project_nodes","GenericProjector");
-
-          START_LOG ("project_edges","GenericProjector");
-
-          // In 3D with non-LAGRANGE, project any edge values next
-          if (dim > 2 &&
-              cont != DISCONTINUOUS &&
-              (fe_type.family != LAGRANGE
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-               || elem->infinite()
-#endif
-               ))
-            {
-              // If we're JUST_COARSENED we'll need a custom
-              // evaluation, not just the standard edge FE
-              const std::vector<Point> & xyz_values =
-#ifdef LIBMESH_ENABLE_AMR
-                (elem->refinement_flag() == Elem::JUST_COARSENED) ?
-                fe->get_xyz() :
-#endif
-                edge_fe->get_xyz();
-              const std::vector<Real> & JxW =
-#ifdef LIBMESH_ENABLE_AMR
-                (elem->refinement_flag() == Elem::JUST_COARSENED) ?
-                fe->get_JxW() :
-#endif
-                edge_fe->get_JxW();
-
-              const std::vector<std::vector<Real>> & phi =
-#ifdef LIBMESH_ENABLE_AMR
-                (elem->refinement_flag() == Elem::JUST_COARSENED) ?
-                fe->get_phi() :
-#endif
-                edge_fe->get_phi();
-              const std::vector<std::vector<RealGradient>> * dphi = nullptr;
-              if (cont == C_ONE)
-                dphi =
-#ifdef LIBMESH_ENABLE_AMR
-                  (elem->refinement_flag() == Elem::JUST_COARSENED) ?
-                  &(fe->get_dphi()) :
-#endif
-                  &(edge_fe->get_dphi());
-
-              for (auto e : elem->edge_index_range())
-                {
-                  context.edge = cast_int<unsigned char>(e);
-
-#ifdef LIBMESH_ENABLE_AMR
-                  if (elem->refinement_flag() == Elem::JUST_COARSENED)
-                    {
-                      std::vector<Point> fine_points;
-
-                      std::unique_ptr<FEBase> fine_fe
-                        (FEBase::build (dim, base_fe_type));
-
-                      std::unique_ptr<QBase> qrule
-                        (base_fe_type.default_quadrature_rule(1));
-                      fine_fe->attach_quadrature_rule(qrule.get());
-
-                      const std::vector<Point> & child_xyz =
-                        fine_fe->get_xyz();
-
-                      for (unsigned int c = 0, nc = elem->n_children();
-                           c != nc; ++c)
-                        {
-                          if (!elem->is_child_on_edge(c, e))
-                            continue;
-
-                          fine_fe->edge_reinit(elem->child_ptr(c), e);
-                          fine_points.insert(fine_points.end(),
-                                             child_xyz.begin(),
-                                             child_xyz.end());
-                        }
-
-                      std::vector<Point> fine_qp;
-                      FEInterface::inverse_map (dim, base_fe_type, elem,
-                                                fine_points, fine_qp);
-
-                      context.elem_fe_reinit(&fine_qp);
-                    }
-                  else
-#endif // LIBMESH_ENABLE_AMR
-                    context.edge_fe_reinit();
-
-                  const unsigned int n_qp =
-                    cast_int<unsigned int>(xyz_values.size());
-
-                  FEInterface::dofs_on_edge(elem, dim, base_fe_type,
-                                            e, side_dofs);
-
-                  const unsigned int n_side_dofs =
-                    cast_int<unsigned int>(side_dofs.size());
-
-                  // Some edge dofs are on nodes and already
-                  // fixed, others are free to calculate
-                  unsigned int free_dofs = 0;
-                  for (unsigned int i=0; i != n_side_dofs; ++i)
-                    if (!dof_is_fixed[side_dofs[i]])
-                      free_dof[free_dofs++] = i;
-
-                  // There may be nothing to project
-                  if (!free_dofs)
-                    continue;
-
-                  Ke.resize (free_dofs, free_dofs); Ke.zero();
-                  Fe.resize (free_dofs); Fe.zero();
-                  // The new edge coefficients
-                  DenseVector<FValue> Uedge(free_dofs);
-
-                  // Loop over the quadrature points
-                  for (unsigned int qp=0; qp<n_qp; qp++)
-                    {
-                      // solution at the quadrature point
-                      FValue fineval = f.eval_at_point(context,
-                                                       var_component,
-                                                       xyz_values[qp],
-                                                       system.time);
-                      // solution grad at the quadrature point
-                      VectorValue<FValue> finegrad;
-                      if (cont == C_ONE)
-                        finegrad = g->eval_at_point(context,
-                                                    var_component,
-                                                    xyz_values[qp],
-                                                    system.time);
-
-                      // Form edge projection matrix
-                      for (unsigned int sidei=0, freei=0;
-                           sidei != n_side_dofs; ++sidei)
-                        {
-                          unsigned int i = side_dofs[sidei];
-                          // fixed DoFs aren't test functions
-                          if (dof_is_fixed[i])
-                            continue;
-                          for (unsigned int sidej=0, freej=0;
-                               sidej != n_side_dofs; ++sidej)
-                            {
-                              unsigned int j = side_dofs[sidej];
-                              if (dof_is_fixed[j])
-                                Fe(freei) -= phi[i][qp] * phi[j][qp] *
-                                  JxW[qp] * Ue(j);
-                              else
-                                Ke(freei,freej) += phi[i][qp] *
-                                  phi[j][qp] * JxW[qp];
-                              if (cont == C_ONE)
-                                {
-                                  if (dof_is_fixed[j])
-                                    Fe(freei) -= ( (*dphi)[i][qp] *
-                                                   (*dphi)[j][qp] ) *
-                                      JxW[qp] * Ue(j);
-                                  else
-                                    Ke(freei,freej) += ( (*dphi)[i][qp] *
-                                                         (*dphi)[j][qp] )
-                                      * JxW[qp];
-                                }
-                              if (!dof_is_fixed[j])
-                                freej++;
-                            }
-                          Fe(freei) += phi[i][qp] * fineval * JxW[qp];
-                          if (cont == C_ONE)
-                            Fe(freei) += (finegrad * (*dphi)[i][qp] ) *
-                              JxW[qp];
-                          freei++;
-                        }
-                    }
-
-                  Ke.cholesky_solve(Fe, Uedge);
-
-                  // Transfer new edge solutions to element
-                  for (unsigned int i=0; i != free_dofs; ++i)
-                    {
-                      FValue & ui = Ue(side_dofs[free_dof[i]]);
-                      libmesh_assert(bool(std::abs(ui) < TOLERANCE) ||
-                                     bool(std::abs(ui - Uedge(i)) < TOLERANCE));
-                      ui = Uedge(i);
-                      dof_is_fixed[side_dofs[free_dof[i]]] = true;
-                    }
-                }
-            } // end if (dim > 2, !DISCONTINUOUS, !LAGRANGE)
-
-          STOP_LOG ("project_edges","GenericProjector");
-
-          START_LOG ("project_sides","GenericProjector");
-
-          // With non-LAGRANGE, project any side values (edges in 2D,
-          // faces in 3D) next.
-          if (dim > 1 &&
-              cont != DISCONTINUOUS &&
-              (fe_type.family != LAGRANGE
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-               || elem->infinite()
-#endif
-               ))
-            {
-              // If we're JUST_COARSENED we'll need a custom
-              // evaluation, not just the standard side FE
-              const std::vector<Point> & xyz_values =
-#ifdef LIBMESH_ENABLE_AMR
-                (elem->refinement_flag() == Elem::JUST_COARSENED) ?
-                fe->get_xyz() :
-#endif // LIBMESH_ENABLE_AMR
-                side_fe->get_xyz();
-              const std::vector<Real> & JxW =
-#ifdef LIBMESH_ENABLE_AMR
-                (elem->refinement_flag() == Elem::JUST_COARSENED) ?
-                fe->get_JxW() :
-#endif // LIBMESH_ENABLE_AMR
-                side_fe->get_JxW();
-              const std::vector<std::vector<Real>> & phi =
-#ifdef LIBMESH_ENABLE_AMR
-                (elem->refinement_flag() == Elem::JUST_COARSENED) ?
-                fe->get_phi() :
-#endif // LIBMESH_ENABLE_AMR
-                side_fe->get_phi();
-              const std::vector<std::vector<RealGradient>> * dphi = nullptr;
-              if (cont == C_ONE)
-                dphi =
-#ifdef LIBMESH_ENABLE_AMR
-                  (elem->refinement_flag() == Elem::JUST_COARSENED) ? &(fe->get_dphi()) :
-#endif // LIBMESH_ENABLE_AMR
-                  &(side_fe->get_dphi());
-
-              for (auto s : elem->side_index_range())
-                {
-                  FEInterface::dofs_on_side(elem, dim, base_fe_type,
-                                            s, side_dofs);
-
-                  unsigned int n_side_dofs =
-                    cast_int<unsigned int>(side_dofs.size());
-
-                  // Some side dofs are on nodes/edges and already
-                  // fixed, others are free to calculate
-                  unsigned int free_dofs = 0;
-                  for (unsigned int i=0; i != n_side_dofs; ++i)
-                    if (!dof_is_fixed[side_dofs[i]])
-                      free_dof[free_dofs++] = i;
-
-                  // There may be nothing to project
-                  if (!free_dofs)
-                    continue;
-
-                  Ke.resize (free_dofs, free_dofs); Ke.zero();
-                  Fe.resize (free_dofs); Fe.zero();
-                  // The new side coefficients
-                  DenseVector<FValue> Uside(free_dofs);
-
-                  context.side = cast_int<unsigned char>(s);
-
-#ifdef LIBMESH_ENABLE_AMR
-                  if (elem->refinement_flag() == Elem::JUST_COARSENED)
-                    {
-                      std::vector<Point> fine_points;
-
-                      std::unique_ptr<FEBase> fine_fe
-                        (FEBase::build (dim, base_fe_type));
-
-                      std::unique_ptr<QBase> qrule
-                        (base_fe_type.default_quadrature_rule(dim-1));
-                      fine_fe->attach_quadrature_rule(qrule.get());
-
-                      const std::vector<Point> & child_xyz =
-                        fine_fe->get_xyz();
-
-                      for (unsigned int c = 0, nc = elem->n_children();
-                           c != nc; ++c)
-                        {
-                          if (!elem->is_child_on_side(c, s))
-                            continue;
-
-                          fine_fe->reinit(elem->child_ptr(c), s);
-                          fine_points.insert(fine_points.end(),
-                                             child_xyz.begin(),
-                                             child_xyz.end());
-                        }
-
-                      std::vector<Point> fine_qp;
-                      FEInterface::inverse_map (dim, base_fe_type, elem,
-                                                fine_points, fine_qp);
-
-                      context.elem_fe_reinit(&fine_qp);
-                    }
-                  else
-#endif // LIBMESH_ENABLE_AMR
-                    context.side_fe_reinit();
-
-                  const unsigned int n_qp =
-                    cast_int<unsigned int>(xyz_values.size());
-
-                  // Loop over the quadrature points
-                  for (unsigned int qp=0; qp<n_qp; qp++)
-                    {
-                      // solution at the quadrature point
-                      FValue fineval = f.eval_at_point(context,
-                                                       var_component,
-                                                       xyz_values[qp],
-                                                       system.time);
-                      // solution grad at the quadrature point
-                      VectorValue<FValue> finegrad;
-                      if (cont == C_ONE)
-                        finegrad = g->eval_at_point(context,
-                                                    var_component,
-                                                    xyz_values[qp],
-                                                    system.time);
-
-                      // Form side projection matrix
-                      for (unsigned int sidei=0, freei=0;
-                           sidei != n_side_dofs; ++sidei)
-                        {
-                          unsigned int i = side_dofs[sidei];
-                          // fixed DoFs aren't test functions
-                          if (dof_is_fixed[i])
-                            continue;
-                          for (unsigned int sidej=0, freej=0;
-                               sidej != n_side_dofs; ++sidej)
-                            {
-                              unsigned int j = side_dofs[sidej];
-                              if (dof_is_fixed[j])
-                                Fe(freei) -= phi[i][qp] * phi[j][qp] *
-                                  JxW[qp] * Ue(j);
-                              else
-                                Ke(freei,freej) += phi[i][qp] *
-                                  phi[j][qp] * JxW[qp];
-                              if (cont == C_ONE)
-                                {
-                                  if (dof_is_fixed[j])
-                                    Fe(freei) -= ( (*dphi)[i][qp] *
-                                                   (*dphi)[j][qp] ) *
-                                      JxW[qp] * Ue(j);
-                                  else
-                                    Ke(freei,freej) += ( (*dphi)[i][qp] *
-                                                         (*dphi)[j][qp] )
-                                      * JxW[qp];
-                                }
-                              if (!dof_is_fixed[j])
-                                freej++;
-                            }
-                          Fe(freei) += (fineval * phi[i][qp]) * JxW[qp];
-                          if (cont == C_ONE)
-                            Fe(freei) += (finegrad * (*dphi)[i][qp] ) *
-                              JxW[qp];
-                          freei++;
-                        }
-                    }
-
-                  Ke.cholesky_solve(Fe, Uside);
-
-                  // Transfer new side solutions to element
-                  for (unsigned int i=0; i != free_dofs; ++i)
-                    {
-                      FValue & ui = Ue(side_dofs[free_dof[i]]);
-                      libmesh_assert(bool(std::abs(ui) < TOLERANCE) ||
-                                     bool(std::abs(ui - Uside(i)) < TOLERANCE));
-                      ui = Uside(i);
-                      dof_is_fixed[side_dofs[free_dof[i]]] = true;
-                    }
-                }
-            } // end if (dim > 1, !DISCONTINUOUS, !LAGRANGE)
-
-          STOP_LOG ("project_sides","GenericProjector");
-
-          START_LOG ("project_interior","GenericProjector");
-
-          // Project the interior values, finally
-
-          // Some interior dofs are on nodes/edges/sides and
-          // already fixed, others are free to calculate
-          unsigned int free_dofs = 0;
-          for (unsigned int i=0; i != n_dofs; ++i)
-            if (!dof_is_fixed[i])
-              free_dof[free_dofs++] = i;
-
-          // Project any remaining (interior) dofs in the non-LAGRANGE
-          // case.
-          if (free_dofs &&
-              (fe_type.family != LAGRANGE
-#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
-               || elem->infinite()
-#endif
-               ))
-            {
-              const std::vector<Point> & xyz_values = fe->get_xyz();
-              const std::vector<Real> & JxW = fe->get_JxW();
-
-              const std::vector<std::vector<Real>> & phi = fe->get_phi();
-              const std::vector<std::vector<RealGradient>> * dphi = nullptr;
-              if (cont == C_ONE)
-                dphi = &(fe->get_dphi());
-
-#ifdef LIBMESH_ENABLE_AMR
-              if (elem->refinement_flag() == Elem::JUST_COARSENED)
-                {
-                  std::vector<Point> fine_points;
-
-                  std::unique_ptr<FEBase> fine_fe
-                    (FEBase::build (dim, base_fe_type));
-
-                  std::unique_ptr<QBase> qrule
-                    (base_fe_type.default_quadrature_rule(dim));
-                  fine_fe->attach_quadrature_rule(qrule.get());
-
-                  const std::vector<Point> & child_xyz =
-                    fine_fe->get_xyz();
-
-                  for (auto & child : elem->child_ref_range())
-                    {
-                      fine_fe->reinit(&child);
-                      fine_points.insert(fine_points.end(),
-                                         child_xyz.begin(),
-                                         child_xyz.end());
-                    }
-
-                  std::vector<Point> fine_qp;
-                  FEInterface::inverse_map (dim, base_fe_type, elem,
-                                            fine_points, fine_qp);
-
-                  context.elem_fe_reinit(&fine_qp);
-                }
-              else
-#endif // LIBMESH_ENABLE_AMR
-                context.elem_fe_reinit();
-
-              const unsigned int n_qp =
-                cast_int<unsigned int>(xyz_values.size());
-
-              Ke.resize (free_dofs, free_dofs); Ke.zero();
-              Fe.resize (free_dofs); Fe.zero();
-              // The new interior coefficients
-              DenseVector<FValue> Uint(free_dofs);
-
-              // Loop over the quadrature points
-              for (unsigned int qp=0; qp<n_qp; qp++)
-                {
-                  // solution at the quadrature point
-                  FValue fineval = f.eval_at_point(context,
-                                                   var_component,
-                                                   xyz_values[qp],
-                                                   system.time);
-                  // solution grad at the quadrature point
-                  VectorValue<FValue> finegrad;
-                  if (cont == C_ONE)
-                    finegrad = g->eval_at_point(context,
-                                                var_component,
-                                                xyz_values[qp],
-                                                system.time);
-
-                  // Form interior projection matrix
-                  for (unsigned int i=0, freei=0; i != n_dofs; ++i)
-                    {
-                      // fixed DoFs aren't test functions
-                      if (dof_is_fixed[i])
-                        continue;
-                      for (unsigned int j=0, freej=0; j != n_dofs; ++j)
-                        {
-                          if (dof_is_fixed[j])
-                            Fe(freei) -= phi[i][qp] * phi[j][qp] * JxW[qp]
-                              * Ue(j);
-                          else
-                            Ke(freei,freej) += phi[i][qp] * phi[j][qp] *
-                              JxW[qp];
-                          if (cont == C_ONE)
-                            {
-                              if (dof_is_fixed[j])
-                                Fe(freei) -= ( (*dphi)[i][qp] *
-                                               (*dphi)[j][qp] ) * JxW[qp] *
-                                  Ue(j);
-                              else
-                                Ke(freei,freej) += ( (*dphi)[i][qp] *
-                                                     (*dphi)[j][qp] ) *
-                                  JxW[qp];
-                            }
-                          if (!dof_is_fixed[j])
-                            freej++;
-                        }
-                      Fe(freei) += phi[i][qp] * fineval * JxW[qp];
-                      if (cont == C_ONE)
-                        Fe(freei) += (finegrad * (*dphi)[i][qp] ) * JxW[qp];
-                      freei++;
-                    }
-                }
-              Ke.cholesky_solve(Fe, Uint);
-
-              // Transfer new interior solutions to element
-              for (unsigned int i=0; i != free_dofs; ++i)
-                {
-                  FValue & ui = Ue(free_dof[i]);
-                  libmesh_assert(bool(std::abs(ui) < TOLERANCE) ||
-                                 bool(std::abs(ui - Uint(i)) < TOLERANCE));
-                  ui = Uint(i);
-                  dof_is_fixed[free_dof[i]] = true;
-                }
-
-            } // if there are free interior dofs
-
-          STOP_LOG ("project_interior","GenericProjector");
-
-          // Make sure every DoF got reached!
-          for (unsigned int i=0; i != n_dofs; ++i)
-            libmesh_assert(dof_is_fixed[i]);
-
-          action.insert(context, var, Ue);
+          std::vector<unsigned int> all_dofs(n_dofs);
+          std::iota(all_dofs.begin(), all_dofs.end(), 0);
+
+          this->construct_projection
+            (dof_indices, all_dofs, var_component, context, nullptr,
+             insert_id, *fe, f, g.get(), ids_to_save);
         } // end variables loop
     } // end elements loop
+  STOP_LOG ("project_interiors","GenericProjector");
 }
+
+
+
+template <typename FFunctor, typename GFunctor,
+          typename FValue, typename ProjectionAction>
+void
+GenericProjector<FFunctor, GFunctor, FValue,
+                 ProjectionAction>::find_dofs_to_send
+  (const Node & node,
+   std::unordered_map<dof_id_type, std::pair<FValue, processor_id_type>> & ids_to_push) const
+{
+  // Any ghosted node in our range might have an owner who needs our
+  // data
+  const processor_id_type owner = node.processor_id();
+  if (owner != system.processor_id())
+    {
+      const MeshBase & mesh = system.get_mesh();
+      const DofMap & dof_map = system.get_dof_map();
+
+      // But let's check and see if we can be certain the owner can
+      // compute any or all of its own dof coefficients on that node
+      std::vector<dof_id_type> node_dof_ids, elem_dof_ids;
+      dof_map.dof_indices(&node, node_dof_ids);
+      libmesh_assert(std::is_sorted(node_dof_ids.begin(),
+                                    node_dof_ids.end()));
+      const std::vector<dof_id_type> & patch =
+        (*nodes_to_elem)[node.id()];
+      for (const auto & elem_id : patch)
+        {
+          const Elem * elem = mesh.query_elem_ptr(elem_id);
+          if (!elem->active())
+            continue;
+          dof_map.dof_indices(elem, elem_dof_ids);
+          std::sort(elem_dof_ids.begin(), elem_dof_ids.end());
+
+          std::vector<dof_id_type> diff_ids(node_dof_ids.size());
+          auto it = std::set_difference(node_dof_ids.begin(), node_dof_ids.end(),
+                                        elem_dof_ids.begin(), elem_dof_ids.end(), diff_ids.begin());
+          diff_ids.resize(it-diff_ids.begin());
+          node_dof_ids.swap(diff_ids);
+          if (node_dof_ids.empty())
+            break;
+        }
+
+      // Give ids_to_push default invalid pid: not yet computed
+      for (auto id : node_dof_ids)
+        ids_to_push[id].second = DofObject::invalid_processor_id;
+    }
+}
+
+
+
+template <typename FFunctor, typename GFunctor,
+          typename FValue, typename ProjectionAction>
+void
+GenericProjector<FFunctor, GFunctor, FValue,
+                 ProjectionAction>::send_and_insert_dof_values
+  (std::unordered_map<dof_id_type, std::pair<FValue, processor_id_type>> & ids_to_push,
+   ProjectionAction & action) const
+{
+  // See if we calculated any ids that need to be pushed; get them
+  // ready to push.
+  std::unordered_map<processor_id_type, std::vector<dof_id_type>>
+    pushed_dof_ids, received_dof_ids;
+  std::unordered_map<processor_id_type, std::vector<typename TypeToSend<FValue>::type>>
+    pushed_dof_values, received_dof_values;
+  for (auto & id_val_pid : ids_to_push)
+    {
+      processor_id_type pid = id_val_pid.second.second;
+      if (pid != DofObject::invalid_processor_id)
+        {
+          pushed_dof_ids[pid].push_back(id_val_pid.first);
+          pushed_dof_values[pid].push_back(convert_to_send(id_val_pid.second.first));
+        }
+    }
+
+  // If and when we get ids pushed to us, act on them if we have
+  // corresponding values or save them if not
+  auto ids_action_functor =
+    [&action, &received_dof_ids, &received_dof_values]
+    (processor_id_type pid,
+     const std::vector<dof_id_type> & data)
+    {
+      auto iter = received_dof_values.find(pid);
+      if (iter == received_dof_values.end())
+        {
+          libmesh_assert(received_dof_ids.find(pid) ==
+                         received_dof_ids.end());
+          received_dof_ids[pid] = data;
+        }
+      else
+        {
+          auto & vals = iter->second;
+          std::size_t vals_size = vals.size();
+          libmesh_assert_equal_to(vals_size, data.size());
+          for (std::size_t i=0; i != vals_size; ++i)
+            {
+              FValue val;
+              convert_from_receive(vals[i], val);
+              action.insert(data[i], val);
+            }
+          received_dof_values.erase(iter);
+        }
+    };
+
+  // If and when we get values pushed to us, act on them if we have
+  // corresponding ids or save them if not
+  auto values_action_functor =
+    [&action, &received_dof_ids, &received_dof_values]
+    (processor_id_type pid,
+     const std::vector<typename TypeToSend<FValue>::type> & data)
+    {
+      auto iter = received_dof_ids.find(pid);
+      if (iter == received_dof_ids.end())
+        {
+          // We get no more than 1 values vector from anywhere
+          libmesh_assert(received_dof_values.find(pid) ==
+                         received_dof_values.end());
+          received_dof_values[pid] = data;
+        }
+      else
+        {
+          auto & ids = iter->second;
+          std::size_t ids_size = ids.size();
+          libmesh_assert_equal_to(ids_size, data.size());
+          for (std::size_t i=0; i != ids_size; ++i)
+            {
+              FValue val;
+              convert_from_receive(data[i], val);
+              action.insert(ids[i], val);
+            }
+          received_dof_ids.erase(iter);
+        }
+    };
+
+  Parallel::push_parallel_vector_data
+    (system.comm(), pushed_dof_ids, ids_action_functor);
+
+  Parallel::push_parallel_vector_data
+    (system.comm(), pushed_dof_values, values_action_functor);
+
+  // At this point we shouldn't have any unprocessed data left
+  libmesh_assert(received_dof_ids.empty());
+  libmesh_assert(received_dof_values.empty());
+
+}
+
+
+
+template <typename FFunctor, typename GFunctor,
+          typename FValue, typename ProjectionAction>
+template <typename InsertId>
+void
+GenericProjector<FFunctor, GFunctor, FValue,
+                 ProjectionAction>::construct_projection
+  (const std::vector<dof_id_type> & dof_indices_var,
+   const std::vector<unsigned int> & involved_dofs,
+   unsigned int var_component,
+   const FEMContext & context,
+   const Node * node,
+   InsertId & insert_id,
+   const FEBase & fe,
+   FFunctor & f,
+   GFunctor * g,
+   const std::unordered_map<dof_id_type, FValue> & ids_to_save
+   ) const
+{
+  const std::vector<Real> & JxW = fe.get_JxW();
+  const std::vector<std::vector<Real>> & phi = fe.get_phi();
+  const std::vector<std::vector<RealGradient>> * dphi = nullptr;
+  const std::vector<Point> & xyz_values = fe.get_xyz();
+  const FEContinuity cont = fe.get_continuity();
+
+  if (cont == C_ONE)
+    dphi = &(fe.get_dphi());
+
+  const unsigned int n_involved_dofs =
+    cast_int<unsigned int>(involved_dofs.size());
+
+  std::vector<dof_id_type> free_dof_ids;
+  DenseVector<FValue> Uinvolved(n_involved_dofs);
+  std::vector<char> dof_is_fixed(n_involved_dofs, false); // bools
+
+  for (auto i : IntRange<unsigned int>(0, n_involved_dofs))
+    {
+      const dof_id_type id = dof_indices_var[involved_dofs[i]];
+      auto iter = ids_to_save.find(id);
+      if (iter == ids_to_save.end())
+        free_dof_ids.push_back(id);
+      else
+        {
+          dof_is_fixed[i] = true;
+          Uinvolved(i) = iter->second;
+        }
+    }
+
+  const unsigned int free_dofs = free_dof_ids.size();
+
+  // There may be nothing to project
+  if (!free_dofs)
+    return;
+
+  // The element matrix and RHS for projections.
+  // Note that Ke is always real-valued, whereas
+  // Fe may be complex valued if complex number
+  // support is enabled
+  DenseMatrix<Real> Ke(free_dofs, free_dofs);
+  DenseVector<FValue> Fe(free_dofs);
+  // The new degree of freedom coefficients to solve for
+  DenseVector<FValue> Ufree(free_dofs);
+
+  const unsigned int n_qp =
+    cast_int<unsigned int>(xyz_values.size());
+
+  // Loop over the quadrature points
+  for (unsigned int qp=0; qp<n_qp; qp++)
+    {
+      // solution at the quadrature point
+      FValue fineval = f.eval_at_point(context,
+                                       var_component,
+                                       xyz_values[qp],
+                                       system.time);
+      // solution grad at the quadrature point
+      VectorValue<FValue> finegrad;
+      if (cont == C_ONE)
+        finegrad = g->eval_at_point(context,
+                                    var_component,
+                                    xyz_values[qp],
+                                    system.time);
+
+      // Form edge projection matrix
+      for (unsigned int sidei=0, freei=0;
+           sidei != n_involved_dofs; ++sidei)
+        {
+          unsigned int i = involved_dofs[sidei];
+          // fixed DoFs aren't test functions
+          if (dof_is_fixed[sidei])
+            continue;
+          for (unsigned int sidej=0, freej=0;
+               sidej != n_involved_dofs; ++sidej)
+            {
+              unsigned int j = involved_dofs[sidej];
+              if (dof_is_fixed[sidej])
+                Fe(freei) -= phi[i][qp] * phi[j][qp] *
+                  JxW[qp] * Uinvolved(sidej);
+              else
+                Ke(freei,freej) += phi[i][qp] *
+                  phi[j][qp] * JxW[qp];
+              if (cont == C_ONE)
+                {
+                  if (dof_is_fixed[sidej])
+                    Fe(freei) -= ( (*dphi)[i][qp] *
+                                   (*dphi)[j][qp] ) *
+                      JxW[qp] * Uinvolved(sidej);
+                  else
+                    Ke(freei,freej) += ( (*dphi)[i][qp] *
+                                         (*dphi)[j][qp] )
+                      * JxW[qp];
+                }
+              if (!dof_is_fixed[sidej])
+                freej++;
+            }
+          Fe(freei) += phi[i][qp] * fineval * JxW[qp];
+          if (cont == C_ONE)
+            Fe(freei) += (finegrad * (*dphi)[i][qp] ) *
+              JxW[qp];
+          freei++;
+        }
+    }
+
+  Ke.cholesky_solve(Fe, Ufree);
+
+  // Transfer new edge solutions to element
+  const processor_id_type pid = node ?
+    node->processor_id() : DofObject::invalid_processor_id;
+  for (unsigned int i=0; i != free_dofs; ++i)
+    insert_id(free_dof_ids[i], Ufree(i), pid);
+}
+
 
 } // namespace libMesh
 

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1560,7 +1560,8 @@ public:
   /**
    * \returns The value of the solution variable \p var at the physical
    * point \p p in the mesh, without knowing a priori which element
-   * contains \p p.
+   * contains \p p, using the degree of freedom coefficients in \p sol
+   * (or in \p current_local_solution if \p sol is left null).
    *
    * \note This function uses \p MeshBase::sub_point_locator(); users
    * may or may not want to call \p MeshBase::clear_point_locator()
@@ -1578,16 +1579,20 @@ public:
    * the method to return 0 when the point is not located.
    */
   Number point_value(unsigned int var, const Point & p,
-                     const bool insist_on_success = true) const;
+                     const bool insist_on_success = true,
+                     const NumericVector<Number> * sol = nullptr) const;
 
   /**
    * \returns The value of the solution variable \p var at the physical
-   * point \p p contained in local Elem \p e
+   * point \p p contained in local Elem \p e, using the degree of
+   * freedom coefficients in \p sol (or in \p current_local_solution
+   * if \p sol is left null).
    *
    * This version of point_value can be run in serial, but assumes \p e is in
    * the local mesh partition or is algebraically ghosted.
    */
-  Number point_value(unsigned int var, const Point & p, const Elem & e) const;
+  Number point_value(unsigned int var, const Point & p, const Elem & e,
+                     const NumericVector<Number> * sol = nullptr) const;
 
   /**
    * Calls the version of point_value() which takes a reference.
@@ -1598,17 +1603,27 @@ public:
   Number point_value(unsigned int var, const Point & p, const Elem * e) const;
 
   /**
+   * Calls the parallel version of point_value().
+   * This function exists only to prevent people from accidentally
+   * calling the version of point_value() that has a boolean third
+   * argument, which would result in incorrect output.
+   */
+  Number point_value(unsigned int var, const Point & p, const NumericVector<Number> * sol) const;
+
+  /**
    * \returns The gradient of the solution variable \p var at the physical
    * point \p p in the mesh, similarly to point_value.
    */
   Gradient point_gradient(unsigned int var, const Point & p,
-                          const bool insist_on_success = true) const;
+                          const bool insist_on_success = true,
+                          const NumericVector<Number> * sol = nullptr) const;
 
   /**
    * \returns The gradient of the solution variable \p var at the physical
    * point \p p in local Elem \p e in the mesh, similarly to point_value.
    */
-  Gradient point_gradient(unsigned int var, const Point & p, const Elem & e) const;
+  Gradient point_gradient(unsigned int var, const Point & p, const Elem & e,
+                          const NumericVector<Number> * sol = nullptr) const;
 
   /**
    * Calls the version of point_gradient() which takes a reference.
@@ -1619,18 +1634,28 @@ public:
   Gradient point_gradient(unsigned int var, const Point & p, const Elem * e) const;
 
   /**
+   * Calls the parallel version of point_gradient().
+   * This function exists only to prevent people from accidentally
+   * calling the version of point_gradient() that has a boolean third
+   * argument, which would result in incorrect output.
+   */
+  Gradient point_gradient(unsigned int var, const Point & p, const NumericVector<Number> * sol) const;
+
+  /**
    * \returns The second derivative tensor of the solution variable \p var
    * at the physical point \p p in the mesh, similarly to point_value.
    */
   Tensor point_hessian(unsigned int var, const Point & p,
-                       const bool insist_on_success = true) const;
+                       const bool insist_on_success = true,
+                       const NumericVector<Number> * sol = nullptr) const;
 
   /**
    * \returns The second derivative tensor of the solution variable \p var
    * at the physical point \p p in local Elem \p e in the mesh, similarly to
    * point_value.
    */
-  Tensor point_hessian(unsigned int var, const Point & p, const Elem & e) const;
+  Tensor point_hessian(unsigned int var, const Point & p, const Elem & e,
+                       const NumericVector<Number> * sol = nullptr) const;
 
   /**
    * Calls the version of point_hessian() which takes a reference.
@@ -1639,6 +1664,15 @@ public:
    * would result in unnecessary PointLocator calls.
    */
   Tensor point_hessian(unsigned int var, const Point & p, const Elem * e) const;
+
+  /**
+   * Calls the parallel version of point_hessian().
+   * This function exists only to prevent people from accidentally
+   * calling the version of point_hessian() that has a boolean third
+   * argument, which would result in incorrect output.
+   */
+  Tensor point_hessian(unsigned int var, const Point & p, const NumericVector<Number> * sol) const;
+
 
   /**
    * Fills the std::set with the degrees of freedom on the local

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2300,7 +2300,7 @@ void DofMap::_node_dof_indices (const Elem & elem,
           di.resize(di.size() + nc, DofObject::invalid_id);
         }
       else
-        for (int i=n_comp-1; i>=dof_offset; i--)
+        for (unsigned int i = dof_offset; i != n_comp; ++i)
           {
             const dof_id_type d =
               obj.dof_number(sys_num, vg, vig, i, n_comp);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2224,6 +2224,105 @@ void DofMap::dof_indices (const Node * const node,
 }
 
 
+void DofMap::dof_indices (const Elem & elem,
+                          unsigned int n,
+                          std::vector<dof_id_type> & di,
+                          const unsigned int vn) const
+{
+  this->_node_dof_indices(elem, n, elem.node_ref(n), di, vn);
+}
+
+
+
+void DofMap::old_dof_indices (const Elem & elem,
+                              unsigned int n,
+                              std::vector<dof_id_type> & di,
+                              const unsigned int vn) const
+{
+  const DofObject * old_obj = elem.node_ref(n).old_dof_object;
+  libmesh_assert(old_obj);
+  this->_node_dof_indices(elem, n, *old_obj, di, vn);
+}
+
+
+
+void DofMap::_node_dof_indices (const Elem & elem,
+                                unsigned int n,
+                                const DofObject & obj,
+                                std::vector<dof_id_type> & di,
+                                const unsigned int vn) const
+{
+  // Half of this is a cut and paste of _dof_indices code below, but
+  // duplication actually seems cleaner than creating a helper
+  // function with a million arguments and hoping the compiler inlines
+  // it properly into one of our most highly trafficked functions.
+
+  LOG_SCOPE("_node_dof_indices()", "DofMap");
+
+  const ElemType type = elem.type();
+  const unsigned int dim = elem.dim();
+
+  const unsigned int sys_num = this->sys_number();
+  const std::pair<unsigned int, unsigned int>
+    vg_and_offset = obj.var_to_vg_and_offset(sys_num,vn);
+  const unsigned int vg = vg_and_offset.first;
+  const unsigned int vig = vg_and_offset.second;
+  const unsigned int n_comp = obj.n_comp_group(sys_num,vg);
+
+  const VariableGroup & var = this->variable_group(vg);
+  FEType fe_type = var.type();
+  fe_type.order = static_cast<Order>(fe_type.order +
+                                     elem.p_level());
+  const bool extra_hanging_dofs =
+    FEInterface::extra_hanging_dofs(fe_type);
+
+  // There is a potential problem with h refinement.  Imagine a
+  // quad9 that has a linear FE on it.  Then, on the hanging side,
+  // it can falsely identify a DOF at the mid-edge node. This is why
+  // we go through FEInterface instead of obj->n_comp() directly.
+  const unsigned int nc =
+    FEInterface::n_dofs_at_node(dim, fe_type, type, n);
+
+  // If this is a non-vertex on a hanging node with extra
+  // degrees of freedom, we use the non-vertex dofs (which
+  // come in reverse order starting from the end, to
+  // simplify p refinement)
+  if (extra_hanging_dofs && !elem.is_vertex(n))
+    {
+      const int dof_offset = n_comp - nc;
+
+      // We should never have fewer dofs than necessary on a
+      // node unless we're getting indices on a parent element,
+      // and we should never need the indices on such a node
+      if (dof_offset < 0)
+        {
+          libmesh_assert(!elem.active());
+          di.resize(di.size() + nc, DofObject::invalid_id);
+        }
+      else
+        for (int i=n_comp-1; i>=dof_offset; i--)
+          {
+            const dof_id_type d =
+              obj.dof_number(sys_num, vg, vig, i, n_comp);
+            libmesh_assert_not_equal_to (d, DofObject::invalid_id);
+            di.push_back(d);
+          }
+    }
+  // If this is a vertex or an element without extra hanging
+  // dofs, our dofs come in forward order coming from the
+  // beginning
+  else
+    for (unsigned int i=0; i<nc; i++)
+      {
+        const dof_id_type d =
+          obj.dof_number(sys_num, vg, vig, i, n_comp);
+        libmesh_assert_not_equal_to (d, DofObject::invalid_id);
+        di.push_back(d);
+      }
+}
+
+
+
 void DofMap::_dof_indices (const Elem & elem,
                            int p_level,
                            std::vector<dof_id_type> & di,
@@ -2270,22 +2369,22 @@ void DofMap::_dof_indices (const Elem & elem,
       // Get the node-based DOF numbers
       for (unsigned int n=0; n != n_nodes; n++)
         {
-          const Node * node      = nodes[n];
+          const Node & node = *nodes[n];
 
           // Cache the intermediate lookups that are common to every
           // component
 #ifdef DEBUG
           const std::pair<unsigned int, unsigned int>
-            vg_and_offset = node->var_to_vg_and_offset(sys_num,v);
+            vg_and_offset = node.var_to_vg_and_offset(sys_num,v);
           libmesh_assert_equal_to (vg, vg_and_offset.first);
           libmesh_assert_equal_to (vig, vg_and_offset.second);
 #endif
-          const unsigned int n_comp = node->n_comp_group(sys_num,vg);
+          const unsigned int n_comp = node.n_comp_group(sys_num,vg);
 
           // There is a potential problem with h refinement.  Imagine a
           // quad9 that has a linear FE on it.  Then, on the hanging side,
           // it can falsely identify a DOF at the mid-edge node. This is why
-          // we go through FEInterface instead of node->n_comp() directly.
+          // we go through FEInterface instead of node.n_comp() directly.
           const unsigned int nc =
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
             is_inf ?
@@ -2313,7 +2412,7 @@ void DofMap::_dof_indices (const Elem & elem,
                 for (int i=n_comp-1; i>=dof_offset; i--)
                   {
                     const dof_id_type d =
-                      node->dof_number(sys_num, vg, vig, i, n_comp);
+                      node.dof_number(sys_num, vg, vig, i, n_comp);
                     libmesh_assert_not_equal_to (d, DofObject::invalid_id);
                     di.push_back(d);
                   }
@@ -2325,7 +2424,7 @@ void DofMap::_dof_indices (const Elem & elem,
             for (unsigned int i=0; i<nc; i++)
               {
                 const dof_id_type d =
-                  node->dof_number(sys_num, vg, vig, i, n_comp);
+                  node.dof_number(sys_num, vg, vig, i, n_comp);
                 libmesh_assert_not_equal_to (d, DofObject::invalid_id);
                 di.push_back(d);
               }

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -2287,7 +2287,7 @@ void DofMap::_node_dof_indices (const Elem & elem,
   // degrees of freedom, we use the non-vertex dofs (which
   // come in reverse order starting from the end, to
   // simplify p refinement)
-  if (extra_hanging_dofs && !elem.is_vertex(n))
+  if (extra_hanging_dofs && nc && !elem.is_vertex(n))
     {
       const int dof_offset = n_comp - nc;
 

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -159,6 +159,7 @@ unsigned int hierarchic_n_dofs_at_node(const ElemType t,
           return 1;
           // Internal DoFs are associated with the elem, not its nodes
         case 2:
+          libmesh_assert_equal_to(t, EDGE3);
           return 0;
         default:
           libmesh_error_msg("ERROR: Invalid node ID " << n << " selected for EDGE2/3!");

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1990,7 +1990,10 @@ void System::user_QOI_derivative(const QoISet & qoi_indices,
 
 
 
-Number System::point_value(unsigned int var, const Point & p, const bool insist_on_success) const
+Number System::point_value(unsigned int var,
+                           const Point & p,
+                           const bool insist_on_success,
+                           const NumericVector<Number> *sol) const
 {
   // This function must be called on every processor; there's no
   // telling where in the partition p falls.
@@ -2024,7 +2027,7 @@ Number System::point_value(unsigned int var, const Point & p, const bool insist_
   Number u = 0;
 
   if (e && this->get_dof_map().is_evaluable(*e, var))
-    u = point_value(var, p, *e);
+    u = point_value(var, p, *e, sol);
 
   // If I have an element containing p, then let's let everyone know
   processor_id_type lowest_owner =
@@ -2043,12 +2046,18 @@ Number System::point_value(unsigned int var, const Point & p, const bool insist_
   return u;
 }
 
-Number System::point_value(unsigned int var, const Point & p, const Elem & e) const
+Number System::point_value(unsigned int var,
+                           const Point & p,
+                           const Elem & e,
+                           const NumericVector<Number> *sol) const
 {
   // Ensuring that the given point is really in the element is an
   // expensive assert, but as long as debugging is turned on we might
   // as well try to catch a particularly nasty potential error
   libmesh_assert (e.contains_point(p));
+
+  if (!sol)
+    sol = this->current_local_solution.get();
 
   // Get the dof map to get the proper indices for our computation
   const DofMap & dof_map = this->get_dof_map();
@@ -2081,7 +2090,7 @@ Number System::point_value(unsigned int var, const Point & p, const Elem & e) co
 
   for (unsigned int l=0; l<num_dofs; l++)
     {
-      u += fe_data.shape[l]*this->current_solution (dof_indices[l]);
+      u += fe_data.shape[l] * (*sol)(dof_indices[l]);
     }
 
   return u;
@@ -2097,7 +2106,18 @@ Number System::point_value(unsigned int var, const Point & p, const Elem * e) co
 
 
 
-Gradient System::point_gradient(unsigned int var, const Point & p, const bool insist_on_success) const
+Number System::point_value(unsigned int var, const Point & p, const NumericVector<Number> * sol) const
+{
+  return this->point_value(var, p, true, sol);
+}
+
+
+
+
+Gradient System::point_gradient(unsigned int var,
+                                const Point & p,
+                                const bool insist_on_success,
+                                const NumericVector<Number> *sol) const
 {
   // This function must be called on every processor; there's no
   // telling where in the partition p falls.
@@ -2131,7 +2151,7 @@ Gradient System::point_gradient(unsigned int var, const Point & p, const bool in
   Gradient grad_u;
 
   if (e && this->get_dof_map().is_evaluable(*e, var))
-    grad_u = point_gradient(var, p, *e);
+    grad_u = point_gradient(var, p, *e, sol);
 
   // If I have an element containing p, then let's let everyone know
   processor_id_type lowest_owner =
@@ -2151,12 +2171,18 @@ Gradient System::point_gradient(unsigned int var, const Point & p, const bool in
 }
 
 
-Gradient System::point_gradient(unsigned int var, const Point & p, const Elem & e) const
+Gradient System::point_gradient(unsigned int var,
+                                const Point & p,
+                                const Elem & e,
+                                const NumericVector<Number> *sol) const
 {
   // Ensuring that the given point is really in the element is an
   // expensive assert, but as long as debugging is turned on we might
   // as well try to catch a particularly nasty potential error
   libmesh_assert (e.contains_point(p));
+
+  if (!sol)
+    sol = this->current_local_solution.get();
 
   // Get the dof map to get the proper indices for our computation
   const DofMap & dof_map = this->get_dof_map();
@@ -2201,7 +2227,7 @@ Gradient System::point_gradient(unsigned int var, const Point & p, const Elem & 
             // FIXME: this needs better syntax: It is matrix-vector multiplication.
             grad_u(xyz) += fe_data.local_transform[v][xyz]
               * fe_data.dshape[l](v)
-              * this->current_solution (dof_indices[l]);
+              * (*sol)(dof_indices[l]);
           }
     }
 
@@ -2218,9 +2244,19 @@ Gradient System::point_gradient(unsigned int var, const Point & p, const Elem * 
 
 
 
+Gradient System::point_gradient(unsigned int var, const Point & p, const NumericVector<Number> * sol) const
+{
+  return this->point_gradient(var, p, true, sol);
+}
+
+
+
 // We can only accumulate a hessian with --enable-second
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-Tensor System::point_hessian(unsigned int var, const Point & p, const bool insist_on_success) const
+Tensor System::point_hessian(unsigned int var,
+                             const Point & p,
+                             const bool insist_on_success,
+                             const NumericVector<Number> *sol) const
 {
   // This function must be called on every processor; there's no
   // telling where in the partition p falls.
@@ -2254,7 +2290,7 @@ Tensor System::point_hessian(unsigned int var, const Point & p, const bool insis
   Tensor hess_u;
 
   if (e && this->get_dof_map().is_evaluable(*e, var))
-    hess_u = point_hessian(var, p, *e);
+    hess_u = point_hessian(var, p, *e, sol);
 
   // If I have an element containing p, then let's let everyone know
   processor_id_type lowest_owner =
@@ -2273,12 +2309,18 @@ Tensor System::point_hessian(unsigned int var, const Point & p, const bool insis
   return hess_u;
 }
 
-Tensor System::point_hessian(unsigned int var, const Point & p, const Elem & e) const
+Tensor System::point_hessian(unsigned int var,
+                             const Point & p,
+                             const Elem & e,
+                             const NumericVector<Number> *sol) const
 {
   // Ensuring that the given point is really in the element is an
   // expensive assert, but as long as debugging is turned on we might
   // as well try to catch a particularly nasty potential error
   libmesh_assert (e.contains_point(p));
+
+  if (!sol)
+    sol = this->current_local_solution.get();
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   if (e.infinite())
@@ -2321,7 +2363,7 @@ Tensor System::point_hessian(unsigned int var, const Point & p, const Elem & e) 
 
   for (unsigned int l=0; l<num_dofs; l++)
     {
-      hess_u.add_scaled (d2phi[l][0], this->current_solution (dof_indices[l]));
+      hess_u.add_scaled (d2phi[l][0], (*sol)(dof_indices[l]));
     }
 
   return hess_u;
@@ -2337,8 +2379,15 @@ Tensor System::point_hessian(unsigned int var, const Point & p, const Elem * e) 
 
 
 
+Tensor System::point_hessian(unsigned int var, const Point & p, const NumericVector<Number> * sol) const
+{
+  return this->point_hessian(var, p, true, sol);
+}
+
 #else
-Tensor System::point_hessian(unsigned int, const Point &, const bool) const
+
+Tensor System::point_hessian(unsigned int, const Point &, const bool,
+                             const NumericVector<Number> *) const
 {
   libmesh_error_msg("We can only accumulate a hessian with --enable-second");
 
@@ -2346,7 +2395,8 @@ Tensor System::point_hessian(unsigned int, const Point &, const bool) const
   return Tensor();
 }
 
-Tensor System::point_hessian(unsigned int, const Point &, const Elem &) const
+Tensor System::point_hessian(unsigned int, const Point &, const Elem &,
+                             const NumericVector<Number> *) const
 {
   libmesh_error_msg("We can only accumulate a hessian with --enable-second");
 
@@ -2355,6 +2405,14 @@ Tensor System::point_hessian(unsigned int, const Point &, const Elem &) const
 }
 
 Tensor System::point_hessian(unsigned int, const Point &, const Elem *) const
+{
+  libmesh_error_msg("We can only accumulate a hessian with --enable-second");
+
+  // Avoid compiler warnings
+  return Tensor();
+}
+
+Tensor System::point_hessian(unsigned int, const Point &, const NumericVector<Number> *) const
 {
   libmesh_error_msg("We can only accumulate a hessian with --enable-second");
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2021,8 +2021,13 @@ Number System::point_value(unsigned int var,
   if (!insist_on_success || !mesh.is_serial())
     locator.enable_out_of_mesh_mode();
 
-  // Get a pointer to the element that contains P
-  const Elem * e = locator(p);
+  // Get a pointer to an element that contains p and allows us to
+  // evaluate var
+  const std::set<subdomain_id_type> & raw_subdomains =
+    this->variable(var).active_subdomains();
+  const std::set<subdomain_id_type> * implicit_subdomains =
+    raw_subdomains.empty() ? nullptr : &raw_subdomains;
+  const Elem * e = locator(p, implicit_subdomains);
 
   Number u = 0;
 
@@ -2145,8 +2150,13 @@ Gradient System::point_gradient(unsigned int var,
   if (!insist_on_success || !mesh.is_serial())
     locator.enable_out_of_mesh_mode();
 
-  // Get a pointer to the element that contains P
-  const Elem * e = locator(p);
+  // Get a pointer to an element that contains p and allows us to
+  // evaluate var
+  const std::set<subdomain_id_type> & raw_subdomains =
+    this->variable(var).active_subdomains();
+  const std::set<subdomain_id_type> * implicit_subdomains =
+    raw_subdomains.empty() ? nullptr : &raw_subdomains;
+  const Elem * e = locator(p, implicit_subdomains);
 
   Gradient grad_u;
 
@@ -2284,8 +2294,13 @@ Tensor System::point_hessian(unsigned int var,
   if (!insist_on_success || !mesh.is_serial())
     locator.enable_out_of_mesh_mode();
 
-  // Get a pointer to the element that contains P
-  const Elem * e = locator(p);
+  // Get a pointer to an element that contains p and allows us to
+  // evaluate var
+  const std::set<subdomain_id_type> & raw_subdomains =
+    this->variable(var).active_subdomains();
+  const std::set<subdomain_id_type> * implicit_subdomains =
+    raw_subdomains.empty() ? nullptr : &raw_subdomains;
+  const Elem * e = locator(p, implicit_subdomains);
 
   Tensor hess_u;
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -501,6 +501,7 @@ public:
                      unsigned int i,
                      unsigned int elem_dim,
                      const Node & n,
+                     bool extra_hanging_dofs,
                      Real /* time */ = 0.);
 
   DSNA eval_at_point(const FEMContext & c,
@@ -701,6 +702,7 @@ eval_at_node(const FEMContext & c,
              unsigned int i,
              unsigned int /* elem_dim */,
              const Node & n,
+             bool extra_hanging_dofs,
              Real /* time */)
 {
   LOG_SCOPE ("Real eval_at_node()", "OldSolutionCoefs");
@@ -711,8 +713,16 @@ eval_at_node(const FEMContext & c,
   // Be sure to handle cases where the variable wasn't defined on
   // this node (due to changing subdomain support) or where the
   // variable has no components on this node (due to Elem order
-  // exceeding FE order)
+  // exceeding FE order) or where the old_dof_object dofs might
+  // correspond to non-vertex dofs (due to extra_hanging_dofs and
+  // refinement)
+
+  const Elem::RefinementState flag = c.get_elem().refinement_flag();
+
   if (n.old_dof_object &&
+      (!extra_hanging_dofs ||
+       flag == Elem::JUST_COARSENED ||
+       flag == Elem::DO_NOTHING) &&
       n.old_dof_object->n_vars(sys.number()) &&
       n.old_dof_object->n_comp(sys.number(), i))
     {
@@ -738,6 +748,7 @@ eval_at_node(const FEMContext & c,
              unsigned int i,
              unsigned int elem_dim,
              const Node & n,
+             bool extra_hanging_dofs,
              Real /* time */)
 {
   LOG_SCOPE ("RealGradient eval_at_node()", "OldSolutionCoefs");
@@ -748,8 +759,16 @@ eval_at_node(const FEMContext & c,
   // Be sure to handle cases where the variable wasn't defined on
   // this node (due to changing subdomain support) or where the
   // variable has no components on this node (due to Elem order
-  // exceeding FE order)
+  // exceeding FE order) or where the old_dof_object dofs might
+  // correspond to non-vertex dofs (due to extra_hanging_dofs and
+  // refinement)
+
+  const Elem::RefinementState flag = c.get_elem().refinement_flag();
+
   if (n.old_dof_object &&
+      (!extra_hanging_dofs ||
+       flag == Elem::JUST_COARSENED ||
+       flag == Elem::DO_NOTHING) &&
       n.old_dof_object->n_vars(sys.number()) &&
       n.old_dof_object->n_comp(sys.number(), i))
     {

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -377,8 +377,8 @@ void System::project_vector (const NumericVector<Number> & old_v,
       OldSolutionValue<Gradient, &FEMContext::point_gradient> g(*this, old_vector);
       VectorSetAction<Number> setter(new_vector);
 
-      Threads::parallel_for (active_local_elem_range,
-                             FEMProjector(*this, f, &g, setter, vars));
+      FEMProjector projector(*this, f, &g, setter, vars);
+      projector.project(active_local_elem_range);
 
       // Copy the SCALAR dofs from old_vector to new_vector
       // Note: We assume that all SCALAR dofs are on the
@@ -809,8 +809,8 @@ void System::projection_matrix (SparseMatrix<Number> & proj_mat) const
       OldSolutionGradientCoefs g(*this);
       MatrixFillAction<Real, Number> setter(proj_mat);
 
-      Threads::parallel_for (active_local_elem_range,
-                             ProjMatFiller(*this, f, &g, setter, vars));
+      ProjMatFiller mat_filler(*this, f, &g, setter, vars);
+      mat_filler.project(active_local_elem_range);
 
       // Set the SCALAR dof transfer entries too.
       // Note: We assume that all SCALAR dofs are on the
@@ -958,14 +958,14 @@ void System::project_vector (NumericVector<Number> & new_vector,
     {
       FEMFunctionWrapper<Gradient> gw(*g);
 
-      Threads::parallel_for
-        (active_local_range,
-         FEMProjector(*this, fw, &gw, setter, vars));
+      FEMProjector projector(*this, fw, &gw, setter, vars);
+      projector.project(active_local_range);
     }
   else
-    Threads::parallel_for
-      (active_local_range,
-       FEMProjector(*this, fw, nullptr, setter, vars));
+    {
+      FEMProjector projector(*this, fw, nullptr, setter, vars);
+      projector.project(active_local_range);
+    }
 
   // Also, load values into the SCALAR dofs
   // Note: We assume that all SCALAR dofs are on the

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -508,18 +508,87 @@ public:
                      const Point & p,
                      Real /* time */ = 0.);
 
-  void eval_old_dofs (const FEMContext & c,
-                      unsigned int var,
+  void eval_old_dofs (const Elem & elem,
+                      unsigned int node_num,
+                      unsigned int var_num,
+                      std::vector<dof_id_type> & indices,
                       std::vector<DSNA> & values)
   {
-    LOG_SCOPE ("eval_old_dofs()", "OldSolutionValue");
+    LOG_SCOPE ("eval_old_dofs(node)", "OldSolutionCoefs");
 
-    this->check_old_context(c);
+    this->sys.get_dof_map().dof_indices(elem, node_num, indices, var_num);
 
-    const std::vector<dof_id_type> & old_dof_indices =
-      this->old_context.get_dof_indices(var);
+    std::vector<dof_id_type> old_indices;
 
-    libmesh_assert_equal_to (old_dof_indices.size(), values.size());
+    this->sys.get_dof_map().old_dof_indices(elem, node_num, old_indices, var_num);
+
+    libmesh_assert_equal_to (old_indices.size(), indices.size());
+
+    values.resize(old_indices.size());
+
+    for (auto i : index_range(values))
+      {
+        values[i].resize(1);
+        values[i].raw_at(0) = 1;
+        values[i].raw_index(0) = old_indices[i];
+      }
+  }
+
+
+  void eval_old_dofs (const Elem & elem,
+                      const FEType & fe_type,
+                      unsigned int sys_num,
+                      unsigned int var_num,
+                      std::vector<dof_id_type> & indices,
+                      std::vector<DSNA> & values)
+  {
+    LOG_SCOPE ("eval_old_dofs(elem)", "OldSolutionCoefs");
+
+    // We're only to be asked for old dofs on elements that can copy
+    // them through DO_NOTHING or through refinement.
+    const Elem & old_elem =
+      (elem.refinement_flag() == Elem::JUST_REFINED) ?
+      *elem.parent() : elem;
+
+    // If there are any element-based DOF numbers, get them
+    const unsigned int nc = FEInterface::n_dofs_per_elem(elem.dim(),
+                                                         fe_type,
+                                                         elem.type());
+
+    std::vector<dof_id_type> old_dof_indices(nc);
+    indices.resize(nc);
+
+    // We should never have fewer dofs than necessary on an
+    // element unless we're getting indices on a parent element,
+    // and we should never need those indices
+    if (nc != 0)
+      {
+        libmesh_assert(old_elem.old_dof_object);
+
+        const std::pair<unsigned int, unsigned int>
+          vg_and_offset = elem.var_to_vg_and_offset(sys_num,var_num);
+        const unsigned int vg = vg_and_offset.first;
+        const unsigned int vig = vg_and_offset.second;
+
+        const unsigned int n_comp = elem.n_comp_group(sys_num,vg);
+        libmesh_assert_greater(elem.n_systems(), sys_num);
+        libmesh_assert_greater_equal(n_comp, nc);
+
+        for (unsigned int i=0; i<nc; i++)
+          {
+            const dof_id_type d_old =
+              old_elem.old_dof_object->dof_number(sys_num, vg, vig, i, n_comp);
+            const dof_id_type d_new =
+              elem.dof_number(sys_num, vg, vig, i, n_comp);
+            libmesh_assert_not_equal_to (d_old, DofObject::invalid_id);
+            libmesh_assert_not_equal_to (d_new, DofObject::invalid_id);
+
+            old_dof_indices[i] = d_old;
+            indices[i] = d_new;
+          }
+      }
+
+    values.resize(old_dof_indices.size());
 
     for (auto i : index_range(values))
       {
@@ -736,16 +805,13 @@ public:
     }
   }
 
-  void insert(const FEMContext & c,
-              unsigned int var_num,
-              const DenseVector<DynamicSparseNumberArray<ValIn, dof_id_type> > & Ue)
+
+  void insert(const std::vector<dof_id_type> & dof_indices,
+              const std::vector<DynamicSparseNumberArray<ValIn, dof_id_type> > & Ue)
   {
     const numeric_index_type
       begin_dof = target_matrix.row_start(),
       end_dof = target_matrix.row_stop();
-
-    const std::vector<dof_id_type> & dof_indices =
-      c.get_dof_indices(var_num);
 
     unsigned int size = Ue.size();
 
@@ -760,7 +826,7 @@ public:
           const dof_id_type dof_i = dof_indices[i];
           if ((dof_i >= begin_dof) && (dof_i < end_dof))
             {
-              const DynamicSparseNumberArray<ValIn,dof_id_type> & dnsa = Ue(i);
+              const DynamicSparseNumberArray<ValIn,dof_id_type> & dnsa = Ue[i];
               const std::size_t dnsa_size = dnsa.size();
               for (unsigned int j = 0; j != dnsa_size; ++j)
                 {

--- a/tests/run_unit_tests.sh.in
+++ b/tests/run_unit_tests.sh.in
@@ -18,6 +18,6 @@ for method in ${MY_METHODS}; do
 @LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@    if [ "x$method" = "xdbg" ]; then
 @LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@      continue;
 @LIBMESH_ENABLE_GLIBCXX_DEBUGGING_CPPUNIT_FALSE@@LIBMESH_ENABLE_GLIBCXX_DEBUGGING_TRUE@    fi
-    echo $LIBMESH_RUN ./unit_tests-$method
-    $LIBMESH_RUN ./unit_tests-$method --option-with-dashes --option_with_underscores 3
+    echo $LIBMESH_RUN ./unit_tests-$method --option-with-dashes --option_with_underscores 3 $LIBMESH_OPTIONS
+    $LIBMESH_RUN ./unit_tests-$method --option-with-dashes --option_with_underscores 3 $LIBMESH_OPTIONS
 done

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -527,6 +527,19 @@ public:
       tripleValueTest(Point(x), sys, *locator,
                       u_subdomains, v_subdomains, w_subdomains,
                       es.parameters);
+
+#ifdef LIBMESH_ENABLE_AMR
+    for (auto & elem : mesh.element_ptr_range())
+      if ((elem->id()/2)%2)
+        elem->set_refinement_flag(Elem::REFINE);
+    es.reinit();
+
+    locator = mesh.sub_point_locator();
+    for (Real x = 0.1; x < 1; x += 0.2)
+      tripleValueTest(Point(x), sys, *locator,
+                      u_subdomains, v_subdomains, w_subdomains,
+                      es.parameters);
+#endif
   }
 
   void testProjectSquare(const ElemType elem_type)
@@ -562,6 +575,20 @@ public:
         tripleValueTest(Point(x,y), sys, *locator,
                         u_subdomains, v_subdomains, w_subdomains,
                         es.parameters);
+
+#ifdef LIBMESH_ENABLE_AMR
+    for (auto & elem : mesh.element_ptr_range())
+      if ((elem->id()/2)%2)
+        elem->set_refinement_flag(Elem::REFINE);
+    es.reinit();
+
+    locator = mesh.sub_point_locator();
+    for (Real x = 0.1; x < 1; x += 0.2)
+      for (Real y = 0.1; y < 1; y += 0.2)
+        tripleValueTest(Point(x,y), sys, *locator,
+                        u_subdomains, v_subdomains, w_subdomains,
+                        es.parameters);
+#endif
   }
 
   void testProjectCube(const ElemType elem_type)
@@ -598,6 +625,21 @@ public:
           tripleValueTest(Point(x,y,z), sys, *locator,
                           u_subdomains, v_subdomains, w_subdomains,
                           es.parameters);
+
+  #ifdef LIBMESH_ENABLE_AMR
+    for (auto & elem : mesh.element_ptr_range())
+      if ((elem->id()/2)%2)
+        elem->set_refinement_flag(Elem::REFINE);
+    es.reinit();
+
+    locator = mesh.sub_point_locator();
+    for (Real x = 0.1; x < 1; x += 0.2)
+      for (Real y = 0.1; y < 1; y += 0.2)
+        for (Real z = 0.1; z < 1; z += 0.2)
+          tripleValueTest(Point(x,y,z), sys, *locator,
+                          u_subdomains, v_subdomains, w_subdomains,
+                          es.parameters);
+  #endif
   }
 
   void testProjectCubeWithMeshFunction(const ElemType elem_type)

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -462,6 +462,31 @@ public:
   CPPUNIT_TEST_SUITE_END();
 
 private:
+  void tripleValueTest (const Point & p,
+                        const System & sys,
+                        const PointLocatorBase & locator,
+                        std::set<subdomain_id_type> & u_subdomains,
+                        std::set<subdomain_id_type> & v_subdomains,
+                        std::set<subdomain_id_type> & w_subdomains,
+                        const Parameters & param)
+  {
+    const Elem * elem = locator(p);
+    subdomain_id_type sbd_id = elem ? elem->subdomain_id() : 0;
+    TestCommWorld->max(sbd_id);
+
+    if (u_subdomains.count(sbd_id))
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
+                                   libmesh_real(cubic_test(p,param,"","")),
+                                   TOLERANCE*TOLERANCE);
+    if (v_subdomains.count(sbd_id))
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(1,p)),
+                                   libmesh_real(new_linear_test(p,param,"","")),
+                                   TOLERANCE*TOLERANCE);
+    if (w_subdomains.count(sbd_id))
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(2,p)),
+                                   libmesh_real(disc_thirds_test(p,param,"","")),
+                                   TOLERANCE*TOLERANCE);
+  }
 
 public:
   void setUp()
@@ -503,25 +528,9 @@ public:
 
     std::unique_ptr<PointLocatorBase> locator = mesh.sub_point_locator();
     for (Real x = 0.1; x < 1; x += 0.2)
-      {
-        Point p(x);
-        const Elem * elem = (*locator)(p);
-        subdomain_id_type sbd_id = elem ? elem->subdomain_id() : 0;
-        TestCommWorld->max(sbd_id);
-
-        if (u_subdomains.count(sbd_id))
-          CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                       libmesh_real(cubic_test(p,es.parameters,"","")),
-                                       TOLERANCE*TOLERANCE);
-        if (v_subdomains.count(sbd_id))
-          CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(1,p)),
-                                       libmesh_real(new_linear_test(p,es.parameters,"","")),
-                                       TOLERANCE*TOLERANCE);
-        if (w_subdomains.count(sbd_id))
-          CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(2,p)),
-                                       libmesh_real(disc_thirds_test(p,es.parameters,"","")),
-                                       TOLERANCE*TOLERANCE);
-      }
+      tripleValueTest(Point(x), sys, *locator,
+                      u_subdomains, v_subdomains, w_subdomains,
+                      es.parameters);
   }
 
   void testProjectSquare(const ElemType elem_type)
@@ -558,25 +567,9 @@ public:
     std::unique_ptr<PointLocatorBase> locator = mesh.sub_point_locator();
     for (Real x = 0.1; x < 1; x += 0.2)
       for (Real y = 0.1; y < 1; y += 0.2)
-        {
-          Point p(x,y);
-          const Elem * elem = (*locator)(p);
-          subdomain_id_type sbd_id = elem ? elem->subdomain_id() : 0;
-          TestCommWorld->max(sbd_id);
-
-          if (u_subdomains.count(sbd_id))
-            CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                         libmesh_real(cubic_test(p,es.parameters,"","")),
-                                         TOLERANCE*TOLERANCE);
-          if (v_subdomains.count(sbd_id))
-            CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(1,p)),
-                                         libmesh_real(new_linear_test(p,es.parameters,"","")),
-                                         TOLERANCE*TOLERANCE);
-          if (w_subdomains.count(sbd_id))
-            CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(2,p)),
-                                         libmesh_real(disc_thirds_test(p,es.parameters,"","")),
-                                         TOLERANCE*TOLERANCE);
-        }
+        tripleValueTest(Point(x,y), sys, *locator,
+                        u_subdomains, v_subdomains, w_subdomains,
+                        es.parameters);
   }
 
   void testProjectCube(const ElemType elem_type)
@@ -614,26 +607,9 @@ public:
     for (Real x = 0.1; x < 1; x += 0.2)
       for (Real y = 0.1; y < 1; y += 0.2)
         for (Real z = 0.1; z < 1; z += 0.2)
-          {
-            Point p(x,y,z);
-            const Elem * elem = (*locator)(p);
-            subdomain_id_type sbd_id = elem ? elem->subdomain_id() : 0;
-            TestCommWorld->max(sbd_id);
-
-            if (u_subdomains.count(sbd_id))
-              CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p)),
-                                           libmesh_real(cubic_test(p,es.parameters,"","")),
-                                           TOLERANCE*TOLERANCE);
-
-            if (v_subdomains.count(sbd_id))
-              CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(1,p)),
-                                           libmesh_real(new_linear_test(p,es.parameters,"","")),
-                                           TOLERANCE*TOLERANCE);
-            if (w_subdomains.count(sbd_id))
-              CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(2,p)),
-                                           libmesh_real(disc_thirds_test(p,es.parameters,"","")),
-                                           TOLERANCE*TOLERANCE);
-          }
+          tripleValueTest(Point(x,y,z), sys, *locator,
+                          u_subdomains, v_subdomains, w_subdomains,
+                          es.parameters);
   }
 
   void testProjectCubeWithMeshFunction(const ElemType elem_type)

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -515,12 +515,8 @@ public:
                                        0., 1.,
                                        elem_type);
 
-    for (unsigned int i=0; i != 6; ++i)
-      {
-        Elem * elem = mesh.query_elem_ptr(i);
-        if (elem)
-          elem->subdomain_id() = i;
-      }
+    for (auto & elem : mesh.element_ptr_range())
+      elem->subdomain_id() = elem->id();
 
     es.init();
     TripleFunction tfunc;
@@ -553,12 +549,8 @@ public:
                                          0., 1., 0., 1.,
                                          elem_type);
 
-    for (unsigned int i=0; i != 9; ++i)
-      {
-        Elem * elem = mesh.query_elem_ptr(i);
-        if (elem)
-          elem->subdomain_id() = i/2;
-      }
+    for (auto & elem : mesh.element_ptr_range())
+      elem->subdomain_id() = elem->id()/2;
 
     es.init();
     TripleFunction tfunc;
@@ -592,12 +584,8 @@ public:
                                        0., 1., 0., 1., 0., 1.,
                                        elem_type);
 
-    for (unsigned int i=0; i != 27; ++i)
-      {
-        Elem * elem = mesh.query_elem_ptr(i);
-        if (elem)
-          elem->subdomain_id() = i/6;
-      }
+    for (auto & elem : mesh.element_ptr_range())
+      elem->subdomain_id() = elem->id()/6;
 
     es.init();
     TripleFunction tfunc;

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -481,10 +481,10 @@ private:
                                      libmesh_real(cubic_test(p,param,"","")),
                                      TOLERANCE*TOLERANCE*10);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p,sys.old_local_solution.get())),
-                                     libmesh_real(cubic_test(p,param,"","") + 10),
+                                     libmesh_real(cubic_test(p,param,"","") + Number(10)),
                                      TOLERANCE*TOLERANCE*100);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(0,p,sys.older_local_solution.get())),
-                                     libmesh_real(cubic_test(p,param,"","") + 20),
+                                     libmesh_real(cubic_test(p,param,"","") + Number(20)),
                                      TOLERANCE*TOLERANCE*100);
       }
     if (v_subdomains.count(sbd_id))
@@ -493,10 +493,10 @@ private:
                                      libmesh_real(new_linear_test(p,param,"","")),
                                      TOLERANCE*TOLERANCE*10);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(1,p,sys.old_local_solution.get())),
-                                     libmesh_real(new_linear_test(p,param,"","") + 10),
+                                     libmesh_real(new_linear_test(p,param,"","") + Number(10)),
                                      TOLERANCE*TOLERANCE*100);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(1,p,sys.older_local_solution.get())),
-                                     libmesh_real(new_linear_test(p,param,"","") + 20),
+                                     libmesh_real(new_linear_test(p,param,"","") + Number(20)),
                                      TOLERANCE*TOLERANCE*100);
       }
     if (w_subdomains.count(sbd_id))
@@ -505,10 +505,10 @@ private:
                                      libmesh_real(disc_thirds_test(p,param,"","")),
                                      TOLERANCE*TOLERANCE*10);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(2,p,sys.old_local_solution.get())),
-                                     libmesh_real(disc_thirds_test(p,param,"","") + 10),
+                                     libmesh_real(disc_thirds_test(p,param,"","") + Number(10)),
                                      TOLERANCE*TOLERANCE*100);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(libmesh_real(sys.point_value(2,p,sys.older_local_solution.get())),
-                                     libmesh_real(disc_thirds_test(p,param,"","") + 20),
+                                     libmesh_real(disc_thirds_test(p,param,"","") + Number(20)),
                                      TOLERANCE*TOLERANCE*100);
       }
   }

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -523,6 +523,7 @@ public:
     sys.project_solution(&tfunc);
 
     std::unique_ptr<PointLocatorBase> locator = mesh.sub_point_locator();
+    locator->enable_out_of_mesh_mode();
     for (Real x = 0.1; x < 1; x += 0.2)
       tripleValueTest(Point(x), sys, *locator,
                       u_subdomains, v_subdomains, w_subdomains,
@@ -535,6 +536,7 @@ public:
     es.reinit();
 
     locator = mesh.sub_point_locator();
+    locator->enable_out_of_mesh_mode();
     for (Real x = 0.1; x < 1; x += 0.2)
       tripleValueTest(Point(x), sys, *locator,
                       u_subdomains, v_subdomains, w_subdomains,
@@ -570,6 +572,7 @@ public:
     sys.project_solution(&tfunc);
 
     std::unique_ptr<PointLocatorBase> locator = mesh.sub_point_locator();
+    locator->enable_out_of_mesh_mode();
     for (Real x = 0.1; x < 1; x += 0.2)
       for (Real y = 0.1; y < 1; y += 0.2)
         tripleValueTest(Point(x,y), sys, *locator,
@@ -583,6 +586,7 @@ public:
     es.reinit();
 
     locator = mesh.sub_point_locator();
+    locator->enable_out_of_mesh_mode();
     for (Real x = 0.1; x < 1; x += 0.2)
       for (Real y = 0.1; y < 1; y += 0.2)
         tripleValueTest(Point(x,y), sys, *locator,
@@ -619,6 +623,7 @@ public:
     sys.project_solution(&tfunc);
 
     std::unique_ptr<PointLocatorBase> locator = mesh.sub_point_locator();
+    locator->enable_out_of_mesh_mode();
     for (Real x = 0.1; x < 1; x += 0.2)
       for (Real y = 0.1; y < 1; y += 0.2)
         for (Real z = 0.1; z < 1; z += 0.2)
@@ -633,6 +638,7 @@ public:
     es.reinit();
 
     locator = mesh.sub_point_locator();
+    locator->enable_out_of_mesh_mode();
     for (Real x = 0.1; x < 1; x += 0.2)
       for (Real y = 0.1; y < 1; y += 0.2)
         for (Real z = 0.1; z < 1; z += 0.2)


### PR DESCRIPTION
I'm posting this at an early stage, both so it can get into CI (it's passing my local tests now but this is a huge change that could have all kinds of corner cases) and so @ajamar1 can try it out (it passes the test case in #1919 for me, at least), but anybody who *isn't* running the impacted transient-repartitioning-of-subdomain-restricted-variables case isn't going to want to use the current unbenchmarked bag of optimizations mixed with pessimizations in the first commits here.  This is going to need more optimization work before it's ready to merge.


The goals:

Make projections faster by removing redundant calculations

Make projections correct even in the corner cases where subdomain-restricted
variables are on DoFs owned by processors which don't own that
subdomain.

The means:

Sort projection operations by vertices, edges, faces, interiors,
avoiding duplication.

Test ghost nodes' patches to see what their owners can compute, and
push our computed data to the owners if necessary, in between the
steps where it's computed and the steps where it's used.

The current problems:

Looping over vertices/edges/nodes rather than over elements is forcing
more context data initialization.

This initial commit is missing some of the common case optimizations that
were in the previous version; those need to be re-added.