### PR TITLE
"Filling" overloads for side_ptr, build_side_ptr

### DIFF
--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -142,6 +142,11 @@ public:
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
 
   /**
+   * Rebuilds a primitive (4-noded) quad for face i.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+
+  /**
    * \returns A quantitative assessment of element quality based on
    * the quality metric \p q specified by the user.
    */

--- a/include/geom/cell_hex20.h
+++ b/include/geom/cell_hex20.h
@@ -154,6 +154,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD8 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_hex27.h
+++ b/include/geom/cell_hex27.h
@@ -170,6 +170,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD9 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_hex8.h
+++ b/include/geom/cell_hex8.h
@@ -133,6 +133,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD4 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a EDGE2 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -145,10 +145,14 @@ public:
                                        unsigned int side_node) const override;
 
   /**
-   * \returns A primitive (4-noded) quad or infquad for
-   * face i.
+   * \returns A primitive (4-noded) quad or infquad for face i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+
+  /**
+   * Rebuilds a primitive (4-noded) quad or infquad for face i.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
 
   /**
    * \returns A quantitative assessment of element quality based on

--- a/include/geom/cell_inf_hex16.h
+++ b/include/geom/cell_inf_hex16.h
@@ -152,6 +152,13 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD8 built coincident with face 0, or an \p
+   * INFQUAD6 built coincident with faces 1 to 4.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * \returns An \p EDGE3 built coincident with edges 0 to 3, or \p
    * INFEDGE2 built coincident with edges 4 to 11.
    *

--- a/include/geom/cell_inf_hex18.h
+++ b/include/geom/cell_inf_hex18.h
@@ -146,6 +146,13 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD9 built coincident with face 0, or an \p
+   * INFQUAD6 built coincident with faces 1 to 4.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * \returns An \p EDGE3 built coincident with edges 0-3, or an \p INFEDGE2
    * built coincident with edges 4 to 11.
    *

--- a/include/geom/cell_inf_hex8.h
+++ b/include/geom/cell_inf_hex8.h
@@ -131,6 +131,13 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD4 built coincident with face 0, or an \p INFQUAD4
+   * built coincident with faces 1 to 4.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * \returns An \p EDGE2 built coincident with edges 0 to 3, or an \p INFEDGE2
    * built coincident with edges 4 to 7.
    *

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -146,6 +146,12 @@ public:
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
 
   /**
+   * Rebuilds a primitive (3-noded) tri or (4-noded) infquad for face
+   * i.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+
+  /**
    * @returns \p true when this element contains the point
    * \p p.  Customized for infinite elements, since knowledge
    * about the envelope can be helpful.

--- a/include/geom/cell_inf_prism12.h
+++ b/include/geom/cell_inf_prism12.h
@@ -143,6 +143,13 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p TRI6 built coincident with face 0, or an \p
+   * INFQUAD6 built coincident with faces 1 to 3.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * \returns An \p EDGE3 built coincident with edges 0 to 2, or an \p INFEDGE2
    * built coincident with edges 3 to 5.
    *

--- a/include/geom/cell_inf_prism6.h
+++ b/include/geom/cell_inf_prism6.h
@@ -133,6 +133,13 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p TRI3 built coincident with face 0, or an \p INFQUAD4
+   * built coincident with faces 1 to 3.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * \returns An \p EDGE2 built coincident with edges 0 to 2, an \p INFEDGE2
    * built coincident with edges 3 to 5.
    *

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -129,11 +129,14 @@ public:
                                        unsigned int side_node) const override;
 
   /**
-   * \returns A primitive triangle or quad for
-   * face i.
+   * \returns A primitive triangle or quad for face i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a primitive triangle or quad for face i.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
 
 protected:
 

--- a/include/geom/cell_prism15.h
+++ b/include/geom/cell_prism15.h
@@ -155,6 +155,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD8 or \p TRI6 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE3 or \p INFEDGE2 coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_prism18.h
+++ b/include/geom/cell_prism18.h
@@ -171,6 +171,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD9 or \p TRI6 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE3 or \p INFEDGE2 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_prism6.h
+++ b/include/geom/cell_prism6.h
@@ -127,6 +127,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD4 or \p TRI3 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE2 or \p INFEDGE2 built coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -134,11 +134,14 @@ public:
                                        unsigned int side_node) const override;
 
   /**
-   * \returns A primitive triangle or quad for
-   * face i.
+   * \returns A primitive triangle or quad for face i.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
 
+  /**
+   * Rebuilds a primitive triangle or quad for face i.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
 
 protected:
 

--- a/include/geom/cell_pyramid13.h
+++ b/include/geom/cell_pyramid13.h
@@ -155,6 +155,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD8 or \p TRI6 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE3 coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_pyramid14.h
+++ b/include/geom/cell_pyramid14.h
@@ -174,6 +174,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD9 or \p TRI6 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE3 coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_pyramid5.h
+++ b/include/geom/cell_pyramid5.h
@@ -127,6 +127,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a \p QUAD4 or \p TRI3 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE2 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -123,6 +123,11 @@ public:
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
 
   /**
+   * Rebuilds a primitive (3-noded) triangle for face i.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+
+  /**
    * \returns A quantitative assessment of element quality based on
    * the quality metric \p q specified by the user.
    */

