### PR TITLE
Pass by reference instead of value in our numerics structures

### DIFF
--- a/include/numerics/tensor_value.h
+++ b/include/numerics/tensor_value.h
@@ -52,32 +52,32 @@ public:
    * Constructor-from-T.  By default sets higher dimensional
    * entries to 0.
    */
-  explicit TensorValue  (const T xx,
-                         const T xy=0,
-                         const T xz=0,
-                         const T yx=0,
-                         const T yy=0,
-                         const T yz=0,
-                         const T zx=0,
-                         const T zy=0,
-                         const T zz=0);
+  explicit TensorValue  (const T & xx,
+                         const T & xy=0,
+                         const T & xz=0,
+                         const T & yx=0,
+                         const T & yy=0,
+                         const T & yz=0,
+                         const T & zx=0,
+                         const T & zy=0,
+                         const T & zz=0);
 
   /**
    * Constructor-from-scalars.  By default sets higher dimensional
    * entries to 0.
    */
   template <typename Scalar>
-  explicit TensorValue  (const Scalar xx,
-                         const Scalar xy=0,
-                         const Scalar xz=0,
-                         const Scalar yx=0,
-                         const Scalar yy=0,
-                         const Scalar yz=0,
-                         const Scalar zx=0,
-                         const Scalar zy=0,
+  explicit TensorValue  (const Scalar & xx,
+                         const Scalar & xy=0,
+                         const Scalar & xz=0,
+                         const Scalar & yx=0,
+                         const Scalar & yy=0,
+                         const Scalar & yz=0,
+                         const Scalar & zx=0,
+                         const Scalar & zy=0,
                          typename
                          boostcopy::enable_if_c<ScalarTraits<Scalar>::value,
-                         const Scalar>::type zz=0);
+                         const Scalar>::type & zz=0);
 
   /**
    * Constructor.  Takes 1 row vector for LIBMESH_DIM=1
@@ -162,15 +162,15 @@ TensorValue<T>::TensorValue () :
 
 template <typename T>
 inline
-TensorValue<T>::TensorValue (const T xx,
-                             const T xy,
-                             const T xz,
-                             const T yx,
-                             const T yy,
-                             const T yz,
-                             const T zx,
-                             const T zy,
-                             const T zz) :
+TensorValue<T>::TensorValue (const T & xx,
+                             const T & xy,
+                             const T & xz,
+                             const T & yx,
+                             const T & yy,
+                             const T & yz,
+                             const T & zx,
+                             const T & zy,
+                             const T & zz) :
   TypeTensor<T> (xx,xy,xz,yx,yy,yz,zx,zy,zz)
 {
 }
@@ -179,17 +179,17 @@ TensorValue<T>::TensorValue (const T xx,
 template <typename T>
 template <typename Scalar>
 inline
-TensorValue<T>::TensorValue (const Scalar xx,
-                             const Scalar xy,
-                             const Scalar xz,
-                             const Scalar yx,
-                             const Scalar yy,
-                             const Scalar yz,
-                             const Scalar zx,
-                             const Scalar zy,
+TensorValue<T>::TensorValue (const Scalar & xx,
+                             const Scalar & xy,
+                             const Scalar & xz,
+                             const Scalar & yx,
+                             const Scalar & yy,
+                             const Scalar & yz,
+                             const Scalar & zx,
+                             const Scalar & zy,
                              typename
                              boostcopy::enable_if_c<ScalarTraits<Scalar>::value,
-                             const Scalar>::type zz) :
+                             const Scalar>::type & zz) :
   TypeTensor<T> (xx,xy,xz,yx,yy,yz,zx,zy,zz)
 {
 }

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -64,32 +64,32 @@ protected:
    * arguments are to be overridden it requires that the "xz = 0."
    * etc. arguments also be given explicitly.
    */
-  explicit TypeTensor  (const T xx,
-                        const T xy=0,
-                        const T xz=0,
-                        const T yx=0,
-                        const T yy=0,
-                        const T yz=0,
-                        const T zx=0,
-                        const T zy=0,
-                        const T zz=0);
+  explicit TypeTensor  (const T & xx,
+                        const T & xy=0,
+                        const T & xz=0,
+                        const T & yx=0,
+                        const T & yy=0,
+                        const T & yz=0,
+                        const T & zx=0,
+                        const T & zy=0,
+                        const T & zz=0);
 
 
   /**
    * Constructor-from-Scalar.
    */
   template <typename Scalar>
