### PR TITLE
Ignore one more warning with GCC 8.x compilers

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -82,6 +82,9 @@
 #if (__GNUC__ > 6)
 #pragma GCC diagnostic ignored "-Wint-in-bool-context"
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#if (__GNUC__ > 8)
+#pragma GCC diagnostic ignored "-Wparentheses"
+#endif // GCC > 8
 #endif // GCC > 6
 #endif // GCC > 5
 #endif // GCC > 4.5


### PR DESCRIPTION
The trigger comes from BOOST distributions