### PR TITLE
Drop long-deprecated Elem APIs.

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -159,15 +159,6 @@ public:
   dof_id_type node_id (const unsigned int i) const;
 
   /**
-   * \returns The global id number of local \p Node \p i.
-   *
-   * \deprecated Use the less ambiguously named node_id() instead.
-   */
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  dof_id_type node (const unsigned int i) const;
-#endif
-
-  /**
    * \returns The local id number of global \p Node id \p i,
    * or \p invalid_uint if Node id \p i is not local.
    */
@@ -203,15 +194,6 @@ public:
    * \returns A writable reference to local \p Node \p i.
    */
   Node & node_ref (const unsigned int i);
-
-  /**
-   * \returns The pointer to local \p Node \p i.
-   *
-   * \deprecated Use the less ambiguously named node_ptr() instead.
-   */
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  Node * get_node (const unsigned int i) const;
-#endif
 
   /**
    * \returns The pointer to local \p Node \p i as a writable reference.
@@ -310,13 +292,6 @@ public:
    * \returns A non-const pointer to the \f$ i^{th} \f$ neighbor of this element.
    */
   Elem * neighbor_ptr (unsigned int i);
-
-  /**
-   * \deprecated Use the const-correct neighbor_ptr() function instead.
-   */
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  Elem * neighbor (const unsigned int i) const;
-#endif
 
   /**
    * Nested "classes" for use iterating over all neighbors of an element.
@@ -806,19 +781,6 @@ public:
   virtual void side_ptr (std::unique_ptr<Elem> & side, const unsigned int i) = 0;
   void side_ptr (std::unique_ptr<const Elem> & side, const unsigned int i) const;
 
-
-  /**
-   * \returns A proxy element coincident with side \p i.
-   *
-   * \deprecated This method will eventually be removed since it
-   * hands back a non-const pointer to a side that could be used to
-   * indirectly modify this.  Please use the the const-correct
-   * side_ptr() function instead.
-   */
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  std::unique_ptr<Elem> side (const unsigned int i) const;
-#endif
-
   /**
    * \returns An element coincident with side \p i wrapped in a smart pointer.
    *
@@ -862,18 +824,6 @@ public:
   void build_side_ptr (std::unique_ptr<const Elem> & side, const unsigned int i) const;
 
   /**
-   * \returns A proxy element coincident with side \p i.
-   *
-   * \deprecated This method will eventually be removed since it
-   * hands back a non-const pointer to a side that could be used to
-   * indirectly modify this.  Please use the the const-correct
-   * build_side_ptr() function instead.
-   */
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  std::unique_ptr<Elem> build_side (const unsigned int i, bool proxy=true) const;
-#endif
-
-  /**
    * \returns An element coincident with edge \p i wrapped in a smart pointer.
    *
    * The element returned is full-ordered.  For example, calling
@@ -888,18 +838,6 @@ public:
    */
   virtual std::unique_ptr<Elem> build_edge_ptr (const unsigned int i) = 0;
   std::unique_ptr<const Elem> build_edge_ptr (const unsigned int i) const;
-
-  /**
-   * Creates an element coincident with edge \p i.
-   *
-   * \deprecated This method will eventually be removed since it
-   * hands back a non-const pointer to an edge that could be used to
-   * indirectly modify this Elem.  Please use the the const-correct
-   * build_edge_ptr() function instead.
-   */
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  std::unique_ptr<Elem> build_edge (const unsigned int i) const;
-#endif
 
   /**
    * \returns The default approximation order for this element type.
@@ -1234,16 +1172,6 @@ public:
    * Do not call if this element has no children, i.e. is active.
    */
   Elem * child_ptr (unsigned int i);
