### PR TITLE
Hiding second derivative quantities in their macro

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -329,7 +329,10 @@ void assemble_shell (EquationSystems & es,
 {
   // This example requires Eigen to actually work, but we should still
   // let it compile and throw a runtime error if you don't.
-#ifdef LIBMESH_HAVE_EIGEN
+
+  // The same holds for second derivatives,
+  // since they are class-members only depending on the config.
+#if defined(LIBMESH_HAVE_EIGEN) && defined(LIBMESH_ENABLE_SECOND_DERIVATIVES)
   // It is a good idea to make sure we are assembling
   // the proper system.
   libmesh_assert_equal_to (system_name, "Shell");
@@ -386,6 +389,7 @@ void assemble_shell (EquationSystems & es,
   // quadrature points.
   const std::vector<RealGradient> & dxyzdxi = fe->get_dxyzdxi();
   const std::vector<RealGradient> & dxyzdeta = fe->get_dxyzdeta();
+
   const std::vector<RealGradient> & d2xyzdxi2 = fe->get_d2xyzdxi2();
   const std::vector<RealGradient> & d2xyzdeta2 = fe->get_d2xyzdeta2();
   const std::vector<RealGradient> & d2xyzdxideta = fe->get_d2xyzdxideta();
@@ -548,6 +552,7 @@ void assemble_shell (EquationSystems & es,
           Eigen::Vector3d d2Xdxi2(d2xyzdxi2[qp](0), d2xyzdxi2[qp](1), d2xyzdxi2[qp](2));
           Eigen::Vector3d d2Xdeta2(d2xyzdeta2[qp](0), d2xyzdeta2[qp](1), d2xyzdeta2[qp](2));
           Eigen::Vector3d d2Xdxideta(d2xyzdxideta[qp](0), d2xyzdxideta[qp](1), d2xyzdxideta[qp](2));
+
 
           Eigen::Matrix2d b;
           b <<
@@ -849,5 +854,5 @@ void assemble_shell (EquationSystems & es,
   // Avoid compiler warnings
   libmesh_ignore(es);
   libmesh_ignore(system_name);
-#endif // LIBMESH_HAVE_EIGEN
+#endif // defined(LIBMESH_HAVE_EIGEN) && defined(LIBMESH_ENABLE_SECOND_DERIVATIVES)
 }

--- a/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
+++ b/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
@@ -331,7 +331,7 @@ void assemble_shell (EquationSystems & es,
 {
   // This example requires Eigen to actually work, but we should still
   // let it compile and throw a runtime error if you don't.
-#ifdef LIBMESH_HAVE_EIGEN
+#if defined(LIBMESH_HAVE_EIGEN) && defined(LIBMESH_ENABLE_SECOND_DERIVATIVES)
   // It is a good idea to make sure we are assembling
   // the proper system.
   libmesh_assert_equal_to (system_name, "Shell");
@@ -765,5 +765,5 @@ void assemble_shell (EquationSystems & es,
   // Avoid compiler warnings
   libmesh_ignore(es);
   libmesh_ignore(system_name);
-#endif // LIBMESH_HAVE_EIGEN
+#endif // defined(LIBMESH_HAVE_EIGEN) && defined(LIBMESH_ENABLE_SECOND_DERIVATIVES)
 }

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -266,6 +266,8 @@ public:
   const std::vector<RealGradient> & get_dxyzdzeta() const
   { return _fe_map->get_dxyzdzeta(); }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
   /**
    * \returns The second partial derivatives in xi.
    */
@@ -278,23 +280,17 @@ public:
   const std::vector<RealGradient> & get_d2xyzdeta2() const
   { return this->_fe_map->get_d2xyzdeta2(); }
 
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-
   /**
    * \returns The second partial derivatives in zeta.
    */
   const std::vector<RealGradient> & get_d2xyzdzeta2() const
   { return this->_fe_map->get_d2xyzdzeta2(); }
 
-#endif
-
   /**
    * \returns The second partial derivatives in xi-eta.
    */
   const std::vector<RealGradient> & get_d2xyzdxideta() const
   { return this->_fe_map->get_d2xyzdxideta(); }
-
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   /**
    * \returns The second partial derivatives in xi-zeta.
@@ -385,11 +381,14 @@ public:
   const std::vector<Point> & get_normals() const
   { return this->_fe_map->get_normals(); }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
    * \returns The curvatures for use in face integration.
    */
   const std::vector<Real> & get_curvatures() const
   { return this->_fe_map->get_curvatures();}
+
+#endif
 
   /**
    * Provides the class with the quadrature rule.  Implement
@@ -546,10 +545,16 @@ protected:
    */
   mutable bool calculate_dphi;
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
    * Should we calculate shape function hessians?
    */
   mutable bool calculate_d2phi;
+#else
+  // Otherwise several interfaces need to be redone.
+  const bool calculate_d2phi=false;
+
+#endif
 
   /**
    * Should we calculate shape function curls?

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -181,6 +181,8 @@ public:
   { libmesh_assert(!calculations_started || calculate_dxyz);
     calculate_dxyz = true; return dxyzdzeta_map; }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
   /**
    * \returns The second partial derivatives in xi.
    */
@@ -195,8 +197,6 @@ public:
   { libmesh_assert(!calculations_started || calculate_d2xyz);
     calculate_d2xyz = true; return d2xyzdeta2_map; }
 
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
-
   /**
    * \returns The second partial derivatives in zeta.
    */
@@ -204,16 +204,12 @@ public:
   { libmesh_assert(!calculations_started || calculate_d2xyz);
     calculate_d2xyz = true; return d2xyzdzeta2_map; }
 
-#endif
-
   /**
    * \returns The second partial derivatives in xi-eta.
    */
   const std::vector<RealGradient> & get_d2xyzdxideta() const
   { libmesh_assert(!calculations_started || calculate_d2xyz);
     calculate_d2xyz = true; return d2xyzdxideta_map; }
-
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   /**
    * \returns The second partial derivatives in xi-zeta.
@@ -374,12 +370,16 @@ public:
   { libmesh_assert(!calculations_started || calculate_dxyz);
     calculate_dxyz = true; return normals; }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
   /**
    * \returns The curvatures for use in face integration.
    */
   const std::vector<Real> & get_curvatures() const
   { libmesh_assert(!calculations_started || calculate_d2xyz);
     calculate_d2xyz = true; return curvatures;}
+
+#endif
 
   /**
    * Prints the Jacobian times the weight for each quadrature point.
@@ -424,6 +424,8 @@ public:
   { libmesh_assert(!calculations_started || calculate_dxyz);
     calculate_dxyz = true; return dpsideta_map; }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
   /**
    * \returns The reference to physical map 2nd derivative for the side/edge
    */
@@ -459,12 +461,15 @@ public:
   { libmesh_assert(!calculations_started || calculate_d2xyz);
     calculate_d2xyz = true; return d2psideta2_map; }
 
+
   /**
    * \returns const reference to physical map 2nd derivative for the side/edge
    */
   const std::vector<std::vector<Real>> & get_d2psideta2() const
   { libmesh_assert(!calculations_started || calculate_d2xyz);
     calculate_d2xyz = true; return d2psideta2_map; }
+
+#endif //LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   /**
    * \returns The reference to physical map for the element
@@ -670,6 +675,8 @@ protected:
    */
   std::vector<RealGradient> dxyzdzeta_map;
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
   /**
    * Vector of second partial derivatives in xi:
    * d^2(x)/d(xi)^2, d^2(y)/d(xi)^2, d^2(z)/d(xi)^2
@@ -687,8 +694,6 @@ protected:
    * d^2(x)/d(eta)^2
    */
   std::vector<RealGradient> d2xyzdeta2_map;
-
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   /**
    * Vector of second partial derivatives in xi-zeta:
@@ -708,7 +713,7 @@ protected:
    */
   std::vector<RealGradient> d2xyzdzeta2_map;
 
-#endif
+#endif //LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   /**
    * Map for partial derivatives:
@@ -857,6 +862,8 @@ protected:
    */
   std::vector<std::vector<Real>> dpsideta_map;
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
   /**
    * Map for the second derivatives (in xi) of the
    * side shape functions.  Useful for computing
@@ -878,6 +885,8 @@ protected:
    */
   std::vector<std::vector<Real>> d2psideta2_map;
 
+#endif
+
   /**
    * Tangent vectors on boundary at quadrature points.
    */
@@ -888,12 +897,15 @@ protected:
    */
   std::vector<Point> normals;
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
    * The mean curvature (= one half the sum of the principal
    * curvatures) on the boundary at the quadrature points.
    * The mean curvature is a scalar value.
    */
   std::vector<Real> curvatures;
+
+#endif
 
   /**
    * Jacobian values at quadrature points
@@ -921,10 +933,14 @@ protected:
    */
   mutable bool calculate_dxyz;
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
   /**
    * Should we calculate mapping hessians?
    */
   mutable bool calculate_d2xyz;
+
+#endif
 
   /**
    * FE classes should be able to reset calculations_started in a few

--- a/src/fe/fe_bernstein_shape_0D.C
+++ b/src/fe/fe_bernstein_shape_0D.C
@@ -78,6 +78,7 @@ Real FE<0,BERNSTEIN>::shape_deriv(const Elem *,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<0,BERNSTEIN>::shape_second_deriv(const ElemType,
@@ -102,5 +103,7 @@ Real FE<0,BERNSTEIN>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_bernstein_shape_1D.C
+++ b/src/fe/fe_bernstein_shape_1D.C
@@ -371,6 +371,7 @@ Real FE<1,BERNSTEIN>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,BERNSTEIN>::shape_second_deriv(const ElemType,
@@ -410,6 +411,8 @@ Real FE<1,BERNSTEIN>::shape_second_deriv(const Elem *,
   warning_given = true;
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh
 

--- a/src/fe/fe_bernstein_shape_2D.C
+++ b/src/fe/fe_bernstein_shape_2D.C
@@ -559,6 +559,7 @@ Real FE<2,BERNSTEIN>::shape_deriv(const Elem * elem,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <>
 Real FE<2,BERNSTEIN>::shape_second_deriv(const ElemType,
                                          const Order,
@@ -596,6 +597,8 @@ Real FE<2,BERNSTEIN>::shape_second_deriv(const Elem *,
   warning_given = true;
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh
 

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -2960,6 +2960,7 @@ Real FE<3,BERNSTEIN>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<3,BERNSTEIN>::shape_second_deriv(const ElemType,
@@ -2998,6 +2999,8 @@ Real FE<3,BERNSTEIN>::shape_second_deriv(const Elem *,
   warning_given = true;
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh
 

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -438,19 +438,23 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
     {
       if (calculate_dxyz)
         this->dpsidxi_map.resize    (n_mapping_shape_functions);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
       if (calculate_d2xyz)
         this->d2psidxi2_map.resize  (n_mapping_shape_functions);
+#endif
     }
 
   if (Dim == 3)
     {
       if (calculate_dxyz)
         this->dpsideta_map.resize     (n_mapping_shape_functions);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
       if (calculate_d2xyz)
         {
           this->d2psidxideta_map.resize (n_mapping_shape_functions);
           this->d2psideta2_map.resize   (n_mapping_shape_functions);
         }
+#endif
     }
 
   for (unsigned int i=0; i<n_mapping_shape_functions; i++)
@@ -463,18 +467,22 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
         {
           if (calculate_dxyz)
             this->dpsidxi_map[i].resize    (n_qp);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           if (calculate_d2xyz)
             this->d2psidxi2_map[i].resize  (n_qp);
+#endif
         }
       if (Dim == 3)
         {
           if (calculate_dxyz)
             this->dpsideta_map[i].resize     (n_qp);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           if (calculate_d2xyz)
             {
               this->d2psidxideta_map[i].resize (n_qp);
               this->d2psideta2_map[i].resize   (n_qp);
             }
+#endif
         }
 
       // Compute the value of shape function i, and its first and
@@ -488,8 +496,10 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
             {
               if (calculate_dxyz)
                 this->dpsidxi_map[i][p]    = FE<Dim-1,LAGRANGE>::shape_deriv       (mapping_elem_type, mapping_order, i, 0, qp[p]);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
               if (calculate_d2xyz)
                 this->d2psidxi2_map[i][p]  = FE<Dim-1,LAGRANGE>::shape_second_deriv(mapping_elem_type, mapping_order, i, 0, qp[p]);
+#endif
             }
           // libMesh::out << "this->d2psidxi2_map["<<i<<"][p]=" << d2psidxi2_map[i][p] << std::endl;
 
@@ -500,11 +510,13 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
             {
               if (calculate_dxyz)
                 this->dpsideta_map[i][p]     = FE<Dim-1,LAGRANGE>::shape_deriv       (mapping_elem_type, mapping_order, i, 1, qp[p]);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
               if (calculate_d2xyz)
                 {
                   this->d2psidxideta_map[i][p] = FE<Dim-1,LAGRANGE>::shape_second_deriv(mapping_elem_type, mapping_order, i, 1, qp[p]);
                   this->d2psideta2_map[i][p]   = FE<Dim-1,LAGRANGE>::shape_second_deriv(mapping_elem_type, mapping_order, i, 2, qp[p]);
                 }
+#endif
             }
         }
     }
@@ -540,8 +552,10 @@ void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
     this->psi_map.resize        (n_mapping_shape_functions);
   if (calculate_dxyz)
     this->dpsidxi_map.resize    (n_mapping_shape_functions);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   if (calculate_d2xyz)
     this->d2psidxi2_map.resize  (n_mapping_shape_functions);
+#endif
 
   for (unsigned int i=0; i<n_mapping_shape_functions; i++)
     {
@@ -551,8 +565,10 @@ void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
         this->psi_map[i].resize        (n_qp);
       if (calculate_dxyz)
         this->dpsidxi_map[i].resize    (n_qp);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
       if (calculate_d2xyz)
         this->d2psidxi2_map[i].resize  (n_qp);
+#endif
 
       // Compute the value of shape function i, and its first and
       // second derivatives at quadrature point p
@@ -563,8 +579,10 @@ void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
             this->psi_map[i][p]        = FE<1,LAGRANGE>::shape             (mapping_elem_type, mapping_order, i,    qp[p]);
           if (calculate_dxyz)
             this->dpsidxi_map[i][p]    = FE<1,LAGRANGE>::shape_deriv       (mapping_elem_type, mapping_order, i, 0, qp[p]);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           if (calculate_d2xyz)
             this->d2psidxi2_map[i][p]  = FE<1,LAGRANGE>::shape_second_deriv(mapping_elem_type, mapping_order, i, 0, qp[p]);
+#endif
         }
     }
 }
@@ -664,11 +682,13 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
               this->JxW.resize(n_qp);
             }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           if (calculate_d2xyz)
             {
               this->d2xyzdxi2_map.resize(n_qp);
               this->curvatures.resize(n_qp);
             }
+#endif
         }
 
         // Clear the entities that will be summed
@@ -682,8 +702,10 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
                 this->tangents[p].resize(LIBMESH_DIM-1); // 1 Tangent in 2D, 2 in 3D
                 this->dxyzdxi_map[p].zero();
               }
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
             if (calculate_d2xyz)
               this->d2xyzdxi2_map[p].zero();
+#endif
           }
 
         const unsigned int n_mapping_shape_functions =
@@ -701,8 +723,10 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
                   this->xyz[p].add_scaled          (side_point, this->psi_map[i][p]);
                 if (calculate_dxyz)
                   this->dxyzdxi_map[p].add_scaled  (side_point, this->dpsidxi_map[i][p]);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                 if (calculate_d2xyz)
                   this->d2xyzdxi2_map[p].add_scaled(side_point, this->d2psidxi2_map[i][p]);
+#endif
               }
           }
 
@@ -742,6 +766,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
 #endif
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                 // The curvature is computed via the familiar Frenet formula:
                 // curvature = [d^2(x) / d (xi)^2] dot [normal]
                 // For a reference, see:
@@ -758,6 +783,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
                     libmesh_assert_not_equal_to (denominator, 0);
                     curvatures[p] = numerator / denominator;
                   }
+#endif
               }
 
             // compute the jacobian at the quadrature points
@@ -792,6 +818,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
               this->normals.resize(n_qp);
               this->JxW.resize(n_qp);
             }
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           if (calculate_d2xyz)
             {
               this->d2xyzdxi2_map.resize(n_qp);
@@ -799,6 +826,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
               this->d2xyzdeta2_map.resize(n_qp);
               this->curvatures.resize(n_qp);
             }
+#endif
         }
 
         // Clear the entities that will be summed
@@ -812,12 +840,14 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
                 this->dxyzdxi_map[p].zero();
                 this->dxyzdeta_map[p].zero();
               }
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
             if (calculate_d2xyz)
               {
                 this->d2xyzdxi2_map[p].zero();
                 this->d2xyzdxideta_map[p].zero();
                 this->d2xyzdeta2_map[p].zero();
               }
+#endif
           }
 
         const unsigned int n_mapping_shape_functions =
@@ -838,12 +868,14 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
                     this->dxyzdxi_map[p].add_scaled (side_point, this->dpsidxi_map[i][p]);
                     this->dxyzdeta_map[p].add_scaled(side_point, this->dpsideta_map[i][p]);
                   }
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                 if (calculate_d2xyz)
                   {
                     this->d2xyzdxi2_map[p].add_scaled   (side_point, this->d2psidxi2_map[i][p]);
                     this->d2xyzdxideta_map[p].add_scaled(side_point, this->d2psidxideta_map[i][p]);
                     this->d2xyzdeta2_map[p].add_scaled  (side_point, this->d2psideta2_map[i][p]);
                   }
+#endif
               }
           }
 
@@ -857,6 +889,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
                 this->tangents[p][0] = this->dxyzdxi_map[p].unit();
                 this->tangents[p][1] = n.cross(this->dxyzdxi_map[p]).unit();
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
                 if (calculate_d2xyz)
                   {
                     // Compute curvature using the typical nomenclature
@@ -877,6 +910,7 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
                     libmesh_assert_not_equal_to (denominator, 0.);
                     curvatures[p] = 0.5*numerator/denominator;
                   }
+#endif
               }
 
             // compute the jacobian at the quadrature points, see
@@ -955,6 +989,7 @@ void FEMap::compute_edge_map(int dim,
       this->normals.resize(n_qp);
       this->JxW.resize(n_qp);
     }
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   if (calculate_d2xyz)
     {
       this->d2xyzdxi2_map.resize(n_qp);
@@ -962,6 +997,7 @@ void FEMap::compute_edge_map(int dim,
       this->d2xyzdeta2_map.resize(n_qp);
       this->curvatures.resize(n_qp);
     }
+#endif
 
   // Clear the entities that will be summed
   for (unsigned int p=0; p<n_qp; p++)
@@ -974,12 +1010,14 @@ void FEMap::compute_edge_map(int dim,
           this->dxyzdxi_map[p].zero();
           this->dxyzdeta_map[p].zero();
         }
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
       if (calculate_d2xyz)
         {
           this->d2xyzdxi2_map[p].zero();
           this->d2xyzdxideta_map[p].zero();
           this->d2xyzdeta2_map[p].zero();
         }
+#endif
     }
 
   // compute x, dxdxi at the quadrature points
@@ -995,8 +1033,10 @@ void FEMap::compute_edge_map(int dim,
             this->xyz[p].add_scaled             (edge_point, this->psi_map[i][p]);
           if (calculate_dxyz)
             this->dxyzdxi_map[p].add_scaled     (edge_point, this->dpsidxi_map[i][p]);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           if (calculate_d2xyz)
             this->d2xyzdxi2_map[p].add_scaled   (edge_point, this->d2psidxi2_map[i][p]);
+#endif
         }
     }
 

--- a/src/fe/fe_clough_shape_0D.C
+++ b/src/fe/fe_clough_shape_0D.C
@@ -78,6 +78,7 @@ Real FE<0,CLOUGH>::shape_deriv(const Elem *,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<0,CLOUGH>::shape_second_deriv(const ElemType,
@@ -102,5 +103,7 @@ Real FE<0,CLOUGH>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_clough_shape_1D.C
+++ b/src/fe/fe_clough_shape_1D.C
@@ -40,9 +40,14 @@ static const Elem * old_elem_ptr = nullptr;
 // local shape function corresponding to normal derivative 2
 static Real d1xd1x, d2xd2x;
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 Real clough_raw_shape_second_deriv(const unsigned int basis_num,
                                    const unsigned int deriv_type,
                                    const Point & p);
+
+#endif
+
 Real clough_raw_shape_deriv(const unsigned int basis_num,
                             const unsigned int deriv_type,
                             const Point & p);
@@ -110,6 +115,8 @@ void clough_compute_coefs(const Elem * elem)
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 // Return shape function second derivatives on the unit interval
 Real clough_raw_shape_second_deriv(const unsigned int basis_num,
                                    const unsigned int deriv_type,
@@ -144,6 +151,7 @@ Real clough_raw_shape_second_deriv(const unsigned int basis_num,
     }
 }
 
+#endif
 
 
 Real clough_raw_shape_deriv(const unsigned int basis_num,
@@ -336,6 +344,7 @@ Real FE<1,CLOUGH>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,CLOUGH>::shape_second_deriv(const Elem * elem,
@@ -386,5 +395,7 @@ Real FE<1,CLOUGH>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << totalorder);
     }
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_clough_shape_2D.C
+++ b/src/fe/fe_clough_shape_2D.C
@@ -52,9 +52,13 @@ static Real N01x, N01y, N10x, N10y;
 static Real N02x, N02y, N20x, N20y;
 static Real N21x, N21y, N12x, N12y;
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 Real clough_raw_shape_second_deriv(const unsigned int basis_num,
                                    const unsigned int deriv_type,
                                    const Point & p);
+#endif
+
 Real clough_raw_shape_deriv(const unsigned int basis_num,
                             const unsigned int deriv_type,
                             const Point & p);
@@ -571,6 +575,8 @@ unsigned char subtriangle_lookup(const Point & p)
   return 1;
 }
 
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 // Return shape function second derivatives on the unit right
 // triangle
 Real clough_raw_shape_second_deriv(const unsigned int basis_num,
@@ -1122,6 +1128,8 @@ Real clough_raw_shape_second_deriv(const unsigned int basis_num,
                         deriv_type);
     }
 }
+
+#endif
 
 
 
@@ -2184,6 +2192,8 @@ Real FE<2,CLOUGH>::shape_deriv(const Elem * elem,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 template <>
 Real FE<2,CLOUGH>::shape_second_deriv(const Elem * elem,
                                       const Order order,
@@ -2358,5 +2368,7 @@ Real FE<2,CLOUGH>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported polynomial order = " << order);
     }
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_clough_shape_3D.C
+++ b/src/fe/fe_clough_shape_3D.C
@@ -82,6 +82,8 @@ Real FE<3,CLOUGH>::shape_deriv(const Elem * libmesh_dbg_var(elem),
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 template <>
 Real FE<3,CLOUGH>::shape_second_deriv(const Elem * libmesh_dbg_var(elem),
                                       const Order,
@@ -93,5 +95,7 @@ Real FE<3,CLOUGH>::shape_second_deriv(const Elem * libmesh_dbg_var(elem),
   libmesh_not_implemented();
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_hermite_shape_0D.C
+++ b/src/fe/fe_hermite_shape_0D.C
@@ -78,6 +78,7 @@ Real FE<0,HERMITE>::shape_deriv(const Elem *,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<0,HERMITE>::shape_second_deriv(const ElemType,
@@ -102,5 +103,7 @@ Real FE<0,HERMITE>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_hermite_shape_1D.C
+++ b/src/fe/fe_hermite_shape_1D.C
@@ -69,6 +69,7 @@ void hermite_compute_coefs(const Elem * elem, Real & d1xd1x, Real & d2xd2x)
 namespace libMesh
 {
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template<>
 Real FEHermite<1>::hermite_raw_shape_second_deriv (const unsigned int i, const Real xi)
@@ -105,6 +106,7 @@ Real FEHermite<1>::hermite_raw_shape_second_deriv (const unsigned int i, const R
     }
 }
 
+#endif
 
 
 template<>
@@ -296,6 +298,7 @@ Real FE<1,HERMITE>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,HERMITE>::shape_second_deriv(const Elem * elem,
@@ -345,5 +348,7 @@ Real FE<1,HERMITE>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_hermite_shape_2D.C
+++ b/src/fe/fe_hermite_shape_2D.C
@@ -322,6 +322,7 @@ Real FE<2,HERMITE>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
@@ -387,5 +388,7 @@ Real FE<2,HERMITE>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported element type = " << type);
     }
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -536,6 +536,7 @@ Real FE<3,HERMITE>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<3,HERMITE>::shape_second_deriv(const Elem * elem,
@@ -632,5 +633,7 @@ Real FE<3,HERMITE>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported polynomial order " << totalorder);
     }
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_hierarchic_shape_0D.C
+++ b/src/fe/fe_hierarchic_shape_0D.C
@@ -77,7 +77,7 @@ Real FE<0,HIERARCHIC>::shape_deriv(const Elem *,
 }
 
 
-
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<0,HIERARCHIC>::shape_second_deriv(const ElemType,
@@ -102,5 +102,7 @@ Real FE<0,HIERARCHIC>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_hierarchic_shape_1D.C
+++ b/src/fe/fe_hierarchic_shape_1D.C
@@ -195,6 +195,7 @@ Real FE<1,HIERARCHIC>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,HIERARCHIC>::shape_second_deriv(const ElemType,
@@ -276,5 +277,7 @@ Real FE<1,HIERARCHIC>::shape_second_deriv(const Elem * elem,
   return FE<1,HIERARCHIC>::shape_second_deriv(elem->type(),
                                               static_cast<Order>(order + elem->p_level()), i, j, p);
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_hierarchic_shape_2D.C
+++ b/src/fe/fe_hierarchic_shape_2D.C
@@ -378,6 +378,7 @@ Real FE<2,HIERARCHIC>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,HIERARCHIC>::shape_second_deriv(const ElemType,
@@ -443,5 +444,7 @@ Real FE<2,HIERARCHIC>::shape_second_deriv(const Elem * elem,
           FE<2,HIERARCHIC>::shape_deriv(elem, order, i, prevj, pm)
           )/2./eps;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -765,6 +765,7 @@ Real FE<3,HIERARCHIC>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<3,HIERARCHIC>::shape_second_deriv(const ElemType,
@@ -855,5 +856,7 @@ Real FE<3,HIERARCHIC>::shape_second_deriv(const Elem * elem,
           FE<3,HIERARCHIC>::shape_deriv(elem, order, i, prevj, pm))
     / 2. / eps;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_l2_hierarchic_shape_0D.C
+++ b/src/fe/fe_l2_hierarchic_shape_0D.C
@@ -78,6 +78,7 @@ Real FE<0,L2_HIERARCHIC>::shape_deriv(const Elem *,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<0,L2_HIERARCHIC>::shape_second_deriv(const ElemType,
@@ -102,5 +103,7 @@ Real FE<0,L2_HIERARCHIC>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_l2_hierarchic_shape_1D.C
+++ b/src/fe/fe_l2_hierarchic_shape_1D.C
@@ -195,6 +195,7 @@ Real FE<1,L2_HIERARCHIC>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,L2_HIERARCHIC>::shape_second_deriv(const ElemType,
@@ -276,5 +277,7 @@ Real FE<1,L2_HIERARCHIC>::shape_second_deriv(const Elem * elem,
   return FE<1,L2_HIERARCHIC>::shape_second_deriv(elem->type(),
                                                  static_cast<Order>(order + elem->p_level()), i, j, p);
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_l2_hierarchic_shape_2D.C
+++ b/src/fe/fe_l2_hierarchic_shape_2D.C
@@ -379,6 +379,7 @@ Real FE<2,L2_HIERARCHIC>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,L2_HIERARCHIC>::shape_second_deriv(const ElemType,
@@ -443,5 +444,7 @@ Real FE<2,L2_HIERARCHIC>::shape_second_deriv(const Elem * elem,
           FE<2,L2_HIERARCHIC>::shape_deriv(elem, order, i, prevj, pm)
           )/2./eps;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_l2_hierarchic_shape_3D.C
+++ b/src/fe/fe_l2_hierarchic_shape_3D.C
@@ -765,6 +765,7 @@ Real FE<3,L2_HIERARCHIC>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<3,L2_HIERARCHIC>::shape_second_deriv(const ElemType,
@@ -855,5 +856,7 @@ Real FE<3,L2_HIERARCHIC>::shape_second_deriv(const Elem * elem,
           FE<3,L2_HIERARCHIC>::shape_deriv(elem, order, i, prevj, pm))
     / 2. / eps;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_l2_lagrange_shape_0D.C
+++ b/src/fe/fe_l2_lagrange_shape_0D.C
@@ -78,6 +78,7 @@ Real FE<0,L2_LAGRANGE>::shape_deriv(const Elem *,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<0,L2_LAGRANGE>::shape_second_deriv(const ElemType,
@@ -102,5 +103,7 @@ Real FE<0,L2_LAGRANGE>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_l2_lagrange_shape_1D.C
+++ b/src/fe/fe_l2_lagrange_shape_1D.C
@@ -230,6 +230,7 @@ Real FE<1,L2_LAGRANGE>::shape_deriv(const Elem * elem,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,L2_LAGRANGE>::shape_second_deriv(const ElemType,
@@ -313,5 +314,7 @@ Real FE<1,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
   return FE<1,L2_LAGRANGE>::shape_second_deriv(elem->type(),
                                                static_cast<Order>(order + elem->p_level()), i, j, p);
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_l2_lagrange_shape_2D.C
+++ b/src/fe/fe_l2_lagrange_shape_2D.C
@@ -562,6 +562,7 @@ Real FE<2,L2_LAGRANGE>::shape_deriv(const Elem * elem,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,L2_LAGRANGE>::shape_second_deriv(const ElemType type,
@@ -913,4 +914,5 @@ Real FE<2,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
   return FE<2,L2_LAGRANGE>::shape_second_deriv(elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
 }
 
+#endif
 } // namespace libMesh

--- a/src/fe/fe_l2_lagrange_shape_3D.C
+++ b/src/fe/fe_l2_lagrange_shape_3D.C
@@ -1205,6 +1205,7 @@ Real FE<3,L2_LAGRANGE>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<3,L2_LAGRANGE>::shape_second_deriv(const ElemType type,
@@ -1457,4 +1458,5 @@ Real FE<3,L2_LAGRANGE>::shape_second_deriv(const Elem * elem,
   return FE<3,L2_LAGRANGE>::shape_second_deriv(elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
 }
 
+#endif
 } // namespace libMesh

--- a/src/fe/fe_lagrange_shape_0D.C
+++ b/src/fe/fe_lagrange_shape_0D.C
@@ -79,6 +79,7 @@ Real FE<0,LAGRANGE>::shape_deriv(const Elem *,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <>
 Real FE<0,LAGRANGE>::shape_second_deriv(const ElemType,
                                         const Order,
@@ -102,5 +103,7 @@ Real FE<0,LAGRANGE>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_lagrange_shape_1D.C
+++ b/src/fe/fe_lagrange_shape_1D.C
@@ -230,6 +230,7 @@ Real FE<1,LAGRANGE>::shape_deriv(const Elem * elem,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,LAGRANGE>::shape_second_deriv(const ElemType,
@@ -313,5 +314,7 @@ Real FE<1,LAGRANGE>::shape_second_deriv(const Elem * elem,
   return FE<1,LAGRANGE>::shape_second_deriv(elem->type(),
                                             static_cast<Order>(order + elem->p_level()), i, j, p);
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -564,6 +564,7 @@ Real FE<2,LAGRANGE>::shape_deriv(const Elem * elem,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,LAGRANGE>::shape_second_deriv(const ElemType type,
@@ -916,5 +917,7 @@ Real FE<2,LAGRANGE>::shape_second_deriv(const Elem * elem,
   // call the orientation-independent shape functions
   return FE<2,LAGRANGE>::shape_second_deriv(elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -1924,6 +1924,7 @@ Real FE<3,LAGRANGE>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<3,LAGRANGE>::shape_second_deriv(const ElemType type,
@@ -3653,5 +3654,7 @@ Real FE<3,LAGRANGE>::shape_second_deriv(const Elem * elem,
   // call the orientation-independent shape function derivatives
   return FE<3,LAGRANGE>::shape_second_deriv(elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_lagrange_vec.C
+++ b/src/fe/fe_lagrange_vec.C
@@ -548,6 +548,9 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape_deriv(const ElemType type, co
   Real value = FE<0,LAGRANGE>::shape_deriv( type, order, i, j, p );
   return libMesh::RealGradient( value );
 }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 template <> RealGradient FE<0,LAGRANGE_VEC>::shape_second_deriv(const ElemType type, const Order order,
                                                                 const unsigned int i, const unsigned int j,
                                                                 const Point & p)
@@ -555,6 +558,7 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape_second_deriv(const ElemType t
   Real value = FE<0,LAGRANGE>::shape_second_deriv( type, order, i, j, p );
   return libMesh::RealGradient( value );
 }
+#endif
 
 // 1-D
 template <> RealGradient FE<1,LAGRANGE_VEC>::shape(const ElemType type, const Order order,
@@ -570,6 +574,7 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape_deriv(const ElemType type, co
   Real value = FE<1,LAGRANGE>::shape_deriv( type, order, i, j, p );
   return libMesh::RealGradient( value );
 }
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <> RealGradient FE<1,LAGRANGE_VEC>::shape_second_deriv(const ElemType type, const Order order,
                                                                 const unsigned int i, const unsigned int j,
                                                                 const Point & p)
@@ -577,6 +582,8 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape_second_deriv(const ElemType t
   Real value = FE<1,LAGRANGE>::shape_second_deriv( type, order, i, j, p );
   return libMesh::RealGradient( value );
 }
+
+#endif
 
 // 2-D
 template <> RealGradient FE<2,LAGRANGE_VEC>::shape(const ElemType type, const Order order,
@@ -620,6 +627,8 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape_deriv(const ElemType type, co
   //dummy
   return libMesh::RealGradient();
 }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <> RealGradient FE<2,LAGRANGE_VEC>::shape_second_deriv(const ElemType type, const Order order,
                                                                 const unsigned int i, const unsigned int j,
                                                                 const Point & p)
@@ -641,6 +650,8 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape_second_deriv(const ElemType t
   //dummy
   return libMesh::RealGradient();
 }
+
+#endif
 
 
 // 3-D
@@ -691,6 +702,9 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape_deriv(const ElemType type, co
   //dummy
   return libMesh::RealGradient();
 }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 template <> RealGradient FE<3,LAGRANGE_VEC>::shape_second_deriv(const ElemType type, const Order order,
                                                                 const unsigned int i, const unsigned int j,
                                                                 const Point & p)
@@ -716,6 +730,7 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape_second_deriv(const ElemType t
   return libMesh::RealGradient();
 }
 
+#endif
 
 
 // 0-D
@@ -732,6 +747,9 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
   Real value = FE<0,LAGRANGE>::shape_deriv( elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
   return libMesh::RealGradient( value );
 }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 template <> RealGradient FE<0,LAGRANGE_VEC>::shape_second_deriv(const Elem * elem, const Order order,
                                                                 const unsigned int i, const unsigned int j,
                                                                 const Point & p)
@@ -739,6 +757,8 @@ template <> RealGradient FE<0,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
   Real value = FE<0,LAGRANGE>::shape_second_deriv( elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
   return libMesh::RealGradient( value );
 }
+
+#endif
 
 // 1-D
 template <> RealGradient FE<1,LAGRANGE_VEC>::shape(const Elem * elem, const Order order,
@@ -754,6 +774,8 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
   Real value = FE<1,LAGRANGE>::shape_deriv( elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
   return libMesh::RealGradient( value );
 }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <> RealGradient FE<1,LAGRANGE_VEC>::shape_second_deriv(const Elem * elem, const Order order,
                                                                 const unsigned int i, const unsigned int j,
                                                                 const Point & p)
@@ -761,6 +783,8 @@ template <> RealGradient FE<1,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
   Real value = FE<1,LAGRANGE>::shape_second_deriv( elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
   return libMesh::RealGradient( value );
 }
+
+#endif
 
 // 2-D
 template <> RealGradient FE<2,LAGRANGE_VEC>::shape(const Elem * elem, const Order order,
@@ -804,6 +828,8 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
   //dummy
   return libMesh::RealGradient();
 }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <> RealGradient FE<2,LAGRANGE_VEC>::shape_second_deriv(const Elem * elem, const Order order,
                                                                 const unsigned int i, const unsigned int j,
                                                                 const Point & p)
@@ -825,6 +851,8 @@ template <> RealGradient FE<2,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
   //dummy
   return libMesh::RealGradient();
 }
+
+#endif
 
 // 3-D
 template <> RealGradient FE<3,LAGRANGE_VEC>::shape(const Elem * elem, const Order order,
@@ -874,6 +902,9 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape_deriv(const Elem * elem, cons
   //dummy
   return libMesh::RealGradient();
 }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 template <> RealGradient FE<3,LAGRANGE_VEC>::shape_second_deriv(const Elem * elem, const Order order,
                                                                 const unsigned int i, const unsigned int j,
                                                                 const Point & p)
@@ -898,6 +929,8 @@ template <> RealGradient FE<3,LAGRANGE_VEC>::shape_second_deriv(const Elem * ele
   //dummy
   return libMesh::RealGradient();
 }
+
+#endif
 
 // Do full-specialization for every dimension, instead
 // of explicit instantiation at the end of this function.

--- a/src/fe/fe_monomial_shape_0D.C
+++ b/src/fe/fe_monomial_shape_0D.C
@@ -78,6 +78,7 @@ Real FE<0,MONOMIAL>::shape_deriv(const Elem *,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<0,MONOMIAL>::shape_second_deriv(const ElemType,
@@ -102,5 +103,7 @@ Real FE<0,MONOMIAL>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_monomial_shape_1D.C
+++ b/src/fe/fe_monomial_shape_1D.C
@@ -136,6 +136,7 @@ Real FE<1,MONOMIAL>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,MONOMIAL>::shape_second_deriv(const ElemType,
@@ -189,5 +190,7 @@ Real FE<1,MONOMIAL>::shape_second_deriv(const Elem * elem,
   return FE<1,MONOMIAL>::shape_second_deriv(elem->type(),
                                             static_cast<Order>(order + elem->p_level()), i, j, p);
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_monomial_shape_2D.C
+++ b/src/fe/fe_monomial_shape_2D.C
@@ -314,6 +314,7 @@ Real FE<2,MONOMIAL>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,MONOMIAL>::shape_second_deriv(const ElemType,
@@ -547,5 +548,6 @@ Real FE<2,MONOMIAL>::shape_second_deriv(const Elem * elem,
   return FE<2,MONOMIAL>::shape_second_deriv(elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
 }
 
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_monomial_shape_3D.C
+++ b/src/fe/fe_monomial_shape_3D.C
@@ -648,6 +648,7 @@ Real FE<3,MONOMIAL>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<3,MONOMIAL>::shape_second_deriv(const ElemType,
@@ -1309,5 +1310,7 @@ Real FE<3,MONOMIAL>::shape_second_deriv(const Elem * elem,
   // call the orientation-independent shape function derivatives
   return FE<3,MONOMIAL>::shape_second_deriv(elem->type(), static_cast<Order>(order + elem->p_level()), i, j, p);
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -603,6 +603,8 @@ template <>
 RealGradient FE<0,NEDELEC_ONE>::shape_deriv(const Elem *,const Order,const unsigned int,
                                             const unsigned int,const Point &)
 { NEDELEC_LOW_D_ERROR_MESSAGE }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <>
 RealGradient FE<0,NEDELEC_ONE>::shape_second_deriv(const ElemType, const Order,const unsigned int,
                                                    const unsigned int,const Point &)
@@ -611,6 +613,8 @@ template <>
 RealGradient FE<0,NEDELEC_ONE>::shape_second_deriv(const Elem *,const Order,const unsigned int,
                                                    const unsigned int,const Point &)
 { NEDELEC_LOW_D_ERROR_MESSAGE }
+
+#endif
 
 template <>
 RealGradient FE<1,NEDELEC_ONE>::shape(const ElemType, const Order,const unsigned int,const Point &)
@@ -626,6 +630,8 @@ template <>
 RealGradient FE<1,NEDELEC_ONE>::shape_deriv(const Elem *,const Order,const unsigned int,
                                             const unsigned int,const Point &)
 { NEDELEC_LOW_D_ERROR_MESSAGE }
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <>
 RealGradient FE<1,NEDELEC_ONE>::shape_second_deriv(const ElemType, const Order,const unsigned int,
                                                    const unsigned int,const Point &)
@@ -634,5 +640,7 @@ template <>
 RealGradient FE<1,NEDELEC_ONE>::shape_second_deriv(const Elem *,const Order,const unsigned int,
                                                    const unsigned int,const Point &)
 { NEDELEC_LOW_D_ERROR_MESSAGE }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -325,6 +325,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 RealGradient FE<2,NEDELEC_ONE>::shape_second_deriv(const ElemType,
@@ -394,5 +395,7 @@ RealGradient FE<2,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
   return RealGradient();
 #endif
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -487,6 +487,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape_deriv(const Elem * elem,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <>
 RealGradient FE<3,NEDELEC_ONE>::shape_second_deriv(const ElemType,
                                                    const Order,
@@ -742,5 +743,7 @@ RealGradient FE<3,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
   return RealGradient();
 #endif
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_scalar_shape_0D.C
+++ b/src/fe/fe_scalar_shape_0D.C
@@ -63,6 +63,8 @@ Real FE<0,SCALAR>::shape_deriv(const Elem *,
   return 0.;
 }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 template <>
 Real FE<0,SCALAR>::shape_second_deriv(const ElemType,
                                       const Order,
@@ -82,5 +84,7 @@ Real FE<0,SCALAR>::shape_second_deriv(const Elem *,
 {
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_scalar_shape_1D.C
+++ b/src/fe/fe_scalar_shape_1D.C
@@ -63,6 +63,9 @@ Real FE<1,SCALAR>::shape_deriv(const Elem *,
   return 0.;
 }
 
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 template <>
 Real FE<1,SCALAR>::shape_second_deriv(const ElemType,
                                       const Order,
@@ -82,5 +85,7 @@ Real FE<1,SCALAR>::shape_second_deriv(const Elem *,
 {
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_scalar_shape_2D.C
+++ b/src/fe/fe_scalar_shape_2D.C
@@ -64,6 +64,7 @@ Real FE<2,SCALAR>::shape_deriv(const Elem *,
   return 0.;
 }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,SCALAR>::shape_second_deriv(const ElemType,
@@ -84,5 +85,7 @@ Real FE<2,SCALAR>::shape_second_deriv(const Elem *,
 {
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_scalar_shape_3D.C
+++ b/src/fe/fe_scalar_shape_3D.C
@@ -63,6 +63,8 @@ Real FE<3,SCALAR>::shape_deriv(const Elem *,
   return 0.;
 }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+
 template <>
 Real FE<3,SCALAR>::shape_second_deriv(const ElemType,
                                       const Order,
@@ -82,5 +84,7 @@ Real FE<3,SCALAR>::shape_second_deriv(const Elem *,
 {
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_szabab_shape_0D.C
+++ b/src/fe/fe_szabab_shape_0D.C
@@ -78,6 +78,7 @@ Real FE<0,SZABAB>::shape_deriv(const Elem *,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<0,SZABAB>::shape_second_deriv(const ElemType,
@@ -102,5 +103,7 @@ Real FE<0,SZABAB>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_szabab_shape_1D.C
+++ b/src/fe/fe_szabab_shape_1D.C
@@ -148,6 +148,7 @@ Real FE<1,SZABAB>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,SZABAB>::shape_second_deriv(const ElemType,
@@ -186,6 +187,7 @@ Real FE<1,SZABAB>::shape_second_deriv(const Elem *,
   warning_given = true;
   return 0.;
 }
+#endif
 
 } // namespace libMesh
 

--- a/src/fe/fe_szabab_shape_2D.C
+++ b/src/fe/fe_szabab_shape_2D.C
@@ -1395,6 +1395,7 @@ Real FE<2,SZABAB>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,SZABAB>::shape_second_deriv(const ElemType,
@@ -1434,7 +1435,8 @@ Real FE<2,SZABAB>::shape_second_deriv(const Elem *,
   return 0.;
 }
 
-} // namespace libMesh
+#endif
 
+} // namespace libMesh
 
 #endif// LIBMESH_ENABLE_HIGHER_ORDER_SHAPES

--- a/src/fe/fe_szabab_shape_3D.C
+++ b/src/fe/fe_szabab_shape_3D.C
@@ -76,6 +76,7 @@ Real FE<3,SZABAB>::shape_deriv(const Elem *,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<3,SZABAB>::shape_second_deriv(const ElemType,
@@ -100,6 +101,8 @@ Real FE<3,SZABAB>::shape_second_deriv(const Elem *,
   libmesh_error_msg("Szabo-Babuska polynomials are not defined in 3D");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh
 

--- a/src/fe/fe_xyz_map.C
+++ b/src/fe/fe_xyz_map.C
@@ -39,10 +39,12 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
         {
           this->xyz.resize(n_qp);
           this->dxyzdxi_map.resize(n_qp);
+#ifdef  LIBMESH_ENABLE_SECOND_DERIVATIVES
           this->d2xyzdxi2_map.resize(n_qp);
+          this->curvatures.resize(n_qp);
+#endif
           this->tangents.resize(n_qp);
           this->normals.resize(n_qp);
-          this->curvatures.resize(n_qp);
 
           this->JxW.resize(n_qp);
         }
@@ -54,7 +56,9 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
             this->tangents[p].resize(LIBMESH_DIM-1); // 1 Tangent in 2D, 2 in 3D
             this->xyz[p].zero();
             this->dxyzdxi_map[p].zero();
+#ifdef  LIBMESH_ENABLE_SECOND_DERIVATIVES
             this->d2xyzdxi2_map[p].zero();
+#endif
           }
 
         // compute x, dxdxi at the quadrature points
@@ -68,7 +72,9 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
               {
                 this->xyz[p].add_scaled          (side_point, this->psi_map[i][p]);
                 this->dxyzdxi_map[p].add_scaled  (side_point, this->dpsidxi_map[i][p]);
+#ifdef  LIBMESH_ENABLE_SECOND_DERIVATIVES
                 this->d2xyzdxi2_map[p].add_scaled(side_point, this->d2psidxi2_map[i][p]);
+#endif
               }
           }
 
@@ -81,7 +87,8 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
             this->tangents[p][0] = this->dxyzdxi_map[p].unit();
 #if LIBMESH_DIM == 3  // Only good in 3D space
             this->tangents[p][1] = this->dxyzdxi_map[p].cross(n).unit();
-#endif
+
+#ifdef  LIBMESH_ENABLE_SECOND_DERIVATIVES
             // The curvature is computed via the familiar Frenet formula:
             // curvature = [d^2(x) / d (xi)^2] dot [normal]
             // For a reference, see:
@@ -95,6 +102,8 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
             const Real denominator = this->dxyzdxi_map[p].norm_sq();
             libmesh_assert_not_equal_to (denominator, 0);
             this->curvatures[p] = numerator / denominator;
+#endif
+#endif
           }
 
         // compute the jacobian at the quadrature points
@@ -118,12 +127,14 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
           this->xyz.resize(n_qp);
           this->dxyzdxi_map.resize(n_qp);
           this->dxyzdeta_map.resize(n_qp);
+#ifdef  LIBMESH_ENABLE_SECOND_DERIVATIVES
           this->d2xyzdxi2_map.resize(n_qp);
           this->d2xyzdxideta_map.resize(n_qp);
           this->d2xyzdeta2_map.resize(n_qp);
+          this->curvatures.resize(n_qp);
+#endif
           this->tangents.resize(n_qp);
           this->normals.resize(n_qp);
-          this->curvatures.resize(n_qp);
 
           this->JxW.resize(n_qp);
         }
@@ -135,9 +146,11 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
             this->xyz[p].zero();
             this->dxyzdxi_map[p].zero();
             this->dxyzdeta_map[p].zero();
+#ifdef  LIBMESH_ENABLE_SECOND_DERIVATIVES
             this->d2xyzdxi2_map[p].zero();
             this->d2xyzdxideta_map[p].zero();
             this->d2xyzdeta2_map[p].zero();
+#endif
           }
 
         // compute x, dxdxi at the quadrature points
@@ -152,9 +165,11 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
                 this->xyz[p].add_scaled             (side_point, this->psi_map[i][p]);
                 this->dxyzdxi_map[p].add_scaled     (side_point, this->dpsidxi_map[i][p]);
                 this->dxyzdeta_map[p].add_scaled    (side_point, this->dpsideta_map[i][p]);
+#ifdef  LIBMESH_ENABLE_SECOND_DERIVATIVES
                 this->d2xyzdxi2_map[p].add_scaled   (side_point, this->d2psidxi2_map[i][p]);
                 this->d2xyzdxideta_map[p].add_scaled(side_point, this->d2psidxideta_map[i][p]);
                 this->d2xyzdeta2_map[p].add_scaled  (side_point, this->d2psideta2_map[i][p]);
+#endif
               }
           }
 
@@ -166,6 +181,7 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
             this->tangents[p][0] = this->dxyzdxi_map[p].unit();
             this->tangents[p][1] = n.cross(this->dxyzdxi_map[p]).unit();
 
+#ifdef  LIBMESH_ENABLE_SECOND_DERIVATIVES
             // Compute curvature using the typical nomenclature
             // of the first and second fundamental forms.
             // For reference, see:
@@ -183,6 +199,7 @@ void FEXYZMap::compute_face_map(int dim, const std::vector<Real> & qw, const Ele
             const Real denominator = E*G - F*F;
             libmesh_assert_not_equal_to (denominator, 0.);
             this->curvatures[p] = 0.5*numerator/denominator;
+#endif
           }
 
         // compute the jacobian at the quadrature points, see

--- a/src/fe/fe_xyz_shape_0D.C
+++ b/src/fe/fe_xyz_shape_0D.C
@@ -78,6 +78,7 @@ Real FE<0,XYZ>::shape_deriv(const Elem *,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<0,XYZ>::shape_second_deriv(const ElemType,
@@ -102,5 +103,7 @@ Real FE<0,XYZ>::shape_second_deriv(const Elem *,
   libmesh_error_msg("No spatial derivatives in 0D!");
   return 0.;
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_xyz_shape_1D.C
+++ b/src/fe/fe_xyz_shape_1D.C
@@ -155,6 +155,7 @@ Real FE<1,XYZ>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<1,XYZ>::shape_second_deriv(const ElemType,
@@ -219,5 +220,6 @@ Real FE<1,XYZ>::shape_second_deriv(const Elem * elem,
       return val/dist2;
     }
 }
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -351,6 +351,7 @@ Real FE<2,XYZ>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,XYZ>::shape_second_deriv(const ElemType,
@@ -600,5 +601,7 @@ Real FE<2,XYZ>::shape_second_deriv(const Elem * elem,
   return 0.;
 #endif
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -691,6 +691,7 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<3,XYZ>::shape_second_deriv(const ElemType,
@@ -1381,5 +1382,7 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
   return 0.;
 #endif
 }
+
+#endif
 
 } // namespace libMesh

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -193,42 +193,53 @@ void InfFE<Dim,T_radial,T_base>::init_face_shape_functions(const std::vector<Poi
           libmesh_assert_less (_base_node_index[n], n_base_mapping_shape_functions);
           libmesh_assert_less (_radial_node_index[n], n_radial_mapping_sf);
         }
-
     }
 
     // resize map data fields
     {
       std::vector<std::vector<Real>> & psi_map = this->_fe_map->get_psi();
       std::vector<std::vector<Real>> & dpsidxi_map = this->_fe_map->get_dpsidxi();
-      std::vector<std::vector<Real>> & d2psidxi2_map = this->_fe_map->get_d2psidxi2();
       psi_map.resize          (n_total_mapping_shape_functions);
       dpsidxi_map.resize      (n_total_mapping_shape_functions);
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+      std::vector<std::vector<Real>> & d2psidxi2_map = this->_fe_map->get_d2psidxi2();
+
       d2psidxi2_map.resize    (n_total_mapping_shape_functions);
+#endif
 
       //  if (Dim == 3)
       {
         std::vector<std::vector<Real>> & dpsideta_map = this->_fe_map->get_dpsideta();
+        dpsideta_map.resize     (n_total_mapping_shape_functions);
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         std::vector<std::vector<Real>> & d2psidxideta_map = this->_fe_map->get_d2psidxideta();
         std::vector<std::vector<Real>> & d2psideta2_map = this->_fe_map->get_d2psideta2();
-        dpsideta_map.resize     (n_total_mapping_shape_functions);
         d2psidxideta_map.resize (n_total_mapping_shape_functions);
         d2psideta2_map.resize   (n_total_mapping_shape_functions);
+#endif
       }
 
       for (unsigned int i=0; i<n_total_mapping_shape_functions; i++)
         {
           psi_map[i].resize         (n_total_qp);
           dpsidxi_map[i].resize     (n_total_qp);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
           d2psidxi2_map[i].resize   (n_total_qp);
+#endif
 
           // if (Dim == 3)
           {
             std::vector<std::vector<Real>> & dpsideta_map = this->_fe_map->get_dpsideta();
+            dpsideta_map[i].resize     (n_total_qp);
+
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
             std::vector<std::vector<Real>> & d2psidxideta_map = this->_fe_map->get_d2psidxideta();
             std::vector<std::vector<Real>> & d2psideta2_map = this->_fe_map->get_d2psideta2();
-            dpsideta_map[i].resize     (n_total_qp);
             d2psidxideta_map[i].resize (n_total_qp);
             d2psideta2_map[i].resize   (n_total_qp);
+#endif
           }
         }
     }


### PR DESCRIPTION
Dear all,
in reference to #1956: This is supposed to be the patch: 
Except for the calculate_d2phi in the FEAbstract class (which enters some function arguments), all second derivative quantities are now optional via the respective macro.
I hope, I didn't forget something; but for me, it runs well (probably all the test cases have second derivatives enabled?)
Best,
Hubert