### PR TITLE
Re-implement parallel sync using the NBX algorithm

### DIFF
--- a/include/parallel/communicator.h
+++ b/include/parallel/communicator.h
@@ -215,6 +215,11 @@ public:
   void barrier () const;
 
   /**
+   * Start a barrier that doesn't block
+   */
+  void nonblocking_barrier (Request & req) const;
+
+  /**
    * Verify that a local variable has the same value on all processors.
    * Containers must have the same value in every entry.
    */
@@ -412,6 +417,36 @@ public:
                 const DataType & type,
                 Request & req,
                 const MessageTag & tag=any_tag) const;
+
+  /**
+   * Nonblocking-receive from one processor with user-defined type.
+   *
+   * Checks to see if a message can be received from the
+   * src_processor_id .  If so, it starts a non-blocking
+   * receive using the passed in request and returns true
+   *
+   * Otherwise - if there is no message to receive it returns false
+   *
+   * Note: The buf does NOT need to properly sized before this call
+   * this will resize the buffer automatically
+   *
+   * If \p T is a container, container-of-containers, etc., then
+   * \p type should be the DataType of the underlying fixed-size
+   * entries in the container(s).
+   *
+   * @param src_processor_id The pid to receive from or "any".
+   * will be set to the actual src being receieved from
+   * @param buf THe buffer to receive into
+   * @param type The intrinsic datatype to receive
+   * @param req The request to use
+   * @param tag The tag to use
+   */
+  template <typename T, typename A>
+  bool possibly_receive (unsigned int & src_processor_id,
+                         std::vector<T,A> & buf,
+                         const DataType & type,
+                         Request & req,
+                         const MessageTag & tag) const;
 
   /**
    * Blocking-send range-of-pointers to one processor.  This

--- a/include/parallel/communicator.h
+++ b/include/parallel/communicator.h
@@ -143,14 +143,18 @@ public:
   const communicator & get() const { return _communicator; }
 
   /**
-   * Get a tag that is unique to this Communicator.
+   * Get a tag that is unique to this Communicator.  A requested tag
+   * value may be provided.  If no request is made then an automatic
+   * unique tag value will be generated; such usage of
+   * get_unique_tag() must be done on every processor in a consistent
+   * order.
    *
    * \note If people are also using magic numbers or copying
    * raw communicators around then we can't guarantee the tag is
    * unique to this MPI_Comm.
    *
-   * \note Leaving \p tagvalue unspecified is recommended.
-   * Manually selecting tag values is dangerous, as tag values may be
+   * \note Leaving \p tagvalue unspecified is recommended in most
+   * cases.  Manually selecting tag values is dangerous, as tag values may be
    * freed and reselected earlier than expected in asynchronous
    * communication algorithms.
    */

--- a/include/parallel/communicator.h
+++ b/include/parallel/communicator.h
@@ -146,10 +146,15 @@ public:
    * Get a tag that is unique to this Communicator.
    *
    * \note If people are also using magic numbers or copying
-   * communicators around then we can't guarantee the tag is unique to
-   * this MPI_Comm.
+   * raw communicators around then we can't guarantee the tag is
+   * unique to this MPI_Comm.
+   *
+   * \note Leaving \p tagvalue unspecified is recommended.
+   * Manually selecting tag values is dangerous, as tag values may be
+   * freed and reselected earlier than expected in asynchronous
+   * communication algorithms.
    */
-  MessageTag get_unique_tag(int tagvalue) const;
+  MessageTag get_unique_tag(int tagvalue = MessageTag::invalid_tag) const;
 
   /**
    * Reference an already-acquired tag, so that we know it will
@@ -191,10 +196,15 @@ private:
   processor_id_type _rank, _size;
   SendMode _send_mode;
 
-  // mutable used_tag_values - not thread-safe, but then Parallel::
-  // isn't thread-safe in general.
+  // mutable used_tag_values and tag_queue - not thread-safe, but then
+  // Parallel:: isn't thread-safe in general.
   mutable std::map<int, unsigned int> used_tag_values;
-  bool          _I_duped_it;
+  mutable int _next_tag;
+
+  int _max_tag;
+
+  // Keep track of duplicate/split operations so we know when to free
+  bool _I_duped_it;
 
   // Communication operations:
 public:

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -990,6 +990,48 @@ inline void Communicator::receive (const unsigned int src_processor_id,
 }
 
 
+template <typename T, typename A>
+inline bool Communicator::possibly_receive (unsigned int & src_processor_id,
+                                            std::vector<T,A> & buf,
+                                            const DataType & type,
+                                            Request & req,
+                                            const MessageTag & tag) const
+{
+  LOG_SCOPE("possibly_receive()", "Parallel");
+
+  Status stat(type);
+
+  int int_flag;
+
+  libmesh_call_mpi(MPI_Iprobe(src_processor_id,
+                              tag.value(),
+                              this->get(),
+                              &int_flag,
+                              stat.get()));
+
+  if (int_flag)
+  {
+    buf.resize(stat.size());
+
+    src_processor_id = stat.source();
+
+    libmesh_call_mpi
+      (MPI_Irecv (buf.data(),
+                  cast_int<int>(buf.size()),
+                  type,
+                  src_processor_id,
+                  tag.value(),
+                  this->get(),
+                  req.get()));
+
+    // The MessageTag should stay registered for the Request lifetime
+    req.add_post_wait_work
+      (new Parallel::PostWaitDereferenceTag(tag));
+  }
+
+  return int_flag;
+}
+
 
 template <typename T, typename A1, typename A2>
 inline Status Communicator::receive (const unsigned int src_processor_id,

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -178,6 +178,9 @@ inline status Communicator::probe (const unsigned int src_processor_id,
 
   status stat;
 
+  libmesh_assert(src_processor_id < this->size() ||
+                 src_processor_id == any_source);
+
   libmesh_call_mpi
     (MPI_Probe (src_processor_id, tag.value(), this->get(), &stat));
 
@@ -196,6 +199,9 @@ inline Status Communicator::packed_range_probe (const unsigned int src_processor
   Status stat((StandardType<typename Packing<T>::buffer_type>()));
 
   int int_flag;
+
+  libmesh_assert(src_processor_id < this->size() ||
+                 src_processor_id == any_source);
 
   libmesh_call_mpi(MPI_Iprobe(src_processor_id,
                               tag.value(),
@@ -218,6 +224,8 @@ inline void Communicator::send (const unsigned int dest_processor_id,
 
   T * dataptr = buf.empty() ? nullptr : const_cast<T *>(buf.data());
 
+  libmesh_assert_less(dest_processor_id, this->size());
+
   libmesh_call_mpi
     (((this->send_mode() == SYNCHRONOUS) ?
       MPI_Ssend : MPI_Send) (dataptr,
@@ -239,6 +247,8 @@ inline void Communicator::send (const unsigned int dest_processor_id,
   LOG_SCOPE("send()", "Parallel");
 
   T * dataptr = buf.empty() ? nullptr : const_cast<T *>(buf.data());
+
+  libmesh_assert_less(dest_processor_id, this->size());
 
   libmesh_call_mpi
     (((this->send_mode() == SYNCHRONOUS) ?
@@ -266,6 +276,8 @@ inline void Communicator::send (const unsigned int dest_processor_id,
 
   T * dataptr = const_cast<T*> (&buf);
 
+  libmesh_assert_less(dest_processor_id, this->size());
+
   libmesh_call_mpi
     (((this->send_mode() == SYNCHRONOUS) ?
       MPI_Ssend : MPI_Send) (dataptr,
@@ -287,6 +299,8 @@ inline void Communicator::send (const unsigned int dest_processor_id,
   LOG_SCOPE("send()", "Parallel");
 
   T * dataptr = const_cast<T*>(&buf);
+
+  libmesh_assert_less(dest_processor_id, this->size());
 
   libmesh_call_mpi
     (((this->send_mode() == SYNCHRONOUS) ?
@@ -416,6 +430,8 @@ inline void Communicator::send (const unsigned int dest_processor_id,
                                 const MessageTag & tag) const
 {
   LOG_SCOPE("send()", "Parallel");
+
+  libmesh_assert_less(dest_processor_id, this->size());
 
   libmesh_call_mpi
     (((this->send_mode() == SYNCHRONOUS) ?
@@ -778,6 +794,9 @@ inline Status Communicator::receive (const unsigned int src_processor_id,
   // datatype so we can later query the size
   Status stat(this->probe(src_processor_id, tag), StandardType<T>(&buf));
 
+  libmesh_assert(src_processor_id < this->size() ||
+                 src_processor_id == any_source);
+
   libmesh_call_mpi
     (MPI_Recv (&buf, 1, StandardType<T>(&buf), src_processor_id,
                tag.value(), this->get(), stat.get()));
@@ -794,6 +813,9 @@ inline void Communicator::receive (const unsigned int src_processor_id,
                                    const MessageTag & tag) const
 {
   LOG_SCOPE("receive()", "Parallel");
+
+  libmesh_assert(src_processor_id < this->size() ||
+                 src_processor_id == any_source);
 
   libmesh_call_mpi
     (MPI_Irecv (&buf, 1, StandardType<T>(&buf), src_processor_id,
@@ -929,6 +951,9 @@ inline Status Communicator::receive (const unsigned int src_processor_id,
 
   buf.resize(stat.size());
 
+  libmesh_assert(src_processor_id < this->size() ||
+                 src_processor_id == any_source);
+
   // Use stat.source() and stat.tag() in the receive - if
   // src_processor_id is or tag is "any" then we want to be sure we
   // try to receive the same message we just probed.
@@ -952,6 +977,9 @@ inline void Communicator::receive (const unsigned int src_processor_id,
                                    const MessageTag & tag) const
 {
   LOG_SCOPE("receive()", "Parallel");
+
+  libmesh_assert(src_processor_id < this->size() ||
+                 src_processor_id == any_source);
 
   libmesh_call_mpi
     (MPI_Irecv (buf.empty() ? nullptr : buf.data(),
@@ -1190,6 +1218,10 @@ inline void Communicator::send_receive(const unsigned int dest_processor_id,
       recv = sendvec;
       return;
     }
+
+  libmesh_assert_less(dest_processor_id, this->size());
+  libmesh_assert(source_processor_id < this->size() ||
+                 source_processor_id == any_source);
 
   // MPI_STATUS_IGNORE is from MPI-2; using it with some versions of
   // MPICH may cause a crash:
@@ -1448,6 +1480,8 @@ inline void Communicator::broadcast (bool & data, const unsigned int root_id) co
   // MPI::BOOL available
   char char_data = data;
 
+  libmesh_assert_less(root_id, this->size());
+
   // Spread data to remote processors.
   libmesh_call_mpi
     (MPI_Bcast (&char_data, 1, StandardType<char>(&char_data),
@@ -1514,6 +1548,8 @@ inline void Communicator::broadcast (std::vector<T,A> & data,
   // and get the data from the remote processors.
   // Pass nullptr if our vector is empty.
   T * data_ptr = data.empty() ? nullptr : data.data();
+
+  libmesh_assert_less(root_id, this->size());
 
   libmesh_call_mpi
     (MPI_Bcast (data_ptr, cast_int<int>(data.size()),
@@ -2618,6 +2654,8 @@ inline void Communicator::gather(const unsigned int root_id,
 
       StandardType<T> send_type(&sendval);
 
+      libmesh_assert_less(root_id, this->size());
+
       libmesh_call_mpi
         (MPI_Gather(const_cast<T*>(&sendval), 1, send_type,
                     recv.empty() ? nullptr : recv.data(), 1, send_type,
@@ -2672,6 +2710,8 @@ inline void Communicator::gather(const unsigned int root_id,
   if (root_id == this->rank())
     r.resize(globalsize);
 
+  libmesh_assert_less(root_id, this->size());
+
   // and get the data from the remote processors
   libmesh_call_mpi
     (MPI_Gatherv (r_src.empty() ? nullptr : r_src.data(), mysize,
@@ -2722,6 +2762,8 @@ inline void Communicator::gather(const unsigned int root_id,
       std::string r;
       if (this->rank() == root_id)
         r.resize(globalsize, 0);
+
+      libmesh_assert_less(root_id, this->size());
 
       // and get the data from the remote processors.
       libmesh_call_mpi
@@ -2942,6 +2984,8 @@ void Communicator::scatter(const std::vector<T,A> & data,
   T * data_ptr = const_cast<T*>(data.empty() ? nullptr : data.data());
   libmesh_ignore(data_ptr); // unused ifndef LIBMESH_HAVE_MPI
 
+  libmesh_assert_less(root_id, this->size());
+
   libmesh_call_mpi
     (MPI_Scatter (data_ptr, 1, StandardType<T>(data_ptr),
                   &recv, 1, StandardType<T>(&recv), root_id, this->get()));
@@ -2979,6 +3023,8 @@ void Communicator::scatter(const std::vector<T,A> & data,
   T * data_ptr = const_cast<T*>(data.empty() ? nullptr : data.data());
   T * recv_ptr = recv.empty() ? nullptr : recv.data();
   libmesh_ignore(data_ptr, recv_ptr); // unused ifndef LIBMESH_HAVE_MPI
+
+  libmesh_assert_less(root_id, this->size());
 
   libmesh_call_mpi
     (MPI_Scatter (data_ptr, recv_buffer_size, StandardType<T>(data_ptr),
@@ -3031,6 +3077,8 @@ void Communicator::scatter(const std::vector<T,A1> & data,
   int * count_ptr = const_cast<int*>(counts.empty() ? nullptr : counts.data());
   T * recv_ptr = recv.empty() ? nullptr : recv.data();
   libmesh_ignore(data_ptr, count_ptr, recv_ptr); // unused ifndef LIBMESH_HAVE_MPI
+
+  libmesh_assert_less(root_id, this->size());
 
   // Scatter the non-uniform chunks
   libmesh_call_mpi
@@ -3219,6 +3267,9 @@ inline bool Communicator::possibly_receive (unsigned int & src_processor_id,
   Status stat(type);
 
   int int_flag = 0;
+
+  libmesh_assert(src_processor_id < this->size() ||
+                 src_processor_id == any_source);
 
   libmesh_call_mpi(MPI_Iprobe(src_processor_id,
                               tag.value(),

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -54,42 +54,14 @@ namespace Parallel {
  * All receives and actions are completed before this function
  * returns.
  *
- * Not all sends may have yet completed.  The supplied container of
- * Request objects, \p req, has more requests inserted, one for each
- * of the data sends.  These requests must be waited on before the \p
- * data map is deleted.
- */
-template <typename MapToVectors,
-          typename RequestContainer,
-          typename ActionFunctor>
-void push_parallel_vector_data(const Communicator & comm,
-                               const MapToVectors & data,
-                               RequestContainer & reqs,
-                               const ActionFunctor & act_on_data);
-
-
-
-/**
- * Send and receive and act on vectors of data.
- *
- * The \p data map is indexed by processor ids as keys, and for each
- * processor id in the map there should be a vector of data to send.
- *
- * Data which is received from other processors will be operated on by
- * act_on_data(processor_id_type pid, const std::vector<datum> & data);
- *
- * No guarantee about operation ordering is made - this function will
- * attempt to act on data in the order in which it is received.
- *
- * All communication and actions are complete when this function
- * returns.
+ * Note: it is very important that the message tag be completely
+ * unique to each invocation
  */
 template <typename MapToVectors,
           typename ActionFunctor>
 void push_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & data,
                                const ActionFunctor & act_on_data);
