### PR TITLE
Mark methods final in Elem subclass superclasses

### DIFF
--- a/include/geom/cell_hex.h
+++ b/include/geom/cell_hex.h
@@ -59,7 +59,7 @@ public:
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.
    */
-  virtual Point master_point (const unsigned int i) const override
+  virtual Point master_point (const unsigned int i) const override final
   {
     libmesh_assert_less(i, this->n_nodes());
     return Point(_master_points[i][0],
@@ -70,45 +70,45 @@ public:
   /**
    * \returns 6.
    */
-  virtual unsigned int n_sides() const override { return 6; }
+  virtual unsigned int n_sides() const override final { return 6; }
 
   /**
    * \returns 8.  All hexahedra have 8 vertices.
    */
-  virtual unsigned int n_vertices() const override { return 8; }
+  virtual unsigned int n_vertices() const override final { return 8; }
 
   /**
    * \returns 12.  All hexahedra have 12 edges.
    */
-  virtual unsigned int n_edges() const override { return 12; }
+  virtual unsigned int n_edges() const override final { return 12; }
 
   /**
    * \returns 6.  All hexahedra have 6 faces.
    */
-  virtual unsigned int n_faces() const override { return 6; }
+  virtual unsigned int n_faces() const override final { return 6; }
 
   /**
    * \returns 8.
    */
-  virtual unsigned int n_children() const override { return 8; }
+  virtual unsigned int n_children() const override final { return 8; }
 
   /**
    * \returns \p true if the specified child is on the specified side.
    */
   virtual bool is_child_on_side(const unsigned int c,
-                                const unsigned int s) const override;
+                                const unsigned int s) const override final;
 
   /**
    * \returns \p true if the specified edge is on the specified side.
    */
   virtual bool is_edge_on_side(const unsigned int e,
-                               const unsigned int s) const override;
+                               const unsigned int s) const override final;
 
   /**
    * \returns The side number opposite to \p s (for a tensor product
    * element), or throws an error otherwise.
    */
-  virtual unsigned int opposite_side(const unsigned int s) const override;
+  virtual unsigned int opposite_side(const unsigned int s) const override final;
 
   /**
    * \returns The local node number for the node opposite to node n
@@ -116,7 +116,7 @@ public:
    * throws an error otherwise.
    */
   virtual unsigned int opposite_node(const unsigned int n,
-                                     const unsigned int s) const override;
+                                     const unsigned int s) const override final;
 
   /**
    * Don't hide Elem::key() defined in the base class.
@@ -139,12 +139,12 @@ public:
   /**
    * \returns A primitive (4-noded) quad for face i.
    */
-  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;
 
   /**
    * Rebuilds a primitive (4-noded) quad for face i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override final;
 
   /**
    * \returns A quantitative assessment of element quality based on

--- a/include/geom/cell_inf_hex.h
+++ b/include/geom/cell_inf_hex.h
@@ -69,7 +69,7 @@ public:
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.
    */
-  virtual Point master_point (const unsigned int i) const override
+  virtual Point master_point (const unsigned int i) const override final
   {
     libmesh_assert_less(i, this->n_nodes());
     return Point(_master_points[i][0],
@@ -82,49 +82,49 @@ public:
    * than their conventional counterparts, since one
    * side is supposed to be located at infinity.
    */
-  virtual unsigned int n_sides() const override { return 5; }
+  virtual unsigned int n_sides() const override final { return 5; }
 
   /**
    * \returns 8.  All infinite hexahedra (in our
    * setting) have 8 vertices.
    */
-  virtual unsigned int n_vertices() const override { return 8; }
+  virtual unsigned int n_vertices() const override final { return 8; }
 
   /**
    * \returns \p true if the specified (local) node number is a
    * "mid-edge" node on an infinite element edge.
    */
   virtual bool is_mid_infinite_edge_node(const unsigned int i) const
-    override { return (i > 3 && i < 8); }
+    override final { return (i > 3 && i < 8); }
 
   /**
    * \returns 8.  All infinite hexahedra have 8 edges,
    * 4 lying in the base, and 4 perpendicular to the base.
    */
-  virtual unsigned int n_edges() const override { return 8; }
+  virtual unsigned int n_edges() const override final { return 8; }
 
   /**
    * \returns 5.  All infinite hexahedra have 5 faces.
    */
-  virtual unsigned int n_faces() const override { return 5; }
+  virtual unsigned int n_faces() const override final { return 5; }
 
   /**
    * \returns 4.
    */
-  virtual unsigned int n_children() const override { return 4; }
+  virtual unsigned int n_children() const override final { return 4; }
 
   /**
    * \returns \p true if the specified child is on the
    * specified side.
    */
   virtual bool is_child_on_side(const unsigned int c,
-                                const unsigned int s) const override;
+                                const unsigned int s) const override final;
 
   /**
    * \returns \p true if the specified edge is on the specified side.
    */
   virtual bool is_edge_on_side(const unsigned int e,
-                               const unsigned int s) const override;
+                               const unsigned int s) const override final;
 
   /**
    * Don't hide Elem::key() defined in the base class.
@@ -147,12 +147,12 @@ public:
   /**
    * \returns A primitive (4-noded) quad or infquad for face i.
    */
