### PR TITLE
Reimplement ExodusII_IO_Helper::NamesData using C APIs.

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -1278,11 +1278,15 @@ class ExodusII_IO_Helper::NamesData
 public:
   /**
    * Constructor.  Allocates enough storage to hold n_strings of
-   * length string_length.  (Actually allocates string_length+1 characters
-   * per string to account for the trailing '\0' character.)
+   * length string_length.
    */
   explicit
-  NamesData(size_t n_strings, size_t string_length);
+  NamesData(std::size_t n_strings, std::size_t string_length);
+
+  /**
+   * Frees memory allocated in the constructor.
+   */
+  ~NamesData();
 
   /**
    * Adds another name to the current data table.
@@ -1300,12 +1304,12 @@ public:
   char * get_char_star(int i);
 
 private:
-  // C++ data structures for managing string memory
-  std::vector<std::vector<char>> data_table;
-  std::vector<char *> data_table_pointers;
+  // Underlying C data structure managed by this class.
+  char ** data_table;
 
-  size_t counter;
-  size_t table_size;
+  std::size_t counter;
+  std::size_t table_size;
+  std::size_t string_len;
 };
 
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1842,7 +1842,8 @@ void ExodusII_IO_Helper::check_existing_vars(ExodusVarType type,
   this->read_var_names(type);
 
   // Both the number of variables and their names (up to the first
-  // MAX_STR_LENGTH characters) must match for the names we are
+  // MAX_STR_LENGTH - 1 characters, the last character is reserved for
+  // a null-terminator character) must match for the names we are
   // planning to write and the names already in the file.
   bool match =
     std::equal(names.begin(), names.end(),
@@ -1850,7 +1851,7 @@ void ExodusII_IO_Helper::check_existing_vars(ExodusVarType type,
                [](const std::string & a,
                   const std::string & b) -> bool
                {
-                 return a.compare(/*pos=*/0, /*len=*/MAX_STR_LENGTH, b) == 0;
+                 return a.compare(/*pos=*/0, /*len=*/MAX_STR_LENGTH - 1, b) == 0;
                });
 
   if (!match)


### PR DESCRIPTION
Even though I think the previous API worked fine, the idea with this
change is that it should be guaranteed to be compatible with the
Exodus C API and there are no questions about std::vector<char>
compatibility.

* Use std::malloc, std::free since we include <cstdlib>
* Use std::calloc to zero-initialize strings. This way there is no
  possibility that any of the strings can have garbage characters in
  them.