### PR TITLE
Deleted two checks that disabled blocks that where more than 1 dimens…

### DIFF
--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -707,10 +707,6 @@ void GmshIO::read_mesh(std::istream & in)
             // libMesh::out << "max_elem_dimension_seen=" << max_elem_dimension_seen << std::endl;
             // libMesh::out << "min_elem_dimension_seen=" << min_elem_dimension_seen << std::endl;
 
-            // If the difference between the max and min element dimension seen is larger than
-            // 1, (e.g. the file has 1D and 3D elements only) we don't handle this case.
-            if (max_elem_dimension_seen - min_elem_dimension_seen > 1)
-              libmesh_error_msg("Cannot handle meshes with dimension mismatch greater than 1.");
 
             // How many different element dimensions did we see while reading from file?
             unsigned n_dims_seen = std::accumulate(elem_dimensions_seen.begin(),
@@ -718,10 +714,6 @@ void GmshIO::read_mesh(std::istream & in)
                                                    static_cast<unsigned>(0),
                                                    std::plus<unsigned>());
 
-            // Have not yet tested a case where 1, 2, and 3D elements are all in the same Mesh,
-            // though it should theoretically be possible to handle.
-            if (n_dims_seen == 3)
-              libmesh_error_msg("Reading meshes with 1, 2, and 3D elements not currently supported.");
 
             // Set mesh_dimension based on the largest element dimension seen.
             mesh.set_mesh_dimension(max_elem_dimension_seen);


### PR DESCRIPTION
I had a 3D mesh with 1D blocks for a MOOSE application and the current gmsh reader wouldn't accept dimensional changes larger than 1 (ex a 2D mesh with 1D blocks or a 3D mesh with 2D blocks). 

Based on the advice of @lindsayad  and @permcody I removed two checks inside of gmsh_io.c. 

I can now verify that the 3D 1D hybrid mesh works with gmsh v2 type meshes. I did not check for the gmsh type 3/4 but I would assume that they would work as well. 