-
 
 /**
  * Send query vectors, receive and answer them with vectors of data,
@@ -117,50 +89,6 @@ void push_parallel_vector_data(const Communicator & comm,
  *
  * All receives and actions are completed before this function
  * returns.
- *
- * Not all sends may have yet completed.  The supplied container of
- * Request objects, \p req, has more requests inserted, one for each
- * of the data sends.  These requests must be waited on before the \p
- * data map is deleted.
- */
-template <typename datum,
-          typename MapToVectors,
-          typename RequestContainer,
-          typename GatherFunctor,
-          typename ActionFunctor>
-void pull_parallel_vector_data(const Communicator & comm,
-                               const MapToVectors & queries,
-                               RequestContainer & reqs,
-                               GatherFunctor & gather_data,
-                               ActionFunctor & act_on_data,
-                               const datum * example);
-
-/**
- * Send query vectors, receive and answer them with vectors of data,
- * then act on those answers.
- *
- * The \p data map is indexed by processor ids as keys, and for each
- * processor id in the map there should be a vector of query ids to send.
- *
- * Query data which is received from other processors will be operated
- * on by
- * gather_data(processor_id_type pid, const std::vector<id> & ids,
- *             std::vector<datum> & data)
- *
- * Answer data which is received from other processors will be operated on by
- * act_on_data(processor_id_type pid, const std::vector<id> & ids,
- *             const std::vector<datum> & data);
- *
- * The example pointer may be null; it merely needs to be of the
- * correct type.  It's just here because function overloading in C++
- * is easy, whereas SFINAE is hard and partial template specialization
- * of functions is impossible.
- *
- * No guarantee about operation ordering is made - this function will
- * attempt to act on data in the order in which it is received.
- *
- * All communication and actions are complete when this function
- * returns.
  */
 template <typename datum,
           typename MapToVectors,
@@ -185,24 +113,6 @@ template <template <typename, typename, typename ...> class MapType,
           typename A1,
           typename A2,
           typename ... ExtraTypes,
