### PR TITLE
Add index_range() helper function.

### DIFF
--- a/configure
+++ b/configure
@@ -39884,6 +39884,13 @@ else
 fi
 
 
+    if test "x$enablenlopt" = "xyes" && test "$dof_bytes" != "4"; then :
+
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< nlopt can only be enabled if libmesh is configured with --with-dof-id-bytes=4. >>>" >&5
+$as_echo "<<< nlopt can only be enabled if libmesh is configured with --with-dof-id-bytes=4. >>>" >&6; }
+            enablenlopt=no
+
+fi
 
   if test "x$enablenlopt" = "xyes"; then :
 

--- a/include/utils/int_range.h
+++ b/include/utils/int_range.h
@@ -24,6 +24,7 @@
 
 // C++ Includes   -----------------------------------
 #include <map>
+#include <vector>
 
 namespace libMesh
 {

--- a/include/utils/int_range.h
+++ b/include/utils/int_range.h
@@ -91,6 +91,19 @@ private:
   iterator _begin, _end;
 };
 
+
+
+/**
+ * Helper function that returns an IntRange<std::size_t> representing
+ * all the indices of the passed-in vector.
+ */
+template <typename T>
+IntRange<std::size_t> index_range(const std::vector<T> & vec)
+{
+  return IntRange<std::size_t>(0, vec.size());
+}
+
+
 } // namespace libMesh
 
 #endif // LIBMESH_INT_RANGE_H

--- a/include/utils/int_range.h
+++ b/include/utils/int_range.h
@@ -22,8 +22,10 @@
 
 #include "libmesh/libmesh_common.h" // cast_int
 
-// C++ Includes   -----------------------------------
-#include <map>
+// libMesh includes
+#include "numeric_vector.h"
+
+// C++ includes
 #include <vector>
 
 namespace libMesh
@@ -104,6 +106,16 @@ IntRange<std::size_t> index_range(const std::vector<T> & vec)
   return IntRange<std::size_t>(0, vec.size());
 }
 
+
+
+/**
+ * Same thing but for NumericVector. Returns a range (first_local_index, last_local_index).
+ */
+template <typename T>
+IntRange<numeric_index_type> index_range(const NumericVector<T> & vec)
+{
+  return {vec.first_local_index(), vec.last_local_index()};
+}
 
 } // namespace libMesh
 

--- a/m4/nlopt.m4
+++ b/m4/nlopt.m4
@@ -16,6 +16,12 @@ AC_DEFUN([CONFIGURE_NLOPT],
                          [AC_MSG_ERROR(bad value ${enableval} for --enable-nlopt)])],
                 [enablenlopt=$enableoptional])
 
