### PR TITLE
gradient with infinite elements (2)

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -297,6 +297,8 @@ public:
    * how close is "good enough."  The map inversion iteration
    * computes the sequence \f$ \{ p_n \} \f$, and the iteration is
    * terminated when \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
+   * The parameter secure (always assumed false in non-debug mode)
+   * switches on integrity-checks on the mapped points.
    */
   static Point inverse_map (const Elem * elem,
                             const Point & p,
@@ -312,6 +314,8 @@ public:
    * close is "good enough."  The map inversion iteration computes the
    * sequence \f$ \{ p_n \} \f$, and the iteration is terminated when
    * \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
+   * The parameter secure (always assumed false in non-debug mode)
+   * switches on integrity-checks on the mapped points.
    */
   static void inverse_map (const Elem * elem,
                            const std::vector<Point> & physical_points,

--- a/include/fe/fe_compute_data.h
+++ b/include/fe/fe_compute_data.h
@@ -21,6 +21,7 @@
 
 // Local includes
 #include "libmesh/libmesh.h"
+#include "libmesh/fe_base.h" // required for the type OutputGradient.
 
 // C++ includes
 #include <vector>
@@ -57,7 +58,8 @@ public:
   FEComputeData (const EquationSystems & es,
                  const Point & pin) :
     equation_systems(es),
-    p(pin)
+    p(pin),
+    _need_dshape(false)
   {
     this->clear();
   }
@@ -78,6 +80,20 @@ public:
    */
   std::vector<Number> shape;
 
+  /**
+   * Storage for the computed shape derivative values.
+   */
+  std::vector<Gradient> dshape;
+
+  /**
+   * Storage for local to global mapping at \p p.
+   * This is needed when the gradient in physical
+   * coordinates is of interest.
+   * FIXME: What kind of type should one use for it?
+   *  The matrix-class don't look as if they were made for it
+   *  and neither are the TensorTool-members.
+   */
+  std::vector<std::vector<Real>> local_transform;
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   /**
@@ -108,6 +124,33 @@ public:
    * the fields are correctly resized.
    */
   void init ();
+
+  /**
+   * Enable the computation of shape gradients (dshape).
+   */
+  void enable_derivative ();
+
+  /**
+   * Disable the computation of shape gradients (dshape).
+   * Default is disabled.
+   */
+  void disable_derivative ()
+  {_need_dshape=false; }
+
+  /**
+   * Check whether derivatives should be computed or not.
+   */
+  bool need_derivative ()
+  {return _need_dshape; }
+
+private:
+  /**
+   * variable indicating whether the shape-derivative should be computed or not.
+   * Default is false to save time and be compatible with elements where derivatives
+   * are not implemented/ cannot be computed.
+   */
+  bool _need_dshape;
+
 };
 
 

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -297,6 +297,41 @@ public:
                     OutputType & phi);
 
   /**
+   * \returns The \f$ j^{th} \f$ coordinate of the gradient of
+   * the \f$ i^{th} \f$ shape function at point \p p.
+   * This method allows you to specify the dimension,
+   * element type, and order directly. Automatically passes the
+   * request to the appropriate *scalar* finite element class member.
+   *
+   * \note On a p-refined element, \p fe_t.order should be the total
+   * order of the element.
+   */
+  static Real shape_deriv(const unsigned int dim,
+                          const FEType & fe_t,
+                          const ElemType t,
+                          const unsigned int i,
+                          const unsigned int j,
+                          const Point & p);
+
+  /**
+   * \returns The \f$ j^{th} \f$ coordinate of the gradient of
+   * the \f$ i^{th} \f$ shape function at point \p p.
+   * This method allows you to specify the dimension,
+   * element type, and order directly. Automatically passes the
+   * request to the appropriate *scalar* finite element class member.
+   *
+   * \note On a p-refined element, \p fe_t.order should be the total
+   * order of the element.
+   */
+  static Real shape_deriv (const unsigned int dim,
+                           const FEType & fe_t,
+                           const Elem *elem,
+                           const unsigned int i,
+                           const unsigned int j,
+                           const Point & p);
+
+
+  /**
    * Lets the appropriate child of \p FEBase compute the requested
    * data for the input specified in \p data, and sets the values in
    * \p data.  See this as a generalization of \p shape().  With
@@ -447,6 +482,21 @@ private:
                          const Elem * elem,
                          const unsigned int i,
                          const Point & p);
+
+
+  static Real ifem_shape_deriv(const unsigned int dim,
+                               const FEType & fe_t,
+                               const ElemType t,
+                               const unsigned int i,
+                               const unsigned int j,
+                               const Point & p);
+
+  static Real ifem_shape_deriv(const unsigned int dim,
+                               const FEType & fe_t,
+                               const Elem * elem,
+                               const unsigned int i,
+                               const unsigned int j,
+                               const Point & p);
 
   static void ifem_compute_data(const unsigned int dim,
                                 const FEType & fe_t,

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -227,25 +227,25 @@ public:
   {}
 
   /**
-   * The approximation order in radial direction of the infinite element.
+   * The approximation order in the base of the infinite element.
    */
   OrderWrapper order;
 
   /**
-   * The approximation order in the base of the infinite element.
+   * The approximation order in radial direction of the infinite element.
    */
   OrderWrapper radial_order;
