### PR TITLE
MeshBase copy ctor: copy _point_locator_close_to_point_tol

### DIFF
--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -96,7 +96,7 @@ MeshBase::MeshBase (const MeshBase & other_mesh) :
   _spatial_dimension(other_mesh._spatial_dimension),
   _default_ghosting(new GhostPointNeighbors(*this)),
   _ghosting_functors(other_mesh._ghosting_functors),
-  _point_locator_close_to_point_tol(0.)
+  _point_locator_close_to_point_tol(other_mesh._point_locator_close_to_point_tol)
 {
   // Make sure we don't accidentally delete the other mesh's default
   // ghosting functor; we'll use our own if that's needed.


### PR DESCRIPTION
Initializing this member to zero in the copy constructor was errantly
copied from the main MeshBase constructor.

Refs #2079.