### PR TITLE
Replace hard-coded formula with get_order()

### DIFF
--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -271,8 +271,7 @@ protected:
    * It is assumed that derived quadrature rules will at least
    * define the init_1D function, therefore it is pure virtual.
    */
-  virtual void init_1D (const ElemType type=INVALID_ELEM,
-                        unsigned int p_level=0) = 0;
+  virtual void init_1D (const ElemType type=INVALID_ELEM) = 0;
 
   /**
    * Initializes the 2D quadrature rule by filling the points and

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -262,7 +262,7 @@ protected:
    * weights vectors with the appropriate values.  Generally this
    * is just one point with weight 1.
    */
-  virtual void init_0D (const ElemType type=INVALID_ELEM);
+  virtual void init_0D ();
 
   /**
    * Initializes the 1D quadrature rule by filling the points and

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -281,8 +281,7 @@ protected:
    * may only be defined in 1D.  If not redefined, gives an
    * error (when \p DEBUG is defined) when called.
    */
-  virtual void init_2D (const ElemType,
-                        unsigned int = 0)
+  virtual void init_2D (const ElemType)
   {
 #ifdef DEBUG
     libmesh_error_msg("ERROR: Seems as if this quadrature rule \nis not implemented for 2D.");

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -281,7 +281,7 @@ protected:
    * may only be defined in 1D.  If not redefined, gives an
    * error (when \p DEBUG is defined) when called.
    */
-  virtual void init_2D (const ElemType)
+  virtual void init_2D ()
   {
 #ifdef DEBUG
     libmesh_error_msg("ERROR: Seems as if this quadrature rule \nis not implemented for 2D.");

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -350,46 +350,6 @@ protected:
   std::vector<Real> _weights;
 };
 
-
-
-// ------------------------------------------------------------
-// QBase class members
-
-inline
-QBase::QBase(unsigned int d,
-             Order o) :
-  allow_rules_with_negative_weights(true),
-  _dim(d),
-  _order(o),
-  _type(INVALID_ELEM),
-  _p_level(0)
-{
-}
-
-
-
-
-inline
-void QBase::print_info(std::ostream & os) const
-{
-  libmesh_assert(!_points.empty());
-  libmesh_assert(!_weights.empty());
-
-  Real summed_weights=0;
-  os << "N_Q_Points=" << this->n_points() << std::endl << std::endl;
-  for (unsigned int qpoint=0; qpoint<this->n_points(); qpoint++)
-    {
-      os << " Point " << qpoint << ":\n"
-         << "  "
-         << _points[qpoint]
-         << "\n Weight:\n "
-         << "  w=" << _weights[qpoint] << "\n" << std::endl;
-
-      summed_weights += _weights[qpoint];
-    }
-  os << "Summed Weights: " << summed_weights << std::endl;
-}
-
 } // namespace libMesh
 
 #endif // LIBMESH_QUADRATURE_H

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -271,7 +271,7 @@ protected:
    * It is assumed that derived quadrature rules will at least
    * define the init_1D function, therefore it is pure virtual.
    */
-  virtual void init_1D (const ElemType type=INVALID_ELEM) = 0;
+  virtual void init_1D () = 0;
 
   /**
    * Initializes the 2D quadrature rule by filling the points and

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -296,7 +296,7 @@ protected:
    * may only be defined in 1D.  If not redefined, gives an
    * error (when \p DEBUG is defined) when called.
    */
