### PR TITLE
ExodusII_IO: Add ability to write more general discontinuous data

### DIFF
--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -196,12 +196,9 @@ public:
    *
    * This may be useful if you have a viz tool which is capable of
    * interpreting this element data as a discontinuous solution field.
-   * This function should generally _not_ be used for writing out
-   * (CONSTANT, MONOMIAL) data as it is always going to be overkill
-   * for that purpose.  (Imagine you have a CONSTANT, MONOMIAL
-   * variable on a Hex8 element, you would get 8 copies of a single
-   * value corresponding to each of the element's nodes, probably not
-   * what you want.)
+   * Note that (CONSTANT, MONOMIAL) data is still written as a single
+   * value per element, as it makes no sense to write n_vertices
+   * copies of the same value.
    *
    * The 'var_suffix' parameter, which defaults to "_elem_node_", is
    * used to generate the elemental variable names, and is inserted

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -185,6 +185,36 @@ public:
   void write_element_data (const EquationSystems & es);
 
   /**
+   * Similar to the function above, but instead of only handling
+   * (CONSTANT, MONOMIAL) data, writes out a general discontinuous
+   * solution field, e.g. (FIRST, L2_LAGRANGE) or (SECOND, MONOMIAL)
+   * as a number of elemental fields equal to the number of vertices in
+   * each element. For example, if you have a (FIRST, L2_LAGRANGE)
+   * variable "u" defined on HEX8 elements, calling this function
+   * would by default write 8 elemental fields named u_elem_node_0,
+   * u_elem_node_1, u_elem_node_2, etc.
+   *
+   * This may be useful if you have a viz tool which is capable of
+   * interpreting this element data as a discontinuous solution field.
+   * This function should generally _not_ be used for writing out
+   * (CONSTANT, MONOMIAL) data as it is always going to be overkill
+   * for that purpose.  (Imagine you have a CONSTANT, MONOMIAL
+   * variable on a Hex8 element, you would get 8 copies of a single
+   * value corresponding to each of the element's nodes, probably not
+   * what you want.)
+   *
+   * The 'var_suffix' parameter, which defaults to "_elem_node_", is
+   * used to generate the elemental variable names, and is inserted
+   * between the base variable name and the node id which the variable
+   * applies to, e.g. "u_elem_node_0", "u_elem_node_1", etc.
+   */
+  void
+  write_element_data_from_discontinuous_nodal_data
+  (const EquationSystems & es,
+   const std::set<std::string> * system_names = nullptr,
+   const std::string & var_suffix = "_elem_node_");
+
+  /**
    * Bring in base class functionality for name resolution and to
    * avoid warnings about hidden overloaded virtual functions.
    */

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -327,11 +327,40 @@ public:
 
   /**
    * Writes the vector of values to the element variables.
+   *
+   * The 'values' vector is assumed to be in the order:
+   * {(u1, u2, u3, ..., uN), (v1, v2, v3, ..., vN), (w1, w2, w3, ..., wN)}
+   * where N is the number of elements.
+   *
+   * This ordering is produced by calls to ES::build_elemental_solution_vector().
+   * ES::build_discontinuous_solution_vector(), on the other hand, produces an
+   * element-major ordering. See the function below for that case.
    */
