### PR TITLE
Explicitly specify scope in else branch: libmesh_make_unique macro

### DIFF
--- a/include/base/auto_ptr.h
+++ b/include/base/auto_ptr.h
@@ -47,7 +47,7 @@ std::unique_ptr<T> make_unique(Args &&... args)
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 }
-#define libmesh_make_unique make_unique
+#define libmesh_make_unique libMesh::make_unique
 
 #endif
 


### PR DESCRIPTION
Currently if not LIBMESH_HAVE_CXX14_MAKE_UNIQUE we define libmesh_make_unique
to be equivalent to make_unique without namespace scoping. I believe
explicitly scoping to libMesh::make_unique makes sense.

This was a actually kind of a saga. See idaholab/moose#12968 for more detail. I guess it's a good thing that the macro doesn't currently explicitly scope because I would have never discovered that issue...but on the other hand I also would have avoided a couple hours of rabbit chasing if we had explicit libMesh scoping in the macro.