### PR TITLE
Add version of FEInterface::n_dofs() taking an Elem *

### DIFF
--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -100,6 +100,17 @@ public:
                              const ElemType t);
 
   /**
+   * Similar to the function above but takes an Elem * and accounts for
+   * p-refinement internally, if any. This function is designed to prevent
+   * users from needing to trick FEInterface::n_dofs() into giving them
+   * the right number of dofs when working with p-refined elements. See,
+   * e.g. FEInterface::compute_data().
+   */
+  static unsigned int n_dofs(const unsigned int dim,
+                             const FEType & fe_t,
+                             const Elem * elem);
+
+  /**
    * \returns The number of dofs at node n for a finite element
    * of type \p fe_t.
    * Automatically decides which finite element class to use.

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -470,6 +470,18 @@ unsigned int FEInterface::n_dofs(const unsigned int dim,
 
 
 
+unsigned int
+FEInterface::n_dofs (const unsigned int dim,
+                     const FEType & fe_t,
+                     const Elem * elem)
+{
+  FEType p_refined_fe_t = fe_t;
+  p_refined_fe_t.order = static_cast<Order>(p_refined_fe_t.order + elem->p_level());
+  return FEInterface::n_dofs(dim, p_refined_fe_t, elem->type());
+}
+
+
+
 unsigned int FEInterface::n_dofs_at_node(const unsigned int dim,
                                          const FEType & fe_t,
                                          const ElemType t,

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -932,15 +932,7 @@ void FEInterface::compute_data(const unsigned int dim,
 
 #endif
 
-  // We need to "trick" the FEInterface::n_dofs() function into giving
-  // us the number of dofs for a potentially p-refined Elem, but we
-  // should _not_ use this temporary FEType object for the shape() or
-  // shape_deriv() calls below because they already take into account
-  // potentially elevated p-levels internally.
-  FEType p_refined_fe_t = fe_t;
-  p_refined_fe_t.order = static_cast<Order>(p_refined_fe_t.order + elem->p_level());
-
-  const unsigned int n_dof = n_dofs (dim, p_refined_fe_t, elem->type());
+  const unsigned int n_dof = n_dofs (dim, fe_t, elem);
   const Point & p = data.p;
   data.shape.resize(n_dof);
 


### PR DESCRIPTION
This lets us avoid the fix (hack) introduced in #1987 and might be useful in other places as well but I did not check into it too closely.
