### PR TITLE
Don't clear stashed DofConstraints

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -936,6 +936,23 @@ public:
     _dof_constraints.swap(_stashed_dof_constraints);
   }
 
+  /**
+   * Similar to the stash/unstash_dof_constraints() API, but swaps
+   * _dof_constraints and _stashed_dof_constraints without asserting
+   * that the source or destination is empty first.
+   *
+   * \note There is an implicit assumption that swapping between sets
+   * of Constraints does not change the sparsity pattern or expand the
+   * send_list, since the only thing changed is the DofConstraints
+   * themselves.  This is intended to work for swapping between
+   * DofConstraints A and B, where A is used to define the send_list,
+   * and B is a subset of A.
+   */
+  void swap_dof_constraints()
+  {
+    _dof_constraints.swap(_stashed_dof_constraints);
+  }
+
 #ifdef LIBMESH_ENABLE_NODE_CONSTRAINTS
   /**
    * \returns An iterator pointing to the first Node constraint row.

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -889,7 +889,7 @@ void DofMap::clear()
 #ifdef LIBMESH_ENABLE_AMR
 
   _dof_constraints.clear();
-  //_stashed_dof_constraints.clear();
+  _stashed_dof_constraints.clear();
   _primal_constraint_values.clear();
   _adjoint_constraint_values.clear();
   _n_old_dfs = 0;

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -889,7 +889,7 @@ void DofMap::clear()
 #ifdef LIBMESH_ENABLE_AMR
 
   _dof_constraints.clear();
-  _stashed_dof_constraints.clear();
+  //_stashed_dof_constraints.clear();
   _primal_constraint_values.clear();
   _adjoint_constraint_values.clear();
   _n_old_dfs = 0;

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1234,9 +1234,10 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
     {
       // Clear out any old constraints; maybe the user just deleted
       // their last remaining dirichlet/periodic/user constraint?
+      // Note: any _stashed_dof_constraints are not cleared as it
+      // may be the user's intention to restore them later.
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
       _dof_constraints.clear();
-      //_stashed_dof_constraints.clear();
       _primal_constraint_values.clear();
       _adjoint_constraint_values.clear();
 #endif
@@ -1288,8 +1289,9 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
 
 
   // recalculate dof constraints from scratch
+  // Note: any _stashed_dof_constraints are not cleared as it
+  // may be the user's intention to restore them later.
   _dof_constraints.clear();
-  //_stashed_dof_constraints.clear();
   _primal_constraint_values.clear();
   _adjoint_constraint_values.clear();
 

--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -1236,7 +1236,7 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
       // their last remaining dirichlet/periodic/user constraint?
 #ifdef LIBMESH_ENABLE_CONSTRAINTS
       _dof_constraints.clear();
-      _stashed_dof_constraints.clear();
+      //_stashed_dof_constraints.clear();
       _primal_constraint_values.clear();
       _adjoint_constraint_values.clear();
 #endif
@@ -1289,7 +1289,7 @@ void DofMap::create_dof_constraints(const MeshBase & mesh, Real time)
 
   // recalculate dof constraints from scratch
   _dof_constraints.clear();
-  _stashed_dof_constraints.clear();
+  //_stashed_dof_constraints.clear();
   _primal_constraint_values.clear();
   _adjoint_constraint_values.clear();
 

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -580,6 +580,12 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
 {
   LOG_SCOPE("add_scaled_matrix_and_vector()", "RBConstruction");
 
+  if(!apply_dof_constraints)
+  {
+    // Use the stashed constraints in this case
+    this->get_dof_map().stash_dof_constraints();
+  }
+
   bool assemble_matrix = (input_matrix != nullptr);
   bool assemble_vector = (input_vector != nullptr);
 
@@ -702,15 +708,12 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
           context.get_elem_jacobian() *= 0.5;
         }
 
-      if (apply_dof_constraints)
-        {
-          // Apply constraints, e.g. Dirichlet and periodic constraints
-          this->get_dof_map().constrain_element_matrix_and_vector
-            (context.get_elem_jacobian(),
-             context.get_elem_residual(),
-             context.get_dof_indices(),
-             /*asymmetric_constraint_rows*/ false );
-        }
+      // Apply constraints, e.g. Dirichlet and periodic constraints
+      this->get_dof_map().constrain_element_matrix_and_vector
+        (context.get_elem_jacobian(),
+          context.get_elem_residual(),
+          context.get_dof_indices(),
+          /*asymmetric_constraint_rows*/ false );
 
       // Scale and add to global matrix and/or vector
       context.get_elem_jacobian() *= scalar;
@@ -761,6 +764,12 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
     input_matrix->close();
   if (assemble_vector)
     input_vector->close();
+
+  if(!apply_dof_constraints)
+  {
+    // Revert to the non-stashed constraints
+    this->get_dof_map().unstash_dof_constraints();
+  }
 }
 
 void RBConstruction::set_context_solution_vec(NumericVector<Number> & vec)

--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -580,10 +580,11 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
 {
   LOG_SCOPE("add_scaled_matrix_and_vector()", "RBConstruction");
 
-  if(!apply_dof_constraints)
+  if (!apply_dof_constraints)
   {
-    // Use the stashed constraints in this case
-    this->get_dof_map().stash_dof_constraints();
+    // Use the stashed constraints, which in this case have the
+    // Dirichlet constraints removed.
+    this->get_dof_map().swap_dof_constraints();
   }
 
   bool assemble_matrix = (input_matrix != nullptr);
@@ -765,10 +766,10 @@ void RBConstruction::add_scaled_matrix_and_vector(Number scalar,
   if (assemble_vector)
     input_vector->close();
 
-  if(!apply_dof_constraints)
+  if (!apply_dof_constraints)
   {
-    // Revert to the non-stashed constraints
-    this->get_dof_map().unstash_dof_constraints();
+    // Revert to the original constraints
+    this->get_dof_map().swap_dof_constraints();
   }
 }
 


### PR DESCRIPTION
We need a way of switching back and forth between a "stashed" subset of the Constraints. There should probably eventually be an API for allowing users to do this, but for now simply not clearing the stashed constraints is sufficient for our needs...