-          typename RequestContainer,
-          typename ActionFunctor>
-void push_parallel_vector_data(const Communicator & comm,
-                               const MapType<processor_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
-                               RequestContainer & reqs,
-                               const ActionFunctor & act_on_data);
-
-
-
-/*
- * A specialization for types that are harder to non-blocking receive.
- */
-template <template <typename, typename, typename ...> class MapType,
-          typename KeyType,
-          typename ValueType,
-          typename A1,
-          typename A2,
-          typename ... ExtraTypes,
           typename ActionFunctor>
 void push_parallel_vector_data(const Communicator & comm,
                                const MapType<processor_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
@@ -214,16 +124,13 @@ void push_parallel_vector_data(const Communicator & comm,
 template <typename datum,
           typename A,
           typename MapToVectors,
-          typename RequestContainer,
           typename GatherFunctor,
           typename ActionFunctor>
 void pull_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & queries,
-                               RequestContainer & reqs,
                                GatherFunctor & gather_data,
                                ActionFunctor & act_on_data,
                                const std::vector<datum,A> * example);
-
 
 
 
@@ -235,11 +142,9 @@ void pull_parallel_vector_data(const Communicator & comm,
 //
 
 template <typename MapToVectors,
-          typename RequestContainer,
           typename ActionFunctor>
 void push_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & data,
-                               RequestContainer & reqs,
                                const ActionFunctor & act_on_data)
 {
   // This function must be run on all processors at once
@@ -269,7 +174,7 @@ void push_parallel_vector_data(const Communicator & comm,
 
   // We'll grab a tag so we can overlap request sends and receives
   // without confusing one for the other
-  MessageTag tag = comm.get_unique_tag(1225);
+  auto tag = comm.get_unique_tag();
 
   MapToVectors received_data;
 
@@ -282,6 +187,9 @@ void push_parallel_vector_data(const Communicator & comm,
   // the sends are complete
   const_cast<Communicator &>(comm).send_mode(Communicator::SYNCHRONOUS);
 
+  // The send requests
+  std::list<Request> reqs;
+
   for (auto & datapair : data)
     {
       processor_id_type destid = datapair.first;
@@ -293,8 +201,8 @@ void push_parallel_vector_data(const Communicator & comm,
       else
         {
           Request sendreq;
-          comm.send(destid, datum, datatype, sendreq, tag);
-          reqs.insert(reqs.end(), sendreq);
+          comm.send(destid, datum,/* datatype,*/ sendreq, tag);
+          reqs.push_back(sendreq);
         }
     }
 
@@ -355,34 +263,38 @@ void push_parallel_vector_data(const Communicator & comm,
                              return false;
                            });
 
+    reqs.remove_if([](Request & req)
+                   {
+                     if (req.test())
+                     {
+                       // Do Post-Wait work
+                       req.wait();
+
+                       return true;
+                     }
+
+                     // Not finished yet
+                     return false;
+                   });
+
+
     // See if all of the sends are finished
-    if (!sends_complete)
-    {
-      for (auto & req : reqs)
-      {
-        sends_complete = req.test();
-
-        if (!sends_complete)
-          break;
-      }
-    }
-
+    if (reqs.empty())
+      sends_complete = true;
 
     // If they've all completed then we can start the barrier
     if (sends_complete && !started_barrier)
     {
-      // Need to wait on each send request to make sure post-wait work is done
-      for (auto & req : reqs)
-        req.wait();
-
       started_barrier = true;
       comm.nonblocking_barrier(barrier_request);
     }
 
-    // See if all proessors have finished all sends (i.e. _done_!)
-    if (started_barrier)
-      if (barrier_request.test())
-        break; // Done!
+    // Must fully receive everything before being allowed to move on!
+    if (receive_reqs.empty())
+      // See if all proessors have finished all sends (i.e. _done_!)
+      if (started_barrier)
+        if (barrier_request.test())
+          break; // Done!
   }
 
   // Reset the send mode
@@ -390,17 +302,14 @@ void push_parallel_vector_data(const Communicator & comm,
 }
 
 
-
 template <template <typename, typename, typename ...> class MapType,
           typename ValueType,
           typename A1,
           typename A2,
           typename ... ExtraTypes,
-          typename RequestContainer,
           typename ActionFunctor>
 void push_parallel_vector_data(const Communicator & comm,
                                const MapType<processor_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
-                               RequestContainer & reqs,
                                const ActionFunctor & act_on_data)
 {
   // This function must be run on all processors at once
@@ -440,7 +349,10 @@ void push_parallel_vector_data(const Communicator & comm,
 
   // We'll grab a tag so we can overlap request sends and receives
   // without confusing one for the other
-  MessageTag tag = comm.get_unique_tag(1225);
+  MessageTag tag = comm.get_unique_tag();
+
+  // The send requests
+  std::list<Request> reqs;
 
   // Post all of the sends, non-blocking
   for (auto & datapair : data)
@@ -459,7 +371,7 @@ void push_parallel_vector_data(const Communicator & comm,
         {
           Request sendreq;
           comm.send(destid, datum, datatype, sendreq, tag);
-          reqs.insert(reqs.end(), sendreq);
+          reqs.push_back(sendreq);
         }
     }
 
@@ -479,52 +391,19 @@ void push_parallel_vector_data(const Communicator & comm,
       comm.receive(proc_id, received_data, datatype, tag);
       act_on_data(proc_id, received_data);
     }
+
+  // Wat on all the sends to complete
+  for (auto & req : reqs)
+    req.wait();
 }
-
-
-
-template <typename MapToVectors,
-          typename ActionFunctor>
-void push_parallel_vector_data(const Communicator & comm,
-                               const MapToVectors & data,
-                               const ActionFunctor & act_on_data)
-{
-  std::vector<Request> requests;
-
-  push_parallel_vector_data(comm, data, requests, act_on_data);
-
-  wait(requests);
-}
-
-
-
-template <template <typename, typename, typename ...> class MapType,
-          typename ValueType,
-          typename A1,
-          typename A2,
-          typename ... ExtraTypes,
-          typename ActionFunctor>
-void push_parallel_vector_data(const Communicator & comm,
-                               const MapType<processor_id_type, std::vector<std::vector<ValueType,A1>,A2>, ExtraTypes...> & data,
-                               const ActionFunctor & act_on_data)
-{
-  std::vector<Request> requests;
-
-  push_parallel_vector_data(comm, data, requests, act_on_data);
-
-  wait(requests);
-}
-
 
 
 template <typename datum,
           typename MapToVectors,
-          typename RequestContainer,
           typename GatherFunctor,
           typename ActionFunctor>
 void pull_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & queries,
-                               RequestContainer & reqs,
                                GatherFunctor & gather_data,
                                ActionFunctor & act_on_data,
                                const datum *)
@@ -533,106 +412,39 @@ void pull_parallel_vector_data(const Communicator & comm,
 
   std::map<processor_id_type, std::vector<datum> >
     response_data, received_data;
-  std::vector<Request> response_reqs;
 
   StandardType<datum> datatype;
 
-  // We'll grab a tag so we can overlap request sends and receives
-  // without confusing one for the other
-  MessageTag tag = comm.get_unique_tag(105);
-
   auto gather_functor =
-    [&comm, &gather_data, &response_data, &response_reqs, &datatype, &tag]
+    [&gather_data, &response_data]
     (processor_id_type pid, query_type query)
     {
       gather_data(pid, query, response_data[pid]);
       libmesh_assert_equal_to(query.size(), response_data[pid].size());
-
-      // Just act on data later if the user requested a send-to-self
-      if (pid != comm.rank())
-        {
-          Request sendreq;
-          comm.send(pid, response_data[pid], datatype, sendreq, tag);
-          response_reqs.push_back(sendreq);
-        }
     };
 
-  push_parallel_vector_data (comm, queries, reqs, gather_functor);
+  push_parallel_vector_data (comm, queries, gather_functor);
 
-  // Every outgoing query should now have an incoming response.
-  // Post all of the receives, non-blocking
-  std::vector<Request> receive_reqs;
-  std::vector<processor_id_type> receive_procids;
-  for (auto & querypair : queries)
+  auto action_functor =
+    [&act_on_data, &queries]
+    (processor_id_type pid, const std::vector<datum> & data)
     {
-      processor_id_type proc_id = querypair.first;
-      libmesh_assert_less(proc_id, comm.size());
+      act_on_data(pid, queries.at(pid), data);
+    };
 
-      if (proc_id == comm.rank())
-        {
-          libmesh_assert(queries.count(proc_id));
-          libmesh_assert_equal_to(queries.at(proc_id).size(),
-                                  response_data.at(proc_id).size());
-          act_on_data(proc_id, queries.at(proc_id), response_data.at(proc_id));
-        }
-      else
-        {
-          auto & querydata = querypair.second;
-          Request req;
-          auto & incoming_data = received_data[proc_id];
-          incoming_data.resize(querydata.size());
-          comm.receive(proc_id, incoming_data, datatype, req, tag);
-          receive_reqs.push_back(req);
-          receive_procids.push_back(proc_id);
-        }
-    }
-
-  while(receive_reqs.size())
-    {
-      std::size_t completed = waitany(receive_reqs);
-      processor_id_type proc_id = receive_procids[completed];
-      receive_reqs.erase(receive_reqs.begin() + completed);
-      receive_procids.erase(receive_procids.begin() + completed);
-
-      libmesh_assert(queries.count(proc_id));
-      libmesh_assert_equal_to(queries.at(proc_id).size(),
-                              received_data[proc_id].size());
-      act_on_data(proc_id, queries.at(proc_id), received_data[proc_id]);
-      received_data.erase(proc_id);
-    }
-
-  wait(response_reqs);
+  push_parallel_vector_data (comm, response_data, action_functor);
 }
 
 
-template <typename datum,
-          typename MapToVectors,
-          typename GatherFunctor,
-          typename ActionFunctor>
-void pull_parallel_vector_data(const Communicator & comm,
-                               const MapToVectors & queries,
-                               GatherFunctor & gather_data,
-                               ActionFunctor & act_on_data,
-                               const datum * example)
-{
-  std::vector<Request> requests;
-
-  pull_parallel_vector_data(comm, queries, requests, gather_data,
-                            act_on_data, example);
-
-  wait(requests);
-}
 
 
 template <typename datum,
           typename A,
           typename MapToVectors,
-          typename RequestContainer,
           typename GatherFunctor,
           typename ActionFunctor>
 void pull_parallel_vector_data(const Communicator & comm,
                                const MapToVectors & queries,
-                               RequestContainer & reqs,
                                GatherFunctor & gather_data,
                                ActionFunctor & act_on_data,
                                const std::vector<datum,A> *)
@@ -645,7 +457,7 @@ void pull_parallel_vector_data(const Communicator & comm,
 
   // We'll grab a tag so we can overlap request sends and receives
   // without confusing one for the other
-  MessageTag tag = comm.get_unique_tag(105);
+  MessageTag tag = comm.get_unique_tag();
 
   auto gather_functor =
     [&comm, &gather_data, &act_on_data,
@@ -669,7 +481,7 @@ void pull_parallel_vector_data(const Communicator & comm,
         }
     };
 
-  push_parallel_vector_data (comm, queries, reqs, gather_functor);
+  push_parallel_vector_data (comm, queries, gather_functor);
 
   // Every outgoing query should now have an incoming response.
   //

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3642,7 +3642,6 @@ void DofMap::scatter_constraints(MeshBase & mesh)
       pushed_keys_vals_to_me[pid] = data;
     };
 
-  // Trade pushed dof constraint rows
   Parallel::push_parallel_vector_data
     (this->comm(), pushed_ids_rhss, ids_rhss_action_functor);
   Parallel::push_parallel_vector_data

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -3060,7 +3060,7 @@ void DofMap::allgather_recursive_constraints(MeshBase & mesh)
 
   // We may be receiving packed_range sends out of order with
   // parallel_sync tags, so make sure they're received correctly.
-  Parallel::MessageTag range_tag = this->comm().get_unique_tag(14142);
+  Parallel::MessageTag range_tag = this->comm().get_unique_tag();
 
   while (unexpanded_set_nonempty)
     {
@@ -3541,7 +3541,7 @@ void DofMap::scatter_constraints(MeshBase & mesh)
 
   // We may be receiving packed_range sends out of order with
   // parallel_sync tags, so make sure they're received correctly.
-  Parallel::MessageTag range_tag = this->comm().get_unique_tag(1414);
+  Parallel::MessageTag range_tag = this->comm().get_unique_tag();
 
 #ifdef LIBMESH_ENABLE_NODE_CONSTRAINTS
   std::map<processor_id_type, std::set<dof_id_type>> pushed_node_ids;

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -449,8 +449,8 @@ void Build::parallel_sync ()
   auto pid = comm.rank();
   auto num_procs = comm.size();
 
-  auto dof_tag = comm.get_unique_tag(998);
-  auto row_tag = comm.get_unique_tag(9998);
+  auto dof_tag = comm.get_unique_tag();
+  auto row_tag = comm.get_unique_tag();
 
   const auto n_global_dofs   = dof_map.n_dofs();
   const auto n_dofs_on_proc  = dof_map.n_dofs_on_processor(pid);

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1836,9 +1836,9 @@ BoundaryInfo::build_node_list_from_side_list()
   // Otherwise we need to push ghost node bcids to their owners, then
   // pull ghost node bcids from their owners.
   Parallel::MessageTag
-    node_pushes_tag = this->comm().get_unique_tag(31337),
-    node_pulls_tag = this->comm().get_unique_tag(31338),
-    node_responses_tag = this->comm().get_unique_tag(31339);
+    node_pushes_tag = this->comm().get_unique_tag(),
+    node_pulls_tag = this->comm().get_unique_tag(),
+    node_responses_tag = this->comm().get_unique_tag();
 
   std::vector<Parallel::Request> node_push_requests(n_proc-1);
 

--- a/src/mesh/mesh_communication.C
+++ b/src/mesh/mesh_communication.C
@@ -588,10 +588,9 @@ void MeshCommunication::gather_neighboring_elements (DistributedMesh & mesh) con
   mesh.find_neighbors (/* reset_remote_elements = */ true,
                        /* reset_current_list    = */ true);
 
-  // Get a unique message tag to use in communications; we'll default
-  // to some numbers around pi*10000
+  // Get a unique message tag to use in communications
   Parallel::MessageTag
-    element_neighbors_tag = mesh.comm().get_unique_tag(31416);
+    element_neighbors_tag = mesh.comm().get_unique_tag();
 
   // Now any element with a nullptr neighbor either
   // (i) lives on the physical domain boundary, or

--- a/src/mesh/mesh_refinement.C
+++ b/src/mesh/mesh_refinement.C
@@ -1100,7 +1100,7 @@ bool MeshRefinement::make_coarsening_compatible()
       parallel_object_only();
 
       Parallel::MessageTag
-        uncoarsenable_tag = this->comm().get_unique_tag(2718);
+        uncoarsenable_tag = this->comm().get_unique_tag();
       std::vector<Parallel::Request> uncoarsenable_push_requests(n_proc-1);
 
       for (processor_id_type p = 0; p != n_proc; ++p)
@@ -1733,7 +1733,7 @@ void MeshRefinement::uniformly_coarsen (unsigned int n)
               parents_to_coarsen[elem->processor_id()].push_back(elem->id());
 
           Parallel::MessageTag
-            coarsen_tag = this->comm().get_unique_tag(271);
+            coarsen_tag = this->comm().get_unique_tag();
           std::vector<Parallel::Request> coarsen_push_requests(n_proc-1);
 
           for (processor_id_type p = 0; p != n_proc; ++p)

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -2365,11 +2365,8 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
         }
     };
 
-  // Push using non-blocking I/O
-  std::vector<Parallel::Request> push_requests;
-
   Parallel::push_parallel_vector_data
-    (mesh.comm(), ids_to_push, push_requests, action_functor);
+    (mesh.comm(), ids_to_push, action_functor);
 
   // Now new_proc_ids is correct for every node we used to own.  Let's
   // ask every other processor about the nodes they used to own.  But
@@ -2382,9 +2379,6 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
       if (it != new_proc_ids.end() && it->second != mesh.processor_id())
         ex_local_nodes.insert(node);
     }
