### PR TITLE
Fix bugs in DTK configure test

### DIFF
--- a/configure
+++ b/configure
@@ -36531,7 +36531,7 @@ else
   enabledtk=no
 fi
 
-          if test "$enabledtk" != "xno"; then :
+          if test "x$enabledtk" != "xno"; then :
 
                   enabledtk=yes
 
@@ -36551,6 +36551,7 @@ fi
           enableifpack=no
 
           enableepetraext=no
+  enableepetra=no
 
 
 

--- a/m4/trilinos.m4
+++ b/m4/trilinos.m4
@@ -365,7 +365,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_9],
                 [DTK_MAKEFILE_EXPORT=$withdtkdir/packages/dtk/Makefile.export.Makefile.export.DataTransferKit],
                 [enabledtk=no])
 
-          AS_IF([test "$enabledtk" != "xno"],
+          AS_IF([test "x$enabledtk" != "xno"],
                 [
                   enabledtk=yes
                   AC_DEFINE(TRILINOS_HAVE_DTK, 1, [Flag indicating whether the library shall be compiled to use the DataTransferKit])
@@ -387,6 +387,7 @@ AC_DEFUN([CONFIGURE_TRILINOS_9],
   dnl anyone ever wants to go back and write a configure test with
   dnl an older Trilinos, that would be great!
   enableepetraext=no
+  enableepetra=no
 
 
   AC_SUBST(AZTECOO_MAKEFILE_EXPORT)


### PR DESCRIPTION
We were missing an "x" character in a string comparison test, causing the comparison to always be true.  This problem also came up in issues #1849, #2003.

Fixes #1849.
