### PR TITLE
Fix buffer size for Exodus

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -840,7 +840,7 @@ void ExodusII_IO_Helper::read_all_nodesets()
   EX_CHECK_ERR(ex_err, "Error reading concatenated nodesets");
 
   // Read the nodeset names from file!
-  char name_buffer[MAX_STR_LENGTH];
+  char name_buffer[MAX_STR_LENGTH+1];
   for (int i=0; i<num_node_sets; ++i)
     {
       ex_err = exII::ex_get_name


### PR DESCRIPTION
Exodus appears to need a buffer of size MAX_STR_LENGTH+1 every time 

Refs #2136