-
-  // Let's finish with previous I/O before we start more.
-  Parallel::wait(push_requests);
 
   SyncProcIdsFromMap sync(new_proc_ids, mesh);
   if (repartition_all_nodes)

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -376,7 +376,7 @@ void Nemesis_IO::read (const std::string & base_filename)
   // we do not own
 
   // Let's get a unique message tag to use for send()/receive()
-  Parallel::MessageTag nodes_tag = mesh.comm().get_unique_tag(12345);
+  Parallel::MessageTag nodes_tag = mesh.comm().get_unique_tag();
 
   std::vector<std::vector<int>>
     needed_node_idxs (nemhelper->num_node_cmaps); // the indices we will ask for

--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -770,8 +770,8 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
         coord_request_handles(this->n_processors()-1);
 
       Parallel::MessageTag
-        id_tag    = mesh.comm().get_unique_tag(1234),
-        coord_tag = mesh.comm().get_unique_tag(1235);
+        id_tag    = mesh.comm().get_unique_tag(),
+        coord_tag = mesh.comm().get_unique_tag();
 
       // Post the receives -- do this on processor 0 only.
       if (this->processor_id() == 0)
@@ -909,8 +909,8 @@ void XdrIO::write_serialized_nodes (Xdr & io, const dof_id_type max_node_id) con
         id_request_handles(this->n_processors()-1);
 
       Parallel::MessageTag
-        unique_id_tag = mesh.comm().get_unique_tag(1236),
-        id_tag    = mesh.comm().get_unique_tag(1237);
+        unique_id_tag = mesh.comm().get_unique_tag(),
+        id_tag    = mesh.comm().get_unique_tag();
 
       // Post the receives -- do this on processor 0 only.
       if (this->processor_id() == 0)

--- a/src/parallel/communicator.C
+++ b/src/parallel/communicator.C
@@ -197,6 +197,19 @@ void Communicator::barrier () const
 void Communicator::barrier () const {}
 #endif
 
+#ifdef LIBMESH_HAVE_MPI
+void Communicator::nonblocking_barrier (Request & req) const
+{
+  if (this->size() > 1)
+    {
+      LOG_SCOPE("nonblocking_barrier()", "Parallel");
+      libmesh_call_mpi(MPI_Ibarrier (this->get(), req.get()));
+    }
+}
+#else
+void Communicator::barrier () const {}
+#endif
+
 
 MessageTag Communicator::get_unique_tag(int tagvalue) const
 {

--- a/src/parallel/communicator.C
+++ b/src/parallel/communicator.C
@@ -21,6 +21,7 @@
 
 // libMesh includes
 #include "libmesh/libmesh_logging.h"
+#include "libmesh/parallel_implementation.h" // for inline max(int)
 
 namespace libMesh
 {

--- a/src/parallel/communicator.C
+++ b/src/parallel/communicator.C
@@ -62,6 +62,8 @@ Communicator::Communicator () :
   _size(1),
   _send_mode(DEFAULT),
   used_tag_values(),
+  _next_tag(0),
+  _max_tag(std::numeric_limits<int>::max()),
   _I_duped_it(false) {}
 
 
@@ -73,6 +75,8 @@ Communicator::Communicator (const communicator & comm) :
   _size(1),
   _send_mode(DEFAULT),
   used_tag_values(),
+  _next_tag(0),
+  _max_tag(std::numeric_limits<int>::max()),
   _I_duped_it(false)
 {
   this->assign(comm);
@@ -170,12 +174,20 @@ void Communicator::assign(const communicator & comm)
 
       libmesh_assert_greater_equal (i, 0);
       _rank = cast_int<processor_id_type>(i);
+
+      int * maxTag;
+      int flag = false;
+      libmesh_call_mpi(MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, &maxTag, &flag));
+      libmesh_assert(flag);
+      _max_tag = *maxTag;
     }
   else
     {
       _rank = 0;
       _size = 1;
+      _max_tag = std::numeric_limits<int>::max();
     }
+  _next_tag = _max_tag / 2;
 #endif
   _send_mode = DEFAULT;
 }
@@ -207,12 +219,15 @@ void Communicator::nonblocking_barrier (Request & req) const
     }
 }
 #else
-void Communicator::barrier () const {}
+void Communicator::nonblocking_barrier (Request & /*req*/) const {}
 #endif
 
 
 MessageTag Communicator::get_unique_tag(int tagvalue) const
 {
+  if (tagvalue == MessageTag::invalid_tag)
+    tagvalue = _next_tag++;
+
   if (used_tag_values.count(tagvalue))
     {
       // Get the largest value in the used values, and pick one
@@ -220,15 +235,13 @@ MessageTag Communicator::get_unique_tag(int tagvalue) const
       tagvalue = used_tag_values.rbegin()->first+1;
       libmesh_assert(!used_tag_values.count(tagvalue));
     }
-  used_tag_values[tagvalue] = 1;
+  if (tagvalue >= _next_tag)
+    _next_tag = tagvalue+1;
 
-  // #ifndef NDEBUG
-  //   // Make sure everyone called get_unique_tag and make sure
-  //   // everyone got the same value
-  //   int maxval = tagvalue;
-  //   this->max(maxval);
-  //   libmesh_assert_equal_to (tagvalue, maxval);
-  // #endif
+  if (_next_tag >= _max_tag)
+    _next_tag = _max_tag/2;
+
+  used_tag_values[tagvalue] = 1;
 
   return MessageTag(tagvalue, this);
 }