-  explicit TypeTensor  (const Scalar xx,
-                        const Scalar xy=0,
-                        const Scalar xz=0,
-                        const Scalar yx=0,
-                        const Scalar yy=0,
-                        const Scalar yz=0,
-                        const Scalar zx=0,
-                        const Scalar zy=0,
+  explicit TypeTensor  (const Scalar & xx,
+                        const Scalar & xy=0,
+                        const Scalar & xz=0,
+                        const Scalar & yx=0,
+                        const Scalar & yy=0,
+                        const Scalar & yz=0,
+                        const Scalar & zx=0,
+                        const Scalar & zy=0,
                         typename
                         boostcopy::enable_if_c<ScalarTraits<Scalar>::value,
-                        const Scalar>::type zz=0);
+                        const Scalar>::type & zz=0);
 
   /**
    * Constructor.  Assigns each vector to a different row of the
@@ -201,7 +201,7 @@ public:
    * Add a scaled tensor to this tensor without creating a temporary.
    */
   template <typename T2>
-  void add_scaled (const TypeTensor<T2> &, const T);
+  void add_scaled (const TypeTensor<T2> &, const T &);
 
   /**
    * Subtract a tensor from this tensor.
@@ -231,7 +231,7 @@ public:
    * temporary.
    */
   template <typename T2>
-  void subtract_scaled (const TypeTensor<T2> &, const T);
+  void subtract_scaled (const TypeTensor<T2> &, const T &);
 
   /**
    * \returns The negative of this tensor in a separate copy.
@@ -245,7 +245,7 @@ public:
    */
   template <typename Scalar>
   auto
-  operator * (const Scalar scalar) const -> typename boostcopy::enable_if_c<
+  operator * (const Scalar & scalar) const -> typename boostcopy::enable_if_c<
     ScalarTraits<Scalar>::value,
     TypeTensor<decltype(T() * scalar)>>::type;
 
@@ -256,7 +256,7 @@ public:
    */
   template <typename Scalar, typename boostcopy::enable_if_c<
                                ScalarTraits<Scalar>::value, int>::type = 0>