-  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;
 
   /**
    * Rebuilds a primitive (4-noded) quad or infquad for face i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override final;
 
   /**
    * \returns A quantitative assessment of element quality based on

--- a/include/geom/cell_inf_prism.h
+++ b/include/geom/cell_inf_prism.h
@@ -65,7 +65,7 @@ public:
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.
    */
-  virtual Point master_point (const unsigned int i) const override
+  virtual Point master_point (const unsigned int i) const override final
   {
     libmesh_assert_less(i, this->n_nodes());
     return Point(_master_points[i][0],
@@ -78,48 +78,48 @@ public:
    * than their conventional counterparts, since one
    * side is supposed to be located at infinity.
    */
-  virtual unsigned int n_sides() const override { return 4; }
+  virtual unsigned int n_sides() const override final { return 4; }
 
   /**
    * \returns 6.  All infinite prisms (in our
    * setting) have 6 vertices.
    */
-  virtual unsigned int n_vertices() const override { return 6; }
+  virtual unsigned int n_vertices() const override final { return 6; }
 
   /**
    * \returns 6.  All infinite prisms have 6 edges,
    * 3 lying in the base, and 3 perpendicular to the base.
    */
-  virtual unsigned int n_edges() const override { return 6; }
+  virtual unsigned int n_edges() const override final { return 6; }
 
   /**
    * \returns 4.  All prisms have 4 faces.
    */
-  virtual unsigned int n_faces() const override { return 4; }
+  virtual unsigned int n_faces() const override final { return 4; }
 
   /**
    * \returns 4.
    */
-  virtual unsigned int n_children() const override { return 4; }
+  virtual unsigned int n_children() const override final { return 4; }
 
   /**
    * \returns \p true if the specified (local) node number is a
    * "mid-edge" node on an infinite element edge.
    */
   virtual bool is_mid_infinite_edge_node(const unsigned int i) const
-    override { return (i > 2 && i < 6); }
+    override final { return (i > 2 && i < 6); }
 
   /**
    * \returns \p true if the specified child is on the specified side.
    */
   virtual bool is_child_on_side(const unsigned int c,
-                                const unsigned int s) const override;
+                                const unsigned int s) const override final;
 
   /**
    * \returns \p true if the specified edge is on the specified side.
    */
   virtual bool is_edge_on_side(const unsigned int e,
-                               const unsigned int s) const override;
+                               const unsigned int s) const override final;
 
   /**
    * Don't hide Elem::key() defined in the base class.
@@ -143,13 +143,13 @@ public:
    * \returns A primitive (3-noded) tri or (4-noded) infquad for
    * face i.
    */
-  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;
 
   /**
    * Rebuilds a primitive (3-noded) tri or (4-noded) infquad for face
    * i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override final;
 
   /**
    * @returns \p true when this element contains the point

--- a/include/geom/cell_prism.h
+++ b/include/geom/cell_prism.h
@@ -59,7 +59,7 @@ public:
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.
    */
