### PR TITLE
DofMap::reinit_send_list(), Overlapping Coupling Test

### DIFF
--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -440,6 +440,16 @@ public:
   void prepare_send_list ();
 
   /**
+   * Clears the \p _send_list vector. This should be done in order to completely
+   * rebuild the send_list from scratch rather than merely adding to the existing
+   * send_list.
+   */
+  void clear_send_list ()
+  {
+    _send_list.clear();
+  }
+
+  /**
    * \returns A constant reference to the \p _send_list for this processor.
    *
    * The \p _send_list contains the global indices of all the

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -450,6 +450,18 @@ public:
   }
 
   /**
+   * Clears the \p _send_list vector and then rebuilds it. This may be needed
+   * in special situations, for example when an algebraic coupling functor cannot
+   * be added to the \p DofMap until after it is completely setup. Then this method
+   * can be used to rebuild the send_list once the algebraic coupling functor is
+   * added. Note that while this will recommunicate constraints with the updated
+   * send_list, this does assume no new constraints have been added since the previous
+   * reinit_constraints call.
+   */
+  void reinit_send_list (MeshBase & mesh);
+
+
+  /**
    * \returns A constant reference to the \p _send_list for this processor.
    *
    * The \p _send_list contains the global indices of all the

--- a/include/base/ghosting_functor.h
+++ b/include/base/ghosting_functor.h
@@ -130,6 +130,23 @@ class Elem;
  * (e.g. subdomain-restricted variables on a neighboring subdomain)
  * will be unaffected.
  *
+ * Typical usage of the GhostingFunctor would be to add a geometric ghosting
+ * functor before the mesh preparation is completed; progmatically, this would
+ * be before MeshBase::prepare_for_use() is called, but many different libMesh
+ * idioms internally call this function. The algebraic and coupling ghosting
+ * functors normally are added before EquationSystems::init() is called.
+ * However, in some circumstances, solution evaluation may be needed within the
+ * GhostingFunctor in order to determine the ghosting, in which case the appropriate
+ * functor would need to be added after EquationSystems::init(). In this case,
+ * the user will need to reinitialize certain parts of the DofMap for
+ * algebraic and coupling functors. For algebraic ghosting functors, the
+ * user will need to call DofMap::reinit_send_list() and then reinitialize
+ * any NumericVectors that are GHOSTED, e.g. the System::current_local_solution.
+ * For coupling ghosting, the user will also need to recompute the sparsity
+ * pattern via DofMap::clear_sparsity() and then DofMap::compute_sparsity() and
+ * then reinitialize any SparseMatrix objects attached to the System, e.g.
+ * the system.get_matrix("System Matrix").
+ *
  * \author Roy H. Stogner
  * \date 2016
  */

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1678,6 +1678,17 @@ void DofMap::prepare_send_list ()
   std::vector<dof_id_type> (_send_list.begin(), new_end).swap (_send_list);
 }
 
