### PR TITLE
CheckpointIO support for extra DofObject integers

### DIFF
--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -227,7 +227,7 @@ public:
    * with \p index, which should have been obtained via a call to \p
    * MeshBase::add_elem_integer or \p MeshBase::add_node_integer
    */
-  dof_id_type get_extra_integer (const unsigned int index);
+  dof_id_type get_extra_integer (const unsigned int index) const;
 
   /**
    * Adds an additional system to the \p DofObject
@@ -994,7 +994,7 @@ DofObject::set_extra_integer(const unsigned int index,
 
 inline
 dof_id_type
-DofObject::get_extra_integer (const unsigned int index)
+DofObject::get_extra_integer (const unsigned int index) const
 {
   libmesh_assert_less(index, this->n_extra_integers());
   libmesh_assert_less(this->n_systems(), _idx_buf.size());

--- a/include/mesh/checkpoint_io.h
+++ b/include/mesh/checkpoint_io.h
@@ -158,6 +158,15 @@ public:
   std::string &       version ()       { return _version; }
 
   /**
+   * \returns \p true if the current file has an XDR/XDA version that
+   * matches or exceeds 1.5
+   *
+   * As of this version we encode any extra integer data that has been
+   * attached to a mesh.
+   */
+  bool version_at_least_1_5() const;
+
+  /**
    * Get/Set the processor id or processor ids to use.
    *
    * The default processor_id to use is the processor_id() of the
@@ -292,6 +301,15 @@ private:
    */
   template <typename file_id_type>
   void read_bc_names(Xdr & io, BoundaryInfo & info, bool is_sideset);
+
+  /**
+   * Read extra integers names information
+   */
+  template <typename file_id_type>
+  void read_integers_names
+    (Xdr & io,
+     std::vector<std::string> & node_integer_names,
+     std::vector<std::string> & elem_integer_names);
 
   /**
    * \returns The number of levels of refinement in the active mesh on

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -739,6 +739,19 @@ public:
    */
   unsigned int get_elem_integer_index(const std::string & name) const;
 
+  /*
+   * \returns The name for the indexed extra element integer
+   * datum, which must have already been added.
+   */
+  const std::string & get_elem_integer_name(unsigned int i) const
+  { return _elem_integer_names[i]; }
+
+  /*
+   * \returns The number of extra element integers for which space is
+   * being reserved on this mesh.
+   */
+  unsigned int n_elem_integers() const { return _elem_integer_names.size(); }
+
   /**
    * Register an integer datum (of type dof_id_type) to be added to
    * each node in the mesh.
@@ -753,6 +766,19 @@ public:
    * datum, which must have already been added.
    */
   unsigned int get_node_integer_index(const std::string & name) const;
+
+  /*
+   * \returns The name for the indexed extra node integer
+   * datum, which must have already been added.
+   */
+  const std::string & get_node_integer_name(unsigned int i) const
+  { return _node_integer_names[i]; }
+
+  /*
+   * \returns The number of extra node integers for which space is
+   * being reserved on this mesh.
+   */
+  unsigned int n_node_integers() const { return _node_integer_names.size(); }
 
   /**
    * Prepare a newly ecreated (or read) mesh for use.

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -136,7 +136,11 @@ public:
   BoundaryInfo & get_boundary_info() { return *boundary_info; }
 
   /**
-   * Deletes all the data that are currently stored.
+   * Deletes all the element and node data that is currently stored.
+   *
+   * elem and node extra_integer data is nevertheless *retained* here,
+   * for better compatibility between that feature and older code's
+   * use of MeshBase::clear()
    */
   virtual void clear ();
 

--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -921,7 +921,9 @@ file_id_type CheckpointIO::read_header (const std::string & name)
       this->read_bc_names<file_id_type>(io, boundary_info, false); // nodeset names
 
       // read extra integer names?
+      std::swap(input_version, this->version());
       const bool read_extra_integers = this->version_at_least_1_5();
+      std::swap(input_version, this->version());
 
       if (read_extra_integers)
         this->read_integers_names<file_id_type>

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -291,6 +291,15 @@ void NameBasedIO::write (const std::string & name)
       else if (name.rfind(".nem") < name.size() ||
                name.rfind(".n")   < name.size())
         Nemesis_IO(mymesh).write(name);
