### PR TITLE
FEInterface::get_continuity() should take a const reference.

### DIFF
--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -423,7 +423,7 @@ public:
    * match the FEBase::get_continuity() specializations/overrides for
    * the different FE types.
    */
-  static FEContinuity get_continuity(FEType & fe_type);
+  static FEContinuity get_continuity(const FEType & fe_type);
 
 private:
 

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -1590,7 +1590,7 @@ unsigned int FEInterface::n_vec_dim (const MeshBase & mesh,
 
 
 
-FEContinuity FEInterface::get_continuity(FEType & fe_type)
+FEContinuity FEInterface::get_continuity(const FEType & fe_type)
 {
   switch (fe_type.family)
     {


### PR DESCRIPTION
This API was present in 1.4.0, so this commit should also be
cherry-picked onto the in-progress v1.4.1_branch.

Refs #2029.