-  void write_element_values(const MeshBase & mesh,
-                            const std::vector<Real> & values,
-                            int timestep,
-                            const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains);
+  void write_element_values
+  (const MeshBase & mesh,
+   const std::vector<Real> & values,
+   int timestep,
+   const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains);
+
+  /**
+   * Same as the function above, but assume the input 'values' vector is
+   * in element-major order, i.e.
+   * {(u1,v1,w1), (u2,v2,w2), ... (uN,vN,wN)}
+   * This function is called by
+   * ExodusII_IO::write_element_data_from_discontinuous_nodal_data()
+   * because ES::build_discontinuous_solution_vector() builds the solution
+   * vector in this order.
+   *
+   * \note If some variables are subdomain-restricted, then the tuples will
+   * be of different lengths for each element, i.e.
+   * {(u1,v1,w1), (u2,v2), ... (uN,vN,wN)}
+   * if variable w is not active on element 2.
+   */
+  void write_element_values_element_major
+  (const MeshBase & mesh,
+   const std::vector<Real> & values,
+   int timestep,
+   const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains);
 
   /**
    * Writes the vector of values to a nodal variable.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -360,7 +360,9 @@ public:
   (const MeshBase & mesh,
    const std::vector<Real> & values,
    int timestep,
-   const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains);
+   const std::vector<std::set<subdomain_id_type>> & vars_active_subdomains,
+   const std::vector<std::string> & derived_var_names,
+   const std::map<subdomain_id_type, std::vector<std::string>> & subdomain_to_var_names);
 
   /**
    * Writes the vector of values to a nodal variable.

--- a/include/systems/equation_systems.h
+++ b/include/systems/equation_systems.h
@@ -379,9 +379,16 @@ public:
    * the names from \p build_variable_names()).
    * If systems_names!=nullptr, only include data from the
    * specified systems.
+   * If vertices_only == true, then for higher-order elements only
+   * the solution at the vertices is computed. This can be useful
+   * when plotting discontinous solutions on higher-order elements
+   * and only a lower-order representation is required.
    */
-  void build_discontinuous_solution_vector (std::vector<Number> & soln,
-                                            const std::set<std::string> * system_names=nullptr) const;
+  void build_discontinuous_solution_vector
+  (std::vector<Number> & soln,
+   const std::set<std::string> * system_names = nullptr,
+   const std::vector<std::string> * var_names = nullptr,
+   bool vertices_only = false) const;
 
   /**
    * Read & initialize the systems from disk using the XDR data format.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -883,8 +883,17 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
   // ES::build_discontinuous_solution_vector() creates a vector with
   // an element-major ordering, so call Helper::write_element_values()
   // passing false for the last argument.
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+  // TODO: Make this work when complex variables are enabled by
+  // writing the real and complex parts separately. See
+  // ExodusII_IO::write_element_data() for details.
+  libmesh_not_implemented_msg
+    ("write_element_data_from_discontinuous_nodal_data() is not "
+     "yet supported when complex variables are enabled.");
+#else
   exio_helper->write_element_values_element_major
     (mesh, v, _timestep, derived_vars_active_subdomains);
+#endif
 }
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -724,11 +724,6 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
   std::vector<std::string> var_names;
   es.build_variable_names (var_names, /*fetype=*/nullptr, system_names);
 
-  // Debugging:
-  // libMesh::out << "List of all variable names: " << std::endl;
-  // for (const auto & var_name : var_names)
-  //   libMesh::out << var_name << std::endl;
-
   // Remove all names from var_names that are not in _output_variables.
   // Note: This approach avoids errors when the user provides invalid
   // variable names in _output_variables, as the code will not try to
@@ -744,11 +739,6 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
                             name);}),
        var_names.end());
 
-  // Debugging:
-  // libMesh::out << "List of variable names after white-listing: " << std::endl;
-  // for (const auto & var_name : var_names)
-  //   libMesh::out << var_name << std::endl;
-
   // Build a solution vector, limiting the results to the variables in
   // var_names and the Systems in system_names, and only computing values
   // at the vertices.
@@ -756,31 +746,9 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
   es.build_discontinuous_solution_vector
     (v, system_names, &var_names, /*vertices_only=*/true);
 
-  // Debugging: what is the ordering of the vector v the ES builds?
-  // libMesh::out << "Vector v from build_discontinuous_solution_vector():" << std::endl;
-  // for (const auto & val : v)
-  //   libMesh::out << val << ' ';
-  // libMesh::out << std::endl;
-
-  // Debugging:
-  // libMesh::out << "Discontinuous solution vector has size: " << v.size() << std::endl;
-
   // Get active subdomains for each variable in var_names.
   std::vector<std::set<subdomain_id_type>> vars_active_subdomains;
   es.get_vars_active_subdomains(var_names, vars_active_subdomains);
-
-  // Debugging: print which of the original variables are active on
-  // which subdomains (or 'All' if they are active on all subdomains).
-  // unsigned int ctr = 0;
-  // for (const auto & s : vars_active_subdomains)
-  //   {
-  //     libMesh::out << "Active subdomains for variable " << ctr++ << ": " << std::endl;
-  //     if (s.empty())
-  //       libMesh::out << "All" << std::endl;
-  //     else
-  //       for (const auto & id : s)
-  //         libMesh::out << id << std::endl;
-  //   }
 
   // Determine names of variables to write based on the number of
   // nodes/vertices the elements in different subdomains have.