+
+      else if (name.rfind(".cpa") < name.size())
+        CheckpointIO(mymesh,false).write(name);
+
+      else if (name.rfind(".cpr") < name.size())
+        CheckpointIO(mymesh,true).write(name);
+
+      else
+        libmesh_error_msg("Couldn't deduce filetype for " << name);
     }
 
   // serial file formats
@@ -364,6 +373,8 @@ void NameBasedIO::write (const std::string & name)
             libMesh::err
               << " ERROR: Unrecognized file extension: " << name
               << "\n   I understand the following:\n\n"
+              << "     *.cpa   -- libMesh ASCII checkpoint format\n"
+              << "     *.cpr   -- libMesh binary checkpoint format,\n"
               << "     *.dat   -- Tecplot ASCII file\n"
               << "     *.e     -- Sandia's ExodusII format\n"
               << "     *.exd   -- Sandia's ExodusII format\n"
@@ -415,7 +426,6 @@ void NameBasedIO::write (const std::string & name)
           mymesh.comm().barrier();
         }
     }
-
 }
 
 

--- a/tests/mesh/extra_integers.C
+++ b/tests/mesh/extra_integers.C
@@ -36,24 +36,45 @@ public:
 
   CPPUNIT_TEST( testExtraIntegersEdge2 );
 
+  CPPUNIT_TEST( testExtraIntegersTri6 );
+
+  CPPUNIT_TEST( testExtraIntegersCheckpointEdge3 );
+
+  CPPUNIT_TEST( testExtraIntegersCheckpointHex8 );
+
   CPPUNIT_TEST_SUITE_END();
 
 protected:
-  // Helper function called by the test implementations, saves a few lines of code.
-  void test_helper_1D(ElemType elem_type)
+  // Helper functions called by the test implementations, saves a few lines of code.
+  std::array<unsigned int, 3>
+    build_mesh(Mesh & mesh, ElemType elem_type, unsigned int n_elem_per_side)
   {
-    Mesh mesh(*TestCommWorld, /*dim=*/2);
-
     // Request some extra integers before building
     unsigned int i1 = mesh.add_elem_integer("i1");
     unsigned int ni1 = mesh.add_node_integer("ni1");
     unsigned int ni2 = mesh.add_node_integer("ni2");
 
-    MeshTools::Generation::build_line(mesh,
-                                      /*nx=*/10,
-                                      /*xmin=*/0., /*xmax=*/1.,
-                                      elem_type);
+    const std::unique_ptr<Elem> test_elem = Elem::build(elem_type);
+    const unsigned int ymax = test_elem->dim() > 1;
+    const unsigned int zmax = test_elem->dim() > 2;
+    const unsigned int ny = ymax * n_elem_per_side;
+    const unsigned int nz = zmax * n_elem_per_side;
 
+    MeshTools::Generation::build_cube (mesh,
+                                       n_elem_per_side,
+                                       ny,
+                                       nz,
+                                       0., 1.,
+                                       0., ymax,
+                                       0., zmax,
+                                       elem_type);
+    return {i1, ni1, ni2};
+  }
+
+
+  void test_and_set_initial_integers
+    (Mesh & mesh, unsigned int i1, unsigned int ni1, unsigned int ni2)
+  {
     for (const auto & elem : mesh.element_ptr_range())
       {
         CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 1u);
@@ -69,6 +90,39 @@ protected:
         CPPUNIT_ASSERT_EQUAL(node->get_extra_integer(ni2), DofObject::invalid_id);
       }
 
