### PR TITLE
gradient with infinite elements

### DIFF
--- a/include/fe/fe_compute_data.h
+++ b/include/fe/fe_compute_data.h
@@ -21,6 +21,7 @@
 
 // Local includes
 #include "libmesh/libmesh.h"
+#include "libmesh/fe_base.h" // required for the type OutputGradient.
 
 // C++ includes
 #include <vector>
@@ -57,7 +58,8 @@ public:
   FEComputeData (const EquationSystems & es,
                  const Point & pin) :
     equation_systems(es),
-    p(pin)
+    p(pin),
+    _need_dshape(false)
   {
     this->clear();
   }
@@ -78,6 +80,20 @@ public:
    */
   std::vector<Number> shape;
 
+  /**
+   * Storage for the computed shape derivative values.
+   */
+  std::vector<Gradient> dshape;
+
+  /**
+   * Storage for local to global mapping at \p p.
+   * This is needed when the gradient in physical
+   * coordinates is of interest.
+   * FIXME: What kind of type should one use for it?
+   *  The matrix-class don't look as if they were made for it
+   *  and neither are the TensorTool-members.
+   */
+  std::vector<std::vector<Real>> local_transform;
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   /**
@@ -108,6 +124,33 @@ public:
    * the fields are correctly resized.
    */
   void init ();
+
+  /**
+   * Enable the computation of shape gradients (dshape).
+   */
+  void enable_derivative ();
+
+  /**
+   * Disable the computation of shape gradients (dshape).
+   * Default is disabled.
+   */
+  void disable_derivative ()
+  {_need_dshape=false; }
+
+  /**
+   * Check whether derivatives should be computed or not.
+   */
+  bool need_derivative ()
+  {return _need_dshape; }
+
+private:
+  /**
+   * variable indicating whether the shape-derivative should be computed or not.
+   * Default is false to save time and be compatible with elements where derivatives
+   * are not implemented/ cannot be computed.
+   */
+  bool _need_dshape;
+
 };
 
 

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -297,6 +297,41 @@ public:
                     OutputType & phi);
 
   /**
+   * \returns The \f$ j^{th} \f$ coordinate of the gradient of
+   * the \f$ i^{th} \f$ shape function at point \p p.
+   * This method allows you to specify the dimension,
+   * element type, and order directly. Automatically passes the
+   * request to the appropriate *scalar* finite element class member.
+   *
+   * \note On a p-refined element, \p fe_t.order should be the total
+   * order of the element.
+   */
+  static Real shape_deriv(const unsigned int dim,
+                          const FEType & fe_t,
+                          const ElemType t,
+                          const unsigned int i,
+                          const unsigned int j,
+                          const Point & p);
+
+  /**
+   * \returns The \f$ j^{th} \f$ coordinate of the gradient of
+   * the \f$ i^{th} \f$ shape function at point \p p.
+   * This method allows you to specify the dimension,
+   * element type, and order directly. Automatically passes the
+   * request to the appropriate *scalar* finite element class member.
+   *
+   * \note On a p-refined element, \p fe_t.order should be the total
+   * order of the element.
+   */
+  static Real shape_deriv (const unsigned int dim,
+                           const FEType & fe_t,
+                           const Elem *elem,
+                           const unsigned int i,
+                           const unsigned int j,
+                           const Point & p);
+
+
+  /**
    * Lets the appropriate child of \p FEBase compute the requested
    * data for the input specified in \p data, and sets the values in
    * \p data.  See this as a generalization of \p shape().  With
@@ -447,6 +482,21 @@ private:
                          const Elem * elem,
                          const unsigned int i,
                          const Point & p);
+
+
+  static Real ifem_shape_deriv(const unsigned int dim,
+                               const FEType & fe_t,
+                               const ElemType t,
+                               const unsigned int i,
+                               const unsigned int j,
+                               const Point & p);
+
+  static Real ifem_shape_deriv(const unsigned int dim,
+                               const FEType & fe_t,
+                               const Elem * elem,
+                               const unsigned int i,
+                               const unsigned int j,
+                               const Point & p);
 
   static void ifem_compute_data(const unsigned int dim,
                                 const FEType & fe_t,

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -227,25 +227,25 @@ public:
   {}
 
   /**
-   * The approximation order in radial direction of the infinite element.
+   * The approximation order in the base of the infinite element.
    */
   OrderWrapper order;
 
   /**
-   * The approximation order in the base of the infinite element.
+   * The approximation order in radial direction of the infinite element.
    */
   OrderWrapper radial_order;
-
-  /**
-   * The type of approximation in radial direction.  Valid types are
-   * \p JACOBI_20_00, \p JACOBI_30_00, etc...
-   */
-  FEFamily family;
 
   /**
    * For InfFE, \p family contains the radial shape family, while
    * \p base_family contains the approximation type in circumferential
    * direction.  Valid types are \p LAGRANGE, \p HIERARCHIC, etc...
+   */
+  FEFamily family;
+
+  /**
+   * The type of approximation in radial direction.  Valid types are
+   * \p JACOBI_20_00, \p JACOBI_30_00, etc...
    */
   FEFamily radial_family;
 

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -406,12 +406,12 @@ public:
                        const std::vector<Real> * const weights = nullptr) override;
 
   /**
-   * Not implemented yet.  Reinitializes all the physical
+   * Reinitializes all the physical
    * element-dependent data based on the \p side of an infinite
    * element.
    */