-
-  /**
-   * The type of approximation in radial direction.  Valid types are
-   * \p JACOBI_20_00, \p JACOBI_30_00, etc...
-   */
-  FEFamily family;
 
   /**
    * For InfFE, \p family contains the radial shape family, while
    * \p base_family contains the approximation type in circumferential
    * direction.  Valid types are \p LAGRANGE, \p HIERARCHIC, etc...
+   */
+  FEFamily family;
+
+  /**
+   * The type of approximation in radial direction.  Valid types are
+   * \p JACOBI_20_00, \p JACOBI_30_00, etc...
    */
   FEFamily radial_family;
 

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -406,12 +406,12 @@ public:
                        const std::vector<Real> * const weights = nullptr) override;
 
   /**
-   * Not implemented yet.  Reinitializes all the physical
+   * Reinitializes all the physical
    * element-dependent data based on the \p side of an infinite
    * element.
    */
-  virtual void reinit (const Elem * elem,
-                       const unsigned int side,
+  virtual void reinit (const Elem * inf_elem,
+                       const unsigned int s,
                        const Real tolerance = TOLERANCE,
                        const std::vector<Point> * const pts = nullptr,
                        const std::vector<Real> * const weights = nullptr) override;
@@ -538,11 +538,11 @@ protected:
                             const Elem * inf_elem);
 
   /**
-   * Not implemented yet.  Initialize all the data fields like \p weight,
+   * Initialize all the data fields like \p weight,
    * \p phi, etc for the side \p s.
    */
-  void init_face_shape_functions (const std::vector<Point> & qp,
-                                  const Elem * side);
+  void init_face_shape_functions (const std::vector<Point> &,
+                                  const Elem * inf_side);
 
   /**
    * Combines the shape functions, which were formed in

--- a/include/fe/inf_fe.h
+++ b/include/fe/inf_fe.h
@@ -281,6 +281,42 @@ public:
                     const Point & p);
 
   /**
+   * \returns The \f$ j^{th} \f$ derivative of the \f$ i^{th} \f$
+   * shape function at point \p p. This method lets you specify the relevant
+   * data directly, and is therefore allowed to be static.
+   *
+   * \note This class member is not as efficient as its counterpart in
+   * \p FE<Dim,T>, and is not employed in the \p reinit() cycle.
+   *
+   * \note This method does not return physically correct shape gradients,
+   * instead use \p compute_data().  The \p shape_deriv() methods should
+   * only be used for mapping.
+   */
+  static Real shape_deriv (const FEType & fet,
+                           const Elem * inf_elem,
+                           const unsigned int i,
+                           const unsigned int j,
+                           const Point & p);
+
+  /**
+   * \returns The \f$ j^{th} \f$ derivative of the \f$ i^{th} \f$
+   * shape function at point \p p. This method lets you specify the relevant
+   * data directly, and is therefore allowed to be static.
+   *
+   * \note This class member is not as efficient as its counterpart in
+   * \p FE<Dim,T>, and is not employed in the \p reinit() cycle.
+   *
+   * \note This method does not return physically correct shape gradients,
+   * instead use \p compute_data().  The \p shape_deriv() methods should
+   * only be used for mapping.
+   */
+  static Real shape_deriv (const FEType & fet,
+                           const ElemType inf_elem_type,
+                           const unsigned int i,
+                           const unsigned int j,
+                           const Point & p);
+
+  /**
    * Generalized version of \p shape(), takes an \p Elem *.  The \p data
    * contains both input and output parameters.  For frequency domain
    * simulations, the complex-valued shape is returned.  In time domain
@@ -806,6 +842,7 @@ private:
    */
   static bool _warned_for_nodal_soln;
   static bool _warned_for_shape;