-  virtual Point master_point (const unsigned int i) const override
+  virtual Point master_point (const unsigned int i) const override final
   {
     libmesh_assert_less(i, this->n_nodes());
     return Point(_master_points[i][0],
@@ -76,39 +76,39 @@ public:
   /**
    * \returns 5.
    */
-  virtual unsigned int n_sides() const override { return 5; }
+  virtual unsigned int n_sides() const override final { return 5; }
 
   /**
    * \returns 6.  All prisms have 6 vertices.
    */
-  virtual unsigned int n_vertices() const override { return 6; }
+  virtual unsigned int n_vertices() const override final { return 6; }
 
   /**
    * \returns 9.  All prisms have 9 edges.
    */
-  virtual unsigned int n_edges() const override { return 9; }
+  virtual unsigned int n_edges() const override final { return 9; }
 
   /**
    * \returns 5.  All prisms have 5 faces.
    */
-  virtual unsigned int n_faces() const override { return 5; }
+  virtual unsigned int n_faces() const override final { return 5; }
 
   /**
    * \returns 8.
    */
-  virtual unsigned int n_children() const override { return 8; }
+  virtual unsigned int n_children() const override final { return 8; }
 
   /**
    * \returns \p true if the specified child is on the specified side.
    */
   virtual bool is_child_on_side(const unsigned int c,
-                                const unsigned int s) const override;
+                                const unsigned int s) const override final;
 
   /**
    * \returns \p true if the specified edge is on the specified side.
    */
   virtual bool is_edge_on_side(const unsigned int e,
-                               const unsigned int s) const override;
+                               const unsigned int s) const override final;
 
   /**
    * Don't hide Elem::key() defined in the base class.
@@ -131,12 +131,12 @@ public:
   /**
    * \returns A primitive triangle or quad for face i.
    */
-  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;
 
   /**
    * Rebuilds a primitive triangle or quad for face i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override final;
 
 protected:
 

--- a/include/geom/cell_tet.h
+++ b/include/geom/cell_tet.h
@@ -60,7 +60,7 @@ public:
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.
    */
-  virtual Point master_point (const unsigned int i) const override
+  virtual Point master_point (const unsigned int i) const override final
   {
     libmesh_assert_less(i, this->n_nodes());
     return Point(_master_points[i][0],
@@ -71,33 +71,33 @@ public:
   /**
    * \returns 4.
    */
-  virtual unsigned int n_sides() const override { return 4; }
+  virtual unsigned int n_sides() const override final { return 4; }
 
   /**
    * \returns 4.  All tetrahedra have 4 vertices.
    */
-  virtual unsigned int n_vertices() const override { return 4; }
+  virtual unsigned int n_vertices() const override final { return 4; }
 
   /**
    * \returns 6.  All tetrahedra have 6 edges.
    */
-  virtual unsigned int n_edges() const override { return 6; }
+  virtual unsigned int n_edges() const override final { return 6; }
 
   /**
    * \returns 4.  All tetrahedra have 4 faces.
    */
-  virtual unsigned int n_faces() const override { return 4; }
+  virtual unsigned int n_faces() const override final { return 4; }
 
   /**
    * \returns 8.
    */
-  virtual unsigned int n_children() const override { return 8; }
+  virtual unsigned int n_children() const override final { return 8; }
 
   /**
    * \returns \p true if the specified edge is on the specified side.
    */
   virtual bool is_edge_on_side(const unsigned int e,
-                               const unsigned int s) const override;
+                               const unsigned int s) const override final;
 
   /**
    * Don't hide Elem::key() defined in the base class.
@@ -120,12 +120,12 @@ public:
   /**
    * \returns A primitive (3-noded) triangle for face i.
    */
-  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;
 
   /**
    * Rebuilds a primitive (3-noded) triangle for face i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override final;
 
   /**
    * \returns A quantitative assessment of element quality based on
@@ -176,7 +176,7 @@ public:
    * But we want to cache topology data based on that matrix.  So we return a
    * "version number" based on the diagonal selection.
    */
-  virtual unsigned int embedding_matrix_version () const override
+  virtual unsigned int embedding_matrix_version () const override final
   {
     this->choose_diagonal();
     return this->diagonal_selection();

--- a/include/geom/edge.h
+++ b/include/geom/edge.h
@@ -61,7 +61,7 @@ public:
   /**
    * \returns 1, the dimensionality of the object.
    */
-  virtual unsigned short dim () const override { return 1; }
+  virtual unsigned short dim () const override final { return 1; }
 
   /**
    * \returns 2. Every edge is guaranteed to have at least 2 nodes.
@@ -71,46 +71,46 @@ public:
   /**
    * \returns 2.
    */
-  virtual unsigned int n_sides() const override { return 2; }
+  virtual unsigned int n_sides() const override final { return 2; }
 
   /**
    * \returns 2.  Every edge has exactly two vertices.
    */
-  virtual unsigned int n_vertices() const override { return 2; }
+  virtual unsigned int n_vertices() const override final { return 2; }
 
   /**
    * \returns 0.  All 1D elements have no edges.
    */
-  virtual unsigned int n_edges() const override { return 0; }
+  virtual unsigned int n_edges() const override final { return 0; }
 
   /**
    * \returns 0.  All 1D elements have no faces.
    */
-  virtual unsigned int n_faces() const override { return 0; }
+  virtual unsigned int n_faces() const override final { return 0; }
 
   /**
    * \returns 2.
    */
-  virtual unsigned int n_children() const override { return 2; }
+  virtual unsigned int n_children() const override final { return 2; }
 
   /**
    * \returns \p true if the specified child is on the specified side.
    */
   virtual bool is_child_on_side(const unsigned int c,
-                                const unsigned int s) const override;
+                                const unsigned int s) const override final;
 
   /**
    * \returns \p true if the specified edge is on the specified side.
    */
   virtual bool is_edge_on_side(const unsigned int,
-                               const unsigned int) const override
+                               const unsigned int) const override final
   { return false; }
 
   /**
    * \returns The side number opposite to \p s (for a tensor product
    * element), or throws an error otherwise.
    */
