### PR TITLE
MeshBase::add_elem_integer() API

### DIFF
--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -91,8 +91,11 @@ public:
 #endif
 
   /**
-   * Clear the \p DofMap data structures and return to
-   * a pristine state.
+   * Clear the \p DofMap data structures holding degree of freedom
+   * data.
+   *
+   * If any extra integers are associated with this \p DofObject,
+   * their count and values are unchanged.
    */
   void clear_dofs ();
 
@@ -196,9 +199,35 @@ public:
   unsigned int n_systems() const;
 
   /**
-   *  Sets the number of systems for this \p DofObject
+   * \returns The total number of pseudo-systems associated with this
+   * \p DofObject :
+   * n_systems(), plus one iff \p this->has_extra_integers()
+   */
+  unsigned int n_pseudo_systems() const;
+
+  /**
+   * Sets the number of systems for this \p DofObject.  If this number
+   * is a change, also clears all variable count and DoF indexing
+   * associated with this \p DofObject.
+   *
+   * If any extra integers are associated with this \p DofObject,
+   * their count and values are unchanged.
    */
   void set_n_systems (const unsigned int s);
+
+  /**
+   * Sets the value on this object of the extra integer associated
+   * with \p index, which should have been obtained via a call to \p
+   * MeshBase::add_elem_integer or \p MeshBase::add_node_integer
+   */
+  void set_extra_integer (const unsigned int index, const dof_id_type value);
+
+  /**
+   * Gets the value on this object of the extra integer associated
+   * with \p index, which should have been obtained via a call to \p
+   * MeshBase::add_elem_integer or \p MeshBase::add_node_integer
+   */
+  dof_id_type get_extra_integer (const unsigned int index);
 
   /**
    * Adds an additional system to the \p DofObject
@@ -342,6 +371,23 @@ public:
                           const unsigned int vg) const;
 
   /**
+   * Assigns a set of extra integers to this \p DofObject.  There will
+   * now be \p n_integers associated; this *replaces*, not augments,
+   * any previous count.
+   */
+  void add_extra_integers (const unsigned int n_integers);
+
+  /**
+   * Returns how many extra integers are associated to the \p DofObject
+   */
+  unsigned int n_extra_integers () const;
+
+  /**
+   * Returns whether extra integers are associated to the \p DofObject
+   */
+  bool has_extra_integers () const;
+
+  /**
    * An invalid \p id to distinguish an uninitialized \p DofObject
    */
   static const dof_id_type invalid_id = static_cast<dof_id_type>(-1);
@@ -456,33 +502,47 @@ private:
    * DoF index information.  This is packed into a contiguous buffer of the following format:
    *
    * \verbatim