-  virtual void reinit (const Elem * elem,
-                       const unsigned int side,
+  virtual void reinit (const Elem * inf_elem,
+                       const unsigned int s,
                        const Real tolerance = TOLERANCE,
                        const std::vector<Point> * const pts = nullptr,
                        const std::vector<Real> * const weights = nullptr) override;
@@ -538,11 +538,11 @@ protected:
                             const Elem * inf_elem);
 
   /**
-   * Not implemented yet.  Initialize all the data fields like \p weight,
+   * Initialize all the data fields like \p weight,
    * \p phi, etc for the side \p s.
    */
-  void init_face_shape_functions (const std::vector<Point> & qp,
-                                  const Elem * side);
+  void init_face_shape_functions (const std::vector<Point> &,
+                                  const Elem * inf_side);
 
   /**
    * Combines the shape functions, which were formed in

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -281,6 +281,42 @@ public:
                     const Point & p);
 
   /**
+   * \returns The \f$ j^{th} \f$ derivative of the \f$ i^{th} \f$
+   * shape function at point \p p. This method lets you specify the relevant
+   * data directly, and is therefore allowed to be static.
+   *
+   * \note This class member is not as efficient as its counterpart in
+   * \p FE<Dim,T>, and is not employed in the \p reinit() cycle.
+   *
+   * \note This method does not return physically correct shape gradients,
+   * instead use \p compute_data().  The \p shape_deriv() methods should
+   * only be used for mapping.
+   */
+  static Real shape_deriv (const FEType & fet,
+                           const Elem * inf_elem,
+                           const unsigned int i,
+                           const unsigned int j,
+                           const Point & p);
+
+  /**
+   * \returns The \f$ j^{th} \f$ derivative of the \f$ i^{th} \f$
+   * shape function at point \p p. This method lets you specify the relevant
+   * data directly, and is therefore allowed to be static.
+   *
+   * \note This class member is not as efficient as its counterpart in
+   * \p FE<Dim,T>, and is not employed in the \p reinit() cycle.
+   *
+   * \note This method does not return physically correct shape gradients,
+   * instead use \p compute_data().  The \p shape_deriv() methods should
+   * only be used for mapping.
+   */
+  static Real shape_deriv (const FEType & fet,
+                           const ElemType inf_elem_type,
+                           const unsigned int i,
+                           const unsigned int j,
+                           const Point & p);
+
+  /**
    * Generalized version of \p shape(), takes an \p Elem *.  The \p data
    * contains both input and output parameters.  For frequency domain
    * simulations, the complex-valued shape is returned.  In time domain
@@ -806,6 +842,7 @@ private:
    */
   static bool _warned_for_nodal_soln;
   static bool _warned_for_shape;
+  static bool _warned_for_dshape;
 
 #endif
 

--- a/src/fe/fe_compute_data.C
+++ b/src/fe/fe_compute_data.C
@@ -25,6 +25,8 @@ namespace libMesh
 void FEComputeData::clear ()
 {
   this->shape.clear();
+  this->dshape.clear();
+  this->local_transform.clear();
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   this->phase = 0.;
   this->speed = 1.;
@@ -67,6 +69,14 @@ void FEComputeData::init ()
 
 #endif //LIBMESH_ENABLE_INFINITE_ELEMENTS
 
+}
+  
+  
+void FEComputeData::enable_derivative ()
+{
+  _need_dshape=true; 
+  if (!(this->dshape.empty()))
+    std::fill (this->dshape.begin(),   this->dshape.end(),  0);
 }
 
 

--- a/src/fe/fe_compute_data.C
+++ b/src/fe/fe_compute_data.C
@@ -70,11 +70,11 @@ void FEComputeData::init ()
 #endif //LIBMESH_ENABLE_INFINITE_ELEMENTS
 
 }
-  
-  
+
+
 void FEComputeData::enable_derivative ()
 {
-  _need_dshape=true; 
+  _need_dshape=true;
   if (!(this->dshape.empty()))
     std::fill (this->dshape.begin(),   this->dshape.end(),  0);
 }

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -803,6 +803,76 @@ void FEInterface::shape<RealGradient>(const unsigned int dim,
   return;
 }
 