@@ -833,11 +801,6 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
       const unsigned int vertices_per_elem =
         subdomain_id_to_vertices_per_elem[sbd_id];
 
-      // Debugging:
-      // libMesh::out << "Subdomain " << sbd_id
-      //              << " has elements with " << vertices_per_elem
-      //              << " vertices." << std::endl;
-
       std::ostringstream oss;
       for (unsigned int n=0; n<vertices_per_elem; ++n)
         for (unsigned int var_id=0; var_id<var_names.size(); ++var_id)
@@ -861,11 +824,6 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
           }
     }
 
-  // Debugging: print the names we constructed.
-  // libMesh::out << "Derived var names:" << std::endl;
-  // for (const auto & name : derived_var_names)
-  //   libMesh::out << name << std::endl;
-
   // For each derived variable name, determine whether it is active
   // based on how many nodes/vertices the elements in a given subdomain have,
   // and whether they were active on the subdomain to begin with.
@@ -882,11 +840,6 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
       // Convenience variables for the map entry's contents.
       const std::string & orig_name = it->second.first;
       const unsigned int node_id = it->second.second;
-
-      // Debugging
-      // libMesh::out << "Derived name: " << derived_name
-      //              << " comes from original name " << orig_name
-      //              << " and node id " << node_id << std::endl;
 
       // For each subdomain, determine whether the current variable
       // should be active on that subdomain.
@@ -919,30 +872,9 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
           // elements in this subdomain have enough nodes for the
           // corresponding derived variable to be active.
           if (orig_var_active && node_id < vertices_per_elem_this_sbd)
-            {
-              // Debugging: status message
-              // libMesh::out << "Derived variable: " << derived_name
-              //              << " is active on subdomain " << sbd_id
-              //              << std::endl;
-              derived_vars_active_subdomains[derived_var_id].insert(sbd_id);
-            }
+            derived_vars_active_subdomains[derived_var_id].insert(sbd_id);
         } // end loop over subdomain_id_to_vertices_per_elem
     } // end loop over derived_var_names
-
-  // Debugging: print the results of the active/inactive determination.
-  // for (auto derived_var_id : index_range(derived_var_names))
-  //   {
-  //     libMesh::out << "Active subdomains for derived variable " << derived_var_names[derived_var_id] << ": ";
-  //     const auto & s = derived_vars_active_subdomains[derived_var_id];
-  //     if (s.empty())
-  //       libMesh::out << "All" << std::endl;
-  //     else
-  //       {
-  //         for (const auto id : s)
-  //           libMesh::out << id << " ";
-  //         libMesh::out << std::endl;
-  //       }
-  //   }
 
   // Call function which writes the derived variable names to the
   // Exodus file.

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1331,6 +1331,17 @@ void ExodusII_IO::write_element_data (const EquationSystems &)
 
 
 
+void
+ExodusII_IO::write_element_data_from_discontinuous_nodal_data
+(const EquationSystems &,
+ const std::set<std::string> *,
+ const std::string & )
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+
+
 void ExodusII_IO::write_nodal_data (const std::string &,
                                     const std::vector<Number> &,
                                     const std::vector<std::string> &)

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -933,16 +933,16 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
               // Reference to ordered list of variable names on this subdomain.
               auto & name_vec = pr.second;
 
-              auto it =
+              auto name_vec_it =
                 std::find(name_vec.begin(),
                           name_vec.end(),
                           derived_var_name);
 
-              if (it != name_vec.end())
+              if (name_vec_it != name_vec.end())
                 {
                   // Actually rename it back to the orig_name, dropping
                   // the "_elem_corner_" stuff.
-                  *it = orig_name;
+                  *name_vec_it = orig_name;
                 }
             }
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -831,9 +831,6 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
             std::string derived_name = oss.str();
 
             // Only add this var name if it's not already in the list.