+void DofMap::reinit_send_list (MeshBase & mesh)
+{
+  this->clear_send_list();
+  this->add_neighbors_to_send_list(mesh);
+
+  // This is assuming that we only need to recommunicate
+  // the constraints and no new ones have been added since
+  // a previous call to reinit_constraints.
+  this->process_constraints(mesh);
+  this->prepare_send_list();
+}
 
 void DofMap::set_implicit_neighbor_dofs(bool implicit_neighbor_dofs)
 {

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -882,7 +882,7 @@ void DofMap::clear()
   _first_df.clear();
   _end_df.clear();
   _first_scalar_df.clear();
-  _send_list.clear();
+  this->clear_send_list();
   this->clear_sparsity();
   need_full_sparsity_pattern = false;
 
@@ -935,7 +935,7 @@ void DofMap::distribute_dofs (MeshBase & mesh)
   dof_id_type next_free_dof = 0;
 
   // Clear the send list before we rebuild it
-  _send_list.clear();
+  this->clear_send_list();
 
   // Set temporary DOF indices on this processor
   if (node_major_dofs)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,6 +24,7 @@ unit_tests_sources = \
   base/default_coupling_test.C \
   base/getpot_test.C \
   base/point_neighbor_coupling_test.C \
+  base/overlapping_coupling_test.C \
   fe/fe_bernstein_test.C \
   fe/fe_clough_test.C \
   fe/fe_hermite_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -185,7 +185,8 @@ PROGRAMS = $(noinst_PROGRAMS)
 am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	stream_redirector.h base/dof_object_test.h base/dof_map_test.C \
 	base/default_coupling_test.C base/getpot_test.C \
-	base/point_neighbor_coupling_test.C fe/fe_bernstein_test.C \
+	base/point_neighbor_coupling_test.C \
+	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -234,6 +235,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	base/unit_tests_dbg-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_dbg-getpot_test.$(OBJEXT) \
 	base/unit_tests_dbg-point_neighbor_coupling_test.$(OBJEXT) \
+	base/unit_tests_dbg-overlapping_coupling_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_hermite_test.$(OBJEXT) \
@@ -311,7 +313,8 @@ unit_tests_dbg_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	stream_redirector.h base/dof_object_test.h base/dof_map_test.C \
 	base/default_coupling_test.C base/getpot_test.C \
-	base/point_neighbor_coupling_test.C fe/fe_bernstein_test.C \
+	base/point_neighbor_coupling_test.C \
+	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -359,6 +362,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	base/unit_tests_devel-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_devel-getpot_test.$(OBJEXT) \
 	base/unit_tests_devel-point_neighbor_coupling_test.$(OBJEXT) \
+	base/unit_tests_devel-overlapping_coupling_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_hermite_test.$(OBJEXT) \
@@ -433,7 +437,8 @@ unit_tests_devel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	stream_redirector.h base/dof_object_test.h base/dof_map_test.C \
 	base/default_coupling_test.C base/getpot_test.C \
-	base/point_neighbor_coupling_test.C fe/fe_bernstein_test.C \
+	base/point_neighbor_coupling_test.C \
+	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -481,6 +486,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	base/unit_tests_oprof-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_oprof-getpot_test.$(OBJEXT) \
 	base/unit_tests_oprof-point_neighbor_coupling_test.$(OBJEXT) \
+	base/unit_tests_oprof-overlapping_coupling_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_hermite_test.$(OBJEXT) \
@@ -555,7 +561,8 @@ unit_tests_oprof_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	stream_redirector.h base/dof_object_test.h base/dof_map_test.C \
 	base/default_coupling_test.C base/getpot_test.C \
-	base/point_neighbor_coupling_test.C fe/fe_bernstein_test.C \
+	base/point_neighbor_coupling_test.C \
+	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -603,6 +610,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	base/unit_tests_opt-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_opt-getpot_test.$(OBJEXT) \
 	base/unit_tests_opt-point_neighbor_coupling_test.$(OBJEXT) \
+	base/unit_tests_opt-overlapping_coupling_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_hermite_test.$(OBJEXT) \
@@ -676,7 +684,8 @@ unit_tests_opt_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	stream_redirector.h base/dof_object_test.h base/dof_map_test.C \
 	base/default_coupling_test.C base/getpot_test.C \
-	base/point_neighbor_coupling_test.C fe/fe_bernstein_test.C \
+	base/point_neighbor_coupling_test.C \
+	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -724,6 +733,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	base/unit_tests_prof-default_coupling_test.$(OBJEXT) \
 	base/unit_tests_prof-getpot_test.$(OBJEXT) \
 	base/unit_tests_prof-point_neighbor_coupling_test.$(OBJEXT) \
+	base/unit_tests_prof-overlapping_coupling_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_bernstein_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_hermite_test.$(OBJEXT) \
@@ -818,22 +828,27 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_dbg-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_dbg-point_neighbor_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_devel-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_devel-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_devel-point_neighbor_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_oprof-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_oprof-point_neighbor_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_opt-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_opt-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_opt-point_neighbor_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_prof-dof_map_test.Po \
 	base/$(DEPDIR)/unit_tests_prof-getpot_test.Po \
+	base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po \
 	base/$(DEPDIR)/unit_tests_prof-point_neighbor_coupling_test.Po \
 	fe/$(DEPDIR)/unit_tests_dbg-fe_bernstein_test.Po \
 	fe/$(DEPDIR)/unit_tests_dbg-fe_clough_test.Po \
@@ -1569,7 +1584,8 @@ AM_LDFLAGS = $(libmesh_LDFLAGS)
 unit_tests_sources = driver.C test_comm.h stream_redirector.h \
 	base/dof_object_test.h base/dof_map_test.C \
 	base/default_coupling_test.C base/getpot_test.C \
-	base/point_neighbor_coupling_test.C fe/fe_bernstein_test.C \
+	base/point_neighbor_coupling_test.C \
+	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
 	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
 	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
@@ -1700,6 +1716,8 @@ base/unit_tests_dbg-default_coupling_test.$(OBJEXT):  \
 base/unit_tests_dbg-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_dbg-point_neighbor_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_dbg-overlapping_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/$(am__dirstamp):
 	@$(MKDIR_P) fe
@@ -1915,6 +1933,8 @@ base/unit_tests_devel-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_devel-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_devel-overlapping_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_devel-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_devel-fe_clough_test.$(OBJEXT): fe/$(am__dirstamp) \
@@ -2062,6 +2082,8 @@ base/unit_tests_oprof-default_coupling_test.$(OBJEXT):  \
 base/unit_tests_oprof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_oprof-point_neighbor_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_oprof-overlapping_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_oprof-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
@@ -2211,6 +2233,8 @@ base/unit_tests_opt-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_opt-point_neighbor_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_opt-overlapping_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_opt-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_opt-fe_clough_test.$(OBJEXT): fe/$(am__dirstamp) \
@@ -2358,6 +2382,8 @@ base/unit_tests_prof-default_coupling_test.$(OBJEXT):  \
 base/unit_tests_prof-getpot_test.$(OBJEXT): base/$(am__dirstamp) \
 	base/$(DEPDIR)/$(am__dirstamp)
 base/unit_tests_prof-point_neighbor_coupling_test.$(OBJEXT):  \
+	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
+base/unit_tests_prof-overlapping_coupling_test.$(OBJEXT):  \
 	base/$(am__dirstamp) base/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_prof-fe_bernstein_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
@@ -2526,22 +2552,27 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_dbg-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_devel-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_oprof-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_opt-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-dof_map_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-getpot_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@base/$(DEPDIR)/unit_tests_prof-point_neighbor_coupling_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-fe_bernstein_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-fe_clough_test.Po@am__quote@ # am--include-marker
@@ -2963,6 +2994,20 @@ base/unit_tests_dbg-point_neighbor_coupling_test.obj: base/point_neighbor_coupli
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/point_neighbor_coupling_test.C' object='base/unit_tests_dbg-point_neighbor_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
+
+base/unit_tests_dbg-overlapping_coupling_test.o: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-overlapping_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Tpo -c -o base/unit_tests_dbg-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_dbg-overlapping_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+
+base/unit_tests_dbg-overlapping_coupling_test.obj: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_dbg-overlapping_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Tpo -c -o base/unit_tests_dbg-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_dbg-overlapping_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_dbg-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
 
 fe/unit_tests_dbg-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_dbg-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_dbg-fe_bernstein_test.Tpo -c -o fe/unit_tests_dbg-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -3930,6 +3975,20 @@ base/unit_tests_devel-point_neighbor_coupling_test.obj: base/point_neighbor_coup
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
 
+base/unit_tests_devel-overlapping_coupling_test.o: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-overlapping_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Tpo -c -o base/unit_tests_devel-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_devel-overlapping_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+
+base/unit_tests_devel-overlapping_coupling_test.obj: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_devel-overlapping_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Tpo -c -o base/unit_tests_devel-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_devel-overlapping_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_devel-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+
 fe/unit_tests_devel-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_devel-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Tpo -c -o fe/unit_tests_devel-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Tpo fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Po
@@ -4895,6 +4954,20 @@ base/unit_tests_oprof-point_neighbor_coupling_test.obj: base/point_neighbor_coup
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/point_neighbor_coupling_test.C' object='base/unit_tests_oprof-point_neighbor_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
+
+base/unit_tests_oprof-overlapping_coupling_test.o: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-overlapping_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Tpo -c -o base/unit_tests_oprof-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_oprof-overlapping_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+
+base/unit_tests_oprof-overlapping_coupling_test.obj: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_oprof-overlapping_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Tpo -c -o base/unit_tests_oprof-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_oprof-overlapping_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_oprof-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
 
 fe/unit_tests_oprof-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_oprof-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_oprof-fe_bernstein_test.Tpo -c -o fe/unit_tests_oprof-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -5862,6 +5935,20 @@ base/unit_tests_opt-point_neighbor_coupling_test.obj: base/point_neighbor_coupli
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
 
+base/unit_tests_opt-overlapping_coupling_test.o: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-overlapping_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Tpo -c -o base/unit_tests_opt-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_opt-overlapping_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+
+base/unit_tests_opt-overlapping_coupling_test.obj: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_opt-overlapping_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Tpo -c -o base/unit_tests_opt-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_opt-overlapping_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_opt-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+
 fe/unit_tests_opt-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_opt-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Tpo -c -o fe/unit_tests_opt-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Tpo fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Po
@@ -6827,6 +6914,20 @@ base/unit_tests_prof-point_neighbor_coupling_test.obj: base/point_neighbor_coupl
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/point_neighbor_coupling_test.C' object='base/unit_tests_prof-point_neighbor_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-point_neighbor_coupling_test.obj `if test -f 'base/point_neighbor_coupling_test.C'; then $(CYGPATH_W) 'base/point_neighbor_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/point_neighbor_coupling_test.C'; fi`
+
+base/unit_tests_prof-overlapping_coupling_test.o: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-overlapping_coupling_test.o -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Tpo -c -o base/unit_tests_prof-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_prof-overlapping_coupling_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-overlapping_coupling_test.o `test -f 'base/overlapping_coupling_test.C' || echo '$(srcdir)/'`base/overlapping_coupling_test.C
+
+base/unit_tests_prof-overlapping_coupling_test.obj: base/overlapping_coupling_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT base/unit_tests_prof-overlapping_coupling_test.obj -MD -MP -MF base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Tpo -c -o base/unit_tests_prof-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Tpo base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='base/overlapping_coupling_test.C' object='base/unit_tests_prof-overlapping_coupling_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o base/unit_tests_prof-overlapping_coupling_test.obj `if test -f 'base/overlapping_coupling_test.C'; then $(CYGPATH_W) 'base/overlapping_coupling_test.C'; else $(CYGPATH_W) '$(srcdir)/base/overlapping_coupling_test.C'; fi`
 
 fe/unit_tests_prof-fe_bernstein_test.o: fe/fe_bernstein_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_prof-fe_bernstein_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_prof-fe_bernstein_test.Tpo -c -o fe/unit_tests_prof-fe_bernstein_test.o `test -f 'fe/fe_bernstein_test.C' || echo '$(srcdir)/'`fe/fe_bernstein_test.C
@@ -7983,22 +8084,27 @@ distclean: distclean-am
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-point_neighbor_coupling_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_clough_test.Po
@@ -8373,22 +8479,27 @@ maintainer-clean: maintainer-clean-am
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_dbg-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_dbg-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_devel-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_devel-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_oprof-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_oprof-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_opt-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_opt-point_neighbor_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-default_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-dof_map_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-getpot_test.Po
+	-rm -f base/$(DEPDIR)/unit_tests_prof-overlapping_coupling_test.Po
 	-rm -f base/$(DEPDIR)/unit_tests_prof-point_neighbor_coupling_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_clough_test.Po

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -300,6 +300,8 @@ protected:
       elem->set_node(3) = _mesh->node_ptr(9);
     }
 