-  virtual unsigned int opposite_side(const unsigned int s) const override;
+  virtual unsigned int opposite_side(const unsigned int s) const override final;
 
   /**
    * \returns The local node number for the node opposite to node n
@@ -118,7 +118,7 @@ public:
    * throws an error otherwise.
    */
   virtual unsigned int opposite_node(const unsigned int n,
-                                     const unsigned int s) const override;
+                                     const unsigned int s) const override final;
 
   /**
    * Don't hide Elem::key() defined in the base class.
@@ -130,41 +130,41 @@ public:
    * The id is not necessarily unique, but should be close.  This is
    * particularly useful in the \p MeshBase::find_neighbors() routine.
    */
-  virtual dof_id_type key (const unsigned int s) const override
+  virtual dof_id_type key (const unsigned int s) const override final
   { return this->compute_key(this->node_id(s)); }
 
   /**
    * \returns \p side after doing some range checking. \p side_node is ignored.
    */
   virtual unsigned int which_node_am_i(unsigned int side,
-                                       unsigned int /*side_node*/) const override;
+                                       unsigned int /*side_node*/) const override final;
 
   /**
    * \returns A pointer to a NodeElem for the specified node.
    */
-  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;
 
   /**
    * Rebuilds a pointer to a NodeElem for the specified node.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override final;
 
   /**
    * \returns A pointer to a NodeElem for the specified node.
    */
   virtual std::unique_ptr<Elem> build_side_ptr (const unsigned int i,
-                                                bool proxy) override;
+                                                bool proxy) override final;
 
   /**
    * Rebuilds a NODEELEM for the specified node.
    */
   virtual void build_side_ptr (std::unique_ptr<Elem> & elem,
-                               const unsigned int i) override;
+                               const unsigned int i) override final;
 
   /**
    * The \p Elem::build_edge_ptr() member makes no sense for edges.
    */
-  virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int) override
+  virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int) override final
   { libmesh_not_implemented(); return std::unique_ptr<Elem>(); }
 
   virtual std::vector<unsigned int> nodes_on_side(const unsigned int s) const override;

--- a/include/geom/face.h
+++ b/include/geom/face.h
@@ -58,25 +58,25 @@ public:
   /**
    * \returns 2, the dimensionality of the object.
    */
-  virtual unsigned short dim () const override { return 2; }
+  virtual unsigned short dim () const override final { return 2; }
 
   /**
    * \returns 0.  All 2D elements have no faces, just
    * edges.
    */
-  virtual unsigned int n_faces() const override { return 0; }
+  virtual unsigned int n_faces() const override final { return 0; }
 
   /**
    * build_side and build_edge are identical for faces.
    */
-  virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override
+  virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override final
   { return build_side_ptr(i); }
 
   /**
    * is_edge_on_side is trivial in 2D.
    */
   virtual bool is_edge_on_side(const unsigned int e,
-                               const unsigned int s) const override
+                               const unsigned int s) const override final
   { return (e == s); }
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
@@ -85,7 +85,7 @@ public:
    * \returns \p false.  All classes derived from \p Face
    * are finite elements.
    */
-  virtual bool infinite () const override { return false; }
+  virtual bool infinite () const override final { return false; }
 
 #endif
 

--- a/include/geom/face_inf_quad.h
+++ b/include/geom/face_inf_quad.h
@@ -81,7 +81,7 @@ public:
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.
    */
