### PR TITLE
PetscDMWrapper Geometric Multigrid + Fieldsplit capabilities

### DIFF
--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -217,6 +217,12 @@ public:
   virtual bool closed() const override;
 
   /**
+   * If set to false, we don't delete the Mat on destruction and allow
+   * instead for \p PETSc to manage it.
+   */
+  virtual void set_destroy_mat_on_exit(bool destroy = true);
+
+  /**
    * Print the contents of the matrix to the screen with the PETSc
    * viewer. This function only allows printing to standard out since
    * we have limited ourselves to one PETSc implementation for

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -96,8 +96,9 @@ protected:
   /**
    * Wrapper object for interacting with PetscDM
    */
+#if !PETSC_VERSION_LESS_THAN(3,7,3)
   PetscDMWrapper _dm_wrapper;
-
+#endif
 private:
 
   /**

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -120,7 +120,7 @@ private:
    * init_dm_data() should be called before this function.
    */
   DM & get_dm(unsigned int level)
-  { libmesh_assert(level < _dms.size());
+    { libmesh_assert_less(level, _dms.size());
     return *(_dms[level].get()); }
 
   //! Get reference to PetscSection for the given mesh level
@@ -128,7 +128,7 @@ private:
    * init_dm_data() should be called before this function.
    */
   PetscSection & get_section(unsigned int level)
-  { libmesh_assert(level < _sections.size());
+    { libmesh_assert_less(level, _sections.size());
     return *(_sections[level].get()); }
 
   //! Get reference to PetscSF for the given mesh level
@@ -136,7 +136,7 @@ private:
    * init_dm_data() should be called before this function.
    */
   PetscSF & get_star_forest(unsigned int level)
-  { libmesh_assert(level < _star_forests.size());
+    { libmesh_assert_less(level, _star_forests.size());
     return *(_star_forests[level].get()); }
 
   //! Takes System, empty PetscSection and populates the PetscSection

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -73,7 +73,7 @@ private:
   std::vector<std::unique_ptr<PetscSF>> _star_forests;
 
   //! Init all the n_mesh_level dependent data structures
-  void init_dm_data(unsigned int n_levels);
+  void init_dm_data(unsigned int n_levels, const Parallel::Communicator & comm);
 
   //! Get reference to DM for the given mesh level
   /**

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -44,18 +44,27 @@ namespace libMesh
   struct PetscDMContext
   {
     int n_dofs;
+    int mesh_dim;
     DM * coarser_dm;
     DM * finer_dm;
+    DM * global_dm;
     libMesh::PetscMatrix<libMesh::Real > * K_interp_ptr;
+    libMesh::PetscMatrix<libMesh::Real > * K_sub_interp_ptr;
     libMesh::PetscMatrix<libMesh::Real > * K_restrict_ptr;
     libMesh::PetscVector<libMesh::Real > * current_vec;
+
+    //! Stores local dofs for each var for use in subprojection matrixes
+    std::vector<std::vector<numeric_index_type>> dof_vec;
 
     PetscDMContext()
     {
       n_dofs = -12345;
+      mesh_dim = -12345;
       coarser_dm = nullptr;
       finer_dm = nullptr;
+      global_dm = nullptr;
       K_interp_ptr = nullptr;
+      K_sub_interp_ptr = nullptr;
       K_restrict_ptr = nullptr;
       current_vec = nullptr;
     }
@@ -99,6 +108,9 @@ private:
   //! Vector of projection matrixes for all grid levels
   std::vector<std::unique_ptr<PetscMatrix<Real>>> _pmtx_vec;
 
+  //! Vector of sub projection matrixes for all grid levels for fieldsplit
+  std::vector<std::unique_ptr<PetscMatrix<Real>>> _subpmtx_vec;
+
   //! Vector of internal PetscDM context structs for all grid levels
   std::vector<std::unique_ptr<PetscDMContext>> _ctx_vec;
 
@@ -110,7 +122,6 @@ private:
 
   //! Stores n_local_dofs for each grid level, to be used for projection vector sizing
   std::vector<unsigned int> _mesh_dof_loc_sizes;
-
 
   //! Init all the n_mesh_level dependent data structures
   void init_dm_data(unsigned int n_levels, const Parallel::Communicator & comm);

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -53,11 +53,11 @@ namespace libMesh
     PetscDMContext()
     {
       n_dofs = -12345;
-      coarser_dm = NULL;
-      finer_dm = NULL;
-      K_interp_ptr = NULL;
-      K_restrict_ptr = NULL;
-      current_vec = NULL;
+      coarser_dm = nullptr;
+      finer_dm = nullptr;
+      K_interp_ptr = nullptr;
+      K_restrict_ptr = nullptr;
+      current_vec = nullptr;
     }
 
   };

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -19,8 +19,10 @@
 #define LIBMESH_PETSC_DM_WRAPPER_H
 
 #include "libmesh/libmesh_common.h"
+#include "libmesh/petsc_macro.h"
 
 #ifdef LIBMESH_HAVE_PETSC
+#if !PETSC_VERSION_LESS_THAN(3,7,3)
 
 #include <vector>
 #include <memory>
@@ -216,6 +218,7 @@ private:
 
 }
 
+#endif // #if PETSC_VERSION
 #endif // #ifdef LIBMESH_HAVE_PETSC
 
 #endif // LIBMESH_PETSC_DM_WRAPPER_H

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -193,7 +193,7 @@ private:
    * The PetscSection contains local dof information. This helper function just facilitates
    * sanity checking that in fact it only has n_local_dofs.
    */
-  dof_id_type check_section_n_dofs( const System & system, PetscSection & section );
+  dof_id_type check_section_n_dofs( PetscSection & section );
 
   //! Helper function to reduce code duplication when setting dofs in section
   void add_dofs_helper (const System & system,

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -50,26 +50,25 @@ namespace libMesh
     DM * coarser_dm;
     DM * finer_dm;
     DM * global_dm;
-    libMesh::PetscMatrix<libMesh::Real > * K_interp_ptr;
-    libMesh::PetscMatrix<libMesh::Real > * K_sub_interp_ptr;
-    libMesh::PetscMatrix<libMesh::Real > * K_restrict_ptr;
-    libMesh::PetscVector<libMesh::Real > * current_vec;
+    PetscMatrix<libMesh::Real > * K_interp_ptr;
+    PetscMatrix<libMesh::Real > * K_sub_interp_ptr;
+    PetscMatrix<libMesh::Real > * K_restrict_ptr;
+    PetscVector<libMesh::Real > * current_vec;
 
     //! Stores local dofs for each var for use in subprojection matrixes
     std::vector<std::vector<numeric_index_type>> dof_vec;
 
-    PetscDMContext()
-    {
-      n_dofs = -12345;
-      mesh_dim = -12345;
-      coarser_dm = nullptr;
-      finer_dm = nullptr;
-      global_dm = nullptr;
-      K_interp_ptr = nullptr;
-      K_sub_interp_ptr = nullptr;
-      K_restrict_ptr = nullptr;
-      current_vec = nullptr;
-    }
+    PetscDMContext() :
+      n_dofs(-12345),
+      mesh_dim(-12345),
+      coarser_dm(nullptr),
+      finer_dm(nullptr),
+      global_dm(nullptr),
+      K_interp_ptr(nullptr),
+      K_sub_interp_ptr(nullptr),
+      K_restrict_ptr(nullptr),
+      current_vec(nullptr)
+    {}
 
   };
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -1204,6 +1204,11 @@ bool PetscMatrix<T>::closed() const
   return (assembled == PETSC_TRUE);
 }
 
+template <typename T>
+void PetscMatrix<T>::set_destroy_mat_on_exit(bool destroy)
+{
+  this->_destroy_mat_on_exit = destroy;
+}
 
 
 template <typename T>

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -227,7 +227,9 @@ void PetscDiffSolver::clear()
   int ierr = LibMeshSNESDestroy(&_snes);
   LIBMESH_CHKERR(ierr);
 
+#if !PETSC_VERSION_LESS_THAN(3,7,3)
   _dm_wrapper.clear();
+#endif
 }
 
 
@@ -354,8 +356,10 @@ void PetscDiffSolver::setup_petsc_data()
   bool use_petsc_dm = libMesh::on_command_line("--use_petsc_dm");
 
   // This needs to be called before SNESSetFromOptions
+#if !PETSC_VERSION_LESS_THAN(3,7,3)
   if (use_petsc_dm)
     this->_dm_wrapper.init_and_attach_petscdm(_system, _snes);
+#endif
 
   // If we're not using PETSc DM, let's keep around
   // the old style for fieldsplit

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -452,7 +452,7 @@ void PetscDMWrapper::build_section( const System & system, PetscSection & sectio
   // Final setup of PetscSection
   // Until Matt Knepley finishes implementing the commented out function
   // below, the PetscSection will be assuming node-major ordering
-  // so let's throw and error if the user tries to use this without
+  // so let's throw an error if the user tries to use this without
   // node-major order
   if (!libMesh::on_command_line("--node-major-dofs"))
     libmesh_error_msg("ERROR: Must use --node-major-dofs with PetscSection!");

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -59,7 +59,7 @@ void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
   // for each grid level, but for now, we're just using the
   // finest level
   unsigned int n_levels = 1;
-  this->init_dm_data(n_levels);
+  this->init_dm_data(n_levels, system.comm());
 
   for(unsigned int level = 0; level < n_levels; level++)
     {
@@ -456,7 +456,7 @@ dof_id_type PetscDMWrapper::check_section_n_dofs( const System & system, PetscSe
   return n_local_dofs;
 }
 
-void PetscDMWrapper::init_dm_data(unsigned int n_levels)
+  void PetscDMWrapper::init_dm_data( unsigned int n_levels, const Parallel::Communicator & comm )
 {
   _dms.resize(n_levels);
   _sections.resize(n_levels);

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -404,7 +404,7 @@ void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
           unsigned int ndofs_old_size  = ndofs_old_end - ndofs_old_first;
 
           // Init and zero the matrix
-          _ctx_vec[i-1]->K_interp_ptr->init(ndofs_f, ndofs_c, ndofs_local, ndofs_old_size);
+          _ctx_vec[i-1]->K_interp_ptr->init(ndofs_f, ndofs_c, ndofs_local, ndofs_old_size, 30 , 20);
 
           // Disable Mat destruction since PETSc destroys these for us
           _ctx_vec[i-1]->K_interp_ptr->set_destroy_mat_on_exit(false);

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -171,6 +171,7 @@ void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
 
   // Theres no need for these code paths while traversing the hierarchy
   mesh.allow_renumbering(false);
+  mesh.allow_remote_element_removal(false);
   mesh.partitioner() = NULL;
 
   // First walk over the active local elements and see how many maximum MG levels we can construct

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -470,7 +470,7 @@ void PetscDMWrapper::build_section( const System & system, PetscSection & sectio
   ierr = PetscSectionSetUp(section);LIBMESH_CHKERR(ierr);
 
   // Sanity checking at least that local_n_dofs match
-  libmesh_assert_equal_to(system.n_local_dofs(),this->check_section_n_dofs(system, section));
+  libmesh_assert_equal_to(system.n_local_dofs(),this->check_section_n_dofs(section));
 
   STOP_LOG ("build_section()", "PetscDMWrapper");
 }
@@ -752,7 +752,7 @@ void PetscDMWrapper::add_dofs_helper (const System & system,
 }
 
 
-dof_id_type PetscDMWrapper::check_section_n_dofs( const System & system, PetscSection & section )
+dof_id_type PetscDMWrapper::check_section_n_dofs( PetscSection & section )
 {
   PetscInt n_local_dofs = 0;
 

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -192,7 +192,7 @@ void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
   // Only construct however many levels were requested if something was actually requested
   if ( usr_requested_mg_lvls != 0 )
     {
-      // Dont request more than avail num levels, require at least 2 levels
+      // Dont request more than avail num levels on mesh, require at least 2 levels
       libmesh_assert_less_equal( (unsigned int)usr_requested_mg_lvls, n_levels );
       libmesh_assert( usr_requested_mg_lvls > 1 );
 
@@ -266,11 +266,6 @@ void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
           START_LOG ("PDM_dist_dof", "PetscDMWrapper");
           system.get_dof_map().distribute_dofs(mesh);
           STOP_LOG  ("PDM_dist_dof", "PetscDMWrapper");
-
-          START_LOG ("PDM_cnstrnts", "PetscDMWrapper");
-          system.reinit_constraints();
-          STOP_LOG  ("PDM_cnstrnts", "PetscDMWrapper");
-
         }
     } // End PETSc data structure creation
 

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -40,11 +40,9 @@ PetscDMWrapper::~PetscDMWrapper()
 
 void PetscDMWrapper::clear()
 {
-  // This will also Destroy the attached PetscSection and PetscSF as well
-  // Destroy doesn't free the memory, but just resets points internally
-  // in the struct, so we'd still need to wipe out the memory on our side
-  for( auto dm_it = _dms.begin(); dm_it < _dms.end(); ++dm_it )
-    DMDestroy( dm_it->get() );
+  // PETSc will destroy the attached PetscSection, PetscSF as well as
+  // other relateds such as the Projections so we just tidy up the
+  // containers here.
 
   _dms.clear();
   _sections.clear();

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -46,6 +46,13 @@ namespace libMesh
   {
 
     //! Help PETSc identify the finer DM given a dmc
+    PetscErrorCode __libmesh_petsc_DMCreateSubDM(DM dm, PetscInt numFields, const PetscInt fields[], IS *is, DM *subdm)
+    {
+
+      return 0;
+    }
+
+    //! Help PETSc identify the finer DM given a dmc
     PetscErrorCode __libmesh_petsc_DMRefine(DM dmc, MPI_Comm comm, DM * dmf)
     {
       libmesh_assert(dmc);
@@ -149,7 +156,6 @@ namespace libMesh
     }
 
   } // end extern C functions
-
 
 
 PetscDMWrapper::~PetscDMWrapper()
@@ -780,6 +786,7 @@ void PetscDMWrapper::init_dm_data(unsigned int n_levels, const Parallel::Communi
   _star_forests.resize(n_levels);
   _ctx_vec.resize(n_levels);
   _pmtx_vec.resize(n_levels);
+  _subpmtx_vec.resize(n_levels);
   _vec_vec.resize(n_levels);
   _mesh_dof_sizes.resize(n_levels);
   _mesh_dof_loc_sizes.resize(n_levels);
@@ -791,6 +798,7 @@ void PetscDMWrapper::init_dm_data(unsigned int n_levels, const Parallel::Communi
       _star_forests[i] = libmesh_make_unique<PetscSF>();
       _ctx_vec[i] = libmesh_make_unique<PetscDMContext>();
       _pmtx_vec[i]= libmesh_make_unique<PetscMatrix<Real>>(comm);
+      _subpmtx_vec[i]= libmesh_make_unique<PetscMatrix<Real>>(comm);
       _vec_vec[i] = libmesh_make_unique<PetscVector<Real>>(comm);
     }
 }

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -47,6 +47,10 @@ void PetscDMWrapper::clear()
   _dms.clear();
   _sections.clear();
   _star_forests.clear();
+  _pmtx_vec.clear();
+  _vec_vec.clear();
+  _ctx_vec.clear();
+
 }
 
 void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
@@ -461,12 +465,20 @@ dof_id_type PetscDMWrapper::check_section_n_dofs( const System & system, PetscSe
   _dms.resize(n_levels);
   _sections.resize(n_levels);
   _star_forests.resize(n_levels);
+  _ctx_vec.resize(n_levels);
+  _pmtx_vec.resize(n_levels);
+  _vec_vec.resize(n_levels);
+  _mesh_dof_sizes.resize(n_levels);
+  _mesh_dof_loc_sizes.resize(n_levels);
 
   for( unsigned int i = 0; i < n_levels; i++ )
     {
       _dms[i] = libmesh_make_unique<DM>();
       _sections[i] = libmesh_make_unique<PetscSection>();
       _star_forests[i] = libmesh_make_unique<PetscSF>();
+      _ctx_vec[i] = libmesh_make_unique<PetscDMContext>();
+      _pmtx_vec[i]= libmesh_make_unique<PetscMatrix<Real>>(comm);
+      _vec_vec[i] = libmesh_make_unique<PetscVector<Real>>(comm);
     }
 }
 

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -184,7 +184,7 @@ void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
   // Theres no need for these code paths while traversing the hierarchy
   mesh.allow_renumbering(false);
   mesh.allow_remote_element_removal(false);
-  mesh.partitioner() = NULL;
+  mesh.partitioner() = nullptr;
 
   // First walk over the active local elements and see how many maximum MG levels we can construct
   unsigned int n_levels = 0;


### PR DESCRIPTION
After far too long, this feature set has finally reached a point where I believe it is ready for further external scrutiny! The idea behind this PR implements step 2 of the discussion in #1567, and also enables the use of fieldsplit capabilities from the command line. I've been testing this fairly extensively on both replicated and distributed meshes up to `np 256` through GRINS for a while now, and have verified that the infrastructure behaves as expected for vanilla GMG on Poisson problems, and also when restricting the GMG construction for example to the velocity block of a Stokes problem.

The change set incorporates quite a long period of development; I've put in a fair amount of effort to condense the commits to logical chunks of core functionalities, but occasionally I include either small fixup commits, or optimization type commits ( such as 26e654c ) which at one point in time exposed certain difficulties that needed to be resolved. Also please note that the occasional documentation improvement slips in incrementally through the commit range, if any such things are troublesome and should be either squashed in or separated please let me know and I can make the necessary adjustments.

While certain core components have been individually tested (mainly the generic projector usage in #1507 and friends), this PR certainly lacks an overall testing suite. I plan to shortly shortly throw together some GRINS based regression testing which will attempt to capture things like the number of linear and nonlinear iterations on some benchmark problems, but am certainly open to suggestions for things that can or should be verified on this end.

Please let me know of things that can be improved, that need fixing, or explaining, and thanks in advance for the review!