### PR TITLE
Fixes for greatly speeding up mesh stitching

### DIFF
--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -159,7 +159,8 @@ public:
                                         const bool skip_find_neighbors = false,
                                         dof_id_type element_id_offset = 0,
                                         dof_id_type node_id_offset = 0,
-                                        unique_id_type unique_id_offset = 0);
+                                        unique_id_type unique_id_offset = 0,
+                                        const bool skip_prepare = false);
 
 
   /**

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -236,7 +236,8 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
     }
 
   // Partition the mesh.
-  this->partition();
+  if (!_skip_partitioning)
+    this->partition();
 
   // If we're using DistributedMesh, we'll probably want it
   // parallelized.

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -66,7 +66,8 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
                                                  unique_id_offset
 #endif
-                                               )
+                                               ,
+                                               const bool skip_prepare)
 {
   LOG_SCOPE("copy_nodes_and_elements()", "UnstructuredMesh");
 
@@ -209,19 +210,22 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
       }
   }
 
-  //Finally prepare the new Mesh for use.  Keep the same numbering and
-  //partitioning for now.
-  this->allow_renumbering(false);
-  this->allow_remote_element_removal(false);
-  this->skip_partitioning(true);
+  if (!skip_prepare)
+  {
+    //Finally prepare the new Mesh for use.  Keep the same numbering and
+    //partitioning for now.
+    this->allow_renumbering(false);
+    this->allow_remote_element_removal(false);
+    this->skip_partitioning(true);
 
-  this->prepare_for_use(false, skip_find_neighbors);
+    this->prepare_for_use(false, skip_find_neighbors);
 
-  //But in the long term, use the same renumbering and partitioning
-  //policies as our source mesh.
-  this->allow_renumbering(other_mesh.allow_renumbering());
-  this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
-  this->skip_partitioning(other_mesh.skip_partitioning());
+    //But in the long term, use the same renumbering and partitioning
+    //policies as our source mesh.
+    this->allow_renumbering(other_mesh.allow_renumbering());
+    this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
+    this->skip_partitioning(other_mesh.skip_partitioning());
+  }
 }
 
 


### PR DESCRIPTION
Related to #1815

Takes the generation of a 2M element mesh from 138 seconds down to 43 seconds.  Will be an even bigger win on larger meshes!