### PR TITLE
Mark new side_ptr functions override to avoid warnings.

### DIFF
--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -144,7 +144,7 @@ public:
   /**
    * Rebuilds a primitive (4-noded) quad for face i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
 
   /**
    * \returns A quantitative assessment of element quality based on

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -152,7 +152,7 @@ public:
   /**
    * Rebuilds a primitive (4-noded) quad or infquad for face i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
 
   /**
    * \returns A quantitative assessment of element quality based on

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -149,7 +149,7 @@ public:
    * Rebuilds a primitive (3-noded) tri or (4-noded) infquad for face
    * i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
 
   /**
    * @returns \p true when this element contains the point

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -136,7 +136,7 @@ public:
   /**
    * Rebuilds a primitive triangle or quad for face i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
 
 protected:
 

--- a/include/geom/cell_pyramid.h
+++ b/include/geom/cell_pyramid.h
@@ -141,7 +141,7 @@ public:
   /**
    * Rebuilds a primitive triangle or quad for face i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
 
 protected:
 

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -125,7 +125,7 @@ public:
   /**
    * Rebuilds a primitive (3-noded) triangle for face i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
 
   /**
    * \returns A quantitative assessment of element quality based on

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -147,7 +147,7 @@ public:
   /**
    * Rebuilds a pointer to a NodeElem for the specified node.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
 
   /**
    * \returns A pointer to a NodeElem for the specified node.

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -161,7 +161,7 @@ public:
   /**
    * Rebuilds a primitive (2-noded) edge or infedge for edge \p i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i);
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
 
   /**
    * build_edge_ptr() and build_side_ptr() are identical in 2D.


### PR DESCRIPTION
clang seems to be more strict on warning about this than GCC...