### PR TITLE
Add const accessor methods for dpsi_maps in FEMap

### DIFF
--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -409,10 +409,18 @@ public:
   { libmesh_assert(!calculations_started || calculate_dxyz);
     calculate_dxyz = true; return dpsidxi_map; }
 
+  const std::vector<std::vector<Real>> & get_dpsidxi() const
+  { libmesh_assert(!calculations_started || calculate_dxyz);
+    calculate_dxyz = true; return dpsidxi_map; }
+
   /**
    * \returns The reference to physical map derivative for the side/edge
    */
   std::vector<std::vector<Real>> & get_dpsideta()
+  { libmesh_assert(!calculations_started || calculate_dxyz);
+    calculate_dxyz = true; return dpsideta_map; }
+
+  const std::vector<std::vector<Real>> & get_dpsideta() const
   { libmesh_assert(!calculations_started || calculate_dxyz);
     calculate_dxyz = true; return dpsideta_map; }
 


### PR DESCRIPTION
Allows accessing this data from `const FEMap` objects