--- a/src/parallel/communicator.C
+++ b/src/parallel/communicator.C
@@ -226,7 +226,15 @@ void Communicator::nonblocking_barrier (Request & /*req*/) const {}
 MessageTag Communicator::get_unique_tag(int tagvalue) const
 {
   if (tagvalue == MessageTag::invalid_tag)
-    tagvalue = _next_tag++;
+    {
+#ifndef NDEBUG
+      // Automatic tag values have to be requested in sync
+      int maxval = _next_tag;
+      this->max(maxval);
+      libmesh_assert_equal_to(_next_tag, maxval);
+#endif
+      tagvalue = _next_tag++;
+    }
 
   if (used_tag_values.count(tagvalue))
     {

--- a/src/systems/system_io.C
+++ b/src/systems/system_io.C
@@ -1133,7 +1133,7 @@ unsigned int System::read_SCALAR_dofs (const unsigned int var,
 #ifdef LIBMESH_HAVE_MPI
   if (this->n_processors() > 1)
     {
-      const Parallel::MessageTag val_tag = this->comm().get_unique_tag(321);
+      const Parallel::MessageTag val_tag = this->comm().get_unique_tag();
 
       // Post the receive on the last processor
       if (this->processor_id() == (this->n_processors()-1))

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -74,6 +74,7 @@ unit_tests_sources = \
   parallel/message_tag.C \
   parallel/packed_range_test.C \
   parallel/parallel_sort_test.C \
+  parallel/parallel_sync_test.C \
   parallel/parallel_test.C \
   parallel/parallel_point_test.C \
   partitioning/partitioner_test.h \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -71,6 +71,7 @@ unit_tests_sources = \
   numerics/vector_value_test.C \
   numerics/type_tensor_test.C \
   numerics/dense_matrix_test.C \
+  parallel/message_tag.C \
   parallel/packed_range_test.C \
   parallel/parallel_sort_test.C \
   parallel/parallel_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -210,7 +210,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/message_tag.C parallel/packed_range_test.C \
+	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
 	partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
@@ -276,8 +277,10 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	numerics/unit_tests_dbg-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_dbg-message_tag.$(OBJEXT) \
 	parallel/unit_tests_dbg-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_sort_test.$(OBJEXT) \
+	parallel/unit_tests_dbg-parallel_sync_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_point_test.$(OBJEXT) \
 	partitioning/unit_tests_dbg-centroid_partitioner_test.$(OBJEXT) \
@@ -333,7 +336,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/message_tag.C parallel/packed_range_test.C \
+	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
 	partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
@@ -398,8 +402,10 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	numerics/unit_tests_devel-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_devel-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_devel-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_devel-message_tag.$(OBJEXT) \
 	parallel/unit_tests_devel-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_sort_test.$(OBJEXT) \
+	parallel/unit_tests_devel-parallel_sync_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_point_test.$(OBJEXT) \
 	partitioning/unit_tests_devel-centroid_partitioner_test.$(OBJEXT) \
@@ -452,7 +458,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/message_tag.C parallel/packed_range_test.C \
+	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
 	partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
@@ -517,8 +524,10 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	numerics/unit_tests_oprof-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_oprof-message_tag.$(OBJEXT) \
 	parallel/unit_tests_oprof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_sort_test.$(OBJEXT) \
+	parallel/unit_tests_oprof-parallel_sync_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_point_test.$(OBJEXT) \
 	partitioning/unit_tests_oprof-centroid_partitioner_test.$(OBJEXT) \
@@ -571,7 +580,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/message_tag.C parallel/packed_range_test.C \
+	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
 	partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
@@ -636,8 +646,10 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	numerics/unit_tests_opt-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_opt-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_opt-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_opt-message_tag.$(OBJEXT) \
 	parallel/unit_tests_opt-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_sort_test.$(OBJEXT) \
+	parallel/unit_tests_opt-parallel_sync_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_point_test.$(OBJEXT) \
 	partitioning/unit_tests_opt-centroid_partitioner_test.$(OBJEXT) \
@@ -689,7 +701,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/message_tag.C parallel/packed_range_test.C \
+	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
 	partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
@@ -754,8 +767,10 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	numerics/unit_tests_prof-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_prof-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_prof-dense_matrix_test.$(OBJEXT) \
+	parallel/unit_tests_prof-message_tag.$(OBJEXT) \
 	parallel/unit_tests_prof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_sort_test.$(OBJEXT) \
+	parallel/unit_tests_prof-parallel_sync_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_point_test.$(OBJEXT) \
 	partitioning/unit_tests_prof-centroid_partitioner_test.$(OBJEXT) \
@@ -1040,25 +1055,35 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-vector_value_test.Po \
+	parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Po \
 	parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Po \
 	parallel/$(DEPDIR)/unit_tests_dbg-parallel_point_test.Po \
 	parallel/$(DEPDIR)/unit_tests_dbg-parallel_sort_test.Po \
+	parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Po \
 	parallel/$(DEPDIR)/unit_tests_dbg-parallel_test.Po \
+	parallel/$(DEPDIR)/unit_tests_devel-message_tag.Po \
 	parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Po \
 	parallel/$(DEPDIR)/unit_tests_devel-parallel_point_test.Po \
 	parallel/$(DEPDIR)/unit_tests_devel-parallel_sort_test.Po \
+	parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Po \
 	parallel/$(DEPDIR)/unit_tests_devel-parallel_test.Po \
+	parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Po \
 	parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Po \
 	parallel/$(DEPDIR)/unit_tests_oprof-parallel_point_test.Po \
 	parallel/$(DEPDIR)/unit_tests_oprof-parallel_sort_test.Po \
+	parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Po \
 	parallel/$(DEPDIR)/unit_tests_oprof-parallel_test.Po \
+	parallel/$(DEPDIR)/unit_tests_opt-message_tag.Po \
 	parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Po \
 	parallel/$(DEPDIR)/unit_tests_opt-parallel_point_test.Po \
 	parallel/$(DEPDIR)/unit_tests_opt-parallel_sort_test.Po \
+	parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Po \
 	parallel/$(DEPDIR)/unit_tests_opt-parallel_test.Po \
+	parallel/$(DEPDIR)/unit_tests_prof-message_tag.Po \
 	parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Po \
 	parallel/$(DEPDIR)/unit_tests_prof-parallel_point_test.Po \
 	parallel/$(DEPDIR)/unit_tests_prof-parallel_sort_test.Po \
+	parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Po \
 	parallel/$(DEPDIR)/unit_tests_prof-parallel_test.Po \
 	partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Po \
 	partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Po \
@@ -1569,7 +1594,8 @@ unit_tests_sources = driver.C test_comm.h stream_redirector.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/message_tag.C parallel/packed_range_test.C \
+	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
 	parallel/parallel_test.C parallel/parallel_point_test.C \
 	partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
@@ -1791,9 +1817,13 @@ parallel/$(am__dirstamp):
 parallel/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) parallel/$(DEPDIR)
 	@: > parallel/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_dbg-message_tag.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_dbg-packed_range_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_dbg-parallel_sort_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_dbg-parallel_sync_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_dbg-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -1971,9 +2001,13 @@ numerics/unit_tests_devel-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_devel-message_tag.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-packed_range_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-parallel_sort_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_devel-parallel_sync_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -2115,9 +2149,13 @@ numerics/unit_tests_oprof-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_oprof-message_tag.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_oprof-packed_range_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_oprof-parallel_sort_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_oprof-parallel_sync_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_oprof-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -2259,9 +2297,13 @@ numerics/unit_tests_opt-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_opt-message_tag.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-packed_range_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-parallel_sort_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_opt-parallel_sync_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -2403,9 +2445,13 @@ numerics/unit_tests_prof-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_prof-message_tag.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_prof-packed_range_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_prof-parallel_sort_test.$(OBJEXT):  \
+	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
+parallel/unit_tests_prof-parallel_sync_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_prof-parallel_test.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -2717,25 +2763,35 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-vector_value_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_dbg-parallel_point_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_dbg-parallel_sort_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_dbg-parallel_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_devel-message_tag.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_devel-parallel_point_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_devel-parallel_sort_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_devel-parallel_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_oprof-parallel_point_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_oprof-parallel_sort_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_oprof-parallel_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_opt-message_tag.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_opt-parallel_point_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_opt-parallel_sort_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_opt-parallel_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-message_tag.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-parallel_point_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-parallel_sort_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@parallel/$(DEPDIR)/unit_tests_prof-parallel_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Po@am__quote@ # am--include-marker
@@ -3510,6 +3566,20 @@ numerics/unit_tests_dbg-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+parallel/unit_tests_dbg-message_tag.o: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Tpo -c -o parallel/unit_tests_dbg-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_dbg-message_tag.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_dbg-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+
+parallel/unit_tests_dbg-message_tag.obj: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-message_tag.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Tpo -c -o parallel/unit_tests_dbg-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_dbg-message_tag.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_dbg-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+
 parallel/unit_tests_dbg-packed_range_test.o: parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Tpo -c -o parallel/unit_tests_dbg-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Po
@@ -3537,6 +3607,20 @@ parallel/unit_tests_dbg-parallel_sort_test.obj: parallel/parallel_sort_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sort_test.C' object='parallel/unit_tests_dbg-parallel_sort_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_dbg-parallel_sort_test.obj `if test -f 'parallel/parallel_sort_test.C'; then $(CYGPATH_W) 'parallel/parallel_sort_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sort_test.C'; fi`
+
+parallel/unit_tests_dbg-parallel_sync_test.o: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-parallel_sync_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Tpo -c -o parallel/unit_tests_dbg-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_dbg-parallel_sync_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_dbg-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+
+parallel/unit_tests_dbg-parallel_sync_test.obj: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-parallel_sync_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Tpo -c -o parallel/unit_tests_dbg-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_dbg-parallel_sync_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_dbg-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
 
 parallel/unit_tests_dbg-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-parallel_test.Tpo -c -o parallel/unit_tests_dbg-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C
@@ -4448,6 +4532,20 @@ numerics/unit_tests_devel-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+parallel/unit_tests_devel-message_tag.o: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo -c -o parallel/unit_tests_devel-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_devel-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_devel-message_tag.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_devel-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+
+parallel/unit_tests_devel-message_tag.obj: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-message_tag.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo -c -o parallel/unit_tests_devel-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_devel-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_devel-message_tag.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_devel-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+
 parallel/unit_tests_devel-packed_range_test.o: parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Tpo -c -o parallel/unit_tests_devel-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Po
@@ -4475,6 +4573,20 @@ parallel/unit_tests_devel-parallel_sort_test.obj: parallel/parallel_sort_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sort_test.C' object='parallel/unit_tests_devel-parallel_sort_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_devel-parallel_sort_test.obj `if test -f 'parallel/parallel_sort_test.C'; then $(CYGPATH_W) 'parallel/parallel_sort_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sort_test.C'; fi`
+
+parallel/unit_tests_devel-parallel_sync_test.o: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-parallel_sync_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Tpo -c -o parallel/unit_tests_devel-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_devel-parallel_sync_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_devel-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+
+parallel/unit_tests_devel-parallel_sync_test.obj: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-parallel_sync_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Tpo -c -o parallel/unit_tests_devel-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_devel-parallel_sync_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_devel-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
 
 parallel/unit_tests_devel-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-parallel_test.Tpo -c -o parallel/unit_tests_devel-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C
@@ -5386,6 +5498,20 @@ numerics/unit_tests_oprof-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+parallel/unit_tests_oprof-message_tag.o: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Tpo -c -o parallel/unit_tests_oprof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_oprof-message_tag.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_oprof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+
+parallel/unit_tests_oprof-message_tag.obj: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-message_tag.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Tpo -c -o parallel/unit_tests_oprof-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_oprof-message_tag.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_oprof-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+
 parallel/unit_tests_oprof-packed_range_test.o: parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Tpo -c -o parallel/unit_tests_oprof-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Po
@@ -5413,6 +5539,20 @@ parallel/unit_tests_oprof-parallel_sort_test.obj: parallel/parallel_sort_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sort_test.C' object='parallel/unit_tests_oprof-parallel_sort_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_oprof-parallel_sort_test.obj `if test -f 'parallel/parallel_sort_test.C'; then $(CYGPATH_W) 'parallel/parallel_sort_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sort_test.C'; fi`
+
+parallel/unit_tests_oprof-parallel_sync_test.o: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-parallel_sync_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Tpo -c -o parallel/unit_tests_oprof-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_oprof-parallel_sync_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_oprof-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+
+parallel/unit_tests_oprof-parallel_sync_test.obj: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-parallel_sync_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Tpo -c -o parallel/unit_tests_oprof-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_oprof-parallel_sync_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_oprof-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
 
 parallel/unit_tests_oprof-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-parallel_test.Tpo -c -o parallel/unit_tests_oprof-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C
@@ -6324,6 +6464,20 @@ numerics/unit_tests_opt-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+parallel/unit_tests_opt-message_tag.o: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo -c -o parallel/unit_tests_opt-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_opt-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_opt-message_tag.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_opt-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+
+parallel/unit_tests_opt-message_tag.obj: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-message_tag.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo -c -o parallel/unit_tests_opt-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_opt-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_opt-message_tag.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_opt-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+
 parallel/unit_tests_opt-packed_range_test.o: parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Tpo -c -o parallel/unit_tests_opt-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Po
@@ -6351,6 +6505,20 @@ parallel/unit_tests_opt-parallel_sort_test.obj: parallel/parallel_sort_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sort_test.C' object='parallel/unit_tests_opt-parallel_sort_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_opt-parallel_sort_test.obj `if test -f 'parallel/parallel_sort_test.C'; then $(CYGPATH_W) 'parallel/parallel_sort_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sort_test.C'; fi`
+
+parallel/unit_tests_opt-parallel_sync_test.o: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-parallel_sync_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Tpo -c -o parallel/unit_tests_opt-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_opt-parallel_sync_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_opt-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+
+parallel/unit_tests_opt-parallel_sync_test.obj: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-parallel_sync_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Tpo -c -o parallel/unit_tests_opt-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_opt-parallel_sync_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_opt-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
 
 parallel/unit_tests_opt-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-parallel_test.Tpo -c -o parallel/unit_tests_opt-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C
@@ -7262,6 +7430,20 @@ numerics/unit_tests_prof-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+parallel/unit_tests_prof-message_tag.o: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo -c -o parallel/unit_tests_prof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_prof-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_prof-message_tag.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_prof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
+
+parallel/unit_tests_prof-message_tag.obj: parallel/message_tag.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-message_tag.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo -c -o parallel/unit_tests_prof-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_prof-message_tag.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/message_tag.C' object='parallel/unit_tests_prof-message_tag.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_prof-message_tag.obj `if test -f 'parallel/message_tag.C'; then $(CYGPATH_W) 'parallel/message_tag.C'; else $(CYGPATH_W) '$(srcdir)/parallel/message_tag.C'; fi`
+
 parallel/unit_tests_prof-packed_range_test.o: parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-packed_range_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Tpo -c -o parallel/unit_tests_prof-packed_range_test.o `test -f 'parallel/packed_range_test.C' || echo '$(srcdir)/'`parallel/packed_range_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Tpo parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Po
@@ -7289,6 +7471,20 @@ parallel/unit_tests_prof-parallel_sort_test.obj: parallel/parallel_sort_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sort_test.C' object='parallel/unit_tests_prof-parallel_sort_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_prof-parallel_sort_test.obj `if test -f 'parallel/parallel_sort_test.C'; then $(CYGPATH_W) 'parallel/parallel_sort_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sort_test.C'; fi`
+
+parallel/unit_tests_prof-parallel_sync_test.o: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-parallel_sync_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Tpo -c -o parallel/unit_tests_prof-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_prof-parallel_sync_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_prof-parallel_sync_test.o `test -f 'parallel/parallel_sync_test.C' || echo '$(srcdir)/'`parallel/parallel_sync_test.C
+
+parallel/unit_tests_prof-parallel_sync_test.obj: parallel/parallel_sync_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-parallel_sync_test.obj -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Tpo -c -o parallel/unit_tests_prof-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Tpo parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='parallel/parallel_sync_test.C' object='parallel/unit_tests_prof-parallel_sync_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o parallel/unit_tests_prof-parallel_sync_test.obj `if test -f 'parallel/parallel_sync_test.C'; then $(CYGPATH_W) 'parallel/parallel_sync_test.C'; else $(CYGPATH_W) '$(srcdir)/parallel/parallel_sync_test.C'; fi`
 
 parallel/unit_tests_prof-parallel_test.o: parallel/parallel_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-parallel_test.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-parallel_test.Tpo -c -o parallel/unit_tests_prof-parallel_test.o `test -f 'parallel/parallel_test.C' || echo '$(srcdir)/'`parallel/parallel_test.C
@@ -8024,25 +8220,35 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-vector_value_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-parallel_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_devel-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_devel-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_devel-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_devel-parallel_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-parallel_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_opt-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_opt-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_opt-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_opt-parallel_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_prof-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_prof-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_prof-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_prof-parallel_test.Po
 	-rm -f partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Po
 	-rm -f partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Po
@@ -8404,25 +8610,35 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-trilinos_epetra_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-type_tensor_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-vector_value_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_dbg-parallel_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_devel-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_devel-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_devel-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_devel-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_devel-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_devel-parallel_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_oprof-parallel_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_opt-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_opt-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_opt-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_opt-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_opt-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_opt-parallel_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_prof-message_tag.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_prof-packed_range_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_prof-parallel_point_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_prof-parallel_sort_test.Po
+	-rm -f parallel/$(DEPDIR)/unit_tests_prof-parallel_sync_test.Po
 	-rm -f parallel/$(DEPDIR)/unit_tests_prof-parallel_test.Po
 	-rm -f partitioning/$(DEPDIR)/unit_tests_dbg-centroid_partitioner_test.Po
 	-rm -f partitioning/$(DEPDIR)/unit_tests_dbg-hilbert_sfc_partitioner_test.Po

--- a/tests/parallel/message_tag.C
+++ b/tests/parallel/message_tag.C
@@ -1,0 +1,103 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/communicator.h>
+#include <libmesh/message_tag.h>
+
+#include "test_comm.h"
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+using namespace libMesh;
+
+class MessageTagTest : public CppUnit::TestCase {
+public:
+  CPPUNIT_TEST_SUITE( MessageTagTest );
+
+  CPPUNIT_TEST( testGetUniqueTagAuto );
+  CPPUNIT_TEST( testGetUniqueTagManual );
+
+  CPPUNIT_TEST_SUITE_END();
+
+private:
+  std::vector<std::string> _number;
+
+public:
+  void setUp()
+  {}
+
+  void tearDown()
+  {}
+
+
+
+  void testGetUniqueTagAuto()
+  {
+    // We need to duplicate the communicator first, because the
+    // original might already have tags used by other unit tests
+
+    Parallel::Communicator newcomm;
+
+    TestCommWorld->duplicate(newcomm);
+
+    const int n_vals = 5;
+    const int n_vals_in_scope = 3;
+    std::vector<int> vals(n_vals);
+
+    {
+      std::vector<Parallel::MessageTag> tags(n_vals_in_scope);
+      for (int i=0; i != n_vals_in_scope; ++i)
+        {
+          tags[i] = newcomm.get_unique_tag();
+          vals[i] = tags[i].value();
+          for (int j=0; j != i; ++j)
+            {
+              CPPUNIT_ASSERT(vals[i] != vals[j]);
+            }
+        }
+    }
+
+    // Even after we go out of scope those values should be used up
+    for (int i=n_vals_in_scope; i != n_vals; ++i)
+      {
+        Parallel::MessageTag another_tag = newcomm.get_unique_tag();
+        vals[i] = another_tag.value();
+        for (int j=0; j != i; ++j)
+          {
+            CPPUNIT_ASSERT(vals[i] != vals[j]);
+          }
+      }
+  }
+
+
+
+  void testGetUniqueTagManual()
+  {
+    // Here we'll use the standard communicator, because even if it
+    // used these tags in other contexts it should have freed them for
+    // reuse later.
+
+    const int requests[] = {2, 4, 6, 8, 8, 6, 8, 123, 3141, 3142};
+
+    for (const int i : requests)
+      {
+        Parallel::MessageTag manual_tag =
+          TestCommWorld->get_unique_tag(i);
+        CPPUNIT_ASSERT_EQUAL(i, manual_tag.value());
+      }
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( MessageTagTest );

--- a/tests/parallel/parallel_sync_test.C
+++ b/tests/parallel/parallel_sync_test.C
@@ -1,0 +1,124 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/parallel_sync.h>
+
+#include "test_comm.h"
+
+#include <algorithm>
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+using namespace libMesh;
+
+class ParallelSyncTest : public CppUnit::TestCase {
+public:
+  CPPUNIT_TEST_SUITE( ParallelSyncTest );
+
+  CPPUNIT_TEST( testPush );
+
+//  CPPUNIT_TEST( testPushOversized );
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp()
+  {}
+
+  void tearDown()
+  {}
+
+  void testPushImpl(int M)
+  {
+    const int size = TestCommWorld->size(),
+              rank = TestCommWorld->rank();
+
+    // Data to send/recieve with each processor rank.  For this test,
+    // processor p will send to destination d the integer d, in a
+    // vector with sqrt(c)+1 copies, iff c := |p-d| is a square number.
+    std::map<processor_id_type, std::vector<unsigned int> > data, received_data;
+
+    for (int d=0; d != M; ++d)
+      {
+        int diffsize = std::abs(d-rank);
+        int diffsqrt = std::sqrt(diffsize);
+        if (diffsqrt*diffsqrt == diffsize)
+          for (int i=-1; i != diffsqrt; ++i)
+            data[d].push_back(d);
+      }
+
+    auto collect_data =
+      [&received_data]
+      (processor_id_type pid,
+       const std::vector<unsigned int> & data)
+      {
+        received_data[pid] = data;
+      };
+
+    // Do the push
+    Parallel::push_parallel_vector_data(*TestCommWorld, data, collect_data);
+
+    // Test the received results, for each processor id p we're in
+    // charge of.
+    std::vector<std::size_t> checked_sizes(size, 0);
+    for (int p=rank; p != M; p += size)
+      for (int srcp=0; srcp != size; ++srcp)
+        {
+          int diffsize = std::abs(srcp-p);
+          int diffsqrt = std::sqrt(diffsize);
+          if (diffsqrt*diffsqrt != diffsize)
+            {
+              CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(0));
+              continue;
+            }
+
+          CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(1));
+          const std::vector<unsigned int> & datum = received_data[srcp];
+          CPPUNIT_ASSERT_EQUAL(std::count(datum.begin(), datum.end(), p), std::ptrdiff_t(diffsqrt+1));
+          checked_sizes[srcp] += diffsqrt+1;
+        }
+
+    for (int srcp=0; srcp != size; ++srcp)
+      CPPUNIT_ASSERT_EQUAL(checked_sizes[srcp], received_data[srcp].size());
+  }
+
+
+  void testPush()
+  {
+    const int size = TestCommWorld->size();
+
+    // Our sync functions are most typically used with a map of
+    // processor ids that *only* includes ranks currently running.
+    const int M = size;
+
+    testPushImpl(M);
+  }
+
+
+  void testPushOversized()
+  {
+    const int size = TestCommWorld->size();
+
+    // Our sync functions need to support sending to ranks that don't
+    // exist!  If we're on N processors but working on a mesh
+    // partitioned into M parts with M > N, then subpartition p
+    // belongs to processor p%N.  Let's make M > N here.
+    const int M = (size + 4) * 2;
+
+    testPushImpl(M);
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( ParallelSyncTest );

--- a/tests/parallel/parallel_sync_test.C
+++ b/tests/parallel/parallel_sync_test.C
@@ -31,6 +31,7 @@ public:
   CPPUNIT_TEST( testPush );
   CPPUNIT_TEST( testPull );
   CPPUNIT_TEST( testPushVecVec );
+  CPPUNIT_TEST( testPullVecVec );
 
   // Our sync functions need to support sending to ranks that don't
   // exist!  If we're on N processors but working on a mesh
@@ -39,6 +40,7 @@ public:
 //  CPPUNIT_TEST( testPushOversized );
 //  CPPUNIT_TEST( testPullOversized );
 //  CPPUNIT_TEST( testPushVecVecOversized );
+//  CPPUNIT_TEST( testPullVecVecOversized );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -49,16 +51,15 @@ public:
   void tearDown()
   {}
 
-  void testPushImpl(int M)
+
+  // Data to send/recieve with each processor rank.  For this test,
+  // processor p will send to destination d the integer d, in a vector
+  // with sqrt(c)+1 copies, iff c := |p-d| is a square number.
+  void fill_scalar_data
+    (std::map<processor_id_type, std::vector<unsigned int>> & data,
+     int M)
   {
-    const int size = TestCommWorld->size(),
-              rank = TestCommWorld->rank();
-
-    // Data to send/recieve with each processor rank.  For this test,
-    // processor p will send to destination d the integer d, in a
-    // vector with sqrt(c)+1 copies, iff c := |p-d| is a square number.
-    std::map<processor_id_type, std::vector<unsigned int> > data, received_data;
-
+    const int rank = TestCommWorld->rank();
     for (int d=0; d != M; ++d)
       {
         int diffsize = std::abs(d-rank);
@@ -67,17 +68,56 @@ public:
           for (int i=-1; i != diffsqrt; ++i)
             data[d].push_back(d);
       }
+  }
 
-    auto collect_data =
+
+  // Data to send/recieve with each processor rank.  For this test,
+  // processor p will send to destination d the integer d, in two
+  // subvectors with sqrt(c) and 1 copies, iff c := |p-d| is a square
+  // number.
+  void fill_vector_data
+    (std::map<processor_id_type, std::vector<std::vector<unsigned int>>> & data,
+     int M)
+  {
+    const int rank = TestCommWorld->rank();
+    for (int d=0; d != M; ++d)
+      {
+        int diffsize = std::abs(d-rank);
+        int diffsqrt = std::sqrt(diffsize);
+        if (diffsqrt*diffsqrt == diffsize)
+          {
+            data[d].resize(2);
+            for (int i=-1; i != diffsqrt; ++i)
+              data[d][0].push_back(d);
+            data[d][1].push_back(d);
+          }
+      }
+  }
+
+  template <typename MapType>
+  std::function<void(processor_id_type, typename MapType::mapped_type)>
+  data_collector (MapType & received_data)
+  {
+    return
       [&received_data]
       (processor_id_type pid,
-       const std::vector<unsigned int> & data)
+       const typename MapType::mapped_type & data)
       {
         received_data[pid] = data;
       };
+  }
 
-    // Do the push
-    Parallel::push_parallel_vector_data(*TestCommWorld, data, collect_data);
+
+  void testPushImpl(int M)
+  {
+    const int size = TestCommWorld->size(),
+              rank = TestCommWorld->rank();
+
+    std::map<processor_id_type, std::vector<unsigned int> > data, received_data;
+
+    fill_scalar_data(data, M);
+
+    Parallel::push_parallel_vector_data(*TestCommWorld, data, data_collector(received_data));
 
     // Test the received results, for each processor id p we're in
     // charge of.
@@ -121,19 +161,9 @@ public:
     const int size = TestCommWorld->size(),
               rank = TestCommWorld->rank();
 
-    // Data to send/recieve with each processor rank.  For this test,
-    // processor p will send to destination d the integer d, in a
-    // vector with sqrt(c)+1 copies, iff c := |p-d| is a square number.
     std::map<processor_id_type, std::vector<unsigned int> > data, received_data;
 
-    for (int d=0; d != M; ++d)
-      {
-        int diffsize = std::abs(d-rank);
-        int diffsqrt = std::sqrt(diffsize);
-        if (diffsqrt*diffsqrt == diffsize)
-          for (int i=-1; i != diffsqrt; ++i)
-            data[d].push_back(d);
-      }
+    fill_scalar_data(data, M);
 
     auto compose_replies =
       []
@@ -210,35 +240,11 @@ public:
     const int size = TestCommWorld->size(),
               rank = TestCommWorld->rank();
 
-    // Data to send/recieve with each processor rank.  For this test,
-    // processor p will send to destination d the integer d, in two
-    // subvectors with sqrt(c) and 1 copies, iff c := |p-d| is a
-    // square number.
     std::map<processor_id_type, std::vector<std::vector<unsigned int>>> data, received_data;
 
-    for (int d=0; d != M; ++d)
-      {
-        int diffsize = std::abs(d-rank);
-        int diffsqrt = std::sqrt(diffsize);
-        if (diffsqrt*diffsqrt == diffsize)
-          {
-            data[d].resize(2);
-            for (int i=-1; i != diffsqrt; ++i)
-              data[d][0].push_back(d);
-            data[d][1].push_back(d);
-          }
-      }
+    fill_vector_data(data, M);
 
-    auto collect_data =
-      [&received_data]
-      (processor_id_type pid,
-       const std::vector<std::vector<unsigned int>> & data)
-      {
-        received_data[pid] = data;
-      };
-
-    // Do the push
-    Parallel::push_parallel_vector_data(*TestCommWorld, data, collect_data);
+    Parallel::push_parallel_vector_data(*TestCommWorld, data, data_collector(received_data));
 
     // Test the received results, for each processor id p we're in
     // charge of.
@@ -264,7 +270,7 @@ public:
         }
 
     for (int srcp=0; srcp != size; ++srcp)
-      CPPUNIT_ASSERT_EQUAL(checked_sizes[srcp], received_data[srcp].size());
+      CPPUNIT_ASSERT_EQUAL(checked_sizes[srcp], received_data[srcp][0].size());
   }
 
 
@@ -278,6 +284,98 @@ public:
   {
     testPushVecVecImpl((TestCommWorld->size() + 4) * 2);
   }
+
+
+  void testPullVecVecImpl(int M)
+  {
+    const int size = TestCommWorld->size(),
+              rank = TestCommWorld->rank();
+
+    std::map<processor_id_type, std::vector<std::vector<unsigned int>>> data, received_data;
+
+    fill_vector_data(data, M);
+
+    auto compose_replies =
+      []
+      (processor_id_type pid,
+       const std::vector<std::vector<unsigned int>> & query,
+       std::vector<std::vector<unsigned int>> & response)
+      {
+        const std::size_t query_size = query.size();
+        response.resize(query_size);
+        for (unsigned int i=0; i != query_size; ++i)
+          {
+            const std::size_t query_i_size = query[i].size();
+            response[i].resize(query_i_size);
+            for (unsigned int j=0; j != query_i_size; ++j)
+            response[i][j] = query[i][j]*query[i][j];
+          }
+      };
+
+
+    auto collect_replies =
+      [&received_data]
+      (processor_id_type pid,
+       const std::vector<std::vector<unsigned int>> & query,
+       const std::vector<std::vector<unsigned int>> & response)
+      {
+        const std::size_t query_size = query.size();
+        CPPUNIT_ASSERT_EQUAL(query_size, response.size());
+        for (unsigned int i=0; i != query_size; ++i)
+          {
+            const std::size_t query_i_size = query[i].size();
+            CPPUNIT_ASSERT_EQUAL(query_i_size, response[i].size());
+            for (unsigned int j=0; j != query_i_size; ++j)
+              CPPUNIT_ASSERT_EQUAL(query[i][j]*query[i][j], response[i][j]);
+          }
+        received_data[pid] = response;
+      };
+
+    // Do the pull
+    std::vector<unsigned int> * ex = nullptr;
+    Parallel::pull_parallel_vector_data
+      (*TestCommWorld, data, compose_replies, collect_replies, ex);
+
+    // Test the received results, for each processor id p we're in
+    // charge of.
+    std::vector<std::size_t> checked_sizes(size, 0);
+    for (int p=rank; p != M; p += size)
+      for (int srcp=0; srcp != size; ++srcp)
+        {
+          int diffsize = std::abs(srcp-p);
+          int diffsqrt = std::sqrt(diffsize);
+          if (diffsqrt*diffsqrt != diffsize)
+            {
+              CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(0));
+              continue;
+            }
+
+          CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(1));
+          CPPUNIT_ASSERT_EQUAL(received_data[srcp].size(), std::size_t(2));
+          const std::vector<unsigned int> & datum = received_data[srcp][0];
+          CPPUNIT_ASSERT_EQUAL(std::count(datum.begin(), datum.end(), p*p), std::ptrdiff_t(diffsqrt+1));
+          checked_sizes[srcp] += diffsqrt+1;
+          CPPUNIT_ASSERT_EQUAL(received_data[srcp][1].size(), std::size_t(1));
+          CPPUNIT_ASSERT_EQUAL(int(received_data[srcp][1][0]), p*p);
+        }
+
+    for (int srcp=0; srcp != size; ++srcp)
+      CPPUNIT_ASSERT_EQUAL(checked_sizes[srcp], received_data[srcp][0].size());
+  }
+
+
+  void testPullVecVec()
+  {
+    testPullVecVecImpl(TestCommWorld->size());
+  }
+
+
+  void testPullVecVecOversized()
+  {
+    testPushVecVecImpl((TestCommWorld->size() + 4) * 2);
+  }
+
+
 
 };
 