-            // TODO: what order will the variables be in in the hybrid
-            // case when a subdomain with elements having nodes comes
-            // before a subdomain with elements having more nodes.
             if (!std::count(derived_var_names.begin(), derived_var_names.end(), derived_name))
               {
                 derived_var_names.push_back(derived_name);

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1823,8 +1823,27 @@ void ExodusII_IO_Helper::check_existing_vars(ExodusVarType type,
   // Fills up names_from_file for us
   this->read_var_names(type);
 
-  // Both the names of the global variables and their order must match
-  if (names_from_file != names)
+  // Both the number of variables and their names (up to the first
+  // MAX_STR_LENGTH characters) must match for the names we are
+  // planning to write and the names already in the file.
+  bool check_failed = false;
+
+  if (names.size() != names_from_file.size())
+    check_failed = true;
+
+  if (!check_failed)
+    {
+      for (const auto i : index_range(names))
+        if (names[i].compare
+            (/*pos=*/0, /*len=*/MAX_STR_LENGTH,
+             names_from_file[i]) != 0)
+          {
+            check_failed = true;
+            break;
+          }
+    }
+
+  if (check_failed)
     {
       libMesh::err << "Error! The Exodus file already contains the variables:" << std::endl;
       for (const auto & name : names_from_file)

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1828,11 +1828,11 @@ void ExodusII_IO_Helper::check_existing_vars(ExodusVarType type,
     {
       libMesh::err << "Error! The Exodus file already contains the variables:" << std::endl;
       for (const auto & name : names_from_file)
-        libMesh::out << name << std::endl;
+        libMesh::err << name << std::endl;
 
       libMesh::err << "And you asked to write:" << std::endl;
       for (const auto & name : names)
-        libMesh::out << name << std::endl;
+        libMesh::err << name << std::endl;
 
       libmesh_error_msg("Cannot overwrite existing variables in Exodus II file.");
     }

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2052,21 +2052,12 @@ void ExodusII_IO_Helper::write_element_values_element_major
                 auto true_index =
                   std::distance(var_names_this_sbd.begin(), pos);
 
-                // Debugging: print the index of this variable on the current subdomain.
-                // libMesh::out << "true_index = " << true_index << std::endl;
-
                 data.push_back(values[values_offset + true_index]);
               }
 
             // The "true" offset is how much we have to advance the index for each Elem
             // in this subdomain.
             auto true_offset = var_names_this_sbd.size();
-
-            // Debugging
-            // libMesh::out << "true_offset = " << true_offset << std::endl;
-
-            // Debugging
-            // libMesh::out << "New method: advance values_offset by " << true_offset << std::endl;
 
             // Increment to the next Elem's values
             values_offset += true_offset;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1970,9 +1970,6 @@ void ExodusII_IO_Helper::write_element_values_element_major
   ex_err = exII::ex_get_var_param(ex_id, "e", &num_elem_vars);
   EX_CHECK_ERR(ex_err, "Error reading number of elemental variables.");
 
-  // Debugging:
-  // libMesh::out << "num_elem_vars=" << num_elem_vars << std::endl;
-
   // We will eventually loop over the element blocks (subdomains) and
   // write the data one block (subdomain) at a time. Build a data
   // structure that keeps track of how many elements are in each
@@ -2010,16 +2007,6 @@ void ExodusII_IO_Helper::write_element_values_element_major
         }
     }
 
-  // Debugging: print the active variables for each subdomain.
-  // for (const auto & pr : subdomain_to_active_vars)
-  //   {
-  //     libMesh::out << "Subdomain " << pr.first
-  //                  << " has active vars: ";
-  //     for (const auto & var_id : pr.second)
-  //       libMesh::out << var_id << " ";
-  //     libMesh::out << std::endl;
-  //   }
-
   // Sanity check: we must have an entry in vars_active_subdomains for
   // each variable that we are potentially writing out.
   libmesh_assert_equal_to
@@ -2053,16 +2040,6 @@ void ExodusII_IO_Helper::write_element_values_element_major
         unsigned int values_offset = 0;
         for (auto & elem : elem_range)
           {
-            // How many active variables are there on the current
-            // subdomain?
-            // unsigned int n_active_vars =
-            //   subdomain_to_active_vars[elem->subdomain_id()].size();
-
-            // Debugging:
-            // libMesh::out << "Elem " << elem->id()
-            //              << " has " << n_active_vars
-            //              << " active variables." << std::endl;
-
             // We'll use the Elem's subdomain id in several places below.
             subdomain_id_type sbd_id = elem->subdomain_id();
 
@@ -2089,17 +2066,8 @@ void ExodusII_IO_Helper::write_element_values_element_major
                   (var_set.count(var_id),
                    "var_id " << var_id << " not found in set of active variables!");
 
-                // Debugging:
-                // libMesh::out << "The local index of this variable is: "
-                //              << local_index << std::endl;
-                // libMesh::out << "Index in the values vector is: "
-                //              << values_offset + local_index
-                //              << std::endl;
                 data.push_back(values[values_offset + local_index]);
               }
-
-            // Debugging: how far are we going to jump ahead in the vector?
-            // libMesh::out << "Incrementing values_offset by " << var_set.size() << std::endl;
 
             // Increment to the next Elem's values
             values_offset += var_set.size();

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1826,24 +1826,16 @@ void ExodusII_IO_Helper::check_existing_vars(ExodusVarType type,
   // Both the number of variables and their names (up to the first
   // MAX_STR_LENGTH characters) must match for the names we are
   // planning to write and the names already in the file.
-  bool check_failed = false;
+  bool match =
+    std::equal(names.begin(), names.end(),
+               names_from_file.begin(),
+               [](const std::string & a,
+                  const std::string & b) -> bool
+               {
+                 return a.compare(/*pos=*/0, /*len=*/MAX_STR_LENGTH, b) == 0;
+               });
 
-  if (names.size() != names_from_file.size())
-    check_failed = true;
-
-  if (!check_failed)
-    {
-      for (const auto i : index_range(names))
-        if (names[i].compare
-            (/*pos=*/0, /*len=*/MAX_STR_LENGTH,
-             names_from_file[i]) != 0)
-          {
-            check_failed = true;
-            break;
-          }
-    }
-
-  if (check_failed)
+  if (!match)
     {
       libMesh::err << "Error! The Exodus file already contains the variables:" << std::endl;
       for (const auto & name : names_from_file)

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2073,13 +2073,19 @@ void ExodusII_IO_Helper::write_element_values_element_major
             values_offset += var_set.size();
           } // for elem
 
-        // Now write 'data' to Exodus file.
-        ex_err = exII::ex_put_elem_var(ex_id,
-                                       timestep,
-                                       var_id+1,
-                                       this->get_block_id(sbd_idx),
-                                       data.size(),
-                                       data.data());
+        // Now write 'data' to Exodus file, in single precision if requested.
+        if (_single_precision)
+          {
+            std::vector<float> float_data(data.begin(), data.end());
+            ex_err = exII::ex_put_elem_var
+              (ex_id, timestep, var_id+1, this->get_block_id(sbd_idx), float_data.size(), float_data.data());
+          }
+        else
+          {
+            ex_err = exII::ex_put_elem_var
+              (ex_id, timestep, var_id+1, this->get_block_id(sbd_idx), data.size(), data.data());
+          }
+
         EX_CHECK_ERR(ex_err, "Error writing element values.");
       } // for each var_id
 

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -1052,8 +1052,12 @@ EquationSystems::build_parallel_elemental_solution_vector (std::vector<std::stri
 
 
 
-void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> & soln,
-                                                           const std::set<std::string> * system_names) const
+void
+EquationSystems::build_discontinuous_solution_vector
+(std::vector<Number> & soln,
+ const std::set<std::string> * system_names,
+ const std::vector<std::string> * var_names,
+ bool vertices_only) const
 {
   LOG_SCOPE("build_discontinuous_solution_vector()", "EquationSystems");
 
@@ -1065,29 +1069,41 @@ void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> &
   // in each system listed in system_names
   unsigned int nv = 0;
 
-  {
-    const_system_iterator       pos = _systems.begin();
-    const const_system_iterator end = _systems.end();
+  for (const auto & pr : _systems)
+    {
+      // Check current system is listed in system_names, and skip pos if not
+      bool use_current_system = (system_names == nullptr);
+      if (!use_current_system)
+        use_current_system = system_names->count(pr.first);
+      if (!use_current_system || pr.second->hide_output())
+        continue;
 
-    for (; pos != end; ++pos)
-      {
-        // Check current system is listed in system_names, and skip pos if not
-        bool use_current_system = (system_names == nullptr);
-        if (!use_current_system)
-          use_current_system = system_names->count(pos->first);
-        if (!use_current_system || pos->second->hide_output())
-          continue;
+      const System * system  = pr.second;
 
-        const System & system  = *(pos->second);
-        nv += system.n_vars();
-      }
-  }
+      // Loop over all variables in this System and check whether we
+      // are supposed to use each one.
+      for (unsigned int var_id=0; var_id<system->n_vars(); ++var_id)
+        {
+          bool use_current_var = (var_names == nullptr);
+          if (!use_current_var)
+            use_current_var = std::count(var_names->begin(),
+                                         var_names->end(),
+                                         system->variable_name(var_id));
 
+          // Only increment the total number of vars if we are
+          // supposed to use this one.
+          if (use_current_var)
+            nv++;
+        }
+    }
+
+  // Debugging: verify we found the expected number of variables to write.
+  // libMesh::out << "In build_discontinuous_solution_vector(), nv = " << nv << std::endl;
   unsigned int tw=0;
 
   // get the total weight
   for (const auto & elem : _mesh.active_element_ptr_range())
-    tw += elem->n_nodes();
+    tw += vertices_only ? elem->n_vertices() : elem->n_nodes();
 
   // Only if we are on processor zero, allocate the storage
   // to hold (number_of_nodes)*(number_of_variables) entries.
@@ -1096,85 +1112,115 @@ void EquationSystems::build_discontinuous_solution_vector (std::vector<Number> &
 
   std::vector<Number> sys_soln;
 
-
-  unsigned int var_num=0;
+  // Keep track of the variable "offset". This is used for indexing
+  // into the global solution vector.
+  unsigned int var_offset = 0;
 
   // For each system in this EquationSystems object,
   // update the global solution and if we are on processor 0,
   // loop over the elements and build the nodal solution
   // from the element solution.  Then insert this nodal solution
   // into the vector passed to build_solution_vector.
-  {
-    const_system_iterator       pos = _systems.begin();
-    const const_system_iterator end = _systems.end();
+  for (const auto & pr : _systems)
+    {
+      // Check current system is listed in system_names, and skip pos if not
+      bool use_current_system = (system_names == nullptr);
+      if (!use_current_system)
+        use_current_system = system_names->count(pr.first);
+      if (!use_current_system || pr.second->hide_output())
+        continue;
 
-    for (; pos != end; ++pos)
-      {
-        // Check current system is listed in system_names, and skip pos if not
-        bool use_current_system = (system_names == nullptr);
-        if (!use_current_system)
-          use_current_system = system_names->count(pos->first);
-        if (!use_current_system || pos->second->hide_output())
-          continue;
+      const System * system  = pr.second;
+      const unsigned int nv_sys = system->n_vars();
 
-        const System & system  = *(pos->second);
-        const unsigned int nv_sys = system.n_vars();
+      system->update_global_solution (sys_soln, 0);
 
-        system.update_global_solution (sys_soln, 0);
+      // Keep track of the number of vars actually written.
+      unsigned int n_vars_written_current_system = 0;
 
-        if (_mesh.processor_id() == 0)
-          {
-            std::vector<Number>       elem_soln;   // The finite element solution
-            std::vector<Number>       nodal_soln;  // The FE solution interpolated to the nodes
-            std::vector<dof_id_type>  dof_indices; // The DOF indices for the finite element
+      if (_mesh.processor_id() == 0)
+        {
+          std::vector<Number>       soln_coeffs; // The finite element solution coeffs
+          std::vector<Number>       nodal_soln;  // The FE solution interpolated to the nodes
+          std::vector<dof_id_type>  dof_indices; // The DOF indices for the finite element
 
-            for (unsigned int var=0; var<nv_sys; var++)
-              {
-                const FEType & fe_type    = system.variable_type(var);
-                const Variable & var_description = system.variable(var);
+          // For each variable, determine if we are supposed to
+          // write it, then loop over the active elements, compute
+          // the nodal_soln and store it to the "soln" vector. We
+          // store zeros for subdomain-restricted variables on
+          // elements where they are not active.
+          for (unsigned int var=0; var<nv_sys; var++)
+            {
+              bool use_current_var = (var_names == nullptr);
+              if (!use_current_var)
+                use_current_var = std::count(var_names->begin(),
+                                             var_names->end(),
+                                             system->variable_name(var));
 
-                unsigned int nn=0;
+              // If we aren't supposed to write this var, go to the
+              // next loop iteration.
+              if (!use_current_var)
+                continue;
 
-                for (auto & elem : _mesh.active_element_ptr_range())
-                  {
-                    if (var_description.active_on_subdomain(elem->subdomain_id()))
+              const FEType & fe_type = system->variable_type(var);
+              const Variable & var_description = system->variable(var);
+
+              unsigned int nn=0;
+
+              for (auto & elem : _mesh.active_element_ptr_range())
+                {
+                  if (var_description.active_on_subdomain(elem->subdomain_id()))
                     {
-                      system.get_dof_map().dof_indices (elem, dof_indices, var);
+                      system->get_dof_map().dof_indices (elem, dof_indices, var);
 
-                      elem_soln.resize(dof_indices.size());
+                      soln_coeffs.resize(dof_indices.size());
 
                       for (std::size_t i=0; i<dof_indices.size(); i++)
-                        elem_soln[i] = sys_soln[dof_indices[i]];
+                        soln_coeffs[i] = sys_soln[dof_indices[i]];
 
+                      // Compute the FE solution at all the nodes, but
+                      // only use the first n_vertices() entries if
+                      // vertices_only == true.
                       FEInterface::nodal_soln (dim,
                                                fe_type,
                                                elem,
-                                               elem_soln,
+                                               soln_coeffs,
                                                nodal_soln);
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
                       // infinite elements should be skipped...
                       if (!elem->infinite())
 #endif
-                      {
-                        libmesh_assert_equal_to (nodal_soln.size(), elem->n_nodes());
-
-                        for (unsigned int n=0; n<elem->n_nodes(); n++)
                         {
-                          soln[nv*(nn++) + (var + var_num)] +=
-                            nodal_soln[n];
-                        }
-                      }
-                    }
-                    else
-                      nn += elem->n_nodes();
-                  }
-              }
-          }
+                          libmesh_assert_equal_to (nodal_soln.size(), elem->n_nodes());
 
-        var_num += nv_sys;
-      }
-  }
+                          const unsigned int n_vals =
+                            vertices_only ? elem->n_vertices() : elem->n_nodes();
+
+                          for (unsigned int n=0; n<n_vals; n++)
+                            {
+                              // Compute index into global solution vector.
+                              std::size_t index =
+                                nv * (nn++) + (n_vars_written_current_system + var_offset);
+
+                              soln[index] += nodal_soln[n];
+                            }
+                        }
+                    }
+                  else
+                    nn += vertices_only ? elem->n_vertices() : elem->n_nodes();
+                } // end loop over active elements
+
+              // If we made it here, we actually wrote a variable, so increment
+              // the number of variables actually written for the current system.
+              n_vars_written_current_system++;
+
+            } // end loop over vars
+        } // end if proc 0
+
+      // Update offset for next loop iteration.
+      var_offset += n_vars_written_current_system;
+    } // end loop over systems
 }
 
 

