### PR TITLE
 Enable base-side in InfFE::reinit(elem, side) 

### DIFF
--- a/src/fe/fe_interface_inf_fe.C
+++ b/src/fe/fe_interface_inf_fe.C
@@ -48,7 +48,7 @@ namespace libMesh
         switch(fe_t.inf_map)                                            \
           {                                                             \
           case CARTESIAN:                                               \
-            prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix \
+            prefix InfFE<dim,JACOBI_20_00,CARTESIAN>::func_and_args suffix \
           case SPHERICAL:                                               \
           case ELLIPSOIDAL:                                             \
             libmesh_not_implemented();                                  \
@@ -59,7 +59,7 @@ namespace libMesh
         switch(fe_t.inf_map)                                            \
           {                                                             \
           case CARTESIAN:                                               \
-            prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix \
+            prefix InfFE<dim,JACOBI_30_00,CARTESIAN>::func_and_args suffix \
           case SPHERICAL:                                               \
           case ELLIPSOIDAL:                                             \
             libmesh_not_implemented();                                  \
@@ -70,7 +70,7 @@ namespace libMesh
         switch(fe_t.inf_map)                                            \
           {                                                             \
           case CARTESIAN:                                               \
-            prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix \
+            prefix InfFE<dim,LEGENDRE,CARTESIAN>::func_and_args suffix \
           case SPHERICAL:                                               \
           case ELLIPSOIDAL:                                             \
             libmesh_not_implemented();                                  \
@@ -81,7 +81,7 @@ namespace libMesh
         switch(fe_t.inf_map)                                            \
           {                                                             \
           case CARTESIAN:                                               \
-            prefix InfFE<dim,INFINITE_MAP,CARTESIAN>::func_and_args suffix \
+            prefix InfFE<dim,LAGRANGE,CARTESIAN>::func_and_args suffix \
           case SPHERICAL:                                               \
           case ELLIPSOIDAL:                                             \
             libmesh_not_implemented();                                  \


### PR DESCRIPTION
The main issue I try to address is that I want to compute properties of the infinite elements at the boundary to the FEM-region. Thus, I need `side==base_side` in `InfFE::reinit(elem, side)`.

Along the lines, I'd like to fix some errors I introduced in #1981 (sorry for that).
and to make the above-mentioned function working, the `InfFE::inverse_map()` must give points outside the element when I feed it with points not being in the element.

The changes are actually more since I ran the `reindent.sh`-script on the code...

I hope not to introduce some strange or wrong behaviour; my tests were all successfull.