### PR TITLE
Stop using deprecated API in misc ex14

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
+++ b/examples/miscellaneous/miscellaneous_ex14/miscellaneous_ex14.C
@@ -200,7 +200,7 @@ int main (int argc, char** argv)
       {
         elem->subdomain_id() = 1;
         // the base elements are always the 0-th neighor.
-        elem->neighbor(0)->subdomain_id()=2;
+        elem->neighbor_ptr(0)->subdomain_id()=2;
       }
 
   // find the neighbours; for correct linking the two areas
@@ -576,7 +576,7 @@ void assemble_SchroedingerEquation(EquationSystems &es, const std::string &syste
          unsigned int num_neighbors=0;
 
          for (unsigned int i=0; i<elem->n_neighbors(); i++){
-            if (elem->neighbor(i)->infinite()){
+            if (elem->neighbor_ptr(i)->infinite()){
                num_neighbors++;
             }
          }
@@ -595,14 +595,14 @@ void assemble_SchroedingerEquation(EquationSystems &es, const std::string &syste
             const std::vector<std::vector<Real> >& phi = face_fe->get_phi();
             const std::vector<Point>& normal = face_fe->get_normals();
 
-            Elem* relevant_neighbor=elem->neighbor(prev_neighbor);
+            const Elem* relevant_neighbor=elem->neighbor_ptr(prev_neighbor);
 
             // Get the correct face to the finite element; for thise, continue looping
             // until a neighbor is an infinite element.
             // If none is found, we leave this loop
             for (; prev_neighbor<elem->n_neighbors(); prev_neighbor++){
-               if (elem->neighbor(prev_neighbor)->infinite()){
-                  relevant_neighbor=elem->neighbor(prev_neighbor);
+               if (elem->neighbor_ptr(prev_neighbor)->infinite()){
+                  relevant_neighbor=elem->neighbor_ptr(prev_neighbor);
                   break;
                }
             }


### PR DESCRIPTION
This is another example we're not hitting in CI, apparently.  Looks like it's only active when we have SLEPc and --enable-complex and --enable-ifem so I'm not too surprised.

Refs #2104