### PR TITLE
Default processor_id_type to 4 bytes

### DIFF
--- a/configure
+++ b/configure
@@ -31375,7 +31375,7 @@ $as_echo "configuring size of dof_id... $dof_bytes" >&6; }
 if test "${with_processor_id_bytes+set}" = set; then :
   withval=$with_processor_id_bytes; processor_bytes="$withval"
 else
-  processor_bytes=2
+  processor_bytes=4
 fi
 
 
@@ -31398,12 +31398,12 @@ $as_echo "#define PROCESSOR_ID_BYTES 8" >>confdefs.h
  ;; #(
   *) :
 
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> unrecognized processor_id size: $processor_bytes - configuring size...2" >&5
-$as_echo ">>> unrecognized processor_id size: $processor_bytes - configuring size...2" >&6; }
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: >>> unrecognized processor_id size: $processor_bytes - configuring size...4" >&5
+$as_echo ">>> unrecognized processor_id size: $processor_bytes - configuring size...4" >&6; }
 
-$as_echo "#define PROCESSOR_ID_BYTES 2" >>confdefs.h
+$as_echo "#define PROCESSOR_ID_BYTES 4" >>confdefs.h
 
-          processor_bytes=2
+          processor_bytes=4
          ;;
 esac
 

--- a/m4/libmesh_core_features.m4
+++ b/m4/libmesh_core_features.m4
@@ -226,7 +226,7 @@ AC_ARG_WITH([processor_id_bytes],
             AS_HELP_STRING([--with-processor-id-bytes=<1|2|4|8>],
                            [bytes used for processor id [4]]),
             [processor_bytes="$withval"],
-            [processor_bytes=2])
+            [processor_bytes=4])
 
 AS_CASE("$processor_bytes",
         [1], [AC_DEFINE(PROCESSOR_ID_BYTES, 1, [size of processor_id])],
@@ -234,9 +234,9 @@ AS_CASE("$processor_bytes",
         [4], [AC_DEFINE(PROCESSOR_ID_BYTES, 4, [size of processor_id])],
         [8], [AC_DEFINE(PROCESSOR_ID_BYTES, 8, [size of processor_id])],
         [
-          AC_MSG_RESULT([>>> unrecognized processor_id size: $processor_bytes - configuring size...2])
-          AC_DEFINE(PROCESSOR_ID_BYTES, 2, [size of processor_id])
-          processor_bytes=2
+          AC_MSG_RESULT([>>> unrecognized processor_id size: $processor_bytes - configuring size...4])
+          AC_DEFINE(PROCESSOR_ID_BYTES, 4, [size of processor_id])
+          processor_bytes=4
         ])
 
 AC_MSG_RESULT([configuring size of processor_id... $processor_bytes])

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -561,8 +561,8 @@ void CheckpointIO::write_connectivity (Xdr & io,
       else
 #endif
         {
-          elem_data[4] = DofObject::invalid_processor_id;
-          elem_data[5] = DofObject::invalid_processor_id;
+          elem_data[4] = static_cast<largest_id_type>(-1);
+          elem_data[5] = static_cast<largest_id_type>(-1);
         }
 
       conn_data.resize(n_nodes);
@@ -1071,16 +1071,17 @@ void CheckpointIO::read_connectivity (Xdr & io)
         cast_int<subdomain_id_type>(elem_data[3]);
       const dof_id_type parent_id          =
         cast_int<dof_id_type>      (elem_data[4]);
-      const unsigned short int child_num   =
-        cast_int<unsigned short>   (elem_data[5]);
-
       Elem * parent =
-        (parent_id == DofObject::invalid_processor_id) ?
-        nullptr : mesh.elem_ptr(parent_id);
+        (elem_data[4] == static_cast<largest_id_type>(-1)) ?
+        nullptr : mesh.elem_ptr(cast_int<dof_id_type>(parent_id));
+      const unsigned short int child_num   =
+        (elem_data[5] == static_cast<largest_id_type>(-1)) ?
+        static_cast<unsigned short>(-1) :
+        cast_int<unsigned short>(elem_data[5]);
 
       if (!parent)
         libmesh_assert_equal_to
-          (child_num, DofObject::invalid_processor_id);
+          (child_num, static_cast<unsigned short>(-1));
 
       Elem * old_elem = mesh.query_elem_ptr(id);
 

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -63,7 +63,7 @@ void chunking(libMesh::processor_id_type size, libMesh::processor_id_type rank, 
       return;
     }
 
-  int nextra = nsplits % size;
+  libMesh::processor_id_type nextra = nsplits % size;
   if (rank < nextra) // leftover chunks cause an extra chunk to be added to this processor
     {
       nchunks = libMesh::cast_int<libMesh::processor_id_type>(nsplits / size + 1);

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -1030,6 +1030,11 @@ void CheckpointIO::read_connectivity (Xdr & io)
   // Keep track of the highest dimensional element we've added to the mesh
   unsigned int highest_elem_dim = 1;
 
+  // RHS: Originally we used invalid_processor_id as a "no parent" tag
+  // number, because I'm an idiot.  Let's try to support broken files
+  // as much as possible.
+  bool file_is_broken = false;
+
   for (unsigned int i=0; i<n_elems_here; i++)
     {
       // id type pid subdomain_id parent_id
@@ -1069,13 +1074,22 @@ void CheckpointIO::read_connectivity (Xdr & io)
         (elem_data[2] % mesh.n_processors());
       const subdomain_id_type subdomain_id =
         cast_int<subdomain_id_type>(elem_data[3]);
-      const dof_id_type parent_id          =
-        cast_int<dof_id_type>      (elem_data[4]);
+
+      // Old broken files used processsor_id_type(-1)...
+      // But we *know* our first element will be level 0
+      if (i == 0 && elem_data[4] == 65535)
+        file_is_broken = true;
+
+      // On a broken file we can't tell whether a parent of 65535 is a
+      // null parent or an actual parent of 65535.  Assuming the
+      // former will cause less breakage.
       Elem * parent =
-        (elem_data[4] == static_cast<largest_id_type>(-1)) ?
-        nullptr : mesh.elem_ptr(cast_int<dof_id_type>(parent_id));
+        (elem_data[4] == static_cast<largest_id_type>(-1) ||
+         (file_is_broken && elem_data[4] == 65535)) ?
+        nullptr : mesh.elem_ptr(cast_int<dof_id_type>(elem_data[4]));
       const unsigned short int child_num   =
-        (elem_data[5] == static_cast<largest_id_type>(-1)) ?
+        (elem_data[5] == static_cast<largest_id_type>(-1) ||
+         (file_is_broken && elem_data[5] == 65535)) ?
         static_cast<unsigned short>(-1) :
         cast_int<unsigned short>(elem_data[5]);
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -306,7 +306,8 @@ void Nemesis_IO::read (const std::string & base_filename)
 
       // In all the samples I have seen, node_cmap_ids[cmap] is the processor
       // rank of the remote processor...
-      const int adjcnt_pid_idx = nemhelper->node_cmap_ids[cmap];
+      const processor_id_type adjcnt_pid_idx =
+        cast_int<processor_id_type>(nemhelper->node_cmap_ids[cmap]);
 
       libmesh_assert_less (adjcnt_pid_idx, this->n_processors());
       libmesh_assert_not_equal_to (adjcnt_pid_idx, this->processor_id());
@@ -320,7 +321,9 @@ void Nemesis_IO::read (const std::string & base_filename)
       for (unsigned int idx=0; idx<to_uint(nemhelper->node_cmap_node_cnts[cmap]); idx++)
         {
           //  Are the node_cmap_ids and node_cmap_proc_ids really redundant?
-          libmesh_assert_equal_to (adjcnt_pid_idx, nemhelper->node_cmap_proc_ids[cmap][idx]);
+          libmesh_assert_equal_to
+            (adjcnt_pid_idx,
+             cast_int<processor_id_type>(nemhelper->node_cmap_proc_ids[cmap][idx]));
 
           // we are expecting the exodus node numbering to be 1-based...
           const unsigned int local_node_idx = nemhelper->node_cmap_node_ids[cmap][idx]-1;
@@ -330,8 +333,7 @@ void Nemesis_IO::read (const std::string & base_filename)
           // if the adjacent processor is lower rank than the current
           // owner for this node, then it will get the node...
           node_ownership[local_node_idx] =
-            std::min(node_ownership[local_node_idx],
-                     cast_int<processor_id_type>(adjcnt_pid_idx));
+            std::min(node_ownership[local_node_idx], adjcnt_pid_idx);
         }
     } // We now should have established proper node ownership.
 


### PR DESCRIPTION
Our configure script was already lying and *saying* it defaulted to 4
bytes; now let's *actually* default to 4 bytes.

This fixes #1939