### PR TITLE
GenericProjector fix

### DIFF
--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -633,6 +633,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::operator()
             context.get_edge_fe( var, edge_fe );
 
           fe->get_xyz();
+          fe->get_JxW();
 
           fe->get_phi();
           if (dim > 1)


### PR DESCRIPTION
This fixes an `Assertion !calculations_started || calculate_dxy' failed` assert/crash for me, but I'm not sure it's the best fix. A simple test code that demonstrates the problem is attached. Note that it seems like you have to have at least two variables on the system in order to trigger the crash, I did not play around with exactly what combinations of variables would trigger it, however. 

cc: @roystgnr 

```c++
#include "libmesh/libmesh.h"
#include "libmesh/mesh.h"
#include "libmesh/mesh_generation.h"
#include "libmesh/exodusII_io.h"
#include "libmesh/equation_systems.h"
#include "libmesh/dof_map.h"
#include "libmesh/numeric_vector.h"
#include "libmesh/elem.h"

// Bring in everything from the libMesh namespace
using namespace libMesh;

Number projection_function (const Point & p,
                            const Parameters & /*params*/,
                            const std::string & /*sys_name*/,
                            const std::string & unknown_name)
{
  if (unknown_name == "u")
    return p(0);
  if (unknown_name == "v")
    return p(1);
  else
    return 0.;
}



int main (int argc, char ** argv)
{
  LibMeshInit init (argc, argv);

  ReplicatedMesh mesh(init.comm());

  MeshTools::Generation::build_cube (mesh,
                                     5, 5, 5,
                                     0., 1.,
                                     0., 1.,
                                     0., 1.,
                                     HEX8);

  // Add discontinuous variables
  EquationSystems es(mesh);
  System & sys = es.add_system<System> ("SimpleSystem");
  sys.add_variable("u", FIRST, MONOMIAL);
  sys.add_variable("v", FIRST, L2_LAGRANGE);

  // Project known function onto the discontinuous space.
  es.init();
  sys.project_solution(projection_function, nullptr, es.parameters);

  // Write solution to file.
  ExodusII_IO exodus(mesh);
  exodus.write_timestep("simple_gp_bug.e",
                        es,
                        /*timestep (1-based)*/1,
                        /*time*/0.);
  return 0;
}
```

Stack trace is below
```
(gdb) bt
#0  libMesh::print_trace (out_stream=...) at ../src/base/print_trace.C:197
#1  0x00007ffff61f2116 in libMesh::MacroFunctions::report_error (file=0x7ffff73adecb "./include/libmesh/fe_map.h", line=553, date=0x7ffff73ad76e "Jan 17 2019", 
    time=0x7ffff73ad765 "08:37:49") at ../src/base/libmesh_common.C:85
#2  0x00007ffff615751c in libMesh::FEMap::get_JxW (this=0x555555829f80) at ./include/libmesh/fe_map.h:553
#3  0x00007ffff6157648 in libMesh::FEAbstract::get_JxW (this=0x5555558299e0) at ./include/libmesh/fe_abstract.h:246
#4  0x00007ffff6e26c8d in libMesh::GenericProjector<libMesh::FEMFunctionWrapper<double>, libMesh::FEMFunctionWrapper<libMesh::VectorValue<double> >, double, libMesh::VectorSetAction<double> >::operator() (this=0x7fffffffc760, range=...) at ./include/libmesh/generic_projector.h:1388
#5  0x00007ffff6e19315 in libMesh::Threads::parallel_for<libMesh::StoredRange<libMesh::MeshBase::const_element_iterator, libMesh::Elem const*>, libMesh::GenericProjector<libMesh::FEMFunctionWrapper<double>, libMesh::FEMFunctionWrapper<libMesh::VectorValue<double> >, double, libMesh::VectorSetAction<double> > > (range=..., body=...) at ./include/libmesh/threads_pthread.h:277
#6  0x00007ffff6e0ff40 in libMesh::System::project_vector (this=0x555555809bd0, new_vector=..., f=0x7fffffffd0c0, g=0x7fffffffd0d0, is_adjoint=-1) at ../src/systems/system_projection.C:909
#7  0x00007ffff6e0fab7 in libMesh::System::project_vector (this=0x555555809bd0, new_vector=..., f=0x7fffffffd340, g=0x7fffffffd380, is_adjoint=-1) at ../src/systems/system_projection.C:866
#8  0x00007ffff6e0f690 in libMesh::System::project_solution (this=0x555555809bd0, f=0x7fffffffd340, g=0x7fffffffd380) at ../src/systems/system_projection.C:813
#9  0x00007ffff6e0f5df in libMesh::System::project_solution (this=0x555555809bd0, 
    fptr=0x55555557ae53 <projection_function(libMesh::Point const&, libMesh::Parameters const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, gptr=0x0, parameters=...) at ../src/systems/system_projection.C:802
```
