### PR TITLE
Use C++11 iterator-returning erase member functions when possible

### DIFF
--- a/include/utils/mapvector.h
+++ b/include/utils/mapvector.h
@@ -118,8 +118,8 @@ public:
     maptype::erase(i);
   }
 
-  void erase(const veclike_iterator & pos) {
-    maptype::erase(pos.it);
+  veclike_iterator erase(const veclike_iterator & pos) {
+    return veclike_iterator(maptype::erase(pos.it));
   }
 
   veclike_iterator begin() {

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3314,7 +3314,7 @@ void DofMap::process_constraints (MeshBase & mesh)
           }
 
         if (constraints_to_expand.empty())
-          unexpanded_set.erase(i++);
+          i = unexpanded_set.erase(i);
         else
           ++i;
       }
@@ -3417,7 +3417,7 @@ void DofMap::check_for_cyclic_constraints()
         //   }
 
         if (constraints_to_expand.empty())
-          unexpanded_set.erase(i++);
+          i = unexpanded_set.erase(i);
         else
           ++i;
       }

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -491,7 +491,7 @@ void Build::parallel_sync ()
     proc_data.second.emplace_back(std::move(row));
 
     // Might as well remove it since it's invalidated anyway
-    nonlocal_pattern.erase(it++);
+    it = nonlocal_pattern.erase(it);
   }
 
   // Tell everyone about where everyone will send to

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1357,10 +1357,7 @@ void BoundaryInfo::remove_edge (const Elem * elem,
       // if this is true we found the requested edge
       // of the element and want to erase the id
       if (e.first->second.first == edge)
-        {
-          // (postfix++ - increment the iterator before it's invalid)
-          _boundary_edge_id.erase(e.first++);
-        }
+        e.first = _boundary_edge_id.erase(e.first);
       else
         ++e.first;
     }
