### PR TITLE
ExodusII_IO: Drop inactive variables from the lists passed to the Exodus helper.

### DIFF
--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -991,6 +991,12 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
                 keep = false;
             }
 
+        // We also don't keep variables that are not active on any subdomains.
+        // Contrary to other uses of the var_active_subdomains container where
+        // the empty set means "all" subdomains, here it really means "none".
+        if (active_set.empty())
+          keep = false;
+
         if (keep)
           {
             derived_var_names_edited.push_back(derived_var_name);


### PR DESCRIPTION
Previously completely inactive variables were passed in with empty lists of active subdomains, which in our convention corresponds to "active on all subdomains", and which is not correct in this case.

This should also be cherry-picked onto #2029 since the feature will be in that release.
