### PR TITLE
Set TAR_OPTIONS to improve portability of tarballs.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,19 @@ CXXFLAGS_PROF += $(ANY_WERROR_FLAG) $(ANY_PARANOID_FLAGS)
 # should do no harm on other platforms.
 AM_LDFLAGS += -no-undefined
 
+# As discussed on this thread [0], automake passes -h to tar in the
+# "make dist" target, and this has the effect of creating hard links
+# out of soft links in the resulting archives.  Since not all
+# filesystems support hard links well (for example AFS, see libmesh
+# #2046) this option causes the directory links to be created as
+# normal files instead. The --hard-dereference option requires at least tar 1.29 to
+# work, but we generally completely control the systems where we run
+# "make dist" and therefore we don't need the most portable "make
+# dist" possible, but rather a "make dist" target that gives us the
+# most portable tarballs possible.
+# [0]: http://gnu-automake.7480.n7.nabble.com/bug-19616-dist-tarball-contains-hardlinks-td21667.html
+TAR_OPTIONS = --hard-dereference
+export TAR_OPTIONS
 
 # AM_CPPFLAGS are method-independent cppflags that
 # we use when compiling libmesh proper, or its utility


### PR DESCRIPTION
Instead of setting TAR_OPTIONS, I also tried calling `AC_SUBST(am__tar,[tar --hard-dereference])` but unforunately this alternate approach did not work, perhaps the AC_SUBST comes too late in the process to take effect or perhaps it is simply not possible to do this. It was an off-hand remark in a [mailing list](http://gnu-automake.7480.n7.nabble.com/bug-19616-dist-tarball-contains-hardlinks-td21667.html), not an officially sanctioned way of doing things.

Refs #2046.
Refs #2029.