@@ -1387,12 +1384,8 @@ void BoundaryInfo::remove_edge (const Elem * elem,
     {
       // if this is true we found the requested edge
       // of the element and want to erase the requested id
-      if (e.first->second.first == edge &&
-          e.first->second.second == id)
-        {
-          // (postfix++ - increment the iterator before it's invalid)
-          _boundary_edge_id.erase(e.first++);
-        }
+      if (e.first->second.first == edge && e.first->second.second == id)
+        e.first = _boundary_edge_id.erase(e.first);
       else
         ++e.first;
     }
@@ -1421,10 +1414,7 @@ void BoundaryInfo::remove_shellface (const Elem * elem,
       // if this is true we found the requested shellface
       // of the element and want to erase the id
       if (e.first->second.first == shellface)
-        {
-          // (postfix++ - increment the iterator before it's invalid)
-          _boundary_shellface_id.erase(e.first++);
-        }
+        e.first = _boundary_shellface_id.erase(e.first);
       else
         ++e.first;
     }
@@ -1458,7 +1448,7 @@ void BoundaryInfo::remove_shellface (const Elem * elem,
           e.first->second.second == id)
         {
           // (postfix++ - increment the iterator before it's invalid)
-          _boundary_shellface_id.erase(e.first++);
+          e.first = _boundary_shellface_id.erase(e.first);
         }
       else
         ++e.first;
@@ -1484,10 +1474,7 @@ void BoundaryInfo::remove_side (const Elem * elem,
       // if this is true we found the requested side
       // of the element and want to erase the id
       if (e.first->second.first == side)
-        {
-          // (postfix++ - increment the iterator before it's invalid)
-          _boundary_side_id.erase(e.first++);
-        }
+        e.first = _boundary_side_id.erase(e.first);
       else
         ++e.first;
     }
@@ -1510,12 +1497,8 @@ void BoundaryInfo::remove_side (const Elem * elem,
     {
       // if this is true we found the requested side
       // of the element and want to erase the requested id
-      if (e.first->second.first == side &&
-          e.first->second.second == id)
-        {
-          // (postfix++ - increment the iterator before it's invalid)
-          _boundary_side_id.erase(e.first++);
-        }
+      if (e.first->second.first == side && e.first->second.second == id)
+        e.first = _boundary_side_id.erase(e.first);
       else
         ++e.first;
     }
@@ -1538,7 +1521,7 @@ void BoundaryInfo::remove_id (boundary_id_type id)
   for (auto it = _boundary_node_id.begin(); it != _boundary_node_id.end(); /*below*/)
     {
       if (it->second == id)
-        _boundary_node_id.erase(it++);
+        it = _boundary_node_id.erase(it);
       else
         ++it;
     }
@@ -1546,7 +1529,7 @@ void BoundaryInfo::remove_id (boundary_id_type id)
   for (auto it = _boundary_edge_id.begin(); it != _boundary_edge_id.end(); /*below*/)
     {
       if (it->second.second == id)
-        _boundary_edge_id.erase(it++);
+        it = _boundary_edge_id.erase(it);
       else
         ++it;
     }
@@ -1554,7 +1537,7 @@ void BoundaryInfo::remove_id (boundary_id_type id)
   for (auto it = _boundary_shellface_id.begin(); it != _boundary_shellface_id.end(); /*below*/)
     {
       if (it->second.second == id)
-        _boundary_shellface_id.erase(it++);
+        it = _boundary_shellface_id.erase(it);
       else
         ++it;
     }
@@ -1562,7 +1545,7 @@ void BoundaryInfo::remove_id (boundary_id_type id)
   for (auto it = _boundary_side_id.begin(); it != _boundary_side_id.end(); /*below*/)
     {
       if (it->second.second == id)
-        _boundary_side_id.erase(it++);
+        it = _boundary_side_id.erase(it);
       else
         ++it;
     }

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -974,14 +974,13 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
   object_iterator it  = objects.begin();
   object_iterator end = objects.end();
 
-  for (; it != end;)
+  while (it != end)
     {
       T * obj = *it;
 
-      // Remove any nullptr container entries while we're here,
-      // being careful not to invalidate our iterator
-      if (!*it)
-        objects.erase(it++);
+      // Remove any nullptr container entries while we're here.
+      if (!obj)
+        it = objects.erase(it);
       else
         {
           processor_id_type obj_procid = obj->processor_id();
@@ -989,6 +988,8 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
             unpartitioned_objects++;
           else
             ghost_objects_from_proc[obj_procid]++;
+
+          // Finally, increment the iterator
           ++it;
         }
     }
@@ -1165,8 +1166,9 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
 
   // Finally shuffle around objects so that container indices
   // match ids
+  it = objects.begin();
   end = objects.end();
-  for (it = objects.begin(); it != end;)
+  while (it != end)
     {
       T * obj = *it;
       if (obj) // don't try shuffling already-nullptr entries
@@ -1193,10 +1195,10 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
               objects[obj->id()] = obj;
             }
         }
-      // Remove any container entries that were left as nullptr,
-      // being careful not to invalidate our iterator
-      if (!*it)
-        objects.erase(it++);
+
+      // Remove any container entries that were left as nullptr.
+      if (!obj)
+        it = objects.erase(it);
       else
         ++it;
     }
@@ -1231,11 +1233,11 @@ void DistributedMesh::renumber_nodes_and_elements ()
     node_iterator_imp  it = _nodes.begin();
     node_iterator_imp end = _nodes.end();
 
