### PR TITLE
Fix buffer overrun in Hilbert SFC Partitioner

### DIFF
--- a/contrib/sfcurves/hilbert.c
+++ b/contrib/sfcurves/hilbert.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>
+#include <stdio.h>
 #include "sfcurves_internal.h"
 
 
@@ -25,7 +26,7 @@ void hsfc3d(
 
   unsigned i ;
   unsigned char axis[3+3] ;
-  
+
   /* GRAY coding */
 
   if ( ! init ) {
@@ -65,10 +66,18 @@ void hsfc3d(
       const unsigned which = off / MaxBits ;           /* Which word */
       const unsigned shift = MaxBits - off % MaxBits ; /* Which bits */
 
-      if ( MaxBits == shift ) { /* Word boundary */
+      /* if ( MaxBits == shift ) { /\* Word boundary *\/ */
+      if (which > 2) {
         key[ which - 1 ] |= bit ;
       }
       else {
+        /* Don't write past the end of key!
+        if (which==3)
+          {
+            printf("Accessed past end of key!\n");
+            exit(1);
+          }
+        */
         key[ which ] |= bit << shift ;
       }
     }
@@ -134,7 +143,7 @@ void fhsfc3d(
   unsigned * nkey ,    /* IN: Word length of key */
   unsigned   key[] )   /* OUT: space-filling curve key */
 {
-  const double imax = ~(0u);
+  const double imax = UINT_MAX; /* ~(0u); */
   unsigned c[3] ;
   c[0] = (unsigned) (coord[0] * imax) ;
   c[1] = (unsigned) (coord[1] * imax) ;
@@ -152,21 +161,45 @@ void hilbert(double *x, double *y, double *z, int *N, int *table)
   double extry[2];
   double extrz[2];
   struct m_str *s;
-    
+
   int i;
 
   double temp[3]={0.0, 0.0, 0.0};
   unsigned leng=3;
 
-  
+  /* debugging print statements */
+  printf("\n");
+  printf("In hilbert, N=%d\n", *N);
+
+  printf("In hilbert, x=");
+  for (i=0; i<*N; i++)
+    printf("%f ", x[i]);
+  printf("\n");
+
+  printf("In hilbert, y=");
+  for (i=0; i<*N; i++)
+    printf("%f ", y[i]);
+  printf("\n");
+
+  printf("In hilbert, z=");
+  for (i=0; i<*N; i++)
+    printf("%f ", z[i]);
+  printf("\n");
+
+  printf("In hilbert, table=");
+  for (i=0; i<*N; i++)
+    printf("%d ", table[i]);
+  printf("\n");
+
   s=malloc((*N)*sizeof(struct m_str ));
-      
+
   extrx[0]=extrx[1]=x[0];
   extry[0]=extry[1]=y[0];
   extrz[0]=extrz[1]=z[0];
   table[0]=1;
 
-  for(i=1;i<*N;i++) { 
+  printf("In hilbert, starting for loop from 1 to N.\n");
+  for(i=1;i<*N;i++) {
     extrx[0]=MIN(extrx[0],x[i]);
     extrx[1]=MAX(extrx[1],x[i]);
     extry[0]=MIN(extry[0],y[i]);
@@ -176,14 +209,18 @@ void hilbert(double *x, double *y, double *z, int *N, int *table)
     table[i]=i+1;
   }
 
-    
+
+  printf("In hilbert, starting for loop from 0 to N.\n");
   for(i=0;i<*N;i++) {
+    printf("i=%d\n", i);
     temp[0]=(x[i]-extrx[0])/(extrx[1]-extrx[0]);
     temp[1]=(y[i]-extry[0])/(extry[1]-extry[0]);
     temp[2]=(z[i]-extrz[0])/(extrz[1]-extrz[0]);
 
+    /* debugging - if you comment out this function, the code does not abort, so the
+       error must be in this function somewhere! */
     fhsfc3d(temp,&leng,index);
-    
+
     s[i].x=x[i];
     s[i].y=y[i];
     s[i].z=z[i];
@@ -194,19 +231,41 @@ void hilbert(double *x, double *y, double *z, int *N, int *table)
 
   }
 
-  
+
+  printf("In hilbert, calling qsort.\n");
   qsort(s,*N,sizeof(struct m_str), cmp_indx);
 
+  printf("In hilbert, final loop from 0 to N.\n");
   for(i=0;i<*N;i++) {
-    
+
     x[i]=s[i].x;
     y[i]=s[i].y;
     z[i]=s[i].z;
     table[i]=s[i].table;
-    
+
   }
 
+  printf("In hilbert, before free(s).\n");
   free(s);
+  printf("In hilbert, after free(s).\n");
+
+  printf("In hilbert, x=");
+  for (i=0; i<*N; i++)
+    printf("%f ", x[i]);
+  printf("\n");
+
+  printf("In hilbert, y=");
+  for (i=0; i<*N; i++)
+    printf("%f ", y[i]);
+  printf("\n");
+
+  printf("In hilbert, z=");
+  for (i=0; i<*N; i++)
+    printf("%f ", z[i]);
+  printf("\n");
+
+  printf("In hilbert, table=");
+  for (i=0; i<*N; i++)
+    printf("%d ", table[i]);
+  printf("\n");
 }
-
-

--- a/contrib/sfcurves/hilbert.c
+++ b/contrib/sfcurves/hilbert.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>
-#include <stdio.h>
 #include "sfcurves_internal.h"
 
 
@@ -66,18 +65,17 @@ void hsfc3d(
       const unsigned which = off / MaxBits ;           /* Which word */
       const unsigned shift = MaxBits - off % MaxBits ; /* Which bits */
 
-      /* if ( MaxBits == shift ) { /\* Word boundary *\/ */
+      /**
+       * The previous test was: "if (MaxBits == shift)" but this
+       * caused an off-by-one error for some meshes so we've changed
+       * it to what you see below. This seems to fix the illegal
+       * access problem, but I'm not sure if it's correct wrt the
+       * algorithm itself.
+       */
       if (which > 2) {
         key[ which - 1 ] |= bit ;
       }
       else {
-        /* Don't write past the end of key!
-        if (which==3)
-          {
-            printf("Accessed past end of key!\n");
-            exit(1);
-          }
-        */
         key[ which ] |= bit << shift ;
       }
     }
@@ -143,7 +141,7 @@ void fhsfc3d(
   unsigned * nkey ,    /* IN: Word length of key */
   unsigned   key[] )   /* OUT: space-filling curve key */
 {
-  const double imax = UINT_MAX; /* ~(0u); */
+  const double imax = UINT_MAX;
   unsigned c[3] ;
   c[0] = (unsigned) (coord[0] * imax) ;
   c[1] = (unsigned) (coord[1] * imax) ;
@@ -167,30 +165,6 @@ void hilbert(double *x, double *y, double *z, int *N, int *table)
   double temp[3]={0.0, 0.0, 0.0};
   unsigned leng=3;
 
-  /* debugging print statements */
-  printf("\n");
-  printf("In hilbert, N=%d\n", *N);
-
-  printf("In hilbert, x=");
-  for (i=0; i<*N; i++)
-    printf("%f ", x[i]);
-  printf("\n");
-
-  printf("In hilbert, y=");
-  for (i=0; i<*N; i++)
-    printf("%f ", y[i]);
-  printf("\n");
-
-  printf("In hilbert, z=");
-  for (i=0; i<*N; i++)
-    printf("%f ", z[i]);
-  printf("\n");
-
-  printf("In hilbert, table=");
-  for (i=0; i<*N; i++)
-    printf("%d ", table[i]);
-  printf("\n");
-
   s=malloc((*N)*sizeof(struct m_str ));
 
   extrx[0]=extrx[1]=x[0];
@@ -198,7 +172,6 @@ void hilbert(double *x, double *y, double *z, int *N, int *table)
   extrz[0]=extrz[1]=z[0];
   table[0]=1;
 
-  printf("In hilbert, starting for loop from 1 to N.\n");
   for(i=1;i<*N;i++) {
     extrx[0]=MIN(extrx[0],x[i]);
     extrx[1]=MAX(extrx[1],x[i]);
@@ -210,15 +183,11 @@ void hilbert(double *x, double *y, double *z, int *N, int *table)
   }
 
 
-  printf("In hilbert, starting for loop from 0 to N.\n");
   for(i=0;i<*N;i++) {
-    printf("i=%d\n", i);
     temp[0]=(x[i]-extrx[0])/(extrx[1]-extrx[0]);
     temp[1]=(y[i]-extry[0])/(extry[1]-extry[0]);
     temp[2]=(z[i]-extrz[0])/(extrz[1]-extrz[0]);
 
-    /* debugging - if you comment out this function, the code does not abort, so the
-       error must be in this function somewhere! */
     fhsfc3d(temp,&leng,index);
 
     s[i].x=x[i];
@@ -232,10 +201,8 @@ void hilbert(double *x, double *y, double *z, int *N, int *table)
   }
 
 
-  printf("In hilbert, calling qsort.\n");
   qsort(s,*N,sizeof(struct m_str), cmp_indx);
 
-  printf("In hilbert, final loop from 0 to N.\n");
   for(i=0;i<*N;i++) {
 
     x[i]=s[i].x;
@@ -245,27 +212,5 @@ void hilbert(double *x, double *y, double *z, int *N, int *table)
 
   }
 
-  printf("In hilbert, before free(s).\n");
   free(s);
-  printf("In hilbert, after free(s).\n");
-
-  printf("In hilbert, x=");
-  for (i=0; i<*N; i++)
-    printf("%f ", x[i]);
-  printf("\n");
-
-  printf("In hilbert, y=");
-  for (i=0; i<*N; i++)
-    printf("%f ", y[i]);
-  printf("\n");
-
-  printf("In hilbert, z=");
-  for (i=0; i<*N; i++)
-    printf("%f ", z[i]);
-  printf("\n");
-
-  printf("In hilbert, table=");
-  for (i=0; i<*N; i++)
-    printf("%d ", table[i]);
-  printf("\n");
 }

--- a/src/partitioning/sfc_partitioner.C
+++ b/src/partitioning/sfc_partitioner.C
@@ -151,7 +151,6 @@ void SFCPartitioner::partition_range(MeshBase & mesh,
                     table.data());
     }
 
-  libMesh::out << "In SFCPartitioner::partition_range() after calling Sfc::hilbert" << std::endl;
 
   // Assign the partitioning to the range elements
   {

--- a/src/partitioning/sfc_partitioner.C
+++ b/src/partitioning/sfc_partitioner.C
@@ -151,6 +151,7 @@ void SFCPartitioner::partition_range(MeshBase & mesh,
                     table.data());
     }
 
+  libMesh::out << "In SFCPartitioner::partition_range() after calling Sfc::hilbert" << std::endl;
 
   // Assign the partitioning to the range elements
   {

--- a/tests/driver.C
+++ b/tests/driver.C
@@ -4,11 +4,38 @@
 #include <cppunit/ui/text/TestRunner.h>
 #include <libmesh/restore_warnings.h>
 
+// libMesh includes
 #include <libmesh/libmesh.h>
-
 #include "test_comm.h"
 
-int main( int argc, char **argv)
+#ifdef LIBMESH_HAVE_CXX11_REGEX
+
+// C++ includes
+#include <regex>
+
+// Add Tests to runner that match user-provided regex.
+void add_matching_tests_to_runner(CppUnit::Test * test, const std::regex & r, CppUnit::TextUi::TestRunner & runner)
+{
+  // If the regex matches and we don't have any "child" tests, add
+  // ourself. The exception is if the regex matches and this is the
+  // "All Tests" test, which isn't a leaf Test but still needs to be
+  // added.
+  if (std::regex_search(test->getName(), r) &&
+      (test->getChildTestCount() == 0 || test->getName() == "All Tests"))
+    {
+      libMesh::out << test->getName() << std::endl;
+      runner.addTest(test);
+    }
+
+  // Call this recursively on each of our children, if any.
+  for (int i = 0; i < test->getChildTestCount(); i++)
+    add_matching_tests_to_runner(test->getChildTestAt(i), r, runner);
+}
+
+#endif
+
+
+int main(int argc, char ** argv)
 {
   // Initialize the library.  This is necessary because the library
   // may depend on a number of other libraries (i.e. MPI  and Petsc)
@@ -16,15 +43,51 @@ int main( int argc, char **argv)
   libMesh::LibMeshInit init(argc, argv);
   TestCommWorld = &init.comm();
 
-  CppUnit::TextUi::TestRunner runner;
-  CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry();
-  runner.addTest( registry.makeTest() );
+  // We can now run all tests that match a regular expression, for
+  // example, "--re PartitionerTest" will match all the Partitioner
+  // unit tests.  If the user does not specify a regex, we run all the
+  // tests returned by makeTest().
 
-  // If the tests all succeed, report success
+  // An example regex_string that would _exactly_ match a _single_ test is:
+  // "PartitionerTest_HilbertSFCPartitioner_ReplicatedMesh::testPartition2"
+  // On the other hand, the regex "HilbertSFC" would match all of the
+  // following tests:
+  //
+  // PartitionerTest_HilbertSFCPartitioner_ReplicatedMesh
+  // PartitionerTest_HilbertSFCPartitioner_ReplicatedMesh::testPartitionEmpty
+  // PartitionerTest_HilbertSFCPartitioner_ReplicatedMesh::testPartition1
+  // PartitionerTest_HilbertSFCPartitioner_ReplicatedMesh::testPartition2
+  // PartitionerTest_HilbertSFCPartitioner_ReplicatedMesh::testPartitionNProc
+  //
+  // If the user does not provide a a regex, the default re is "All Tests",
+  // which runs all the unit tests.
+
+  // Read command line argument specifying the regular expression.
+  std::string regex_string = "All Tests";
+  regex_string = libMesh::command_line_next("--re", regex_string);
+
+  // Recursively add tests matching the regex tothe runner object.
+  CppUnit::TextUi::TestRunner runner;
+
+  // The Cppunit registry object that knows about all the tests.
+  CppUnit::TestFactoryRegistry & registry = CppUnit::TestFactoryRegistry::getRegistry();
+
+#ifdef LIBMESH_HAVE_CXX11_REGEX
+  // Make regex object from user's input.
+  std::regex the_regex(regex_string);
+
+  // Add all tests which match the re to the runner object.
+  libMesh::out << "Will run the following tests:" << std::endl;
+  add_matching_tests_to_runner(registry.makeTest(), the_regex, runner);
+#else
+  // If no C++11 <regex> just run all the tests.
+  runner.addTest(registry.makeTest());
+#endif
+
+  // Finally, run the matching tests.
   if (runner.run())
     return 0;
 
-  // If any test fails report failure
   return 1;
 }
 


### PR DESCRIPTION
This PR fixes a buffer overrun that we probably would never have caught except for the fact that it was causing the unit tests to occasionally fail when libmesh was configured with `--disable-strict-lgpl`. Note that I'm not sure if the fix is correct as far as the algorithm is concerned, but it does fix the problem with the aborts and the partitions are unchanged from before (when the code actually ran).

This PR also adds the ability to pass a regular expression (via "--re foo") to the unit tests executables so that only a subset of all the unit tests are run. Now that we have so many unit tests, this can greatly help the turnaround time when you are just trying to debug a single one. This new capability requires C++11 `<regex>` support to work, and falls back on running all tests if your compiler happens to not support that.

Refs #1967 
Refs #1968 

