### PR TITLE
Fix for NaNs in block restricted vector variables using PetSc 3.8.3

### DIFF
--- a/src/systems/equation_systems.C
+++ b/src/systems/equation_systems.C
@@ -781,7 +781,7 @@ EquationSystems::build_parallel_solution_vector(const std::set<std::string> * sy
                   // Only do this if this variable has NO DoFs at this node... it might have some from an adjoining element...
                   if (!elem->node_ptr(n)->n_dofs(sys_num, var))
                     for (unsigned int d=0; d < n_vec_dim; d++)
-                      repeat_count.add(nv*(elem->node_id(n)) + (var+d + var_num), 1);
+                      repeat_count.add(nv*(elem->node_id(n)) + (var_inc+d + var_num), 1);
 
             } // end loop over elements
           var_inc += n_vec_dim;


### PR DESCRIPTION
closes #2141