### PR TITLE
Add GMG+Fieldsplit testing for fem_sys_ex1 

### DIFF
--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -36,7 +36,7 @@
 #include "libmesh/exodusII_io.h"
 #include "libmesh/kelly_error_estimator.h"
 #include "libmesh/mesh.h"
-#include "libmesh/serial_mesh.h"
+#include "libmesh/replicated_mesh.h"
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/mesh_generation.h"
 #include "libmesh/mesh_refinement.h"
@@ -98,7 +98,7 @@ int main (int argc, char ** argv)
   const unsigned int max_adaptivesteps = infile("max_adaptivesteps", 10);
   const unsigned int dim               = infile("dimension", 2);
   const std::string slvr_type          = infile("solver_type", "newton");
-  const std::string mesh_type          = infile("mesh_type"  , "serial");
+  const std::string mesh_type          = infile("mesh_type"  , "replicated");
 
 #ifdef LIBMESH_HAVE_EXODUS_API
   const unsigned int write_interval    = infile("write_interval", 5);
@@ -116,8 +116,8 @@ int main (int argc, char ** argv)
 
   if (mesh_type == "distributed")
     mesh.reset(new DistributedMesh(init.comm()));
-  else if (mesh_type == "serial")
-    mesh.reset(new SerialMesh(init.comm()));
+  else if (mesh_type == "replicated")
+    mesh.reset(new ReplicatedMesh(init.comm()));
   else
     libmesh_error_msg("Error: specified mesh_type not understood");
 

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -190,12 +190,10 @@ int main (int argc, char ** argv)
   if (slvr_type == "newton")
     system.time_solver->diff_solver() = libmesh_make_unique<NewtonSolver>(system);
   else if (slvr_type == "petscdiff")
-#ifdef LIBMESH_HAVE_PETSC
-#ifdef LIBMESH_HAVE_METAPHYSICL
+#if defined(LIBMESH_HAVE_PETSC) && defined(LIBMESH_HAVE_METAPHYSICL)
     system.time_solver->diff_solver() = libmesh_make_unique<PetscDiffSolver>(system);
 #else
   libmesh_example_requires(false, "--enable-petsc --enable-metaphysicl-required");
-#endif
 #endif
   else
     libmesh_error_msg("Error: specified solver_type not understood");

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -190,7 +190,13 @@ int main (int argc, char ** argv)
   if (slvr_type == "newton")
     system.time_solver->diff_solver() = libmesh_make_unique<NewtonSolver>(system);
   else if (slvr_type == "petscdiff")
+#ifndef LIBMESH_HAVE_PETSC
+#ifndef LIBMESH_HAVE_METAPHYSICL
     system.time_solver->diff_solver() = libmesh_make_unique<PetscDiffSolver>(system);
+#else
+  libmesh_example_requires(false, "--enable-petsc --enable-metaphysicl-required");
+#endif
+#endif
   else
     libmesh_error_msg("Error: specified solver_type not understood");
 

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -190,8 +190,8 @@ int main (int argc, char ** argv)
   if (slvr_type == "newton")
     system.time_solver->diff_solver() = libmesh_make_unique<NewtonSolver>(system);
   else if (slvr_type == "petscdiff")
-#ifndef LIBMESH_HAVE_PETSC
-#ifndef LIBMESH_HAVE_METAPHYSICL
+#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_METAPHYSICL
     system.time_solver->diff_solver() = libmesh_make_unique<PetscDiffSolver>(system);
 #else
   libmesh_example_requires(false, "--enable-petsc --enable-metaphysicl-required");

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -36,6 +36,8 @@
 #include "libmesh/exodusII_io.h"
 #include "libmesh/kelly_error_estimator.h"
 #include "libmesh/mesh.h"
+#include "libmesh/serial_mesh.h"
+#include "libmesh/distributed_mesh.h"
 #include "libmesh/mesh_generation.h"
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/uniform_refinement_estimator.h"
@@ -46,8 +48,11 @@
 // The systems and solvers we may use
 #include "naviersystem.h"
 #include "libmesh/diff_solver.h"
+#include "libmesh/petsc_diff_solver.h"
+#include "libmesh/newton_solver.h"
 #include "libmesh/euler_solver.h"
 #include "libmesh/steady_solver.h"
+#include "libmesh/partitioner.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;
@@ -79,6 +84,9 @@ int main (int argc, char ** argv)
   // Parse the input file
   GetPot infile("fem_system_ex1.in");
 
