### PR TITLE
Add shape and skew metrics for Hexes.

### DIFF
--- a/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
+++ b/examples/systems_of_equations/systems_of_equations_ex6/systems_of_equations_ex6.C
@@ -99,10 +99,10 @@ public:
   {
     PetscErrorCode ierr = 0;
     ierr = KSPSetType (_petsc_linear_solver.ksp(), const_cast<KSPType>(KSPCG));
-    LIBMESH_CHKERR(ierr);
+    CHKERRABORT(_petsc_linear_solver.comm().get(), ierr);
 
     ierr = PCSetType (_petsc_linear_solver.pc(), const_cast<PCType>(PCBJACOBI));
-    LIBMESH_CHKERR(ierr);
+    CHKERRABORT(_petsc_linear_solver.comm().get(), ierr);
   }
 
   // The linear solver object that we are configuring

--- a/tests/geom/side_test.C
+++ b/tests/geom/side_test.C
@@ -54,16 +54,16 @@ class SideTest : public CppUnit::TestCase {
 
 private:
   ElemClass elem;
-  std::vector<Node> nodes;
+  std::vector<std::unique_ptr<Node>> nodes;
 
 public:
   void setUp() {
     elem.set_id() = 0;
-    nodes.resize(elem.n_nodes());
+    Point dummy;
     for (auto i : elem.node_index_range())
       {
-        nodes[i].set_id() = i;
-        elem.set_node(i) = &nodes[i];
+        nodes.push_back(libmesh_make_unique<Node>(dummy, /*id=*/i));
+        elem.set_node(i) = nodes[i].get();
       }
   }
 

--- a/tests/mesh/mesh_function.C
+++ b/tests/mesh/mesh_function.C
@@ -47,7 +47,9 @@ public:
   CPPUNIT_TEST_SUITE( MeshFunctionTest );
 
 #if LIBMESH_DIM > 1
+#ifdef LIBMESH_ENABLE_AMR
   CPPUNIT_TEST( test_p_level );
+#endif
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -61,6 +63,7 @@ public:
 
   // test that mesh function works correctly with non-zero
   // Elem::p_level() values.
+#ifdef LIBMESH_ENABLE_AMR
   void test_p_level()
   {
     ReplicatedMesh mesh(*TestCommWorld);
@@ -125,6 +128,7 @@ public:
         CPPUNIT_ASSERT_DOUBLES_EQUAL(vec_values(0), mesh_function_value, TOLERANCE*TOLERANCE);
       }
   }
+#endif // LIBMESH_ENABLE_AMR
 };
 
 


### PR DESCRIPTION
This is a follow-up to work in #1535 (60487b58), where we added the
analogous shape quality metrics for Quads.  The formulas used are
from:

P. Knupp, "Algebraic mesh quality metrics for
unstructured initial meshes," Finite Elements in Analysis
and Design 39, 2003, p. 217-241, Sections 6.2 and 6.3.