### PR TITLE
DofMap::local_variable_indices() bugfix

### DIFF
--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -1110,7 +1110,7 @@ void DofMap::local_variable_indices(std::vector<dof_id_type> & idx,
             {
               Node & node = elem->node_ref(n);
 
-              if (node.processor_id() < this->processor_id())
+              if (node.processor_id() != this->processor_id())
                 continue;
 
               const unsigned int n_comp = node.n_comp(sys_num, var_num);


### PR DESCRIPTION
If we have anything but the traditional node partitioning, we can have
ghosted nodes owned by either higher or lower ranks than the elements
they're attached to.

Combining this with #2111 fixes #2022 for me.