+  // Override input file arguments from the command line
+  infile.parse_command_line(argc, argv);
+
   // Read in parameters from the input file
   const Real global_tolerance          = infile("global_tolerance", 0.);
   const unsigned int nelem_target      = infile("n_elements", 400);
@@ -89,6 +97,8 @@ int main (int argc, char ** argv)
   const unsigned int coarserefinements = infile("coarserefinements", 0);
   const unsigned int max_adaptivesteps = infile("max_adaptivesteps", 10);
   const unsigned int dim               = infile("dimension", 2);
+  const std::string slvr_type          = infile("solver_type", "newton");
+  const std::string mesh_type          = infile("mesh_type"  , "serial");
 
 #ifdef LIBMESH_HAVE_EXODUS_API
   const unsigned int write_interval    = infile("write_interval", 5);
@@ -102,10 +112,17 @@ int main (int argc, char ** argv)
 
   // Create a mesh, with dimension to be overridden later, distributed
   // across the default MPI communicator.
-  Mesh mesh(init.comm());
+  std::shared_ptr<UnstructuredMesh> mesh;
+
+  if (mesh_type == "distributed")
+    mesh.reset(new DistributedMesh(init.comm()));
+  else if (mesh_type == "serial")
+    mesh.reset(new SerialMesh(init.comm()));
+  else
+    libmesh_error_msg("Error: specified mesh_type not understood");
 
   // And an object to refine it
-  MeshRefinement mesh_refinement(mesh);
+  MeshRefinement mesh_refinement(*mesh);
   mesh_refinement.coarsen_by_parents() = true;
   mesh_refinement.absolute_global_tolerance() = global_tolerance;
   mesh_refinement.nelem_target() = nelem_target;
@@ -119,14 +136,14 @@ int main (int argc, char ** argv)
   // elements in 3D.  Building these higher-order elements allows
   // us to use higher-order approximation, as in example 3.
   if (dim == 2)