--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -1097,11 +1097,8 @@ EquationSystems::build_discontinuous_solution_vector
         }
     }
 
-  // Debugging: verify we found the expected number of variables to write.
-  // libMesh::out << "In build_discontinuous_solution_vector(), nv = " << nv << std::endl;
-  unsigned int tw=0;
-
   // get the total weight
+  unsigned int tw=0;
   for (const auto & elem : _mesh.active_element_ptr_range())
     tw += vertices_only ? elem->n_vertices() : elem->n_nodes();
 

--- a/tests/mesh/mesh_input.C
+++ b/tests/mesh/mesh_input.C
@@ -10,6 +10,7 @@
 #include <libmesh/mesh_generation.h>
 #include <libmesh/replicated_mesh.h>
 #include <libmesh/exodusII_io.h>
+#include <libmesh/dof_map.h>
 
 #include "test_comm.h"
 
@@ -45,6 +46,10 @@ public:
 #if LIBMESH_DIM > 1
 #ifdef LIBMESH_HAVE_EXODUS_API
   CPPUNIT_TEST( testExodusCopyElementSolution );
+#ifndef LIBMESH_USE_COMPLEX_NUMBERS
+  // Eventually this will support complex numbers.
+  CPPUNIT_TEST( testExodusWriteElementDataFromDiscontinuousNodalData );
+#endif
 #endif
 
   CPPUNIT_TEST( testMeshMoveConstructor );