+  static bool _warned_for_dshape;
 
 #endif
 

--- a/src/fe/fe_compute_data.C
+++ b/src/fe/fe_compute_data.C
@@ -25,6 +25,8 @@ namespace libMesh
 void FEComputeData::clear ()
 {
   this->shape.clear();
+  this->dshape.clear();
+  this->local_transform.clear();
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   this->phase = 0.;
   this->speed = 1.;
@@ -67,6 +69,14 @@ void FEComputeData::init ()
 
 #endif //LIBMESH_ENABLE_INFINITE_ELEMENTS
 
+}
+
+
+void FEComputeData::enable_derivative ()
+{
+  _need_dshape=true;
+  if (!(this->dshape.empty()))
+    std::fill (this->dshape.begin(),   this->dshape.end(),  0);
 }
 
 

--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -29,6 +29,69 @@ namespace libMesh
 {
 
 
+#define inf_fe_family_mapping_switch(dim, func_and_args, prefix, suffix) \
+  do {                                                                  \
+    switch (fe_t.radial_family)                                         \
+      {                                                                 \
+      case INFINITE_MAP:                                                \
+        switch(fe_t.inf_map)                                            \
+          {                                                             \
+          case CARTESIAN:                                               \
+            prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix \
+          case SPHERICAL:                                               \
+          case ELLIPSOIDAL:                                             \
+            libmesh_not_implemented();                                  \
+          default:                                                      \
+            libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+          }                                                             \
+      case JACOBI_20_00:                                                \
+        switch(fe_t.inf_map)                                            \
+          {                                                             \
+          case CARTESIAN:                                               \
+            prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix \
+          case SPHERICAL:                                               \
+          case ELLIPSOIDAL:                                             \
+            libmesh_not_implemented();                                  \
+          default:                                                      \
+            libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+          }                                                             \
+      case JACOBI_30_00:                                                \
+        switch(fe_t.inf_map)                                            \
+          {                                                             \
+          case CARTESIAN:                                               \
+            prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix \
+          case SPHERICAL:                                               \
+          case ELLIPSOIDAL:                                             \
+            libmesh_not_implemented();                                  \
+          default:                                                      \
+            libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+          }                                                             \
+      case LEGENDRE:                                                    \
+        switch(fe_t.inf_map)                                            \
+          {                                                             \
+          case CARTESIAN:                                               \
+            prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix \
+          case SPHERICAL:                                               \
+          case ELLIPSOIDAL:                                             \
+            libmesh_not_implemented();                                  \
+          default:                                                      \
+            libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+          }                                                             \
+      case LAGRANGE:                                                    \
+        switch(fe_t.inf_map)                                            \
+          {                                                             \
+          case CARTESIAN:                                               \
+            prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix \
+          case SPHERICAL:                                               \
+          case ELLIPSOIDAL:                                             \
+            libmesh_not_implemented();                                  \
+          default:                                                      \
+            libmesh_error_msg("Invalid radial mapping " << fe_t.inf_map); \
+          }                                                             \
+      default:                                                          \
+        libmesh_error_msg("Invalid radial family = " << fe_t.radial_family); \
+      }                                                                 \
+  } while (0)
 
 
 //------------------------------------------------------------
@@ -802,7 +865,54 @@ Real FEInterface::ifem_shape(const unsigned int dim,
     }
 }
 
