### PR TITLE
ExodusII: read all nodesets simultaneously.

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -239,6 +239,13 @@ public:
   void read_nodeset(int id);
 
   /**
+   * New API that reads all nodesets simultaneously. This may be slightly
+   * faster than reading them one at a time. Calls ex_get_concat_node_sets()
+   * under the hood.
+   */
+  void read_all_nodesets();
+
+  /**
    * Closes the \p ExodusII mesh file.
    */
   void close();
@@ -524,6 +531,22 @@ public:
 
   // Number of distribution factors per set
   std::vector<int> num_node_df_per_set;
+
+  // Starting indices for each nodeset in the node_sets_node_list vector.
+  // Used in the calls to ex_{put,get}_concat_node_sets().
+  std::vector<int> node_sets_node_index;
+
+  // Starting indices for each nodeset in the node_sets_dist_fact vector.
+  // Used in the calls to ex_{put,get}_concat_node_sets().
+  std::vector<int> node_sets_dist_index;
+
+  // Node ids for all nodes in nodesets, concatenated together.
+  // Used in the calls to ex_{put,get}_concat_node_sets().
+  std::vector<int> node_sets_node_list;
+
+  // Distribution factors for all nodes in all nodesets, concatenated together.
+  // Used in the calls to ex_{put,get}_concat_node_sets().
+  std::vector<Real> node_sets_dist_fact;
 
   // List of element numbers in all sidesets
   std::vector<int> elem_list;

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -378,7 +378,15 @@ void ExodusII_IO::read (const std::string & fname)
 
   // Read nodeset info
   {
-    exio_helper->read_nodeset_info();
+    // This fills in the following fields of the helper for later use:
+    // nodeset_ids
+    // num_nodes_per_set
+    // num_node_df_per_set
+    // node_sets_node_index
+    // node_sets_dist_index
+    // node_sets_node_list
+    // node_sets_dist_fact
+    exio_helper->read_all_nodesets();
 
     for (int nodeset=0; nodeset<exio_helper->num_node_sets; nodeset++)
       {
@@ -389,10 +397,13 @@ void ExodusII_IO::read (const std::string & fname)
         if (!nodeset_name.empty())
           mesh.get_boundary_info().nodeset_name(nodeset_id) = nodeset_name;
 
-        exio_helper->read_nodeset(nodeset);
+        // Get starting index of node ids for current nodeset.
+        unsigned int offset = exio_helper->node_sets_node_index[nodeset];
 
-        for (const auto & exodus_id : exio_helper->node_list)
+        for (int i=0; i<exio_helper->num_nodes_per_set[nodeset]; ++i)
           {
+            int exodus_id = exio_helper->node_sets_node_list[i + offset];
+
             // As before, the entries in 'node_list' are 1-based
             // indices into the node_num_map array, so we have to map
             // them.  See comment above.


### PR DESCRIPTION
* Add data vectors as class members so they can be used during
  ex_{put,get}_concat_node_sets(). This is consistent with the design
  of the rest of the Exodus helper.
* Use ex_inquire() to pre-size data vectors.
* Use new Helper APIs to read all nodesets simultaneously.
* The old Helper APIs, read_nodeset_info() and read_nodeset(), are
  still used by the Nemesis writer. That could probably be updated as
  well at some point, but not in this PR.
* Counterpart to work in #2132.