-  virtual void init_3D (const ElemType)
+  virtual void init_3D ()
   {
 #ifdef DEBUG
     libmesh_error_msg("ERROR: Seems as if this quadrature rule \nis not implemented for 3D.");

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -278,30 +278,20 @@ protected:
    * weights vectors with the appropriate values.  The order of
    * the rule will be defined by the implementing class.
    * Should not be pure virtual since a derived quadrature rule
-   * may only be defined in 1D.  If not redefined, gives an
-   * error (when \p DEBUG is defined) when called.
+   * may only be defined in 1D.  If not overridden, throws an
+   * error.
    */
-  virtual void init_2D ()
-  {
-#ifdef DEBUG
-    libmesh_error_msg("ERROR: Seems as if this quadrature rule \nis not implemented for 2D.");
-#endif
-  }
+  virtual void init_2D ();
 
   /**
    * Initializes the 3D quadrature rule by filling the points and
    * weights vectors with the appropriate values.  The order of
    * the rule will be defined by the implementing class.
    * Should not be pure virtual since a derived quadrature rule
-   * may only be defined in 1D.  If not redefined, gives an
-   * error (when \p DEBUG is defined) when called.
+   * may only be defined in 1D.  If not overridden, throws an
+   * error.
    */
-  virtual void init_3D ()
-  {
-#ifdef DEBUG
-    libmesh_error_msg("ERROR: Seems as if this quadrature rule \nis not implemented for 3D.");
-#endif
-  }
+  virtual void init_3D ();
 
   /**
    * Constructs a 2D rule from the tensor product of \p q1D with

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -261,8 +261,13 @@ protected:
    * Initializes the 0D quadrature rule by filling the points and
    * weights vectors with the appropriate values.  Generally this
    * is just one point with weight 1.
+   *
+   * \note The arguments should no longer be used for anything in
+   * derived classes, they are only maintained for backwards
+   * compatibility and will eventually be removed.
    */
-  virtual void init_0D ();
+  virtual void init_0D (const ElemType type=INVALID_ELEM,
+                        unsigned int p_level=0);
 
   /**
    * Initializes the 1D quadrature rule by filling the points and
@@ -270,8 +275,13 @@ protected:
    * the rule will be defined by the implementing class.
    * It is assumed that derived quadrature rules will at least
    * define the init_1D function, therefore it is pure virtual.
+   *
+   * \note The arguments should no longer be used for anything in
+   * derived classes, they are only maintained for backwards
+   * compatibility and will eventually be removed.
    */
-  virtual void init_1D () = 0;
+  virtual void init_1D (const ElemType type=INVALID_ELEM,
+                        unsigned int p_level=0) = 0;
 
   /**
    * Initializes the 2D quadrature rule by filling the points and
@@ -280,8 +290,13 @@ protected:
    * Should not be pure virtual since a derived quadrature rule
    * may only be defined in 1D.  If not overridden, throws an
    * error.
+   *
+   * \note The arguments should no longer be used for anything in
+   * derived classes, they are only maintained for backwards
+   * compatibility and will eventually be removed.
    */
-  virtual void init_2D ();
+  virtual void init_2D (const ElemType type=INVALID_ELEM,
+                        unsigned int p_level=0);
 
   /**
    * Initializes the 3D quadrature rule by filling the points and
@@ -290,8 +305,13 @@ protected:
    * Should not be pure virtual since a derived quadrature rule
    * may only be defined in 1D.  If not overridden, throws an
    * error.
+   *
+   * \note The arguments should no longer be used for anything in
+   * derived classes, they are only maintained for backwards
+   * compatibility and will eventually be removed.
    */
-  virtual void init_3D ();
+  virtual void init_3D (const ElemType type=INVALID_ELEM,
+                        unsigned int p_level=0);
 
   /**
    * Constructs a 2D rule from the tensor product of \p q1D with

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -296,8 +296,7 @@ protected:
    * may only be defined in 1D.  If not redefined, gives an
    * error (when \p DEBUG is defined) when called.
    */
-  virtual void init_3D (const ElemType,
-                        unsigned int = 0)
+  virtual void init_3D (const ElemType)
   {
 #ifdef DEBUG
     libmesh_error_msg("ERROR: Seems as if this quadrature rule \nis not implemented for 3D.");

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -262,8 +262,7 @@ protected:
    * weights vectors with the appropriate values.  Generally this
    * is just one point with weight 1.
    */
-  virtual void init_0D (const ElemType type=INVALID_ELEM,
-                        unsigned int p_level=0);
+  virtual void init_0D (const ElemType type=INVALID_ELEM);
 
   /**
    * Initializes the 1D quadrature rule by filling the points and

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -65,8 +65,7 @@ public:
 private:
 
   void init_1D (const ElemType _type=INVALID_ELEM) override;
-  void init_2D (const ElemType _type=INVALID_ELEM,
-                unsigned int p_level=0) override;
+  void init_2D (const ElemType _type=INVALID_ELEM) override;
   void init_3D (const ElemType _type=INVALID_ELEM,
                 unsigned int p_level=0) override;
 };

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -64,9 +64,9 @@ public:
 
 private:
 
-  void init_1D () override;
-  void init_2D () override;
-  void init_3D () override;
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -64,8 +64,7 @@ public:
 
 private:
 
-  void init_1D (const ElemType _type=INVALID_ELEM,
-                unsigned int p_level=0) override;
+  void init_1D (const ElemType _type=INVALID_ELEM) override;
   void init_2D (const ElemType _type=INVALID_ELEM,
                 unsigned int p_level=0) override;
   void init_3D (const ElemType _type=INVALID_ELEM,

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -66,7 +66,7 @@ private:
 
   void init_1D () override;
   void init_2D () override;
-  void init_3D (const ElemType _type=INVALID_ELEM) override;
+  void init_3D () override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -64,7 +64,7 @@ public:
 
 private:
 
-  void init_1D (const ElemType _type=INVALID_ELEM) override;
+  void init_1D () override;
   void init_2D (const ElemType _type=INVALID_ELEM) override;
   void init_3D (const ElemType _type=INVALID_ELEM) override;
 };

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -65,7 +65,7 @@ public:
 private:
 
   void init_1D () override;
-  void init_2D (const ElemType _type=INVALID_ELEM) override;
+  void init_2D () override;
   void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 

--- a/include/quadrature/quadrature_clough.h
+++ b/include/quadrature/quadrature_clough.h
@@ -66,8 +66,7 @@ private:
 
   void init_1D (const ElemType _type=INVALID_ELEM) override;
   void init_2D (const ElemType _type=INVALID_ELEM) override;
-  void init_3D (const ElemType _type=INVALID_ELEM,
-                unsigned int p_level=0) override;
+  void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -72,7 +72,7 @@ private:
   /**
    * The optimal "conical product" rule in 1D is simply Gauss.
    */
-  virtual void init_1D (const ElemType) override;
+  virtual void init_1D () override;
 
   /**
    * The conical product rules are defined in 2D only for Tris.

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -81,7 +81,7 @@ private:
   /**
    * The conical product rules are defined in 3D only for Tets.
    */
-  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_3D () override;
 
   /**
    * Implementation of conical product rule for a Tri in 2D of

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -85,9 +85,9 @@ private:
 
   /**
    * Implementation of conical product rule for a Tri in 2D of
-   * order = _order+2*p.
+   * order get_order().
    */
-  void conical_product_tri(unsigned int p);
+  void conical_product_tri();
 
   /**
    * Implementation of conical product rule for a Tet in 3D of

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -72,8 +72,7 @@ private:
   /**
    * The optimal "conical product" rule in 1D is simply Gauss.
    */
-  virtual void init_1D (const ElemType,
-                        unsigned int = 0) override;
+  virtual void init_1D (const ElemType) override;
 
   /**
    * The conical product rules are defined in 2D only for Tris.

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -70,18 +70,13 @@ public:
 private:
 
   /**
-   * The optimal "conical product" rule in 1D is simply Gauss.
+   * In 1D, use a Gauss rule.
+   * In 2D, the conical product rule is only defined for Tris.
+   * In 3D, the conical product rule is only defined for Tets.
    */
-  virtual void init_1D () override;
-
-  /**
-   * The conical product rules are defined in 2D only for Tris.
-   */
-  virtual void init_2D () override;
-  /**
-   * The conical product rules are defined in 3D only for Tets.
-   */
-  virtual void init_3D () override;
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
 
   /**
    * Implementation of conical product rule for a Tri in 2D of

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -77,8 +77,7 @@ private:
   /**
    * The conical product rules are defined in 2D only for Tris.
    */
-  virtual void init_2D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   /**
    * The conical product rules are defined in 3D only for Tets.
    */

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -81,8 +81,7 @@ private:
   /**
    * The conical product rules are defined in 3D only for Tets.
    */
-  virtual void init_3D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 
   /**
    * Implementation of conical product rule for a Tri in 2D of

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -91,9 +91,9 @@ private:
 
   /**
    * Implementation of conical product rule for a Tet in 3D of
-   * order = _order+2*p.
+   * order get_order().
    */
-  void conical_product_tet(unsigned int p);
+  void conical_product_tet();
 
   /**
    * Implementation of conical product rule for a Pyramid in 3D of

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -97,9 +97,9 @@ private:
 
   /**
    * Implementation of conical product rule for a Pyramid in 3D of
-   * order = _order+2*p.
+   * order get_order().
    */
-  void conical_product_pyramid(unsigned int p);
+  void conical_product_pyramid();
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_conical.h
+++ b/include/quadrature/quadrature_conical.h
@@ -77,7 +77,7 @@ private:
   /**
    * The conical product rules are defined in 2D only for Tris.
    */
-  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_2D () override;
   /**
    * The conical product rules are defined in 3D only for Tets.
    */

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -77,7 +77,7 @@ private:
 
   virtual void init_1D () override;
   virtual void init_2D () override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_3D () override;
 
   /**
    * The Dunavant rules are for triangles. This function takes

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -75,9 +75,9 @@ public:
 
 private:
 
-  virtual void init_1D () override;
-  virtual void init_2D () override;
-  virtual void init_3D () override;
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
 
   /**
    * The Dunavant rules are for triangles. This function takes

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -77,8 +77,7 @@ private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 
   /**
    * The Dunavant rules are for triangles. This function takes

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -75,8 +75,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -75,7 +75,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_1D () override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -76,7 +76,7 @@ public:
 private:
 
   virtual void init_1D () override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_2D () override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 
   /**

--- a/include/quadrature/quadrature_gauss.h
+++ b/include/quadrature/quadrature_gauss.h
@@ -76,8 +76,7 @@ public:
 private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
 

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -65,9 +65,9 @@ public:
 
 private:
 
-  virtual void init_1D () override;
-  virtual void init_2D () override;
-  virtual void init_3D () override;
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -65,8 +65,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -66,8 +66,7 @@ public:
 private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
 };

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -65,7 +65,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_1D () override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -66,7 +66,7 @@ public:
 private:
 
   virtual void init_1D () override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_2D () override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -67,8 +67,7 @@ private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_gauss_lobatto.h
+++ b/include/quadrature/quadrature_gauss_lobatto.h
@@ -67,7 +67,7 @@ private:
 
   virtual void init_1D () override;
   virtual void init_2D () override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_3D () override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -131,7 +131,7 @@ private:
   /**
    * Initialize a 2D GM rule.  Only makes sense for Tris.
    */
-  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_2D () override;
 
   /**
    * Initialize a 3D GM rule.  Only makes sense for Tets.

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -129,15 +129,14 @@ private:
   virtual void init_1D (const ElemType) override;
 
   /**
+   * Initialize a 2D GM rule.  Only makes sense for Tris.
+   */
+  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
+
+  /**
    * Initialize a 3D GM rule.  Only makes sense for Tets.
    */
   virtual void init_3D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
-
-  /**
-   * Initialize a 2D GM rule.  Only makes sense for Tris.
-   */
-  virtual void init_2D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
 
   /**

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -136,8 +136,7 @@ private:
   /**
    * Initialize a 3D GM rule.  Only makes sense for Tets.
    */
-  virtual void init_3D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 
   /**
    * This routine is called from init_2D() and init_3D().  It actually

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -126,8 +126,7 @@ private:
   /**
    * In 1D, simply use a Gauss rule.
    */
-  virtual void init_1D (const ElemType,
-                        unsigned int = 0) override;
+  virtual void init_1D (const ElemType) override;
 
   /**
    * Initialize a 3D GM rule.  Only makes sense for Tets.

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -124,19 +124,13 @@ public:
 private:
 
   /**
-   * In 1D, simply use a Gauss rule.
+   * In 1D, use a Gauss rule.
+   * In 2D, the GM product rule is only defined for Tris.
+   * In 3D, the GM product rule is only defined for Tets.
    */
-  virtual void init_1D () override;
-
-  /**
-   * Initialize a 2D GM rule.  Only makes sense for Tris.
-   */
-  virtual void init_2D () override;
-
-  /**
-   * Initialize a 3D GM rule.  Only makes sense for Tets.
-   */
-  virtual void init_3D () override;
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
 
   /**
    * This routine is called from init_2D() and init_3D().  It actually

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -126,7 +126,7 @@ private:
   /**
    * In 1D, simply use a Gauss rule.
    */
-  virtual void init_1D (const ElemType) override;
+  virtual void init_1D () override;
 
   /**
    * Initialize a 2D GM rule.  Only makes sense for Tris.

--- a/include/quadrature/quadrature_gm.h
+++ b/include/quadrature/quadrature_gm.h
@@ -136,7 +136,7 @@ private:
   /**
    * Initialize a 3D GM rule.  Only makes sense for Tets.
    */
-  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_3D () override;
 
   /**
    * This routine is called from init_2D() and init_3D().  It actually

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -74,9 +74,9 @@ public:
 
 private:
 
-  virtual void init_1D () override;
-  virtual void init_2D () override;
-  virtual void init_3D () override;
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -74,8 +74,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -75,7 +75,7 @@ public:
 private:
 
   virtual void init_1D () override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_2D () override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -75,8 +75,7 @@ public:
 private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
 };

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -74,7 +74,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_1D () override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -76,8 +76,7 @@ private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_grid.h
+++ b/include/quadrature/quadrature_grid.h
@@ -76,7 +76,7 @@ private:
 
   virtual void init_1D () override;
   virtual void init_2D () override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_3D () override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_jacobi.h
+++ b/include/quadrature/quadrature_jacobi.h
@@ -85,7 +85,7 @@ private:
   const unsigned int _alpha;
   const unsigned int _beta;
 
-  virtual void init_1D () override;
+  virtual void init_1D (const ElemType, unsigned int) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_jacobi.h
+++ b/include/quadrature/quadrature_jacobi.h
@@ -85,8 +85,7 @@ private:
   const unsigned int _alpha;
   const unsigned int _beta;
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_jacobi.h
+++ b/include/quadrature/quadrature_jacobi.h
@@ -85,7 +85,7 @@ private:
   const unsigned int _alpha;
   const unsigned int _beta;
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_1D () override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -88,8 +88,7 @@ private:
   /**
    * Just uses a Gauss rule in 1D.
    */
-  virtual void init_1D (const ElemType,
-                        unsigned int =0) override;
+  virtual void init_1D (const ElemType) override;
 
   /**
    * More efficient rules for quadrilaterals.

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -98,8 +98,7 @@ private:
   /**
    * More efficient rules for hexahedra.
    */
-  virtual void init_3D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 
 
 

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -93,7 +93,7 @@ private:
   /**
    * More efficient rules for quadrilaterals.
    */
-  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_2D () override;
 
   /**
    * More efficient rules for hexahedra.

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -86,21 +86,12 @@ public:
 private:
 
   /**
-   * Just uses a Gauss rule in 1D.
+   * Uses a Gauss rule in 1D.  More efficient rules for non tensor
+   * product bases on quadrilaterals and hexahedra.
    */
-  virtual void init_1D () override;
-
-  /**
-   * More efficient rules for quadrilaterals.
-   */
-  virtual void init_2D () override;
-
-  /**
-   * More efficient rules for hexahedra.
-   */
-  virtual void init_3D () override;
-
-
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
 
   /**
    * Wissmann published three interesting "partially symmetric" rules

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -93,8 +93,7 @@ private:
   /**
    * More efficient rules for quadrilaterals.
    */
-  virtual void init_2D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
 
   /**
    * More efficient rules for hexahedra.

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -98,7 +98,7 @@ private:
   /**
    * More efficient rules for hexahedra.
    */
-  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_3D () override;
 
 
 

--- a/include/quadrature/quadrature_monomial.h
+++ b/include/quadrature/quadrature_monomial.h
@@ -88,7 +88,7 @@ private:
   /**
    * Just uses a Gauss rule in 1D.
    */
-  virtual void init_1D (const ElemType) override;
+  virtual void init_1D () override;
 
   /**
    * More efficient rules for quadrilaterals.

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -75,9 +75,9 @@ public:
 
 private:
 
-  virtual void init_1D () override;
-  virtual void init_2D () override;
-  virtual void init_3D () override;
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -77,7 +77,7 @@ private:
 
   virtual void init_1D () override;
   virtual void init_2D () override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_3D () override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -75,7 +75,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_1D () override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -75,8 +75,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -76,8 +76,7 @@ public:
 private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
 };

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -76,7 +76,7 @@ public:
 private:
 
   virtual void init_1D () override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_2D () override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 

--- a/include/quadrature/quadrature_simpson.h
+++ b/include/quadrature/quadrature_simpson.h
@@ -77,8 +77,7 @@ private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -74,9 +74,9 @@ public:
 
 private:
 
-  virtual void init_1D () override;
-  virtual void init_2D () override;
-  virtual void init_3D () override;
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -74,8 +74,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -75,7 +75,7 @@ public:
 private:
 
   virtual void init_1D () override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_2D () override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -75,8 +75,7 @@ public:
 private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_2D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM,
                         unsigned int p_level=0) override;
 };

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -74,7 +74,7 @@ public:
 
 private:
 
-  virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_1D () override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -76,8 +76,7 @@ private:
 
   virtual void init_1D (const ElemType _type=INVALID_ELEM) override;
   virtual void init_2D (const ElemType _type=INVALID_ELEM) override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM,
-                        unsigned int p_level=0) override;
+  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
 };
 
 } // namespace libMesh

--- a/include/quadrature/quadrature_trap.h
+++ b/include/quadrature/quadrature_trap.h
@@ -76,7 +76,7 @@ private:
 
   virtual void init_1D () override;
   virtual void init_2D () override;
-  virtual void init_3D (const ElemType _type=INVALID_ELEM) override;
+  virtual void init_3D () override;
 };
 
 } // namespace libMesh

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -47,7 +47,7 @@ void QBase::init(const ElemType t,
       return;
 
     case 1:
-      this->init_1D(_type);
+      this->init_1D();
 
       return;
 

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -47,7 +47,7 @@ void QBase::init(const ElemType t,
       return;
 
     case 1:
-      this->init_1D(_type,_p_level);
+      this->init_1D(_type);
 
       return;
 

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -110,7 +110,7 @@ void QBase::init (const Elem & elem,
 
 
 
-void QBase::init_0D()
+void QBase::init_0D(const ElemType, unsigned int)
 {
   _points.resize(1);
   _weights.resize(1);
@@ -120,14 +120,14 @@ void QBase::init_0D()
 
 
 
-void QBase::init_2D ()
+void QBase::init_2D (const ElemType, unsigned int)
 {
   libmesh_not_implemented();
 }
 
 
 
-void QBase::init_3D ()
+void QBase::init_3D (const ElemType, unsigned int)
 {
   libmesh_not_implemented();
 }

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -42,7 +42,7 @@ void QBase::init(const ElemType t,
   switch(_dim)
     {
     case 0:
-      this->init_0D(_type);
+      this->init_0D();
 
       return;
 
@@ -78,7 +78,7 @@ void QBase::init (const Elem & elem,
 
 
 
-void QBase::init_0D(const ElemType)
+void QBase::init_0D()
 {
   _points.resize(1);
   _weights.resize(1);

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -24,6 +24,38 @@
 namespace libMesh
 {
 
+QBase::QBase(unsigned int d,
+             Order o) :
+  allow_rules_with_negative_weights(true),
+  _dim(d),
+  _order(o),
+  _type(INVALID_ELEM),
+  _p_level(0)
+{}
+
+
+void QBase::print_info(std::ostream & os) const
+{
+  libmesh_assert(!_points.empty());
+  libmesh_assert(!_weights.empty());
+
+  Real summed_weights=0;
+  os << "N_Q_Points=" << this->n_points() << std::endl << std::endl;
+  for (unsigned int qpoint=0; qpoint<this->n_points(); qpoint++)
+    {
+      os << " Point " << qpoint << ":\n"
+         << "  "
+         << _points[qpoint]
+         << "\n Weight:\n "
+         << "  w=" << _weights[qpoint] << "\n" << std::endl;
+
+      summed_weights += _weights[qpoint];
+    }
+  os << "Summed Weights: " << summed_weights << std::endl;
+}
+
+
+
 void QBase::init(const ElemType t,
                  unsigned int p)
 {

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -88,6 +88,20 @@ void QBase::init_0D()
 
 
 
+void QBase::init_2D ()
+{
+  libmesh_not_implemented();
+}
+
+
+
+void QBase::init_3D ()
+{
+  libmesh_not_implemented();
+}
+
+
+
 void QBase::scale(std::pair<Real, Real> old_range,
                   std::pair<Real, Real> new_range)
 {

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -57,7 +57,7 @@ void QBase::init(const ElemType t,
       return;
 
     case 3:
-      this->init_3D(_type);
+      this->init_3D();
 
       return;
 

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -57,7 +57,7 @@ void QBase::init(const ElemType t,
       return;
 
     case 3:
-      this->init_3D(_type,_p_level);
+      this->init_3D(_type);
 
       return;
 

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -52,7 +52,7 @@ void QBase::init(const ElemType t,
       return;
 
     case 2:
-      this->init_2D(_type,_p_level);
+      this->init_2D(_type);
 
       return;
 

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -42,7 +42,7 @@ void QBase::init(const ElemType t,
   switch(_dim)
     {
     case 0:
-      this->init_0D(_type,_p_level);
+      this->init_0D(_type);
 
       return;
 
@@ -78,8 +78,7 @@ void QBase::init (const Elem & elem,
 
 
 
-void QBase::init_0D(const ElemType,
-                    unsigned int)
+void QBase::init_0D(const ElemType)
 {
   _points.resize(1);
   _weights.resize(1);

--- a/src/quadrature/quadrature.C
+++ b/src/quadrature/quadrature.C
@@ -52,7 +52,7 @@ void QBase::init(const ElemType t,
       return;
 
     case 2:
-      this->init_2D(_type);
+      this->init_2D();
 
       return;
 

--- a/src/quadrature/quadrature_clough_1D.C
+++ b/src/quadrature/quadrature_clough_1D.C
@@ -24,10 +24,10 @@
 namespace libMesh
 {
 
-void QClough::init_1D(const ElemType _elemtype)
+void QClough::init_1D()
 {
   QGauss gauss_rule(1, _order);
-  gauss_rule.init(_elemtype, _p_level);
+  gauss_rule.init(_type, _p_level);
 
   _points.swap(gauss_rule.get_points());
   _weights.swap(gauss_rule.get_weights());

--- a/src/quadrature/quadrature_clough_1D.C
+++ b/src/quadrature/quadrature_clough_1D.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-void QClough::init_1D()
+void QClough::init_1D(const ElemType, unsigned int)
 {
   QGauss gauss_rule(1, _order);
   gauss_rule.init(_type, _p_level);

--- a/src/quadrature/quadrature_clough_1D.C
+++ b/src/quadrature/quadrature_clough_1D.C
@@ -17,8 +17,6 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/quadrature_clough.h"
 #include "libmesh/quadrature_gauss.h"
@@ -26,18 +24,13 @@
 namespace libMesh
 {
 
-
-
-void QClough::init_1D(const ElemType _elemtype,
-                      unsigned int p)
+void QClough::init_1D(const ElemType _elemtype)
 {
   QGauss gauss_rule(1, _order);
-  gauss_rule.init(_elemtype, p);
+  gauss_rule.init(_elemtype, _p_level);
 
   _points.swap(gauss_rule.get_points());
   _weights.swap(gauss_rule.get_weights());
-
-  return;
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_clough_2D.C
+++ b/src/quadrature/quadrature_clough_2D.C
@@ -25,12 +25,11 @@ namespace libMesh
 {
 
 
-void QClough::init_2D(const ElemType type_in,
-                      unsigned int p)
+void QClough::init_2D(const ElemType type_in)
 {
 #if LIBMESH_DIM > 1
   QGauss gauss_rule(2, _order);
-  gauss_rule.init(TRI6, p);
+  gauss_rule.init(TRI6, _p_level);
 
   //-----------------------------------------------------------------------
   // 2D quadrature rules

--- a/src/quadrature/quadrature_clough_2D.C
+++ b/src/quadrature/quadrature_clough_2D.C
@@ -26,7 +26,7 @@ namespace libMesh
 {
 
 
-void QClough::init_2D()
+void QClough::init_2D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM > 1
   QGauss gauss_rule(2, _order);

--- a/src/quadrature/quadrature_clough_2D.C
+++ b/src/quadrature/quadrature_clough_2D.C
@@ -20,12 +20,13 @@
 // Local includes
 #include "libmesh/quadrature_clough.h"
 #include "libmesh/quadrature_gauss.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
 
-void QClough::init_2D(const ElemType type_in)
+void QClough::init_2D()
 {
 #if LIBMESH_DIM > 1
   QGauss gauss_rule(2, _order);
@@ -33,7 +34,7 @@ void QClough::init_2D(const ElemType type_in)
 
   //-----------------------------------------------------------------------
   // 2D quadrature rules
-  switch (type_in)
+  switch (_type)
     {
 
       //---------------------------------------------
@@ -71,7 +72,7 @@ void QClough::init_2D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported type
     default:
-      libmesh_error_msg("Element type not supported!:" << type_in);
+      libmesh_error_msg("Element type not supported: " << Utility::enum_to_string(_type));
     }
 #endif
 }

--- a/src/quadrature/quadrature_clough_3D.C
+++ b/src/quadrature/quadrature_clough_3D.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-void QClough::init_3D()
+void QClough::init_3D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM == 3
   // QClough not supported on any 3D elements

--- a/src/quadrature/quadrature_clough_3D.C
+++ b/src/quadrature/quadrature_clough_3D.C
@@ -24,13 +24,10 @@ namespace libMesh
 {
 
 
-void QClough::init_3D(const ElemType type_in,
-                      unsigned int)
+void QClough::init_3D(const ElemType type_in)
 {
 #if LIBMESH_DIM == 3
 
-  //-----------------------------------------------------------------------
-  // 3D quadrature rules
   switch (type_in)
     {
       // Unsupported type

--- a/src/quadrature/quadrature_clough_3D.C
+++ b/src/quadrature/quadrature_clough_3D.C
@@ -19,21 +19,16 @@
 
 // Local includes
 #include "libmesh/quadrature_clough.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-
-void QClough::init_3D(const ElemType type_in)
+void QClough::init_3D()
 {
 #if LIBMESH_DIM == 3
-
-  switch (type_in)
-    {
-      // Unsupported type
-    default:
-      libmesh_error_msg("ERROR: Unsupported type: " << type_in);
-    }
+  // QClough not supported on any 3D elements
+  libmesh_error_msg("ERROR: Unsupported type: " << Utility::enum_to_string(_type));
 #endif
 }
 

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -100,15 +100,15 @@ void QConical::conical_product_tri()
 // Builds and scales a Gauss rule and a Jacobi rule.
 // Then combines them to compute points and weights
 // of a 3D conical product rule for the Tet.
-void QConical::conical_product_tet(unsigned int p)
+void QConical::conical_product_tet()
 {
   // Be sure the underlying rule object was built with the same dimension as the
   // rule we are about to construct.
   libmesh_assert_equal_to (this->get_dim(), 3);
 
-  QGauss  gauss1D(1,static_cast<Order>(_order+2*p));
-  QJacobi jacA1D(1,static_cast<Order>(_order+2*p),1,0);
-  QJacobi jacB1D(1,static_cast<Order>(_order+2*p),2,0);
+  QGauss  gauss1D(1, get_order());
+  QJacobi jacA1D(1, get_order(), /*alpha=*/1, /*beta=*/0);
+  QJacobi jacB1D(1, get_order(), /*alpha=*/2, /*beta=*/0);
 
   // The Gauss rule needs to be scaled to [0,1]
   std::pair<Real, Real> old_range(-1.0L, 1.0L);

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -35,7 +35,7 @@ QuadratureType QConical::type() const
   return QCONICAL;
 }
 