+  }
+
+
+  void test_final_integers(Mesh & mesh, unsigned int i1)
+  {
+    // Make sure old (level 0) elements have the same integers and any new
+    // elements have inherited their ancestors' settings
+    for (const auto & elem : mesh.element_ptr_range())
+      {
+        const Elem * top_parent = elem;
+#ifdef LIBMESH_ENABLE_AMR
+        top_parent = elem->top_parent();
+
+        if (!elem->level())
+#endif
+          for (auto & node : elem->node_ref_range())
+            CPPUNIT_ASSERT_EQUAL(node.n_extra_integers(), 2u);
+
+        CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 1u);
+        CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(top_parent->point(0)(0)*100));
+      }
+  }
+
+
+  void test_helper(ElemType elem_type, unsigned int n_elem_per_side)
+  {
+    Mesh mesh(*TestCommWorld);
+
+    std::array<unsigned int, 3> ini = build_mesh(mesh, elem_type, n_elem_per_side);
+    const unsigned int i1 = ini[0], ni1 = ini[1], ni2 = ini[2];
+
+    test_and_set_initial_integers(mesh, i1, ni1, ni2);
+
     // Force (in parallel) a different partitioning - we'll simply put
     // everything on rank 0, which hopefully is not what our default
     // partitioner did!
@@ -79,34 +133,43 @@ protected:
     CPPUNIT_ASSERT_EQUAL(ni2, mesh.add_node_integer("ni2"));
 
     // Make sure we didn't screw up any extra integers thereby.
-    for (const auto & elem : mesh.element_ptr_range())
-      {
-        CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 1u);
-        CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->point(0)(0)*100));
-      }
-
-    for (const auto & node : mesh.node_ptr_range())
-      {
-        CPPUNIT_ASSERT_EQUAL(node->n_extra_integers(), 2u);
-        CPPUNIT_ASSERT_EQUAL(node->get_extra_integer(ni1), DofObject::invalid_id);
-        CPPUNIT_ASSERT_EQUAL(node->get_extra_integer(ni2), DofObject::invalid_id);
-      }
+    test_final_integers(mesh, i1);
 
 #ifdef LIBMESH_ENABLE_AMR
     MeshRefinement mr(mesh);
     mr.uniformly_refine(1);
 
-    // Make sure the old elements have the same integers and the new
-    // elements have be initialized as undefined.
-    for (const auto & elem : mesh.element_ptr_range())
-      {
-        CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 1u);
-        CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(i1), dof_id_type(elem->top_parent()->point(0)(0)*100));
-        if (!elem->level())
-          for (auto & node : elem->node_ref_range())
-            CPPUNIT_ASSERT_EQUAL(node.n_extra_integers(), 2u);
-      }
+    test_final_integers(mesh, i1);
 #endif
+  }
+
+  void checkpoint_helper(ElemType elem_type, unsigned int n_elem_per_side, bool binary)
+  {
+    Mesh mesh(*TestCommWorld);
+
+    std::array<unsigned int, 3> ini = build_mesh(mesh, elem_type, n_elem_per_side);
+    const unsigned int i1 = ini[0], ni1 = ini[1], ni2 = ini[2];
+
+    test_and_set_initial_integers(mesh, i1, ni1, ni2);
+
+    const std::string filename =
+      std::string("extra_integers.cp") + (binary ? "r" : "a");
+
+    mesh.write(filename);
+
+    TestCommWorld->barrier();
+
+    Mesh mesh2(*TestCommWorld);
+
+    mesh2.read(filename);
+
+    // Make sure everything got transferred to the second mesh
+    CPPUNIT_ASSERT_EQUAL(i1, mesh2.add_elem_integer("i1"));
+    CPPUNIT_ASSERT_EQUAL(ni1, mesh2.add_node_integer("ni1"));
+    CPPUNIT_ASSERT_EQUAL(ni2, mesh2.add_node_integer("ni2"));
+
+    // Make sure we didn't screw up any extra integers thereby.
+    test_final_integers(mesh2, i1);
   }
 
 public:
@@ -114,7 +177,14 @@ public:
 
   void tearDown() {}
 
-  void testExtraIntegersEdge2() { test_helper_1D(EDGE2); }
+  void testExtraIntegersEdge2() { test_helper(EDGE2, 5); }
+
+  void testExtraIntegersTri6() { test_helper(TRI6, 4); }
+
+  void testExtraIntegersCheckpointEdge3() { checkpoint_helper(EDGE3, 5, false); }
+
+  void testExtraIntegersCheckpointHex8() { checkpoint_helper(HEX8, 2, true); }
+
 };
 
 


### PR DESCRIPTION
If this works, it should *actually* close #2095 

My brain is pretty frazzled right now, so it probably doesn't work yet and shouldn't be merged until it gets some test coverage; I just want to let CI and @YaqiWang get an early look before I get started on unit tests.