--- a/tests/parallel/parallel_sync_test.C
+++ b/tests/parallel/parallel_sync_test.C
@@ -37,9 +37,9 @@ public:
   // exist!  If we're on N processors but working on a mesh
   // partitioned into M parts with M > N, then subpartition p belongs
   // to processor p%N.  Let's make M > N for these tests.
-//  CPPUNIT_TEST( testPushOversized );
+  CPPUNIT_TEST( testPushOversized );
 //  CPPUNIT_TEST( testPullOversized );
-//  CPPUNIT_TEST( testPushVecVecOversized );
+  CPPUNIT_TEST( testPushVecVecOversized );
 //  CPPUNIT_TEST( testPullVecVecOversized );
 
   CPPUNIT_TEST_SUITE_END();
@@ -94,19 +94,6 @@ public:
       }
   }
 
-  template <typename MapType>
-  std::function<void(processor_id_type, typename MapType::mapped_type)>
-  data_collector (MapType & received_data)
-  {
-    return
-      [&received_data]
-      (processor_id_type pid,
-       const typename MapType::mapped_type & data)
-      {
-        received_data[pid] = data;
-      };
-  }
-
 
   void testPushImpl(int M)
   {
@@ -117,7 +104,16 @@ public:
 
     fill_scalar_data(data, M);
 
-    Parallel::push_parallel_vector_data(*TestCommWorld, data, data_collector(received_data));
+    auto collect_data =
+      [&received_data]
+      (processor_id_type pid,
+       const typename std::vector<unsigned int> & data)
+      {
+        auto & vec = received_data[pid];
+        vec.insert(vec.end(), data.begin(), data.end());
+      };
+
+    Parallel::push_parallel_vector_data(*TestCommWorld, data, collect_data);
 
     // Test the received results, for each processor id p we're in
     // charge of.
@@ -129,7 +125,11 @@ public:
           int diffsqrt = std::sqrt(diffsize);
           if (diffsqrt*diffsqrt != diffsize)
             {
-              CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(0));
+              if (received_data.count(srcp))
+                {
+                  const std::vector<unsigned int> & datum = received_data[srcp];
+                  CPPUNIT_ASSERT_EQUAL(std::count(datum.begin(), datum.end(), p), std::ptrdiff_t(0));
+                }
               continue;
             }
 