+Real FEInterface::shape_deriv(const unsigned int dim,
+                              const FEType & fe_t,
+                              const ElemType t,
+                              const unsigned int i,
+                              const unsigned int j,
+                              const Point & p)
+{
+  libmesh_assert_greater (dim,j);
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (is_InfFE_elem(t)){
+    return ifem_shape_deriv(dim, fe_t, t, i, j, p);
+  }
+
+#endif
+
+  const Order o = fe_t.order;
+
+  switch(dim)
+    {
+    case 0:
+      fe_family_switch (0, shape_deriv(t, o, i, j, p), return , ;);
+    case 1:
+      fe_family_switch (1, shape_deriv(t, o, i, j, p), return , ;);
+    case 2:
+      fe_family_switch (2, shape_deriv(t, o, i, j, p), return  , ;);
+    case 3:
+      fe_family_switch (3, shape_deriv(t, o, i, j, p), return , ;);
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+  return 0;
+}
+
+
+Real FEInterface::shape_deriv(const unsigned int dim,
+                              const FEType & fe_t,
+                              const Elem * elem,
+                              const unsigned int i,
+                              const unsigned int j,
+                              const Point & p)
+{
+  libmesh_assert_greater (dim,j);
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+  if (elem->infinite()){
+    return ifem_shape_deriv(dim, fe_t, elem, i, j, p);
+  }
+
+#endif
+
+  const Order o = fe_t.order;
+
+  switch(dim)
+    {
+    case 0:
+      fe_family_switch (0, shape_deriv(elem, o, i, j, p), return , ;);
+    case 1:
+      fe_family_switch (1, shape_deriv(elem, o, i, j, p), return , ;);
+    case 2:
+      fe_family_switch (2, shape_deriv(elem, o, i, j, p), return , ;);
+    case 3:
+      fe_family_switch (3, shape_deriv(elem, o, i, j, p), return , ;);
+    default:
+      libmesh_error_msg("Invalid dimension = " << dim);
+    }
+  return 0;
+}
+
+
 template<>
 void FEInterface::shape<RealGradient>(const unsigned int dim,
                                       const FEType & fe_t,
@@ -857,11 +927,50 @@ void FEInterface::compute_data(const unsigned int dim,
   const Point &       p     = data.p;
   data.shape.resize(n_dof);
 
+  if (data.need_derivative())
+    {
+      data.dshape.resize(n_dof);
+      data.local_transform.resize(dim);
+
+      for (unsigned int d=0; d<dim; d++)
+         data.local_transform[dim].resize(dim);
+
+      UniquePtr<FEBase> fe (FEBase::build(dim, fe_t));
+      std::vector<Point> pt(1);
+      pt[0]=p;
+      fe->get_dphideta(); // to compute the map
+      fe->reinit(elem, &pt);
+
+      // compute the reference->physical map.
+      data.local_transform[0][0] = fe->get_dxidx()[0];
+      if (dim > 1)
+        {
+          data.local_transform[1][0] = fe->get_detadx()[0];
+          data.local_transform[1][1] = fe->get_detady()[0];
+          data.local_transform[0][1] = fe->get_dxidy()[0];
+          if (dim > 2)
+            {
+                data.local_transform[2][0] = fe->get_dzetadx()[0];
+                data.local_transform[2][1] = fe->get_dzetady()[0];
+                data.local_transform[2][2] = fe->get_dzetadz()[0];
+                data.local_transform[1][2] = fe->get_detadz()[0];
+                data.local_transform[0][2] = fe->get_dxidz()[0];
+            }
+        }
+    }
+
   // set default values for all the output fields
   data.init();
 
   for (unsigned int n=0; n<n_dof; n++)
+   {
     data.shape[n] = shape(dim, p_refined, elem, n, p);
+    if (data.need_derivative())
+      {
+        for (unsigned int j=0; j<dim; j++)
+          data.dshape[n](j) = shape_deriv(dim, p_refined, elem, n, j, p);
+      }
+   }
 
   return;
 }

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -29,6 +29,69 @@ namespace libMesh
 {
 
 
+#define inf_fe_family_mapping_switch(dim, func_and_args, prefix, suffix)   \
+  do {                                                                     \
+    switch (fe_t.radial_family)                                            \
+      {                                                                    \
+       case INFINITE_MAP:                                                  \
+       switch(fe_t.inf_map)                                                \
+         {                                                                 \
+           case CARTESIAN:                                                 \
+             prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix  \
+           case SPHERICAL:                                                 \
+           case ELLIPSOIDAL:                                               \
+             libmesh_not_implemented();                                    \
+           default:                                                        \
+             libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+         }                                                                 \
+       case JACOBI_20_00:                                                  \
+       switch(fe_t.inf_map)                                                \
+         {                                                                 \
+           case CARTESIAN:                                                 \
+             prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix  \
+           case SPHERICAL:                                                 \
+           case ELLIPSOIDAL:                                               \
+             libmesh_not_implemented();                                    \
+           default:                                                        \
+             libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+         }                                                                 \
+       case JACOBI_30_00:                                                  \
+       switch(fe_t.inf_map)                                                \
+         {                                                                 \
+           case CARTESIAN:                                                 \
+             prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix  \
+           case SPHERICAL:                                                 \
+           case ELLIPSOIDAL:                                               \
+             libmesh_not_implemented();                                    \
+           default:                                                        \
+             libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+         }                                                                 \
+       case LEGENDRE:                                                      \
+       switch(fe_t.inf_map)                                                \
+         {                                                                 \
+           case CARTESIAN:                                                 \
+             prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix  \
+           case SPHERICAL:                                                 \
+           case ELLIPSOIDAL:                                               \
+             libmesh_not_implemented();                                    \
+           default:                                                        \
+             libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+         }                                                                 \
+       case LAGRANGE:                                                      \
+       switch(fe_t.inf_map)                                                \
+         {                                                                 \
+           case CARTESIAN:                                                 \
+             prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix  \
+           case SPHERICAL:                                                 \
+           case ELLIPSOIDAL:                                               \
+             libmesh_not_implemented();                                    \
+           default:                                                        \
+             libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+         }                                                                 \
+       default:                                                            \
+         libmesh_error_msg("Invalid radial family = " << fe_t.radial_family);\
+       }                                                                   \
+  } while (0)
 
 
 //------------------------------------------------------------
@@ -802,7 +865,54 @@ Real FEInterface::ifem_shape(const unsigned int dim,
     }
 }
 
+Real FEInterface::ifem_shape_deriv (const unsigned int dim,
+                                    const FEType & fe_t,
+                                    const Elem * elem,
+                                    const unsigned int i,
+                                    const unsigned int j,
+                                    const Point & p)
+{
+  switch (dim)
+    {
+      // 1D
+    case 1:
+       inf_fe_family_mapping_switch(1, shape_deriv(fe_t, elem, i, j, p), return, ;);
+      // 2D
+    case 2:
+       inf_fe_family_mapping_switch(2, shape_deriv(fe_t, elem, i, j, p), return, ;);
+      // 3D
+    case 3:
+       inf_fe_family_mapping_switch(3, shape_deriv(fe_t, elem, i, j, p), return, ;);
 
+    default:
+      libmesh_error_msg("Invalid dim = " << dim);
+    }
+}
+
+
+Real FEInterface::ifem_shape_deriv(const unsigned int dim,
+                                   const FEType & fe_t,
+                                   const ElemType t,
+                                   const unsigned int i,
+                                   const unsigned int j,
+                                   const Point & p)
+{
+  switch (dim)
+    {
+      // 1D
+    case 1:
+       inf_fe_family_mapping_switch(1, shape_deriv(fe_t, t, i, j, p), return, ;);
+      // 2D
+    case 2:
+       inf_fe_family_mapping_switch(2, shape_deriv(fe_t, t, i, j, p), return, ;);
+      // 3D
+    case 3:
+       inf_fe_family_mapping_switch(3, shape_deriv(fe_t, t, i, j, p), return, ;);
+
+    default:
+      libmesh_error_msg("Invalid dim = " << dim);
+    }
+}
 
 
 void FEInterface::ifem_compute_data(const unsigned int dim,

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -54,6 +54,7 @@ void InfFE<Dim,T_radial,T_base>::reinit(const Elem * inf_elem,
   // Don't do this for the base
   libmesh_assert_not_equal_to (s, 0);
 
+
   // Build the side of interest
   const std::unique_ptr<const Elem> side(inf_elem->build_side_ptr(s));
 

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -327,7 +327,7 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
         * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
         * InfFE<Dim,T_radial,T_map>::Radial::decay(v);
 }
- 
+
 
 
 

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -44,6 +44,9 @@ bool InfFE<Dim,T_radial,T_map>::_warned_for_nodal_soln = false;
 template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 bool InfFE<Dim,T_radial,T_map>::_warned_for_shape      = false;
 
+template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
+bool InfFE<Dim,T_radial,T_map>::_warned_for_dshape     = false;
+
 #endif
 
 
@@ -232,7 +235,99 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType & fet,
 }
 
 
+template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
+Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
+                                             const ElemType inf_elem_type,
+                                             const unsigned int i,
+                                             const unsigned int j,
+                                             const Point & p)
+{
+  libmesh_assert_not_equal_to (Dim, 0);
+  libmesh_assert_greater (Dim,j);
+#ifdef DEBUG
+  // this makes only sense when used for mapping
+  if ((T_radial != INFINITE_MAP) && !_warned_for_dshape)
+    {
+      libMesh::err << "WARNING: InfFE<Dim,T_radial,T_map>::shape_deriv(...) does _not_" << std::endl
+                   << " return the correct trial function gradients!  Use " << std::endl
+                   << " InfFE<Dim,T_radial,T_map>::compute_data(..) instead!"
+                   << std::endl;
+      _warned_for_dshape = true;
+    }
+#endif
 
+  const ElemType     base_et  (Base::get_elem_type(inf_elem_type));
+  const Order o_radial (fe_t.radial_order);
+  const Real v (p(Dim-1));
+
+  unsigned int i_base, i_radial;
+  compute_shape_indices(fe_t, inf_elem_type, i, i_base, i_radial);
+
+  if (j== Dim -1)
+    {
+      Real RadialDeriv = InfFE<Dim,T_radial,T_map>::eval_deriv(v, o_radial, i_radial)
+        * InfFE<Dim,T_radial,T_map>::Radial::decay(v)
+        + InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
+        * InfFE<Dim,T_radial,T_map>::Radial::decay_deriv(v);
+
+      return FEInterface::shape(Dim-1, fe_t, base_et, i_base, p)*RadialDeriv;
+    }
+
+  return FEInterface::shape_deriv(Dim-1, fe_t, base_et, i_base, j, p)
+        * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
+        * InfFE<Dim,T_radial,T_map>::Radial::decay(v);
+}
+
+
+template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
+Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
+                                             const Elem * inf_elem,
+                                             const unsigned int i,
+                                             const unsigned int j,
+                                             const Point & p)
+{
+  libmesh_assert_not_equal_to (Dim, 0);
+  libmesh_assert_greater (Dim,j);
+#ifdef DEBUG
+  // this makes only sense when used for mapping
+  if ((T_radial != INFINITE_MAP) && !_warned_for_dshape)
+    {
+      libMesh::err << "WARNING: InfFE<Dim,T_radial,T_map>::shape_deriv(...) does _not_" << std::endl
+                   << " return the correct trial function gradients!  Use " << std::endl
+                   << " InfFE<Dim,T_radial,T_map>::compute_data(..) instead!"
+                   << std::endl;
+      _warned_for_dshape = true;
+    }
+#endif
+  const Order o_radial (fe_t.radial_order);
+  const Real v (p(Dim-1));
+
+  std::unique_ptr<const Elem> base_el (inf_elem->build_side_ptr(0));
+
+  unsigned int i_base, i_radial;
+
+  if ((-1. > v ) || (v  > 1.))
+   {
+     //TODO: This is for debugging. We should never come here.
+     //   Therefore we can do very useless things then:
+      i_base=0;
+   }
+  compute_shape_indices(fe_t, inf_elem->type(), i, i_base, i_radial);
+
+  if (j== Dim -1)
+    {
+      Real RadialDeriv = InfFE<Dim,T_radial,T_map>::eval_deriv(v, o_radial, i_radial)
+        * InfFE<Dim,T_radial,T_map>::Radial::decay(v)
+        + InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
+        * InfFE<Dim,T_radial,T_map>::Radial::decay_deriv(v);
+
+      return FEInterface::shape(Dim-1, fe_t, base_el.get(), i_base, p)*RadialDeriv;
+    }
+  return FEInterface::shape_deriv(Dim-1, fe_t, base_el.get(), i_base, j, p)
+        * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
+        * InfFE<Dim,T_radial,T_map>::Radial::decay(v);
+}
+ 
 
 
 