--- a/include/geom/cell_tet10.h
+++ b/include/geom/cell_tet10.h
@@ -153,6 +153,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a TRI6 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE3 built coincident with edge i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/cell_tet4.h
+++ b/include/geom/cell_tet4.h
@@ -146,6 +146,12 @@ public:
                                                 bool proxy) override;
 
   /**
+   * Rebuilds a TRI3 built coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+  /**
    * Builds a \p EDGE2 built coincident with face i.
    * The \p std::unique_ptr<Elem> handles the memory aspect.
    */

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -145,10 +145,21 @@ public:
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
 
   /**
+   * Rebuilds a pointer to a NodeElem for the specified node.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+
+  /**
    * \returns A pointer to a NodeElem for the specified node.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) override;
+
+  /**
+   * Rebuilds a NODEELEM for the specified node.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
 
   /**
    * The \p Elem::build_edge_ptr() member makes no sense for edges.

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -159,6 +159,11 @@ public:
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
 
   /**
+   * Rebuilds a primitive (2-noded) edge or infedge for edge \p i.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+
+  /**
    * build_edge_ptr() and build_side_ptr() are identical in 2D.
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override

--- a/include/geom/face_inf_quad4.h
+++ b/include/geom/face_inf_quad4.h
@@ -125,6 +125,13 @@ public:
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) override;
 
+  /**
+   * Rebuilds an EDGE2 or INFEDGE2 coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_inf_quad6.h
+++ b/include/geom/face_inf_quad6.h
@@ -147,6 +147,12 @@ public:
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) override;
 
+  /**
+   * Rebuilds an EDGE3 or INFEDGE2 coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -157,6 +157,12 @@ public:
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
 
   /**
+   * Rebuilds an EDGE2 coincident with face i.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & elem,
+                         const unsigned int i) override;
+
+  /**
    * \returns A quantitative assessment of element quality based on
    * the quality metric \p q specified by the user.
    */

--- a/include/geom/face_quad4.h
+++ b/include/geom/face_quad4.h
@@ -121,6 +121,12 @@ public:
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) override;
 
+  /**
+   * Rebuilds an EDGE2 coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_quad8.h
+++ b/include/geom/face_quad8.h
@@ -148,6 +148,12 @@ public:
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) override;
 
+  /**
+   * Rebuilds an EDGE3 coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_quad9.h
+++ b/include/geom/face_quad9.h
@@ -156,6 +156,12 @@ public:
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) override;
 
+  /**
+   * Rebuilds an EDGE3 coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -144,6 +144,12 @@ public:
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
 
   /**
+   * Rebuilds an EDGE2 coincident with face i.
+   */
+  virtual void side_ptr (std::unique_ptr<Elem> & elem,
+                         const unsigned int i) override;
+
+  /**
    * \returns A quantitative assessment of element quality based on
    * the quality metric \p q specified by the user.
    */

--- a/include/geom/face_tri3.h
+++ b/include/geom/face_tri3.h
@@ -132,6 +132,12 @@ public:
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) override;
 