-  virtual Point master_point (const unsigned int i) const override
+  virtual Point master_point (const unsigned int i) const override final
   {
     libmesh_assert_less(i, this->n_nodes());
     return Point(_master_points[i][0],
@@ -92,48 +92,48 @@ public:
   /**
    * \returns 2, the dimensionality of the object.
    */
-  virtual unsigned short dim() const override { return 2; }
+  virtual unsigned short dim() const override final { return 2; }
 
   /**
    * \returns 3.  Infinite faces have one side less
    * than their conventional counterparts, since one
    * side is supposed to be located at infinity.
    */
-  virtual unsigned int n_sides() const override { return 3; }
+  virtual unsigned int n_sides() const override final { return 3; }
 
   /**
    * \returns 4.  All infinite quads (in our setting) have 4 vertices.
    */
-  virtual unsigned int n_vertices() const override { return 4; }
+  virtual unsigned int n_vertices() const override final { return 4; }
 
   /**
    * \returns 3.  All infinite quads have 1 edge in the
    * base, and 2 perpendicular to the base.
    */
-  virtual unsigned int n_edges() const override { return 3; }
+  virtual unsigned int n_edges() const override final { return 3; }
 
   /**
    * \returns 0.  All 2D elements have no faces, just edges.
    */
-  virtual unsigned int n_faces() const override { return 0; }
+  virtual unsigned int n_faces() const override final { return 0; }
 
   /**
    * \returns 2.
    */
-  virtual unsigned int n_children() const override { return 2; }
+  virtual unsigned int n_children() const override final { return 2; }
 
   /**
    * \returns \p true if the specified (local) node number is a
    * "mid-edge" node on an infinite element edge.
    */
   virtual bool is_mid_infinite_edge_node(const unsigned int i) const
-    override { return (i > 2 && i < 4); }
+    override final { return (i > 2 && i < 4); }
 
   /**
    * \returns \p true if the specified child is on the specified side.
    */
   virtual bool is_child_on_side(const unsigned int c,
-                                const unsigned int s) const override;
+                                const unsigned int s) const override final;
 
   /**
    * Don't hide Elem::key() defined in the base class.
@@ -156,24 +156,24 @@ public:
   /**
    * \returns A primitive (2-noded) edge or infedge for edge \p i.
    */
-  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;
 
   /**
    * Rebuilds a primitive (2-noded) edge or infedge for edge \p i.
    */
-  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override;
+  virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) override final;
 
   /**
    * build_edge_ptr() and build_side_ptr() are identical in 2D.
    */
-  virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override
+  virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) override final
   { return build_side_ptr(i); }
 
   /**
    * is_edge_on_side is trivial in 2D.
    */
   virtual bool is_edge_on_side(const unsigned int e,
-                               const unsigned int s) const override
+                               const unsigned int s) const override final
   { return (e == s); }
 
   /**
@@ -193,12 +193,12 @@ public:
    * \returns \p true.  All classes derived from \p InfQuad
    * are infinite elements.
    */
-  virtual bool infinite () const override { return true; }
+  virtual bool infinite () const override final { return true; }
 
   /**
    * \returns The origin of this infinite element.
    */
-  virtual Point origin () const override
+  virtual Point origin () const override final
   {
     return ( this->point(0)*2 - this->point(this->n_vertices()/2) );
   }

--- a/include/geom/face_quad.h
+++ b/include/geom/face_quad.h
@@ -71,7 +71,7 @@ public:
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.
    */
-  virtual Point master_point (const unsigned int i) const override
+  virtual Point master_point (const unsigned int i) const override final
   {
     libmesh_assert_less(i, this->n_nodes());
     return Point(_master_points[i][0],
@@ -88,35 +88,35 @@ public:
   /**
    * \returns 4.
    */
-  virtual unsigned int n_sides() const override { return 4; }
+  virtual unsigned int n_sides() const override final { return 4; }
 
   /**
    * \returns 4.  All quadrilaterals have 4 vertices.
    */
-  virtual unsigned int n_vertices() const override { return 4; }
+  virtual unsigned int n_vertices() const override final { return 4; }
 
   /**
    * \returns 4.  All quadrilaterals have 4 edges.
    */
-  virtual unsigned int n_edges() const override { return 4; }
+  virtual unsigned int n_edges() const override final { return 4; }
 
   /**
    * \returns 4.
    */
-  virtual unsigned int n_children() const override { return 4; }
+  virtual unsigned int n_children() const override final { return 4; }
 
   /**
    * \returns \p true if the specified child is on the
    * specified side.
    */
   virtual bool is_child_on_side(const unsigned int c,
-                                const unsigned int s) const override;
+                                const unsigned int s) const override final;
 
   /**
    * \returns The side number opposite to \p s (for a tensor product
    * element), or throws an error otherwise.
    */
-  virtual unsigned int opposite_side(const unsigned int s) const override;
+  virtual unsigned int opposite_side(const unsigned int s) const override final;
 
   /**
    * \returns The local node number for the node opposite to node n
@@ -124,7 +124,7 @@ public:
    * throws an error otherwise.
    */
   virtual unsigned int opposite_node(const unsigned int n,
-                                     const unsigned int s) const override;
+                                     const unsigned int s) const override final;
 
   /**
    * Don't hide Elem::key() defined in the base class.
@@ -154,13 +154,13 @@ public:
   /**
    * \returns A primitive (2-noded) edge for edge i.
    */
