### PR TITLE
eval_old_dofs needs var, not var_component

### DIFF
--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -739,7 +739,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
             {
               LOG_SCOPE ("copy_dofs", "GenericProjector");
 
-              f.eval_old_dofs(context, var_component, Ue.get_values());
+              f.eval_old_dofs(context, var, Ue.get_values());
 
               action.insert(context, var, Ue);
 


### PR DESCRIPTION
Hopefully this fixes the newer bug found in
https://github.com/idaholab/moose/issues/12309