### PR TITLE
Fix femsystem ex3 warning w/o Eigen sparse

### DIFF
--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -241,8 +241,8 @@ int main (int argc, char ** argv)
   if( newton_solver &&
       (time_solver == std::string("euler") || time_solver == std::string("euler2") ) )
     {
-      LinearSolver<Number> & linear_solver = newton_solver->get_linear_solver();
 #ifdef LIBMESH_HAVE_EIGEN_SPARSE
+      LinearSolver<Number> & linear_solver = newton_solver->get_linear_solver();
       EigenSparseLinearSolver<Number> * eigen_linear_solver =
         dynamic_cast<EigenSparseLinearSolver<Number> *>(&linear_solver);
 


### PR DESCRIPTION
We could get an unused variable warning here in some configurations
before.