### PR TITLE
The 'node' variable is now used independently of setting unique ids.

### DIFF
--- a/src/mesh/checkpoint_io.C
+++ b/src/mesh/checkpoint_io.C
@@ -1088,9 +1088,7 @@ void CheckpointIO::read_nodes (Xdr & io)
         }
       else
         {
-#ifdef LIBMESH_ENABLE_UNIQUE_ID
           Node * node =
-#endif
             mesh.add_point(p, id, pid);
 
 #ifdef LIBMESH_ENABLE_UNIQUE_ID


### PR DESCRIPTION
See also: 4ad3d936f9
Refs #2108.

Thanks to @MartinLuethi for pointing this out.