### PR TITLE
Allow changing the tolerance for an element Jacobian mapping failure

### DIFF
--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -907,7 +907,7 @@ protected:
   /**
    * The Jacobian tolerance used for determining when the mapping fails. The mapping is
    * determined to fail if jac <= jacobian_tolerance. If not set by the user, this number
-   * defaults to -TOLERANCE*TOLERANCE (-1e-12 for double precision calculations)
+   * defaults to 0
    */
   Real jacobian_tolerance;
 

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -519,6 +519,12 @@ public:
   { libmesh_assert(!calculations_started || calculate_dxyz);
     calculate_dxyz = true; return JxW; }
 
+  /**
+   * Set the Jacobian tolerance used for determining when the mapping fails. The mapping is
+   * determined to fail if jac <= jacobian_tolerance.
+   */
+  void set_jacobian_tolerance(Real tol) { jacobian_tolerance = tol; }
+
 protected:
 
   /**
@@ -897,6 +903,13 @@ protected:
    */
   template <unsigned int Dim, FEFamily T>
   friend class FE;
+
+  /**
+   * The Jacobian tolerance used for determining when the mapping fails. The mapping is
+   * determined to fail if jac <= jacobian_tolerance. If not set by the user, this number
+   * defaults to -TOLERANCE*TOLERANCE (-1e-12 for double precision calculations)
+   */
+  Real jacobian_tolerance;
 
 private:
   /**

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -49,7 +49,7 @@ class FEMap
 {
 public:
 
-  FEMap();
+  FEMap(Real jtol = 0);
   virtual ~FEMap(){}
 
   static std::unique_ptr<FEMap> build(FEType fe_type);

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -45,7 +45,8 @@ FEMap::FEMap() :
   calculations_started(false),
   calculate_xyz(false),
   calculate_dxyz(false),
-  calculate_d2xyz(false)
+  calculate_d2xyz(false),
+  jacobian_tolerance(-TOLERANCE * TOLERANCE)
 {}
 
 
@@ -497,7 +498,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
           {
             jac[p] = dxyzdxi_map[p].norm();
 
-            if (jac[p] <= -TOLERANCE * TOLERANCE)
+            if (jac[p] <= jacobian_tolerance)
               {
                 // Don't call print_info() recursively if we're already
                 // failing.  print_info() calls Elem::volume() which may
@@ -742,7 +743,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
             // jac = dx/dxi*dy/deta - dx/deta*dy/dxi
             jac[p] = (dx_dxi*dy_deta - dx_deta*dy_dxi);
 
-            if (jac[p] <= -TOLERANCE * TOLERANCE)
+            if (jac[p] <= jacobian_tolerance)
               {
                 // Don't call print_info() recursively if we're already
                 // failing.  print_info() calls Elem::volume() which may
@@ -1075,7 +1076,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                       dy_dxi*(dz_deta*dx_dzeta - dx_deta*dz_dzeta)  +
                       dz_dxi*(dx_deta*dy_dzeta - dy_deta*dx_dzeta));
 
-            if (jac[p] <= -TOLERANCE * TOLERANCE)
+            if (jac[p] <= jacobian_tolerance)
               {
                 // Don't call print_info() recursively if we're already
                 // failing.  print_info() calls Elem::volume() which may

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -41,12 +41,12 @@ namespace libMesh
 {
 
 // Constructor
-FEMap::FEMap() :
+FEMap::FEMap(Real jtol) :
   calculations_started(false),
   calculate_xyz(false),
   calculate_dxyz(false),
   calculate_d2xyz(false),
-  jacobian_tolerance(0)
+  jacobian_tolerance(jtol)
 {}
 
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -497,7 +497,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
           {
             jac[p] = dxyzdxi_map[p].norm();
 
-            if (jac[p] <= 0.)
+            if (jac[p] <= -TOLERANCE * TOLERANCE)
               {
                 // Don't call print_info() recursively if we're already
                 // failing.  print_info() calls Elem::volume() which may
@@ -742,7 +742,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
             // jac = dx/dxi*dy/deta - dx/deta*dy/dxi
             jac[p] = (dx_dxi*dy_deta - dx_deta*dy_dxi);
 
-            if (jac[p] <= 0.)
+            if (jac[p] <= -TOLERANCE * TOLERANCE)
               {
                 // Don't call print_info() recursively if we're already
                 // failing.  print_info() calls Elem::volume() which may
@@ -1075,7 +1075,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                       dy_dxi*(dz_deta*dx_dzeta - dx_deta*dz_dzeta)  +
                       dz_dxi*(dx_deta*dy_dzeta - dy_deta*dx_dzeta));
 
-            if (jac[p] <= 0.)
+            if (jac[p] <= -TOLERANCE * TOLERANCE)
               {
                 // Don't call print_info() recursively if we're already
                 // failing.  print_info() calls Elem::volume() which may

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -46,7 +46,7 @@ FEMap::FEMap() :
   calculate_xyz(false),
   calculate_dxyz(false),
   calculate_d2xyz(false),
-  jacobian_tolerance(-TOLERANCE * TOLERANCE)
+  jacobian_tolerance(0)
 {}
 
 


### PR DESCRIPTION
This is a slippery slope perhaps, but in some ALE simulations I was running into issues where the (element) Jacobian would be > 0 during residual calculations, and then between 0 and -machine_epsilon during the (matrix) Jacobian calculations. PETSc has a graceful way to stop a solve during an issue in the residual computation routine; not so during the Jacobian calculation. The result is an aborted simulation due to some numeric fluctuations leading to a very small negative element Jacobian. This patch made the simulations much more robust. @jwpeterson 