-
-  /**
-   * \returns A non-constant pointer to the \f$ i^{th} \f$ child for this element.
-   *
-   * \deprecated Use the more accurately-named and const correct
-   * child_ptr() function instead.
-   */
-#ifdef LIBMESH_ENABLE_DEPRECATED
-  Elem * child (const unsigned int i) const;
-#endif
 
   /**
    * Nested classes for use iterating over all children of a parent
@@ -2022,17 +1950,6 @@ dof_id_type Elem::node_id (const unsigned int i) const
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-inline
-dof_id_type Elem::node (const unsigned int i) const
-{
-  libmesh_deprecated();
-  return this->node_id(i);
-}
-#endif
-
-
-
 inline
 unsigned int Elem::local_node (const dof_id_type i) const
 {
@@ -2091,23 +2008,6 @@ Node & Elem::node_ref (const unsigned int i)
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-inline
-Node * Elem::get_node (const unsigned int i) const
-{
-  // This const function has incorrectly returned a non-const pointer
-  // for years.  Now that it is reimplemented in terms of the new
-  // interface which does return a const pointer, we need to use a
-  // const_cast to mimic the old (incorrect) behavior.  This function
-  // is now deprecated and eventually will be removed entirely,
-  // obviating the need for this ugly cast.
-  libmesh_deprecated();
-  return const_cast<Node *>(this->node_ptr(i));
-}
-#endif
-
-
-
 inline
 unsigned int Elem::get_node_index (const Node * node_ptr) const
 {
@@ -2163,19 +2063,6 @@ Elem * Elem::neighbor_ptr (unsigned int i)
 
   return _elemlinks[i+1];
 }
-
-
-
-#ifdef LIBMESH_ENABLE_DEPRECATED
-inline
-Elem * Elem::neighbor (const unsigned int i) const
-{
-  // Support the deprecated interface by calling the new,
-  // const-correct interface and casting the result to an Elem *.
-  libmesh_deprecated();
-  return const_cast<Elem *>(this->neighbor_ptr(i));
-}
-#endif
 
 
 
@@ -2297,19 +2184,6 @@ Elem::side_ptr (std::unique_ptr<const Elem> & elem,
 
 
 
-#ifdef LIBMESH_ENABLE_DEPRECATED
-inline
-std::unique_ptr<Elem> Elem::side (const unsigned int i) const
-{
-  // Call the const version of side_ptr(), and const_cast the result.
-  libmesh_deprecated();
-  Elem * s = const_cast<Elem *>(this->side_ptr(i).release());
-  return std::unique_ptr<Elem>(s);
-}
-#endif
-
-
-
 inline
 std::unique_ptr<const Elem>
 Elem::build_side_ptr (const unsigned int i, bool proxy) const
@@ -2334,20 +2208,6 @@ Elem::build_side_ptr (std::unique_ptr<const Elem> & elem,
   me->build_side_ptr(e, i);
   elem.reset(e.release());
 }
-
-
-
-#ifdef LIBMESH_ENABLE_DEPRECATED
-inline
-std::unique_ptr<Elem>
-Elem::build_side (const unsigned int i, bool proxy) const
-{
-  // Call the const version of build_side_ptr(), and const_cast the result.
-  libmesh_deprecated();
-  Elem * s = const_cast<Elem *>(this->build_side_ptr(i, proxy).release());
-  return std::unique_ptr<Elem>(s);
-}
-#endif
 
 
 
@@ -2411,20 +2271,6 @@ Elem::build_edge_ptr (const unsigned int i) const
   const Elem * e = const_cast<const Elem *>(me->build_edge_ptr(i).release());
   return std::unique_ptr<const Elem>(e);
 }
-
-
-
-#ifdef LIBMESH_ENABLE_DEPRECATED
-inline
-std::unique_ptr<Elem>
-Elem::build_edge (const unsigned int i) const
-{
-  // Call the const version of build_edge_ptr(), and const_cast the result.
-  libmesh_deprecated();
-  Elem * e = const_cast<Elem *>(this->build_edge_ptr(i).release());
-  return std::unique_ptr<Elem>(e);
-}
-#endif
 
 
 
@@ -2719,19 +2565,6 @@ Elem * Elem::child_ptr (unsigned int i)
 
   return _children[i];
 }
-
-
-#ifdef LIBMESH_ENABLE_DEPRECATED
-inline
-Elem * Elem::child (const unsigned int i) const
-{
-  // Support the deprecated interface by calling the new,
-  // const-correct interface and casting the result to an Elem *.
-  libmesh_deprecated();
-  return const_cast<Elem *>(this->child_ptr(i));
-}
-#endif
-
 
 
 inline


### PR DESCRIPTION
Seems like a good time to do this since 1.4.0 was released. I don't
think these will ever be truly gone from application codes until we
just remove them, so let's remove them.