+    _mesh->partitioner() = std::unique_ptr<Partitioner>(new OverlappingTestPartitioner);
+
     _mesh->prepare_for_use();
 
     if (n_refinements > 0)

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -1,0 +1,131 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/equation_systems.h>
+#include <libmesh/replicated_mesh.h>
+#include <libmesh/numeric_vector.h>
+#include <libmesh/dof_map.h>
+#include <libmesh/elem.h>
+#include <libmesh/ghosting_functor.h>
+#include <libmesh/coupling_matrix.h>
+#include <libmesh/quadrature_gauss.h>
+#include <libmesh/linear_implicit_system.h>
+#include <libmesh/mesh_refinement.h>
+#include <libmesh/mesh_modification.h>
+
+
+#include "test_comm.h"
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+using namespace libMesh;
+
+
+// This coupling functor is attempting to mimic in a basic way
+// a particular use case. The idea is that the mesh has overlapping domains
+// (we assume only two in this test) and that the elements are not
+// topologically connected between the overlapping domains, but when the user
+// solves their problem, some dofs on are coupled between the overlapping
+// elements. So we want to exercise the GhostingFunctor for this scenario,
+// in particular both algebraic ghosting (dof ghosting) and coupling
+// ghosting (sparsity pattern). In the use case, the coupling happens at
+// quadrature points, so we look for the overlap based on the quadrature points.
+//
+// Additionally, the use case also has an issue that the coupling functor
+// cannot be added until after the System is initialized because the overlap
+// depends on the solution. So we will exercise that case as well.
+class OverlappingCouplingFunctor : public GhostingFunctor
+{
+  public:
+
+  OverlappingCouplingFunctor( System & system )
+    : GhostingFunctor(),
+      _system(system),
+      _mesh(system.get_mesh()),
+      _point_locator(system.get_mesh().sub_point_locator()),
+      _coupling_matrix(nullptr)
+  {
+    // This is a highly specalized coupling functor where we are assuming
+    // only two subdomains that are overlapping so make sure there's only two.
+    CPPUNIT_ASSERT_EQUAL(2, (int)_mesh.n_subdomains());
+
+    // We're assuming a specific set of subdomain ids
+    std::set<subdomain_id_type> ids;
+    _mesh.subdomain_ids(ids);
+    CPPUNIT_ASSERT( ids.find(1) != ids.end() );
+    CPPUNIT_ASSERT( ids.find(2) != ids.end() );
+
+    _point_locator->enable_out_of_mesh_mode();
+  }
+
+  virtual ~OverlappingCouplingFunctor(){};
+
+  void set_coupling_matrix (std::unique_ptr<CouplingMatrix> & coupling_matrix)
+  { _coupling_matrix = std::move(coupling_matrix); }
+
+  virtual void operator()
+  (const MeshBase::const_element_iterator & range_begin,
+   const MeshBase::const_element_iterator & range_end,
+   processor_id_type p,
+   std::unordered_map<const Elem *,const CouplingMatrix*> & coupled_elements) override
+  {
+
+    for( const auto & elem : as_range(range_begin,range_end) )
+      {
+        std::set<subdomain_id_type> allowed_subdomains;
+        unsigned int var = 0;
+        if( elem->subdomain_id() == 1 )
+          {
+            var = _system.variable_number("V");
+            allowed_subdomains.insert(2);
+          }
+        else if( elem->subdomain_id() == 2 )
+          {
+            var = _system.variable_number("U");
+            allowed_subdomains.insert(1);
+          }
+        else
+          CPPUNIT_FAIL("Something bad happpend");
+
+        unsigned int dim = 2;
+        FEType fe_type = _system.variable_type(var);
+        std::unique_ptr<FEBase> fe (FEBase::build(dim, fe_type));
+        QGauss qrule (dim, fe_type.default_quadrature_order());
+        fe->attach_quadrature_rule (&qrule);
+
+        const std::vector<libMesh::Point> & qpoints = fe->get_xyz();
+
+        fe->reinit(elem);
+
+        for ( const auto & qp : qpoints )
+          {
+            const Elem * overlapping_elem = (*_point_locator)( qp, &allowed_subdomains );
+
+            if( overlapping_elem && overlapping_elem->processor_id() != p )
+              coupled_elements.insert( std::make_pair(overlapping_elem,_coupling_matrix.get()) );
+          }
+      }
+  }
+
+private:
+
+  System & _system;
+
+  const MeshBase & _mesh;
+
+  std::unique_ptr<PointLocatorBase> _point_locator;
+
+  std::unique_ptr<CouplingMatrix> _coupling_matrix;
+};
+


