### PR TITLE
Update to RBEIMAssembly::evaluate_basis_function()

### DIFF
--- a/examples/reduced_basis/reduced_basis_ex4/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex4/assembly.h
@@ -132,16 +132,13 @@ struct EIM_F : RBEIMAssembly
     // The number of local degrees of freedom in each variable
     const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
 
-    // Now we will build the affine operator
-    unsigned int n_qpoints = c.get_element_qrule().n_points();
-
     std::vector<Number> eim_values;
     evaluate_basis_function(eim_var,
                             c.get_elem(),
-                            c.get_element_qrule(),
+                            c.get_element_qrule().get_points(),
                             eim_values);
 
-    for (unsigned int qp=0; qp != n_qpoints; qp++)
+    for (unsigned int qp=0; qp != c.get_element_qrule().n_points(); qp++)
       for (unsigned int i=0; i != n_u_dofs; i++)
         c.get_elem_residual()(i) += JxW[qp] * (eim_values[qp]*phi[i][qp]);
   }

--- a/examples/reduced_basis/reduced_basis_ex6/assembly.h
+++ b/examples/reduced_basis/reduced_basis_ex6/assembly.h
@@ -270,28 +270,25 @@ struct AssemblyEIM : RBEIMAssembly
     // The number of local degrees of freedom in each variable
     const unsigned int n_u_dofs = c.get_dof_indices(u_var).size();
 
-    // Now we will build the affine operator
-    unsigned int n_qpoints = c.get_element_qrule().n_points();
-
     std::vector<Number> eim_values_Gx;
     evaluate_basis_function(Gx_var,
                             c.get_elem(),
-                            c.get_element_qrule(),
+                            c.get_element_qrule().get_points(),
                             eim_values_Gx);
 
     std::vector<Number> eim_values_Gy;
     evaluate_basis_function(Gy_var,
                             c.get_elem(),
-                            c.get_element_qrule(),
+                            c.get_element_qrule().get_points(),
                             eim_values_Gy);
 
     std::vector<Number> eim_values_Gz;
     evaluate_basis_function(Gz_var,
                             c.get_elem(),
-                            c.get_element_qrule(),
+                            c.get_element_qrule().get_points(),
                             eim_values_Gz);
 
-    for (unsigned int qp=0; qp != n_qpoints; qp++)
+    for (unsigned int qp=0; qp != c.get_element_qrule().n_points(); qp++)
       for (unsigned int i=0; i != n_u_dofs; i++)
         for (unsigned int j=0; j != n_u_dofs; j++)
           c.get_elem_jacobian()(i,j) += JxW[qp] * (eim_values_Gx[qp]*dphi[i][qp](0)*dphi[j][qp](0) +

--- a/include/reduced_basis/rb_eim_assembly.h
+++ b/include/reduced_basis/rb_eim_assembly.h
@@ -64,11 +64,12 @@ public:
 
   /**
    * Evaluate variable \p var_number of this object's EIM basis function
-   * at the points \p qpoints. Fill \p values with the basis function values.
+   * at the points \p points, where the points are in reference coordinates.
+   * Fill \p values with the basis function values.
    */
   virtual void evaluate_basis_function(unsigned int var,
                                        const Elem & element,
-                                       const QBase & element_qrule,
+                                       const std::vector<Point> & points,
                                        std::vector<Number> & values);
 
   /**
@@ -111,10 +112,10 @@ private:
   std::unique_ptr<NumericVector<Number>> _ghosted_basis_function;
 
   /**
-   * We store an FE object and an associated quadrature rule.
+   * We store an FE object so we can easiyl reinit in evaluate_basis_function.
    */
   std::unique_ptr<FEBase> _fe;
-  std::unique_ptr<QBase> _qrule;
+
 };
 
 }


### PR DESCRIPTION
Change this function so that it takes in a set of points rather than a quadrature rule. The new approach is more general and less error prone, e.g. the previous approach led to problems when using separate meshes for the EIM and the RB assembly since the quadrature rules may not be consistent, but by passing in the appropriate points using the new approach we can now make sure that it works correctly.