@@ -125,7 +130,92 @@ public:
           }
     }
   }
-#endif
+
+
+#ifndef LIBMESH_USE_COMPLEX_NUMBERS
+  void testExodusWriteElementDataFromDiscontinuousNodalData()
+  {
+    // first scope: write file
+    {
+      Mesh mesh(*TestCommWorld);
+
+      EquationSystems es(mesh);
+      System & sys = es.add_system<System> ("SimpleSystem");
+      sys.add_variable("u", FIRST, L2_LAGRANGE);
+
+      MeshTools::Generation::build_cube
+        (mesh, 2, 2, 2, 0., 1., 0., 1., 0., 1., HEX8);
+
+      es.init();
+
+      // Set solution u^e_i = i, for the ith vertex of a given element e.
+      const DofMap & dof_map = sys.get_dof_map();
+      std::vector<dof_id_type> dof_indices;
+      for (const auto & elem : mesh.element_ptr_range())
+        {
+          dof_map.dof_indices(elem, dof_indices, /*var_id=*/0);
+          for (unsigned int i=0; i<dof_indices.size(); ++i)
+            sys.solution->set(dof_indices[i], i);
+        }
+      sys.solution->close();
+
+      // Now write to file.
+      ExodusII_IO exii(mesh);
+
+      // Don't try to write element data as averaged nodal data.
+      std::set<std::string> sys_list;
+      exii.write_equation_systems("elemental_from_nodal.e", es, &sys_list);
+
+      // Write one elemental data field per vertex value.
+      sys_list = {"SimpleSystem"};
+
+      exii.write_element_data_from_discontinuous_nodal_data
+        (es, &sys_list, /*var_suffix=*/"_elem_corner_");
+    } // end first scope
+
+    // second scope: read values back in, verify they are correct.
+    {
+      std::vector<std::string> file_var_names =
+        {"u_elem_corner_0",
+         "u_elem_corner_1",
+         "u_elem_corner_2",
+         "u_elem_corner_3"};
+      std::vector<Real> expected_values = {0., 1., 2., 3.};
+
+      // copy_elemental_solution currently requires ReplicatedMesh
+      ReplicatedMesh mesh(*TestCommWorld);
+
+      EquationSystems es(mesh);
+      System & sys = es.add_system<System> ("SimpleSystem");
+      for (auto i : index_range(file_var_names))
+        sys.add_variable(file_var_names[i], CONSTANT, MONOMIAL);
+
+      ExodusII_IO exii(mesh);
+
+      if (mesh.processor_id() == 0)
+        exii.read("elemental_from_nodal.e");
+      MeshCommunication().broadcast(mesh);
+      mesh.prepare_for_use();
+
+      es.init();
+
+      for (auto i : index_range(file_var_names))
+        exii.copy_elemental_solution
+          (sys, sys.variable_name(i), file_var_names[i]);
+
+      // Check that the values we read back in are as expected.
+      for (const auto & elem : mesh.active_element_ptr_range())
+        for (auto i : index_range(file_var_names))
+          {
+            Real read_val = sys.point_value(i, elem->centroid());
+            CPPUNIT_ASSERT_DOUBLES_EQUAL
+              (read_val, expected_values[i], TOLERANCE*TOLERANCE);
+          }
+    } // end second scope
+  } // end testExodusWriteElementDataFromDiscontinuousNodalData
+
+#endif // !LIBMESH_USE_COMPLEX_NUMBERS
+#endif // LIBMESH_HAVE_EXODUS_API
 
   void testMeshMoveConstructor ()
   {


### PR DESCRIPTION
This new API, `ExodusII_IO::write_discontinuous_nodal_data_as_elemental()`, is similar to `ExodusII_IO::write_element_data()`, but instead of only writing (CONSTANT, MONOMIAL) data, it can be used to write general discontinuous solution fields, e.g. (FIRST, L2_LAGRANGE) and (SECOND, MONOMIAL) as a number of elemental data fields matching the number of vertices of a given element.
