### PR TITLE
Guard against --disable-{amr,metaphysical} for PETScDMWrapper

### DIFF
--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -97,8 +97,13 @@ protected:
    * Wrapper object for interacting with PetscDM
    */
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
+#ifdef LIBMESH_ENABLE_AMR
+#ifdef LIBMESH_HAVE_METAPHYSICL
   PetscDMWrapper _dm_wrapper;
 #endif
+#endif
+#endif
+
 private:
 
   /**

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -23,6 +23,8 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
+#ifdef LIBMESH_ENABLE_AMR
+#ifdef LIBMESH_HAVE_METAPHYSICL
 
 #include <vector>
 #include <memory>
@@ -217,6 +219,8 @@ private:
 
 }
 
+#endif // #if LIBMESH_HAVE_METAPHYSICL
+#endif // #if LIBMESH_ENABLE_AMR
 #endif // #if PETSC_VERSION
 #endif // #ifdef LIBMESH_HAVE_PETSC
 

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -228,7 +228,11 @@ void PetscDiffSolver::clear()
   LIBMESH_CHKERR(ierr);
 
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
+#ifdef LIBMESH_ENABLE_AMR
+#ifdef LIBMESH_HAVE_METAPHYSICL
   _dm_wrapper.clear();
+#endif
+#endif
 #endif
 }
 
@@ -357,8 +361,12 @@ void PetscDiffSolver::setup_petsc_data()
 
   // This needs to be called before SNESSetFromOptions
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
+#ifdef LIBMESH_ENABLE_AMR
+#ifdef LIBMESH_HAVE_METAPHYSICL
   if (use_petsc_dm)
     this->_dm_wrapper.init_and_attach_petscdm(_system, _snes);
+#endif
+#endif
 #endif
 
   // If we're not using PETSc DM, let's keep around

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -20,6 +20,8 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
+#ifdef LIBMESH_ENABLE_AMR
+#ifdef LIBMESH_HAVE_METAPHYSICL
 
 #include "libmesh/ignore_warnings.h"
 #include <petscsf.h>
@@ -1028,5 +1030,7 @@ void PetscDMWrapper::init_dm_data(unsigned int n_levels, const Parallel::Communi
 
 } // end namespace libMesh
 
+#endif // LIBMESH_HAVE_METAPHYSICL
+#endif // LIBMESH_ENABLE_AMR
 #endif // PETSC_VERSION
 #endif // LIBMESH_HAVE_PETSC


### PR DESCRIPTION
This PR should fix the issue brought up by @friedmud in #2047 related to the missing System::projection_matrix member function.  Guess I'm a bit confused by the second error because I thought that is what #2027 fixed and my work was on top of that.

This PR also guards against a disabled AMR build as discovered needed by @roystgnr in #1507, and since pretty much all the GMG stuff will fail without MeshRefinement. 