-    for (; it != end;)
+    while (it != end)
       {
         Node * nd = *it;
         if (!nd)
-          _nodes.erase(it++);
+          it = _nodes.erase(it);
         else if (!used_nodes.count(nd->id()))
           {
             // remove any boundary information associated with
@@ -1245,7 +1247,7 @@ void DistributedMesh::renumber_nodes_and_elements ()
             // delete the node
             delete nd;
 
-            _nodes.erase(it++);
+            it = _nodes.erase(it);
           }
         else
           ++it;
@@ -1364,17 +1366,17 @@ void DistributedMesh::delete_remote_elements()
   // any newly-created nullptr voids out of the element array
   mapvector<Elem *,dof_id_type>::veclike_iterator e_it        = _elements.begin();
   const mapvector<Elem *,dof_id_type>::veclike_iterator e_end = _elements.end();
-  for (; e_it != e_end;)
+  while (e_it != e_end)
     if (!*e_it)
-      _elements.erase(e_it++);
+      e_it = _elements.erase(e_it);
     else
       ++e_it;
 
   mapvector<Node *,dof_id_type>::veclike_iterator n_it        = _nodes.begin();
   const mapvector<Node *,dof_id_type>::veclike_iterator n_end = _nodes.end();
-  for (; n_it != n_end;)
+  while (n_it != n_end)
     if (!*n_it)
-      _nodes.erase(n_it++);
+      n_it = _nodes.erase(n_it);
     else
       ++n_it;
 

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -411,12 +411,11 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
 
 
   {
-    std::set<std::pair<dof_id_type,unsigned int>>::iterator face_it = faces.begin();
+    auto face_it = faces.begin();
+    auto face_end = faces.end();
     unsigned int facesfound=0;
-    while (face_it != faces.end()) {
-
-      std::pair<dof_id_type, unsigned int> p;
-      p = *face_it;
+    while (face_it != face_end) {
+      std::pair<dof_id_type, unsigned int> p = *face_it;
 
       // This has to be a full-ordered side element,
       // since we need the correct n_nodes,
@@ -430,7 +429,6 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
             break;
           }
 
-
       // If a new oface is found, include its nodes in onodes
       if (found)
         {
@@ -438,14 +436,13 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
             onodes.insert(side->node_id(sn));
 
           ofaces.insert(p);
-          ++face_it; // iteration is done here
-          faces.erase(p);
+          face_it = faces.erase(face_it); // increment is done here
 
           facesfound++;
         }
 
       else
-        ++face_it; // iteration is done here
+        ++face_it; // increment is done here
 
       // If at least one new oface was found in this cycle,
       // do another search cycle.
@@ -454,7 +451,6 @@ void InfElemBuilder::build_inf_elem(const Point & origin,
           facesfound = 0;
           face_it    = faces.begin();
         }
-
     }
   }
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -1308,6 +1308,13 @@ void ReplicatedMesh::stitching_helper (const ReplicatedMesh * other_mesh,
                                         {
                                           neighbor->set_neighbor(ns,el);
                                         }
+                                      // It's OK to invalidate the
+                                      // bounds.first iterator here,
+                                      // as we are immediately going
+                                      // to break out of this while
+                                      // loop. bounds.first will
+                                      // therefore not be used for
+                                      // anything else.
                                       side_to_elem_map.erase (bounds.first);
                                       break;
                                     }

--- a/src/utils/plt_loader_read.C
+++ b/src/utils/plt_loader_read.C
@@ -70,8 +70,7 @@ void PltLoader::read_header (std::istream & in)
   {
     in.read (buf, 8);
 
-    // Using erase for GCC 2.95.3
-    this->version().erase();
+    this->version().clear();
 
     for (unsigned int i=0; i<8; i++)
       this->version() += buf[i];
@@ -117,8 +116,7 @@ void PltLoader::read_header (std::istream & in)
       {
         int i=0;
 
-        // Using erase for GCC 2.95.3
-        this->title().erase();
+        this->title().clear();
 
         do
           {
@@ -148,8 +146,7 @@ void PltLoader::read_header (std::istream & in)
         {
           int i=0;
 
-          // Using erase for GCC 2.95.3
-          this->var_name(v).erase();
+          this->var_name(v).clear();
 
           do
             {
@@ -320,8 +317,7 @@ void PltLoader::read_header (std::istream & in)
       {
         int i=0;
 
-        // Using erase() for GCC 2.95.3
-        this->title().erase();
+        this->title().clear();
         do
           {
             in.read (buf, LIBMESH_SIZEOF_INT);
@@ -350,8 +346,7 @@ void PltLoader::read_header (std::istream & in)
         {
           int i=0;
 
-          // Using erase() for GCC 2.95.3
-          this->var_name(v).erase();
+          this->var_name(v).clear();
 
           do
             {


### PR DESCRIPTION
The old post-increment-while-erasing idiom wasn't wrong by any means... but it caused me to have a "wait, what?" reaction one too many times, and it turns out there is a nicer API for this in C++11. I already added configure tests for it in #1893, this PR just uses the capability in more places in the library.