@@ -334,6 +429,37 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
     {
       const unsigned int n_dof = n_dofs (fet, inf_elem->type());
       data.shape.resize(n_dof);
+      if (data.need_derivative())
+        {
+          data.dshape.resize(n_dof);
+          data.local_transform.resize(Dim);
+
+          for (unsigned int d=0; d<Dim; d++)
+            data.local_transform[d].resize(Dim);
+
+          // compute the reference->physical map at the point \p p.
+          // Use another fe_map to avoid interference with \p this->_fe_map
+          // which is initialized at the quadrature points...
+          UniquePtr<FEBase> fe (FEBase::build_InfFE(Dim, fet));
+          std::vector<Point> pt(1);
+          pt[0]=p;
+          fe->get_dphideta(); // to compute the map
+          fe->reinit(inf_elem, &pt);
+
+          // compute the reference->physical map.
+          data.local_transform[0][0] = fe->get_dxidx()[0];
+          data.local_transform[1][0] = fe->get_detadx()[0];
+          data.local_transform[1][1] = fe->get_detady()[0];
+          data.local_transform[0][1] = fe->get_dxidy()[0];
+          if (Dim > 2)
+            {
+                data.local_transform[2][0] = fe->get_dzetadx()[0];
+                data.local_transform[2][1] = fe->get_dzetady()[0];
+                data.local_transform[2][2] = fe->get_dzetadz()[0];
+                data.local_transform[1][2] = fe->get_detadz()[0];
+                data.local_transform[0][2] = fe->get_dxidz()[0];
+            }
+        } // endif data.need_derivative()
 
       for (unsigned int i=0; i<n_dof; i++)
         {
@@ -345,6 +471,36 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
                            *  FEInterface::shape(Dim-1, fet, base_el.get(), i_base, p)  /* S_n(s,t)                 */
                            * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial))    /* L_n(v)                   */
                            * time_harmonic;                                             /* e^(i*k*phase(s,t,v)      */