-    MeshTools::Generation::build_square (mesh,
+    MeshTools::Generation::build_square (*mesh,
                                          coarsegridsize,
                                          coarsegridsize,
                                          0., 1.,
                                          0., 1.,
                                          QUAD9);
   else if (dim == 3)
-    MeshTools::Generation::build_cube (mesh,
+    MeshTools::Generation::build_cube (*mesh,
                                        coarsegridsize,
                                        coarsegridsize,
                                        coarsegridsize,
@@ -135,13 +152,20 @@ int main (int argc, char ** argv)
                                        0., 1.,
                                        HEX27);
 
+  if  (slvr_type == "petscdiff")
+    {
+      mesh->allow_renumbering(false);
+      mesh->allow_remote_element_removal(false);
+      mesh->partitioner() = nullptr;
+    }
+
   mesh_refinement.uniformly_refine(coarserefinements);
 
   // Print information about the mesh to the screen.
-  mesh.print_info();
+  mesh->print_info();
 
   // Create an equation systems object.
-  EquationSystems equation_systems (mesh);
+  EquationSystems equation_systems (*mesh);
 
   // Declare the system "Navier-Stokes" and its variables.
   NavierSystem & system =
@@ -163,7 +187,16 @@ int main (int argc, char ** argv)
   system.deltat = deltat;
 
   // And the nonlinear solver options
+  if (slvr_type == "newton")
+    system.time_solver->diff_solver() = libmesh_make_unique<NewtonSolver>(system);
+  else if (slvr_type == "petscdiff")
+    system.time_solver->diff_solver() = libmesh_make_unique<PetscDiffSolver>(system);
+  else
+    libmesh_error_msg("Error: specified solver_type not understood");
+
   DiffSolver & solver = *(system.time_solver->diff_solver().get());
+  solver.init();
+
   solver.quiet = infile("solver_quiet", true);
   solver.verbose = !solver.quiet;
   solver.max_nonlinear_iterations =
@@ -293,7 +326,7 @@ int main (int argc, char ** argv)
           equation_systems.reinit();
 
           libMesh::out << "Refined mesh to "
-                       << mesh.n_active_elem()
+                       << mesh->n_active_elem()
                        << " active elements and "
                        << equation_systems.n_active_dofs()
                        << " active dofs."
@@ -324,7 +357,7 @@ int main (int argc, char ** argv)
                     << t_step+1
                     << ".e";
 
-          ExodusII_IO(mesh).write_timestep(file_name.str(),
+          ExodusII_IO(*mesh).write_timestep(file_name.str(),
                                            equation_systems,
                                            1, // This number indicates how many time steps
                                               // are being written to the file

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.in
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.in
@@ -26,7 +26,13 @@ coarsegridsize = 20
 # The maximum number of adaptive steps per timestep
 max_adaptivesteps = 0
 
-# Turn this off to see the NewtonSolver chatter
+# Choice of DiffSolver type. Options are: {newton, petscdiff}
+solver_type = newton
+
+# Choice of mesh type. Options are: {serial, distributed}
+mesh_type = serial
+
+# Turn this on to silence the Solver chatter
 solver_quiet = false
 
 # Solve the 2D or 3D problem

--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.in
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.in
@@ -29,8 +29,8 @@ max_adaptivesteps = 0
 # Choice of DiffSolver type. Options are: {newton, petscdiff}
 solver_type = newton
 
-# Choice of mesh type. Options are: {serial, distributed}
-mesh_type = serial
+# Choice of mesh type. Options are: {replicated, distributed}
+mesh_type = replicated
 
 # Turn this on to silence the Solver chatter
 solver_quiet = false

--- a/examples/fem_system/fem_system_ex1/run.sh
+++ b/examples/fem_system/fem_system_ex1/run.sh
@@ -8,4 +8,28 @@ example_name=fem_system_ex1
 
 example_dir=examples/fem_system/$example_name
 
+# First, run with standard options from input files.
 run_example "$example_name"
+
+# Rerun with options demonstrating fieldpslit+gmg on the velocity block.
+solver_options="--use_petsc_dm --node-major-dofs \
+ -snes_view -snes_monitor -snes_converged_reason -snes_rtol 1.0e-4 \
+ -ksp_type fgmres -ksp_rtol 1.0e-5 \
+-pc_type fieldsplit -pc_fieldsplit_0_fields 0,1 -pc_fieldsplit_1_fields 2 \
+-pc_fieldsplit_type schur -pc_fieldsplit_schur_fact_type full -pc_fieldsplit_schur_precondition a11 \
+-fieldsplit_0_pc_type mg -fieldsplit_0_pc_mg_galerkin both -fieldsplit_0_pc_mg_type full \
+-pc_mg_levels 3 -fieldsplit_0_pc_mg_levels 3 \
+-fieldsplit_0_mg_levels_pc_type sor -fieldsplit_0_mg_levels_pc_sor_its 5 \
+-fieldsplit_0_mg_levels_ksp_type richardson -fieldsplit_0_mg_levels_ksp_richardson_self_scale \
+-fieldsplit_0_mg_levels_ksp_max_it 5 \
+-fieldsplit_0_mg_coarse_pc_type lu -fieldsplit_0_mg_coarse_ksp_type preonly \
+-fieldsplit_0_ksp_max_it 1 -fieldsplit_0_ksp_type gmres \
+-fieldsplit_p_ksp_max_it 5 -fieldsplit_p_ksp_type gmres \
+-fieldsplit_p_pc_type none -fieldsplit_p_ksp_rtol 1.0e-4 \
+-fieldsplit_p_inner_pc_type lu -fieldsplit_p_inner_ksp_type preonly \
+-fieldsplit_p_upper_pc_type lu -fieldsplit_p_upper_ksp_type preonly"
+
+run_example "$example_name" "solver_type=petscdiff coarsegridsize=6 coarserefinements=2 transient=false n_timesteps=1 $solver_options"
+
+# Now rerun same thing with over a distributed mesh
+run_example "$example_name" "mesh_type=distributed solver_type=petscdiff coarsegridsize=6 coarserefinements=2 transient=false n_timesteps=1 $solver_options"

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -337,6 +337,15 @@ unsigned int PetscDiffSolver::solve()
   SNESConvergedReason reason;
   SNESGetConvergedReason(_snes, &reason);
 
+  PetscInt l_its, nl_its;
+  ierr = SNESGetLinearSolveIterations(_snes,&l_its);
+  LIBMESH_CHKERR(ierr);
+  this->_inner_iterations = l_its;
+
+  ierr = SNESGetIterationNumber(_snes,&nl_its);
+  LIBMESH_CHKERR(ierr);
+  this->_outer_iterations = nl_its;
+
   return convert_solve_result(reason);
 }
 


### PR DESCRIPTION
This PR exercises the capabilities added in #2047 by adding a minimal working example for fem_system ex1 which solves a steady Navier-Stokes system by utilizing GMG on the velocity block for both Distributed and Serial meshes.

The cd44332 commit captures the iteration counts from PETSc in the DiffSolver which will shortly be used in some regression testing being done through GRINS.