+Real FEInterface::ifem_shape_deriv (const unsigned int dim,
+                                    const FEType & fe_t,
+                                    const Elem * elem,
+                                    const unsigned int i,
+                                    const unsigned int j,
+                                    const Point & p)
+{
+  switch (dim)
+    {
+      // 1D
+    case 1:
+      inf_fe_family_mapping_switch(1, shape_deriv(fe_t, elem, i, j, p), return, ;);
+      // 2D
+    case 2:
+      inf_fe_family_mapping_switch(2, shape_deriv(fe_t, elem, i, j, p), return, ;);
+      // 3D
+    case 3:
+      inf_fe_family_mapping_switch(3, shape_deriv(fe_t, elem, i, j, p), return, ;);
 
+    default:
+      libmesh_error_msg("Invalid dim = " << dim);
+    }
+}
+
+
+Real FEInterface::ifem_shape_deriv(const unsigned int dim,
+                                   const FEType & fe_t,
+                                   const ElemType t,
+                                   const unsigned int i,
+                                   const unsigned int j,
+                                   const Point & p)
+{
+  switch (dim)
+    {
+      // 1D
+    case 1:
+      inf_fe_family_mapping_switch(1, shape_deriv(fe_t, t, i, j, p), return, ;);
+      // 2D
+    case 2:
+      inf_fe_family_mapping_switch(2, shape_deriv(fe_t, t, i, j, p), return, ;);
+      // 3D
+    case 3:
+      inf_fe_family_mapping_switch(3, shape_deriv(fe_t, t, i, j, p), return, ;);
+
+    default:
+      libmesh_error_msg("Invalid dim = " << dim);
+    }
+}
 
 
 void FEInterface::ifem_compute_data(const unsigned int dim,

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -85,8 +85,9 @@ void InfFE<Dim,T_radial,T_map>::attach_quadrature_rule (QBase * q)
   // in radial direction, always use Gauss quadrature
   radial_qrule.reset(new QGauss(1, radial_int_order));
 
-  // currently not used. But maybe helpful to store the QBase *
-  // with which we initialized our own quadrature rules
+  // Maybe helpful to store the QBase *
+  // with which we initialized our own quadrature rules.
+  // Used e.g. in \p InfFE::reinit(elem,side)
   qrule = q;
 }
 

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -217,7 +217,7 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
       // right now, and it will generalize a bit, and it won't break
       // the assumptions elsewhere in InfFE.
       std::vector<Point> radial_pts;