-   * [ns end_0 end_1 ... end_{ns-2} (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_0
-   *                                (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_1
-   *                                ...
-   *                                (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_{ns-2} ]
+   * [hdr end_0 end_1 ... end_{nps-2} (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_0
+   *                                  (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_1
+   *                                   ...
+   *                                  (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_{nps-2} ]
    * \endverbatim
    *
-   * where 'end_s' is the index past the end of the variable group storage for system \p s.
+   * 'hdr' determines whether this \p DofObject \p has_extra_integers()
+   * associated with it; iff so then it is negative.
    *
-   * \note We specifically do not store the end for the last system - this always _idx_buf.size().
+   * The total number of "pseudo systems" is nps := abs(hdr).
    *
-   * Specifically, consider the case of 4 systems, with 3, 0, 1, 2 variable groups, respectively.  The _idx_buf then looks like:
+   * The total number of true systems is
+   * \verbatim
+   * ns = hdr,            hdr >= 0
+   *    = abs(hdr) - 1,   otherwise.
+   * \endverbatim
+   *
+   * 'end_s' is the index past the end of the variable group (or
+   * integer) storage for (pseudo) system \p s.
+   *
+   * \note We specifically do not store the end for the last (pseudo)
+   * system - this always _idx_buf.size().
+   *
+   * As a first example, consider the case of 4 systems, with 3, 0, 1,
+   * 2 variable groups, respectively.  The _idx_buf then looks like:
    *
    * \verbatim
    * [4 10 10 12 () (ncv_0 idx_0 ncv_1 idx_1 ncv_2 idx_2) () (ncv_0 idx_0) (ncv_0 idx_0 ncv_1 idx_1)]
    * [0  1  2  3         4     5     6     7     8     9         10    11      12    13    14    15]
    * \endverbatim
    *
-   * The ending index is then given by:
+   * The ending index for each (pseudo) system is then given by:
    *
    * \verbatim
-   * end_s = _idx_buf.size(), s == (ns-1),
-   *       = _idx_buf[s+1]    otherwise.
+   * end_s = _idx_buf.size(),                        s == (nps-1),
+   *       = _idx_buf[s+1] + has_extra_integers(),   otherwise.
    * \endverbatim
    *
    * The starting indices are not specifically stored, but rather inferred as follows:
    *
-   * start_s = _idx_buf[s];
+   * start_s = abs(_idx_buf[s])
    *
    * Now, the defining characteristic of the \p VariableGroup is that it supports
    * an arbitrary number of variables of the same type.  At the \p DofObject level, what
@@ -502,6 +562,23 @@ private:
    * *within the system*. So for a system with 2 variable groups, 4 and 8 variables each,
    * the 5th variable in the system is the 1st variable in 2nd variable group.
    * (Now of course 0-base everything...  but you get the idea.)
+   *
+   * When hdr is *negative* when cast to a signed type, then we
+   * interpret that to mean there exists one pseudo-system following
+   * the true systems, one for which the _idx_buf data stores the
+   * values associated with add_extra_integer entries, not ncv and idx
+   * data associated with system variables.  We still return only the
+   * number of true systems for n_systems(), but we report
+   * has_extra_integers() as true iff hdr is negative, and abs(hdr)
+   * will reflect the total number of pseudo-systems, n_systems()+1.
+   *
+   * E.g. if we had added two extra integers to the example case
+   * above, the _idx_buf then looks like:
+   *
+   * \verbatim
+   * [-5 11 11 13 17 () (ncv_0 idx_0 ncv_1 idx_1 ncv_2 idx_2) () (ncv_0 idx_0) (ncv_0 idx_0 ncv_1 idx_1) (xtra1 xtra2)]
+   * [0   1  2  3  4         5     6     7     8     9    10         11    12      13    14    15    16      17    18]
+   * \endverbatim
    */
   typedef dof_id_type index_t;
   typedef std::vector<index_t> index_buffer_t;
@@ -528,6 +605,16 @@ private:
    * The ending index for system \p s.
    */
   unsigned int end_idx(const unsigned int s) const;
+
+  /**
+   * The starting index for an extra_integers pseudosystem
+   */
+  unsigned int start_idx_ints() const;
+
+  /**
+   * The ending index for an extra_integers pseudosystem
+   */
+  unsigned int end_idx_ints() const;
 
   // methods only available for unit testing
 #ifdef LIBMESH_IS_UNIT_TESTING
@@ -620,11 +707,7 @@ void DofObject::invalidate ()
 inline
 void DofObject::clear_dofs ()
 {
-  // vector swap trick to force deallocation
-  index_buffer_t().swap(_idx_buf);
-
-  libmesh_assert_equal_to (this->n_systems(), 0);
-  libmesh_assert (_idx_buf.empty());
+  this->set_n_systems(0);
 }
 
 
@@ -748,8 +831,19 @@ bool DofObject::valid_processor_id () const
 inline
 unsigned int DofObject::n_systems () const
 {
-  return _idx_buf.empty() ?
-    0 : cast_int<unsigned int>(_idx_buf[0]);
+  const int hdr = _idx_buf.empty() ?
+    0 : cast_int<int>(dof_id_signed_type(_idx_buf[0]));
+  return hdr >= 0 ? hdr : (-hdr-1);
+}
+
+
+
+inline
+unsigned int DofObject::n_pseudo_systems () const
+{
+  const int hdr = _idx_buf.empty() ?
+    0 : cast_int<int>(dof_id_signed_type(_idx_buf[0]));
+  return std::abs(hdr);
 }
 
 
@@ -883,6 +977,67 @@ dof_id_type DofObject::dof_number(const unsigned int s,
 
 
 inline
+void
+DofObject::set_extra_integer(const unsigned int index,
+                             const dof_id_type value)
+{
+  libmesh_assert_less(index, this->n_extra_integers());
+  libmesh_assert_less(this->n_pseudo_systems(), _idx_buf.size());
+
+  const unsigned int start_idx_i = this->start_idx_ints();
+
+  libmesh_assert_less(start_idx_i+index, _idx_buf.size());
+  _idx_buf[start_idx_i+index] = value;
+}
+
+
+
+inline
+dof_id_type
+DofObject::get_extra_integer (const unsigned int index)
+{
+  libmesh_assert_less(index, this->n_extra_integers());
+  libmesh_assert_less(this->n_systems(), _idx_buf.size());
+
+  const unsigned int start_idx_i = this->start_idx_ints();
+
+  libmesh_assert_less(start_idx_i+index, _idx_buf.size());
+  return _idx_buf[start_idx_i+index];
+}
+
+
+
+inline
+unsigned int
+DofObject::n_extra_integers () const
+{
+  if (_idx_buf.empty())
+    return 0;
+
+  const int hdr = dof_id_signed_type(_idx_buf[0]);
+  if (hdr >= 0)
+    return 0;
+
+  const unsigned int start_idx_i = this->start_idx_ints();
+
+  return _idx_buf.size() - start_idx_i;
+}
+
+
+
+inline
+bool
+DofObject::has_extra_integers () const
+{
+  if (_idx_buf.empty())
+    return 0;
+
+  return (dof_id_signed_type(_idx_buf[0]) < 0);
+}
+
+
+
+inline
 std::pair<unsigned int, unsigned int>
 DofObject::var_to_vg_and_offset(const unsigned int s,
                                 const unsigned int var) const
@@ -938,7 +1093,7 @@ unsigned int DofObject::start_idx (const unsigned int s) const
   libmesh_assert_less (s, this->n_systems());
   libmesh_assert_less (s, _idx_buf.size());
 
-  return cast_int<unsigned int>(_idx_buf[s]);
+  return cast_int<unsigned int>(std::abs(dof_id_signed_type(_idx_buf[s])));
 }
 
 
@@ -949,9 +1104,33 @@ unsigned int DofObject::end_idx (const unsigned int s) const
   libmesh_assert_less (s, this->n_systems());
   libmesh_assert_less (s, _idx_buf.size());
 
-  return ((s+1) == this->n_systems()) ?
+  return ((s+1) == this->n_pseudo_systems()) ?
     cast_int<unsigned int>(_idx_buf.size()) :
     cast_int<unsigned int>(_idx_buf[s+1]);
+}
+
+
+
+inline
+unsigned int DofObject::start_idx_ints () const
+{
+  libmesh_assert (this->has_extra_integers());
+
+  unsigned int n_sys = this->n_systems();
+
+  libmesh_assert_less(this->n_systems(), _idx_buf.size());
+  return n_sys ? cast_int<unsigned int>(_idx_buf[this->n_systems()]) :
+                 (n_sys+1);
+}
+
+
+
+inline
+unsigned int DofObject::end_idx_ints () const
+{
+  libmesh_assert (this->has_extra_integers());
+
+  return cast_int<unsigned int>(_idx_buf.size());
 }
 
 

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -456,10 +456,10 @@ private:
    * DoF index information.  This is packed into a contiguous buffer of the following format:
    *
    * \verbatim
-   * [ns end_0 end_1 ... end_{ns-1} (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_0
+   * [ns end_0 end_1 ... end_{ns-2} (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_0
    *                                (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_1
    *                                ...
-   *                                (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_ns ]
+   *                                (ncv_0 idx_0 ncv_1 idx_1 ... ncv_nv idx_nv)_{ns-2} ]
    * \endverbatim
    *
    * where 'end_s' is the index past the end of the variable group storage for system \p s.

--- a/include/base/id_types.h
+++ b/include/base/id_types.h
@@ -60,14 +60,21 @@ typedef int16_t boundary_id_type;
 
 // How many bytes do we need to specify DoFObjects?  By default we'll
 // allow for a few billion (each) nodes & elements.
+//
+// We'll need a sign bit in some internal buffers, so let's also
+// define a signed type that we can convert to without loss.
 #if LIBMESH_DOF_ID_BYTES == 1
 typedef uint8_t dof_id_type;
+typedef  int8_t dof_id_signed_type;
 #elif LIBMESH_DOF_ID_BYTES == 2
 typedef uint16_t dof_id_type;
+typedef  int16_t dof_id_signed_type;
 #elif LIBMESH_DOF_ID_BYTES == 8
 typedef uint64_t dof_id_type;
+typedef  int64_t dof_id_signed_type;
 #else // LIBMESH_DOF_ID_BYTES = 4 (default)
 typedef uint32_t dof_id_type;
+typedef  int32_t dof_id_signed_type;
 #endif
 
 

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -734,6 +734,15 @@ public:
   unsigned int add_elem_integer(const std::string & name);
 
   /**
+   * Register an integer datum (of type dof_id_type) to be added to
+   * each node in the mesh.
+   *
+   * \returns The index number for the new datum, or for the existing
+   * datum if one by the same name has already been added.
+   */
+  unsigned int add_node_integer(const std::string & name);
+
+  /**
    * Prepare a newly ecreated (or read) mesh for use.
    * This involves 4 steps:
    *  1.) call \p find_neighbors()
@@ -1519,6 +1528,12 @@ protected:
    * in the mesh
    */
   std::vector<std::string> _elem_integer_names;
+
+  /**
+   * The array of names for integer data associated with each node
+   * in the mesh
+   */
+  std::vector<std::string> _node_integer_names;
 
   /**
    * The default geometric GhostingFunctor, used to implement standard

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -733,6 +733,12 @@ public:
    */
   unsigned int add_elem_integer(const std::string & name);
 
+  /*
+   * \returns The index number for the named extra element integer
+   * datum, which must have already been added.
+   */
+  unsigned int get_elem_integer_index(const std::string & name) const;
+
   /**
    * Register an integer datum (of type dof_id_type) to be added to
    * each node in the mesh.
@@ -741,6 +747,12 @@ public:
    * datum if one by the same name has already been added.
    */
   unsigned int add_node_integer(const std::string & name);
+
+  /*
+   * \returns The index number for the named extra node integer
+   * datum, which must have already been added.
+   */
+  unsigned int get_node_integer_index(const std::string & name) const;
 
   /**
    * Prepare a newly ecreated (or read) mesh for use.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -725,7 +725,16 @@ public:
 #endif
 
   /**
-   * Prepare a newly created (or read) mesh for use.
+   * Register an integer datum (of type dof_id_type) to be added to
+   * each element in the mesh.
+   *
+   * \returns The index number for the new datum, or for the existing
+   * datum if one by the same name has already been added.
+   */
+  unsigned int add_elem_integer(const std::string & name);
+
+  /**
+   * Prepare a newly ecreated (or read) mesh for use.
    * This involves 4 steps:
    *  1.) call \p find_neighbors()
    *  2.) call \p partition()
@@ -1504,6 +1513,12 @@ protected:
    * Mesh::spatial_dimension() for more information.
    */
   unsigned char _spatial_dimension;
+
+  /**
+   * The array of names for integer data associated with each element
+   * in the mesh
+   */
+  std::vector<std::string> _elem_integer_names;
 
   /**
    * The default geometric GhostingFunctor, used to implement standard

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -497,7 +497,7 @@ DofObject::add_extra_integers (const unsigned int n_integers)
     {
       if (n_integers)
         {
-          _idx_buf.resize(n_integers+1);
+          _idx_buf.resize(n_integers+1, DofObject::invalid_id);
           _idx_buf[0] = dof_id_type(-1);
         }
       return;
@@ -514,7 +514,7 @@ DofObject::add_extra_integers (const unsigned int n_integers)
           if (n_integers != old_n_integers)
             {
               // Make or remove space as needed by count change
-              _idx_buf.resize(_idx_buf.size()+n_integers-old_n_integers);
+              _idx_buf.resize(_idx_buf.size()+n_integers-old_n_integers, DofObject::invalid_id);
 
               // The start index for the extra integers is unchanged.
             }
@@ -535,7 +535,7 @@ DofObject::add_extra_integers (const unsigned int n_integers)
             _idx_buf[i]++;
 
           // Append space for extra integers
-          _idx_buf.resize(_idx_buf.size()+n_integers);
+          _idx_buf.resize(_idx_buf.size()+n_integers, DofObject::invalid_id);
         }
     }
 }

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -622,7 +622,6 @@ void DofObject::unpack_indexing(std::vector<largest_id_type>::const_iterator beg
 }
 
 
-// FIXME: it'll be tricky getting this to work with 64-bit dof_id_type
 void
 DofObject::pack_indexing(std::back_insert_iterator<std::vector<largest_id_type>> target) const
 {

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -592,7 +592,8 @@ void DofObject::unpack_indexing(std::vector<largest_id_type>::const_iterator beg
 
   // Check as best we can for internal consistency now
   libmesh_assert(_idx_buf.empty() ||
-                 (std::abs(dof_id_signed_type(_idx_buf[0])) <= _idx_buf.size()));
+                 (std::abs(dof_id_signed_type(_idx_buf[0])) <=
+                  cast_int<dof_id_signed_type>(_idx_buf.size())));
 #ifdef DEBUG
   if (!_idx_buf.empty())
     {

--- a/src/base/dof_object.C
+++ b/src/base/dof_object.C
@@ -165,7 +165,7 @@ void DofObject::set_old_dof_object ()
 void DofObject::set_n_systems (const unsigned int ns)
 {
   const unsigned int old_ns = this->n_systems();
- 
+
   // Check for trivial return
   if (ns == old_ns)
     return;

--- a/src/geom/elem_refinement.C
+++ b/src/geom/elem_refinement.C
@@ -51,6 +51,7 @@ void Elem::refine (MeshRefinement & mesh_refinement)
       _children = new Elem *[nc];
 
       unsigned int parent_p_level = this->p_level();
+      const unsigned int nei = this->n_extra_integers();
       for (unsigned int c = 0; c != nc; c++)
         {
           _children[c] = Elem::build(this->type(), this).release();
@@ -71,6 +72,10 @@ void Elem::refine (MeshRefinement & mesh_refinement)
 
           mesh_refinement.add_elem (current_child);
           current_child->set_n_systems(this->n_systems());
+          libmesh_assert_equal_to (current_child->n_extra_integers(),
+                                   this->n_extra_integers());
+          for (unsigned int i=0; i != nei; ++i)
+            current_child->set_extra_integer(i, this->get_extra_integer(i));
         }
     }
   else

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -519,6 +519,10 @@ Elem * DistributedMesh::add_elem (Elem * e)
   //     }
   // #endif
 
+  // Make sure any new element is given space for any extra integers
+  // we've requested
+  e->add_extra_integers(_elem_integer_names.size());
+
   return e;
 }
 
@@ -552,6 +556,10 @@ Elem * DistributedMesh::insert_elem (Elem * e)
     _n_elem++;
 
   _elements[e->id()] = e;
+
+  // Make sure any new element is given space for any extra integers
+  // we've requested
+  e->add_extra_integers(_elem_integer_names.size());
 
   return e;
 }

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -725,6 +725,7 @@ Node * DistributedMesh::add_node (Node * n)
     }
 #endif
 
+  n->add_extra_integers(_node_integer_names.size());
 
   // Unpartitioned nodes should be added on every processor
   // And shouldn't be added in the same batch as ghost nodes

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -153,6 +153,18 @@ void MeshBase::set_spatial_dimension(unsigned char d)
 
 
 
+unsigned int MeshBase::add_elem_integer(const std::string & name)
+{
+  for (auto i : index_range(_elem_integer_names))
+    if (_elem_integer_names[i] == name)
+      return i;
+
+  _elem_integer_names.push_back(name);
+  return _elem_integer_names.size()-1;
+}
+
+
+
 void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, const bool skip_find_neighbors)
 {
   LOG_SCOPE("prepare_for_use()", "MeshBase");

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -165,6 +165,18 @@ unsigned int MeshBase::add_elem_integer(const std::string & name)
 
 
 
+unsigned int MeshBase::add_node_integer(const std::string & name)
+{
+  for (auto i : index_range(_node_integer_names))
+    if (_node_integer_names[i] == name)
+      return i;
+
+  _node_integer_names.push_back(name);
+  return _node_integer_names.size()-1;
+}
+
+
+
 void MeshBase::prepare_for_use (const bool skip_renumber_nodes_and_elements, const bool skip_find_neighbors)
 {
   LOG_SCOPE("prepare_for_use()", "MeshBase");

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -165,6 +165,18 @@ unsigned int MeshBase::add_elem_integer(const std::string & name)
 
 
 
+unsigned int MeshBase::get_elem_integer_index(const std::string & name) const
+{
+  for (auto i : index_range(_elem_integer_names))
+    if (_elem_integer_names[i] == name)
+      return i;
+
+  libmesh_error_msg("Unknown elem integer " << name);
+  return libMesh::invalid_uint;
+}
+
+
+
 unsigned int MeshBase::add_node_integer(const std::string & name)
 {
   for (auto i : index_range(_node_integer_names))
@@ -173,6 +185,18 @@ unsigned int MeshBase::add_node_integer(const std::string & name)
 
   _node_integer_names.push_back(name);
   return _node_integer_names.size()-1;
+}
+
+
+
+unsigned int MeshBase::get_node_integer_index(const std::string & name) const
+{
+  for (auto i : index_range(_node_integer_names))
+    if (_node_integer_names[i] == name)
+      return i;
+
+  libmesh_error_msg("Unknown node integer " << name);
+  return libMesh::invalid_uint;
 }
 
 

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -311,6 +311,10 @@ Elem * ReplicatedMesh::add_elem (Elem * e)
 
   _elements[id] = e;
 
+  // Make sure any new element is given space for any extra integers
+  // we've requested
+  e->add_extra_integers(_elem_integer_names.size());
+
   return e;
 }
 
@@ -334,6 +338,10 @@ Elem * ReplicatedMesh::insert_elem (Elem * e)
     }
 
   _elements[e->id()] = e;
+
+  // Make sure any new element is given space for any extra integers
+  // we've requested
+  e->add_extra_integers(_elem_integer_names.size());
 
   return e;
 }

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -439,6 +439,8 @@ Node * ReplicatedMesh::add_point (const Point & p,
                       cast_int<dof_id_type>(_nodes.size()-1) : id).release();
       n->processor_id() = proc_id;
 
+      n->add_extra_integers(_node_integer_names.size());
+
 #ifdef LIBMESH_ENABLE_UNIQUE_ID
       if (!n->valid_unique_id())
         n->set_unique_id() = _next_unique_id++;
@@ -470,6 +472,8 @@ Node * ReplicatedMesh::add_node (Node * n)
   if (!n->valid_unique_id())
     n->set_unique_id() = _next_unique_id++;
 #endif
+
+  n->add_extra_integers(_node_integer_names.size());
 
   _nodes.push_back(n);
 
@@ -509,6 +513,8 @@ Node * ReplicatedMesh::insert_node(Node * n)
   if (!n->valid_unique_id())
     n->set_unique_id() = _next_unique_id++;
 #endif
+
+  n->add_extra_integers(_node_integer_names.size());
 
   // We have enough space and this spot isn't already occupied by
   // another node, so go ahead and add it.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,6 +48,7 @@ unit_tests_sources = \
   mesh/boundary_info.C \
   mesh/checkpoint.C \
   mesh/contains_point.C \
+  mesh/extra_integers.C \
   mesh/mesh_input.C \
   mesh/mesh_function.C \
   mesh/mixed_dim_mesh_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -195,10 +195,10 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	geom/point_test.C geom/point_test.h geom/side_test.C \
 	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C mesh/mesh_function.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
 	numerics/composite_function_test.C \
@@ -257,6 +257,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_dbg-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_dbg-contains_point.$(OBJEXT) \
+	mesh/unit_tests_dbg-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT) \
@@ -323,10 +324,10 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	geom/point_test.C geom/point_test.h geom/side_test.C \
 	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C mesh/mesh_function.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
 	numerics/composite_function_test.C \
@@ -384,6 +385,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_devel-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_devel-contains_point.$(OBJEXT) \
+	mesh/unit_tests_devel-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT) \
@@ -447,10 +449,10 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	geom/point_test.C geom/point_test.h geom/side_test.C \
 	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C mesh/mesh_function.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
 	numerics/composite_function_test.C \
@@ -508,6 +510,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_oprof-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_oprof-contains_point.$(OBJEXT) \
+	mesh/unit_tests_oprof-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT) \
@@ -571,10 +574,10 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	geom/point_test.C geom/point_test.h geom/side_test.C \
 	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C mesh/mesh_function.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
 	numerics/composite_function_test.C \
@@ -632,6 +635,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_opt-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_opt-contains_point.$(OBJEXT) \
+	mesh/unit_tests_opt-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT) \
@@ -694,10 +698,10 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	geom/point_test.C geom/point_test.h geom/side_test.C \
 	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C mesh/mesh_function.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
 	numerics/composite_function_test.C \
@@ -755,6 +759,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-boundary_info.$(OBJEXT) \
 	mesh/unit_tests_prof-checkpoint.$(OBJEXT) \
 	mesh/unit_tests_prof-contains_point.$(OBJEXT) \
+	mesh/unit_tests_prof-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_function.$(OBJEXT) \
 	mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT) \
@@ -936,6 +941,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-checkpoint.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-contains_point.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-distort.Po \
+	mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po \
@@ -952,6 +958,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-checkpoint.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-contains_point.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-distort.Po \
+	mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po \
@@ -968,6 +975,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-checkpoint.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-contains_point.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-distort.Po \
+	mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po \
@@ -984,6 +992,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-checkpoint.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-contains_point.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-distort.Po \
+	mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po \
@@ -1000,6 +1009,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-checkpoint.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-contains_point.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-distort.Po \
+	mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po \
@@ -1594,10 +1604,10 @@ unit_tests_sources = driver.C test_comm.h stream_redirector.h \
 	geom/point_test.C geom/point_test.h geom/side_test.C \
 	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
 	mesh/boundary_mesh.C mesh/boundary_info.C mesh/checkpoint.C \
-	mesh/contains_point.C mesh/mesh_input.C mesh/mesh_function.C \
-	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
-	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
-	mesh/spatial_dimension_test.C \
+	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
+	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
+	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
+	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
 	numerics/composite_function_test.C \
@@ -1778,6 +1788,8 @@ mesh/unit_tests_dbg-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_dbg-checkpoint.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
@@ -1977,6 +1989,8 @@ mesh/unit_tests_devel-checkpoint.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2126,6 +2140,8 @@ mesh/unit_tests_oprof-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_oprof-checkpoint.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2277,6 +2293,8 @@ mesh/unit_tests_opt-checkpoint.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2426,6 +2444,8 @@ mesh/unit_tests_prof-boundary_info.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_prof-checkpoint.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-contains_point.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2660,6 +2680,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-checkpoint.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-contains_point.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-distort.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po@am__quote@ # am--include-marker
@@ -2676,6 +2697,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-checkpoint.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-contains_point.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-distort.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po@am__quote@ # am--include-marker
@@ -2692,6 +2714,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-checkpoint.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-contains_point.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-distort.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po@am__quote@ # am--include-marker
@@ -2708,6 +2731,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-checkpoint.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-contains_point.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-distort.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po@am__quote@ # am--include-marker
@@ -2724,6 +2748,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-checkpoint.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-contains_point.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-distort.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po@am__quote@ # am--include-marker
@@ -3302,6 +3327,20 @@ mesh/unit_tests_dbg-contains_point.obj: mesh/contains_point.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/contains_point.C' object='mesh/unit_tests_dbg-contains_point.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-contains_point.obj `if test -f 'mesh/contains_point.C'; then $(CYGPATH_W) 'mesh/contains_point.C'; else $(CYGPATH_W) '$(srcdir)/mesh/contains_point.C'; fi`
+
+mesh/unit_tests_dbg-extra_integers.o: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-extra_integers.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Tpo -c -o mesh/unit_tests_dbg-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_dbg-extra_integers.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+
+mesh/unit_tests_dbg-extra_integers.obj: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-extra_integers.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Tpo -c -o mesh/unit_tests_dbg-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_dbg-extra_integers.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
 
 mesh/unit_tests_dbg-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Tpo -c -o mesh/unit_tests_dbg-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
@@ -4283,6 +4322,20 @@ mesh/unit_tests_devel-contains_point.obj: mesh/contains_point.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-contains_point.obj `if test -f 'mesh/contains_point.C'; then $(CYGPATH_W) 'mesh/contains_point.C'; else $(CYGPATH_W) '$(srcdir)/mesh/contains_point.C'; fi`
 
+mesh/unit_tests_devel-extra_integers.o: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-extra_integers.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Tpo -c -o mesh/unit_tests_devel-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_devel-extra_integers.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+
+mesh/unit_tests_devel-extra_integers.obj: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-extra_integers.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Tpo -c -o mesh/unit_tests_devel-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_devel-extra_integers.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+
 mesh/unit_tests_devel-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Tpo -c -o mesh/unit_tests_devel-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po
@@ -5262,6 +5315,20 @@ mesh/unit_tests_oprof-contains_point.obj: mesh/contains_point.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/contains_point.C' object='mesh/unit_tests_oprof-contains_point.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-contains_point.obj `if test -f 'mesh/contains_point.C'; then $(CYGPATH_W) 'mesh/contains_point.C'; else $(CYGPATH_W) '$(srcdir)/mesh/contains_point.C'; fi`
+
+mesh/unit_tests_oprof-extra_integers.o: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-extra_integers.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Tpo -c -o mesh/unit_tests_oprof-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_oprof-extra_integers.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+
+mesh/unit_tests_oprof-extra_integers.obj: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-extra_integers.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Tpo -c -o mesh/unit_tests_oprof-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_oprof-extra_integers.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
 
 mesh/unit_tests_oprof-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Tpo -c -o mesh/unit_tests_oprof-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
@@ -6243,6 +6310,20 @@ mesh/unit_tests_opt-contains_point.obj: mesh/contains_point.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-contains_point.obj `if test -f 'mesh/contains_point.C'; then $(CYGPATH_W) 'mesh/contains_point.C'; else $(CYGPATH_W) '$(srcdir)/mesh/contains_point.C'; fi`
 
+mesh/unit_tests_opt-extra_integers.o: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-extra_integers.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Tpo -c -o mesh/unit_tests_opt-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_opt-extra_integers.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+
+mesh/unit_tests_opt-extra_integers.obj: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-extra_integers.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Tpo -c -o mesh/unit_tests_opt-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_opt-extra_integers.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+
 mesh/unit_tests_opt-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Tpo -c -o mesh/unit_tests_opt-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po
@@ -7223,6 +7304,20 @@ mesh/unit_tests_prof-contains_point.obj: mesh/contains_point.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-contains_point.obj `if test -f 'mesh/contains_point.C'; then $(CYGPATH_W) 'mesh/contains_point.C'; else $(CYGPATH_W) '$(srcdir)/mesh/contains_point.C'; fi`
 
+mesh/unit_tests_prof-extra_integers.o: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-extra_integers.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Tpo -c -o mesh/unit_tests_prof-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_prof-extra_integers.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-extra_integers.o `test -f 'mesh/extra_integers.C' || echo '$(srcdir)/'`mesh/extra_integers.C
+
+mesh/unit_tests_prof-extra_integers.obj: mesh/extra_integers.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-extra_integers.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Tpo -c -o mesh/unit_tests_prof-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Tpo mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/extra_integers.C' object='mesh/unit_tests_prof-extra_integers.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-extra_integers.obj `if test -f 'mesh/extra_integers.C'; then $(CYGPATH_W) 'mesh/extra_integers.C'; else $(CYGPATH_W) '$(srcdir)/mesh/extra_integers.C'; fi`
+
 mesh/unit_tests_prof-mesh_input.o: mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_input.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Tpo -c -o mesh/unit_tests_prof-mesh_input.o `test -f 'mesh/mesh_input.C' || echo '$(srcdir)/'`mesh/mesh_input.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po
@@ -8192,6 +8287,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
@@ -8208,6 +8304,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
@@ -8224,6 +8321,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
@@ -8240,6 +8338,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
@@ -8256,6 +8355,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po
@@ -8587,6 +8687,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
@@ -8603,6 +8704,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
@@ -8619,6 +8721,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
@@ -8635,6 +8738,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
@@ -8651,6 +8755,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-checkpoint.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-contains_point.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-distort.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-extra_integers.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mapped_subdomain_partitioner_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_extruder.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po

--- a/tests/base/dof_object_test.h
+++ b/tests/base/dof_object_test.h
@@ -135,34 +135,70 @@ public:
 
     CPPUNIT_ASSERT_EQUAL( (unsigned int) 9, aobject.n_extra_integers() );
 
+    for (unsigned int i=0; i != 9; ++i)
+      {
+        CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
+        aobject.set_extra_integer(i, i);
+        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      }
+
     aobject.add_extra_integers (6);
 
     CPPUNIT_ASSERT(aobject.has_extra_integers());
 
     CPPUNIT_ASSERT_EQUAL( (unsigned int) 6, aobject.n_extra_integers() );
+
+    for (unsigned int i=0; i != 6; ++i)
+      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
   }
 
   void testSetNSystemsExtraInts()
   {
     DofObject aobject(*instance);
 
-    aobject.add_extra_integers (9);
+    aobject.add_extra_integers (5);
 
     aobject.set_n_systems (10);
 
     CPPUNIT_ASSERT(aobject.has_extra_integers());
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 9, aobject.n_extra_integers() );
+    CPPUNIT_ASSERT_EQUAL( (unsigned int) 5, aobject.n_extra_integers() );
 
     CPPUNIT_ASSERT_EQUAL( (unsigned int) 10, aobject.n_systems() );
 
-    aobject.add_extra_integers (5);
+    for (unsigned int i=0; i != 5; ++i)
+      {
+        CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
+        aobject.set_extra_integer(i, i);
+        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      }
+
+    aobject.add_extra_integers (9);
+
+    for (unsigned int i=0; i != 5; ++i)
+      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+
+    for (unsigned int i=5; i != 9; ++i)
+      CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
 
     aobject.set_n_systems (6);
 
-    CPPUNIT_ASSERT_EQUAL( (unsigned int) 5, aobject.n_extra_integers() );
+    CPPUNIT_ASSERT_EQUAL( (unsigned int) 9, aobject.n_extra_integers() );
+
+    for (unsigned int i=0; i != 5; ++i)
+      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+
+    for (unsigned int i=5; i != 9; ++i)
+      {
+        CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
+        aobject.set_extra_integer(i, i);
+        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      }
 
     CPPUNIT_ASSERT_EQUAL( (unsigned int) 6, aobject.n_systems() );
+
+    for (unsigned int i=0; i != 9; ++i)
+      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
   }
 
   void testSetNVariableGroupsExtraInts()
@@ -172,6 +208,13 @@ public:
     aobject.set_n_systems (2);
 
     aobject.add_extra_integers (5);
+
+    for (unsigned int i=0; i != 5; ++i)
+      {
+        CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
+        aobject.set_extra_integer(i, i);
+        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      }
 
     std::vector<unsigned int> nvpg;
 
@@ -192,6 +235,9 @@ public:
       }
 
     CPPUNIT_ASSERT_EQUAL( (unsigned int) 5, aobject.n_extra_integers() );
+
+    for (unsigned int i=0; i != 5; ++i)
+      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
   }
 
 

--- a/tests/base/dof_object_test.h
+++ b/tests/base/dof_object_test.h
@@ -13,6 +13,9 @@
   CPPUNIT_TEST( testInvalidateProcId );         \
   CPPUNIT_TEST( testSetNSystems );              \
   CPPUNIT_TEST( testSetNVariableGroups );       \
+  CPPUNIT_TEST( testAddExtraInts );             \
+  CPPUNIT_TEST( testSetNSystemsExtraInts );     \
+  CPPUNIT_TEST( testSetNVariableGroupsExtraInts ); \
   CPPUNIT_TEST( testManualDofCalculation );     \
   CPPUNIT_TEST( testJensEftangBug );
 
@@ -121,6 +124,76 @@ public:
           CPPUNIT_ASSERT_EQUAL( nvpg[vg], aobject.n_vars(s,vg) );
       }
   }
+
+  void testAddExtraInts()
+  {
+    DofObject aobject(*instance);
+
+    aobject.add_extra_integers (9);
+
+    CPPUNIT_ASSERT(aobject.has_extra_integers());
+
+    CPPUNIT_ASSERT_EQUAL( (unsigned int) 9, aobject.n_extra_integers() );
+
+    aobject.add_extra_integers (6);
+
+    CPPUNIT_ASSERT(aobject.has_extra_integers());
+
+    CPPUNIT_ASSERT_EQUAL( (unsigned int) 6, aobject.n_extra_integers() );
+  }
+
+  void testSetNSystemsExtraInts()
+  {
+    DofObject aobject(*instance);
+
+    aobject.add_extra_integers (9);
+
+    aobject.set_n_systems (10);
+
+    CPPUNIT_ASSERT(aobject.has_extra_integers());
+
+    CPPUNIT_ASSERT_EQUAL( (unsigned int) 9, aobject.n_extra_integers() );
+
+    CPPUNIT_ASSERT_EQUAL( (unsigned int) 10, aobject.n_systems() );
+
+    aobject.add_extra_integers (5);
+
+    aobject.set_n_systems (6);
+
+    CPPUNIT_ASSERT_EQUAL( (unsigned int) 5, aobject.n_extra_integers() );
+
+    CPPUNIT_ASSERT_EQUAL( (unsigned int) 6, aobject.n_systems() );
+  }
+
+  void testSetNVariableGroupsExtraInts()
+  {
+    DofObject aobject(*instance);
+
+    aobject.set_n_systems (2);
+
+    aobject.add_extra_integers (5);
+
+    std::vector<unsigned int> nvpg;
+
+    nvpg.push_back(10);
+    nvpg.push_back(20);
+    nvpg.push_back(30);
+
+    aobject.set_n_vars_per_group (0, nvpg);
+    aobject.set_n_vars_per_group (1, nvpg);
+
+    for (unsigned int s=0; s<2; s++)
+      {
+        CPPUNIT_ASSERT_EQUAL( (unsigned int) 60, aobject.n_vars(s) );
+        CPPUNIT_ASSERT_EQUAL( (unsigned int) 3,  aobject.n_var_groups(s) );
+
+        for (unsigned int vg=0; vg<3; vg++)
+          CPPUNIT_ASSERT_EQUAL( nvpg[vg], aobject.n_vars(s,vg) );
+      }
+
+    CPPUNIT_ASSERT_EQUAL( (unsigned int) 5, aobject.n_extra_integers() );
+  }
+
 
   void testManualDofCalculation()
   {

--- a/tests/mesh/extra_integers.C
+++ b/tests/mesh/extra_integers.C
@@ -46,6 +46,8 @@ protected:
 
     // Request some extra integers before building
     unsigned int i1 = mesh.add_elem_integer("i1");
+    unsigned int ni1 = mesh.add_node_integer("ni1");
+    unsigned int ni2 = mesh.add_node_integer("ni2");
 
     MeshTools::Generation::build_line(mesh,
                                       /*nx=*/10,
@@ -60,18 +62,34 @@ protected:
         CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->point(0)(0)*100));
       }
 
+    for (const auto & node : mesh.node_ptr_range())
+      {
+        CPPUNIT_ASSERT_EQUAL(node->n_extra_integers(), 2u);
+        CPPUNIT_ASSERT_EQUAL(node->get_extra_integer(ni1), DofObject::invalid_id);
+        CPPUNIT_ASSERT_EQUAL(node->get_extra_integer(ni2), DofObject::invalid_id);
+      }
+
     // Force (in parallel) a different partitioning - we'll simply put
     // everything on rank 0, which hopefully is not what our default
     // partitioner did!
     mesh.partition(1);
 
     CPPUNIT_ASSERT_EQUAL(i1, mesh.add_elem_integer("i1"));
+    CPPUNIT_ASSERT_EQUAL(ni1, mesh.add_node_integer("ni1"));
+    CPPUNIT_ASSERT_EQUAL(ni2, mesh.add_node_integer("ni2"));
 
     // Make sure we didn't screw up any extra integers thereby.
     for (const auto & elem : mesh.element_ptr_range())
       {
         CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 1u);
         CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->point(0)(0)*100));
+      }
+
+    for (const auto & node : mesh.node_ptr_range())
+      {
+        CPPUNIT_ASSERT_EQUAL(node->n_extra_integers(), 2u);
+        CPPUNIT_ASSERT_EQUAL(node->get_extra_integer(ni1), DofObject::invalid_id);
+        CPPUNIT_ASSERT_EQUAL(node->get_extra_integer(ni2), DofObject::invalid_id);
       }
 
 #ifdef LIBMESH_ENABLE_AMR
@@ -88,6 +106,8 @@ protected:
         else
           {
             CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->point(0)(0)*100));
+            for (auto & node : elem->node_ref_range())
+              CPPUNIT_ASSERT_EQUAL(node.n_extra_integers(), 2u);
           }
       }
 #endif