-  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;
 
   /**
    * Rebuilds an EDGE2 coincident with face i.
    */
   virtual void side_ptr (std::unique_ptr<Elem> & elem,
-                         const unsigned int i) override;
+                         const unsigned int i) override final;
 
   /**
    * \returns A quantitative assessment of element quality based on

--- a/include/geom/face_tri.h
+++ b/include/geom/face_tri.h
@@ -72,7 +72,7 @@ public:
    * \returns The \p Point associated with local \p Node \p i,
    * in master element rather than physical coordinates.
    */
-  virtual Point master_point (const unsigned int i) const override
+  virtual Point master_point (const unsigned int i) const override final
   {
     libmesh_assert_less(i, this->n_nodes());
     return Point(_master_points[i][0],
@@ -89,29 +89,29 @@ public:
   /**
    * \returns 3.
    */
-  virtual unsigned int n_sides() const override { return 3; }
+  virtual unsigned int n_sides() const override final { return 3; }
 
   /**
    * \returns 3.  All triangles have 3 vertices.
    */
-  virtual unsigned int n_vertices() const override { return 3; }
+  virtual unsigned int n_vertices() const override final { return 3; }
 
   /**
    * \returns 3.  All triangles have 3 edges.
    */
-  virtual unsigned int n_edges() const override { return 3; }
+  virtual unsigned int n_edges() const override final { return 3; }
 
   /**
    * \returns 4.
    */
-  virtual unsigned int n_children() const override { return 4; }
+  virtual unsigned int n_children() const override final { return 4; }
 
   /**
    * \returns \p true if the specified child is on the
    * specified side.
    */
   virtual bool is_child_on_side(const unsigned int c,
-                                const unsigned int s) const override;
+                                const unsigned int s) const override final;
 
   /**
    * Don't hide Elem::key() defined in the base class.
@@ -130,7 +130,7 @@ public:
    * element.  The id is not necessarily unique, but should be
    * close.
    */
-  virtual dof_id_type key () const override;
+  virtual dof_id_type key () const override final;
 
   /**
    * \returns \p Tri3::side_nodes_map[side][side_node] after doing some range checking.
@@ -141,13 +141,13 @@ public:
   /**
    * \returns A primitive (2-noded) edge for edge i.
    */
-  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override;
+  virtual std::unique_ptr<Elem> side_ptr (const unsigned int i) override final;
 
   /**
    * Rebuilds an EDGE2 coincident with face i.
    */
   virtual void side_ptr (std::unique_ptr<Elem> & elem,
-                         const unsigned int i) override;
+                         const unsigned int i) override final;
 
   /**
    * \returns A quantitative assessment of element quality based on

--- a/include/geom/side.h
+++ b/include/geom/side.h
@@ -82,17 +82,6 @@ public:
     return this->parent()->set_node (ParentType::side_nodes_map[_side_number][i]);
   }
 
-  /**
-   * Sides do not have sides.
-   */
-  virtual unsigned int n_sides () const override
-  { return 0; }
-
-  virtual bool is_child_on_side(const unsigned int,
-                                const unsigned int) const override
-  { libmesh_not_implemented(); return false; }
-
-
 private:
 
   /**
@@ -143,11 +132,6 @@ public:
     libmesh_assert_less (i, this->n_nodes());
     return this->parent()->set_node (ParentType::edge_nodes_map[_edge_number][i]);
   }
-
-  /**
-   * \returns 0. Edges do not have sides, so don't even ask!
-   */
-  virtual unsigned int n_sides () const override { return 0; }
 
 private:
 


### PR DESCRIPTION
We have the leaf classes marked final, but some of the intermediate
classes in the hierarchy also have methods that shouldn't be
overwritten.  On a typical run this should allow the compiler to save
thousands of nanoseconds!