-      for (auto p : index_range(*pts))
+      for (std::size_t p=1; p < pts->size(); ++p)
         {
           Real radius = (*pts)[p](Dim-1);
           //IMHO this is a dangerous check:

--- a/src/fe/inf_fe.C
+++ b/src/fe/inf_fe.C
@@ -217,33 +217,46 @@ void InfFE<Dim,T_radial,T_map>::reinit(const Elem * inf_elem,
       // right now, and it will generalize a bit, and it won't break
       // the assumptions elsewhere in InfFE.
       std::vector<Point> radial_pts;
-      for (std::size_t p=1; p < pts->size(); ++p)
+      if (pts->size() > 0)
         {
-          Real radius = (*pts)[p](Dim-1);
-          //IMHO this is a dangerous check:
-          // 1) it is not guaranteed that two points have numerically equal radii
-          // 2) if there several radii but not sorted/regular, this breaks
-          if (radial_pts.size() && radial_pts[0](0) == radius)
-            break;
+          Real radius = (*pts)[0](Dim-1);
           radial_pts.push_back(Point(radius));
+          unsigned int n_radial_pts=1;
+          unsigned int n_angular_pts=1;
+          for (std::size_t p=1; p < pts->size(); ++p)
+            {
+              radius = (*pts)[p](Dim-1);
+              // check for repetition of radius: The max. allowed distance is somewhat arbitrary
+              // but the given value should not produce false positives...
+              if (abs(radial_pts[p-n_radial_pts*n_angular_pts](0) - radius)< 1e-4)
+                {
+                  // should the next one be in the next segment?
+                  if (p+1 == n_radial_pts*(n_angular_pts+1))
+                     n_angular_pts++;
+                }
+              // if none yet repeated:
+              else if (n_angular_pts == 1)
+                radial_pts.push_back(Point(radius));
+              // if there was repetition but this does not, the assumed
+              // format does not work:
+              else
+                {
+                  libmesh_error_msg("We assumed that the "<<pts->size()
+                                  <<" points are of tensor-product type with "
+                                  <<n_radial_pts<<" radial points and "
+                                  <<n_angular_pts<< " angular points."<<std::endl
+                                  <<"But apparently point "<<p
+                                  <<" does not fit that scheme: Its radius is "
+                                  <<radius <<"but should have "
+                                  <<radial_pts[p-n_radial_pts*n_angular_pts]<<".");
+                }
+            }
         }
       const std::size_t radial_pts_size = radial_pts.size();
       const std::size_t base_pts_size = pts->size() / radial_pts_size;
       // If we're a tensor product we should have no remainder
       libmesh_assert_equal_to
         (base_pts_size * radial_pts_size, pts->size());
-
-      if (pts->size() > 1)
-        {
-           // lets inform the user about our assumptions.
-           // If this warning appears very often, this should be taken as a reason
-           // for rewriting this.
-           libmesh_experimental();
-           libmesh_warning("We assume that the "<<pts->size()
-                           <<" points are of tensor-product type with "
-                           <<radial_pts_size<<" radial points and "
-                           <<base_pts_size<< " angular points.");
-        }
 
 
       std::vector<Point> base_pts;

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -54,6 +54,7 @@ void InfFE<Dim,T_radial,T_base>::reinit(const Elem * inf_elem,
   // Don't do this for the base
   libmesh_assert_not_equal_to (s, 0);
 
+
   // Build the side of interest
   const std::unique_ptr<const Elem> side(inf_elem->build_side_ptr(s));
 

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -165,10 +165,11 @@ void InfFE<Dim,T_radial,T_base>::init_face_shape_functions(const std::vector<Poi
     const Order    base_mapping_order     ( base_elem->default_order() );
     const ElemType base_mapping_elem_type ( base_elem->type()          );
 
-    // the number of mapping shape functions
+    // the number of mapping shape functions. For base side it is 1.
     // (Lagrange shape functions are used for mapping in the base)
     const unsigned int n_radial_mapping_sf =
-      cast_int<unsigned int>(radial_map.size());
+      inf_side->infinite() ? cast_int<unsigned int>(radial_map.size()) : 1;
+
     const unsigned int n_base_mapping_shape_functions = Base::n_base_mapping_sf(base_mapping_elem_type,
                                                                                 base_mapping_order);
 

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -607,7 +607,6 @@ void MeshFunction::discontinuous_gradient (const Point & p,
               const std::vector<std::vector<RealGradient>> & dphi = point_fe->get_dphi();
               point_fe->reinit(element, & point_list);
 
-              temp_output[index] = grad;
               for (auto i : index_range(dof_indices))
                 grad.add_scaled(dphi[i][0], this->_vector(dof_indices[i]));
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
@@ -669,7 +668,7 @@ void MeshFunction::hessian (const Point & p,
     {
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
       if(element->infinite())
-        libmesh_warning("Warning: Requested the Hessian of an Infinit element."
+        libmesh_warning("Warning: Requested the Hessian of an Infinite element."
                         << "Second derivatives for Infinite elements"
                         << " are not yet implemented!"
                         << std::endl);

--- a/src/quadrature/quadrature_gauss_1D.C
+++ b/src/quadrature/quadrature_gauss_1D.C
@@ -28,11 +28,11 @@ namespace libMesh
 
 
 void QGauss::init_1D(const ElemType,
-                     unsigned int p)
+                     unsigned int p_level)
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules
-  switch(_order + 2*p)
+  switch(_order + 2*p_level)
     {
     case CONSTANT:
     case FIRST:

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -26,7 +26,7 @@ namespace libMesh
 
 
 void QGauss::init_2D(const ElemType type_in,
-                     unsigned int p)
+                     unsigned int p_level)
 {
 #if LIBMESH_DIM > 1
 
@@ -60,7 +60,7 @@ void QGauss::init_2D(const ElemType type_in,
         //    yx^2   xy^2
         //       x^2y^2
         QGauss q1D(1,_order);
-        q1D.init(EDGE2,p);
+        q1D.init(EDGE2,p_level);
         tensor_product_quad( q1D );
         return;
       }
@@ -73,7 +73,7 @@ void QGauss::init_2D(const ElemType type_in,
     case TRI3SUBDIVISION:
     case TRI6:
       {
-        switch(_order + 2*p)
+        switch(_order + 2*p_level)
           {
           case CONSTANT:
           case FIRST:
@@ -1277,7 +1277,7 @@ void QGauss::init_2D(const ElemType type_in,
               // automatically generate using a 1D Gauss rule on
               // [0,1] and two 1D Jacobi-Gauss rules on [0,1].
               QConical conical_rule(2, _order);
-              conical_rule.init(type_in, p);
+              conical_rule.init(type_in, p_level);
 
               // Swap points and weights with the about-to-be destroyed rule.
               _points.swap (conical_rule.get_points() );

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -26,7 +26,7 @@ namespace libMesh
 {
 
 void QGauss::init_3D(const ElemType type_in,
-                     unsigned int p)
+                     unsigned int p_level)
 {
 #if LIBMESH_DIM == 3
 
@@ -43,7 +43,7 @@ void QGauss::init_3D(const ElemType type_in,
         // We compute the 3D quadrature rule as a tensor
         // product of the 1D quadrature rule.
         QGauss q1D(1,_order);
-        q1D.init(EDGE2,p);
+        q1D.init(EDGE2,p_level);
 
         tensor_product_hex( q1D );
 
@@ -57,7 +57,7 @@ void QGauss::init_3D(const ElemType type_in,
     case TET4:
     case TET10:
       {
-        switch(_order + 2*p)
+        switch(_order + 2*p_level)
           {
             // Taken from pg. 222 of "The finite element method," vol. 1
             // ed. 5 by Zienkiewicz & Taylor
@@ -169,7 +169,7 @@ void QGauss::init_3D(const ElemType type_in,
                   // product rule is third-order accurate and has less points than
                   // the next-available positive-weight rule at FIFTH order.
                   QConical conical_rule(3, _order);
-                  conical_rule.init(type_in, p);
+                  conical_rule.init(type_in, p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (conical_rule.get_points() );
@@ -459,7 +459,7 @@ void QGauss::init_3D(const ElemType type_in,
             // Fall back on Grundmann-Moller or Conical Product rules at high orders.
           default:
             {
-              if ((allow_rules_with_negative_weights) && (_order + 2*p < 34))
+              if ((allow_rules_with_negative_weights) && (_order + 2*p_level < 34))
                 {
                   // The Grundmann-Moller rules are defined to arbitrary order and
                   // can have significantly fewer evaluation points than conical product
@@ -469,7 +469,7 @@ void QGauss::init_3D(const ElemType type_in,
                   // to round-off error.  Safest is to disallow rules with negative
                   // weights, but this decision should be made on a case-by-case basis.
                   QGrundmann_Moller gm_rule(3, _order);
-                  gm_rule.init(type_in, p);
+                  gm_rule.init(type_in, p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (gm_rule.get_points() );
@@ -487,7 +487,7 @@ void QGauss::init_3D(const ElemType type_in,
                   // automatically generate using a 1D Gauss rule on
                   // [0,1] and two 1D Jacobi-Gauss rules on [0,1].
                   QConical conical_rule(3, _order);
-                  conical_rule.init(type_in, p);
+                  conical_rule.init(type_in, p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (conical_rule.get_points() );
@@ -515,8 +515,8 @@ void QGauss::init_3D(const ElemType type_in,
         QGauss q2D(2,_order);
 
         // Initialize
-        q1D.init(EDGE2,p);
-        q2D.init(TRI3,p);
+        q1D.init(EDGE2,p_level);
+        q2D.init(TRI3,p_level);
 
         tensor_product_prism(q1D, q2D);
 
@@ -537,7 +537,7 @@ void QGauss::init_3D(const ElemType type_in,
         // from: Stroud, A.H. "Approximate Calculation of Multiple
         // Integrals."
         QConical conical_rule(3, _order);
-        conical_rule.init(type_in, p);
+        conical_rule.init(type_in, p_level);
 
         // Swap points and weights with the about-to-be destroyed rule.
         _points.swap (conical_rule.get_points() );


### PR DESCRIPTION
This is the corrected version of #1969, having some minor changes (and rebased to current master).

 * 671fe8b  contains some minor fixes in the documentations: The main changes are to name the variables in the declaration (.h-file) and the function (.C-file) consistent.
    The main purpose is, however, to adapt the MeshFunction::gradient()-function to infinite elements.
    Respectively, several functions and objects are added to FEInterface.

I have one open question related to this, denoted by the FIXME-tag: To get the gradient in physical coordinates, I need to hold the transformation in the FEInterface; therefore, I added the std::vector<std::vector<Real>> local_transform variable; but maybe there is a better way to do so?
I would think of some Tensor- or matrix-type or so?

Any other thoughts about this?
I hope, you are ok with the introduction of this new feature?

Best,
Hubert