+
+          // use differentiation of the above equation
+          if (data.need_derivative())
+            {
+              data.dshape[i](0)     = (InfFE<Dim,T_radial,T_map>::Radial::decay(v)
+                                    * FEInterface::shape_deriv(Dim-1, fet, base_el.get(), i_base, 0, p)
+                                    * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial));
+              if (Dim > 2)
+                {
+                  data.dshape[i](1)   = (InfFE<Dim,T_radial,T_map>::Radial::decay(v)
+                                      * FEInterface::shape_deriv(Dim-1, fet, base_el.get(), i_base, 1, p)
+                                      * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial))
+                                      * time_harmonic;
+                }
+              data.dshape[i](Dim-1)  = (InfFE<Dim,T_radial,T_map>::Radial::decay_deriv(v)
+                                     * FEInterface::shape(Dim-1, fet, base_el.get(), i_base, p)
+                                     * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial))
+                                     * time_harmonic;
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+              data.dshape[i](Dim-1)+= data.shape[i]* imaginary*wavenumber
+                                    * interpolated_dist* InfFE<Dim,INFINITE_MAP,T_map>::eval_deriv(v, radial_mapping_order, 1);
+#else
+              /*
+               * The gradient in infinite elements is dominated by the contribution due to the oscillating phase.
+               * Since this term is imaginary, I think there is no means to look at it without having complex numbers.
+               */
+              libmesh_not_implemented();
+              // Maybe we can solve it with a warning as well, but I think one really should not do this...
+#endif
+            }
         }
     }
 