+  dnl Do not enable nlopt if libmesh is configured with dof_bytes != 4.
+  AS_IF([test "x$enablenlopt" = "xyes" && test "$dof_bytes" != "4"],
+        [
+            AC_MSG_RESULT([<<< nlopt can only be enabled if libmesh is configured with --with-dof-id-bytes=4. >>>])
+            enablenlopt=no
+        ])
 
   AS_IF([test "x$enablenlopt" = "xyes"],
         [

--- a/src/apps/amr.C
+++ b/src/apps/amr.C
@@ -235,9 +235,7 @@ void assemble(EquationSystems & es,
               {
                 fe_face->reinit (elem, side);
 
-                //fe_face->print_info();
-
-                for (std::size_t gp=0; gp<JxW_face.size(); gp++)
+                for (auto gp : IntRange<std::size_t>(0, JxW_face.size()))
                   area += JxW_face[gp];
               }
         }

--- a/src/apps/amr.C
+++ b/src/apps/amr.C
@@ -235,8 +235,8 @@ void assemble(EquationSystems & es,
               {
                 fe_face->reinit (elem, side);
 
-                for (auto gp : index_range(JxW_face))
-                  area += JxW_face[gp];
+                for (const auto & val : JxW_face)
+                  area += val;
               }
         }
 

--- a/src/apps/amr.C
+++ b/src/apps/amr.C
@@ -235,7 +235,7 @@ void assemble(EquationSystems & es,
               {
                 fe_face->reinit (elem, side);
 
-                for (auto gp : IntRange<std::size_t>(0, JxW_face.size()))
+                for (auto gp : index_range(JxW_face))
                   area += JxW_face[gp];
               }
         }

--- a/src/apps/meshavg.C
+++ b/src/apps/meshavg.C
@@ -18,13 +18,12 @@
 
 // Open the solution files named on standard input, take the average
 // of their fields' values, and output to a new solution file.
-
 #include "libmesh/libmesh.h"
-
 #include "libmesh/equation_systems.h"
 #include "libmesh/mesh.h"
 #include "libmesh/namebased_io.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/int_range.h"
 
 using namespace libMesh;
 
@@ -73,7 +72,7 @@ int main(int argc, char ** argv)
                EquationSystems::READ_BASIC_ONLY);
       libMesh::out << "Loaded next solution " << argv[i] << std::endl;
 
-      for (unsigned int s = 0; s != sysnames.size(); ++s)
+      for (auto s : IntRange<std::size_t>(0, sysnames.size()))
         {
           if (!es2.has_system(sysnames[s]))
             libmesh_error_msg("EquationSystems object does not have " << sysnames[s]);
@@ -84,7 +83,7 @@ int main(int argc, char ** argv)
 
   int n_solutions = argc - 3;
 
-  for (unsigned int s = 0; s != sysnames.size(); ++s)
+  for (auto s : IntRange<std::size_t>(0, sysnames.size()))
     {
       (*summed_solutions[s]) /= n_solutions;
       es1.get_system(s).solution->swap(*summed_solutions[s]);

--- a/src/apps/meshavg.C
+++ b/src/apps/meshavg.C
@@ -72,7 +72,7 @@ int main(int argc, char ** argv)
                EquationSystems::READ_BASIC_ONLY);
       libMesh::out << "Loaded next solution " << argv[i] << std::endl;
 
-      for (auto s : IntRange<std::size_t>(0, sysnames.size()))
+      for (auto s : index_range(sysnames))
         {
           if (!es2.has_system(sysnames[s]))
             libmesh_error_msg("EquationSystems object does not have " << sysnames[s]);
@@ -83,7 +83,7 @@ int main(int argc, char ** argv)
 
   int n_solutions = argc - 3;
 
-  for (auto s : IntRange<std::size_t>(0, sysnames.size()))
+  for (auto s : index_range(sysnames))
     {
       (*summed_solutions[s]) /= n_solutions;
       es1.get_system(s).solution->swap(*summed_solutions[s]);

--- a/src/apps/meshdiff.C
+++ b/src/apps/meshdiff.C
@@ -80,7 +80,7 @@ int main(int argc, char ** argv)
     libMesh::out << "No systems found in fine or coarse solution!"
                  << std::endl;
 
-  for (auto i : IntRange<std::size_t>(0, sysnames.size()))
+  for (auto i : index_range(sysnames))
     {
       const std::string sysname = sysnames[i];
       const System & coarse_sys = coarse_es.get_system(sysname);
@@ -135,7 +135,7 @@ int main(int argc, char ** argv)
     {
       libMesh::out << "Writing diff solution " << argv[5] << std::endl;
 
-      for (auto i : IntRange<std::size_t>(0, sysnames.size()))
+      for (auto i : index_range(sysnames))
         {
           const std::string sysname = sysnames[i];
           const System & coarse_sys = coarse_es.get_system(sysname);

--- a/src/apps/meshdiff.C
+++ b/src/apps/meshdiff.C
@@ -28,6 +28,7 @@
 #include "libmesh/namebased_io.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/enum_norm_type.h"
+#include "libmesh/int_range.h"
 
 using namespace libMesh;
 
@@ -79,7 +80,7 @@ int main(int argc, char ** argv)
     libMesh::out << "No systems found in fine or coarse solution!"
                  << std::endl;
 
-  for (std::size_t i = 0; i != sysnames.size(); ++i)
+  for (auto i : IntRange<std::size_t>(0, sysnames.size()))
     {
       const std::string sysname = sysnames[i];
       const System & coarse_sys = coarse_es.get_system(sysname);
@@ -134,7 +135,7 @@ int main(int argc, char ** argv)
     {
       libMesh::out << "Writing diff solution " << argv[5] << std::endl;
 
-      for (std::size_t i = 0; i != sysnames.size(); ++i)
+      for (auto i : IntRange<std::size_t>(0, sysnames.size()))
         {
           const std::string sysname = sysnames[i];
           const System & coarse_sys = coarse_es.get_system(sysname);

--- a/src/apps/splitter.C
+++ b/src/apps/splitter.C
@@ -77,7 +77,7 @@ int main (int argc, char ** argv)
 
   mesh.read(filename);
 
-  for (std::size_t i = 0; i < all_n_procs.size(); i++)
+  for (auto i : index_range(all_n_procs))
     {
       processor_id_type n_procs = all_n_procs[i];
       libMesh::out << "splitting " << n_procs << " ways..." << std::endl;

--- a/src/apps/splitter.C
+++ b/src/apps/splitter.C
@@ -77,9 +77,8 @@ int main (int argc, char ** argv)
 
   mesh.read(filename);
 
-  for (auto i : index_range(all_n_procs))
+  for (const auto & n_procs : all_n_procs)
     {
-      processor_id_type n_procs = all_n_procs[i];
       libMesh::out << "splitting " << n_procs << " ways..." << std::endl;
 
       auto cpr = split_mesh(mesh, n_procs);

--- a/src/base/default_coupling.C
+++ b/src/base/default_coupling.C
@@ -19,11 +19,11 @@
 
 // Local Includes
 #include "libmesh/default_coupling.h"
-
 #include "libmesh/coupling_matrix.h"
 #include "libmesh/elem.h"
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/remote_elem.h"
+#include "libmesh/int_range.h"
 
 // C++ Includes
 #include <unordered_set>
@@ -160,7 +160,7 @@ void DefaultCoupling::operator()
               active_neighbors.push_back(neigh);
 #endif
 
-              for (std::size_t a=0; a != active_neighbors.size(); ++a)
+              for (auto a : index_range(active_neighbors))
                 {
                   const Elem * neighbor = active_neighbors[a];
 

--- a/src/base/default_coupling.C
+++ b/src/base/default_coupling.C
@@ -160,10 +160,8 @@ void DefaultCoupling::operator()
               active_neighbors.push_back(neigh);
 #endif
 
-              for (auto a : index_range(active_neighbors))
+              for (const auto & neighbor : active_neighbors)
                 {
-                  const Elem * neighbor = active_neighbors[a];
-
                   if (!elements_checked.count(neighbor))
                     next_elements_to_check.insert(neighbor);
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -41,6 +41,7 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/threads.h"
 #include "libmesh/mesh_subdivision_support.h"
+#include "libmesh/int_range.h"
 
 // C++ Includes
 #include <set>
@@ -207,8 +208,8 @@ DofMap::~DofMap()
   _mesh.remove_ghosting_functor(*_default_evaluating);
 
 #ifdef LIBMESH_ENABLE_DIRICHLET
-  for (std::size_t q = 0; q != _adjoint_dirichlet_boundaries.size(); ++q)
-    delete _adjoint_dirichlet_boundaries[q];
+  for (auto & bnd : _adjoint_dirichlet_boundaries)
+    delete bnd;
 #endif
 }
 
@@ -1583,10 +1584,8 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
           const std::vector<unsigned int> & variable_list =
             column_variable_list->second;
 
-          for (std::size_t j=0; j != variable_list.size(); ++j)
+          for (const auto & vj : variable_list)
             {
-              const unsigned int vj=variable_list[j];
-
               std::vector<dof_id_type> di;
               this->dof_indices (partner, di, vj);
 
@@ -1602,9 +1601,9 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
           this->dof_indices (partner, di);
 
           // Insert the remote DOF indices into the send list
-          for (std::size_t j=0; j != di.size(); ++j)
-            if (!this->local_index(di[j]))
-              _send_list.push_back(di[j]);
+          for (const auto & dof : di)
+            if (!this->local_index(dof))
+              _send_list.push_back(dof);
         }
 
     }
@@ -1629,9 +1628,9 @@ void DofMap::add_neighbors_to_send_list(MeshBase & mesh)
       this->dof_indices (elem, di);
 
       // Insert the remote DOF indices into the send list
-      for (std::size_t j=0; j != di.size(); ++j)
-        if (!this->local_index(di[j]))
-          _send_list.push_back(di[j]);
+      for (const auto & dof : di)
+        if (!this->local_index(dof))
+          _send_list.push_back(dof);
     }
 }
 
@@ -2401,12 +2400,9 @@ bool DofMap::semilocal_index (dof_id_type dof_index) const
 bool DofMap::all_semilocal_indices (const std::vector<dof_id_type> & dof_indices_in) const
 {
   // We're all semilocal unless we find a counterexample
-  for (std::size_t i=0; i != dof_indices_in.size(); ++i)
-    {
-      const dof_id_type di = dof_indices_in[i];
-      if (!this->semilocal_index(di))
-        return false;
-    }
+  for (const auto & di : dof_indices_in)
+    if (!this->semilocal_index(di))
+      return false;
 
   return true;
 }
@@ -2648,12 +2644,12 @@ void DofMap::find_connected_dofs (std::vector<dof_id_type> & elem_dofs) const
   // in turn depend on others.  So, we need to repeat this process
   // in that case until the system depends only on unconstrained
   // degrees of freedom.
-  for (std::size_t i=0; i<elem_dofs.size(); i++)
-    if (this->is_constrained_dof(elem_dofs[i]))
+  for (const auto & dof : elem_dofs)
+    if (this->is_constrained_dof(dof))
       {
         // If the DOF is constrained
         DofConstraints::const_iterator
-          pos = _dof_constraints.find(elem_dofs[i]);
+          pos = _dof_constraints.find(dof);
 
         libmesh_assert (pos != _dof_constraints.end());
 
@@ -2724,10 +2720,10 @@ std::string DofMap::get_info() const
 
   if (_n_nz)
     {
-      for (std::size_t i = 0; i != _n_nz->size(); ++i)
+      for (const auto & val : *_n_nz)
         {
-          max_n_nz = std::max(max_n_nz, (*_n_nz)[i]);
-          avg_n_nz += (*_n_nz)[i];
+          max_n_nz = std::max(max_n_nz, val);
+          avg_n_nz += val;
         }
 
       std::size_t n_nz_size = _n_nz->size();
@@ -2740,10 +2736,10 @@ std::string DofMap::get_info() const
 
       libmesh_assert(_n_oz);
 
-      for (std::size_t i = 0; i != (*_n_oz).size(); ++i)
+      for (const auto & val : *_n_oz)
         {
-          max_n_oz = std::max(max_n_oz, (*_n_oz)[i]);
-          avg_n_oz += (*_n_oz)[i];
+          max_n_oz = std::max(max_n_oz, val);
+          avg_n_oz += val;
         }
 
       std::size_t n_oz_size = _n_oz->size();

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -41,6 +41,7 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/threads.h"
 #include "libmesh/mesh_subdivision_support.h"
+#include "libmesh/int_range.h"
 
 // C++ Includes
 #include <set>
@@ -424,7 +425,7 @@ void DofMap::set_nonlocal_dof_objects(iterator_type objects_begin,
         n_var_groups = this->n_variable_groups();
 
       // Copy the id changes we've now been informed of
-      for (std::size_t i=0, n_ids = ids.size(); i != n_ids; ++i)
+      for (auto i : index_range(ids))
         {
           DofObject * requested = (this->*objects)(mesh, ids[i]);
           libmesh_assert(requested);

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -41,7 +41,6 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/threads.h"
 #include "libmesh/mesh_subdivision_support.h"
-#include "libmesh/int_range.h"
 
 // C++ Includes
 #include <set>

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -47,6 +47,7 @@
 #include "libmesh/system.h" // needed by enforce_constraints_exactly()
 #include "libmesh/threads.h"
 #include "libmesh/tensor_tools.h"
+#include "libmesh/int_range.h"
 
 // C++ Includes
 #include <set>
@@ -1121,10 +1122,8 @@ public:
      */
 
     // Loop over all the variables we've been requested to project
-    for (std::size_t v=0; v!=dirichlet.variables.size(); v++)
+    for (const auto & var : dirichlet.variables)
       {
-        const unsigned int var = dirichlet.variables[v];
-
         const Variable & variable = dof_map.variable(var);
 
         const FEType & fe_type = variable.type();
@@ -2386,8 +2385,8 @@ void DofMap::build_constraint_matrix (DenseMatrix<Number> & C,
   if (!we_have_constraints)
     return;
 
-  for (std::size_t i=0; i != elem_dofs.size(); ++i)
-    dof_set.erase (elem_dofs[i]);
+  for (const auto & dof : elem_dofs)
+    dof_set.erase (dof);
 
   // If we added any DOFS then we need to do this recursively.
   // It is possible that we just added a DOF that is also
@@ -2859,7 +2858,7 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
         libmesh_assert_equal_to (pushed_ids_to_me.size(),
                                  pushed_rhss_to_me.size());
 
-        for (std::size_t i = 0; i != pushed_ids_to_me.size(); ++i)
+        for (auto i : index_range(pushed_ids_to_me))
           {
             dof_id_type constrained = pushed_ids_to_me[i];
 
@@ -2924,7 +2923,7 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
         libmesh_assert_equal_to (pushed_node_ids_to_me.size(),
                                  pushed_offsets_to_me.size());
 
-        for (std::size_t i = 0; i != pushed_node_ids_to_me.size(); ++i)
+        for (auto i : index_range(pushed_node_ids_to_me))
           {
             dof_id_type constrained_id = pushed_node_ids_to_me[i];
 
@@ -3580,7 +3579,7 @@ void DofMap::scatter_constraints(MeshBase & mesh)
             (ids_rhss.size(), keys_vals.size());
 
           // Add the dof constraints that I've been sent
-          for (std::size_t i = 0, size = ids_rhss.size(); i != size; ++i)
+          for (auto i : index_range(ids_rhss))
             {
               dof_id_type constrained = ids_rhss[i].first;
 
@@ -3730,7 +3729,7 @@ void DofMap::scatter_constraints(MeshBase & mesh)
            (Node**)nullptr, range_tag);
 
       // Add the node constraints that I've been sent
-      for (std::size_t i = 0, size = ids_offsets.size(); i != size; ++i)
+      for (auto i : index_range(ids_offsets))
         {
           dof_id_type constrained_id = ids_offsets[i].first;
 
@@ -3796,10 +3795,9 @@ void DofMap::scatter_constraints(MeshBase & mesh)
       std::vector<dof_id_type> my_dof_indices;
       this->dof_indices (elem, my_dof_indices);
 
-      for (std::size_t i=0; i != my_dof_indices.size(); ++i)
+      for (const auto & dof : my_dof_indices)
         {
-          DofConstrainsMap::const_iterator dcmi =
-            dof_id_constrains.find(my_dof_indices[i]);
+          DofConstrainsMap::const_iterator dcmi = dof_id_constrains.find(dof);
           if (dcmi != dof_id_constrains.end())
             {
               for (const auto & constrained : dcmi->second)

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2497,8 +2497,8 @@ void DofMap::build_constraint_matrix_and_vector (DenseMatrix<Number> & C,
   if (!we_have_constraints)
     return;
 
-  for (std::size_t i=0; i != elem_dofs.size(); ++i)
-    dof_set.erase (elem_dofs[i]);
+  for (const auto & dof : elem_dofs)
+    dof_set.erase (dof);
 
   // If we added any DOFS then we need to do this recursively.
   // It is possible that we just added a DOF that is also

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -316,11 +316,6 @@ void DofObject::set_n_vars_per_group(const unsigned int s,
 
 #ifdef DEBUG
 
-  // libMesh::out << " [ ";
-  // for (std::size_t i=0; i<_idx_buf.size(); i++)
-  //   libMesh::out << _idx_buf[i] << " ";
-  // libMesh::out << "]\n";
-
   libmesh_assert_equal_to (this->n_var_groups(s), nvpg.size());
 
   for (unsigned int vg=0; vg<this->n_var_groups(s); vg++)
@@ -441,13 +436,6 @@ void DofObject::set_dof_number(const unsigned int s,
   else
     base_idx = dn;
 
-  // #ifdef DEBUG
-  //   libMesh::out << " [ ";
-  //   for (std::size_t i=0; i<_idx_buf.size(); i++)
-  //     libMesh::out << _idx_buf[i] << " ";
-  //   libMesh::out << "]\n";
-  // #endif
-
   libmesh_assert_equal_to (this->dof_number(s, var, comp), dn);
 }
 
@@ -550,8 +538,8 @@ DofObject::pack_indexing(std::back_insert_iterator<std::vector<largest_id_type>>
 void DofObject::debug_buffer () const
 {
   libMesh::out << " [ ";
-  for (std::size_t i=0; i<_idx_buf.size(); i++)
-    libMesh::out << _idx_buf[i] << " ";
+  for (const auto & idx : _idx_buf)
+    libMesh::out << idx << " ";
   libMesh::out << "]\n";
 }
 

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -45,7 +45,7 @@
 #include "libmesh/adjoint_refinement_estimator.h"
 #include "libmesh/enum_error_estimator_type.h"
 #include "libmesh/enum_norm_type.h"
-
+#include "libmesh/utility.h"
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -507,11 +507,9 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
               // We will have to manually do the dot products.
               Number local_contribution = 0.;
 
-              for (std::size_t j=0; j != dof_indices.size(); j++)
-                {
-                  // The contribution to the error indicator for this element from the current QoI
-                  local_contribution += (*localized_projected_residual)(dof_indices[j]) * (*localized_adjoint_solution)(dof_indices[j]);
-                }
+              // Sum the contribution to the error indicator for each element from the current QoI
+              for (const auto & dof : dof_indices)
+                local_contribution += Utility::pow<2>((*localized_projected_residual)(dof));
 
               // Multiply by the error weight for this QoI
               local_contribution *= error_weight;

--- a/src/error_estimation/adjoint_refinement_estimator.C
+++ b/src/error_estimation/adjoint_refinement_estimator.C
@@ -509,7 +509,7 @@ void AdjointRefinementEstimator::estimate_error (const System & _system,
 
               // Sum the contribution to the error indicator for each element from the current QoI
               for (const auto & dof : dof_indices)
-                local_contribution += Utility::pow<2>((*localized_projected_residual)(dof));
+                local_contribution += (*localized_projected_residual)(dof) * (*localized_adjoint_solution)(dof);
 
               // Multiply by the error weight for this QoI
               local_contribution *= error_weight;

--- a/src/error_estimation/adjoint_residual_error_estimator.C
+++ b/src/error_estimation/adjoint_residual_error_estimator.C
@@ -26,6 +26,7 @@
 #include "libmesh/system_norm.h"
 #include "libmesh/qoi_set.h"
 #include "libmesh/enum_error_estimator_type.h"
+#include "libmesh/int_range.h"
 
 // C++ includes
 #include <iostream>
@@ -249,7 +250,7 @@ void AdjointResidualErrorEstimator::estimate_error (const System & _system,
 
   // Weight the primal error by the dual error using the system norm object
   // FIXME: we ought to thread this
-  for (std::size_t i=0; i != error_per_cell.size(); ++i)
+  for (auto i : index_range(error_per_cell))
     {
       // Have we been asked to weight the variable error contributions in any specific manner
       if (!error_norm_is_identity) // If we do

--- a/src/error_estimation/error_estimator.C
+++ b/src/error_estimation/error_estimator.C
@@ -23,8 +23,7 @@
 #include "libmesh/equation_systems.h"
 #include "libmesh/parallel.h"
 #include "libmesh/enum_error_estimator_type.h"
-
-
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -74,7 +73,7 @@ void ErrorEstimator::estimate_errors(const EquationSystems & equation_systems,
       if (s)
         {
           libmesh_assert_equal_to (error_per_cell.size(), system_error_per_cell.size());
-          for (std::size_t i=0; i != error_per_cell.size(); ++i)
+          for (auto i : index_range(error_per_cell))
             error_per_cell[i] += system_error_per_cell[i];
         }
       else

--- a/src/error_estimation/exact_error_estimator.C
+++ b/src/error_estimation/exact_error_estimator.C
@@ -376,7 +376,7 @@ void ExactErrorEstimator::estimate_error (const System & system,
   // Compute the square-root of each component.
   {
     LOG_SCOPE("std::sqrt()", "ExactErrorEstimator");
-    for (auto & val : error_per_cell) // std::size_t i=0; i<error_per_cell.size(); i++)
+    for (auto & val : error_per_cell)
       if (val != 0.)
         {
           libmesh_assert_greater (val, 0.);

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -501,17 +501,17 @@ void ExactSolution::_compute_error(const std::string & sys_name,
     }
 
   // Initialize any functors we're going to use
-  for (std::size_t i=0; i != _exact_values.size(); ++i)
-    if (_exact_values[i])
-      _exact_values[i]->init();
+  for (auto & ev : _exact_values)
+    if (ev)
+      ev->init();
 
-  for (std::size_t i=0; i != _exact_derivs.size(); ++i)
-    if (_exact_derivs[i])
-      _exact_derivs[i]->init();
+  for (auto & ed : _exact_derivs)
+    if (ed)
+      ed->init();
 
-  for (std::size_t i=0; i != _exact_hessians.size(); ++i)
-    if (_exact_hessians[i])
-      _exact_hessians[i]->init();
+  for (auto & eh : _exact_hessians)
+    if (eh)
+      eh->init();
 
   // Get a reference to the dofmap and mesh for that system
   const DofMap & computed_dof_map = computed_system.get_dof_map();

--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -106,12 +106,8 @@ void HPCoarsenTest::add_projection(const System & system,
             system.current_solution(dof_num);
           if (cont == C_ZERO || cont == C_ONE)
             grad.add_scaled((*dphi)[i][qp],system.current_solution(dof_num));
-          // grad += (*dphi)[i][qp] *
-          //  system.current_solution(dof_num);
           if (cont == C_ONE)
             hess.add_scaled((*d2phi)[i][qp], system.current_solution(dof_num));
-          // hess += (*d2phi)[i][qp] *
-          //  system.current_solution(dof_num);
         }
 
       // The projection matrix and vector
@@ -125,8 +121,6 @@ void HPCoarsenTest::add_projection(const System & system,
           if (cont == C_ONE)
             Fe(i) += (*JxW)[qp] *
               hess.contract((*d2phi_coarse)[i][qp]);
-          // Fe(i) += (*JxW)[qp] *
-          //  (*d2phi_coarse)[i][qp].contract(hess);
 
           for (unsigned int j=0; j != Fe.size(); ++j)
             {
@@ -341,12 +335,8 @@ void HPCoarsenTest::select_refinement (System & system)
                         system.current_solution(dof_num);
                       if (cont == C_ZERO || cont == C_ONE)
                         grad.add_scaled((*dphi)[i][qp], system.current_solution(dof_num));
-                      // grad += (*dphi)[i][qp] *
-                      //  system.current_solution(dof_num);
                       if (cont == C_ONE)
                         hess.add_scaled((*d2phi)[i][qp], system.current_solution(dof_num));
-                      // hess += (*d2phi)[i][qp] *
-                      //  system.current_solution(dof_num);
                     }
 
                   // The projection matrix and vector
@@ -392,12 +382,8 @@ void HPCoarsenTest::select_refinement (System & system)
                     system.current_solution(dof_num);
                   if (cont == C_ZERO || cont == C_ONE)
                     grad_error.add_scaled((*dphi)[i][qp], system.current_solution(dof_num));
-                  // grad_error += (*dphi)[i][qp] *
-                  //  system.current_solution(dof_num);
                   if (cont == C_ONE)
                     hessian_error.add_scaled((*d2phi)[i][qp], system.current_solution(dof_num));
-                  // hessian_error += (*d2phi)[i][qp] *
-                  //    system.current_solution(dof_num);
                 }
               if (elem->p_level() == 0)
                 {
@@ -410,10 +396,8 @@ void HPCoarsenTest::select_refinement (System & system)
                       value_error -= (*phi_coarse)[i][qp] * Up(i);
                       if (cont == C_ZERO || cont == C_ONE)
                         grad_error.subtract_scaled((*dphi_coarse)[i][qp], Up(i));
-                      // grad_error -= (*dphi_coarse)[i][qp] * Up(i);
                       if (cont == C_ONE)
                         hessian_error.subtract_scaled((*d2phi_coarse)[i][qp], Up(i));
-                      // hessian_error -= (*d2phi_coarse)[i][qp] * Up(i);
                     }
                 }
 
@@ -470,23 +454,17 @@ void HPCoarsenTest::select_refinement (System & system)
                         system.current_solution(dof_num);
                       if (cont == C_ZERO || cont == C_ONE)
                         grad_error.add_scaled((*dphi)[i][qp], system.current_solution(dof_num));
-                      // grad_error += (*dphi)[i][qp] *
-                      //  system.current_solution(dof_num);
                       if (cont == C_ONE)
                         hessian_error.add_scaled((*d2phi)[i][qp], system.current_solution(dof_num));
-                      // hessian_error += (*d2phi)[i][qp] *
-                      //  system.current_solution(dof_num);
                     }
 
                   for (unsigned int i=0; i != n_coarse_dofs; ++i)
                     {
                       value_error -= (*phi_coarse)[i][qp] * Uc(i);
                       if (cont == C_ZERO || cont == C_ONE)
-                        // grad_error -= (*dphi_coarse)[i][qp] * Uc(i);
                         grad_error.subtract_scaled((*dphi_coarse)[i][qp], Uc(i));
                       if (cont == C_ONE)
                         hessian_error.subtract_scaled((*d2phi_coarse)[i][qp], Uc(i));
-                      // hessian_error -= (*d2phi_coarse)[i][qp] * Uc(i);
                     }
 
                   h_error_per_cell[e_id] += static_cast<ErrorVectorReal>

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -35,9 +35,9 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/system.h"
-
 #include "libmesh/dense_vector.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -379,7 +379,7 @@ void JumpErrorEstimator::estimate_error (const System & system,
   this->reduce_error(error_per_cell, system.comm());
 
   // Compute the square-root of each component.
-  for (std::size_t i=0; i<error_per_cell.size(); i++)
+  for (auto i : index_range(error_per_cell))
     if (error_per_cell[i] != 0.)
       error_per_cell[i] = std::sqrt(error_per_cell[i]);
 
@@ -392,17 +392,16 @@ void JumpErrorEstimator::estimate_error (const System & system,
       // Sanity check: Make sure the number of flux faces is
       // always an integer value
 #ifdef DEBUG
-      for (std::size_t i=0; i<n_flux_faces.size(); ++i)
-        libmesh_assert_equal_to (n_flux_faces[i], static_cast<float>(static_cast<unsigned int>(n_flux_faces[i])) );
+      for (const auto & val : n_flux_faces)
+        libmesh_assert_equal_to (val, static_cast<float>(static_cast<unsigned int>(val)));
 #endif
 
       // Scale the error by the number of flux faces for each element
-      for (std::size_t i=0; i<n_flux_faces.size(); ++i)
+      for (auto i : index_range(n_flux_faces))
         {
           if (n_flux_faces[i] == 0.0) // inactive or non-local element
             continue;
 
-          //libMesh::out << "Element " << i << " has " << n_flux_faces[i] << " flux faces." << std::endl;
           error_per_cell[i] /= static_cast<ErrorVectorReal>(n_flux_faces[i]);
         }
     }

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -42,6 +42,7 @@
 #include "libmesh/tensor_tools.h"
 #include "libmesh/enum_error_estimator_type.h"
 #include "libmesh/enum_norm_type.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -83,21 +84,21 @@ std::vector<Real> PatchRecoveryErrorEstimator::specpoly(const unsigned int dim,
   std::vector<Real> xpow(npows,1.), ypow, zpow;
   {
     Real x = p(0);
-    for (unsigned int i=1; i != npows; ++i)
+    for (auto i : IntRange<int>(1, npows))
       xpow[i] = xpow[i-1] * x;
   }
   if (dim > 1)
     {
       Real y = p(1);
       ypow.resize(npows,1.);
-      for (unsigned int i=1; i != npows; ++i)
+      for (auto i : IntRange<int>(1, npows))
         ypow[i] = ypow[i-1] * y;
     }
   if (dim > 2)
     {
       Real z = p(2);
       zpow.resize(npows,1.);
-      for (unsigned int i=1; i != npows; ++i)
+      for (auto i : IntRange<int>(1, npows))
         zpow[i] = zpow[i-1] * z;
     }
 

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -40,6 +40,7 @@
 #include "libmesh/tensor_tools.h"
 #include "libmesh/enum_error_estimator_type.h"
 #include "libmesh/enum_norm_type.h"
+#include "libmesh/int_range.h"
 
 #ifdef LIBMESH_ENABLE_AMR
 
@@ -231,7 +232,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
   const bool old_renumbering_setting = mesh.allow_renumbering();
   mesh.allow_renumbering(false);
 
-  for (std::size_t i=0; i != system_list.size(); ++i)
+  for (auto i : index_range(system_list))
     {
       System & system = *system_list[i];
 
@@ -300,7 +301,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
       es.reinit();
     }
 
-  for (std::size_t i=0; i != system_list.size(); ++i)
+  for (auto i : index_range(system_list))
     {
       System & system = *system_list[i];
 
@@ -356,9 +357,8 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
                          !solution_vectors->find(system_list[0])->second);
 
 #ifdef DEBUG
-          for (std::size_t i=0; i != system_list.size(); ++i)
+          for (const auto & sys : system_list)
             {
-              System * sys = system_list[i];
               libmesh_assert (solution_vectors->find(sys) !=
                               solution_vectors->end());
               const NumericVector<Number> * vec = solution_vectors->find(sys)->second;
@@ -388,7 +388,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
               std::vector<unsigned int> adjs(system_list.size(),
                                              libMesh::invalid_uint);
               // Set up proper initial guesses
-              for (std::size_t i=0; i != system_list.size(); ++i)
+              for (auto i : index_range(system_list))
                 {
                   System * sys = system_list[i];
                   libmesh_assert (solution_vectors->find(sys) !=
@@ -407,8 +407,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
                         }
                     }
                   libmesh_assert_not_equal_to (adjs[i], libMesh::invalid_uint);
-                  system_list[i]->get_adjoint_solution(adjs[i]) =
-                    *system_list[i]->solution;
+                  sys->get_adjoint_solution(adjs[i]) = *sys->solution;
                 }
 
               es.adjoint_solve();
@@ -479,8 +478,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
     }
 
   // Get the error in the uniformly refined solution(s).
-
-  for (std::size_t sysnum=0; sysnum != system_list.size(); ++sysnum)
+  for (auto sysnum : index_range(system_list))
     {
       System & system = *system_list[sysnum];
 
@@ -714,7 +712,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
     }
 
   // Restore old solutions and clean up the heap
-  for (std::size_t i=0; i != system_list.size(); ++i)
+  for (auto i : index_range(system_list))
     {
       System & system = *system_list[i];
 

--- a/src/error_estimation/uniform_refinement_estimator.C
+++ b/src/error_estimation/uniform_refinement_estimator.C
@@ -414,7 +414,7 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
 
               // Put the adjoint_solution into solution for
               // comparisons
-              for (std::size_t i=0; i != system_list.size(); ++i)
+              for (auto i : index_range(system_list))
                 {
                   system_list[i]->get_adjoint_solution(adjs[i]).swap(*system_list[i]->solution);
                   system_list[i]->update();
@@ -691,9 +691,9 @@ void UniformRefinementEstimator::_estimate_error (const EquationSystems * _es,
 
       // Compute the square-root of each component.
       LOG_SCOPE("std::sqrt()", "UniformRefinementEstimator");
-      for (std::size_t i=0; i<error_per_cell->size(); i++)
-        if ((*error_per_cell)[i] != 0.)
-          (*error_per_cell)[i] = std::sqrt((*error_per_cell)[i]);
+      for (auto & val : *error_per_cell)
+        if (val != 0.)
+          val = std::sqrt(val);
     }
   else
     {

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -706,8 +706,8 @@ void FEGenericBase<OutputType>::compute_shape_functions (const Elem * elem,
 template <typename OutputType>
 void FEGenericBase<OutputType>::print_phi(std::ostream & os) const
 {
-  for (std::size_t i=0; i<phi.size(); ++i)
-    for (std::size_t j=0; j<phi[i].size(); ++j)
+  for (auto i : index_range(phi))
+    for (auto j : index_range(phi[i]))
       os << " phi[" << i << "][" << j << "]=" << phi[i][j] << std::endl;
 }
 
@@ -717,8 +717,8 @@ void FEGenericBase<OutputType>::print_phi(std::ostream & os) const
 template <typename OutputType>
 void FEGenericBase<OutputType>::print_dphi(std::ostream & os) const
 {
-  for (std::size_t i=0; i<dphi.size(); ++i)
-    for (std::size_t j=0; j<dphi[i].size(); ++j)
+  for (auto i : index_range(dphi))
+    for (auto j : index_range(dphi[i]))
       os << " dphi[" << i << "][" << j << "]=" << dphi[i][j];
 }
 
@@ -775,8 +775,8 @@ void FEGenericBase<OutputType>::determine_calculations()
 template <typename OutputType>
 void FEGenericBase<OutputType>::print_d2phi(std::ostream & os) const
 {
-  for (std::size_t i=0; i<dphi.size(); ++i)
-    for (std::size_t j=0; j<dphi[i].size(); ++j)
+  for (auto i : index_range(dphi))
+    for (auto j : index_range(dphi[i]))
       os << " d2phi[" << i << "][" << j << "]=" << d2phi[i][j];
 }
 
@@ -1813,7 +1813,7 @@ compute_periodic_constraints (DofConstraints & constraints,
                   // Translate the quadrature points over to the
                   // neighbor's boundary
                   std::vector<Point> neigh_point(q_point.size());
-                  for (std::size_t i=0; i != neigh_point.size(); ++i)
+                  for (auto i : index_range(neigh_point))
                     neigh_point[i] = periodic->get_corresponding_pos(q_point[i]);
 
                   FEInterface::inverse_map (Dim, base_fe_type, neigh,

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -396,7 +396,8 @@ void FE<Dim,T>::side_map (const Elem * elem,
 
   const std::vector<std::vector<Real>> & psi_map = this->_fe_map->get_psi();
 
-  for (std::size_t i=0; i<psi_map.size(); i++) // sum over the nodes
+  // sum over the nodes
+  for (auto i : index_range(psi_map))
     {
       const Point & side_node = refspace_nodes[elem_nodes_map[i]];
       for (unsigned int p=0; p<n_points; p++)

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -35,6 +35,7 @@
 #include "libmesh/tensor_value.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 #include "libmesh/enum_elem_type.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -457,7 +458,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
 #endif
 
         // compute x, dx, d2x at the quadrature point
-        for (std::size_t i=0; i<elem_nodes.size(); i++) // sum over the nodes
+        for (auto i : index_range(elem_nodes)) // sum over the nodes
           {
             // Reference to the point, helps eliminate
             // excessive temporaries in the inner loop
@@ -696,7 +697,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
 
 
         // compute (x,y) at the quadrature points, derivatives once
-        for (std::size_t i=0; i<elem_nodes.size(); i++) // sum over the nodes
+        for (auto i : index_range(elem_nodes)) // sum over the nodes
           {
             // Reference to the point, helps eliminate
             // excessive temporaries in the inner loop
@@ -1018,7 +1019,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
         // dxdxi,   dydxi,   dzdxi,
         // dxdeta,  dydeta,  dzdeta,
         // dxdzeta, dydzeta, dzdzeta  all once
-        for (std::size_t i=0; i<elem_nodes.size(); i++) // sum over the nodes
+        for (auto i : index_range(elem_nodes)) // sum over the nodes
           {
             // Reference to the point, helps eliminate
             // excessive temporaries in the inner loop
@@ -1169,7 +1170,7 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
 
       // Inverse map second derivatives
       d2xidxyz2_map.resize(n_qp);
-      for (std::size_t i=0; i<d2xidxyz2_map.size(); ++i)
+      for (auto i : index_range(d2xidxyz2_map))
         d2xidxyz2_map[i].assign(6, 0.);
     }
 #endif
@@ -1190,7 +1191,7 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
 
           // Inverse map second derivatives
           d2etadxyz2_map.resize(n_qp);
-          for (std::size_t i=0; i<d2etadxyz2_map.size(); ++i)
+          for (auto i : index_range(d2etadxyz2_map))
             d2etadxyz2_map[i].assign(6, 0.);
         }
 #endif
@@ -1212,7 +1213,7 @@ void FEMap::resize_quadrature_map_vectors(const unsigned int dim, unsigned int n
 
               // Inverse map second derivatives
               d2zetadxyz2_map.resize(n_qp);
-              for (std::size_t i=0; i<d2zetadxyz2_map.size(); ++i)
+              for (auto i : index_range(d2zetadxyz2_map))
                 d2zetadxyz2_map[i].assign(6, 0.);
             }
 #endif
@@ -1256,8 +1257,8 @@ void FEMap::compute_affine_map(const unsigned int dim,
     for (unsigned int p=1; p<n_qp; p++)
       {
         xyz[p].zero();
-        for (std::size_t i=0; i<phi_map.size(); i++) // sum over the nodes
-          xyz[p].add_scaled        (*_elem_nodes[i], phi_map[i][p]    );
+        for (auto i : index_range(phi_map)) // sum over the nodes
+          xyz[p].add_scaled (*_elem_nodes[i], phi_map[i][p]);
       }
 
   // Copy other map data from quadrature point 0
@@ -1436,15 +1437,15 @@ void FEMap::compute_map(const unsigned int dim,
 
 void FEMap::print_JxW(std::ostream & os) const
 {
-  for (std::size_t i=0; i<JxW.size(); ++i)
-    os << " [" << i << "]: " <<  JxW[i] << std::endl;
+  for (auto i : index_range(JxW))
+    os << " [" << i << "]: " << JxW[i] << std::endl;
 }
 
 
 
 void FEMap::print_xyz(std::ostream & os) const
 {
-  for (std::size_t i=0; i<xyz.size(); ++i)
+  for (auto i : index_range(xyz))
     os << " [" << i << "]: " << xyz[i];
 }
 

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -23,6 +23,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -727,16 +728,13 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
     case 1:
       {
         if (this->calculate_phi)
-          for (unsigned int i=0,
-               n_phi = cast_int<unsigned int>(this->phi.size());
-               i != n_phi; i++)
-            for (std::size_t p=0; p<this->phi[i].size(); p++)
+          for (auto i : index_range(this->phi))
+            for (auto p : index_range(this->phi[i]))
               this->phi[i][p] = FE<Dim,XYZ>::shape (elem, this->fe_type.order, i, xyz_qp[p]);
+
         if (this->calculate_dphi)
-          for (unsigned int i=0,
-               n_dphi = cast_int<unsigned int>(this->dphi.size());
-               i != n_dphi; i++)
-            for (std::size_t p=0; p<this->dphi[i].size(); p++)
+          for (auto i : index_range(this->dphi))
+            for (auto p : index_range(this->dphi[i]))
               {
                 this->dphi[i][p](0) =
                   this->dphidx[i][p] = FE<Dim,XYZ>::shape_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -746,10 +744,8 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
               }
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         if (this->calculate_d2phi)
-          for (unsigned int i=0,
-               n_d2phi = cast_int<unsigned int>(this->d2phi.size());
-               i != n_d2phi; i++)
-            for (std::size_t p=0; p<this->d2phi[i].size(); p++)
+          for (auto i : index_range(this->d2phi))
+            for (auto p : index_range(this->d2phi[i]))
               {
                 this->d2phi[i][p](0,0) =
                   this->d2phidx2[i][p] = FE<Dim,XYZ>::shape_second_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -776,16 +772,13 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
     case 2:
       {
         if (this->calculate_phi)
-          for (unsigned int i=0,
-               n_phi = cast_int<unsigned int>(this->phi.size());
-               i != n_phi; i++)
-            for (std::size_t p=0; p<this->phi[i].size(); p++)
+          for (auto i : index_range(this->phi))
+            for (auto p : index_range(this->phi[i]))
               this->phi[i][p] = FE<Dim,XYZ>::shape (elem, this->fe_type.order, i, xyz_qp[p]);
+
         if (this->calculate_dphi)
-          for (unsigned int i=0,
-               n_dphi = cast_int<unsigned int>(this->dphi.size());
-               i != n_dphi; i++)
-            for (std::size_t p=0; p<this->dphi[i].size(); p++)
+          for (auto i : index_range(this->dphi))
+            for (auto p : index_range(this->dphi[i]))
               {
                 this->dphi[i][p](0) =
                   this->dphidx[i][p] = FE<Dim,XYZ>::shape_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -800,10 +793,8 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
               }
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         if (this->calculate_d2phi)
-          for (unsigned int i=0,
-               n_d2phi = cast_int<unsigned int>(this->d2phi.size());
-               i != n_d2phi; i++)
-            for (std::size_t p=0; p<this->d2phi[i].size(); p++)
+          for (auto i : index_range(this->d2phi))
+            for (auto p : index_range(this->d2phi[i]))
               {
                 this->d2phi[i][p](0,0) =
                   this->d2phidx2[i][p] = FE<Dim,XYZ>::shape_second_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -829,17 +820,13 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
     case 3:
       {
         if (this->calculate_phi)
-          for (unsigned int i=0,
-               n_phi = cast_int<unsigned int>(this->phi.size());
-               i != n_phi; i++)
-            for (std::size_t p=0; p<this->phi[i].size(); p++)
+          for (auto i : index_range(this->phi))
+            for (auto p : index_range(this->phi[i]))
               this->phi[i][p] = FE<Dim,XYZ>::shape (elem, this->fe_type.order, i, xyz_qp[p]);
 
         if (this->calculate_dphi)
-          for (unsigned int i=0,
-               n_dphi = cast_int<unsigned int>(this->dphi.size());
-               i != n_dphi; i++)
-            for (std::size_t p=0; p<this->dphi[i].size(); p++)
+          for (auto i : index_range(this->dphi))
+            for (auto p : index_range(this->dphi[i]))
               {
                 this->dphi[i][p](0) =
                   this->dphidx[i][p] = FE<Dim,XYZ>::shape_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);
@@ -852,10 +839,8 @@ void FEXYZ<Dim>::compute_shape_functions (const Elem * elem,
               }
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         if (this->calculate_d2phi)
-          for (unsigned int i=0,
-               n_d2phi = cast_int<unsigned int>(this->d2phi.size());
-               i != n_d2phi; i++)
-            for (std::size_t p=0; p<this->d2phi[i].size(); p++)
+          for (auto i : index_range(this->d2phi))
+            for (auto p : index_range(this->d2phi[i]))
               {
                 this->d2phi[i][p](0,0) =
                   this->d2phidx2[i][p] = FE<Dim,XYZ>::shape_second_deriv (elem, this->fe_type.order, i, 0, xyz_qp[p]);

--- a/src/fe/h1_fe_transformation.C
+++ b/src/fe/h1_fe_transformation.C
@@ -19,6 +19,7 @@
 #include "libmesh/h1_fe_transformation.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/elem.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -58,48 +59,40 @@ void H1FETransformation<OutputShape>::map_phi( const unsigned int dim,
     {
     case 0:
       {
-        for (unsigned int i=0,
-             n_phi = cast_int<unsigned int>(phi.size());
-             i != n_phi; i++)
+        for (auto i : index_range(phi))
           {
             libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (std::size_t p=0; p<phi[i].size(); p++)
+            for (auto p : index_range(phi[i]))
               FEInterface::shape<OutputShape>(0, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
           }
         break;
       }
     case 1:
       {
-        for (unsigned int i=0,
-             n_phi = cast_int<unsigned int>(phi.size());
-             i != n_phi; i++)
+        for (auto i : index_range(phi))
           {
             libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (std::size_t p=0; p<phi[i].size(); p++)
+            for (auto p : index_range(phi[i]))
               FEInterface::shape<OutputShape>(1, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
           }
         break;
       }
     case 2:
       {
-        for (unsigned int i=0,
-             n_phi = cast_int<unsigned int>(phi.size());
-             i != n_phi; i++)
+        for (auto i : index_range(phi))
           {
             libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (std::size_t p=0; p<phi[i].size(); p++)
+            for (auto p : index_range(phi[i]))
               FEInterface::shape<OutputShape>(2, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
           }
         break;
       }
     case 3:
       {
-        for (unsigned int i=0,
-             n_phi = cast_int<unsigned int>(phi.size());
-             i != n_phi; i++)
+        for (auto i : index_range(phi))
           {
             libmesh_assert_equal_to ( qp.size(), phi[i].size() );
-            for (std::size_t p=0; p<phi[i].size(); p++)
+            for (auto p : index_range(phi[i]))
               FEInterface::shape<OutputShape>(3, fe.get_fe_type(), elem, i, qp[p], phi[i][p]);
           }
         break;
@@ -125,8 +118,8 @@ void H1FETransformation<OutputShape>::map_dphi( const unsigned int dim,
     {
     case 0: // No derivatives in 0D
       {
-        for (std::size_t i=0; i<dphi.size(); i++)
-          for (std::size_t p=0; p<dphi[i].size(); p++)
+        for (auto i : index_range(dphi))
+          for (auto p : index_range(dphi[i]))
             dphi[i][p] = 0.;
         break;
       }
@@ -143,8 +136,8 @@ void H1FETransformation<OutputShape>::map_dphi( const unsigned int dim,
         const std::vector<Real> & dxidz_map = fe.get_fe_map().get_dxidz();
 #endif
 
-        for (std::size_t i=0; i<dphi.size(); i++)
-          for (std::size_t p=0; p<dphi[i].size(); p++)
+        for (auto i : index_range(dphi))
+          for (auto p : index_range(dphi[i]))
             {
               // dphi/dx    = (dphi/dxi)*(dxi/dx)
               dphi[i][p].slice(0) = dphidx[i][p] = dphidxi[i][p]*dxidx_map[p];
@@ -177,8 +170,8 @@ void H1FETransformation<OutputShape>::map_dphi( const unsigned int dim,
         const std::vector<Real> & detadz_map = fe.get_fe_map().get_detadz();
 #endif
 
-        for (std::size_t i=0; i<dphi.size(); i++)
-          for (std::size_t p=0; p<dphi[i].size(); p++)
+        for (auto i : index_range(dphi))
+          for (auto p : index_range(dphi[i]))
             {
               // dphi/dx    = (dphi/dxi)*(dxi/dx) + (dphi/deta)*(deta/dx)
               dphi[i][p].slice(0) = dphidx[i][p] = (dphidxi[i][p]*dxidx_map[p] +
@@ -216,8 +209,8 @@ void H1FETransformation<OutputShape>::map_dphi( const unsigned int dim,
         const std::vector<Real> & dzetady_map = fe.get_fe_map().get_dzetady();
         const std::vector<Real> & dzetadz_map = fe.get_fe_map().get_dzetadz();
 
-        for (std::size_t i=0; i<dphi.size(); i++)
-          for (std::size_t p=0; p<dphi[i].size(); p++)
+        for (auto i : index_range(dphi))
+          for (auto p : index_range(dphi[i]))
             {
               // dphi/dx    = (dphi/dxi)*(dxi/dx) + (dphi/deta)*(deta/dx) + (dphi/dzeta)*(dzeta/dx);
               dphi[i][p].slice(0) = dphidx[i][p] = (dphidxi[i][p]*dxidx_map[p] +
@@ -259,8 +252,8 @@ void H1FETransformation<OutputShape>::map_d2phi(const unsigned int dim,
     {
     case 0: // No derivatives in 0D
       {
-        for (std::size_t i=0; i<d2phi.size(); i++)
-          for (std::size_t p=0; p<d2phi[i].size(); p++)
+        for (auto i : index_range(d2phi))
+          for (auto p : index_range(d2phi[i]))
             d2phi[i][p] = 0.;
 
         break;
@@ -284,8 +277,8 @@ void H1FETransformation<OutputShape>::map_d2phi(const unsigned int dim,
         // Inverse map second derivatives
         const std::vector<std::vector<Real>> & d2xidxyz2 = fe.get_fe_map().get_d2xidxyz2();
 
-        for (std::size_t i=0; i<d2phi.size(); i++)
-          for (std::size_t p=0; p<d2phi[i].size(); p++)
+        for (auto i : index_range(d2phi))
+          for (auto p : index_range(d2phi[i]))
             {
               // phi_{x x}
               d2phi[i][p].slice(0).slice(0) = d2phidx2[i][p] =
@@ -355,8 +348,8 @@ void H1FETransformation<OutputShape>::map_d2phi(const unsigned int dim,
         const std::vector<std::vector<Real>> & d2xidxyz2 = fe.get_fe_map().get_d2xidxyz2();
         const std::vector<std::vector<Real>> & d2etadxyz2 = fe.get_fe_map().get_d2etadxyz2();
 
-        for (std::size_t i=0; i<d2phi.size(); i++)
-          for (std::size_t p=0; p<d2phi[i].size(); p++)
+        for (auto i : index_range(d2phi))
+          for (auto p : index_range(d2phi[i]))
             {
               // phi_{x x}
               d2phi[i][p].slice(0).slice(0) = d2phidx2[i][p] =
@@ -445,8 +438,8 @@ void H1FETransformation<OutputShape>::map_d2phi(const unsigned int dim,
         const std::vector<std::vector<Real>> & d2etadxyz2 = fe.get_fe_map().get_d2etadxyz2();
         const std::vector<std::vector<Real>> & d2zetadxyz2 = fe.get_fe_map().get_d2zetadxyz2();
 
-        for (std::size_t i=0; i<d2phi.size(); i++)
-          for (std::size_t p=0; p<d2phi[i].size(); p++)
+        for (auto i : index_range(d2phi))
+          for (auto p : index_range(d2phi[i]))
             {
               // phi_{x x}
               d2phi[i][p].slice(0).slice(0) = d2phidx2[i][p] =
@@ -570,13 +563,10 @@ void H1FETransformation<RealGradient>::map_curl(const unsigned int dim,
         const std::vector<Real> & detadz_map = fe.get_fe_map().get_detadz();
 #endif
 
-        /*
-          For 2D elements in 3D space:
-
-          curl = ( -dphi_y/dz, dphi_x/dz, dphi_y/dx - dphi_x/dy )
-        */
-        for (std::size_t i=0; i<curl_phi.size(); i++)
-          for (std::size_t p=0; p<curl_phi[i].size(); p++)
+        // For 2D elements in 3D space:
+        // curl = ( -dphi_y/dz, dphi_x/dz, dphi_y/dx - dphi_x/dy )
+        for (auto i : index_range(curl_phi))
+          for (auto p : index_range(curl_phi[i]))
             {
 
               Real dphiy_dx = (dphidxi[i][p].slice(1))*dxidx_map[p]
@@ -619,11 +609,9 @@ void H1FETransformation<RealGradient>::map_curl(const unsigned int dim,
         const std::vector<Real> & dzetady_map = fe.get_fe_map().get_dzetady();
         const std::vector<Real> & dzetadz_map = fe.get_fe_map().get_dzetadz();
 
-        /*
-          In 3D: curl = ( dphi_z/dy - dphi_y/dz, dphi_x/dz - dphi_z/dx, dphi_y/dx - dphi_x/dy )
-        */
-        for (std::size_t i=0; i<curl_phi.size(); i++)
-          for (std::size_t p=0; p<curl_phi[i].size(); p++)
+        // In 3D: curl = ( dphi_z/dy - dphi_y/dz, dphi_x/dz - dphi_z/dx, dphi_y/dx - dphi_x/dy )
+        for (auto i : index_range(curl_phi))
+          for (auto p : index_range(curl_phi[i]))
             {
               Real dphiz_dy = (dphidxi[i][p].slice(2))*dxidy_map[p]
                 + (dphideta[i][p].slice(2))*detady_map[p]
@@ -700,10 +688,9 @@ void H1FETransformation<RealGradient>::map_div(const unsigned int dim,
         const std::vector<Real> & detady_map = fe.get_fe_map().get_detady();
 
         // In 2D: div = dphi_x/dx + dphi_y/dy
-        for (std::size_t i=0; i<div_phi.size(); i++)
-          for (std::size_t p=0; p<div_phi[i].size(); p++)
+        for (auto i : index_range(div_phi))
+          for (auto p : index_range(div_phi[i]))
             {
-
               Real dphix_dx = (dphidxi[i][p].slice(0))*dxidx_map[p]
                 + (dphideta[i][p].slice(0))*detadx_map[p];
 
@@ -732,11 +719,9 @@ void H1FETransformation<RealGradient>::map_div(const unsigned int dim,
         const std::vector<Real> & dzetady_map = fe.get_fe_map().get_dzetady();
         const std::vector<Real> & dzetadz_map = fe.get_fe_map().get_dzetadz();
 
-        /*
-          In 3D: div = dphi_x/dx + dphi_y/dy + dphi_z/dz
-        */
-        for (std::size_t i=0; i<div_phi.size(); i++)
-          for (std::size_t p=0; p<div_phi[i].size(); p++)
+        // In 3D: div = dphi_x/dx + dphi_y/dy + dphi_z/dz
+        for (auto i : index_range(div_phi))
+          for (auto p : index_range(div_phi[i]))
             {
               Real dphix_dx = (dphidxi[i][p].slice(0))*dxidx_map[p]
                 + (dphideta[i][p].slice(0))*detadx_map[p]
@@ -756,8 +741,8 @@ void H1FETransformation<RealGradient>::map_div(const unsigned int dim,
         break;
       }
 
-    default:                                                  \
-      libmesh_error_msg("Invalid dim = " << dim);             \
+    default:
+      libmesh_error_msg("Invalid dim = " << dim);
     } // switch(dim)
 
   return;

--- a/src/fe/hcurl_fe_transformation.C
+++ b/src/fe/hcurl_fe_transformation.C
@@ -17,6 +17,7 @@
 
 #include "libmesh/hcurl_fe_transformation.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -70,20 +71,17 @@ void HCurlFETransformation<OutputShape>::map_phi(const unsigned int dim,
         const std::vector<Real> & detady_map = fe.get_fe_map().get_detady();
 
         // FIXME: Need to update for 2D elements in 3D space
-        /* phi = (dx/dxi)^-T * \hat{phi}
-           In 2D:
-           (dx/dxi)^{-1} = [  dxi/dx   dxi/dy
-           deta/dx  deta/dy ]
-
-           so: dxi/dx^{-T} * \hat{phi} = [ dxi/dx  deta/dx   [ \hat{phi}_xi
-           dxi/dy  deta/dy ]   \hat{phi}_eta ]
-
-           or in indicial notation:  phi_j = xi_{i,j}*\hat{phi}_i */
-
-        for (unsigned int i=0,
-             n_phi = cast_int<unsigned int>(phi.size());
-             i != n_phi; i++)
-          for (std::size_t p=0; p<phi[i].size(); p++)
+        // phi = (dx/dxi)^-T * \hat{phi}
+        // In 2D:
+        // (dx/dxi)^{-1} = [  dxi/dx   dxi/dy
+        // deta/dx  deta/dy ]
+        //
+        // so: dxi/dx^{-T} * \hat{phi} = [ dxi/dx  deta/dx   [ \hat{phi}_xi
+        // dxi/dy  deta/dy ]   \hat{phi}_eta ]
+        //
+        // or in indicial notation:  phi_j = xi_{i,j}*\hat{phi}_i
+        for (auto i : index_range(phi))
+          for (auto p : index_range(phi[i]))
             {
               // Need to temporarily cache reference shape functions
               // TODO: PB: Might be worth trying to build phi_ref separately to see
@@ -113,22 +111,19 @@ void HCurlFETransformation<OutputShape>::map_phi(const unsigned int dim,
         const std::vector<Real> & dzetady_map = fe.get_fe_map().get_dzetady();
         const std::vector<Real> & dzetadz_map = fe.get_fe_map().get_dzetadz();
 
-        /* phi = (dx/dxi)^-T * \hat{phi}
-           In 3D:
-           dx/dxi^-1 = [  dxi/dx    dxi/dy    dxi/dz
-           deta/dx   deta/dy   deta/dz
-           dzeta/dx  dzeta/dy  dzeta/dz]
-
-           so: dxi/dx^-T * \hat{phi} = [ dxi/dx  deta/dx  dzeta/dx   [ \hat{phi}_xi
-           dxi/dy  deta/dy  dzeta/dy     \hat{phi}_eta
-           dxi/dz  deta/dz  dzeta/dz ]   \hat{phi}_zeta ]
-
-           or in indicial notation:  phi_j = xi_{i,j}*\hat{phi}_i */
-
-        for (unsigned int i=0,
-             n_phi = cast_int<unsigned int>(phi.size());
-             i != n_phi; i++)
-          for (std::size_t p=0; p<phi[i].size(); p++)
+        // phi = (dx/dxi)^-T * \hat{phi}
+        // In 3D:
+        // dx/dxi^-1 = [  dxi/dx    dxi/dy    dxi/dz
+        // deta/dx   deta/dy   deta/dz
+        // dzeta/dx  dzeta/dy  dzeta/dz]
+        //
+        // so: dxi/dx^-T * \hat{phi} = [ dxi/dx  deta/dx  dzeta/dx   [ \hat{phi}_xi
+        // dxi/dy  deta/dy  dzeta/dy     \hat{phi}_eta
+        // dxi/dz  deta/dz  dzeta/dz ]   \hat{phi}_zeta ]
+        //
+        // or in indicial notation:  phi_j = xi_{i,j}*\hat{phi}_i
+        for (auto i : index_range(phi))
+          for (auto p : index_range(phi[i]))
             {
               // Need to temporarily cache reference shape functions
               // TODO: PB: Might be worth trying to build phi_ref separately to see
@@ -174,12 +169,11 @@ void HCurlFETransformation<OutputShape>::map_curl(const unsigned int dim,
         const std::vector<Real> & J = fe.get_fe_map().get_jacobian();
 
         // FIXME: I don't think this is valid for 2D elements in 3D space
-        /* In 2D: curl(phi) = J^{-1} * curl(\hat{phi}) */
-        for (std::size_t i=0; i<curl_phi.size(); i++)
-          for (std::size_t p=0; p<curl_phi[i].size(); p++)
+        // In 2D: curl(phi) = J^{-1} * curl(\hat{phi})
+        for (auto i : index_range(curl_phi))
+          for (auto p : index_range(curl_phi[i]))
             {
               curl_phi[i][p].slice(0) = curl_phi[i][p].slice(1) = 0.0;
-
               curl_phi[i][p].slice(2) = ( dphi_dxi[i][p].slice(1) - dphi_deta[i][p].slice(0) )/J[p];
             }
 
@@ -198,8 +192,8 @@ void HCurlFETransformation<OutputShape>::map_curl(const unsigned int dim,
 
         const std::vector<Real> & J = fe.get_fe_map().get_jacobian();
 
-        for (std::size_t i=0; i<curl_phi.size(); i++)
-          for (std::size_t p=0; p<curl_phi[i].size(); p++)
+        for (auto i : index_range(curl_phi))
+          for (auto p : index_range(curl_phi[i]))
             {
               Real dx_dxi   = dxyz_dxi[p](0);
               Real dx_deta  = dxyz_deta[p](0);

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -19,11 +19,13 @@
 
 // Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
 #include "libmesh/inf_fe.h"
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/elem.h"
 #include "libmesh/libmesh_logging.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -214,7 +216,7 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
       // right now, and it will generalize a bit, and it won't break
       // the assumptions elsewhere in InfFE.
       std::vector<Point> radial_pts;
-      for (std::size_t p=0; p != pts->size(); ++p)
+      for (auto p : index_range(*pts))
         {
           Real radius = (*pts)[p](Dim-1);
           //IMHO this is a dangerous check:
@@ -916,7 +918,7 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_functions(const Elem *,
         const std::vector<Real> & dzetadz_map = this->_fe_map->get_dzetadz();
 
         // These are _all_ shape functions of this infinite element
-        for (std::size_t i=0; i<phi.size(); i++)
+        for (auto i : index_range(phi))
           for (unsigned int p=0; p<n_total_qp; p++)
             {
               // dphi/dx    = (dphi/dxi)*(dxi/dx) + (dphi/deta)*(deta/dx) + (dphi/dzeta)*(dzeta/dx);

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -24,6 +24,7 @@
 #include "libmesh/face_tri6.h"
 #include "libmesh/enum_io_package.h"
 #include "libmesh/enum_order.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -253,7 +254,7 @@ std::unique_ptr<Elem> Prism18::build_side_ptr (const unsigned int i,
       face->subdomain_id() = this->subdomain_id();
 
       // Set the nodes
-      for (unsigned n=0; n<face->n_nodes(); ++n)
+      for (auto n : face->node_index_range())
         face->set_node(n) = this->node_ptr(Prism18::side_nodes_map[i][n]);
 
       return face;
@@ -457,7 +458,7 @@ void Prism18::connectivity(const unsigned int sc,
         // VTK's VTK_BIQUADRATIC_QUADRATIC_WEDGE first 9 (vertex) and
         // last 3 (mid-face) nodes match.  The middle and top layers
         // of mid-edge nodes are reversed from LibMesh's.
-        for (unsigned int i=0; i != conn_size; ++i)
+        for (auto i : IntRange<int>(0, conn_size))
           conn[i] = this->node_id(i);
 
         // top "ring" of mid-edge nodes
@@ -471,112 +472,6 @@ void Prism18::connectivity(const unsigned int sc,
         conn[14] = this->node_id(11);
 
         return;
-
-        /*
-          conn.resize(6);
-          switch (sc)
-          {
-
-          case 0:
-          {
-          conn[0] = this->node_id(0);
-          conn[1] = this->node_id(6);
-          conn[2] = this->node_id(8);
-          conn[3] = this->node_id(9);
-          conn[4] = this->node_id(15);
-          conn[5] = this->node_id(17);
-
-          return;
-          }
-
-          case 1:
-          {
-          conn[0] = this->node_id(6);
-          conn[1] = this->node_id(1);
-          conn[2] = this->node_id(7);
-          conn[3] = this->node_id(15);
-          conn[4] = this->node_id(10);
-          conn[5] = this->node_id(16);
-
-          return;
-          }
-
-          case 2:
-          {
-          conn[0] = this->node_id(8);
-          conn[1] = this->node_id(7);
-          conn[2] = this->node_id(2);
-          conn[3] = this->node_id(17);
-          conn[4] = this->node_id(16);
-          conn[5] = this->node_id(11);
-
-          return;
-          }
-
-          case 3:
-          {
-          conn[0] = this->node_id(6);
-          conn[1] = this->node_id(7);
-          conn[2] = this->node_id(8);
-          conn[3] = this->node_id(15);
-          conn[4] = this->node_id(16);
-          conn[5] = this->node_id(17);
-
-          return;
-          }
-
-          case 4:
-          {
-          conn[0] = this->node_id(9);
-          conn[1] = this->node_id(15);
-          conn[2] = this->node_id(17);
-          conn[3] = this->node_id(3);
-          conn[4] = this->node_id(12);
-          conn[5] = this->node_id(14);
-
-          return;
-          }
-
-          case 5:
-          {
-          conn[0] = this->node_id(15);
-          conn[1] = this->node_id(10);
-          conn[2] = this->node_id(16);
-          conn[3] = this->node_id(12);
-          conn[4] = this->node_id(4);
-          conn[5] = this->node_id(13);
-
-          return;
-          }
-
-          case 6:
-          {
-          conn[0] = this->node_id(17);
-          conn[1] = this->node_id(16);
-          conn[2] = this->node_id(11);
-          conn[3] = this->node_id(14);
-          conn[4] = this->node_id(13);
-          conn[5] = this->node_id(5);
-
-          return;
-          }
-
-          case 7:
-          {
-          conn[0] = this->node_id(15);
-          conn[1] = this->node_id(16);
-          conn[2] = this->node_id(17);
-          conn[3] = this->node_id(12);
-          conn[4] = this->node_id(13);
-          conn[5] = this->node_id(14);
-
-          return;
-          }
-
-          default:
-          libmesh_error_msg("Invalid sc = " << sc);
-          }
-        */
       }
 
     default:

--- a/src/geom/cell_prism18.C
+++ b/src/geom/cell_prism18.C
@@ -458,7 +458,7 @@ void Prism18::connectivity(const unsigned int sc,
         // VTK's VTK_BIQUADRATIC_QUADRATIC_WEDGE first 9 (vertex) and
         // last 3 (mid-face) nodes match.  The middle and top layers
         // of mid-edge nodes are reversed from LibMesh's.
-        for (auto i : IntRange<int>(0, conn_size))
+        for (auto i : index_range(conn))
           conn[i] = this->node_id(i);
 
         // top "ring" of mid-edge nodes

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1110,9 +1110,12 @@ void Elem::make_links_to_me_local(unsigned int n)
     neigh_family.push_back(neigh);
 
   // And point them to elem
-  for (std::size_t i = 0; i != neigh_family.size(); ++i)
+  for (auto & const_elem : neigh_family)
     {
-      Elem * neigh_family_member = const_cast<Elem *>(neigh_family[i]);
+      // This const_cast is necessary until we have a version of
+      // family_tree_by_side that returns a vector of non-constant
+      // pointers when called on a non-constant Elem.
+      Elem * neigh_family_member = const_cast<Elem *>(const_elem);
 
       // Only subactive elements point to other subactive elements
       if (this->subactive() && !neigh_family_member->subactive())
@@ -1175,9 +1178,9 @@ void Elem::make_links_to_me_remote()
               // FIXME - There's a lot of ugly const_casts here; we
               // may want to make remote_elem non-const and create
               // non-const versions of the family_tree methods
-              for (std::size_t i=0; i != family.size(); ++i)
+              for (auto & const_elem : family)
                 {
-                  Elem * n = const_cast<Elem *>(family[i]);
+                  Elem * n = const_cast<Elem *>(const_elem);
                   libmesh_assert (n);
                   if (n == remote_elem)
                     continue;
@@ -1221,9 +1224,9 @@ void Elem::make_links_to_me_remote()
               // FIXME - There's a lot of ugly const_casts here; we
               // may want to make remote_elem non-const and create
               // non-const versions of the family_tree methods
-              for (std::size_t i=0; i != family.size(); ++i)
+              for (auto & const_elem : family)
                 {
-                  Elem * n = const_cast<Elem *>(family[i]);
+                  Elem * n = const_cast<Elem *>(const_elem);
                   libmesh_assert (n);
                   if (n == remote_elem)
                     continue;
@@ -1284,9 +1287,9 @@ void Elem::remove_links_to_me()
               // FIXME - There's a lot of ugly const_casts here; we
               // may want to make remote_elem non-const and create
               // non-const versions of the family_tree methods
-              for (std::size_t i=0; i != family.size(); ++i)
+              for (auto & const_elem : family)
                 {
-                  Elem * n = const_cast<Elem *>(family[i]);
+                  Elem * n = const_cast<Elem *>(const_elem);
                   libmesh_assert (n);
                   if (n == remote_elem)
                     continue;
@@ -1330,9 +1333,9 @@ void Elem::remove_links_to_me()
               // FIXME - There's a lot of ugly const_casts here; we
               // may want to make remote_elem non-const and create
               // non-const versions of the family_tree methods
-              for (std::size_t i=0; i != family.size(); ++i)
+              for (auto & const_elem : family)
                 {
-                  Elem * n = const_cast<Elem *>(family[i]);
+                  Elem * n = const_cast<Elem *>(const_elem);
                   libmesh_assert (n);
                   if (n == remote_elem)
                     continue;
@@ -2208,12 +2211,12 @@ Elem::bracketing_nodes(unsigned int child,
   const std::vector<std::pair<unsigned char, unsigned char>> & pbc =
     this->parent_bracketing_nodes(child,child_node);
 
-  for (std::size_t i = 0; i != pbc.size(); ++i)
+  for (const auto & pb : pbc)
     {
       const unsigned short n_n = this->n_nodes();
-      if (pbc[i].first < n_n && pbc[i].second < n_n)
-        returnval.push_back(std::make_pair(this->node_id(pbc[i].first),
-                                           this->node_id(pbc[i].second)));
+      if (pb.first < n_n && pb.second < n_n)
+        returnval.push_back(std::make_pair(this->node_id(pb.first),
+                                           this->node_id(pb.second)));
       else
         {
           // We must be on a non-full-order higher order element...
@@ -2246,7 +2249,7 @@ Elem::bracketing_nodes(unsigned int child,
                 if (c == child && n == child_node)
                   break;
 
-                if (pbc[i].first == full_elem->as_parent_node(c,n))
+                if (pb.first == full_elem->as_parent_node(c,n))
                   {
                     // We should be consistent
                     if (pt1 != DofObject::invalid_id)
@@ -2255,7 +2258,7 @@ Elem::bracketing_nodes(unsigned int child,
                     pt1 = this->child_ptr(c)->node_id(n);
                   }
 
-                if (pbc[i].second == full_elem->as_parent_node(c,n))
+                if (pb.second == full_elem->as_parent_node(c,n))
                   {
                     // We should be consistent
                     if (pt2 != DofObject::invalid_id)

--- a/src/geom/reference_elem.C
+++ b/src/geom/reference_elem.C
@@ -64,18 +64,18 @@ class SingletonCache : public libMesh::Singleton
 public:
   ~SingletonCache()
   {
-    for (std::size_t e=0; e<elem_list.size(); e++)
+    for (auto & elem : elem_list)
       {
-        delete elem_list[e];
-        elem_list[e] = nullptr;
+        delete elem;
+        elem = nullptr;
       }
 
     elem_list.clear();
 
-    for (std::size_t n=0; n<node_list.size(); n++)
+    for (auto & node : node_list)
       {
-        delete node_list[n];
-        node_list[n] = nullptr;
+        delete node;
+        node = nullptr;
       }
 
     node_list.clear();

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -906,10 +906,10 @@ void AbaqusIO::assign_subdomain_ids()
         std::vector<dof_id_type> & id_vector = it->second;
 
         // Loop over this vector
-        for (std::size_t i=0; i<id_vector.size(); ++i)
+        for (const auto & id : id_vector)
           {
-            // Map the id_vector[i]'th element ID (Abaqus numbering) to LibMesh numbering
-            dof_id_type libmesh_elem_id = _abaqus_to_libmesh_elem_mapping[ id_vector[i] ];
+            // Map the id'th element ID (Abaqus numbering) to LibMesh numbering
+            dof_id_type libmesh_elem_id = _abaqus_to_libmesh_elem_mapping[id];
 
             // Get reference to that element
             Elem & elem = the_mesh.elem_ref(libmesh_elem_id);
@@ -960,10 +960,10 @@ void AbaqusIO::assign_boundary_node_ids()
       // Get a reference to the current vector of nodeset ID values
       std::vector<dof_id_type> & nodeset_ids = it->second;
 
-      for (std::size_t i=0; i<nodeset_ids.size(); ++i)
+      for (const auto & id : nodeset_ids)
         {
           // Map the Abaqus global node ID to the libmesh node ID
-          dof_id_type libmesh_global_node_id = _abaqus_to_libmesh_node_mapping[nodeset_ids[i]];
+          dof_id_type libmesh_global_node_id = _abaqus_to_libmesh_node_mapping[id];
 
           // Get node pointer from the mesh
           Node * node = the_mesh.node_ptr(libmesh_global_node_id);
@@ -1000,12 +1000,12 @@ void AbaqusIO::assign_sideset_ids()
         // Get a reference to the current vector of nodeset ID values
         std::vector<std::pair<dof_id_type,unsigned>> & sideset_ids = it->second;
 
-        for (std::size_t i=0; i<sideset_ids.size(); ++i)
+        for (const auto & id : sideset_ids)
           {
             // sideset_ids is a vector of pairs (elem id, side id).  Pull them out
             // now to make the code below more readable.
-            dof_id_type  abaqus_elem_id = sideset_ids[i].first;
-            unsigned abaqus_side_number = sideset_ids[i].second;
+            dof_id_type  abaqus_elem_id = id.first;
+            unsigned abaqus_side_number = id.second;
 
             // Map the Abaqus element ID to LibMesh numbering
             dof_id_type libmesh_elem_id = _abaqus_to_libmesh_elem_mapping[ abaqus_elem_id ];
@@ -1062,10 +1062,10 @@ void AbaqusIO::assign_sideset_ids()
         std::vector<dof_id_type> & id_vector = it->second;
 
         // Loop over this vector
-        for (std::size_t i=0; i<id_vector.size(); ++i)
+        for (const auto & id : id_vector)
           {
             // Map the id_vector[i]'th element ID (Abaqus numbering) to LibMesh numbering
-            dof_id_type libmesh_elem_id = _abaqus_to_libmesh_elem_mapping[ id_vector[i] ];
+            dof_id_type libmesh_elem_id = _abaqus_to_libmesh_elem_mapping[id];
 
             // Get a reference to that element
             Elem & elem = the_mesh.elem_ref(libmesh_elem_id);

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1923,11 +1923,8 @@ BoundaryInfo::build_node_list_from_side_list()
         {
           this->boundary_ids(_mesh.node_ptr(id), bcids);
 
-          for (std::size_t i=0; i != bcids.size(); ++i)
-            {
-              const boundary_id_type b = bcids[i];
-              responses[p-1].push_back(std::make_pair(id, b));
-            }
+          for (const auto & b : bcids)
+            responses[p-1].push_back(std::make_pair(id, b));
         }
 
       this->comm().send

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -34,6 +34,7 @@
 #include "libmesh/xdr_io.h"
 #include "libmesh/xdr_cxx.h"
 #include "libmesh/utility.h"
+#include "libmesh/int_range.h"
 
 // C++ includes
 #include <iostream>
@@ -937,7 +938,7 @@ void CheckpointIO::read_subdomain_names(Xdr & io)
       io.data(subdomain_ids);
       io.data(subdomain_names);
 
-      for (std::size_t i=0; i<subdomain_ids.size(); i++)
+      for (auto i : index_range(subdomain_ids))
         subdomain_map[cast_int<subdomain_id_type>(subdomain_ids[i])] =
           subdomain_names[i];
     }
@@ -1187,7 +1188,7 @@ void CheckpointIO::read_remote_elem (Xdr & io, bool libmesh_dbg_var(expect_all_r
 
   libmesh_assert_equal_to(elem_ids.size(), elem_sides.size());
 
-  for (std::size_t i=0; i != elem_ids.size(); ++i)
+  for (auto i : index_range(elem_ids))
     {
       Elem & elem = mesh.elem_ref(cast_int<dof_id_type>(elem_ids[i]));
       if (!elem.neighbor_ptr(elem_sides[i]))
@@ -1205,7 +1206,7 @@ void CheckpointIO::read_remote_elem (Xdr & io, bool libmesh_dbg_var(expect_all_r
   io.data(child_numbers, "# remote child_numbers");
 
 #ifdef LIBMESH_ENABLE_AMR
-  for (std::size_t i=0; i != parent_ids.size(); ++i)
+  for (auto i : index_range(parent_ids))
     {
       Elem & elem = mesh.elem_ref(cast_int<dof_id_type>(parent_ids[i]));
 
@@ -1243,7 +1244,7 @@ void CheckpointIO::read_bcs (Xdr & io)
   io.data(side_list, "# sides of elements for bcs");
   io.data(bc_id_list, "# bc ids");
 
-  for (std::size_t i=0; i<element_id_list.size(); i++)
+  for (auto i : index_range(element_id_list))
     boundary_info.add_side
       (cast_int<dof_id_type>(element_id_list[i]), side_list[i],
        cast_int<boundary_id_type>(bc_id_list[i]));
@@ -1266,7 +1267,7 @@ void CheckpointIO::read_nodesets (Xdr & io)
   io.data(node_id_list, "# node id list");
   io.data(bc_id_list, "# nodeset bc id list");
 
-  for (std::size_t i=0; i<node_id_list.size(); i++)
+  for (auto i : index_range(node_id_list))
     boundary_info.add_node
       (cast_int<dof_id_type>(node_id_list[i]),
        cast_int<boundary_id_type>(bc_id_list[i]));
@@ -1297,7 +1298,7 @@ void CheckpointIO::read_bc_names(Xdr & io, BoundaryInfo & info, bool is_sideset)
     }
 
   // Add them back into the map
-  for (std::size_t i=0; i<boundary_ids.size(); i++)
+  for (auto i : index_range(boundary_ids))
     boundary_map[cast_int<boundary_id_type>(boundary_ids[i])] =
       boundary_names[i];
 }

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1092,7 +1092,7 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
      const std::vector<dof_id_type> & data)
     {
       // Copy the id changes we've now been informed of
-      for (std::size_t i=0, ids_size = ids.size(); i != ids_size; ++i)
+      for (auto i : index_range(ids))
         {
           T * obj = objects[ids[i]];
           libmesh_assert (obj);
@@ -1138,7 +1138,7 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
      const std::vector<dof_id_type> & ids,
      const std::vector<unique_id_type> & data)
     {
-      for (std::size_t i=0, ids_size = ids.size(); i != ids_size; ++i)
+      for (auto i : index_range(ids))
         {
           T * obj = objects[ids[i]];
           libmesh_assert (obj);

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -26,6 +26,7 @@
 #include "libmesh/system.h"
 #include "libmesh/elem.h"
 #include "libmesh/enum_elem_type.h"
+#include "libmesh/int_range.h"
 
 // C++ includes
 #include <sstream>
@@ -242,11 +243,11 @@ void EnsightIO::write_geometry_ascii()
       mesh_stream << std::setw(10) << elem_ref.size() << "\n";
 
       // Write element id
-      for (std::size_t i = 0; i < elem_ref.size(); i++)
-        mesh_stream << std::setw(10) << elem_ref[i]->id() << "\n";
+      for (const auto & elem : elem_ref)
+        mesh_stream << std::setw(10) << elem->id() << "\n";
 
       // Write connectivity
-      for (std::size_t i = 0; i < elem_ref.size(); i++)
+      for (auto i : index_range(elem_ref))
         {
           for (const auto & node : elem_ref[i]->node_ref_range())
             {
@@ -309,8 +310,8 @@ void EnsightIO::write_case()
           case_stream << "filename start number:   " << std::setw(10) << 0 << "\n";
           case_stream << "filename increment:  " << std::setw(10) << 1 << "\n";
           case_stream << "time values:\n";
-          for (std::size_t i = 0; i < _time_steps.size(); i++)
-            case_stream << std::setw(12) << std::setprecision(5) << std::scientific << _time_steps[i] << "\n";
+          for (const auto & time : _time_steps)
+            case_stream << std::setw(12) << std::setprecision(5) << std::scientific << time << "\n";
         }
     }
 }
@@ -380,7 +381,7 @@ void EnsightIO::write_scalar_ascii(const std::string & sys,
 
       elem_soln.resize(dof_indices_scl.size());
 
-      for (std::size_t i = 0; i < dof_indices_scl.size(); i++)
+      for (auto i : index_range(dof_indices_scl))
         elem_soln[i] = system.current_solution(dof_indices_scl[i]);
 
       FEInterface::nodal_soln (dim, fe_type, elem, elem_soln, nodal_soln);
@@ -473,7 +474,7 @@ void EnsightIO::write_vector_ascii(const std::string & sys,
       if (dim == 3)
         elem_soln_w.resize(dof_indices_w.size());
 
-      for (std::size_t i = 0; i < dof_indices_u.size(); i++)
+      for (auto i : index_range(dof_indices_u))
         {
           elem_soln_u[i] = system.current_solution(dof_indices_u[i]);
           elem_soln_v[i] = system.current_solution(dof_indices_v[i]);

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -318,7 +318,7 @@ void ExodusII_IO::read (const std::string & fname)
             = sideset_name;
       }
 
-    for (std::size_t e=0; e<exio_helper->elem_list.size(); e++)
+    for (auto e : index_range(exio_helper->elem_list))
       {
         // The numbers in the Exodus file sidesets should be thought
         // of as (1-based) indices into the elem_num_map array.  So,
@@ -391,12 +391,12 @@ void ExodusII_IO::read (const std::string & fname)
 
         exio_helper->read_nodeset(nodeset);
 
-        for (std::size_t node=0; node<exio_helper->node_list.size(); node++)
+        for (const auto & exodus_id : exio_helper->node_list)
           {
             // As before, the entries in 'node_list' are 1-based
             // indices into the node_num_map array, so we have to map
             // them.  See comment above.
-            int libmesh_node_id = exio_helper->node_num_map[exio_helper->node_list[node] - 1] - 1;
+            int libmesh_node_id = exio_helper->node_num_map[exodus_id - 1] - 1;
             mesh.get_boundary_info().add_node(cast_int<dof_id_type>(libmesh_node_id),
                                               nodeset_id);
           }

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1806,7 +1806,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
       current_block_connectivity.clear();
       current_block_connectivity.resize(elem_ids_this_subdomain.size() * this->num_nodes_per_elem);
 
-      for (auto i : IntRange<int>(0, elem_ids_this_subdomain.size()))
+      for (auto i : index_range(elem_ids_this_subdomain))
         {
           auto elem_id = elem_ids_this_subdomain[i];
 

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -29,6 +29,7 @@
 #include "libmesh/parallel.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/numeric_vector.h"
+#include "libmesh/int_range.h"
 
 #if defined(LIBMESH_HAVE_NEMESIS_API) && defined(LIBMESH_HAVE_EXODUS_API)
 
@@ -267,12 +268,12 @@ void Nemesis_IO_Helper::get_elem_map()
   if (verbose)
     {
       libMesh::out << "[" << this->processor_id() << "] elem_mapi[i] = ";
-      for (unsigned int i=0; i<static_cast<unsigned int>(num_internal_elems-1); ++i)
+      for (auto i : IntRange<int>(0, num_internal_elems-1))
         libMesh::out << elem_mapi[i] << ", ";
       libMesh::out << "... " << elem_mapi.back() << std::endl;
 
       libMesh::out << "[" << this->processor_id() << "] elem_mapb[i] = ";
-      for (unsigned int i=0; i<static_cast<unsigned int>(std::min(10, num_border_elems-1)); ++i)
+      for (auto i : IntRange<int>(0, std::min(10, num_border_elems-1)))
         libMesh::out << elem_mapb[i] << ", ";
       libMesh::out << "... " << elem_mapb.back() << std::endl;
     }
@@ -1285,10 +1286,8 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
       // border_elem_ids and the entries which go into proc_border_elem_sets.
       // The latter is for communication purposes, ie determining which elements
       // should be shared between processors.
-      for (unsigned int node=0; node<elem->n_nodes(); ++node)
-        {
-          this->nodes_attached_to_local_elems.insert(elem->node_id(node));
-        } // end loop over element's nodes
+      for (auto node : elem->node_index_range())
+        this->nodes_attached_to_local_elems.insert(elem->node_id(node));
 
       // Loop over element's neighbors, see if it has a neighbor which is off-processor
       for (auto n : elem->side_index_range())
@@ -1733,7 +1732,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
   for (const auto & elem : pmesh.active_local_element_ptr_range())
     {
       // Grab the nodes while we're here.
-      for (unsigned int n=0; n<elem->n_nodes(); ++n)
+      for (auto n : elem->node_index_range())
         this->nodes_attached_to_local_elems.insert( elem->node_id(n) );
 
       subdomain_id_type cur_subdomain = elem->subdomain_id();
@@ -1807,7 +1806,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
       current_block_connectivity.clear();
       current_block_connectivity.resize(elem_ids_this_subdomain.size() * this->num_nodes_per_elem);
 
-      for (unsigned int i=0; i<elem_ids_this_subdomain.size(); i++)
+      for (auto i : IntRange<int>(0, elem_ids_this_subdomain.size()))
         {
           auto elem_id = elem_ids_this_subdomain[i];
 
@@ -1825,7 +1824,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
           // the same block...
           libmesh_assert_equal_to (elem.n_nodes(), Elem::build(conv.get_canonical_type(), nullptr)->n_nodes());
 
-          for (unsigned int j=0; j < static_cast<unsigned int>(this->num_nodes_per_elem); j++)
+          for (auto j : IntRange<int>(0, this->num_nodes_per_elem))
             {
               const unsigned int connect_index   = (i*this->num_nodes_per_elem)+j;
               const unsigned int elem_node_index = conv.get_node_map(j);
@@ -1868,7 +1867,7 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
         std::set<unsigned> & set_p = proc_nodes_touched[ elem->processor_id() ];
 
         // Insert all nodes touched by this element into the set
-        for (unsigned int node=0; node<elem->n_nodes(); ++node)
+        for (auto node : elem->node_index_range())
           set_p.insert(elem->node_id(node));
       }
 
@@ -2285,18 +2284,14 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
 
 void Nemesis_IO_Helper::write_nodal_coordinates(const MeshBase & mesh, bool /*use_discontinuous*/)
 {
-  // Make sure that the reference passed in is really a DistributedMesh
-  // const DistributedMesh & pmesh = cast_ref<const DistributedMesh &>(mesh);
-
-  unsigned local_num_nodes =
-    cast_int<unsigned int>(this->exodus_node_num_to_libmesh.size());
+  auto local_num_nodes = this->exodus_node_num_to_libmesh.size();
 
   x.resize(local_num_nodes);
   y.resize(local_num_nodes);
   z.resize(local_num_nodes);
 
   // Just loop over our list outputting the nodes the way we built the map
-  for (unsigned int i=0; i<local_num_nodes; ++i)
+  for (auto i : IntRange<int>(0, local_num_nodes))
     {
       const Point & pt = mesh.point(this->exodus_node_num_to_libmesh[i]);
       x[i]=pt(0);
@@ -2357,7 +2352,7 @@ void Nemesis_IO_Helper::write_elements(const MeshBase & mesh, bool /*use_discont
 
       // Loop over all blocks, even if we don't have elements in each block.
       // If we don't have elements we need to write out a 0 for that block...
-      for (unsigned int i=0; i<static_cast<unsigned>(this->num_elem_blks_global); ++i)
+      for (auto i : IntRange<int>(0, this->num_elem_blks_global))
         {
           // Even if there are no elements for this block on the current
           // processor, we still want to write its name to file, if

--- a/src/numerics/dense_matrix_blas_lapack.C
+++ b/src/numerics/dense_matrix_blas_lapack.C
@@ -19,7 +19,7 @@
 // Local Includes
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
-
+#include "libmesh/int_range.h"
 
 #if (LIBMESH_HAVE_PETSC)
 # include "libmesh/petsc_macro.h"
@@ -307,9 +307,8 @@ void DenseMatrix<T>::_svd_lapack (DenseVector<Real> & sigma)
 
   // Copy the singular values into sigma, ignore U_val and VT_val
   sigma.resize(cast_int<unsigned int>(sigma_val.size()));
-  for (unsigned int i=0; i<sigma.size(); i++)
+  for (auto i : IntRange<int>(0, sigma.size()))
     sigma(i) = sigma_val[i];
-
 }
 
 template<typename T>
@@ -372,7 +371,7 @@ void DenseMatrix<T>::_svd_lapack (DenseVector<Real> & sigma,
 
   // Copy the singular values into sigma.
   sigma.resize(cast_int<unsigned int>(sigma_val.size()));
-  for (unsigned int i=0; i<sigma.size(); i++)
+  for (auto i : IntRange<int>(0, sigma.size()))
     sigma(i) = sigma_val[i];
 }
 
@@ -584,7 +583,7 @@ void DenseMatrix<T>::_svd_solve_lapack(const DenseVector<T> & rhs,
   // now.  x needs to be long enough to hold both the (Nx1) solution
   // vector or the (Mx1) rhs, so size it to the max of those.
   x.resize(max_MN);
-  for (unsigned i=0; i<rhs.size(); ++i)
+  for (auto i : IntRange<int>(0, rhs.size()))
     x(i) = rhs(i);
 
   // Make the syntax below simpler by grabbing a reference to this array.
@@ -719,8 +718,8 @@ void DenseMatrix<T>::_evd_lapack (DenseVector<T> & lambda_real,
   // the same.
   if (VL || VR)
     {
-      for (unsigned int i=0; i<this->_m; ++i)
-        for (unsigned int j=0; j<i; ++j)
+      for (auto i : IntRange<int>(0, this->_m))
+        for (auto j : IntRange<int>(0, i))
           std::swap((*this)(i,j), (*this)(j,i));
     }
 
@@ -876,15 +875,15 @@ void DenseMatrix<T>::_evd_lapack (DenseVector<T> & lambda_real,
   // transpose it in place before handing it back.
   if (VR)
     {
-      for (unsigned int i=0; i<static_cast<unsigned int>(N); ++i)
-        for (unsigned int j=0; j<i; ++j)
+      for (auto i : IntRange<int>(0, N))
+        for (auto j : IntRange<int>(0, i))
           std::swap((*VR)(i,j), (*VR)(j,i));
     }
 
   if (VL)
     {
-      for (unsigned int i=0; i<static_cast<unsigned int>(N); ++i)
-        for (unsigned int j=0; j<i; ++j)
+      for (auto i : IntRange<int>(0, N))
+        for (auto j : IntRange<int>(0, i))
           std::swap((*VL)(i,j), (*VL)(j,i));
     }
 }

--- a/src/numerics/dense_vector_base.C
+++ b/src/numerics/dense_vector_base.C
@@ -22,6 +22,7 @@
 
 // Local Includes
 #include "libmesh/dense_vector_base.h"
+#include "libmesh/int_range.h"
 
 namespace libMesh
 {
@@ -33,7 +34,7 @@ void DenseVectorBase<T>::print_scientific (std::ostream & os, unsigned precision
   std::ios_base::fmtflags os_flags = os.flags();
 
   // Print the vector entries.
-  for (unsigned int i=0; i<this->size(); i++)
+  for (auto i : IntRange<int>(0, this->size()))
     os << std::setw(10)
        << std::scientific
        << std::setprecision(precision)
@@ -49,7 +50,7 @@ void DenseVectorBase<T>::print_scientific (std::ostream & os, unsigned precision
 template<typename T>
 void DenseVectorBase<T>::print (std::ostream & os) const
 {
-  for (unsigned int i=0; i<this->size(); i++)
+  for (auto i : IntRange<int>(0, this->size()))
     os << std::setw(8)
        << this->el(i)
        << std::endl;

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -447,7 +447,7 @@ Partitioner::processor_pairs_to_interface_nodes(MeshBase & mesh,
       for (unsigned int inode = 0; inode < n_nodes; inode++)
         mynodes.insert(elem->node_id(inode));
 
-      for (auto i = decltype(elem->n_neighbors())(0); i < elem->n_neighbors(); ++i)
+      for (auto i : elem->side_index_range())
         {
           auto neigh = elem->neighbor_ptr(i);
           if (neigh && !neigh->is_remote() && neigh->processor_id() != elem->processor_id())

--- a/src/solvers/nlopt_optimization_solver.C
+++ b/src/solvers/nlopt_optimization_solver.C
@@ -86,7 +86,7 @@ double __libmesh_nlopt_objective(unsigned n,
 
           std::vector<double> grad;
           sys.rhs->localize_to_one(grad);
-          for (auto i : IntRange<dof_id_type>(0, n))
+          for (unsigned int i = 0; i < n; ++i)
             gradient[i] = grad[i];
         }
       else
@@ -152,7 +152,7 @@ void __libmesh_nlopt_equality_constraints(unsigned m,
       // TODO: Even better would be if we could use 'result' directly
       // as the storage of eq_constraints.  Perhaps a serial-only
       // NumericVector variant which supports this option?
-      for (auto i : IntRange<dof_id_type>(0, m))
+      for (unsigned int i = 0; i < m; ++i)
         result[i] = (*sys.C_eq)(i);
 
       // If gradient != nullptr, then the Jacobian matrix of the equality
@@ -233,7 +233,7 @@ void __libmesh_nlopt_inequality_constraints(unsigned m,
       // TODO: Even better would be if we could use 'result' directly
       // as the storage of ineq_constraints.  Perhaps a serial-only
       // NumericVector variant which supports this option?
-      for (auto i : IntRange<dof_id_type>(0, m))
+      for (unsigned int i = 0; i < m; ++i)
         result[i] = (*sys.C_ineq)(i);
 
       // If gradient != nullptr, then the Jacobian matrix of the equality
@@ -370,7 +370,7 @@ void NloptOptimizationSolver<T>::solve ()
 
       std::vector<Real> nlopt_lb(nlopt_size);
       std::vector<Real> nlopt_ub(nlopt_size);
-      for (auto i : IntRange<dof_id_type>(0, nlopt_size))
+      for (unsigned int i = 0; i < nlopt_size; ++i)
         {
           nlopt_lb[i] = this->system().get_vector("lower_bounds")(i);
           nlopt_ub[i] = this->system().get_vector("upper_bounds")(i);

--- a/src/solvers/nlopt_optimization_solver.C
+++ b/src/solvers/nlopt_optimization_solver.C
@@ -281,6 +281,13 @@ NloptOptimizationSolver<T>::NloptOptimizationSolver (OptimizationSystem & system
   _iteration_count(0),
   _constraints_tolerance(1.e-8)
 {
+  // The nlopt interfaces all use unsigned int as their index type, so
+  // don't risk using the NloptOptimizationSolver with a libmesh that
+  // is configured to use 64-bit indices. We can detect this at
+  // configure time, so it should not be possible to actually reach
+  // this error message... it's here just in case.
+  if (sizeof(dof_id_type) != sizeof(unsigned int))
+    libmesh_error_msg("The NloptOptimizationSolver should not be used with dof_id_type != unsigned int.");
 }
 
 

--- a/src/solvers/nlopt_optimization_solver.C
+++ b/src/solvers/nlopt_optimization_solver.C
@@ -49,8 +49,7 @@ double __libmesh_nlopt_objective(unsigned n,
 
   // We'll use current_local_solution below, so let's ensure that it's consistent
   // with the vector x that was passed in.
-  for (auto i : IntRange<dof_id_type>(sys.solution->first_local_index(),
-                                      sys.solution->last_local_index()))
+  for (auto i : index_range(*sys.solution))
     sys.solution->set(i, x[i]);
 
   // Make sure the solution vector is parallel-consistent
@@ -127,8 +126,7 @@ void __libmesh_nlopt_equality_constraints(unsigned m,
   if (sys.solution->size() != n)
     libmesh_error_msg("Error: Input vector x has different length than sys.solution!");
 
-  for (auto i : IntRange<dof_id_type>(sys.solution->first_local_index(),
-                                      sys.solution->last_local_index()))
+  for (auto i : index_range(*sys.solution))
     sys.solution->set(i, x[i]);
   sys.solution->close();
 
@@ -208,8 +206,7 @@ void __libmesh_nlopt_inequality_constraints(unsigned m,
   if (sys.solution->size() != n)
     libmesh_error_msg("Error: Input vector x has different length than sys.solution!");
 
-  for (auto i : IntRange<dof_id_type>(sys.solution->first_local_index(),
-                                      sys.solution->last_local_index())
+  for (auto i : index_range(*sys.solution))
     sys.solution->set(i, x[i]);
   sys.solution->close();
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -360,10 +360,8 @@ void System::project_vector (const NumericVector<Number> & old_v,
                 const unsigned int new_n_dofs =
                   cast_int<unsigned int>(new_SCALAR_indices.size());
 
-                for (unsigned int i=0; i<new_n_dofs; i++)
-                  {
-                    new_vector.set( new_SCALAR_indices[i], old_vector(old_SCALAR_indices[i]) );
-                  }
+                for (auto i : IntRange<int>(0, new_n_dofs))
+                  new_vector.set(new_SCALAR_indices[i], old_vector(old_SCALAR_indices[i]));
               }
         }
     }
@@ -491,7 +489,7 @@ public:
     std::size_t size = values.size();
     libmesh_assert_equal_to (old_dof_indices.size(), size);
 
-    for (unsigned int i=0; i != size; ++i)
+    for (auto i : IntRange<std::size_t>(0, size))
       {
         values[i].resize(1);
         values[i].raw_at(0) = 1;
@@ -536,7 +534,7 @@ eval_at_point(const FEMContext & c,
   DynamicSparseNumberArray<Real, dof_id_type> returnval;
   returnval.resize(n_dofs);
 
-  for (auto j : IntRange<unsigned int>(0, n_dofs))
+  for (auto j : IntRange<std::size_t>(0, n_dofs))
     {
       returnval.raw_at(j) = phi[j][0];
       returnval.raw_index(j) = dof_indices[j];
@@ -583,14 +581,12 @@ eval_at_point(const FEMContext & c,
   for (unsigned int d = 0; d != LIBMESH_DIM; ++d)
     returnval(d).resize(n_dofs);
 
-  for (auto j : IntRange<unsigned int>(0, n_dofs))
-    {
-      for (unsigned int d = 0; d != LIBMESH_DIM; ++d)
-        {
-          returnval(d).raw_at(j) = dphi[j][0](d);
-          returnval(d).raw_index(j) = dof_indices[j];
-        }
-    }
+  for (auto j : IntRange<std::size_t>(0, n_dofs))
+    for (auto d : IntRange<int>(0, LIBMESH_DIM))
+      {
+        returnval(d).raw_at(j) = dphi[j][0](d);
+        returnval(d).raw_index(j) = dof_indices[j];
+      }
 
   return returnval;
 }
@@ -1545,7 +1541,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                 // Some edge dofs are on nodes and already
                 // fixed, others are free to calculate
                 unsigned int free_dofs = 0;
-                for (auto i : IntRange<unsigned int>(0, n_side_dofs))
+                for (auto i : IntRange<std::size_t>(0, n_side_dofs))
                   if (!dof_is_fixed[side_dofs[i]])
                     free_dof[free_dofs++] = i;
 
@@ -1646,7 +1642,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                 // Some side dofs are on nodes/edges and already
                 // fixed, others are free to calculate
                 unsigned int free_dofs = 0;
-                for (auto i : IntRange<unsigned int>(0, n_side_dofs))
+                for (auto i : IntRange<std::size_t>(0, n_side_dofs))
                   if (!dof_is_fixed[side_dofs[i]])
                     free_dof[free_dofs++] = i;
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -357,10 +357,7 @@ void System::project_vector (const NumericVector<Number> & old_v,
                 std::vector<dof_id_type> new_SCALAR_indices, old_SCALAR_indices;
                 dof_map.SCALAR_dof_indices (new_SCALAR_indices, var, false);
                 dof_map.SCALAR_dof_indices (old_SCALAR_indices, var, true);
-                const unsigned int new_n_dofs =
-                  cast_int<unsigned int>(new_SCALAR_indices.size());
-
-                for (auto i : IntRange<int>(0, new_n_dofs))
+                for (auto i : index_range(new_SCALAR_indices))
                   new_vector.set(new_SCALAR_indices[i], old_vector(old_SCALAR_indices[i]));
               }
         }
@@ -486,10 +483,9 @@ public:
     const std::vector<dof_id_type> & old_dof_indices =
       this->old_context.get_dof_indices(var);
 
-    std::size_t size = values.size();
-    libmesh_assert_equal_to (old_dof_indices.size(), size);
+    libmesh_assert_equal_to (old_dof_indices.size(), values.size());
 
-    for (auto i : IntRange<std::size_t>(0, size))
+    for (auto i : index_range(values))
       {
         values[i].resize(1);
         values[i].raw_at(0) = 1;
@@ -534,7 +530,7 @@ eval_at_point(const FEMContext & c,
   DynamicSparseNumberArray<Real, dof_id_type> returnval;
   returnval.resize(n_dofs);
 
-  for (auto j : IntRange<std::size_t>(0, n_dofs))
+  for (auto j : index_range(phi))
     {
       returnval.raw_at(j) = phi[j][0];
       returnval.raw_index(j) = dof_indices[j];
@@ -581,8 +577,8 @@ eval_at_point(const FEMContext & c,
   for (unsigned int d = 0; d != LIBMESH_DIM; ++d)
     returnval(d).resize(n_dofs);
 
-  for (auto j : IntRange<std::size_t>(0, n_dofs))
-    for (auto d : IntRange<int>(0, LIBMESH_DIM))
+  for (auto j : index_range(dphi))
+    for (int d = 0; d != LIBMESH_DIM; ++d)
       {
         returnval(d).raw_at(j) = dphi[j][0](d);
         returnval(d).raw_index(j) = dof_indices[j];
@@ -1541,7 +1537,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                 // Some edge dofs are on nodes and already
                 // fixed, others are free to calculate
                 unsigned int free_dofs = 0;
-                for (auto i : IntRange<std::size_t>(0, n_side_dofs))
+                for (auto i : IntRange<unsigned int>(0, n_side_dofs))
                   if (!dof_is_fixed[side_dofs[i]])
                     free_dof[free_dofs++] = i;
 
@@ -1636,13 +1632,10 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                 FEInterface::dofs_on_side(elem, dim, fe_type, s,
                                           side_dofs);
 
-                const unsigned int n_side_dofs =
-                  cast_int<unsigned int>(side_dofs.size());
-
                 // Some side dofs are on nodes/edges and already
                 // fixed, others are free to calculate
                 unsigned int free_dofs = 0;
-                for (auto i : IntRange<std::size_t>(0, n_side_dofs))
+                for (auto i : index_range(side_dofs))
                   if (!dof_is_fixed[side_dofs[i]])
                     free_dof[free_dofs++] = i;
 
@@ -1659,6 +1652,9 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                 fe->attach_quadrature_rule (qsiderule.get());
                 fe->reinit (elem, s);
                 const unsigned int n_qp = qsiderule->n_points();
+
+                const unsigned int n_side_dofs =
+                  cast_int<unsigned int>(side_dofs.size());
 
                 // Loop over the quadrature points
                 for (unsigned int qp=0; qp<n_qp; qp++)


### PR DESCRIPTION
This helper allows us to rewrite loops over `std::vectors` in which indices are required in such a way that:

1. No explicit index type is used at the call site.
1. We avoid repeated calls to `vector::size()` in the loop termination test (although it's not clear if that's really much of an optimization...)

So, for example, a typical for-loop could be rewritten as:
```diff
-      for (unsigned int s = 0; s != sysnames.size(); ++s)
+      for (auto s : index_range(sysnames))
```
Note that the underlying index type is `std::size_t` as that is the type returned by `vector::size()`. It is still possible to do explicit signed integer iteration by constructing an `IntRange<int>` on the fly, and I have also done that in a few cases in this patch. I still need to test how well compilers are able to vectorize `IntRange<int>` loops... if it doesn't seem to work, I'll revert to non range-based loops instead in those cases.  

As you might imagine, we have many places in the library where we can use this helper, I've only fixed about 10% of them in this initial PR. I'm planning to keep all these small commits on this branch just in case I've broken something and need to go back and bisect.


