### PR TITLE
Fix for example when Exodus II is not available.

### DIFF
--- a/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
+++ b/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
@@ -349,6 +349,11 @@ int main (int argc, char ** argv)
   libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
                            "--enable-petsc, --enable-trilinos, or --enable-eigen");
 
+#ifndef LIBMESH_HAVE_EXODUS_API
+  // example requires ExodusII to load the mesh
+  libmesh_example_requires(false, "--enable-exodus");
+#endif
+
   // Initialize the cantilever mesh
   const unsigned int dim = 3;
 


### PR DESCRIPTION
The example `systems_of_equations_ex9` fails, when Exodus II is not available. This PR adds a corresponding check to the example.