### PR TITLE
Loosened condition in contains_point()

### DIFF
--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -458,10 +458,17 @@ bool InfHex::contains_point (const Point & p, Real tol) const
   Point pt1_o(this->point(1) - my_origin);
   Point pt2_o(this->point(2) - my_origin);
   Point pt3_o(this->point(3) - my_origin);
-  const Real min_distance_sq = std::min(pt0_o.norm_sq(),
-                                        std::min(pt1_o.norm_sq(),
-                                                 std::min(pt2_o.norm_sq(),
-                                                          pt3_o.norm_sq())));
+  const Real tmp_min_distance_sq = std::min(pt0_o.norm_sq(),
+                                            std::min(pt1_o.norm_sq(),
+                                                     std::min(pt2_o.norm_sq(),
+                                                              pt3_o.norm_sq())));
+  // for a coarse grid, it is important to account for tha fact
+  // that the sides are not spherical, thus the closest point
+  // can be closer than all edges.
+  // This is an estimator using Pythagoras:
+  const Real min_distance_sq = tmp_min_distance_sq
+                              - .5*std::max((point(0)-point(2)).norm_sq(),
+                                            (point(1)-point(3)).norm_sq());
 
   // work with 1% allowable deviation.  We can still fall
   // back to the InfFE::inverse_map()

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -221,10 +221,17 @@ bool InfPrism::contains_point (const Point & p, Real tol) const
   Point pt0_o(this->point(0) - my_origin);
   Point pt1_o(this->point(1) - my_origin);
   Point pt2_o(this->point(2) - my_origin);
-  const Real min_distance_sq = std::min(pt0_o.norm_sq(),
-                                        std::min(pt1_o.norm_sq(),
-                                                 pt2_o.norm_sq()));
-
+  const Real tmp_min_distance_sq = std::min(pt0_o.norm_sq(),
+                                            std::min(pt1_o.norm_sq(),
+                                                     pt2_o.norm_sq()));
+  // for a coarse grid, it is important to account for tha fact
+  // that the sides are not spherical, thus the closest point
+  // can be closer than all edges.
+  // This is an estimator using Pythagoras:
+  const Real min_distance_sq = tmp_min_distance_sq
+                              - .5*std::max((point(0)-point(1)).norm_sq(),
+                                             std::max((point(0)-point(2)).norm_sq(),
+                                                      (point(1)-point(2)).norm_sq()));
   // work with 1% allowable deviation.  We can still fall
   // back to the InfFE::inverse_map()
   const Real conservative_p_dist_sq = 1.01 * (Point(p - my_origin).norm_sq());


### PR DESCRIPTION
Hi,
The contains_point()-function gives false negatives when working on the inner face of infinite elements: The point closest to the origin is not necessarily on the edges; to account for this, some looser condition is required, especially for coarse grids this makes a difference.
I think, with this one is on the safe side finally.
Best regards