### PR TITLE
Only skip noncritical partitioning in BoundaryMesh

### DIFF
--- a/tests/mesh/boundary_mesh.C
+++ b/tests/mesh/boundary_mesh.C
@@ -55,15 +55,15 @@ protected:
     MeshTools::Generation::build_square(*_mesh, 3, 5,
                                         0.2, 0.8, 0.2, 0.7, QUAD9);
 
-    // We'll need to skip repartitioning with DistributedMesh for now;
-    // otherwise the boundary meshes' interior parents might get
+    // We'll need to skip most repartitioning with DistributedMesh for
+    // now; otherwise the boundary meshes' interior parents might get
     // shuffled off to different processors.
     if (!_mesh->is_serial())
       {
-        _mesh->skip_partitioning(true);
-        _left_boundary_mesh->skip_partitioning(true);
-        _all_boundary_mesh->skip_partitioning(true);
-        _internal_boundary_mesh->skip_partitioning(true);
+        _mesh->skip_noncritical_partitioning(true);
+        _left_boundary_mesh->skip_noncritical_partitioning(true);
+        _all_boundary_mesh->skip_noncritical_partitioning(true);
+        _internal_boundary_mesh->skip_noncritical_partitioning(true);
       }
 
     // Set subdomain ids for specific elements. This allows us to later


### PR DESCRIPTION
Under the new skip_partitioning semantics, on a DistributedMesh we
don't appear to be getting even *initial* nodal partitioning into a
valid state.

This is one of (and if we're really really lucky the only one of) the bugs that seems to be throwing current DistributedMesh sweeps for a loop, foiling #1938 and #2088 tests.

While the initial CI sweeps are running on this fix, I'll start digging for any other ```skip_repartitioning()``` uses that need to be converted to ```skip_noncritical_repartitioning()``` to conform to the change in #2061