### PR TITLE
Change error message when constraint loops are detected.

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -490,11 +490,16 @@ public:
 
   /**
    * Specify whether or not we perform an extra (opt-mode enabled) check
-   * for cyclic constraints. If a cyclic constraint is present then
-   * the system constraints are not valid, so if \p error_on_cyclic_constraint
+   * for constraint loops. If a constraint loop is present then
+   * the system constraints are not valid, so if \p error_on_constraint_loop
    * is true we will throw an error in this case.
+   *
+   * \note We previously referred to these types of constraints as
+   * "cyclic" but that has now been deprecated, and these will now
+   * instead be referred to as "constraint loops" in libMesh.
    */
   void set_error_on_cyclic_constraint(bool error_on_cyclic_constraint);
+  void set_error_on_constraint_loop(bool error_on_constraint_loop);
 
   /**
    * \returns The \p VariableGroup description object for group \p g.
@@ -856,11 +861,21 @@ public:
   void process_constraints (MeshBase &);
 
   /**
-   * Throw an error if we detect and cyclic constraints, since these
-   * are not supported by libMesh and give erroneous results if they
-   * are present.
+   * Throw an error if we detect any constraint loops, i.e.
+   * A -> B -> C -> A
+   * that is, "dof A is constrained in terms of dof B which is
+   * constrained in terms of dof C which is constrained in terms of
+   * dof A", since these are not supported by libMesh and give
+   * erroneous results if they are present.
+   *
+   * \note The original "cyclic constraint" terminology was
+   * unfortunate since the word cyclic is used by some software to
+   * indicate an actual type of rotational/angular contraint and not
+   * (as here) a cyclic graph. The former nomenclature will eventually
+   * be deprecated in favor of "constraint loop".
    */
   void check_for_cyclic_constraints();
+  void check_for_constraint_loops();
 
   /**
    * Adds a copy of the user-defined row to the constraint matrix, using
@@ -1496,9 +1511,10 @@ private:
 
   /**
    * This flag indicates whether or not we do an opt-mode check for
-   * the presence of cyclic constraints.
+   * the presence of constraint loops, i.e. cases where the constraint
+   * graph is cyclic.
    */
-  bool _error_on_cyclic_constraint;
+  bool _error_on_constraint_loop;
 
   /**
    * The finite element type for each variable.

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -131,7 +131,7 @@ DofMap::DofMap(const unsigned int number,
                MeshBase & mesh) :
   ParallelObject (mesh.comm()),
   _dof_coupling(nullptr),
-  _error_on_cyclic_constraint(false),
+  _error_on_constraint_loop(false),
   _variables(),
   _variable_groups(),
   _variable_group_numbers(),
@@ -237,7 +237,14 @@ bool DofMap::is_periodic_boundary (const boundary_id_type boundaryid) const
 
 void DofMap::set_error_on_cyclic_constraint(bool error_on_cyclic_constraint)
 {
-  _error_on_cyclic_constraint = error_on_cyclic_constraint;
+  // This function will eventually be officially libmesh_deprecated();
+  // Call DofMap::set_error_on_constraint_loop() instead.
+  set_error_on_constraint_loop(error_on_cyclic_constraint);
+}
+
+void DofMap::set_error_on_constraint_loop(bool error_on_constraint_loop)
+{
+  _error_on_constraint_loop = error_on_constraint_loop;
 }
 
 

--- a/tests/base/dof_map_test.C
+++ b/tests/base/dof_map_test.C
@@ -24,7 +24,7 @@
 
 using namespace libMesh;
 
-// This class is used by testCyclicConstraintDetection
+// This class is used by testConstraintLoopDetection
 class MyConstraint : public System::Constraint
 {
 private:
@@ -69,7 +69,7 @@ public:
 #endif
 
 #if defined(LIBMESH_ENABLE_CONSTRAINTS) && defined(LIBMESH_ENABLE_EXCEPTIONS) && LIBMESH_DIM > 1
-  CPPUNIT_TEST( testCyclicConstraintDetection );
+  CPPUNIT_TEST( testConstraintLoopDetection );
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -126,7 +126,7 @@ public:
   void testDofOwnerOnHex27() { testDofOwner(HEX27); }
 
 #if defined(LIBMESH_ENABLE_CONSTRAINTS) && defined(LIBMESH_ENABLE_EXCEPTIONS)
-  void testCyclicConstraintDetection()
+  void testConstraintLoopDetection()
   {
     Mesh mesh(*TestCommWorld);
 
@@ -139,11 +139,11 @@ public:
 
     MeshTools::Generation::build_square (mesh,4,4,-1., 1.,-1., 1., QUAD4);
 
-    // Tell the dof_map to check for cyclic constraints
+    // Tell the dof_map to check for constraint loops
     DofMap & dof_map = sys.get_dof_map();
-    dof_map.set_error_on_cyclic_constraint(true);
+    dof_map.set_error_on_constraint_loop(true);
 
-    CPPUNIT_ASSERT_THROW_MESSAGE("Cyclic constraint not detected", es.init(), libMesh::LogicError);
+    CPPUNIT_ASSERT_THROW_MESSAGE("Constraint loop not detected", es.init(), libMesh::LogicError);
   }
 #endif
 


### PR DESCRIPTION
As discussed in the documentation accompanying this PR, the "cyclic
constraint" terminology is used by some software to indicate a certain
type of rotational constraint, and we don't want our error message to
be confused with this. Both APIs can remain in place for a while but
eventually DofMap::check_for_cyclic_constraints() will be deprecated.