-void QConical::init_1D()
+void QConical::init_1D(const ElemType, unsigned int)
 {
   QGauss gauss1D(1, get_order());
 

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -35,10 +35,9 @@ QuadratureType QConical::type() const
   return QCONICAL;
 }
 
-void QConical::init_1D(const ElemType /*type_in*/,
-                       unsigned int p)
+void QConical::init_1D(const ElemType /*type_in*/)
 {
-  QGauss gauss1D(1, static_cast<Order>(_order+2*p));
+  QGauss gauss1D(1, get_order());
 
   // Swap points and weights with the about-to-be destroyed rule.
   _points.swap(gauss1D.get_points());

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -35,7 +35,7 @@ QuadratureType QConical::type() const
   return QCONICAL;
 }
 
-void QConical::init_1D(const ElemType /*type_in*/)
+void QConical::init_1D()
 {
   QGauss gauss1D(1, get_order());
 

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -49,14 +49,14 @@ void QConical::init_1D()
 // Builds and scales a Gauss rule and a Jacobi rule.
 // Then combines them to compute points and weights
 // of a 2D conical product rule.
-void QConical::conical_product_tri(unsigned int p)
+void QConical::conical_product_tri()
 {
   // Be sure the underlying rule object was built with the same dimension as the
   // rule we are about to construct.
   libmesh_assert_equal_to (this->get_dim(), 2);
 
-  QGauss  gauss1D(1,static_cast<Order>(_order+2*p));
-  QJacobi jac1D(1,static_cast<Order>(_order+2*p),1,0);
+  QGauss  gauss1D(1, get_order());
+  QJacobi jac1D(1, get_order(), 1, 0);
 
   // The Gauss rule needs to be scaled to [0,1]
   std::pair<Real, Real> old_range(-1.0L, 1.0L);

--- a/src/quadrature/quadrature_conical.C
+++ b/src/quadrature/quadrature_conical.C
@@ -177,14 +177,14 @@ void QConical::conical_product_tet()
 // The integral can now be approximated by the product of three 1D quadrature rules:
 // A Jacobi rule with alpha==2, beta==0 in w, and Gauss rules in v and u.  In this way
 // we can obtain 3D rules to any order for which the 1D rules exist.
-void QConical::conical_product_pyramid(unsigned int p)
+void QConical::conical_product_pyramid()
 {
   // Be sure the underlying rule object was built with the same dimension as the
   // rule we are about to construct.
   libmesh_assert_equal_to (this->get_dim(), 3);
 
-  QGauss  gauss1D(1,static_cast<Order>(_order+2*p));
-  QJacobi jac1D(1,static_cast<Order>(_order+2*p),2,0);
+  QGauss  gauss1D(1, get_order());
+  QJacobi jac1D(1, get_order(), 2, 0);
 
   // These rules should have the same number of points
   libmesh_assert_equal_to (gauss1D.n_points(), jac1D.n_points());

--- a/src/quadrature/quadrature_conical_2D.C
+++ b/src/quadrature/quadrature_conical_2D.C
@@ -25,7 +25,7 @@ namespace libMesh
 
 
 
-void QConical::init_2D()
+void QConical::init_2D(const ElemType, unsigned int)
 {
   switch (_type)
     {

--- a/src/quadrature/quadrature_conical_2D.C
+++ b/src/quadrature/quadrature_conical_2D.C
@@ -18,15 +18,16 @@
 
 // Local includes
 #include "libmesh/quadrature_conical.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
 
 
-void QConical::init_2D(const ElemType type_in)
+void QConical::init_2D()
 {
-  switch (type_in)
+  switch (_type)
     {
     case TRI3:
     case TRI6:
@@ -38,7 +39,7 @@ void QConical::init_2D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported element type
     default:
-      libmesh_error_msg("ERROR: Unsupported element type: " << type_in);
+      libmesh_error_msg("ERROR: Unsupported element type: " << Utility::enum_to_string(_type));
     } // end switch (type_in)
 }
 

--- a/src/quadrature/quadrature_conical_2D.C
+++ b/src/quadrature/quadrature_conical_2D.C
@@ -32,7 +32,7 @@ void QConical::init_2D()
     case TRI3:
     case TRI6:
       {
-        this->conical_product_tri(_p_level);
+        this->conical_product_tri();
         return;
       } // end case TRI3, TRI6
 

--- a/src/quadrature/quadrature_conical_2D.C
+++ b/src/quadrature/quadrature_conical_2D.C
@@ -24,15 +24,14 @@ namespace libMesh
 
 
 
-void QConical::init_2D(const ElemType type_in,
-                       unsigned int p)
+void QConical::init_2D(const ElemType type_in)
 {
   switch (type_in)
     {
     case TRI3:
     case TRI6:
       {
-        this->conical_product_tri(p);
+        this->conical_product_tri(_p_level);
         return;
       } // end case TRI3, TRI6
 

--- a/src/quadrature/quadrature_conical_3D.C
+++ b/src/quadrature/quadrature_conical_3D.C
@@ -24,15 +24,14 @@ namespace libMesh
 
 
 
-void QConical::init_3D(const ElemType type_in,
-                       unsigned int p)
+void QConical::init_3D(const ElemType type_in)
 {
   switch (type_in)
     {
     case TET4:
     case TET10:
       {
-        this->conical_product_tet(p);
+        this->conical_product_tet(_p_level);
         return;
       } // end case TET4, TET10
 
@@ -40,7 +39,7 @@ void QConical::init_3D(const ElemType type_in,
     case PYRAMID13:
     case PYRAMID14:
       {
-        this->conical_product_pyramid(p);
+        this->conical_product_pyramid(_p_level);
         return;
       } // end case PYRAMID5
 

--- a/src/quadrature/quadrature_conical_3D.C
+++ b/src/quadrature/quadrature_conical_3D.C
@@ -23,7 +23,7 @@
 namespace libMesh
 {
 
-void QConical::init_3D()
+void QConical::init_3D(const ElemType, unsigned int)
 {
   switch (_type)
     {

--- a/src/quadrature/quadrature_conical_3D.C
+++ b/src/quadrature/quadrature_conical_3D.C
@@ -18,15 +18,14 @@
 
 // Local includes
 #include "libmesh/quadrature_conical.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-
-
-void QConical::init_3D(const ElemType type_in)
+void QConical::init_3D()
 {
-  switch (type_in)
+  switch (_type)
     {
     case TET4:
     case TET10:
@@ -47,8 +46,8 @@ void QConical::init_3D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported element type
     default:
-      libmesh_error_msg("ERROR: Unsupported element type: " << type_in);
-    } // end switch (type_in)
+      libmesh_error_msg("ERROR: Unsupported element type: " << Utility::enum_to_string(_type));
+    } // end switch (_type)
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_conical_3D.C
+++ b/src/quadrature/quadrature_conical_3D.C
@@ -38,7 +38,7 @@ void QConical::init_3D()
     case PYRAMID13:
     case PYRAMID14:
       {
-        this->conical_product_pyramid(_p_level);
+        this->conical_product_pyramid();
         return;
       } // end case PYRAMID5
 

--- a/src/quadrature/quadrature_conical_3D.C
+++ b/src/quadrature/quadrature_conical_3D.C
@@ -30,7 +30,7 @@ void QConical::init_3D()
     case TET4:
     case TET10:
       {
-        this->conical_product_tet(_p_level);
+        this->conical_product_tet();
         return;
       } // end case TET4, TET10
 

--- a/src/quadrature/quadrature_gauss_1D.C
+++ b/src/quadrature/quadrature_gauss_1D.C
@@ -27,8 +27,7 @@ namespace libMesh
 
 
 
-void QGauss::init_1D(const ElemType,
-                     unsigned int /*p_level*/)
+void QGauss::init_1D(const ElemType)
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules

--- a/src/quadrature/quadrature_gauss_1D.C
+++ b/src/quadrature/quadrature_gauss_1D.C
@@ -28,11 +28,11 @@ namespace libMesh
 
 
 void QGauss::init_1D(const ElemType,
-                     unsigned int p_level)
+                     unsigned int /*p_level*/)
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules
-  switch(_order + 2*p_level)
+  switch(get_order())
     {
     case CONSTANT:
     case FIRST:

--- a/src/quadrature/quadrature_gauss_1D.C
+++ b/src/quadrature/quadrature_gauss_1D.C
@@ -27,7 +27,7 @@ namespace libMesh
 
 
 
-void QGauss::init_1D(const ElemType)
+void QGauss::init_1D()
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules

--- a/src/quadrature/quadrature_gauss_1D.C
+++ b/src/quadrature/quadrature_gauss_1D.C
@@ -27,7 +27,7 @@ namespace libMesh
 
 
 
-void QGauss::init_1D()
+void QGauss::init_1D(const ElemType, unsigned int)
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -25,8 +25,7 @@ namespace libMesh
 {
 
 
-void QGauss::init_2D(const ElemType type_in,
-                     unsigned int p_level)
+void QGauss::init_2D(const ElemType type_in)
 {
 #if LIBMESH_DIM > 1
 
@@ -60,7 +59,7 @@ void QGauss::init_2D(const ElemType type_in,
         //    yx^2   xy^2
         //       x^2y^2
         QGauss q1D(1,_order);
-        q1D.init(EDGE2,p_level);
+        q1D.init(EDGE2, _p_level);
         tensor_product_quad( q1D );
         return;
       }
@@ -1277,7 +1276,7 @@ void QGauss::init_2D(const ElemType type_in,
               // automatically generate using a 1D Gauss rule on
               // [0,1] and two 1D Jacobi-Gauss rules on [0,1].
               QConical conical_rule(2, _order);
-              conical_rule.init(type_in, p_level);
+              conical_rule.init(type_in, _p_level);
 
               // Swap points and weights with the about-to-be destroyed rule.
               _points.swap (conical_rule.get_points() );

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -20,18 +20,19 @@
 // Local includes
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/quadrature_conical.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
 
-void QGauss::init_2D(const ElemType type_in)
+void QGauss::init_2D()
 {
 #if LIBMESH_DIM > 1
 
   //-----------------------------------------------------------------------
   // 2D quadrature rules
-  switch (type_in)
+  switch (_type)
     {
 
 
@@ -1276,7 +1277,7 @@ void QGauss::init_2D(const ElemType type_in)
               // automatically generate using a 1D Gauss rule on
               // [0,1] and two 1D Jacobi-Gauss rules on [0,1].
               QConical conical_rule(2, _order);
-              conical_rule.init(type_in, _p_level);
+              conical_rule.init(_type, _p_level);
 
               // Swap points and weights with the about-to-be destroyed rule.
               _points.swap (conical_rule.get_points() );
@@ -1291,7 +1292,7 @@ void QGauss::init_2D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported type
     default:
-      libmesh_error_msg("Element type not supported!:" << type_in);
+      libmesh_error_msg("Element type not supported:" << Utility::enum_to_string(_type));
     }
 #endif
 }

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -26,7 +26,7 @@ namespace libMesh
 {
 
 
-void QGauss::init_2D()
+void QGauss::init_2D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM > 1
 

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -73,7 +73,7 @@ void QGauss::init_2D(const ElemType type_in,
     case TRI3SUBDIVISION:
     case TRI6:
       {
-        switch(_order + 2*p_level)
+        switch(get_order())
           {
           case CONSTANT:
           case FIRST:

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -26,7 +26,7 @@
 namespace libMesh
 {
 
-void QGauss::init_3D()
+void QGauss::init_3D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM == 3
 

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -25,8 +25,7 @@
 namespace libMesh
 {
 
-void QGauss::init_3D(const ElemType type_in,
-                     unsigned int p_level)
+void QGauss::init_3D(const ElemType type_in)
 {
 #if LIBMESH_DIM == 3
 
@@ -42,11 +41,9 @@ void QGauss::init_3D(const ElemType type_in,
       {
         // We compute the 3D quadrature rule as a tensor
         // product of the 1D quadrature rule.
-        QGauss q1D(1,_order);
-        q1D.init(EDGE2,p_level);
-
+        QGauss q1D(1, _order);
+        q1D.init(EDGE2, _p_level);
         tensor_product_hex( q1D );
-
         return;
       }
 
@@ -169,7 +166,7 @@ void QGauss::init_3D(const ElemType type_in,
                   // product rule is third-order accurate and has less points than
                   // the next-available positive-weight rule at FIFTH order.
                   QConical conical_rule(3, _order);
-                  conical_rule.init(type_in, p_level);
+                  conical_rule.init(type_in, _p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (conical_rule.get_points() );
@@ -469,7 +466,7 @@ void QGauss::init_3D(const ElemType type_in,
                   // to round-off error.  Safest is to disallow rules with negative
                   // weights, but this decision should be made on a case-by-case basis.
                   QGrundmann_Moller gm_rule(3, _order);
-                  gm_rule.init(type_in, p_level);
+                  gm_rule.init(type_in, _p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (gm_rule.get_points() );
@@ -487,7 +484,7 @@ void QGauss::init_3D(const ElemType type_in,
                   // automatically generate using a 1D Gauss rule on
                   // [0,1] and two 1D Jacobi-Gauss rules on [0,1].
                   QConical conical_rule(3, _order);
-                  conical_rule.init(type_in, p_level);
+                  conical_rule.init(type_in, _p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (conical_rule.get_points() );
@@ -515,8 +512,8 @@ void QGauss::init_3D(const ElemType type_in,
         QGauss q2D(2,_order);
 
         // Initialize
-        q1D.init(EDGE2,p_level);
-        q2D.init(TRI3,p_level);
+        q1D.init(EDGE2, _p_level);
+        q2D.init(TRI3, _p_level);
 
         tensor_product_prism(q1D, q2D);
 
@@ -537,7 +534,7 @@ void QGauss::init_3D(const ElemType type_in,
         // from: Stroud, A.H. "Approximate Calculation of Multiple
         // Integrals."
         QConical conical_rule(3, _order);
-        conical_rule.init(type_in, p_level);
+        conical_rule.init(type_in, _p_level);
 
         // Swap points and weights with the about-to-be destroyed rule.
         _points.swap (conical_rule.get_points() );

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -21,17 +21,18 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/quadrature_conical.h"
 #include "libmesh/quadrature_gm.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-void QGauss::init_3D(const ElemType type_in)
+void QGauss::init_3D()
 {
 #if LIBMESH_DIM == 3
 
   //-----------------------------------------------------------------------
   // 3D quadrature rules
-  switch (type_in)
+  switch (_type)
     {
       //---------------------------------------------
       // Hex quadrature rules
@@ -166,7 +167,7 @@ void QGauss::init_3D(const ElemType type_in)
                   // product rule is third-order accurate and has less points than
                   // the next-available positive-weight rule at FIFTH order.
                   QConical conical_rule(3, _order);
-                  conical_rule.init(type_in, _p_level);
+                  conical_rule.init(_type, _p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (conical_rule.get_points() );
@@ -466,7 +467,7 @@ void QGauss::init_3D(const ElemType type_in)
                   // to round-off error.  Safest is to disallow rules with negative
                   // weights, but this decision should be made on a case-by-case basis.
                   QGrundmann_Moller gm_rule(3, _order);
-                  gm_rule.init(type_in, _p_level);
+                  gm_rule.init(_type, _p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (gm_rule.get_points() );
@@ -484,7 +485,7 @@ void QGauss::init_3D(const ElemType type_in)
                   // automatically generate using a 1D Gauss rule on
                   // [0,1] and two 1D Jacobi-Gauss rules on [0,1].
                   QConical conical_rule(3, _order);
-                  conical_rule.init(type_in, _p_level);
+                  conical_rule.init(_type, _p_level);
 
                   // Swap points and weights with the about-to-be destroyed rule.
                   _points.swap (conical_rule.get_points() );
@@ -534,7 +535,7 @@ void QGauss::init_3D(const ElemType type_in)
         // from: Stroud, A.H. "Approximate Calculation of Multiple
         // Integrals."
         QConical conical_rule(3, _order);
-        conical_rule.init(type_in, _p_level);
+        conical_rule.init(_type, _p_level);
 
         // Swap points and weights with the about-to-be destroyed rule.
         _points.swap (conical_rule.get_points() );
@@ -549,7 +550,7 @@ void QGauss::init_3D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported type
     default:
-      libmesh_error_msg("ERROR: Unsupported type: " << type_in);
+      libmesh_error_msg("ERROR: Unsupported type: " << Utility::enum_to_string(_type));
     }
 #endif
 }

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -57,7 +57,7 @@ void QGauss::init_3D(const ElemType type_in,
     case TET4:
     case TET10:
       {
-        switch(_order + 2*p_level)
+        switch(get_order())
           {
             // Taken from pg. 222 of "The finite element method," vol. 1
             // ed. 5 by Zienkiewicz & Taylor
@@ -459,7 +459,7 @@ void QGauss::init_3D(const ElemType type_in,
             // Fall back on Grundmann-Moller or Conical Product rules at high orders.
           default:
             {
-              if ((allow_rules_with_negative_weights) && (_order + 2*p_level < 34))
+              if ((allow_rules_with_negative_weights) && (get_order() < 34))
                 {
                   // The Grundmann-Moller rules are defined to arbitrary order and
                   // can have significantly fewer evaluation points than conical product

--- a/src/quadrature/quadrature_gauss_lobatto_1D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_1D.C
@@ -25,12 +25,11 @@
 namespace libMesh
 {
 
-void QGaussLobatto::init_1D(const ElemType,
-                            unsigned int p)
+void QGaussLobatto::init_1D(const ElemType)
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules
-  switch(_order + 2*p)
+  switch(get_order())
     {
       // Since Gauss-Lobatto rules must include the endpoints of the
       // domain, there is no 1-point rule.  The two-point

--- a/src/quadrature/quadrature_gauss_lobatto_1D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_1D.C
@@ -25,7 +25,7 @@
 namespace libMesh
 {
 
-void QGaussLobatto::init_1D(const ElemType)
+void QGaussLobatto::init_1D()
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules

--- a/src/quadrature/quadrature_gauss_lobatto_1D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_1D.C
@@ -25,7 +25,7 @@
 namespace libMesh
 {
 
-void QGaussLobatto::init_1D()
+void QGaussLobatto::init_1D(const ElemType, unsigned int)
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules

--- a/src/quadrature/quadrature_gauss_lobatto_2D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_2D.C
@@ -19,13 +19,14 @@
 
 // Local includes
 #include "libmesh/quadrature_gauss_lobatto.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-void QGaussLobatto::init_2D(const ElemType type_in)
+void QGaussLobatto::init_2D()
 {
-  switch (type_in)
+  switch (_type)
     {
     case QUAD4:
     case QUADSHELL4:
@@ -46,7 +47,7 @@ void QGaussLobatto::init_2D(const ElemType type_in)
       // for a Gauss-Lobatto rule, i.e. a rule with integration points
       // on the element boundary, for a reason.
     default:
-      libmesh_error_msg("Element type not supported!:" << type_in);
+      libmesh_error_msg("Element type not supported:" << Utility::enum_to_string(_type));
     }
 }
 

--- a/src/quadrature/quadrature_gauss_lobatto_2D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_2D.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-void QGaussLobatto::init_2D()
+void QGaussLobatto::init_2D(const ElemType, unsigned int)
 {
   switch (_type)
     {

--- a/src/quadrature/quadrature_gauss_lobatto_2D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_2D.C
@@ -23,8 +23,7 @@
 namespace libMesh
 {
 
-void QGaussLobatto::init_2D(const ElemType type_in,
-                            unsigned int p)
+void QGaussLobatto::init_2D(const ElemType type_in)
 {
   switch (type_in)
     {
@@ -37,7 +36,7 @@ void QGaussLobatto::init_2D(const ElemType type_in,
         // We compute the 2D quadrature rule as a tensor
         // product of the 1D quadrature rule.
         QGaussLobatto q1D(1, _order);
-        q1D.init(EDGE2, p);
+        q1D.init(EDGE2, _p_level);
         tensor_product_quad(q1D);
         return;
       }

--- a/src/quadrature/quadrature_gauss_lobatto_3D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_3D.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-void QGaussLobatto::init_3D()
+void QGaussLobatto::init_3D(const ElemType, unsigned int)
 {
   switch (_type)
     {

--- a/src/quadrature/quadrature_gauss_lobatto_3D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_3D.C
@@ -19,13 +19,14 @@
 
 // Local includes
 #include "libmesh/quadrature_gauss_lobatto.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-void QGaussLobatto::init_3D(const ElemType type_in)
+void QGaussLobatto::init_3D()
 {
-  switch (type_in)
+  switch (_type)
     {
     case HEX8:
     case HEX20:
@@ -44,7 +45,7 @@ void QGaussLobatto::init_3D(const ElemType type_in)
       // for a Gauss-Lobatto rule, i.e. a rule with integration points
       // on the element boundary, for a reason.
     default:
-      libmesh_error_msg("ERROR: Unsupported type: " << type_in);
+      libmesh_error_msg("ERROR: Unsupported type: " << Utility::enum_to_string(_type));
     }
 }
 

--- a/src/quadrature/quadrature_gauss_lobatto_3D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_3D.C
@@ -23,8 +23,7 @@
 namespace libMesh
 {
 
-void QGaussLobatto::init_3D(const ElemType type_in,
-                            unsigned int p)
+void QGaussLobatto::init_3D(const ElemType type_in)
 {
   switch (type_in)
     {
@@ -35,7 +34,7 @@ void QGaussLobatto::init_3D(const ElemType type_in,
         // We compute the 3D quadrature rule as a tensor
         // product of the 1D quadrature rule.
         QGaussLobatto q1D(1, _order);
-        q1D.init(EDGE2, p);
+        q1D.init(EDGE2, _p_level);
         tensor_product_hex(q1D);
         return;
       }

--- a/src/quadrature/quadrature_gm.C
+++ b/src/quadrature/quadrature_gm.C
@@ -36,10 +36,9 @@ QuadratureType QGrundmann_Moller::type() const
 
 
 
-void QGrundmann_Moller::init_1D(const ElemType /*type_in*/,
-                                unsigned int p)
+void QGrundmann_Moller::init_1D(const ElemType /*type_in*/)
 {
-  QGauss gauss1D(1, static_cast<Order>(_order+2*p));
+  QGauss gauss1D(1, get_order());
 
   // Swap points and weights with the about-to-be destroyed rule.
   _points.swap(gauss1D.get_points());

--- a/src/quadrature/quadrature_gm.C
+++ b/src/quadrature/quadrature_gm.C
@@ -36,7 +36,7 @@ QuadratureType QGrundmann_Moller::type() const
 
 
 
-void QGrundmann_Moller::init_1D()
+void QGrundmann_Moller::init_1D(const ElemType, unsigned int)
 {
   QGauss gauss1D(1, get_order());
 

--- a/src/quadrature/quadrature_gm.C
+++ b/src/quadrature/quadrature_gm.C
@@ -36,7 +36,7 @@ QuadratureType QGrundmann_Moller::type() const
 
 
 
-void QGrundmann_Moller::init_1D(const ElemType /*type_in*/)
+void QGrundmann_Moller::init_1D()
 {
   QGauss gauss1D(1, get_order());
 

--- a/src/quadrature/quadrature_gm_2D.C
+++ b/src/quadrature/quadrature_gm_2D.C
@@ -25,8 +25,7 @@ namespace libMesh
 
 
 
-void QGrundmann_Moller::init_2D(const ElemType type_in,
-                                unsigned int p)
+void QGrundmann_Moller::init_2D(const ElemType type_in)
 {
   // Nearly all GM rules contain negative weights, so if you are not
   // allowing rules with negative weights, we cannot continue!
@@ -41,13 +40,13 @@ void QGrundmann_Moller::init_2D(const ElemType type_in,
     case TRI3:
     case TRI6:
       {
-        switch(_order + 2*p)
+        switch(get_order())
           {
 
           default:
             {
               // Untested above _order=23 but should work...
-              gm_rule((_order + 2*p)/2, /*dim=*/2);
+              gm_rule(get_order()/2, /*dim=*/2);
               return;
             }
           } // end switch (order)

--- a/src/quadrature/quadrature_gm_2D.C
+++ b/src/quadrature/quadrature_gm_2D.C
@@ -24,9 +24,7 @@
 namespace libMesh
 {
 
-
-
-void QGrundmann_Moller::init_2D()
+void QGrundmann_Moller::init_2D(const ElemType, unsigned int)
 {
   // Nearly all GM rules contain negative weights, so if you are not
   // allowing rules with negative weights, we cannot continue!

--- a/src/quadrature/quadrature_gm_2D.C
+++ b/src/quadrature/quadrature_gm_2D.C
@@ -19,13 +19,14 @@
 
 // Local includes
 #include "libmesh/quadrature_gm.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
 
 
-void QGrundmann_Moller::init_2D(const ElemType type_in)
+void QGrundmann_Moller::init_2D()
 {
   // Nearly all GM rules contain negative weights, so if you are not
   // allowing rules with negative weights, we cannot continue!
@@ -35,7 +36,7 @@ void QGrundmann_Moller::init_2D(const ElemType type_in)
                       << "Either select a different quadrature class or\n" \
                       << "set allow_rules_with_negative_weights==true.");
 
-  switch (type_in)
+  switch (_type)
     {
     case TRI3:
     case TRI6:
@@ -53,8 +54,8 @@ void QGrundmann_Moller::init_2D(const ElemType type_in)
       } // end case TRI3, TRI6
 
     default:
-      libmesh_error_msg("ERROR: Unsupported element type: " << type_in);
-    } // end switch (type_in)
+      libmesh_error_msg("ERROR: Unsupported element type: " << Utility::enum_to_string(_type));
+    } // end switch (_type)
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_gm_3D.C
+++ b/src/quadrature/quadrature_gm_3D.C
@@ -19,13 +19,12 @@
 
 // Local includes
 #include "libmesh/quadrature_gm.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-
-
-void QGrundmann_Moller::init_3D(const ElemType type_in)
+void QGrundmann_Moller::init_3D()
 {
   // Nearly all GM rules contain negative weights, so if you are not
   // allowing rules with negative weights, we cannot continue!
@@ -35,7 +34,7 @@ void QGrundmann_Moller::init_3D(const ElemType type_in)
                       << "Either select a different quadrature class or\n" \
                       << "set allow_rules_with_negative_weights==true.");
 
-  switch (type_in)
+  switch (_type)
     {
     case TET4:
     case TET10:
@@ -159,8 +158,8 @@ void QGrundmann_Moller::init_3D(const ElemType type_in)
       } // end case TET4, TET10
 
     default:
-      libmesh_error_msg("ERROR: Unsupported element type: " << type_in);
-    } // end switch (type_in)
+      libmesh_error_msg("ERROR: Unsupported element type: " << Utility::enum_to_string(_type));
+    } // end switch (_type)
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_gm_3D.C
+++ b/src/quadrature/quadrature_gm_3D.C
@@ -25,8 +25,7 @@ namespace libMesh
 
 
 
-void QGrundmann_Moller::init_3D(const ElemType type_in,
-                                unsigned int p)
+void QGrundmann_Moller::init_3D(const ElemType type_in)
 {
   // Nearly all GM rules contain negative weights, so if you are not
   // allowing rules with negative weights, we cannot continue!
@@ -41,7 +40,7 @@ void QGrundmann_Moller::init_3D(const ElemType type_in,
     case TET4:
     case TET10:
       {
-        switch(_order + 2*p)
+        switch(get_order())
           {
             // We hard-code the first few orders based on output from
             // the mp-quadrature library:
@@ -153,7 +152,7 @@ void QGrundmann_Moller::init_3D(const ElemType type_in,
           default:
             {
               // Untested above _order=23 but should work...
-              gm_rule((_order + 2*p)/2, /*dim=*/3);
+              gm_rule(get_order()/2, /*dim=*/3);
               return;
             }
           } // end switch (order)

--- a/src/quadrature/quadrature_gm_3D.C
+++ b/src/quadrature/quadrature_gm_3D.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-void QGrundmann_Moller::init_3D()
+void QGrundmann_Moller::init_3D(const ElemType, unsigned int)
 {
   // Nearly all GM rules contain negative weights, so if you are not
   // allowing rules with negative weights, we cannot continue!

--- a/src/quadrature/quadrature_grid_1D.C
+++ b/src/quadrature/quadrature_grid_1D.C
@@ -25,16 +25,8 @@
 namespace libMesh
 {
 
-
-
-void QGrid::init_1D(const ElemType,
-                    unsigned int)
+void QGrid::init_1D(const ElemType)
 {
-  //----------------------------------------------------------------------
-  // 1D quadrature rules
-
-  // We ignore p - the grid rule is just for experimentation
-
   _points.resize(_order + 1);
   _weights.resize(_order + 1);
   const Real dx = Real(2)/(_order+1);
@@ -43,7 +35,6 @@ void QGrid::init_1D(const ElemType,
       _points[i](0) = (i+0.5)*dx-1;
       _weights[i] = dx;
     }
-  return;
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_grid_1D.C
+++ b/src/quadrature/quadrature_grid_1D.C
@@ -25,7 +25,7 @@
 namespace libMesh
 {
 
-void QGrid::init_1D()
+void QGrid::init_1D(const ElemType, unsigned int)
 {
   _points.resize(_order + 1);
   _weights.resize(_order + 1);

--- a/src/quadrature/quadrature_grid_1D.C
+++ b/src/quadrature/quadrature_grid_1D.C
@@ -25,7 +25,7 @@
 namespace libMesh
 {
 
-void QGrid::init_1D(const ElemType)
+void QGrid::init_1D()
 {
   _points.resize(_order + 1);
   _weights.resize(_order + 1);

--- a/src/quadrature/quadrature_grid_2D.C
+++ b/src/quadrature/quadrature_grid_2D.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-void QGrid::init_2D()
+void QGrid::init_2D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM > 1
 

--- a/src/quadrature/quadrature_grid_2D.C
+++ b/src/quadrature/quadrature_grid_2D.C
@@ -19,16 +19,16 @@
 
 // Local includes
 #include "libmesh/quadrature_grid.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-
-void QGrid::init_2D(const ElemType type_in)
+void QGrid::init_2D()
 {
 #if LIBMESH_DIM > 1
 
-  switch (type_in)
+  switch (_type)
     {
 
 
@@ -78,7 +78,7 @@ void QGrid::init_2D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported type
     default:
-      libmesh_error_msg("Element type not supported!:" << type_in);
+      libmesh_error_msg("Element type not supported!:" << Utility::enum_to_string(_type));
     }
 #endif
 }

--- a/src/quadrature/quadrature_grid_2D.C
+++ b/src/quadrature/quadrature_grid_2D.C
@@ -24,15 +24,9 @@ namespace libMesh
 {
 
 
-void QGrid::init_2D(const ElemType type_in,
-                    unsigned int)
+void QGrid::init_2D(const ElemType type_in)
 {
 #if LIBMESH_DIM > 1
-
-  //-----------------------------------------------------------------------
-  // 2D quadrature rules
-
-  // We ignore p - the grid rule is just for experimentation
 
   switch (type_in)
     {
@@ -48,7 +42,7 @@ void QGrid::init_2D(const ElemType type_in,
       {
         // We compute the 2D quadrature rule as a tensor
         // product of the 1D quadrature rule.
-        QGrid q1D(1,_order);
+        QGrid q1D(1, _order);
         q1D.init(EDGE2);
         tensor_product_quad( q1D );
         return;

--- a/src/quadrature/quadrature_grid_3D.C
+++ b/src/quadrature/quadrature_grid_3D.C
@@ -24,15 +24,10 @@ namespace libMesh
 {
 
 
-void QGrid::init_3D(const ElemType type_in,
-                    unsigned int)
+void QGrid::init_3D(const ElemType type_in)
 {
 #if LIBMESH_DIM == 3
 
-  //-----------------------------------------------------------------------
-  // 3D quadrature rules
-
-  // We ignore p - the grid rule is just for experimentation
   switch (type_in)
     {
       //---------------------------------------------

--- a/src/quadrature/quadrature_grid_3D.C
+++ b/src/quadrature/quadrature_grid_3D.C
@@ -19,16 +19,17 @@
 
 // Local includes
 #include "libmesh/quadrature_grid.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
 
-void QGrid::init_3D(const ElemType type_in)
+void QGrid::init_3D()
 {
 #if LIBMESH_DIM == 3
 
-  switch (type_in)
+  switch (_type)
     {
       //---------------------------------------------
       // Hex quadrature rules
@@ -141,7 +142,7 @@ void QGrid::init_3D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported type
     default:
-      libmesh_error_msg("ERROR: Unsupported type: " << type_in);
+      libmesh_error_msg("ERROR: Unsupported type: " << Utility::enum_to_string(_type));
     }
 #endif
 }

--- a/src/quadrature/quadrature_grid_3D.C
+++ b/src/quadrature/quadrature_grid_3D.C
@@ -25,7 +25,7 @@ namespace libMesh
 {
 
 
-void QGrid::init_3D()
+void QGrid::init_3D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM == 3
 

--- a/src/quadrature/quadrature_jacobi_1D.C
+++ b/src/quadrature/quadrature_jacobi_1D.C
@@ -25,7 +25,7 @@ namespace libMesh
 
 
 
-void QJacobi::init_1D(const ElemType)
+void QJacobi::init_1D()
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules

--- a/src/quadrature/quadrature_jacobi_1D.C
+++ b/src/quadrature/quadrature_jacobi_1D.C
@@ -25,8 +25,7 @@ namespace libMesh
 
 
 
-void QJacobi::init_1D(const ElemType,
-                      unsigned int p)
+void QJacobi::init_1D(const ElemType)
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules
@@ -39,7 +38,7 @@ void QJacobi::init_1D(const ElemType,
 
   if ((_alpha == 1) && (_beta == 0))
     {
-      switch(_order + 2*p)
+      switch(get_order())
         {
         case CONSTANT:
         case FIRST:
@@ -791,7 +790,7 @@ void QJacobi::init_1D(const ElemType,
   else if ((_alpha == 2) && (_beta == 0))
     {
 
-      switch(_order + 2*p)
+      switch(get_order())
         {
         case CONSTANT:
         case FIRST:

--- a/src/quadrature/quadrature_jacobi_1D.C
+++ b/src/quadrature/quadrature_jacobi_1D.C
@@ -23,9 +23,7 @@
 namespace libMesh
 {
 
-
-
-void QJacobi::init_1D()
+void QJacobi::init_1D(const ElemType, unsigned int)
 {
   //----------------------------------------------------------------------
   // 1D quadrature rules

--- a/src/quadrature/quadrature_monomial_1D.C
+++ b/src/quadrature/quadrature_monomial_1D.C
@@ -26,11 +26,10 @@
 namespace libMesh
 {
 
-void QMonomial::init_1D(const ElemType _elemtype,
-                        unsigned int p)
+void QMonomial::init_1D(const ElemType _elemtype)
 {
   QGauss gauss_rule(1, _order);
-  gauss_rule.init(_elemtype, p);
+  gauss_rule.init(_elemtype, _p_level);
 
   _points.swap(gauss_rule.get_points());
   _weights.swap(gauss_rule.get_weights());

--- a/src/quadrature/quadrature_monomial_1D.C
+++ b/src/quadrature/quadrature_monomial_1D.C
@@ -26,7 +26,7 @@
 namespace libMesh
 {
 
-void QMonomial::init_1D()
+void QMonomial::init_1D(const ElemType, unsigned int)
 {
   QGauss gauss_rule(1, _order);
   gauss_rule.init(_type, _p_level);

--- a/src/quadrature/quadrature_monomial_1D.C
+++ b/src/quadrature/quadrature_monomial_1D.C
@@ -26,10 +26,10 @@
 namespace libMesh
 {
 
-void QMonomial::init_1D(const ElemType _elemtype)
+void QMonomial::init_1D()
 {
   QGauss gauss_rule(1, _order);
-  gauss_rule.init(_elemtype, _p_level);
+  gauss_rule.init(_type, _p_level);
 
   _points.swap(gauss_rule.get_points());
   _weights.swap(gauss_rule.get_weights());

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -25,10 +25,10 @@ namespace libMesh
 {
 
 
-void QMonomial::init_2D(const ElemType type_in)
+void QMonomial::init_2D()
 {
 
-  switch (type_in)
+  switch (_type)
     {
       //---------------------------------------------
       // Quadrilateral quadrature rules
@@ -529,7 +529,7 @@ void QMonomial::init_2D(const ElemType type_in)
     default:
       {
         QGauss gauss_rule(2, _order);
-        gauss_rule.init(type_in, _p_level);
+        gauss_rule.init(_type, _p_level);
 
         // Swap points and weights with the about-to-be destroyed rule.
         _points.swap (gauss_rule.get_points() );
@@ -537,7 +537,7 @@ void QMonomial::init_2D(const ElemType type_in)
 
         return;
       }
-    } // end switch (type_in)
+    } // end switch (_type)
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -25,8 +25,7 @@ namespace libMesh
 {
 
 
-void QMonomial::init_2D(const ElemType type_in,
-                        unsigned int p)
+void QMonomial::init_2D(const ElemType type_in)
 {
 
   switch (type_in)
@@ -39,7 +38,7 @@ void QMonomial::init_2D(const ElemType type_in,
     case QUADSHELL8:
     case QUAD9:
       {
-        switch(_order + 2*p)
+        switch(get_order())
           {
           case SECOND:
             {
@@ -530,7 +529,7 @@ void QMonomial::init_2D(const ElemType type_in,
     default:
       {
         QGauss gauss_rule(2, _order);
-        gauss_rule.init(type_in, p);
+        gauss_rule.init(type_in, _p_level);
 
         // Swap points and weights with the about-to-be destroyed rule.
         _points.swap (gauss_rule.get_points() );

--- a/src/quadrature/quadrature_monomial_2D.C
+++ b/src/quadrature/quadrature_monomial_2D.C
@@ -25,7 +25,7 @@ namespace libMesh
 {
 
 
-void QMonomial::init_2D()
+void QMonomial::init_2D(const ElemType, unsigned int)
 {
 
   switch (_type)

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -25,10 +25,10 @@ namespace libMesh
 {
 
 
-void QMonomial::init_3D(const ElemType type_in)
+void QMonomial::init_3D()
 {
 
-  switch (type_in)
+  switch (_type)
     {
       //---------------------------------------------
       // Hex quadrature rules
@@ -322,7 +322,7 @@ void QMonomial::init_3D(const ElemType type_in)
     default:
       {
         QGauss gauss_rule(3, _order);
-        gauss_rule.init(type_in, _p_level);
+        gauss_rule.init(_type, _p_level);
 
         // Swap points and weights with the about-to-be destroyed rule.
         _points.swap (gauss_rule.get_points() );
@@ -330,7 +330,7 @@ void QMonomial::init_3D(const ElemType type_in)
 
         return;
       }
-    } // end switch (type_in)
+    } // end switch (_type)
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -25,8 +25,7 @@ namespace libMesh
 {
 
 
-void QMonomial::init_3D(const ElemType type_in,
-                        unsigned int p)
+void QMonomial::init_3D(const ElemType type_in)
 {
 
   switch (type_in)
@@ -37,7 +36,7 @@ void QMonomial::init_3D(const ElemType type_in,
     case HEX20:
     case HEX27:
       {
-        switch(_order + 2*p)
+        switch(get_order())
           {
 
             // The CONSTANT/FIRST rule is the 1-point Gauss "product" rule...we fall
@@ -323,7 +322,7 @@ void QMonomial::init_3D(const ElemType type_in,
     default:
       {
         QGauss gauss_rule(3, _order);
-        gauss_rule.init(type_in, p);
+        gauss_rule.init(type_in, _p_level);
 
         // Swap points and weights with the about-to-be destroyed rule.
         _points.swap (gauss_rule.get_points() );

--- a/src/quadrature/quadrature_monomial_3D.C
+++ b/src/quadrature/quadrature_monomial_3D.C
@@ -25,7 +25,7 @@ namespace libMesh
 {
 
 
-void QMonomial::init_3D()
+void QMonomial::init_3D(const ElemType, unsigned int)
 {
 
   switch (_type)

--- a/src/quadrature/quadrature_simpson_1D.C
+++ b/src/quadrature/quadrature_simpson_1D.C
@@ -23,7 +23,7 @@
 namespace libMesh
 {
 
-void QSimpson::init_1D()
+void QSimpson::init_1D(const ElemType, unsigned int)
 {
   _points.resize(3);
   _weights.resize(3);

--- a/src/quadrature/quadrature_simpson_1D.C
+++ b/src/quadrature/quadrature_simpson_1D.C
@@ -23,7 +23,7 @@
 namespace libMesh
 {
 
-void QSimpson::init_1D(const ElemType)
+void QSimpson::init_1D()
 {
   _points.resize(3);
   _weights.resize(3);

--- a/src/quadrature/quadrature_simpson_1D.C
+++ b/src/quadrature/quadrature_simpson_1D.C
@@ -23,13 +23,8 @@
 namespace libMesh
 {
 
-
-
-void QSimpson::init_1D(const ElemType,
-                       unsigned int)
+void QSimpson::init_1D(const ElemType)
 {
-  //----------------------------------------------------------------------
-  // 1D quadrature rules
   _points.resize(3);
   _weights.resize(3);
 
@@ -40,8 +35,6 @@ void QSimpson::init_1D(const ElemType,
   _weights[0] = Real(1)/3;
   _weights[1] = Real(4)/3;
   _weights[2] = Real(1)/3;
-
-  return;
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_simpson_2D.C
+++ b/src/quadrature/quadrature_simpson_2D.C
@@ -19,19 +19,20 @@
 
 // Local includes
 #include "libmesh/quadrature_simpson.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
 
 
-void QSimpson::init_2D(const ElemType type_in)
+void QSimpson::init_2D()
 {
 #if LIBMESH_DIM > 1
 
   //-----------------------------------------------------------------------
   // 2D quadrature rules
-  switch (type_in)
+  switch (_type)
     {
 
 
@@ -102,7 +103,7 @@ void QSimpson::init_2D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported type
     default:
-      libmesh_error_msg("Element type not supported!:" << type_in);
+      libmesh_error_msg("Element type not supported!:" << Utility::enum_to_string(_type));
     }
 #endif
 }

--- a/src/quadrature/quadrature_simpson_2D.C
+++ b/src/quadrature/quadrature_simpson_2D.C
@@ -24,9 +24,7 @@
 namespace libMesh
 {
 
-
-
-void QSimpson::init_2D()
+void QSimpson::init_2D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM > 1
 

--- a/src/quadrature/quadrature_simpson_2D.C
+++ b/src/quadrature/quadrature_simpson_2D.C
@@ -25,8 +25,7 @@ namespace libMesh
 
 
 
-void QSimpson::init_2D(const ElemType type_in,
-                       unsigned int)
+void QSimpson::init_2D(const ElemType type_in)
 {
 #if LIBMESH_DIM > 1
 

--- a/src/quadrature/quadrature_simpson_3D.C
+++ b/src/quadrature/quadrature_simpson_3D.C
@@ -19,17 +19,18 @@
 
 // Local includes
 #include "libmesh/quadrature_simpson.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-void QSimpson::init_3D(const ElemType type_in)
+void QSimpson::init_3D()
 {
 #if LIBMESH_DIM == 3
 
   //-----------------------------------------------------------------------
   // 3D quadrature rules
-  switch (type_in)
+  switch (_type)
     {
       //---------------------------------------------
       // Hex quadrature rules
@@ -133,7 +134,7 @@ void QSimpson::init_3D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported type
     default:
-      libmesh_error_msg("ERROR: Unsupported type: " << type_in);
+      libmesh_error_msg("ERROR: Unsupported type: " << Utility::enum_to_string(_type));
     }
 #endif
 }

--- a/src/quadrature/quadrature_simpson_3D.C
+++ b/src/quadrature/quadrature_simpson_3D.C
@@ -23,12 +23,7 @@
 namespace libMesh
 {
 
-
-
-
-
-void QSimpson::init_3D(const ElemType type_in,
-                       unsigned int)
+void QSimpson::init_3D(const ElemType type_in)
 {
 #if LIBMESH_DIM == 3
 

--- a/src/quadrature/quadrature_simpson_3D.C
+++ b/src/quadrature/quadrature_simpson_3D.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-void QSimpson::init_3D()
+void QSimpson::init_3D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM == 3
 

--- a/src/quadrature/quadrature_trap_1D.C
+++ b/src/quadrature/quadrature_trap_1D.C
@@ -23,7 +23,7 @@
 namespace libMesh
 {
 
-void QTrap::init_1D(const ElemType)
+void QTrap::init_1D()
 {
   _points.resize(2);
   _weights.resize(2);

--- a/src/quadrature/quadrature_trap_1D.C
+++ b/src/quadrature/quadrature_trap_1D.C
@@ -23,7 +23,7 @@
 namespace libMesh
 {
 
-void QTrap::init_1D()
+void QTrap::init_1D(const ElemType, unsigned int)
 {
   _points.resize(2);
   _weights.resize(2);

--- a/src/quadrature/quadrature_trap_1D.C
+++ b/src/quadrature/quadrature_trap_1D.C
@@ -23,13 +23,8 @@
 namespace libMesh
 {
 
-
-
-void QTrap::init_1D(const ElemType,
-                    unsigned int)
+void QTrap::init_1D(const ElemType)
 {
-  //----------------------------------------------------------------------
-  // 1D quadrature rules
   _points.resize(2);
   _weights.resize(2);
 
@@ -38,8 +33,6 @@ void QTrap::init_1D(const ElemType,
 
   _weights[0] = 1.;
   _weights[1] = 1.;
-
-  return;
 }
 
 } // namespace libMesh

--- a/src/quadrature/quadrature_trap_2D.C
+++ b/src/quadrature/quadrature_trap_2D.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-void QTrap::init_2D()
+void QTrap::init_2D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM > 1
 

--- a/src/quadrature/quadrature_trap_2D.C
+++ b/src/quadrature/quadrature_trap_2D.C
@@ -25,8 +25,7 @@ namespace libMesh
 
 
 
-void QTrap::init_2D(const ElemType type_in,
-                    unsigned int)
+void QTrap::init_2D(const ElemType type_in)
 {
 #if LIBMESH_DIM > 1
 

--- a/src/quadrature/quadrature_trap_2D.C
+++ b/src/quadrature/quadrature_trap_2D.C
@@ -19,19 +19,18 @@
 
 // Local includes
 #include "libmesh/quadrature_trap.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-
-
-void QTrap::init_2D(const ElemType type_in)
+void QTrap::init_2D()
 {
 #if LIBMESH_DIM > 1
 
   //-----------------------------------------------------------------------
   // 2D quadrature rules
-  switch (type_in)
+  switch (_type)
     {
 
 
@@ -85,7 +84,7 @@ void QTrap::init_2D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported type
     default:
-      libmesh_error_msg("Element type not supported!:" << type_in);
+      libmesh_error_msg("Element type not supported!:" << Utility::enum_to_string(_type));
     }
 #endif
 }

--- a/src/quadrature/quadrature_trap_3D.C
+++ b/src/quadrature/quadrature_trap_3D.C
@@ -24,7 +24,7 @@
 namespace libMesh
 {
 
-void QTrap::init_3D()
+void QTrap::init_3D(const ElemType, unsigned int)
 {
 #if LIBMESH_DIM == 3
 

--- a/src/quadrature/quadrature_trap_3D.C
+++ b/src/quadrature/quadrature_trap_3D.C
@@ -27,8 +27,7 @@ namespace libMesh
 
 
 
-void QTrap::init_3D(const ElemType type_in,
-                    unsigned int)
+void QTrap::init_3D(const ElemType type_in)
 {
 #if LIBMESH_DIM == 3
 

--- a/src/quadrature/quadrature_trap_3D.C
+++ b/src/quadrature/quadrature_trap_3D.C
@@ -19,21 +19,18 @@
 
 // Local includes
 #include "libmesh/quadrature_trap.h"
+#include "libmesh/string_to_enum.h"
 
 namespace libMesh
 {
 
-
-
-
-
-void QTrap::init_3D(const ElemType type_in)
+void QTrap::init_3D()
 {
 #if LIBMESH_DIM == 3
 
   //-----------------------------------------------------------------------
   // 3D quadrature rules
-  switch (type_in)
+  switch (_type)
     {
       //---------------------------------------------
       // Hex quadrature rules
@@ -115,7 +112,7 @@ void QTrap::init_3D(const ElemType type_in)
       //---------------------------------------------
       // Unsupported type
     default:
-      libmesh_error_msg("ERROR: Unsupported type: " << type_in);
+      libmesh_error_msg("ERROR: Unsupported type: " << Utility::enum_to_string(_type));
     }
 #endif
 }


### PR DESCRIPTION
This also revealed that some of our protected and private APIs in the QBase hierarchy were a bit misleading... they made it seem like it was possible for the quadrature rule to be initialized with *any* ElemType and *any* p_level, when in reality only `_type` and `_p_level` were being used... so I cleaned that up as well.

Refs #2149.
