### PR TITLE
Add MeshBase interface for specifying PointLocator customizations.

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -981,6 +981,18 @@ public:
   std::unique_ptr<PointLocatorBase> sub_point_locator () const;
 
   /**
+   * Set value used by PointLocatorBase::close_to_point_tol().
+   *
+   * Defaults to 0.0. If nonzero, calls close_to_point_tol() whenever
+   * a new PointLocator is built for use by this Mesh.  Since the Mesh
+   * controls the creation and destruction of the PointLocator, if
+   * there are any parameters we need to customize on it, the Mesh
+   * will need to know about them.
+   */
+  void set_point_locator_close_to_point_tol(Real val);
+  Real get_point_locator_close_to_point_tol() const;
+
+  /**
    * Releases the current \p PointLocator object.
    */
   void clear_point_locator ();
@@ -1473,6 +1485,12 @@ protected:
    * MeshBase because the cost is trivial.
    */
   std::set<GhostingFunctor *> _ghosting_functors;
+
+  /**
+   * If nonzero, we will call PointLocatorBase::set_close_to_point_tol()
+   * on any PointLocators that we create.
+   */
+  Real _point_locator_close_to_point_tol;
 
   /**
    * The partitioner class is a friend so that it can set

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -40,9 +40,13 @@ PointLocatorBase::PointLocatorBase (const MeshBase & mesh,
   _use_close_to_point_tol  (false),
   _close_to_point_tol      (TOLERANCE)
 {
+  // If we have a non-nullptr master, inherit its close-to-point tolerances.
+  if (_master)
+    {
+      _use_close_to_point_tol = _master->_use_close_to_point_tol;
+      _close_to_point_tol = _master->_close_to_point_tol;
+    }
 }
-
-
 
 
 


### PR DESCRIPTION
Since you only get access to "sub" PointLocators via calls to
MeshBase::sub_point_locator(), there's not really a good way to set
values on the "real" PointLocator stored by the Mesh.  One approach is
to let the Mesh handle it, which is what we're doing in this PR.

* Set close_to_point tolerance when building PointLocator.
* Inherit the master PointLocator's tolerances if possible.