### PR TITLE
Fix formula for computing total quadrature order.

### DIFF
--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -198,9 +198,18 @@ public:
                      unsigned int p_level=0);
 
   /**
-   * \returns The order of the quadrature rule.
+   * \returns The current "total" order of the quadrature rule which
+   * can vary element by element, depending on the Elem::p_level(),
+   * which gets passed to us during init().
+   *
+   * Each additional power of p increases the quadrature order
+   * required to integrate the mass matrix by 2, hence the formula
+   * below.
+   *
+   * \todo This function should also be used in all of the Order
+   * switch statements in the rules themselves.
    */
-  Order get_order() const { return static_cast<Order>(_order + _p_level); }
+  Order get_order() const { return static_cast<Order>(_order + 2 * _p_level); }
 
   /**
    * Prints information relevant to the quadrature rule, by default to


### PR DESCRIPTION
Also update the documentation for this function to explain its purpose
a bit better.

It also occurred to me that we should probably be calling get_order()
in all the various rules' Order switch statements instead of repeating
the same formula over and over, so that will be a topic for another
PR.

Refs #2148.