### PR TITLE
Fix output data format in legacy SCM writes

### DIFF
--- a/src/reduced_basis/rb_scm_evaluation.C
+++ b/src/reduced_basis/rb_scm_evaluation.C
@@ -395,7 +395,7 @@ void RBSCMEvaluation::legacy_write_offline_data_to_files(const std::string & dir
       file_name << directory_name << "/C_J_length" << suffix;
       Xdr C_J_length_out(file_name.str(), mode);
 
-      std::size_t C_J_length = C_J.size();
+      unsigned int C_J_length = cast_int<unsigned int>(C_J.size());
       C_J_length_out << C_J_length;
       C_J_length_out.close();
 


### PR DESCRIPTION
This fixes reduced_basis_ex2 for me, from a bug in 7b63e4a which
somehow made it through CI.

Apologies to @dknez and I hope this didn't bite any of his users.  Is there any easy way we could get that example running in parallel?  I apparently go many months in between running "make check" on one processor.

@jwpeterson, could we add SLEPC and GLPK modules to the environment of "Test"?