### PR TITLE
RB: Include "extra" parameters when getting parameters.

### DIFF
--- a/include/reduced_basis/rb_parameters.h
+++ b/include/reduced_basis/rb_parameters.h
@@ -105,14 +105,16 @@ public:
   void get_extra_parameter_names(std::set<std::string> & param_names) const;
 
   /**
-   * Get a constant iterator to beginning of this RBParameters object.
+   * Get const_iterator access to the parameters stored in this RBParameters object.
    */
   const_iterator begin() const;
+  const_iterator end() const;
 
   /**
-   * Get a constant iterator to the end of this RBParameters object.
+   * Get const_iterator access to the extra parameters stored in this RBParameters object.
    */
-  const_iterator end() const;
+  const_iterator extra_begin() const;
+  const_iterator extra_end() const;
 
   /**
    * Two RBParameters are equal if they have the same _parameters map.

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -149,13 +149,9 @@ RBParameters RBConstructionBase<Base>::get_params_from_training_set(unsigned int
     }
 
   // Add potential extra values
-  std::set<std::string> extra_param_names;
-  get_parameters().get_extra_parameter_names(extra_param_names);
-  for (auto & name : extra_param_names)
-    {
-      const Real val = get_parameters().get_extra_value(name);
-      params.set_extra_value(name, val);
-    }
+  const auto & mine = get_parameters();
+  for (const auto & pr : as_range(mine.extra_begin(), mine.extra_end()))
+    params.set_extra_value(pr.first, pr.second);
 
   return params;
 }

--- a/src/reduced_basis/rb_construction_base.C
+++ b/src/reduced_basis/rb_construction_base.C
@@ -148,6 +148,15 @@ RBParameters RBConstructionBase<Base>::get_params_from_training_set(unsigned int
       params.set_value(param_name, param_value);
     }
 
+  // Add potential extra values
+  std::set<std::string> extra_param_names;
+  get_parameters().get_extra_parameter_names(extra_param_names);
+  for (auto & name : extra_param_names)
+    {
+      const Real val = get_parameters().get_extra_value(name);
+      params.set_extra_value(name, val);
+    }
+
   return params;
 }
 

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -109,6 +109,16 @@ RBParameters::const_iterator RBParameters::end() const
   return _parameters.end();
 }
 
+RBParameters::const_iterator RBParameters::extra_begin() const
+{
+  return _extra_parameters.begin();
+}
+
+RBParameters::const_iterator RBParameters::extra_end() const
+{
+  return _extra_parameters.end();
+}
+
 bool RBParameters::operator==(const RBParameters & rhs) const
 {
   return (this->_parameters == rhs._parameters &&


### PR DESCRIPTION
We are checking whether this unreasonably slows down the `get_params_from_training_set()` call before merging...
