### PR TITLE
Skip partitioning in copy_nodes_and_elems if we should

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -792,24 +792,47 @@ public:
   bool allow_remote_element_removal() const { return _allow_remote_element_removal; }
 
   /**
-   * If true is passed in then this mesh will no longer be
-   * (re)partitioned.  It would probably be a bad idea to call this on
-   * a DistributedMesh _before_ the first partitioning has
-   * happened... because no elements would get assigned to your
-   * processor pool.
+   * If true is passed in then the elements on this mesh will no
+   * longer be (re)partitioned, and the nodes on this mesh will only
+   * be repartitioned if they are found "orphaned" via coarsening or
+   * other removal of the last element responsible for their
+   * node/element processor id consistency.
    *
-   * \note Turning on skip_partitioning() can have adverse effects on
-   * your performance when using AMR... i.e. you could get large load
+   * \note It would probably be a bad idea to call this on a
+   * DistributedMesh _before_ the first partitioning has happened...
+   * because no elements would get assigned to your processor pool.
+   *
+   * \note Skipping partitioning can have adverse effects on your
+   * performance when using AMR... i.e. you could get large load
    * imbalances.  However you might still want to use this if the
    * communication and computation of the rebalance and repartition is
    * too high for your application.
    *
    * It is also possible, for backwards-compatibility purposes, to
-   * skip partitioning by resetting the partitioner() pointer for this
-   * mesh.
+   * skip noncritical partitioning by resetting the partitioner()
+   * pointer for this mesh.
    */
-  void skip_partitioning(bool skip) { _skip_partitioning = skip; }
-  bool skip_partitioning() const { return _skip_partitioning || !_partitioner.get(); }
+  void skip_noncritical_partitioning(bool skip)
+  { _skip_noncritical_partitioning = skip; }
+
+  bool skip_noncritical_partitioning() const
+  { return _skip_noncritical_partitioning || _skip_all_partitioning || !_partitioner.get(); }
+
+
+  /**
+   * If true is passed in then nothing on this mesh will be
+   * (re)partitioned.
+   *
+   * \note The caveats for skip_noncritical_partitioning() still
+   * apply, and removing elements from a mesh with this setting
+   * enabled can leave node processor ids in an inconsistent state
+   * (not matching any attached element), causing failures in other
+   * library code.  Do not use this setting along with element
+   * deletion or coarsening.
+   */
+  void skip_partitioning(bool skip) { _skip_all_partitioning = skip; }
+
+  bool skip_partitioning() const { return _skip_all_partitioning; }
 
   /**
    * Adds a functor which can specify ghosting requirements for use on
@@ -1431,9 +1454,15 @@ protected:
 #endif
 
   /**
+   * If this is true then no partitioning should be done with the
+   * possible exception of orphaned nodes.
+   */
+  bool _skip_noncritical_partitioning;
+
+  /**
    * If this is true then no partitioning should be done.
    */
-  bool _skip_partitioning;
+  bool _skip_all_partitioning;
 
   /**
    * If this is true then renumbering will be kept to a minimum.

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -238,7 +238,8 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
     }
 
   // Partition the mesh.
-  this->partition();
+  if (!skip_partitioning())
+    this->partition();
 
   // If we're using DistributedMesh, we'll probably want it
   // parallelized.

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -60,7 +60,8 @@ MeshBase::MeshBase (const Parallel::Communicator & comm_in,
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   _next_unique_id(DofObject::invalid_unique_id),
 #endif
-  _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
+  _skip_noncritical_partitioning(false),
+  _skip_all_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false),
   _allow_remote_element_removal(true),
   _spatial_dimension(d),
@@ -87,7 +88,8 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
   _next_unique_id(other_mesh._next_unique_id),
 #endif
-  _skip_partitioning(libMesh::on_command_line("--skip-partitioning")),
+  _skip_noncritical_partitioning(false),
+  _skip_all_partitioning(libMesh::on_command_line("--skip-partitioning")),
   _skip_renumber_nodes_and_elements(false),
   _allow_remote_element_removal(true),
   _elem_dims(other_mesh._elem_dims),
@@ -237,7 +239,9 @@ void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, con
       gf->mesh_reinit();
     }
 
-  // Partition the mesh.
+  // Partition the mesh unless *all* partitioning is to be skipped.
+  // If only noncritical partitioning is to be skipped, the
+  // partition() call will still check for orphaned nodes.
   if (!skip_partitioning())
     this->partition();
 
@@ -436,10 +440,10 @@ void MeshBase::partition (const unsigned int n_parts)
       libmesh_assert (this->is_serial());
       partitioner()->partition (*this, n_parts);
     }
-  // A nullptr partitioner means don't repartition; skip_partitioning()
-  // checks on this.
-  // Non-serial meshes may not be ready for repartitioning here.
-  else if (!skip_partitioning())
+  // A nullptr partitioner or a skip_partitioning(true) call or a
+  // skip_noncritical_partitioning(true) call means don't repartition;
+  // skip_noncritical_partitioning() checks all these.
+  else if (!skip_noncritical_partitioning())
     {
       partitioner()->partition (*this, n_parts);
     }

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -2291,7 +2291,7 @@ void MeshTools::correct_node_proc_ids (MeshBase & mesh)
   // balancing.  But if the mesh is disallowing repartitioning, we
   // won't touch processor_id on any node where it's valid, regardless
   // of whether or not it's canonical.
-  bool repartition_all_nodes = !mesh.skip_partitioning();
+  bool repartition_all_nodes = !mesh.skip_noncritical_partitioning();
   std::unordered_set<const Node *> valid_nodes;
 
   // If we aren't allowed to repartition, then we're going to leave

--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -213,6 +213,9 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
   //partitioning for now.
   this->allow_renumbering(false);
   this->allow_remote_element_removal(false);
+
+  // We should generally be able to skip *all* partitioning here
+  // because we're only adding one already-consistent mesh to another.
   this->skip_partitioning(true);
 
   this->prepare_for_use(false, skip_find_neighbors);
@@ -221,7 +224,8 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
   //policies as our source mesh.
   this->allow_renumbering(other_mesh.allow_renumbering());
   this->allow_remote_element_removal(other_mesh.allow_remote_element_removal());
-  this->skip_partitioning(other_mesh.skip_partitioning());
+  this->skip_partitioning(other_mesh._skip_all_partitioning);
+  this->skip_noncritical_partitioning(other_mesh._skip_noncritical_partitioning);
 }
 
 


### PR DESCRIPTION
```skip_noncritical_partitioning()``` as well as the old "reset the partitioner pointer trick" should still have the old/safe behavior; "skip_partitioning()" has the literal-as-the-name dangerous/fast behavior.

It turns out that the refinement estimators were using the partitioner pointer trick, so hopefully this will fix the GRINS CI with no subsequent changes, although I really should update those eventually.

If this works it should be safe to merge and would supercede #1815.  I'm still begging for those test cases to replicate the original problem, though.  The correctness problem has to be due to a bug that I'd rather fix than hide, and the performance problem may be hurting us elsewhere even if we can avoid it here.