### PR TITLE
Don't try to test Hessians unless we have them

### DIFF
--- a/tests/numerics/parsed_fem_function_test.C
+++ b/tests/numerics/parsed_fem_function_test.C
@@ -123,7 +123,9 @@ public:
 #if LIBMESH_DIM > 2
   CPPUNIT_TEST(testValues);
   CPPUNIT_TEST(testGradients);
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   CPPUNIT_TEST(testHessians);
+#endif
   CPPUNIT_TEST(testInlineGetter);
   CPPUNIT_TEST(testInlineSetter);
   CPPUNIT_TEST(testNormals);


### PR DESCRIPTION
This test fails with second derivatives disabled, as expected, so
let's not run it in that case.