@@ -934,6 +1090,12 @@ INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, Real, shape(const FEType &, const Elem *, 
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, Real, shape(const FEType &, const ElemType, const unsigned int, const Point &));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, Real, shape(const FEType &, const ElemType, const unsigned int, const Point &));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, Real, shape(const FEType &, const ElemType, const unsigned int, const Point &));
+INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, Real, shape_deriv(const FEType &, const Elem *, const unsigned int, const unsigned int, const Point &));
+INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, Real, shape_deriv(const FEType &, const Elem *, const unsigned int, const unsigned int, const Point &));
+INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, Real, shape_deriv(const FEType &, const Elem *, const unsigned int, const unsigned int, const Point &));
+INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, Real, shape_deriv(const FEType &, const ElemType, const unsigned int, const unsigned int, const Point &));
+INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, Real, shape_deriv(const FEType &, const ElemType, const unsigned int, const unsigned int, const Point &));
+INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, Real, shape_deriv(const FEType &, const ElemType, const unsigned int, const unsigned int, const Point &));
 INSTANTIATE_INF_FE_MBRF(1, CARTESIAN, void, compute_data(const FEType &, const Elem *, FEComputeData &));
 INSTANTIATE_INF_FE_MBRF(2, CARTESIAN, void, compute_data(const FEType &, const Elem *, FEComputeData &));
 INSTANTIATE_INF_FE_MBRF(3, CARTESIAN, void, compute_data(const FEType &, const Elem *, FEComputeData &));

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -523,7 +523,7 @@ void MeshFunction::gradient (const Point & p,
                     for (std::size_t v=0; v<dim; v++)
                     for (std::size_t xyz=0; xyz<dim; xyz++)
                       {
-                       // FIXME: this needs better syntax: It is matrix-vector multiplication. 
+                       // FIXME: this needs better syntax: It is matrix-vector multiplication.
                         grad(xyz) += data.local_transform[v][xyz]
                                    * data.dshape[i](v)
                                    * this->_vector(dof_indices[i]);
@@ -642,7 +642,7 @@ void MeshFunction::discontinuous_gradient (const Point & p,
                  for (std::size_t v=0; v<dim; v++)
                  for (std::size_t xyz=0; xyz<dim; xyz++)
                    {
-                     // FIXME: this needs better syntax: It is matrix-vector multiplication. 
+                     // FIXME: this needs better syntax: It is matrix-vector multiplication.
                      grad(xyz) += data.local_transform[v][xyz]
                                 * data.dshape[i](v)
                                 * this->_vector(dof_indices[i]);
@@ -684,7 +684,7 @@ void MeshFunction::hessian (const Point & p,
                      << "Second derivatives for Infinite elements"
                      << " are not yet implemented!"
                      << std::endl);
-#endif 
+#endif
       // resize the output vector to the number of output values
       // that the user told us
       output.resize (this->_system_vars.size());

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -33,6 +33,7 @@
 #include "libmesh/mesh_base.h"
 #include "libmesh/point.h"
 #include "libmesh/elem.h"
+#include "libmesh/fe_map.h"
 
 namespace libMesh
 {
@@ -440,6 +441,7 @@ void MeshFunction::gradient (const Point & p,
   if (!element)
     {
       output.resize(0);
+      return;
     }
   else
     {
@@ -484,20 +486,51 @@ void MeshFunction::gradient (const Point & p,
 
             const FEType & fe_type = this->_dof_map.variable_type(var);
 
-            std::unique_ptr<FEBase> point_fe (FEBase::build(dim, fe_type));
-            const std::vector<std::vector<RealGradient>> & dphi = point_fe->get_dphi();
-            point_fe->reinit(element, &point_list);
-
             // where the solution values for the var-th variable are stored
             std::vector<dof_id_type> dof_indices;
             this->_dof_map.dof_indices (element, dof_indices, var);
 
             // interpolate the solution
             Gradient grad(0.);
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+            //The other algorithm works in case of finite elements as well,
+            //but this one is faster.
+            if (!element->infinite())
+              {
+#endif
+                std::unique_ptr<FEBase> point_fe (FEBase::build(dim, fe_type));
+                const std::vector<std::vector<RealGradient>> & dphi = point_fe->get_dphi();
+                point_fe->reinit(element, &point_list);
 
-            for (std::size_t i=0; i<dof_indices.size(); i++)
-              grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
-
+                for (std::size_t i=0; i<dof_indices.size(); i++)
+                    grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+               }
+             else
+              {
+                /**
+                 * Build an FEComputeData that contains both input and output data
+                 * for the specific compute_data method.
+                 */
+                FEComputeData data (this->_eqn_systems, mapped_point);
+                data.enable_derivative();
+                FEInterface::compute_data (dim, fe_type, element, data);
+                //grad [x] = data.dshape[i](v) * dv/dx  * dof_index [i]
+                // sum over all indices
+                for (std::size_t i=0; i<dof_indices.size(); i++)
+                  {
+                    // local coordinates
+                    for (std::size_t v=0; v<dim; v++)
+                    for (std::size_t xyz=0; xyz<dim; xyz++)
+                      {
+                       // FIXME: this needs better syntax: It is matrix-vector multiplication. 
+                        grad(xyz) += data.local_transform[v][xyz]
+                                   * data.dshape[i](v)
+                                   * this->_vector(dof_indices[i]);
+                      }
+                  }
+             }
+#endif
             output[index] = grad;
           }
       }
@@ -568,19 +601,55 @@ void MeshFunction::discontinuous_gradient (const Point & p,
 
           const FEType & fe_type = this->_dof_map.variable_type(var);
 
-          std::unique_ptr<FEBase> point_fe (FEBase::build(dim, fe_type));
-          const std::vector<std::vector<RealGradient>> & dphi = point_fe->get_dphi();
-          point_fe->reinit(element, &point_list);
-
           // where the solution values for the var-th variable are stored
           std::vector<dof_id_type> dof_indices;
           this->_dof_map.dof_indices (element, dof_indices, var);
 
           Gradient grad(0.);
 
-          for (std::size_t i = 0; i < dof_indices.size(); ++i)
-            grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
+          // for performance-reasons, we use different algorithms now.
+          // TODO: Check that both give the same result for finite elements.
+          // Otherwive it is wrong...
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+          if (!element->infinite())
+            {
+#endif
+              std::unique_ptr<FEBase> point_fe (FEBase::build(dim, fe_type));
+              const std::vector<std::vector<RealGradient>> & dphi = point_fe->get_dphi();
+              point_fe->reinit(element, & point_list);
 
+          temp_output[index] = grad;
+              for (std::size_t i=0; i<dof_indices.size(); i++)
+                  grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+             }
+          else
+           {
+             /**
+              * Build an FEComputeData that contains both input and output data
+              * for the specific compute_data method.
+              */
+             //TODO: enable this for a vector of points as well...
+             FEComputeData data (this->_eqn_systems, mapped_point);
+             data.enable_derivative();
+             FEInterface::compute_data (dim, fe_type, element, data);
+
+             //grad [x] = data.dshape[i](v) * dv/dx  * dof_index [i]
+             // sum over all indices
+             for (std::size_t i=0; i<dof_indices.size(); i++)
+               {
+                 // local coordinates
+                 for (std::size_t v=0; v<dim; v++)
+                 for (std::size_t xyz=0; xyz<dim; xyz++)
+                   {
+                     // FIXME: this needs better syntax: It is matrix-vector multiplication. 
+                     grad(xyz) += data.local_transform[v][xyz]
+                                * data.dshape[i](v)
+                                * this->_vector(dof_indices[i]);
+                   }
+               }
+            }
+#endif
           temp_output[index] = grad;
 
           // next variable
@@ -609,6 +678,13 @@ void MeshFunction::hessian (const Point & p,
     }
   else
     {
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+      if(element->infinite())
+        libmesh_warning("Warning: Requested the Hessian of an Infinit element."
+                     << "Second derivatives for Infinite elements"
+                     << " are not yet implemented!"
+                     << std::endl);
+#endif 
       // resize the output vector to the number of output values
       // that the user told us
       output.resize (this->_system_vars.size());

--- a/src/quadrature/quadrature_gauss_1D.C
+++ b/src/quadrature/quadrature_gauss_1D.C
@@ -28,11 +28,11 @@ namespace libMesh
 
 
 void QGauss::init_1D(const ElemType,
-                     unsigned int p)
+                     unsigned int p_level)
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules
-  switch(_order + 2*p)
+  switch(_order + 2*p_level)
     {
     case CONSTANT:
     case FIRST:

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -26,7 +26,7 @@ namespace libMesh
 
 
 void QGauss::init_2D(const ElemType type_in,
-                     unsigned int p)
+                     unsigned int p_level)
 {
 #if LIBMESH_DIM > 1
 
@@ -60,7 +60,7 @@ void QGauss::init_2D(const ElemType type_in,
         //    yx^2   xy^2
         //       x^2y^2
         QGauss q1D(1,_order);
-        q1D.init(EDGE2,p);
+        q1D.init(EDGE2,p_level);
         tensor_product_quad( q1D );
         return;
       }
@@ -73,7 +73,7 @@ void QGauss::init_2D(const ElemType type_in,
     case TRI3SUBDIVISION:
     case TRI6:
       {
-        switch(_order + 2*p)
+        switch(_order + 2*p_level)
           {
           case CONSTANT:
           case FIRST:
@@ -1277,7 +1277,7 @@ void QGauss::init_2D(const ElemType type_in,
               // automatically generate using a 1D Gauss rule on
               // [0,1] and two 1D Jacobi-Gauss rules on [0,1].
               QConical conical_rule(2, _order);
-              conical_rule.init(type_in, p);
+              conical_rule.init(type_in, p_level);
 
               // Swap points and weights with the about-to-be destroyed rule.
               _points.swap (conical_rule.get_points() );

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -26,7 +26,7 @@ namespace libMesh
 {
 
 void QGauss::init_3D(const ElemType type_in,
-                     unsigned int p)
+                     unsigned int p_level)
 {
 #if LIBMESH_DIM == 3
 
@@ -43,7 +43,7 @@ void QGauss::init_3D(const ElemType type_in,
         // We compute the 3D quadrature rule as a tensor
         // product of the 1D quadrature rule.
         QGauss q1D(1,_order);
-        q1D.init(EDGE2,p);
+        q1D.init(EDGE2,p_level);
 
         tensor_product_hex( q1D );
 
@@ -57,7 +57,7 @@ void QGauss::init_3D(const ElemType type_in,
     case TET4:
     case TET10:
       {
-        switch(_order + 2*p)
+        switch(_order + 2*p_level)
           {
             // Taken from pg. 222 of "The finite element method," vol. 1
             // ed. 5 by Zienkiewicz & Taylor
@@ -169,7 +169,7 @@ void QGauss::init_3D(const ElemType type_in,
                   // product rule is third-order accurate and has less points than
                   // the next-available positive-weight rule at FIFTH order.
                   QConical conical_rule(3, _order);
-                  conical_rule.init(type_in, p);
+                  conical_rule.init(type_in, p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (conical_rule.get_points() );
@@ -459,7 +459,7 @@ void QGauss::init_3D(const ElemType type_in,
             // Fall back on Grundmann-Moller or Conical Product rules at high orders.
           default:
             {
-              if ((allow_rules_with_negative_weights) && (_order + 2*p < 34))
+              if ((allow_rules_with_negative_weights) && (_order + 2*p_level < 34))
                 {
                   // The Grundmann-Moller rules are defined to arbitrary order and
                   // can have significantly fewer evaluation points than conical product
@@ -469,7 +469,7 @@ void QGauss::init_3D(const ElemType type_in,
                   // to round-off error.  Safest is to disallow rules with negative
                   // weights, but this decision should be made on a case-by-case basis.
                   QGrundmann_Moller gm_rule(3, _order);
-                  gm_rule.init(type_in, p);
+                  gm_rule.init(type_in, p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (gm_rule.get_points() );
@@ -487,7 +487,7 @@ void QGauss::init_3D(const ElemType type_in,
                   // automatically generate using a 1D Gauss rule on
                   // [0,1] and two 1D Jacobi-Gauss rules on [0,1].
                   QConical conical_rule(3, _order);
-                  conical_rule.init(type_in, p);
+                  conical_rule.init(type_in, p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (conical_rule.get_points() );
@@ -515,8 +515,8 @@ void QGauss::init_3D(const ElemType type_in,
         QGauss q2D(2,_order);
 
         // Initialize
-        q1D.init(EDGE2,p);
-        q2D.init(TRI3,p);
+        q1D.init(EDGE2,p_level);
+        q2D.init(TRI3,p_level);
 
         tensor_product_prism(q1D, q2D);
 
@@ -537,7 +537,7 @@ void QGauss::init_3D(const ElemType type_in,
         // from: Stroud, A.H. "Approximate Calculation of Multiple
         // Integrals."
         QConical conical_rule(3, _order);
-        conical_rule.init(type_in, p);
+        conical_rule.init(type_in, p_level);
 
         // Swap points and weights with the about-to-be destroyed rule.
         _points.swap (conical_rule.get_points() );


### PR DESCRIPTION
Dear all,
I am sorry to mix these things up in one PR:
- 32ae391 contains some minor fixes in the documentations: The main changes are to name the variables in the declaration (``.h``-file) and the function (``.C``-file) consistent.
The main purpose is, however, to adapt the MeshFunction::gradient()-function to infinite elements.
Respectively, several functions and objects are added to FEInterface.

I have one open question related to this, denoted by the FIXME-tag: To get the gradient in physical coordinates, I need to hold the transformation in the FEInterface; therefore, I added the `` std::vector<std::vector<Real>> local_transform`` variable; but maybe there is a better way to do so?
I would think of some Tensor- or matrix-type or so? 

Any other thoughts about this?
I hope, you are all ok with the introduction of this new feature?

Best,
Hubert