@@ -240,11 +240,24 @@ public:
     const int size = TestCommWorld->size(),
               rank = TestCommWorld->rank();
 
-    std::map<processor_id_type, std::vector<std::vector<unsigned int>>> data, received_data;
+    std::map<processor_id_type, std::vector<std::vector<unsigned int>>> data;
+    std::map<processor_id_type, std::vector<unsigned int>> received_data;
 
     fill_vector_data(data, M);
 
-    Parallel::push_parallel_vector_data(*TestCommWorld, data, data_collector(received_data));
+    auto collect_data =
+      [&received_data]
+      (processor_id_type pid,
+       const typename std::vector<std::vector<unsigned int>> & data)
+      {
+        auto & vec = received_data[pid];
+        vec.insert(vec.end(), data[0].begin(), data[0].end());
+        CPPUNIT_ASSERT_EQUAL(data.size(), std::size_t(2));
+        CPPUNIT_ASSERT_EQUAL(data[1].size(), std::size_t(1));
+        CPPUNIT_ASSERT_EQUAL(data[0][0], data[1][0]);
+      };
+
+    Parallel::push_parallel_vector_data(*TestCommWorld, data, collect_data);
 
     // Test the received results, for each processor id p we're in
     // charge of.
@@ -256,21 +269,22 @@ public:
           int diffsqrt = std::sqrt(diffsize);
           if (diffsqrt*diffsqrt != diffsize)
             {
-              CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(0));
+              if (received_data.count(srcp))
+                {
+                  const std::vector<unsigned int> & datum = received_data[srcp];
+                  CPPUNIT_ASSERT_EQUAL(std::count(datum.begin(), datum.end(), p), std::ptrdiff_t(0));
+                }
               continue;
             }
 
           CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(1));
