### PR TITLE
Add Communicator::split_by_type()

### DIFF
--- a/include/parallel/communicator.h
+++ b/include/parallel/communicator.h
@@ -65,6 +65,11 @@ class Packing;
 typedef MPI_Comm communicator;
 
 /**
+ * Info object used by some MPI-3 methods
+ */
+typedef MPI_Info info;
+
+/**
  * Processor id meaning "Accept from any source"
  */
 const unsigned int any_source =
@@ -76,6 +81,8 @@ const unsigned int any_source =
 // unique types for function overloading to work
 // properly.
 typedef int communicator; // Must match petsc-nompi definition
+
+typedef int info;
 
 const unsigned int any_source=0;
 
@@ -124,9 +131,16 @@ public:
   ~Communicator ();
 
   /*
-   * Create a new communicator between some subset of \p this
+   * Create a new communicator between some subset of \p this,
+   * based on specified "color"
    */
   void split(int color, int key, Communicator & target) const;
+
+  /*
+   * Create a new communicator between some subset of \p this,
+   * based on specified split "type" (e.g. MPI_COMM_TYPE_SHARED)
+   */
+  void split_by_type(int split_type, int key, info i, Communicator & target) const;
 
   /*
    * Create a new duplicate of \p this communicator

--- a/src/parallel/communicator.C
+++ b/src/parallel/communicator.C
@@ -102,8 +102,27 @@ void Communicator::split(int color, int key, Communicator & target) const
   target._I_duped_it = (color != MPI_UNDEFINED);
   target.send_mode(this->send_mode());
 }
+
+
+void Communicator::split_by_type(int split_type, int key, info i, Communicator & target) const
+{
+  target.clear();
+  MPI_Comm newcomm;
+  libmesh_call_mpi
+    (MPI_Comm_split_type(this->get(), split_type, key, i, &newcomm));
+
+  target.assign(newcomm);
+  target._I_duped_it = (split_type != MPI_UNDEFINED);
+  target.send_mode(this->send_mode());
+}
+
 #else
 void Communicator::split(int, int, Communicator & target) const
+{
+  target.assign(this->get());
+}
+
+void Communicator::split_by_type(int, int, info, Communicator & target) const
 {
   target.assign(this->get());
 }

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -624,6 +624,17 @@ public:
   }
 
 
+  void testSplitByType ()
+  {
+    Parallel::Communicator subcomm;
+    unsigned int rank = TestCommWorld->rank();
+    Parallel::info i;
+    int type = 0;
+#ifdef LIBMESH_HAVE_MPI
+    type = MPI_COMM_TYPE_SHARED;
+#endif
+    TestCommWorld->split_by_type(type, rank, i, subcomm);
+  }
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( ParallelTest );

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -621,6 +621,10 @@ public:
     unsigned int rank = TestCommWorld->rank();
     unsigned int color = rank % 2;
     TestCommWorld->split(color, rank, subcomm);
+
+    CPPUNIT_ASSERT(subcomm.size() >= 1);
+    CPPUNIT_ASSERT(subcomm.size() >= TestCommWorld->size() / 2);
+    CPPUNIT_ASSERT(subcomm.size() <= TestCommWorld->size() / 2 + 1);
   }
 
 
@@ -634,6 +638,9 @@ public:
     type = MPI_COMM_TYPE_SHARED;
 #endif
     TestCommWorld->split_by_type(type, rank, i, subcomm);
+
+    CPPUNIT_ASSERT(subcomm.size() >= 1);
+    CPPUNIT_ASSERT(subcomm.size() <= TestCommWorld->size());
   }
 };
 


### PR DESCRIPTION
I don't have a proper test case for this; hopefully @permcody can catch me if I've missed anything.