### PR TITLE
Fix remote_elem copying in UnstructuredMesh

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -133,10 +133,6 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
 
         el->subdomain_id() = old->subdomain_id();
 
-        for (auto s : old->side_index_range())
-          if (old->neighbor_ptr(s) == remote_elem)
-            el->set_neighbor(s, const_cast<RemoteElem *>(remote_elem));
-
 #ifdef LIBMESH_ENABLE_AMR
         if (old->has_children())
           for (unsigned int c = 0, nc = old->n_children(); c != nc; ++c)
@@ -180,6 +176,9 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
         //Hold onto it
         if (!skip_find_neighbors)
           {
+            for (auto s : old->side_index_range())
+              if (old->neighbor_ptr(s) == remote_elem)
+                el->set_neighbor(s, const_cast<RemoteElem *>(remote_elem));
             this->add_elem(el);
           }
         else
@@ -187,15 +186,13 @@ void UnstructuredMesh::copy_nodes_and_elements(const UnstructuredMesh & other_me
             Elem * new_el = this->add_elem(el);
             old_elems_to_new_elems[old] = new_el;
           }
-
-        // Add the link between the original element and this copy to the map
-        if (skip_find_neighbors)
-          old_elems_to_new_elems[old] = el;
       }
 
     // Loop (again) over the elements to fill in the neighbors
     if (skip_find_neighbors)
       {
+        old_elems_to_new_elems[remote_elem] = const_cast<RemoteElem*>(remote_elem);
+
         for (const auto & old_elem : other_mesh.element_ptr_range())
           {
             Elem * new_elem = old_elems_to_new_elems[old_elem];


### PR DESCRIPTION
We've never been correctly copying remote_elem neighbor links in the
skip_find_neighbors code path (or rather, we've been copying them
correctly and then accidentally *undoing* them), and since #2028
made skip_find_neighbors the default behavior in more code paths, that
bug was starting to be triggered e.g. in the #1938 tests.

This commit gets remote_elem into the old-to-new-elements map so the
skip_find_neighbors code path will recognize it, and removes a bit of
redundancy in the rest of the old-to-new-elements map initialization,
and moves the manual remote_elem-specific copying code into the
!skip_find_neighbors path to avoid redundancy with that.