-  const TypeTensor<T> & operator *= (const Scalar factor)
+  const TypeTensor<T> & operator *= (const Scalar & factor)
     {
       for (unsigned int i=0; i<LIBMESH_DIM*LIBMESH_DIM; i++)
         _coords[i] *= factor;
@@ -273,14 +273,14 @@ public:
   typename boostcopy::enable_if_c<
     ScalarTraits<Scalar>::value,
     TypeTensor<typename CompareTypes<T, Scalar>::supertype>>::type
-  operator / (const Scalar) const;
+  operator / (const Scalar &) const;
 
   /**
    * Divide each entry of this tensor by a scalar value.
    *
    * \returns A reference to *this.
    */
-  const TypeTensor<T> & operator /= (const T);
+  const TypeTensor<T> & operator /= (const T &);
 
   /**
    * Multiply 2 tensors together, i.e. matrix-matrix product.
@@ -524,15 +524,15 @@ TypeTensor<T>::TypeTensor ()
 
 template <typename T>
 inline
-TypeTensor<T>::TypeTensor (const T xx,
-                           const T xy,
-                           const T xz,
-                           const T yx,
-                           const T yy,
-                           const T yz,
-                           const T zx,
-                           const T zy,
-                           const T zz)
+TypeTensor<T>::TypeTensor (const T & xx,
+                           const T & xy,
+                           const T & xz,
+                           const T & yx,
+                           const T & yy,
+                           const T & yz,
+                           const T & zx,
+                           const T & zy,
+                           const T & zz)
 {
   _coords[0] = xx;
 
@@ -568,17 +568,17 @@ TypeTensor<T>::TypeTensor (const T xx,
 template <typename T>
 template <typename Scalar>
 inline
-TypeTensor<T>::TypeTensor (const Scalar xx,
-                           const Scalar xy,
-                           const Scalar xz,
-                           const Scalar yx,
-                           const Scalar yy,
-                           const Scalar yz,
-                           const Scalar zx,
-                           const Scalar zy,
+TypeTensor<T>::TypeTensor (const Scalar & xx,
+                           const Scalar & xy,
+                           const Scalar & xz,
+                           const Scalar & yx,
+                           const Scalar & yy,
+                           const Scalar & yz,
+                           const Scalar & zx,
+                           const Scalar & zy,
                            typename
                            boostcopy::enable_if_c<ScalarTraits<Scalar>::value,
-                           const Scalar>::type zz)
+                           const Scalar>::type & zz)
 {
   _coords[0] = xx;
 
@@ -805,7 +805,7 @@ void TypeTensor<T>::add (const TypeTensor<T2> & p)
 template <typename T>
 template <typename T2>
 inline
-void TypeTensor<T>::add_scaled (const TypeTensor<T2> & p, const T factor)
+void TypeTensor<T>::add_scaled (const TypeTensor<T2> & p, const T & factor)
 {
   for (unsigned int i=0; i<LIBMESH_DIM*LIBMESH_DIM; i++)
     _coords[i] += factor*p._coords[i];
@@ -875,7 +875,7 @@ void TypeTensor<T>::subtract (const TypeTensor<T2> & p)
 template <typename T>
 template <typename T2>
 inline
-void TypeTensor<T>::subtract_scaled (const TypeTensor<T2> & p, const T factor)
+void TypeTensor<T>::subtract_scaled (const TypeTensor<T2> & p, const T & factor)
 {
   for (unsigned int i=0; i<LIBMESH_DIM*LIBMESH_DIM; i++)
     _coords[i] -= factor*p._coords[i];
@@ -919,7 +919,7 @@ template <typename T>
 template <typename Scalar>
 inline
 auto
-TypeTensor<T>::operator * (const Scalar factor) const -> typename boostcopy::enable_if_c<
+TypeTensor<T>::operator * (const Scalar & factor) const -> typename boostcopy::enable_if_c<
   ScalarTraits<Scalar>::value,
   TypeTensor<decltype(T() * factor)>>::type
 {
@@ -957,7 +957,7 @@ inline
 typename boostcopy::enable_if_c<
   ScalarTraits<Scalar>::value,
   TypeTensor<typename CompareTypes<T, Scalar>::supertype>>::type
-operator * (const Scalar factor,
+operator * (const Scalar & factor,
             const TypeTensor<T> & t)
 {
   return t * factor;
@@ -969,7 +969,7 @@ inline
 typename boostcopy::enable_if_c<
   ScalarTraits<Scalar>::value,
   TypeTensor<typename CompareTypes<T, Scalar>::supertype>>::type
-TypeTensor<T>::operator / (const Scalar factor) const
+TypeTensor<T>::operator / (const Scalar & factor) const
 {
   libmesh_assert_not_equal_to (factor, static_cast<T>(0.));
 
@@ -1134,7 +1134,7 @@ void TypeTensor<T>::solve(const TypeVector<T> & b, TypeVector<T> & x) const
 
 template <typename T>
 inline
-const TypeTensor<T> & TypeTensor<T>::operator /= (const T factor)
+const TypeTensor<T> & TypeTensor<T>::operator /= (const T & factor)
 {
   libmesh_assert_not_equal_to (factor, static_cast<T>(0.));
 

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -66,9 +66,9 @@ protected:
    * Constructor-from-T.  By default sets higher dimensional
    * entries to 0.
    */
-  TypeVector (const T x,
-              const T y=0,
-              const T z=0);
+  TypeVector (const T & x,
+              const T & y=0,
+              const T & z=0);
 
   /**
    * Constructor-from-scalars.  By default sets higher dimensional
@@ -77,13 +77,13 @@ protected:
   template <typename Scalar1, typename Scalar2, typename Scalar3>
   TypeVector (typename
               boostcopy::enable_if_c<ScalarTraits<Scalar1>::value,
-              const Scalar1>::type x,
+              const Scalar1>::type & x,
               typename
               boostcopy::enable_if_c<ScalarTraits<Scalar2>::value,
-              const Scalar2>::type y=0,
+              const Scalar2>::type & y=0,
               typename
               boostcopy::enable_if_c<ScalarTraits<Scalar3>::value,
-              const Scalar3>::type z=0);
+              const Scalar3>::type & z=0);
 
   /**
    * Constructor-from-scalar.  Sets higher dimensional entries to 0.
@@ -92,7 +92,7 @@ protected:
    * TypeVector<Complex> v = 0;
    */
   template <typename Scalar>
-  TypeVector (const Scalar x,
+  TypeVector (const Scalar & x,
               typename
               boostcopy::enable_if_c<ScalarTraits<Scalar>::value,
               const Scalar>::type * sfinae = nullptr);
@@ -175,7 +175,7 @@ public:
    * Add a scaled value to this vector without creating a temporary.
    */
   template <typename T2>
-  void add_scaled (const TypeVector<T2> &, const T);
+  void add_scaled (const TypeVector<T2> &, const T &);
 
   /**
    * Subtract from this vector.
@@ -205,7 +205,7 @@ public:
    * temporary.
    */
   template <typename T2>
-  void subtract_scaled (const TypeVector<T2> &, const T);
+  void subtract_scaled (const TypeVector<T2> &, const T &);
 
   /**
    * \returns The negative of this vector in a separate copy.
@@ -221,14 +221,14 @@ public:
   typename boostcopy::enable_if_c<
     ScalarTraits<Scalar>::value,
     TypeVector<typename CompareTypes<T, Scalar>::supertype>>::type
-  operator * (const Scalar) const;
+  operator * (const Scalar &) const;
 
   /**
    * Multiply this vector by a scalar value.
    *
    * \returns A reference to *this.
    */
-  const TypeVector<T> & operator *= (const T);
+  const TypeVector<T> & operator *= (const T &);
 
   /**
    * Divide each entry of this vector by scalar value.
@@ -239,14 +239,14 @@ public:
   typename boostcopy::enable_if_c<
     ScalarTraits<Scalar>::value,
     TypeVector<typename CompareTypes<T, Scalar>::supertype>>::type
-  operator / (const Scalar) const;
+  operator / (const Scalar &) const;
 
   /**
    * Divide each entry of this vector by scalar value.
    *
    * \returns A reference to *this.
    */
-  const TypeVector<T> & operator /= (const T);
+  const TypeVector<T> & operator /= (const T &);
 
   /**
    * \returns The dot-product of this vector with another vector.
@@ -435,9 +435,9 @@ TypeVector<T>::TypeVector ()
 
 template <typename T>
 inline
-TypeVector<T>::TypeVector (const T x,
-                           const T y,
-                           const T z)
+TypeVector<T>::TypeVector (const T & x,
+                           const T & y,
+                           const T & z)
 {
   _coords[0] = x;
 
@@ -460,13 +460,13 @@ template <typename Scalar1, typename Scalar2, typename Scalar3>
 inline
 TypeVector<T>::TypeVector (typename
                            boostcopy::enable_if_c<ScalarTraits<Scalar1>::value,
-                           const Scalar1>::type x,
+                           const Scalar1>::type & x,
                            typename
                            boostcopy::enable_if_c<ScalarTraits<Scalar2>::value,
-                           const Scalar2>::type y,
+                           const Scalar2>::type & y,
                            typename
                            boostcopy::enable_if_c<ScalarTraits<Scalar3>::value,
-                           const Scalar3>::type z)
+                           const Scalar3>::type & z)
 {
   _coords[0] = x;
 
@@ -488,7 +488,7 @@ TypeVector<T>::TypeVector (typename
 template <typename T>
 template <typename Scalar>
 inline
-TypeVector<T>::TypeVector (const Scalar x,
+TypeVector<T>::TypeVector (const Scalar & x,
                            typename
                            boostcopy::enable_if_c<ScalarTraits<Scalar>::value,
                            const Scalar>::type * /*sfinae*/)
@@ -624,7 +624,7 @@ void TypeVector<T>::add (const TypeVector<T2> & p)
 template <typename T>
 template <typename T2>
 inline
-void TypeVector<T>::add_scaled (const TypeVector<T2> & p, const T factor)
+void TypeVector<T>::add_scaled (const TypeVector<T2> & p, const T & factor)
 {
 #if LIBMESH_DIM == 1
   _coords[0] += factor*p(0);
@@ -698,7 +698,7 @@ void TypeVector<T>::subtract (const TypeVector<T2> & p)
 template <typename T>
 template <typename T2>
 inline
-void TypeVector<T>::subtract_scaled (const TypeVector<T2> & p, const T factor)
+void TypeVector<T>::subtract_scaled (const TypeVector<T2> & p, const T & factor)
 {
   for (unsigned int i=0; i<LIBMESH_DIM; i++)
     _coords[i] -= factor*p(i);
@@ -736,7 +736,7 @@ inline
 typename boostcopy::enable_if_c<
   ScalarTraits<Scalar>::value,
   TypeVector<typename CompareTypes<T, Scalar>::supertype>>::type
-TypeVector<T>::operator * (const Scalar factor) const
+TypeVector<T>::operator * (const Scalar & factor) const
 {
   typedef typename CompareTypes<T, Scalar>::supertype SuperType;
 
@@ -763,7 +763,7 @@ inline
 typename boostcopy::enable_if_c<
   ScalarTraits<Scalar>::value,
   TypeVector<typename CompareTypes<T, Scalar>::supertype>>::type
-operator * (const Scalar factor,
+operator * (const Scalar & factor,
             const TypeVector<T> & v)
 {
   return v * factor;
@@ -773,7 +773,7 @@ operator * (const Scalar factor,
 
 template <typename T>
 inline
-const TypeVector<T> & TypeVector<T>::operator *= (const T factor)
+const TypeVector<T> & TypeVector<T>::operator *= (const T & factor)
 {
 #if LIBMESH_DIM == 1
   _coords[0] *= factor;
@@ -801,7 +801,7 @@ inline
 typename boostcopy::enable_if_c<
   ScalarTraits<Scalar>::value,
   TypeVector<typename CompareTypes<T, Scalar>::supertype>>::type
-TypeVector<T>::operator / (const Scalar factor) const
+TypeVector<T>::operator / (const Scalar & factor) const
 {
   libmesh_assert_not_equal_to (factor, static_cast<T>(0.));
 
@@ -830,7 +830,7 @@ TypeVector<T>::operator / (const Scalar factor) const
 template <typename T>
 inline
 const TypeVector<T> &
-TypeVector<T>::operator /= (const T factor)
+TypeVector<T>::operator /= (const T & factor)
 {
   libmesh_assert_not_equal_to (factor, static_cast<T>(0.));
 

--- a/include/numerics/vector_value.h
+++ b/include/numerics/vector_value.h
@@ -52,9 +52,9 @@ public:
    * Constructor-from-T.  By default sets higher dimensional
    * entries to 0.
    */
-  VectorValue (const T x,
-               const T y=0,
-               const T z=0);
+  VectorValue (const T & x,
+               const T & y=0,
+               const T & z=0);
 
   /**
    * Constructor-from-scalars.  By default sets higher dimensional
@@ -63,13 +63,13 @@ public:
   template <typename Scalar1, typename Scalar2, typename Scalar3>
   VectorValue (typename
                boostcopy::enable_if_c<ScalarTraits<Scalar1>::value,
-               const Scalar1>::type x,
+               const Scalar1>::type & x,
                typename
                boostcopy::enable_if_c<ScalarTraits<Scalar2>::value,
-               const Scalar2>::type y = 0,
+               const Scalar2>::type & y = 0,
                typename
                boostcopy::enable_if_c<ScalarTraits<Scalar3>::value,
-               const Scalar3>::type z = 0);
+               const Scalar3>::type & z = 0);
 
 
   /**
@@ -79,7 +79,7 @@ public:
    * VectorValue<Complex> v = 0;
    */
   template <typename Scalar>
-  VectorValue (const Scalar x,
+  VectorValue (const Scalar & x,
                typename
                boostcopy::enable_if_c<ScalarTraits<Scalar>::value,
                const Scalar>::type * sfinae = nullptr);
@@ -144,9 +144,9 @@ VectorValue<T>::VectorValue () :
 
 template <typename T>
 inline
-VectorValue<T>::VectorValue (const T x,
-                             const T y,
-                             const T z) :
+VectorValue<T>::VectorValue (const T & x,
+                             const T & y,
+                             const T & z) :
   TypeVector<T> (x,y,z)
 {
 }
@@ -158,13 +158,13 @@ template <typename Scalar1, typename Scalar2, typename Scalar3>
 inline
 VectorValue<T>::VectorValue (typename
                              boostcopy::enable_if_c<ScalarTraits<Scalar1>::value,
-                             const Scalar1>::type x,
+                             const Scalar1>::type & x,
                              typename
                              boostcopy::enable_if_c<ScalarTraits<Scalar2>::value,
-                             const Scalar2>::type y,
+                             const Scalar2>::type & y,
                              typename
                              boostcopy::enable_if_c<ScalarTraits<Scalar3>::value,
-                             const Scalar3>::type z) :
+                             const Scalar3>::type & z) :
   TypeVector<T> (x,y,z)
 {
 }
@@ -173,7 +173,7 @@ VectorValue<T>::VectorValue (typename
 template <typename T>
 template <typename Scalar>
 inline
-VectorValue<T>::VectorValue (const Scalar x,
+VectorValue<T>::VectorValue (const Scalar & x,
                              typename
                              boostcopy::enable_if_c<ScalarTraits<Scalar>::value,
                              const Scalar>::type * /*sfinae*/) :


### PR DESCRIPTION
This can be discussed, but if we're keeping the code very general, pass-by-value is painful for `T=DualNumber<T2,D>`