--- a/tests/mesh/extra_integers.C
+++ b/tests/mesh/extra_integers.C
@@ -1,0 +1,105 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include <libmesh/libmesh.h>
+#include <libmesh/mesh.h>
+#include <libmesh/elem.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/mesh_refinement.h>
+
+#include "test_comm.h"
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+using namespace libMesh;
+
+class ExtraIntegersTest : public CppUnit::TestCase
+{
+  /**
+   * The goal of this test is to verify the ability to add extra
+   * integer storage to a Mesh object, then set and query those extra
+   * integers in the objects within the mesh.
+   */
+public:
+  CPPUNIT_TEST_SUITE( ExtraIntegersTest );
+
+  CPPUNIT_TEST( testExtraIntegersEdge2 );
+
+  CPPUNIT_TEST_SUITE_END();
+
+protected:
+  // Helper function called by the test implementations, saves a few lines of code.
+  void test_helper_1D(ElemType elem_type)
+  {
+    Mesh mesh(*TestCommWorld, /*dim=*/2);
+
+    // Request some extra integers before building
+    unsigned int i1 = mesh.add_elem_integer("i1");
+
+    MeshTools::Generation::build_line(mesh,
+                                      /*nx=*/10,
+                                      /*xmin=*/0., /*xmax=*/1.,
+                                      elem_type);
+
+    for (const auto & elem : mesh.element_ptr_range())
+      {
+        CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 1u);
+        CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), DofObject::invalid_id);
+        elem->set_extra_integer(i1, dof_id_type(elem->point(0)(0)*100));
+        CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->point(0)(0)*100));
+      }
+
+    // Force (in parallel) a different partitioning - we'll simply put
+    // everything on rank 0, which hopefully is not what our default
+    // partitioner did!
+    mesh.partition(1);
+
+    CPPUNIT_ASSERT_EQUAL(i1, mesh.add_elem_integer("i1"));
+
+    // Make sure we didn't screw up any extra integers thereby.
+    for (const auto & elem : mesh.element_ptr_range())
+      {
+        CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 1u);
+        CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->point(0)(0)*100));
+      }
+
+#ifdef LIBMESH_ENABLE_AMR
+    MeshRefinement mr(mesh);
+    mr.uniformly_refine(1);
+
+    // Make sure the old elements have the same integers and the new
+    // elements have be initialized as undefined.
+    for (const auto & elem : mesh.element_ptr_range())
+      {
+        CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 1u);
+        if (elem->level())
+          CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), DofObject::invalid_id);
+        else
+          {
+            CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->point(0)(0)*100));
+          }
+      }
+#endif
+  }
+
+public:
+  void setUp() {}
+
+  void tearDown() {}
+
+  void testExtraIntegersEdge2() { test_helper_1D(EDGE2); }
+};
+
+
+CPPUNIT_TEST_SUITE_REGISTRATION( ExtraIntegersTest );

--- a/tests/mesh/extra_integers.C
+++ b/tests/mesh/extra_integers.C
@@ -101,14 +101,10 @@ protected:
     for (const auto & elem : mesh.element_ptr_range())
       {
         CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 1u);
-        if (elem->level())
-          CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), DofObject::invalid_id);
-        else
-          {
-            CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->point(0)(0)*100));
-            for (auto & node : elem->node_ref_range())
-              CPPUNIT_ASSERT_EQUAL(node.n_extra_integers(), 2u);
-          }
+        CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->top_parent()->point(0)(0)*100));
+        if (!elem->level())
+          for (auto & node : elem->node_ref_range())
+            CPPUNIT_ASSERT_EQUAL(node.n_extra_integers(), 2u);
       }
 #endif
   }


### PR DESCRIPTION
This could use a few more convenience APIs and overloads (looking up an already-added index by name, adding multiple integers in one call), but the basic functionality ought to be sufficiently functional to close #2095, and getting the sneaky _idx_buf work correct was difficult enough that I want to get CI (and @YaqiWang and @friedmud if they have time) taking a look at it right away.

It was passing my own tests fine just a minute ago, so hopefully my interactive rebase cleanup didn't screw anything up and it'll be ready to merge when moosebuild is happy too.