+  /**
+   * Rebuilds an EDGE2 coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/face_tri6.h
+++ b/include/geom/face_tri6.h
@@ -153,6 +153,12 @@ public:
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
                                                 bool proxy) override;
 
+  /**
+   * Rebuilds an EDGE2 coincident with face i.
+   */
+  virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
+                               const unsigned int i) override;
+
   virtual void connectivity(const unsigned int sf,
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const override;

--- a/include/geom/node_elem.h
+++ b/include/geom/node_elem.h
@@ -122,16 +122,22 @@ public:
   { libmesh_error_msg("Calling NodeElem::which_node_am_i() does not make sense."); return 0; }
 
   /**
-   * The \p Elem::side() member makes no sense for nodes.
+   * The \p Elem::side_ptr() member makes no sense for nodes.
    */
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int) override
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }
+
+  virtual void side_ptr (std::unique_ptr<Elem> &, const unsigned int) override
+  { libmesh_not_implemented(); }
 
   /**
    * The \p Elem::build_side_ptr() member makes no sense for nodes.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int, bool) override
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }
+
+  virtual void build_side_ptr (std::unique_ptr<Elem> &, const unsigned int) override
+  { libmesh_not_implemented(); }
 
   /**
    * The \p Elem::build_edge_ptr() member makes no sense for nodes.

--- a/include/geom/remote_elem.h
+++ b/include/geom/remote_elem.h
@@ -167,9 +167,17 @@ public:
   virtual std::unique_ptr<Elem> side_ptr (const unsigned int) override
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }
 
+  virtual void side_ptr (std::unique_ptr<Elem> &,
+                         const unsigned int) override
+  { libmesh_not_implemented(); }
+
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int,
                                                 bool) override
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }
+
+  virtual void build_side_ptr (std::unique_ptr<Elem> &,
+                               const unsigned int) override
+  { libmesh_not_implemented(); }
 
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int) override
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -835,7 +835,9 @@ void FEAbstract::compute_node_constraints (NodeConstraints & constraints,
   // We currently always use LAGRANGE mappings for geometry
   const FEType fe_type(elem->default_order(), LAGRANGE);
 
+  // Pull objects out of the loop to reduce heap operations
   std::vector<const Node *> my_nodes, parent_nodes;
+  std::unique_ptr<const Elem> my_side, parent_side;
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
@@ -853,8 +855,8 @@ void FEAbstract::compute_node_constraints (NodeConstraints & constraints,
           // level than their neighbors!
           libmesh_assert(parent);
 
-          const std::unique_ptr<const Elem> my_side     (elem->build_side_ptr(s));
-          const std::unique_ptr<const Elem> parent_side (parent->build_side_ptr(s));
+          elem->build_side_ptr(my_side, s);
+          parent->build_side_ptr(parent_side, s);
 
           const unsigned int n_side_nodes = my_side->n_nodes();
 
@@ -981,7 +983,9 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
   // We currently always use LAGRANGE mappings for geometry
   const FEType fe_type(elem->default_order(), LAGRANGE);
 
+  // Pull objects out of the loop to reduce heap operations
   std::vector<const Node *> my_nodes, neigh_nodes;
+  std::unique_ptr<const Elem> my_side, neigh_side;
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
@@ -1016,8 +1020,8 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
                   libmesh_assert(neigh->active());
 #endif // #ifdef LIBMESH_ENABLE_AMR
 
-                  const std::unique_ptr<const Elem> my_side    (elem->build_side_ptr(s));
-                  const std::unique_ptr<const Elem> neigh_side (neigh->build_side_ptr(s_neigh));
+                  elem->build_side_ptr(my_side, s);
+                  neigh->build_side_ptr(neigh_side, s_neigh);
 
                   const unsigned int n_side_nodes = my_side->n_nodes();
 

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -58,6 +58,9 @@ const Elem * primary_boundary_point_neighbor(const Elem * elem,
   // Container to catch boundary IDs passed back by BoundaryInfo.
   std::vector<boundary_id_type> bc_ids;
 
+  // Pull object out of the loop to reduce heap operations
+  std::unique_ptr<const Elem> periodic_side;
+
   std::set<const Elem *> point_neighbors;
   elem->find_point_neighbors(p, point_neighbors);
   for (const auto & pt_neighbor : point_neighbors)
@@ -87,7 +90,8 @@ const Elem * primary_boundary_point_neighbor(const Elem * elem,
           if (!on_relevant_boundary)
             continue;
 
-          if (!pt_neighbor->build_side_ptr(ns)->contains_point(p))
+          pt_neighbor->build_side_ptr(periodic_side, ns);
+          if (!periodic_side->contains_point(p))
             continue;
 
           vertex_on_periodic_side = true;
@@ -118,6 +122,9 @@ const Elem * primary_boundary_edge_neighbor(const Elem * elem,
   // Container to catch boundary IDs handed back by BoundaryInfo
   std::vector<boundary_id_type> bc_ids;
 
+  // Pull object out of the loop to reduce heap operations
+  std::unique_ptr<const Elem> periodic_side;
+
   for (const auto & e_neighbor : edge_neighbors)
     {
       // If this edge neighbor isn't at least
@@ -145,7 +152,7 @@ const Elem * primary_boundary_edge_neighbor(const Elem * elem,
           if (!on_relevant_boundary)
             continue;
 
-          std::unique_ptr<const Elem> periodic_side = e_neighbor->build_side_ptr(ns);
+          e_neighbor->build_side_ptr(periodic_side, ns);
           if (!(periodic_side->contains_point(p1) &&
                 periodic_side->contains_point(p2)))
             continue;

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -687,7 +687,9 @@ void lagrange_compute_constraints (DofConstraints & constraints,
   FEType fe_type = dof_map.variable_type(variable_number);
   fe_type.order = static_cast<Order>(fe_type.order + elem->p_level());
 
+  // Pull objects out of the loop to reduce heap operations
   std::vector<dof_id_type> my_dof_indices, parent_dof_indices;
+  std::unique_ptr<const Elem> my_side, parent_side;
 
   // Look at the element faces.  Check to see if we need to
   // build constraints.
@@ -705,8 +707,8 @@ void lagrange_compute_constraints (DofConstraints & constraints,
           // level than their neighbors!
           libmesh_assert(parent);
 
-          const std::unique_ptr<const Elem> my_side     (elem->build_side_ptr(s));
-          const std::unique_ptr<const Elem> parent_side (parent->build_side_ptr(s));
+          elem->build_side_ptr(my_side, s);
+          parent->build_side_ptr(parent_side, s);
 
           // This function gets called element-by-element, so there
           // will be a lot of memory allocation going on.  We can

--- a/src/geom/cell.C
+++ b/src/geom/cell.C
@@ -29,10 +29,14 @@ BoundingBox Cell::loose_bounding_box () const
   // through 4-D space, so the full bounding box is just the merger of
   // the sides' bounding boxes.
 
-  BoundingBox bbox = this->build_side_ptr(0)->loose_bounding_box();
+  std::unique_ptr<const Elem> side_ptr { this->build_side_ptr(0, false) };
+  BoundingBox bbox = side_ptr->loose_bounding_box();
   unsigned int my_n_sides = this->n_sides();
   for (unsigned s=1; s < my_n_sides; ++s)
-    bbox.union_with(this->build_side_ptr(s)->loose_bounding_box());
+    {
+      this->build_side_ptr(side_ptr, s);
+      bbox.union_with(side_ptr->loose_bounding_box());
+    }
 
   return bbox;
 }

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -108,6 +108,14 @@ std::unique_ptr<Elem> Hex::side_ptr (const unsigned int i)
 
 
 
+void Hex::side_ptr (std::unique_ptr<Elem> & side,
+                    const unsigned int i)
+{
+  this->simple_build_side_ptr<Hex8>(side, i, QUAD4);
+}
+
+
+
 bool Hex::is_child_on_side(const unsigned int c,
                            const unsigned int s) const
 {

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -182,6 +182,24 @@ std::unique_ptr<Elem> Hex20::build_side_ptr (const unsigned int i,
 
 
 
+void Hex20::build_side_ptr (std::unique_ptr<Elem> & side,
+                            const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  if (!side.get() || side->type() != QUAD8)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      for (auto n : side->node_index_range())
+        side->set_node(n) = this->node_ptr(Hex20::side_nodes_map[i][n]);
+    }
+}
+
+
+
 unsigned int Hex20::which_node_am_i(unsigned int side,
                                     unsigned int side_node) const
 {

--- a/src/geom/cell_hex20.C
+++ b/src/geom/cell_hex20.C
@@ -185,17 +185,7 @@ std::unique_ptr<Elem> Hex20::build_side_ptr (const unsigned int i,
 void Hex20::build_side_ptr (std::unique_ptr<Elem> & side,
                             const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (!side.get() || side->type() != QUAD8)
-    side = this->build_side_ptr(i, false);
-  else
-    {
-      side->subdomain_id() = this->subdomain_id();
-
-      for (auto n : side->node_index_range())
-        side->set_node(n) = this->node_ptr(Hex20::side_nodes_map[i][n]);
-    }
+  this->simple_build_side_ptr<Hex20>(side, i, QUAD8);
 }
 
 

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -242,10 +242,28 @@ std::unique_ptr<Elem> Hex27::build_side_ptr (const unsigned int i,
       std::unique_ptr<Elem> face = libmesh_make_unique<Quad9>();
       face->subdomain_id() = this->subdomain_id();
 
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Hex27::side_nodes_map[i][n]);
 
       return face;
+    }
+}
+
+
+
+void Hex27::build_side_ptr (std::unique_ptr<Elem> & side,
+                            const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  if (!side.get() || side->type() != QUAD9)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      for (unsigned n=0; n != 9; ++n)
+        side->set_node(n) = this->node_ptr(Hex27::side_nodes_map[i][n]);
     }
 }
 

--- a/src/geom/cell_hex27.C
+++ b/src/geom/cell_hex27.C
@@ -254,17 +254,7 @@ std::unique_ptr<Elem> Hex27::build_side_ptr (const unsigned int i,
 void Hex27::build_side_ptr (std::unique_ptr<Elem> & side,
                             const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (!side.get() || side->type() != QUAD9)
-    side = this->build_side_ptr(i, false);
-  else
-    {
-      side->subdomain_id() = this->subdomain_id();
-
-      for (unsigned n=0; n != 9; ++n)
-        side->set_node(n) = this->node_ptr(Hex27::side_nodes_map[i][n]);
-    }
+  this->simple_build_side_ptr<Hex27>(side, i, QUAD9);
 }
 
 

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -158,6 +158,24 @@ std::unique_ptr<Elem> Hex8::build_side_ptr (const unsigned int i,
 
 
 
+void Hex8::build_side_ptr (std::unique_ptr<Elem> & side,
+                           const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  if (!side.get() || side->type() != QUAD4)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      for (auto n : side->node_index_range())
+        side->set_node(n) = this->node_ptr(Hex8::side_nodes_map[i][n]);
+    }
+}
+
+
+
 std::unique_ptr<Elem> Hex8::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_hex8.C
+++ b/src/geom/cell_hex8.C
@@ -161,17 +161,7 @@ std::unique_ptr<Elem> Hex8::build_side_ptr (const unsigned int i,
 void Hex8::build_side_ptr (std::unique_ptr<Elem> & side,
                            const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (!side.get() || side->type() != QUAD4)
-    side = this->build_side_ptr(i, false);
-  else
-    {
-      side->subdomain_id() = this->subdomain_id();
-
-      for (auto n : side->node_index_range())
-        side->set_node(n) = this->node_ptr(Hex8::side_nodes_map[i][n]);
-    }
+  this->simple_build_side_ptr<Hex8>(side, i, QUAD4);
 }
 
 

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -147,6 +147,52 @@ std::unique_ptr<Elem> InfHex::side_ptr (const unsigned int i)
 
 
 
+void InfHex::side_ptr (std::unique_ptr<Elem> & side,
+                       const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
+  switch (i)
+    {
+      // the base face
+    case 0:
+      {
+        if (!side.get() || side->type() != QUAD4)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+      // connecting to another infinite element
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+      {
+        if (!side.get() || side->type() != INFQUAD4)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfHex8::side_nodes_map[i][n]);
+}
+
+
+
 bool InfHex::is_child_on_side(const unsigned int c,
                               const unsigned int s) const
 {

--- a/src/geom/cell_inf_hex16.C
+++ b/src/geom/cell_inf_hex16.C
@@ -206,6 +206,54 @@ std::unique_ptr<Elem> InfHex16::build_side_ptr (const unsigned int i,
     }
 }
 
+
+
+void InfHex16::build_side_ptr (std::unique_ptr<Elem> & side,
+                               const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
+  switch (i)
+    {
+      // the base face
+    case 0:
+      {
+        if (!side.get() || side->type() != QUAD8)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+      // connecting to another infinite element
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+      {
+        if (!side.get() || side->type() != INFQUAD6)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfHex16::side_nodes_map[i][n]);
+}
+
+
+
 std::unique_ptr<Elem> InfHex16::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_inf_hex18.C
+++ b/src/geom/cell_inf_hex18.C
@@ -228,6 +228,52 @@ std::unique_ptr<Elem> InfHex18::build_side_ptr (const unsigned int i,
 
 
 
+void InfHex18::build_side_ptr (std::unique_ptr<Elem> & side,
+                               const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
+  switch (i)
+    {
+      // the base face
+    case 0:
+      {
+        if (!side.get() || side->type() != QUAD9)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+      // connecting to another infinite element
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+      {
+        if (!side.get() || side->type() != INFQUAD6)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfHex18::side_nodes_map[i][n]);
+}
+
+
+
 std::unique_ptr<Elem> InfHex18::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -185,6 +185,52 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
 }
 
 
+void InfHex8::build_side_ptr (std::unique_ptr<Elem> & side,
+                              const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
+  switch (i)
+    {
+      // the base face
+    case 0:
+      {
+        if (!side.get() || side->type() != QUAD4)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+      // connecting to another infinite element
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+      {
+        if (!side.get() || side->type() != INFQUAD4)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfHex8::side_nodes_map[i][n]);
+}
+
+
+
 std::unique_ptr<Elem> InfHex8::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_inf_hex8.C
+++ b/src/geom/cell_inf_hex8.C
@@ -188,45 +188,7 @@ std::unique_ptr<Elem> InfHex8::build_side_ptr (const unsigned int i,
 void InfHex8::build_side_ptr (std::unique_ptr<Elem> & side,
                               const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
-  switch (i)
-    {
-      // the base face
-    case 0:
-      {
-        if (!side.get() || side->type() != QUAD4)
-          {
-            side = this->build_side_ptr(i, false);
-            return;
-          }
-        break;
-      }
-
-      // connecting to another infinite element
-    case 1:
-    case 2:
-    case 3:
-    case 4:
-      {
-        if (!side.get() || side->type() != INFQUAD4)
-          {
-            side = this->build_side_ptr(i, false);
-            return;
-          }
-        break;
-      }
-
-    default:
-      libmesh_error_msg("Invalid side i = " << i);
-    }
-
-  side->subdomain_id() = this->subdomain_id();
-
-  // Set the nodes
-  for (auto n : side->node_index_range())
-    side->set_node(n) = this->node_ptr(InfHex8::side_nodes_map[i][n]);
+  this->side_ptr(side, i);
 }
 
 

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -134,6 +134,51 @@ std::unique_ptr<Elem> InfPrism::side_ptr (const unsigned int i)
 
 
 
+void InfPrism::side_ptr (std::unique_ptr<Elem> & side,
+                         const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+      // the base face
+    case 0:
+      {
+        if (!side.get() || side->type() != TRI3)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+      // connecting to another infinite element
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+      {
+        if (!side.get() || side->type() != INFQUAD4)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfPrism6::side_nodes_map[i][n]);
+}
+
+
+
 bool InfPrism::is_child_on_side(const unsigned int c,
                                 const unsigned int s) const
 {

--- a/src/geom/cell_inf_prism12.C
+++ b/src/geom/cell_inf_prism12.C
@@ -190,6 +190,47 @@ std::unique_ptr<Elem> InfPrism12::build_side_ptr (const unsigned int i,
 }
 
 
+void InfPrism12::build_side_ptr (std::unique_ptr<Elem> & side,
+                                 const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+    case 0: // the triangular face at z=-1, base face
+      {
+        if (!side.get() || side->type() != TRI6)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    case 1: // the quad face at y=0
+    case 2: // the other quad face
+    case 3: // the quad face at x=0
+      {
+        if (!side.get() || side->type() != INFQUAD6)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfPrism12::side_nodes_map[i][n]);
+}
+
+
 std::unique_ptr<Elem> InfPrism12::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -183,41 +183,7 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
 void InfPrism6::build_side_ptr (std::unique_ptr<Elem> & side,
                                 const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  switch (i)
-    {
-    case 0: // the triangular face at z=-1, base face
-      {
-        if (!side.get() || side->type() != TRI3)
-          {
-            side = this->build_side_ptr(i, false);
-            return;
-          }
-        break;
-      }
-
-    case 1: // the quad face at y=0
-    case 2: // the other quad face
-    case 3: // the quad face at x=0
-      {
-        if (!side.get() || side->type() != INFQUAD4)
-          {
-            side = this->build_side_ptr(i, false);
-            return;
-          }
-        break;
-      }
-
-    default:
-      libmesh_error_msg("Invalid side i = " << i);
-    }
-
-  side->subdomain_id() = this->subdomain_id();
-
-  // Set the nodes
-  for (auto n : side->node_index_range())
-    side->set_node(n) = this->node_ptr(InfPrism6::side_nodes_map[i][n]);
+  this->side_ptr(side, i);
 }
 
 

--- a/src/geom/cell_inf_prism6.C
+++ b/src/geom/cell_inf_prism6.C
@@ -180,6 +180,47 @@ std::unique_ptr<Elem> InfPrism6::build_side_ptr (const unsigned int i,
 }
 
 
+void InfPrism6::build_side_ptr (std::unique_ptr<Elem> & side,
+                                const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+    case 0: // the triangular face at z=-1, base face
+      {
+        if (!side.get() || side->type() != TRI3)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    case 1: // the quad face at y=0
+    case 2: // the other quad face
+    case 3: // the quad face at x=0
+      {
+        if (!side.get() || side->type() != INFQUAD4)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfPrism6::side_nodes_map[i][n]);
+}
+
+
 std::unique_ptr<Elem> InfPrism6::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, n_edges());

--- a/src/geom/cell_prism.C
+++ b/src/geom/cell_prism.C
@@ -138,6 +138,50 @@ std::unique_ptr<Elem> Prism::side_ptr (const unsigned int i)
 
 
 
+void Prism::side_ptr (std::unique_ptr<Elem> & side,
+                      const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+      // the base face
+    case 0: // the triangular face at z=0
+    case 4: // the triangular face at z=1
+      {
+        if (!side.get() || side->type() != TRI3)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    case 1: // the quad face at y=0
+    case 2: // the other quad face
+    case 3: // the quad face at x=0
+      {
+        if (!side.get() || side->type() != QUAD4)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(Prism6::side_nodes_map[i][n]);
+}
+
+
+
 bool Prism::is_child_on_side(const unsigned int c,
                              const unsigned int s) const
 {

--- a/src/geom/cell_prism15.C
+++ b/src/geom/cell_prism15.C
@@ -223,6 +223,49 @@ std::unique_ptr<Elem> Prism15::build_side_ptr (const unsigned int i,
 }
 
 
+void Prism15::build_side_ptr (std::unique_ptr<Elem> & side,
+                              const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+    case 0: // the triangular face at z=-1
+    case 4: // the triangular face at z=1
+      {
+        if (!side.get() || side->type() != TRI6)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    case 1: // the quad face at y=0
+    case 2: // the other quad face
+    case 3: // the quad face at x=0
+      {
+        if (!side.get() || side->type() != QUAD8)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(Prism15::side_nodes_map[i][n]);
+}
+
+
+
 std::unique_ptr<Elem> Prism15::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -262,6 +262,49 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
 
 
 
+void Prism18::build_side_ptr (std::unique_ptr<Elem> & side,
+                              const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+    case 0: // the triangular face at z=-1
+    case 4: // the triangular face at z=1
+      {
+        if (!side.get() || side->type() != TRI6)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    case 1: // the quad face at y=0
+    case 2: // the other quad face
+    case 3: // the quad face at x=0
+      {
+        if (!side.get() || side->type() != QUAD9)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(Prism18::side_nodes_map[i][n]);
+}
+
+
+
 std::unique_ptr<Elem> Prism18::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_prism6.C
+++ b/src/geom/cell_prism6.C
@@ -195,6 +195,14 @@ std::unique_ptr<Elem> Prism6::build_side_ptr (const unsigned int i,
 
 
 
+void Prism6::build_side_ptr (std::unique_ptr<Elem> & side,
+                             const unsigned int i)
+{
+  this->side_ptr(side, i);
+}
+
+
+
 std::unique_ptr<Elem> Prism6::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_pyramid.C
+++ b/src/geom/cell_pyramid.C
@@ -133,6 +133,49 @@ std::unique_ptr<Elem> Pyramid::side_ptr (const unsigned int i)
 
 
 
+void Pyramid::side_ptr (std::unique_ptr<Elem> & side,
+                        const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+    case 0: // triangular face 1
+    case 1: // triangular face 2
+    case 2: // triangular face 3
+    case 3: // triangular face 4
+      {
+        if (!side.get() || side->type() != TRI3)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    case 4:  // the quad face at z=0
+      {
+        if (!side.get() || side->type() != QUAD4)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(Pyramid5::side_nodes_map[i][n]);
+}
+
+
+
 bool Pyramid::is_child_on_side(const unsigned int c,
                                const unsigned int s) const
 {

--- a/src/geom/cell_pyramid13.C
+++ b/src/geom/cell_pyramid13.C
@@ -209,6 +209,47 @@ std::unique_ptr<Elem> Pyramid13::build_side_ptr (const unsigned int i, bool prox
 
 
 
+void Pyramid13::build_side_ptr (std::unique_ptr<Elem> & side,
+                                const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+    case 0: // triangular face 1
+    case 1: // triangular face 2
+    case 2: // triangular face 3
+    case 3: // triangular face 4
+      {
+        if (!side.get() || side->type() != TRI6)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+    case 4:  // the quad face at z=0
+      {
+        if (!side.get() || side->type() != QUAD8)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(Pyramid13::side_nodes_map[i][n]);
+}
+
+
+
 std::unique_ptr<Elem> Pyramid13::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_pyramid14.C
+++ b/src/geom/cell_pyramid14.C
@@ -235,6 +235,47 @@ std::unique_ptr<Elem> Pyramid14::build_side_ptr (const unsigned int i, bool prox
 
 
 
+void Pyramid14::build_side_ptr (std::unique_ptr<Elem> & side,
+                                const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+    case 0: // triangular face 1
+    case 1: // triangular face 2
+    case 2: // triangular face 3
+    case 3: // triangular face 4
+      {
+        if (!side.get() || side->type() != TRI6)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+    case 4:  // the quad face at z=0
+      {
+        if (!side.get() || side->type() != QUAD9)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(Pyramid14::side_nodes_map[i][n]);
+}
+
+
+
 std::unique_ptr<Elem> Pyramid14::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -184,6 +184,47 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
 
 
 
+void Pyramid5::build_side_ptr (std::unique_ptr<Elem> & side,
+                               const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+    case 0: // triangular face 1
+    case 1: // triangular face 2
+    case 2: // triangular face 3
+    case 3: // triangular face 4
+      {
+        if (!side.get() || side->type() != TRI3)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+    case 4:  // the quad face at z=0
+      {
+        if (!side.get() || side->type() != QUAD4)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(Pyramid5::side_nodes_map[i][n]);
+}
+
+
+
 std::unique_ptr<Elem> Pyramid5::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_pyramid5.C
+++ b/src/geom/cell_pyramid5.C
@@ -187,40 +187,7 @@ std::unique_ptr<Elem> Pyramid5::build_side_ptr (const unsigned int i,
 void Pyramid5::build_side_ptr (std::unique_ptr<Elem> & side,
                                const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  switch (i)
-    {
-    case 0: // triangular face 1
-    case 1: // triangular face 2
-    case 2: // triangular face 3
-    case 3: // triangular face 4
-      {
-        if (!side.get() || side->type() != TRI3)
-          {
-            side = this->build_side_ptr(i, false);
-            return;
-          }
-        break;
-      }
-    case 4:  // the quad face at z=0
-      {
-        if (!side.get() || side->type() != QUAD4)
-          {
-            side = this->build_side_ptr(i, false);
-            return;
-          }
-        break;
-      }
-    default:
-      libmesh_error_msg("Invalid side i = " << i);
-    }
-
-  side->subdomain_id() = this->subdomain_id();
-
-  // Set the nodes
-  for (auto n : side->node_index_range())
-    side->set_node(n) = this->node_ptr(Pyramid5::side_nodes_map[i][n]);
+  this->side_ptr(side, i);
 }
 
 

--- a/src/geom/cell_tet.C
+++ b/src/geom/cell_tet.C
@@ -86,6 +86,15 @@ std::unique_ptr<Elem> Tet::side_ptr (const unsigned int i)
 }
 
 
+
+void Tet::side_ptr (std::unique_ptr<Elem> & side,
+                    const unsigned int i)
+{
+  this->simple_build_side_ptr<Tet4>(side, i, TRI3);
+}
+
+
+
 void Tet::select_diagonal (const Diagonal diag) const
 {
   libmesh_assert_equal_to (_diagonal_selection, INVALID_DIAG);

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -208,17 +208,7 @@ std::unique_ptr<Elem> Tet10::build_side_ptr (const unsigned int i,
 void Tet10::build_side_ptr (std::unique_ptr<Elem> & side,
                             const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (!side.get() || side->type() != TRI6)
-    side = this->build_side_ptr(i, false);
-  else
-    {
-      side->subdomain_id() = this->subdomain_id();
-
-      for (auto n : side->node_index_range())
-        side->set_node(n) = this->node_ptr(Tet10::side_nodes_map[i][n]);
-    }
+  this->simple_build_side_ptr<Tet10>(side, i, TRI6);
 }
 
 

--- a/src/geom/cell_tet10.C
+++ b/src/geom/cell_tet10.C
@@ -205,6 +205,24 @@ std::unique_ptr<Elem> Tet10::build_side_ptr (const unsigned int i,
 
 
 
+void Tet10::build_side_ptr (std::unique_ptr<Elem> & side,
+                            const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  if (!side.get() || side->type() != TRI6)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      for (auto n : side->node_index_range())
+        side->set_node(n) = this->node_ptr(Tet10::side_nodes_map[i][n]);
+    }
+}
+
+
+
 std::unique_ptr<Elem> Tet10::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -169,17 +169,7 @@ std::unique_ptr<Elem> Tet4::build_side_ptr (const unsigned int i,
 void Tet4::build_side_ptr (std::unique_ptr<Elem> & side,
                            const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (!side.get() || side->type() != TRI3)
-    side = this->build_side_ptr(i, false);
-  else
-    {
-      side->subdomain_id() = this->subdomain_id();
-
-      for (auto n : side->node_index_range())
-        side->set_node(n) = this->node_ptr(Tet4::side_nodes_map[i][n]);
-    }
+  this->simple_build_side_ptr<Tet4>(side, i, TRI3);
 }
 
 

--- a/src/geom/cell_tet4.C
+++ b/src/geom/cell_tet4.C
@@ -165,6 +165,25 @@ std::unique_ptr<Elem> Tet4::build_side_ptr (const unsigned int i,
 }
 
 
+
+void Tet4::build_side_ptr (std::unique_ptr<Elem> & side,
+                           const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  if (!side.get() || side->type() != TRI3)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      for (auto n : side->node_index_range())
+        side->set_node(n) = this->node_ptr(Tet4::side_nodes_map[i][n]);
+    }
+}
+
+
+
 std::unique_ptr<Elem> Tet4::build_edge_ptr (const unsigned int i)
 {
   libmesh_assert_less (i, this->n_edges());

--- a/src/geom/edge.C
+++ b/src/geom/edge.C
@@ -42,6 +42,24 @@ std::unique_ptr<Elem> Edge::side_ptr (const unsigned int i)
 }
 
 
+void Edge::side_ptr (std::unique_ptr<Elem> & side,
+                           const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  if (!side.get() || side->type() != NODEELEM)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      side->set_node(0) = this->node_ptr(i);
+    }
+}
+
+
+
+
 std::unique_ptr<Elem> Edge::build_side_ptr (const unsigned int i, bool)
 {
   libmesh_assert_less (i, 2);
@@ -49,6 +67,15 @@ std::unique_ptr<Elem> Edge::build_side_ptr (const unsigned int i, bool)
   nodeelem->set_node(0) = this->node_ptr(i);
   return nodeelem;
 }
+
+
+void Edge::build_side_ptr (std::unique_ptr<Elem> & side,
+                           const unsigned int i)
+{
+  this->side_ptr(side, i);
+}
+
+
 
 
 bool Edge::is_child_on_side(const unsigned int c,

--- a/src/geom/face_inf_quad.C
+++ b/src/geom/face_inf_quad.C
@@ -107,6 +107,48 @@ std::unique_ptr<Elem> InfQuad::side_ptr (const unsigned int i)
 
 
 
+void InfQuad::side_ptr (std::unique_ptr<Elem> & side,
+                        const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  switch (i)
+    {
+      // the base face
+    case 0:
+      {
+        if (!side.get() || side->type() != EDGE2)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+      // connecting to another infinite element
+    case 1:
+    case 2:
+      {
+        if (!side.get() || side->type() != INFEDGE2)
+          {
+            side = this->side_ptr(i);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfQuad4::side_nodes_map[i][n]);
+}
+
+
 bool InfQuad::is_child_on_side(const unsigned int c,
                                const unsigned int s) const
 {

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -241,6 +241,51 @@ std::unique_ptr<Elem> InfQuad4::build_side_ptr (const unsigned int i,
 }
 
 
+
+void InfQuad4::build_side_ptr (std::unique_ptr<Elem> & side,
+                               const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
+  switch (i)
+    {
+      // the base face
+    case 0:
+      {
+        if (!side.get() || side->type() != EDGE2)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+      // connecting to another infinite element
+    case 1:
+    case 2:
+      {
+        if (!side.get() || side->type() != INFEDGE2)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfQuad4::side_nodes_map[i][n]);
+}
+
+
+
 void InfQuad4::connectivity(const unsigned int libmesh_dbg_var(sf),
                             const IOPackage iop,
                             std::vector<dof_id_type> & conn) const

--- a/src/geom/face_inf_quad6.C
+++ b/src/geom/face_inf_quad6.C
@@ -219,6 +219,49 @@ std::unique_ptr<Elem> InfQuad6::build_side_ptr (const unsigned int i,
 
 
 
+void InfQuad6::build_side_ptr (std::unique_ptr<Elem> & side,
+                               const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  // Think of a unit cube: (-1,1) x (-1,1) x (1,1)
+  switch (i)
+    {
+      // the base face
+    case 0:
+      {
+        if (!side.get() || side->type() != EDGE3)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+      // connecting to another infinite element
+    case 1:
+    case 2:
+      {
+        if (!side.get() || side->type() != INFEDGE2)
+          {
+            side = this->build_side_ptr(i, false);
+            return;
+          }
+        break;
+      }
+
+    default:
+      libmesh_error_msg("Invalid side i = " << i);
+    }
+
+  side->subdomain_id() = this->subdomain_id();
+
+  // Set the nodes
+  for (auto n : side->node_index_range())
+    side->set_node(n) = this->node_ptr(InfQuad6::side_nodes_map[i][n]);
+}
+
+
 
 void InfQuad6::connectivity(const unsigned int sf,
                             const IOPackage iop,

--- a/src/geom/face_quad.C
+++ b/src/geom/face_quad.C
@@ -97,6 +97,14 @@ std::unique_ptr<Elem> Quad::side_ptr (const unsigned int i)
 
 
 
+void Quad::side_ptr (std::unique_ptr<Elem> & side,
+                     const unsigned int i)
+{
+  this->simple_build_side_ptr<Quad4>(side, i, EDGE2);
+}
+
+
+
 bool Quad::is_child_on_side(const unsigned int c,
                             const unsigned int s) const
 {

--- a/src/geom/face_quad4.C
+++ b/src/geom/face_quad4.C
@@ -163,6 +163,22 @@ std::unique_ptr<Elem> Quad4::build_side_ptr (const unsigned int i,
 
 
 
+void Quad4::build_side_ptr (std::unique_ptr<Elem> & side,
+                            const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  if (!side.get() || side->type() != EDGE2)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      for (auto n : side->node_index_range())
+        side->set_node(n) = this->node_ptr(Quad4::side_nodes_map[i][n]);
+    }
+}
+
 
 
 void Quad4::connectivity(const unsigned int libmesh_dbg_var(sf),

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -237,6 +237,24 @@ std::unique_ptr<Elem> Quad8::build_side_ptr (const unsigned int i,
 
 
 
+void Quad8::build_side_ptr (std::unique_ptr<Elem> & side,
+                            const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  if (!side.get() || side->type() != EDGE3)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      for (auto n : side->node_index_range())
+        side->set_node(n) = this->node_ptr(Quad8::side_nodes_map[i][n]);
+    }
+}
+
+
+
 
 
 

--- a/src/geom/face_quad8.C
+++ b/src/geom/face_quad8.C
@@ -240,17 +240,7 @@ std::unique_ptr<Elem> Quad8::build_side_ptr (const unsigned int i,
 void Quad8::build_side_ptr (std::unique_ptr<Elem> & side,
                             const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (!side.get() || side->type() != EDGE3)
-    side = this->build_side_ptr(i, false);
-  else
-    {
-      side->subdomain_id() = this->subdomain_id();
-
-      for (auto n : side->node_index_range())
-        side->set_node(n) = this->node_ptr(Quad8::side_nodes_map[i][n]);
-    }
+  this->simple_build_side_ptr<Quad8>(side, i, EDGE3);
 }
 
 

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -258,17 +258,7 @@ std::unique_ptr<Elem> Quad9::build_side_ptr (const unsigned int i,
 void Quad9::build_side_ptr (std::unique_ptr<Elem> & side,
                             const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (!side.get() || side->type() != EDGE3)
-    side = this->build_side_ptr(i, false);
-  else
-    {
-      side->subdomain_id() = this->subdomain_id();
-
-      for (auto n : side->node_index_range())
-        side->set_node(n) = this->node_ptr(Quad9::side_nodes_map[i][n]);
-    }
+  this->simple_build_side_ptr<Quad9>(side, i, EDGE3);
 }
 
 

--- a/src/geom/face_quad9.C
+++ b/src/geom/face_quad9.C
@@ -255,7 +255,21 @@ std::unique_ptr<Elem> Quad9::build_side_ptr (const unsigned int i,
 
 
 
+void Quad9::build_side_ptr (std::unique_ptr<Elem> & side,
+                            const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
 
+  if (!side.get() || side->type() != EDGE3)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      for (auto n : side->node_index_range())
+        side->set_node(n) = this->node_ptr(Quad9::side_nodes_map[i][n]);
+    }
+}
 
 
 

--- a/src/geom/face_tri.C
+++ b/src/geom/face_tri.C
@@ -92,6 +92,14 @@ std::unique_ptr<Elem> Tri::side_ptr (const unsigned int i)
 
 
 
+void Tri::side_ptr (std::unique_ptr<Elem> & side,
+                    const unsigned int i)
+{
+  this->simple_build_side_ptr<Tri3>(side, i, EDGE2);
+}
+
+
+
 bool Tri::is_child_on_side(const unsigned int c,
                            const unsigned int s) const
 {

--- a/src/geom/face_tri3.C
+++ b/src/geom/face_tri3.C
@@ -144,6 +144,15 @@ std::unique_ptr<Elem> Tri3::build_side_ptr (const unsigned int i,
 }
 
 
+
+void Tri3::build_side_ptr (std::unique_ptr<Elem> & side,
+                           const unsigned int i)
+{
+  this->simple_build_side_ptr<Tri3>(side, i, EDGE2);
+}
+
+
+
 void Tri3::connectivity(const unsigned int libmesh_dbg_var(sf),
                         const IOPackage iop,
                         std::vector<dof_id_type> & conn) const

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -220,6 +220,25 @@ std::unique_ptr<Elem> Tri6::build_side_ptr (const unsigned int i,
 }
 
 
+
+void Tri6::build_side_ptr (std::unique_ptr<Elem> & side,
+                           const unsigned int i)
+{
+  libmesh_assert_less (i, this->n_sides());
+
+  if (!side.get() || side->type() != EDGE3)
+    side = this->build_side_ptr(i, false);
+  else
+    {
+      side->subdomain_id() = this->subdomain_id();
+
+      for (auto n : side->node_index_range())
+        side->set_node(n) = this->node_ptr(Tri6::side_nodes_map[i][n]);
+    }
+}
+
+
+
 void Tri6::connectivity(const unsigned int sf,
                         const IOPackage iop,
                         std::vector<dof_id_type> & conn) const

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -224,17 +224,7 @@ std::unique_ptr<Elem> Tri6::build_side_ptr (const unsigned int i,
 void Tri6::build_side_ptr (std::unique_ptr<Elem> & side,
                            const unsigned int i)
 {
-  libmesh_assert_less (i, this->n_sides());
-
-  if (!side.get() || side->type() != EDGE3)
-    side = this->build_side_ptr(i, false);
-  else
-    {
-      side->subdomain_id() = this->subdomain_id();
-
-      for (auto n : side->node_index_range())
-        side->set_node(n) = this->node_ptr(Tri6::side_nodes_map[i][n]);
-    }
+  this->simple_build_side_ptr<Tri6>(side, i, EDGE3);
 }
 
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -619,6 +619,9 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
   {
     std::set<dof_id_type> my_interface_node_set;
 
+    // Pull objects out of the loop to reduce heap operations
+    std::unique_ptr<const Elem> side;
+
     // since parent nodes are a subset of children nodes, this should be sufficient
     for (const auto & elem : mesh.active_local_element_ptr_range())
       {
@@ -631,7 +634,7 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
             for (auto s : elem->side_index_range())
               if (elem->neighbor_ptr(s) == nullptr)
                 {
-                  std::unique_ptr<const Elem> side(elem->build_side_ptr(s));
+                  elem->build_side_ptr(side, s);
 
                   for (unsigned int n=0; n<side->n_vertices(); n++)
                     my_interface_node_set.insert (side->node_id(n));

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -271,7 +271,8 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
     // A map from side keys to corresponding elements & side numbers
     map_type side_to_elem_map;
 
-
+    // Pull objects out of the loop to reduce heap operations
+    std::unique_ptr<Elem> my_side, their_side;
 
     for (const auto & element : this->element_ptr_range())
       {
@@ -295,7 +296,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
                 if (bounds.first != bounds.second)
                   {
                     // Get the side for this element
-                    const std::unique_ptr<Elem> my_side(element->side_ptr(ms));
+                    element->side_ptr(my_side, ms);
 
                     // Look at all the entries with an equivalent key
                     while (bounds.first != bounds.second)
@@ -305,7 +306,7 @@ void UnstructuredMesh::find_neighbors (const bool reset_remote_elements,
 
                         // Get the side for the neighboring element
                         const unsigned int ns = bounds.first->second.second;
-                        const std::unique_ptr<Elem> their_side(neighbor->side_ptr(ns));
+                        neighbor->side_ptr(their_side, ns);
                         //libmesh_assert(my_side.get());
                         //libmesh_assert(their_side.get());
 


### PR DESCRIPTION
@friedmud swears that build_side_ptr heap allocations can trash multithreaded scalability on some apps, and this gives us a way to avoid those.

Hopefully we'll even see some speedup on the single-threaded find_neighbors(), as he speculated in #1821