### PR DESCRIPTION
DO NOT MERGE!

This is exposing a failing use case as a unit test to help decipher what's going on.

The first two commits are additions to the DofMap API to facilitate the following use case of the GhostingFunctor. (The physical context for the following is fluid-structure interaction.)

Suppose I have two subdomains that are not topologically connected, but overlap each other. I have different, subdomain-restricted variables declared on each subdomain. The variables on the subdomains are coupled. So I want to use the GhostingFunctor interface to express the algebraic ghosting and the coupling ghosting. However, the ghosting that I want to generate depends on the solution (think deformed solid). So I have to be able to evaluate the solution when the GhostingFunctor is going to be called. Which means that I can't attach the GhostingFunctor until after the System has been initialized. So the idea is to add the DofMap API so that I can attach the GhostingFunctor after the system is initialized, call DofMap::reinit_send_list(), and then reinitialize any ghosted vectors and the sparsity pattern (if doing coupling ghosting). 

In my application, I make the following observations:

1. If I pass an explicit CouplingMatrix, the algebraic ghosting appears to be incorrect.
2. If I pass a null CouplingMatrix, the algebraic ghosting does not throw an error, but I get incorrect results after a linear solve for certain processor counts.

So this WIP explicitly shows issue 1. (I'm hoping if we fix issue 1, issue 2 will also magically get fixed). It fails on the simple 3 element mesh I construct by hand in the test and on 2 (or more) processors. Everything passes on one processor.

The unit test is a little involved (I need the GhostingFunctor mimicing my use case, a Partitioner to make sure it will always trip the algebraic ghosting error by making sure the subdomains always sit on different processors (which gets its own unit testing) and then the actual testing that triggers failures), but it does mimic my use case pretty closely. I'll enrich it a bit more and can clean it up, but wanted to get this put up now so that it at least exposes the failing case.