### PR TITLE
Forward declare DualNumber in order to use DenseMatrix<DualNumber>

### DIFF
--- a/include/numerics/dense_matrix.h
+++ b/include/numerics/dense_matrix.h
@@ -34,6 +34,23 @@
 #include <vector>
 #include <algorithm>
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
+namespace MetaPhysicL
+{
+template <typename, typename>
+class DualNumber;
+}
+namespace std
+{
+// These declarations must be visible to the DenseMatrix method declarations that use
+// a std::abs trailing return type in order to instantiate a DenseMatrix<DualNumber>
+template <typename T, typename D>
+MetaPhysicL::DualNumber<T, D> abs(const MetaPhysicL::DualNumber<T, D> & in);
+template <typename T, typename D>
+MetaPhysicL::DualNumber<T, D> abs(MetaPhysicL::DualNumber<T, D> && in);
+}
+#endif
+
 namespace libMesh
 {
 

--- a/include/numerics/dense_matrix_impl.h
+++ b/include/numerics/dense_matrix_impl.h
@@ -28,6 +28,23 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/libmesh.h"
 
+#ifdef LIBMESH_HAVE_METAPHYSICL
+namespace MetaPhysicL
+{
+template <typename, typename>
+class DualNumber;
+}
+namespace std
+{
+// When instantiating a DenseMatrix<DualNumber> we need these declarations visible
+// in order to compile the DenseMatrix<T>::_cholesky_decompose method
+template <typename T, typename D>
+MetaPhysicL::DualNumber<T, D> sqrt(const MetaPhysicL::DualNumber<T, D> & in);
+template <typename T, typename D>
+MetaPhysicL::DualNumber<T, D> sqrt(MetaPhysicL::DualNumber<T, D> && in);
+}
+#endif
+
 namespace libMesh
 {
 


### PR DESCRIPTION
In order to instantiate a `DenseMatrix<DualNumber>` and not have to worry about header include order, we need these forward declarations.