### PR TITLE
Disable PetscDMWrapper in --enable-complex builds for now

### DIFF
--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -72,6 +72,12 @@ int main (int argc, char ** argv)
   libmesh_example_requires(false, "--disable-singleprecision");
 #endif
 
+  // This example uses the new PetscDMWrapper which currently does not
+  // compile when complex numbers are enabled.
+#ifdef LIBMESH_USE_COMPLEX_NUMBERS
+  libmesh_example_requires(false, "--disable-complex");
+#endif
+
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_example_requires(false, "--enable-amr");
 #else

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -97,10 +97,8 @@ protected:
    * Wrapper object for interacting with PetscDM
    */
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#ifdef LIBMESH_ENABLE_AMR
-#ifdef LIBMESH_HAVE_METAPHYSICL
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
   PetscDMWrapper _dm_wrapper;
-#endif
 #endif
 #endif
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -23,8 +23,7 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#ifdef LIBMESH_ENABLE_AMR
-#ifdef LIBMESH_HAVE_METAPHYSICL
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
 
 #include <vector>
 #include <memory>
@@ -219,8 +218,7 @@ private:
 
 }
 
-#endif // #if LIBMESH_HAVE_METAPHYSICL
-#endif // #if LIBMESH_ENABLE_AMR
+#endif // #if LIBMESH_ENABLE_AMR && LIBMESH_HAVE_METAPHYSICL && !LIBMESH_USE_COMPLEX_NUMBERS
 #endif // #if PETSC_VERSION
 #endif // #ifdef LIBMESH_HAVE_PETSC
 

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -228,10 +228,8 @@ void PetscDiffSolver::clear()
   LIBMESH_CHKERR(ierr);
 
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#ifdef LIBMESH_ENABLE_AMR
-#ifdef LIBMESH_HAVE_METAPHYSICL
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
   _dm_wrapper.clear();
-#endif
 #endif
 #endif
 }
@@ -370,11 +368,9 @@ void PetscDiffSolver::setup_petsc_data()
 
   // This needs to be called before SNESSetFromOptions
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#ifdef LIBMESH_ENABLE_AMR
-#ifdef LIBMESH_HAVE_METAPHYSICL
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
   if (use_petsc_dm)
     this->_dm_wrapper.init_and_attach_petscdm(_system, _snes);
-#endif
 #endif
 #endif
 

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -20,8 +20,7 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#ifdef LIBMESH_ENABLE_AMR
-#ifdef LIBMESH_HAVE_METAPHYSICL
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
 
 #include "libmesh/ignore_warnings.h"
 #include <petscsf.h>
@@ -1030,7 +1029,6 @@ void PetscDMWrapper::init_dm_data(unsigned int n_levels, const Parallel::Communi
 
 } // end namespace libMesh
 
-#endif // LIBMESH_HAVE_METAPHYSICL
-#endif // LIBMESH_ENABLE_AMR
+#endif // #if LIBMESH_ENABLE_AMR && LIBMESH_HAVE_METAPHYSICL && !LIBMESH_USE_COMPLEX_NUMBERS
 #endif // PETSC_VERSION
 #endif // LIBMESH_HAVE_PETSC

--- a/tests/mesh/mesh_function.C
+++ b/tests/mesh/mesh_function.C
@@ -120,12 +120,16 @@ public:
     for (const auto & node : mesh.local_node_ptr_range())
       {
         (*mesh_function)(*node, /*time=*/ 0., vec_values);
-        Real mesh_function_value = projection_function(*node,
-                                                       es.parameters,
-                                                       dummy,
-                                                       dummy);
+        Number mesh_function_value =
+          projection_function(*node,
+                              es.parameters,
+                              dummy,
+                              dummy);
 
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(vec_values(0), mesh_function_value, TOLERANCE*TOLERANCE);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL
+          (libmesh_real(vec_values(0)),
+           libmesh_real(mesh_function_value),
+           TOLERANCE*TOLERANCE);
       }
   }
 #endif // LIBMESH_ENABLE_AMR


### PR DESCRIPTION
Currently we only instantiate `PetscVector<Number>`, so when building with `--enable-complex` anything that hardcodes `PetscVector<Real>` doesn't compile. This includes the new `PetscDMWrapper` stuff, so for the moment I've simply ifdef'd that new class out in this configuration. I suspect that it could be fixed for "real" just by changing all the declarations to use `Number`, but I'll leave that decision to @pbauman and @bboutkov.

This PR fixes #2071 for me, so it should get @cticenhour working again.