-          CPPUNIT_ASSERT_EQUAL(received_data[srcp].size(), std::size_t(2));
-          const std::vector<unsigned int> & datum = received_data[srcp][0];
+          const std::vector<unsigned int> & datum = received_data[srcp];
           CPPUNIT_ASSERT_EQUAL(std::count(datum.begin(), datum.end(), p), std::ptrdiff_t(diffsqrt+1));
           checked_sizes[srcp] += diffsqrt+1;
-          CPPUNIT_ASSERT_EQUAL(received_data[srcp][1].size(), std::size_t(1));
-          CPPUNIT_ASSERT_EQUAL(int(received_data[srcp][1][0]), p);
         }
 
     for (int srcp=0; srcp != size; ++srcp)
-      CPPUNIT_ASSERT_EQUAL(checked_sizes[srcp], received_data[srcp][0].size());
+      CPPUNIT_ASSERT_EQUAL(checked_sizes[srcp], received_data[srcp].size());
   }
 
 
@@ -291,7 +305,8 @@ public:
     const int size = TestCommWorld->size(),
               rank = TestCommWorld->rank();
 
-    std::map<processor_id_type, std::vector<std::vector<unsigned int>>> data, received_data;
+    std::map<processor_id_type, std::vector<std::vector<unsigned int>>> data;
+    std::map<processor_id_type, std::vector<unsigned int>> received_data;
 
     fill_vector_data(data, M);
 
@@ -328,7 +343,10 @@ public:
             for (unsigned int j=0; j != query_i_size; ++j)
               CPPUNIT_ASSERT_EQUAL(query[i][j]*query[i][j], response[i][j]);
           }
-        received_data[pid] = response;
+        auto & vec = received_data[pid];
+        vec.insert(vec.end(), response[0].begin(), response[0].end());
+        CPPUNIT_ASSERT_EQUAL(response[1].size(), std::size_t(1));
+        CPPUNIT_ASSERT_EQUAL(response[1][0], response[0][0]);
       };
 
     // Do the pull
@@ -346,21 +364,22 @@ public:
           int diffsqrt = std::sqrt(diffsize);
           if (diffsqrt*diffsqrt != diffsize)
             {
-              CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(0));
+              if (received_data.count(srcp))
+                {
+                  const std::vector<unsigned int> & datum = received_data[srcp];
+                  CPPUNIT_ASSERT_EQUAL(std::count(datum.begin(), datum.end(), p*p), std::ptrdiff_t(0));
+                }
               continue;
             }
 
           CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(1));
-          CPPUNIT_ASSERT_EQUAL(received_data[srcp].size(), std::size_t(2));
-          const std::vector<unsigned int> & datum = received_data[srcp][0];
+          const std::vector<unsigned int> & datum = received_data[srcp];
           CPPUNIT_ASSERT_EQUAL(std::count(datum.begin(), datum.end(), p*p), std::ptrdiff_t(diffsqrt+1));
           checked_sizes[srcp] += diffsqrt+1;
-          CPPUNIT_ASSERT_EQUAL(received_data[srcp][1].size(), std::size_t(1));
-          CPPUNIT_ASSERT_EQUAL(int(received_data[srcp][1][0]), p*p);
         }
 
     for (int srcp=0; srcp != size; ++srcp)
-      CPPUNIT_ASSERT_EQUAL(checked_sizes[srcp], received_data[srcp][0].size());
+      CPPUNIT_ASSERT_EQUAL(checked_sizes[srcp], received_data[srcp].size());
   }
 
 

--- a/tests/parallel/parallel_sync_test.C
+++ b/tests/parallel/parallel_sync_test.C
@@ -26,13 +26,19 @@ class ParallelSyncTest : public CppUnit::TestCase {
 public:
   CPPUNIT_TEST_SUITE( ParallelSyncTest );
 
+  // Our sync functions are most typically used with a map of
+  // processor ids that *only* includes ranks currently running.
   CPPUNIT_TEST( testPush );
-
-//  CPPUNIT_TEST( testPushOversized );
-
   CPPUNIT_TEST( testPull );
+  CPPUNIT_TEST( testPushVecVec );
 
+  // Our sync functions need to support sending to ranks that don't
+  // exist!  If we're on N processors but working on a mesh
+  // partitioned into M parts with M > N, then subpartition p belongs
+  // to processor p%N.  Let's make M > N for these tests.
+//  CPPUNIT_TEST( testPushOversized );
 //  CPPUNIT_TEST( testPullOversized );
+//  CPPUNIT_TEST( testPushVecVecOversized );
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -100,27 +106,13 @@ public:
 
   void testPush()
   {
-    const int size = TestCommWorld->size();
-
-    // Our sync functions are most typically used with a map of
-    // processor ids that *only* includes ranks currently running.
-    const int M = size;
-
-    testPushImpl(M);
+    testPushImpl(TestCommWorld->size());
   }
 
 
   void testPushOversized()
   {
-    const int size = TestCommWorld->size();
-
-    // Our sync functions need to support sending to ranks that don't
-    // exist!  If we're on N processors but working on a mesh
-    // partitioned into M parts with M > N, then subpartition p
-    // belongs to processor p%N.  Let's make M > N here.
-    const int M = (size + 4) * 2;
-
-    testPushImpl(M);
+    testPushImpl((TestCommWorld->size() + 4) * 2);
   }
 
 
@@ -203,29 +195,89 @@ public:
 
   void testPull()
   {
-    const int size = TestCommWorld->size();
-
-    // Our sync functions are most typically used with a map of
-    // processor ids that *only* includes ranks currently running.
-    const int M = size;
-
-    testPullImpl(M);
+    testPullImpl(TestCommWorld->size());
   }
 
 
   void testPullOversized()
   {
-    const int size = TestCommWorld->size();
-
-    // Our sync functions need to support sending to ranks that don't
-    // exist!  If we're on N processors but working on a mesh
-    // partitioned into M parts with M > N, then subpartition p
-    // belongs to processor p%N.  Let's make M > N here.
-    const int M = (size + 4) * 2;
-
-    testPullImpl(M);
+    testPullImpl((TestCommWorld->size() + 4) * 2);
   }
 
+
+  void testPushVecVecImpl(int M)
+  {
+    const int size = TestCommWorld->size(),
+              rank = TestCommWorld->rank();
+
+    // Data to send/recieve with each processor rank.  For this test,
+    // processor p will send to destination d the integer d, in two
+    // subvectors with sqrt(c) and 1 copies, iff c := |p-d| is a
+    // square number.
+    std::map<processor_id_type, std::vector<std::vector<unsigned int>>> data, received_data;
+
+    for (int d=0; d != M; ++d)
+      {
+        int diffsize = std::abs(d-rank);
+        int diffsqrt = std::sqrt(diffsize);
+        if (diffsqrt*diffsqrt == diffsize)
+          {
+            data[d].resize(2);
+            for (int i=-1; i != diffsqrt; ++i)
+              data[d][0].push_back(d);
+            data[d][1].push_back(d);
+          }
+      }
+
+    auto collect_data =
+      [&received_data]
+      (processor_id_type pid,
+       const std::vector<std::vector<unsigned int>> & data)
+      {
+        received_data[pid] = data;
+      };
+
+    // Do the push
+    Parallel::push_parallel_vector_data(*TestCommWorld, data, collect_data);
+
+    // Test the received results, for each processor id p we're in
+    // charge of.
+    std::vector<std::size_t> checked_sizes(size, 0);
+    for (int p=rank; p != M; p += size)
+      for (int srcp=0; srcp != size; ++srcp)
+        {
+          int diffsize = std::abs(srcp-p);
+          int diffsqrt = std::sqrt(diffsize);
+          if (diffsqrt*diffsqrt != diffsize)
+            {
+              CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(0));
+              continue;
+            }
+
+          CPPUNIT_ASSERT_EQUAL(received_data.count(srcp), std::size_t(1));
+          CPPUNIT_ASSERT_EQUAL(received_data[srcp].size(), std::size_t(2));
+          const std::vector<unsigned int> & datum = received_data[srcp][0];
+          CPPUNIT_ASSERT_EQUAL(std::count(datum.begin(), datum.end(), p), std::ptrdiff_t(diffsqrt+1));
+          checked_sizes[srcp] += diffsqrt+1;
+          CPPUNIT_ASSERT_EQUAL(received_data[srcp][1].size(), std::size_t(1));
+          CPPUNIT_ASSERT_EQUAL(int(received_data[srcp][1][0]), p);
+        }
+
+    for (int srcp=0; srcp != size; ++srcp)
+      CPPUNIT_ASSERT_EQUAL(checked_sizes[srcp], received_data[srcp].size());
+  }
+
+
+  void testPushVecVec()
+  {
+    testPushVecVecImpl(TestCommWorld->size());
+  }
+
+
+  void testPushVecVecOversized()
+  {
+    testPushVecVecImpl((TestCommWorld->size() + 4) * 2);
+  }
 
 };
 

--- a/tests/parallel/parallel_sync_test.C
+++ b/tests/parallel/parallel_sync_test.C
@@ -44,7 +44,7 @@ public:
   CPPUNIT_TEST( testPushOversized );
   CPPUNIT_TEST( testPullOversized );
   CPPUNIT_TEST( testPushVecVecOversized );
-//  CPPUNIT_TEST( testPullVecVecOversized );
+  CPPUNIT_TEST( testPullVecVecOversized );
   CPPUNIT_TEST( testPushMultimapOversized );
   CPPUNIT_TEST( testPushMultimapVecVecOversized );
 


### PR DESCRIPTION
This takes the algorithm from @friedmud in #1826, but fixes the MPI_TAG_UB bug, retains the ability to generate a MessageTag with a specified value, and adds a dbg/devel mode verification of automatic tag values when those are included.

This still needs a couple unit tests and I'm just getting started with my own private testing but I think it's in shape to throw at Civet and I'm done for today.

Also, we need to look at the tag choices in System::write_serialized_blocked_dof_objects - is it just me, or is that going to risk failure once num_blks exceeds 100, with only a few hundred million elements?