### PR TITLE
PETScDMWrapper Fixups

### DIFF
--- a/examples/fem_system/fem_system_ex1/fem_system_ex1.C
+++ b/examples/fem_system/fem_system_ex1/fem_system_ex1.C
@@ -72,12 +72,6 @@ int main (int argc, char ** argv)
   libmesh_example_requires(false, "--disable-singleprecision");
 #endif
 
-  // This example uses the new PetscDMWrapper which currently does not
-  // compile when complex numbers are enabled.
-#ifdef LIBMESH_USE_COMPLEX_NUMBERS
-  libmesh_example_requires(false, "--disable-complex");
-#endif
-
 #ifndef LIBMESH_ENABLE_AMR
   libmesh_example_requires(false, "--enable-amr");
 #else

--- a/examples/fem_system/fem_system_ex1/run.sh
+++ b/examples/fem_system/fem_system_ex1/run.sh
@@ -11,8 +11,29 @@ example_dir=examples/fem_system/$example_name
 # First, run with standard options from input files.
 run_example "$example_name"
 
+# Next, lets run with pure fieldsplit without gmg
+fs_lu_options="--use_petsc_dm --node-major-dofs \
+-snes_view -snes_monitor -snes_converged_reason -snes_rtol 1.0e-4 \
+-ksp_type fgmres -ksp_converged_reason -ksp_monitor_true_residual \
+-ksp_rtol 1.0e-5 \
+-pc_type fieldsplit -pc_fieldsplit_0_fields 0,1 -pc_fieldsplit_1_fields 2 \
+-pc_fieldsplit_type schur -pc_fieldsplit_schur_fact_type full -pc_fieldsplit_schur_precondition a11 \
+-fieldsplit_0_pc_type lu \
+-fieldsplit_0_ksp_type preonly \
+-fieldsplit_0_ksp_converged_reason \
+-fieldsplit_p_pc_type jacobi \
+-fieldsplit_p_ksp_type gmres \
+-fieldsplit_p_ksp_converged_reason \
+-fieldsplit_p_inner_pc_type lu -fieldsplit_p_inner_ksp_type preonly \
+-fieldsplit_p_upper_pc_type lu -fieldsplit_p_upper_ksp_type preonly"
+
+run_example "$example_name" "solver_type=petscdiff coarsegridsize=6 transient=false n_timesteps=1 $fs_lu_options"
+
+# And again with some timestepping coverage
+run_example "$example_name" "solver_type=petscdiff coarsegridsize=6 coarserefinements=1 transient=true n_timesteps=3 $fs_lu_options"
+
 # Rerun with options demonstrating fieldpslit+gmg on the velocity block.
-solver_options="--use_petsc_dm --node-major-dofs \
+fs_gmg_options="--use_petsc_dm --node-major-dofs \
  -snes_view -snes_monitor -snes_converged_reason -snes_rtol 1.0e-4 \
  -ksp_type fgmres -ksp_rtol 1.0e-5 \
 -pc_type fieldsplit -pc_fieldsplit_0_fields 0,1 -pc_fieldsplit_1_fields 2 \
@@ -29,7 +50,7 @@ solver_options="--use_petsc_dm --node-major-dofs \
 -fieldsplit_p_inner_pc_type lu -fieldsplit_p_inner_ksp_type preonly \
 -fieldsplit_p_upper_pc_type lu -fieldsplit_p_upper_ksp_type preonly"
 
-run_example "$example_name" "solver_type=petscdiff coarsegridsize=6 coarserefinements=2 transient=false n_timesteps=1 $solver_options"
+run_example "$example_name" "solver_type=petscdiff coarsegridsize=6 coarserefinements=2 transient=false n_timesteps=1 $fs_gmg_options"
 
 # Now rerun same thing with over a distributed mesh
-run_example "$example_name" "mesh_type=distributed solver_type=petscdiff coarsegridsize=6 coarserefinements=2 transient=false n_timesteps=1 $solver_options"
+run_example "$example_name" "mesh_type=distributed solver_type=petscdiff coarsegridsize=6 coarserefinements=2 transient=false n_timesteps=1 $fs_gmg_options"

--- a/include/solvers/petsc_diff_solver.h
+++ b/include/solvers/petsc_diff_solver.h
@@ -97,7 +97,7 @@ protected:
    * Wrapper object for interacting with PetscDM
    */
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL)
   PetscDMWrapper _dm_wrapper;
 #endif
 #endif

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -23,7 +23,7 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL)
 
 #include <vector>
 #include <memory>
@@ -218,7 +218,7 @@ private:
 
 }
 
-#endif // #if LIBMESH_ENABLE_AMR && LIBMESH_HAVE_METAPHYSICL && !LIBMESH_USE_COMPLEX_NUMBERS
+#endif // #if LIBMESH_ENABLE_AMR && LIBMESH_HAVE_METAPHYSICL
 #endif // #if PETSC_VERSION
 #endif // #ifdef LIBMESH_HAVE_PETSC
 

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -43,7 +43,7 @@ namespace libMesh
   class System;
   class DofObject;
 
-  //! Struct to house data regarding where in the mesh hierarchy we are located
+  //! Struct to house data regarding where in the mesh hierarchy we are located.
   struct PetscDMContext
   {
     int n_dofs;
@@ -59,8 +59,11 @@ namespace libMesh
     //! Stores local dofs for each var for use in subprojection matrixes
     std::vector<std::vector<numeric_index_type>> dof_vec;
 
-    PetscDMContext() :
-      n_dofs(-12345),
+    //! Stores subfield ids for use in subprojection matrixes on coarser DMs
+    std::vector<PetscInt> subfields;
+
+  PetscDMContext() :
+    n_dofs(-12345),
       mesh_dim(-12345),
       coarser_dm(nullptr),
       finer_dm(nullptr),

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -51,10 +51,10 @@ namespace libMesh
     DM * coarser_dm;
     DM * finer_dm;
     DM * global_dm;
-    PetscMatrix<libMesh::Real > * K_interp_ptr;
-    PetscMatrix<libMesh::Real > * K_sub_interp_ptr;
-    PetscMatrix<libMesh::Real > * K_restrict_ptr;
-    PetscVector<libMesh::Real > * current_vec;
+    PetscMatrix<libMesh::Number> * K_interp_ptr;
+    PetscMatrix<libMesh::Number> * K_sub_interp_ptr;
+    PetscMatrix<libMesh::Number> * K_restrict_ptr;
+    PetscVector<libMesh::Number> * current_vec;
 
     //! Stores local dofs for each var for use in subprojection matrixes
     std::vector<std::vector<numeric_index_type>> dof_vec;
@@ -108,16 +108,16 @@ private:
   std::vector<std::unique_ptr<PetscSF>> _star_forests;
 
   //! Vector of projection matrixes for all grid levels
-  std::vector<std::unique_ptr<PetscMatrix<Real>>> _pmtx_vec;
+  std::vector<std::unique_ptr<PetscMatrix<Number>>> _pmtx_vec;
 
   //! Vector of sub projection matrixes for all grid levels for fieldsplit
-  std::vector<std::unique_ptr<PetscMatrix<Real>>> _subpmtx_vec;
+  std::vector<std::unique_ptr<PetscMatrix<Number>>> _subpmtx_vec;
 
   //! Vector of internal PetscDM context structs for all grid levels
   std::vector<std::unique_ptr<PetscDMContext>> _ctx_vec;
 
   //! Vector of solution vectors for all grid levels
-  std::vector<std::unique_ptr<PetscVector<Real>>> _vec_vec;
+  std::vector<std::unique_ptr<PetscVector<Number>>> _vec_vec;
 
   //! Stores n_dofs for each grid level, to be used for projection matrix sizing
   std::vector<unsigned int> _mesh_dof_sizes;

--- a/include/solvers/petsc_dm_wrapper.h
+++ b/include/solvers/petsc_dm_wrapper.h
@@ -76,148 +76,148 @@ namespace libMesh
 
   };
 
-/**
- * This class defines a wrapper around the PETSc DM infrastructure.
- * By coordinating DM data structures with libMesh, we can use libMesh
- * mesh hierarchies for geometric multigrid. Additionally, by setting the
- * DM data, we can additionally (with or without multigrid) define recursive
- * fieldsplits of our variables.
- *
- * \author Paul T. Bauman, Boris Boutkov
- * \date 2018
- */
-class PetscDMWrapper
-{
-public:
-
-  PetscDMWrapper() = default;
-
-  ~PetscDMWrapper();
-
-  //! Destroys and clears all build DM-related data
-  void clear();
-
-  void init_and_attach_petscdm(System & system, SNES & snes);
-
-private:
-
-  //! Vector of DMs for all grid levels
-  std::vector<std::unique_ptr<DM>> _dms;
-
-  //! Vector of PETScSections for all grid levels
-  std::vector<std::unique_ptr<PetscSection>> _sections;
-
-  //! Vector of star forests for all grid levels
-  std::vector<std::unique_ptr<PetscSF>> _star_forests;
-
-  //! Vector of projection matrixes for all grid levels
-  std::vector<std::unique_ptr<PetscMatrix<Number>>> _pmtx_vec;
-
-  //! Vector of sub projection matrixes for all grid levels for fieldsplit
-  std::vector<std::unique_ptr<PetscMatrix<Number>>> _subpmtx_vec;
-
-  //! Vector of internal PetscDM context structs for all grid levels
-  std::vector<std::unique_ptr<PetscDMContext>> _ctx_vec;
-
-  //! Vector of solution vectors for all grid levels
-  std::vector<std::unique_ptr<PetscVector<Number>>> _vec_vec;
-
-  //! Stores n_dofs for each grid level, to be used for projection matrix sizing
-  std::vector<unsigned int> _mesh_dof_sizes;
-
-  //! Stores n_local_dofs for each grid level, to be used for projection vector sizing
-  std::vector<unsigned int> _mesh_dof_loc_sizes;
-
-  //! Init all the n_mesh_level dependent data structures
-  void init_dm_data(unsigned int n_levels, const Parallel::Communicator & comm);
-
-  //! Get reference to DM for the given mesh level
   /**
-   * init_dm_data() should be called before this function.
-   */
-  DM & get_dm(unsigned int level)
-    { libmesh_assert_less(level, _dms.size());
-    return *(_dms[level].get()); }
-
-  //! Get reference to PetscSection for the given mesh level
-  /**
-   * init_dm_data() should be called before this function.
-   */
-  PetscSection & get_section(unsigned int level)
-    { libmesh_assert_less(level, _sections.size());
-    return *(_sections[level].get()); }
-
-  //! Get reference to PetscSF for the given mesh level
-  /**
-   * init_dm_data() should be called before this function.
-   */
-  PetscSF & get_star_forest(unsigned int level)
-    { libmesh_assert_less(level, _star_forests.size());
-    return *(_star_forests[level].get()); }
-
-  //! Takes System, empty PetscSection and populates the PetscSection
-  /**
-   * Take the System in its current state and an empty PetscSection and then
-   * populate the PetscSection. The PetscSection is comprised of global "point"
-   * numbers, where a "point" in PetscDM parlance is a geometric entity: node, edge,
-   * face, or element. Then, we also add the DoF numbering for each variable
-   * for each of the "points". The PetscSection, together the with PetscSF
-   * will allow for recursive fieldsplits from the command line using PETSc.
-   */
-  void build_section(const System & system, PetscSection & section);
-
-  //! Takes System, empty PetscSF and populates the PetscSF
-  /**
-   * The PetscSF (star forest) is a cousin of PetscSection. PetscSection
-   * has the DoF info, and PetscSF gives the parallel distribution of the
-   * DoF info. So PetscSF should only be necessary when we have more than
-   * one MPI rank. Essentially, we are copying the DofMap.send_list(): we
-   * are specifying the local dofs, what rank communicates that dof info
-   * (for off-processor dofs that are communicated) and the dofs local
-   * index on that rank.
+   * This class defines a wrapper around the PETSc DM infrastructure.
+   * By coordinating DM data structures with libMesh, we can use libMesh
+   * mesh hierarchies for geometric multigrid. Additionally, by setting the
+   * DM data, we can additionally (with or without multigrid) define recursive
+   * fieldsplits of our variables.
    *
-   * https://jedbrown.org/files/StarForest.pdf
+   * \author Paul T. Bauman, Boris Boutkov
+   * \date 2018
    */
-  void build_sf( const System & system, PetscSF & star_forest );
+  class PetscDMWrapper
+  {
+  public:
 
-  //! Helper function for build_section.
-  /**
-   * This function will count how many "points" on the current processor have
-   * DoFs associated with them and give that count to PETSc. We need to cache
-   * a mapping between the global node id and our local count that we do in this
-   * function because we will need the local number again in the add_dofs_to_section
-   * function.
-   */
-  void set_point_range_in_section( const System & system,
-                                   PetscSection & section,
-                                   std::unordered_map<dof_id_type,dof_id_type> & node_map,
-                                   std::unordered_map<dof_id_type,dof_id_type> & elem_map,
-                                   std::map<dof_id_type,unsigned int> & scalar_map);
+    PetscDMWrapper() = default;
 
-  //! Helper function for build_section.
-  /**
-   * This function will set the DoF info for each "point" in the PetscSection.
-   */
-  void add_dofs_to_section (const System & system,
-                            PetscSection & section,
-                            const std::unordered_map<dof_id_type,dof_id_type> & node_map,
-                            const std::unordered_map<dof_id_type,dof_id_type> & elem_map,
-                            const std::map<dof_id_type,unsigned int> & scalar_map);
+    ~PetscDMWrapper();
 
-  //! Helper function to sanity check PetscSection construction
-  /**
-   * The PetscSection contains local dof information. This helper function just facilitates
-   * sanity checking that in fact it only has n_local_dofs.
-   */
-  dof_id_type check_section_n_dofs( PetscSection & section );
+    //! Destroys and clears all build DM-related data
+    void clear();
 
-  //! Helper function to reduce code duplication when setting dofs in section
-  void add_dofs_helper (const System & system,
-                        const DofObject & dof_object,
-                        dof_id_type local_id,
-                        PetscSection & section);
+    void init_and_attach_petscdm(System & system, SNES & snes);
 
-};
+  private:
+
+    //! Vector of DMs for all grid levels
+    std::vector<std::unique_ptr<DM>> _dms;
+
+    //! Vector of PETScSections for all grid levels
+    std::vector<std::unique_ptr<PetscSection>> _sections;
+
+    //! Vector of star forests for all grid levels
+    std::vector<std::unique_ptr<PetscSF>> _star_forests;
+
+    //! Vector of projection matrixes for all grid levels
+    std::vector<std::unique_ptr<PetscMatrix<Number>>> _pmtx_vec;
+
+    //! Vector of sub projection matrixes for all grid levels for fieldsplit
+    std::vector<std::unique_ptr<PetscMatrix<Number>>> _subpmtx_vec;
+
+    //! Vector of internal PetscDM context structs for all grid levels
+    std::vector<std::unique_ptr<PetscDMContext>> _ctx_vec;
+
+    //! Vector of solution vectors for all grid levels
+    std::vector<std::unique_ptr<PetscVector<Number>>> _vec_vec;
+
+    //! Stores n_dofs for each grid level, to be used for projection matrix sizing
+    std::vector<unsigned int> _mesh_dof_sizes;
+
+    //! Stores n_local_dofs for each grid level, to be used for projection vector sizing
+    std::vector<unsigned int> _mesh_dof_loc_sizes;
+
+    //! Init all the n_mesh_level dependent data structures
+    void init_dm_data(unsigned int n_levels, const Parallel::Communicator & comm);
+
+    //! Get reference to DM for the given mesh level
+    /**
+     * init_dm_data() should be called before this function.
+     */
+    DM & get_dm(unsigned int level)
+      { libmesh_assert_less(level, _dms.size());
+        return *(_dms[level].get()); }
+
+    //! Get reference to PetscSection for the given mesh level
+    /**
+     * init_dm_data() should be called before this function.
+     */
+    PetscSection & get_section(unsigned int level)
+      { libmesh_assert_less(level, _sections.size());
+        return *(_sections[level].get()); }
+
+    //! Get reference to PetscSF for the given mesh level
+    /**
+     * init_dm_data() should be called before this function.
+     */
+    PetscSF & get_star_forest(unsigned int level)
+      { libmesh_assert_less(level, _star_forests.size());
+        return *(_star_forests[level].get()); }
+
+    //! Takes System, empty PetscSection and populates the PetscSection
+    /**
+     * Take the System in its current state and an empty PetscSection and then
+     * populate the PetscSection. The PetscSection is comprised of global "point"
+     * numbers, where a "point" in PetscDM parlance is a geometric entity: node, edge,
+     * face, or element. Then, we also add the DoF numbering for each variable
+     * for each of the "points". The PetscSection, together the with PetscSF
+     * will allow for recursive fieldsplits from the command line using PETSc.
+     */
+    void build_section(const System & system, PetscSection & section);
+
+    //! Takes System, empty PetscSF and populates the PetscSF
+    /**
+     * The PetscSF (star forest) is a cousin of PetscSection. PetscSection
+     * has the DoF info, and PetscSF gives the parallel distribution of the
+     * DoF info. So PetscSF should only be necessary when we have more than
+     * one MPI rank. Essentially, we are copying the DofMap.send_list(): we
+     * are specifying the local dofs, what rank communicates that dof info
+     * (for off-processor dofs that are communicated) and the dofs local
+     * index on that rank.
+     *
+     * https://jedbrown.org/files/StarForest.pdf
+     */
+    void build_sf( const System & system, PetscSF & star_forest );
+
+    //! Helper function for build_section.
+    /**
+     * This function will count how many "points" on the current processor have
+     * DoFs associated with them and give that count to PETSc. We need to cache
+     * a mapping between the global node id and our local count that we do in this
+     * function because we will need the local number again in the add_dofs_to_section
+     * function.
+     */
+    void set_point_range_in_section( const System & system,
+                                     PetscSection & section,
+                                     std::unordered_map<dof_id_type,dof_id_type> & node_map,
+                                     std::unordered_map<dof_id_type,dof_id_type> & elem_map,
+                                     std::map<dof_id_type,unsigned int> & scalar_map);
+
+    //! Helper function for build_section.
+    /**
+     * This function will set the DoF info for each "point" in the PetscSection.
+     */
+    void add_dofs_to_section (const System & system,
+                              PetscSection & section,
+                              const std::unordered_map<dof_id_type,dof_id_type> & node_map,
+                              const std::unordered_map<dof_id_type,dof_id_type> & elem_map,
+                              const std::map<dof_id_type,unsigned int> & scalar_map);
+
+    //! Helper function to sanity check PetscSection construction
+    /**
+     * The PetscSection contains local dof information. This helper function just facilitates
+     * sanity checking that in fact it only has n_local_dofs.
+     */
+    dof_id_type check_section_n_dofs( PetscSection & section );
+
+    //! Helper function to reduce code duplication when setting dofs in section
+    void add_dofs_helper (const System & system,
+                          const DofObject & dof_object,
+                          dof_id_type local_id,
+                          PetscSection & section);
+
+  };
 
 }
 

--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -228,7 +228,7 @@ void PetscDiffSolver::clear()
   LIBMESH_CHKERR(ierr);
 
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL)
   _dm_wrapper.clear();
 #endif
 #endif
@@ -368,7 +368,7 @@ void PetscDiffSolver::setup_petsc_data()
 
   // This needs to be called before SNESSetFromOptions
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL)
   if (use_petsc_dm)
     this->_dm_wrapper.init_and_attach_petscdm(_system, _snes);
 #endif

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -240,7 +240,7 @@ namespace libMesh
       // the subDMs. We do this by checking the number of fields. When
       // less than all the fields are used, we need to create the
       // proper subDMs. We get the number of fields and their names
-      // from the incomming fine DM and the global reference DM
+      // from the incoming fine DM and the global reference DM
       PetscInt nfieldsf, nfieldsg;
       char ** fieldnamesf;
       char ** fieldnamesg;
@@ -401,7 +401,7 @@ namespace libMesh
 
       PetscErrorCode ierr;
 
-      // get a communicator from incomming DM
+      // get a communicator from incoming DM
       MPI_Comm comm;
       PetscObjectGetComm((PetscObject)dmc, &comm);
 

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -100,6 +100,11 @@ namespace libMesh
               ierr = DMShellSetCreateRestriction(*subdm, dm->ops->createrestriction);
               LIBMESH_CHKERR(ierr);
             }
+          if (dm->ops->createsubdm)
+            {
+              ierr = DMShellSetCreateSubDM(*subdm, dm->ops->createsubdm);
+              LIBMESH_CHKERR(ierr);
+            }
           ierr = DMShellGetContext(dm, &ctx);
           LIBMESH_CHKERR(ierr);
           if (ctx)

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -56,7 +56,7 @@ namespace libMesh
 #if PETSC_VERSION_LESS_THAN(3,9,0)
     PetscErrorCode libmesh_petsc_DMCreateSubDM(DM dm, PetscInt numFields, PetscInt fields[], IS *is, DM *subdm)
 #else
-    PetscErrorCode libmesh_petsc_DMCreateSubDM(DM dm, PetscInt numFields, const PetscInt fields[], IS *is, DM *subdm)
+      PetscErrorCode libmesh_petsc_DMCreateSubDM(DM dm, PetscInt numFields, const PetscInt fields[], IS *is, DM *subdm)
 #endif
     {
       PetscErrorCode ierr;
@@ -421,688 +421,688 @@ namespace libMesh
   } // end extern C functions
 
 
-PetscDMWrapper::~PetscDMWrapper()
-{
-  this->clear();
-}
+  PetscDMWrapper::~PetscDMWrapper()
+  {
+    this->clear();
+  }
 
-void PetscDMWrapper::clear()
-{
-  // PETSc will destroy the attached PetscSection, PetscSF as well as
-  // other relateds such as the Projections so we just tidy up the
-  // containers here.
+  void PetscDMWrapper::clear()
+  {
+    // PETSc will destroy the attached PetscSection, PetscSF as well as
+    // other relateds such as the Projections so we just tidy up the
+    // containers here.
 
-  _dms.clear();
-  _sections.clear();
-  _star_forests.clear();
-  _pmtx_vec.clear();
-  _vec_vec.clear();
-  _ctx_vec.clear();
+    _dms.clear();
+    _sections.clear();
+    _star_forests.clear();
+    _pmtx_vec.clear();
+    _vec_vec.clear();
+    _ctx_vec.clear();
 
-}
+  }
 
-void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
-{
-  START_LOG ("init_and_attach_petscdm()", "PetscDMWrapper");
+  void PetscDMWrapper::init_and_attach_petscdm(System & system, SNES & snes)
+  {
+    START_LOG ("init_and_attach_petscdm()", "PetscDMWrapper");
 
-  PetscErrorCode ierr;
+    PetscErrorCode ierr;
 
-  MeshBase & mesh = system.get_mesh();   // Convenience
-  MeshRefinement mesh_refinement(mesh); // Used for swapping between grids
+    MeshBase & mesh = system.get_mesh();   // Convenience
+    MeshRefinement mesh_refinement(mesh); // Used for swapping between grids
 
-  // Theres no need for these code paths while traversing the hierarchy
-  mesh.allow_renumbering(false);
-  mesh.allow_remote_element_removal(false);
-  mesh.partitioner() = nullptr;
+    // Theres no need for these code paths while traversing the hierarchy
+    mesh.allow_renumbering(false);
+    mesh.allow_remote_element_removal(false);
+    mesh.partitioner() = nullptr;
 
-  // First walk over the active local elements and see how many maximum MG levels we can construct
-  unsigned int n_levels = 0;
-  for ( auto & elem : mesh.active_local_element_ptr_range() )
-    {
-      if ( elem->level() > n_levels )
-        n_levels = elem->level();
-    }
-  // On coarse grids some processors may have no active local elements,
-  // these processors shouldnt make projections
-  if (n_levels >= 1)
-    n_levels += 1;
+    // First walk over the active local elements and see how many maximum MG levels we can construct
+    unsigned int n_levels = 0;
+    for ( auto & elem : mesh.active_local_element_ptr_range() )
+      {
+        if ( elem->level() > n_levels )
+          n_levels = elem->level();
+      }
+    // On coarse grids some processors may have no active local elements,
+    // these processors shouldnt make projections
+    if (n_levels >= 1)
+      n_levels += 1;
 
-  // How many MG levels did the user request?
-  unsigned int usr_requested_mg_lvls = 0;
-  usr_requested_mg_lvls = command_line_next("-pc_mg_levels", usr_requested_mg_lvls);
+    // How many MG levels did the user request?
+    unsigned int usr_requested_mg_lvls = 0;
+    usr_requested_mg_lvls = command_line_next("-pc_mg_levels", usr_requested_mg_lvls);
 
-  // Only construct however many levels were requested if something was actually requested
-  if ( usr_requested_mg_lvls != 0 )
-    {
-      // Dont request more than avail num levels on mesh, require at least 2 levels
-      libmesh_assert_less_equal( usr_requested_mg_lvls, n_levels );
-      libmesh_assert( usr_requested_mg_lvls > 1 );
+    // Only construct however many levels were requested if something was actually requested
+    if ( usr_requested_mg_lvls != 0 )
+      {
+        // Dont request more than avail num levels on mesh, require at least 2 levels
+        libmesh_assert_less_equal( usr_requested_mg_lvls, n_levels );
+        libmesh_assert( usr_requested_mg_lvls > 1 );
 
-      n_levels = usr_requested_mg_lvls;
-    }
-  else
-    {
-      // if -pc_mg_levels is not specified we just construct fieldsplit related
-      // structures on the finest mesh.
-      n_levels = 1;
-    }
+        n_levels = usr_requested_mg_lvls;
+      }
+    else
+      {
+        // if -pc_mg_levels is not specified we just construct fieldsplit related
+        // structures on the finest mesh.
+        n_levels = 1;
+      }
 
 
-  // Init data structures: data[0] ~ coarse grid, data[n_levels-1] ~ fine grid
-  this->init_dm_data(n_levels, system.comm());
+    // Init data structures: data[0] ~ coarse grid, data[n_levels-1] ~ fine grid
+    this->init_dm_data(n_levels, system.comm());
 
-  // Step 1.  contract : all active elements have no children
-  mesh.contract();
+    // Step 1.  contract : all active elements have no children
+    mesh.contract();
 
-  // Start on finest grid. Construct DM datas and stash some info for
-  // later projection_matrix and vec sizing
-  for(unsigned int level = n_levels; level >= 1; level--)
-    {
-      // Save the n_fine_dofs before coarsening for later projection matrix sizing
-      _mesh_dof_sizes[level-1] = system.get_dof_map().n_dofs();
-      _mesh_dof_loc_sizes[level-1] = system.get_dof_map().n_local_dofs();
+    // Start on finest grid. Construct DM datas and stash some info for
+    // later projection_matrix and vec sizing
+    for(unsigned int level = n_levels; level >= 1; level--)
+      {
+        // Save the n_fine_dofs before coarsening for later projection matrix sizing
+        _mesh_dof_sizes[level-1] = system.get_dof_map().n_dofs();
+        _mesh_dof_loc_sizes[level-1] = system.get_dof_map().n_local_dofs();
 
-      // Get refs to things we will fill
-      DM & dm = this->get_dm(level-1);
-      PetscSection & section = this->get_section(level-1);
-      PetscSF & star_forest = this->get_star_forest(level-1);
+        // Get refs to things we will fill
+        DM & dm = this->get_dm(level-1);
+        PetscSection & section = this->get_section(level-1);
+        PetscSF & star_forest = this->get_star_forest(level-1);
 
-      // The shell will contain other DM info
-      ierr = DMShellCreate(system.comm().get(), &dm);
-      LIBMESH_CHKERR(ierr);
-
-      // Set the DM embedding dimension to help PetscDS (Discrete System)
-      ierr = DMSetCoordinateDim(dm, mesh.mesh_dimension());
-      CHKERRABORT(system.comm().get(),ierr);
-
-      // Build the PetscSection and attach it to the DM
-      this->build_section(system, section);
-      ierr = DMSetDefaultSection(dm, section);
-      LIBMESH_CHKERR(ierr);
-
-      // We only need to build the star forest if we're in a parallel environment
-      if (system.n_processors() > 1)
-        {
-          // Build the PetscSF and attach it to the DM
-          this->build_sf(system, star_forest);
-          ierr = DMSetDefaultSF(dm, star_forest);
-          LIBMESH_CHKERR(ierr);
-        }
-
-      // Set PETSC's Restriction, Interpolation, Coarsen and Refine functions for the current DM
-      ierr = DMShellSetCreateInterpolation ( dm, libmesh_petsc_DMCreateInterpolation );
-      LIBMESH_CHKERR(ierr);
-
-      // Not implemented. For now we rely on galerkin style restrictions
-      bool supply_restriction = false;
-      if (supply_restriction)
-        {
-        ierr = DMShellSetCreateRestriction ( dm, libmesh_petsc_DMCreateRestriction  );
+        // The shell will contain other DM info
+        ierr = DMShellCreate(system.comm().get(), &dm);
         LIBMESH_CHKERR(ierr);
-        }
-
-      ierr = DMShellSetCoarsen ( dm, libmesh_petsc_DMCoarsen );
-      LIBMESH_CHKERR(ierr);
-
-      ierr = DMShellSetRefine ( dm, libmesh_petsc_DMRefine );
-      LIBMESH_CHKERR(ierr);
-
-      ierr= DMShellSetCreateSubDM(dm, libmesh_petsc_DMCreateSubDM);
-      CHKERRABORT(system.comm().get(), ierr);
-
-      // Uniformly coarsen if not the coarsest grid and distribute dof info.
-      if ( level != 1 )
-        {
-          START_LOG ("PDM_coarsen", "PetscDMWrapper");
-          mesh_refinement.uniformly_coarsen(1);
-          STOP_LOG  ("PDM_coarsen", "PetscDMWrapper");
-
-          START_LOG ("PDM_dist_dof", "PetscDMWrapper");
-          system.get_dof_map().distribute_dofs(mesh);
-          STOP_LOG  ("PDM_dist_dof", "PetscDMWrapper");
-        }
-    } // End PETSc data structure creation
-
-  // Now fill the corresponding internal PetscDMContext for each created DM
-  for( unsigned int i=1; i <= n_levels; i++ )
-    {
-      // Set context dimension
-      (*_ctx_vec[i-1]).mesh_dim = mesh.mesh_dimension();
-
-      // Create and attach a sized vector to the current ctx
-      _vec_vec[i-1]->init( _mesh_dof_sizes[i-1] );
-      _ctx_vec[i-1]->current_vec = _vec_vec[i-1].get();
-
-      // Set a global DM to be used as reference when using fieldsplit
-      _ctx_vec[i-1]->global_dm = &(this->get_dm(n_levels-1));
-
-      if (n_levels > 1 )
-        {
-          // Set pointers to surrounding dm levels to help PETSc refine/coarsen
-          if ( i == 1 ) // were at the coarsest mesh
-            {
-              (*_ctx_vec[i-1]).coarser_dm = nullptr;
-              (*_ctx_vec[i-1]).finer_dm   = _dms[1].get();
-            }
-          else if( i == n_levels ) // were at the finest mesh
-            {
-              (*_ctx_vec[i-1]).coarser_dm = _dms[_dms.size() - 2].get();
-              (*_ctx_vec[i-1]).finer_dm   = nullptr;
-            }
-          else // were in the middle of the hierarchy
-            {
-              (*_ctx_vec[i-1]).coarser_dm = _dms[i-2].get();
-              (*_ctx_vec[i-1]).finer_dm   = _dms[i].get();
-            }
-        }
-
-    } // End context creation
-
-  // Attach a vector and context to each DM
-  if ( n_levels >= 1 )
-    {
-
-      for ( unsigned int i = 1; i <= n_levels ; ++i)
-        {
-          DM & dm = this->get_dm(i-1);
-
-          ierr = DMShellSetGlobalVector( dm, (*_ctx_vec[ i-1 ]).current_vec->vec() );
-          LIBMESH_CHKERR(ierr);
-
-          ierr = DMShellSetContext( dm, _ctx_vec[ i-1 ].get() );
-          LIBMESH_CHKERR(ierr);
-        }
-    }
-
-  // DM structures created, now we need projection matrixes if GMG is requested.
-  // To prepare for projection creation go to second coarsest mesh so we can utilize
-  // old_dof_indices information in the projection creation.
-  if (n_levels > 1 )
-    {
-
-      // First, stash the coarse dof indices for FS purposes
-      unsigned int n_vars  = system.n_vars();
-      _ctx_vec[0]->dof_vec.resize(n_vars);
-
-      for( unsigned int v = 0; v < n_vars; v++ )
-        {
-          std::vector<numeric_index_type> di;
-          system.get_dof_map().local_variable_indices(di, system.get_mesh(), v);
-          _ctx_vec[0]->dof_vec[v] = di;
-        }
-
-      START_LOG ("PDM_refine", "PetscDMWrapper");
-      mesh_refinement.uniformly_refine(1);
-      STOP_LOG  ("PDM_refine", "PetscDMWrapper");
-
-      START_LOG ("PDM_dist_dof", "PetscDMWrapper");
-      system.get_dof_map().distribute_dofs(mesh);
-      STOP_LOG  ("PDM_dist_dof", "PetscDMWrapper");
-
-      START_LOG ("PDM_cnstrnts", "PetscDMWrapper");
-      system.reinit_constraints();
-      STOP_LOG ("PDM_cnstrnts", "PetscDMWrapper");
-    }
-
-  // Create the Interpolation Matrices between adjacent mesh levels
-  for ( unsigned int i = 1 ; i < n_levels ; ++i )
-    {
-      if ( i != n_levels )
-        {
-          // Stash the rest of the dof indices
-          unsigned int n_vars  = system.n_vars();
-          _ctx_vec[i]->dof_vec.resize(n_vars);
-
-          for( unsigned int v = 0; v < n_vars; v++ )
-            {
-              std::vector<numeric_index_type> di;
-              system.get_dof_map().local_variable_indices(di, system.get_mesh(), v);
-              _ctx_vec[i]->dof_vec[v] = di;
-            }
-
-          unsigned int ndofs_c = _mesh_dof_sizes[i-1];
-          unsigned int ndofs_f = _mesh_dof_sizes[i];
-
-          // Create the Interpolation matrix and set its pointer
-          _ctx_vec[i-1]->K_interp_ptr = _pmtx_vec[i-1].get();
-          _ctx_vec[i-1]->K_sub_interp_ptr = _subpmtx_vec[i-1].get();
-
-          unsigned int ndofs_local     = system.get_dof_map().n_dofs_on_processor(system.processor_id());
-          unsigned int ndofs_old_first = system.get_dof_map().first_old_dof(system.processor_id());
-          unsigned int ndofs_old_end   = system.get_dof_map().end_old_dof(system.processor_id());
-          unsigned int ndofs_old_size  = ndofs_old_end - ndofs_old_first;
-
-          // Init and zero the matrix
-          _ctx_vec[i-1]->K_interp_ptr->init(ndofs_f, ndofs_c, ndofs_local, ndofs_old_size, 30 , 20);
-
-          // Disable Mat destruction since PETSc destroys these for us
-          _ctx_vec[i-1]->K_interp_ptr->set_destroy_mat_on_exit(false);
-          _ctx_vec[i-1]->K_sub_interp_ptr->set_destroy_mat_on_exit(false);
-
-          // TODO: Projection matrix sparsity pattern?
-          //MatSetOption(_ctx_vec[i-1]->K_interp_ptr->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
-
-          // Compute the interpolation matrix and set K_interp_ptr
-          START_LOG ("PDM_proj_mat", "PetscDMWrapper");
-          system.projection_matrix(*_ctx_vec[i-1]->K_interp_ptr);
-          STOP_LOG  ("PDM_proj_mat", "PetscDMWrapper");
-
-          // Always close matrix that contains altered data
-          _ctx_vec[i-1]->K_interp_ptr->close();
-        }
-
-      // Move to next grid to make next projection
-      if ( i != n_levels - 1 )
-        {
-          START_LOG ("PDM_refine", "PetscDMWrapper");
-          mesh_refinement.uniformly_refine(1);
-          STOP_LOG  ("PDM_refine", "PetscDMWrapper");
-
-          START_LOG ("PDM_dist_dof", "PetscDMWrapper");
-          system.get_dof_map().distribute_dofs(mesh);
-          STOP_LOG ("PDM_dist_dof", "PetscDMWrapper");
-
-          START_LOG ("PDM_cnstrnts", "PetscDMWrapper");
-          system.reinit_constraints();
-          STOP_LOG  ("PDM_cnstrnts", "PetscDMWrapper");
-
-        }
-    } // End create transfer operators. System back at the finest grid
-
-  // Lastly, give SNES the finest level DM
-  DM & dm = this->get_dm(n_levels-1);
-  ierr = SNESSetDM(snes, dm);
-  LIBMESH_CHKERR(ierr);
-
-  STOP_LOG ("init_and_attach_petscdm()", "PetscDMWrapper");
-}
-
-void PetscDMWrapper::build_section( const System & system, PetscSection & section )
-{
-  START_LOG ("build_section()", "PetscDMWrapper");
-
-  PetscErrorCode ierr;
-  ierr = PetscSectionCreate(system.comm().get(),&section);
-  LIBMESH_CHKERR(ierr);
-
-  // Tell the PetscSection about all of our System variables
-  ierr = PetscSectionSetNumFields(section,system.n_vars());
-  LIBMESH_CHKERR(ierr);
-
-  // Set the actual names of all the field variables
-  for( unsigned int v = 0; v < system.n_vars(); v++ )
-    {
-      ierr = PetscSectionSetFieldName( section, v, system.variable_name(v).c_str() );
-      LIBMESH_CHKERR(ierr);
-    }
-
-  // For building the section, we need to create local-to-global map
-  // of local "point" ids to the libMesh global id of that point.
-  // A "point" in PETSc nomenclature is a geometric object that can have
-  // dofs associated with it, e.g. Node, Edge, Face, Elem.
-  // The numbering PETSc expects is continuous for the local numbering.
-  // Since we're only using this interface for solvers, then we can just
-  // assign whatever local id to any of the global ids. But it is local
-  // so we don't need to worry about processor numbering for the local
-  // point ids.
-  std::unordered_map<dof_id_type,dof_id_type> node_map;
-  std::unordered_map<dof_id_type,dof_id_type> elem_map;
-  std::map<dof_id_type,unsigned int> scalar_map;
-
-  // First we tell the PetscSection about all of our points that have
-  // dofs associated with them.
-  this->set_point_range_in_section(system, section, node_map, elem_map, scalar_map);
-
-  // Now we can build up the dofs per "point" in the PetscSection
-  this->add_dofs_to_section(system, section, node_map, elem_map, scalar_map);
-
-  // Final setup of PetscSection
-  // Until Matt Knepley finishes implementing the commented out function
-  // below, the PetscSection will be assuming node-major ordering
-  // so let's throw an error if the user tries to use this without
-  // node-major order
-  if (!libMesh::on_command_line("--node-major-dofs"))
-    libmesh_error_msg("ERROR: Must use --node-major-dofs with PetscSection!");
-
-  //else if (!system.identify_variable_groups())
-  //  ierr = PetscSectionSetUseFieldOffsets(section,PETSC_TRUE);LIBMESH_CHKERR(ierr);
-  //else
-  //  {
-  //    std::string msg = "ERROR: Only node-major or var-major ordering supported for PetscSection!\n";
-  //    msg += "       var-group-major ordering not supported!\n";
-  //    msg += "       Must use --node-major-dofs or set System::identify_variable_groups() = false!\n";
-  //    libmesh_error_msg(msg);
-  //  }
-
-  ierr = PetscSectionSetUp(section);LIBMESH_CHKERR(ierr);
-
-  // Sanity checking at least that local_n_dofs match
-  libmesh_assert_equal_to(system.n_local_dofs(),this->check_section_n_dofs(section));
-
-  STOP_LOG ("build_section()", "PetscDMWrapper");
-}
-
-void PetscDMWrapper::build_sf( const System & system, PetscSF & star_forest )
-{
-  START_LOG ("build_sf()", "PetscDMWrapper");
-
-  const DofMap & dof_map = system.get_dof_map();
-
-  const std::vector<dof_id_type> & send_list = dof_map.get_send_list();
-
-  // Number of ghost dofs that send information to this processor
-  const PetscInt n_leaves = cast_int<PetscInt>(send_list.size());
-
-  // Number of local dofs, including ghosts dofs
-  const PetscInt n_roots = dof_map.n_local_dofs() + n_leaves;
-
-  // This is the vector of dof indices coming from other processors
-  // We need to give this to the PetscSF
-  // We'll be extra paranoid about this ugly double cast
-  static_assert(sizeof(PetscInt) == sizeof(dof_id_type),"PetscInt is not a dof_id_type!");
-  PetscInt * local_dofs = reinterpret_cast<PetscInt *>(const_cast<dof_id_type *>(send_list.data()));
-
-  // This is the vector of PetscSFNode's for the local_dofs.
-  // For each entry in local_dof, we have to supply the rank from which
-  // that dof stems and its local index on that rank.
-  // PETSc documentation here:
-  // http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/PetscSF/PetscSFNode.html
-  std::vector<PetscSFNode> sf_nodes(send_list.size());
-
-  for( unsigned int i = 0; i < send_list.size(); i++ )
-    {
-      dof_id_type incoming_dof = send_list[i];
-
-      const processor_id_type rank = dof_map.dof_owner(incoming_dof);
-
-      // Dofs are sorted and continuous on the processor so local index
-      // is counted up from the first dof on the processor.
-      PetscInt index = incoming_dof - dof_map.first_dof(rank);
-
-      sf_nodes[i].rank  = rank; /* Rank of owner */
-      sf_nodes[i].index = index;/* Index of dof on rank */
-    }
-
-  PetscSFNode * remote_dofs = sf_nodes.data();
-
-  PetscErrorCode ierr;
-  ierr = PetscSFCreate(system.comm().get(), &star_forest);LIBMESH_CHKERR(ierr);
-
-  // TODO: We should create pointers to arrays so we don't have to copy
-  //       and then can use PETSC_OWN_POINTER where PETSc will take ownership
-  //       and delete the memory for us. But then we'd have to use PetscMalloc.
-  ierr = PetscSFSetGraph(star_forest,
-                         n_roots,
-                         n_leaves,
-                         local_dofs,
-                         PETSC_COPY_VALUES,
-                         remote_dofs,
-                         PETSC_COPY_VALUES);
-  LIBMESH_CHKERR(ierr);
-
-  STOP_LOG ("build_sf()", "PetscDMWrapper");
-}
-
-void PetscDMWrapper::set_point_range_in_section (const System & system,
-                                                 PetscSection & section,
-                                                 std::unordered_map<dof_id_type,dof_id_type> & node_map,
-                                                 std::unordered_map<dof_id_type,dof_id_type> & elem_map,
-                                                 std::map<dof_id_type,unsigned int> & scalar_map)
-{
-  // We're expecting this to be empty coming in
-  libmesh_assert(node_map.empty());
-
-  // We need to count up the number of active "points" on this processor.
-  // Nominally, a "point" in PETSc parlance is a geometric object that can
-  // hold DoFs, i.e node, edge, face, elem. Since we handle the mesh and are only
-  // interested in solvers, then the only thing PETSc needs is a unique *local* number
-  // for each "point" that has active DoFs; note however this local numbering
-  // we construct must be continuous.
-  //
-  // In libMesh, for most finite elements, we just associate those DoFs with the
-  // geometric nodes. So can we loop over the nodes on this processor and check
-  // if any of the fields are have active DoFs on that node.
-  // If so, then we tell PETSc about that "point". At this stage, we just need
-  // to count up how many active "points" we have and cache the local number to global id
-  // mapping.
-
-
-  // These will be our local counters. pstart should always be zero.
-  // pend will track our local "point" count.
-  // If we're on a processor who coarsened the mesh to have no local elements,
-  // we should make an empty PetscSection. An empty PetscSection is specified
-  // by passing [0,0) to the PetscSectionSetChart call at the end. So, if we
-  // have nothing on this processor, these are the correct values to pass to
-  // PETSc.
-  dof_id_type pstart = 0;
-  dof_id_type pend = 0;
-
-  const MeshBase & mesh = system.get_mesh();
-
-  const DofMap & dof_map = system.get_dof_map();
-
-  // If we don't have any local dofs, then there's nothing to tell to the PetscSection
-  if (dof_map.n_local_dofs() > 0)
-    {
-      // Conservative estimate of space needed so we don't thrash
-      node_map.reserve(mesh.n_local_nodes());
-      elem_map.reserve(mesh.n_active_local_elem());
-
-      // We loop over active elements and then cache the global/local node mapping to make sure
-      // we only count active nodes. For example, if we're calling this function and we're
-      // not the finest level in the Mesh tree, we don't want to include nodes of child elements
-      // that aren't active on this level.
-      for (const auto & elem : mesh.active_local_element_ptr_range())
-        {
-          for (unsigned int n = 0; n < elem->n_nodes(); n++)
-            {
-              // get the global id number of local node n
-              const Node & node = elem->node_ref(n);
-
-              // Only register nodes with the PetscSection if they have dofs that belong to
-              // this processor. Even though we're active local elements, the dofs associated
-              // with the node may belong to a different processor. The processor who owns
-              // those dofs will register that node with the PetscSection on that processor.
-              std::vector<dof_id_type> node_dof_indices;
-              dof_map.dof_indices( &node, node_dof_indices );
-              if( !node_dof_indices.empty() && dof_map.local_index(node_dof_indices[0]) )
-                {
+
+        // Set the DM embedding dimension to help PetscDS (Discrete System)
+        ierr = DMSetCoordinateDim(dm, mesh.mesh_dimension());
+        CHKERRABORT(system.comm().get(),ierr);
+
+        // Build the PetscSection and attach it to the DM
+        this->build_section(system, section);
+        ierr = DMSetDefaultSection(dm, section);
+        LIBMESH_CHKERR(ierr);
+
+        // We only need to build the star forest if we're in a parallel environment
+        if (system.n_processors() > 1)
+          {
+            // Build the PetscSF and attach it to the DM
+            this->build_sf(system, star_forest);
+            ierr = DMSetDefaultSF(dm, star_forest);
+            LIBMESH_CHKERR(ierr);
+          }
+
+        // Set PETSC's Restriction, Interpolation, Coarsen and Refine functions for the current DM
+        ierr = DMShellSetCreateInterpolation ( dm, libmesh_petsc_DMCreateInterpolation );
+        LIBMESH_CHKERR(ierr);
+
+        // Not implemented. For now we rely on galerkin style restrictions
+        bool supply_restriction = false;
+        if (supply_restriction)
+          {
+            ierr = DMShellSetCreateRestriction ( dm, libmesh_petsc_DMCreateRestriction  );
+            LIBMESH_CHKERR(ierr);
+          }
+
+        ierr = DMShellSetCoarsen ( dm, libmesh_petsc_DMCoarsen );
+        LIBMESH_CHKERR(ierr);
+
+        ierr = DMShellSetRefine ( dm, libmesh_petsc_DMRefine );
+        LIBMESH_CHKERR(ierr);
+
+        ierr= DMShellSetCreateSubDM(dm, libmesh_petsc_DMCreateSubDM);
+        CHKERRABORT(system.comm().get(), ierr);
+
+        // Uniformly coarsen if not the coarsest grid and distribute dof info.
+        if ( level != 1 )
+          {
+            START_LOG ("PDM_coarsen", "PetscDMWrapper");
+            mesh_refinement.uniformly_coarsen(1);
+            STOP_LOG  ("PDM_coarsen", "PetscDMWrapper");
+
+            START_LOG ("PDM_dist_dof", "PetscDMWrapper");
+            system.get_dof_map().distribute_dofs(mesh);
+            STOP_LOG  ("PDM_dist_dof", "PetscDMWrapper");
+          }
+      } // End PETSc data structure creation
+
+    // Now fill the corresponding internal PetscDMContext for each created DM
+    for( unsigned int i=1; i <= n_levels; i++ )
+      {
+        // Set context dimension
+        (*_ctx_vec[i-1]).mesh_dim = mesh.mesh_dimension();
+
+        // Create and attach a sized vector to the current ctx
+        _vec_vec[i-1]->init( _mesh_dof_sizes[i-1] );
+        _ctx_vec[i-1]->current_vec = _vec_vec[i-1].get();
+
+        // Set a global DM to be used as reference when using fieldsplit
+        _ctx_vec[i-1]->global_dm = &(this->get_dm(n_levels-1));
+
+        if (n_levels > 1 )
+          {
+            // Set pointers to surrounding dm levels to help PETSc refine/coarsen
+            if ( i == 1 ) // were at the coarsest mesh
+              {
+                (*_ctx_vec[i-1]).coarser_dm = nullptr;
+                (*_ctx_vec[i-1]).finer_dm   = _dms[1].get();
+              }
+            else if( i == n_levels ) // were at the finest mesh
+              {
+                (*_ctx_vec[i-1]).coarser_dm = _dms[_dms.size() - 2].get();
+                (*_ctx_vec[i-1]).finer_dm   = nullptr;
+              }
+            else // were in the middle of the hierarchy
+              {
+                (*_ctx_vec[i-1]).coarser_dm = _dms[i-2].get();
+                (*_ctx_vec[i-1]).finer_dm   = _dms[i].get();
+              }
+          }
+
+      } // End context creation
+
+    // Attach a vector and context to each DM
+    if ( n_levels >= 1 )
+      {
+
+        for ( unsigned int i = 1; i <= n_levels ; ++i)
+          {
+            DM & dm = this->get_dm(i-1);
+
+            ierr = DMShellSetGlobalVector( dm, (*_ctx_vec[ i-1 ]).current_vec->vec() );
+            LIBMESH_CHKERR(ierr);
+
+            ierr = DMShellSetContext( dm, _ctx_vec[ i-1 ].get() );
+            LIBMESH_CHKERR(ierr);
+          }
+      }
+
+    // DM structures created, now we need projection matrixes if GMG is requested.
+    // To prepare for projection creation go to second coarsest mesh so we can utilize
+    // old_dof_indices information in the projection creation.
+    if (n_levels > 1 )
+      {
+
+        // First, stash the coarse dof indices for FS purposes
+        unsigned int n_vars  = system.n_vars();
+        _ctx_vec[0]->dof_vec.resize(n_vars);
+
+        for( unsigned int v = 0; v < n_vars; v++ )
+          {
+            std::vector<numeric_index_type> di;
+            system.get_dof_map().local_variable_indices(di, system.get_mesh(), v);
+            _ctx_vec[0]->dof_vec[v] = di;
+          }
+
+        START_LOG ("PDM_refine", "PetscDMWrapper");
+        mesh_refinement.uniformly_refine(1);
+        STOP_LOG  ("PDM_refine", "PetscDMWrapper");
+
+        START_LOG ("PDM_dist_dof", "PetscDMWrapper");
+        system.get_dof_map().distribute_dofs(mesh);
+        STOP_LOG  ("PDM_dist_dof", "PetscDMWrapper");
+
+        START_LOG ("PDM_cnstrnts", "PetscDMWrapper");
+        system.reinit_constraints();
+        STOP_LOG ("PDM_cnstrnts", "PetscDMWrapper");
+      }
+
+    // Create the Interpolation Matrices between adjacent mesh levels
+    for ( unsigned int i = 1 ; i < n_levels ; ++i )
+      {
+        if ( i != n_levels )
+          {
+            // Stash the rest of the dof indices
+            unsigned int n_vars  = system.n_vars();
+            _ctx_vec[i]->dof_vec.resize(n_vars);
+
+            for( unsigned int v = 0; v < n_vars; v++ )
+              {
+                std::vector<numeric_index_type> di;
+                system.get_dof_map().local_variable_indices(di, system.get_mesh(), v);
+                _ctx_vec[i]->dof_vec[v] = di;
+              }
+
+            unsigned int ndofs_c = _mesh_dof_sizes[i-1];
+            unsigned int ndofs_f = _mesh_dof_sizes[i];
+
+            // Create the Interpolation matrix and set its pointer
+            _ctx_vec[i-1]->K_interp_ptr = _pmtx_vec[i-1].get();
+            _ctx_vec[i-1]->K_sub_interp_ptr = _subpmtx_vec[i-1].get();
+
+            unsigned int ndofs_local     = system.get_dof_map().n_dofs_on_processor(system.processor_id());
+            unsigned int ndofs_old_first = system.get_dof_map().first_old_dof(system.processor_id());
+            unsigned int ndofs_old_end   = system.get_dof_map().end_old_dof(system.processor_id());
+            unsigned int ndofs_old_size  = ndofs_old_end - ndofs_old_first;
+
+            // Init and zero the matrix
+            _ctx_vec[i-1]->K_interp_ptr->init(ndofs_f, ndofs_c, ndofs_local, ndofs_old_size, 30 , 20);
+
+            // Disable Mat destruction since PETSc destroys these for us
+            _ctx_vec[i-1]->K_interp_ptr->set_destroy_mat_on_exit(false);
+            _ctx_vec[i-1]->K_sub_interp_ptr->set_destroy_mat_on_exit(false);
+
+            // TODO: Projection matrix sparsity pattern?
+            //MatSetOption(_ctx_vec[i-1]->K_interp_ptr->mat(), MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+
+            // Compute the interpolation matrix and set K_interp_ptr
+            START_LOG ("PDM_proj_mat", "PetscDMWrapper");
+            system.projection_matrix(*_ctx_vec[i-1]->K_interp_ptr);
+            STOP_LOG  ("PDM_proj_mat", "PetscDMWrapper");
+
+            // Always close matrix that contains altered data
+            _ctx_vec[i-1]->K_interp_ptr->close();
+          }
+
+        // Move to next grid to make next projection
+        if ( i != n_levels - 1 )
+          {
+            START_LOG ("PDM_refine", "PetscDMWrapper");
+            mesh_refinement.uniformly_refine(1);
+            STOP_LOG  ("PDM_refine", "PetscDMWrapper");
+
+            START_LOG ("PDM_dist_dof", "PetscDMWrapper");
+            system.get_dof_map().distribute_dofs(mesh);
+            STOP_LOG ("PDM_dist_dof", "PetscDMWrapper");
+
+            START_LOG ("PDM_cnstrnts", "PetscDMWrapper");
+            system.reinit_constraints();
+            STOP_LOG  ("PDM_cnstrnts", "PetscDMWrapper");
+
+          }
+      } // End create transfer operators. System back at the finest grid
+
+    // Lastly, give SNES the finest level DM
+    DM & dm = this->get_dm(n_levels-1);
+    ierr = SNESSetDM(snes, dm);
+    LIBMESH_CHKERR(ierr);
+
+    STOP_LOG ("init_and_attach_petscdm()", "PetscDMWrapper");
+  }
+
+  void PetscDMWrapper::build_section( const System & system, PetscSection & section )
+  {
+    START_LOG ("build_section()", "PetscDMWrapper");
+
+    PetscErrorCode ierr;
+    ierr = PetscSectionCreate(system.comm().get(),&section);
+    LIBMESH_CHKERR(ierr);
+
+    // Tell the PetscSection about all of our System variables
+    ierr = PetscSectionSetNumFields(section,system.n_vars());
+    LIBMESH_CHKERR(ierr);
+
+    // Set the actual names of all the field variables
+    for( unsigned int v = 0; v < system.n_vars(); v++ )
+      {
+        ierr = PetscSectionSetFieldName( section, v, system.variable_name(v).c_str() );
+        LIBMESH_CHKERR(ierr);
+      }
+
+    // For building the section, we need to create local-to-global map
+    // of local "point" ids to the libMesh global id of that point.
+    // A "point" in PETSc nomenclature is a geometric object that can have
+    // dofs associated with it, e.g. Node, Edge, Face, Elem.
+    // The numbering PETSc expects is continuous for the local numbering.
+    // Since we're only using this interface for solvers, then we can just
+    // assign whatever local id to any of the global ids. But it is local
+    // so we don't need to worry about processor numbering for the local
+    // point ids.
+    std::unordered_map<dof_id_type,dof_id_type> node_map;
+    std::unordered_map<dof_id_type,dof_id_type> elem_map;
+    std::map<dof_id_type,unsigned int> scalar_map;
+
+    // First we tell the PetscSection about all of our points that have
+    // dofs associated with them.
+    this->set_point_range_in_section(system, section, node_map, elem_map, scalar_map);
+
+    // Now we can build up the dofs per "point" in the PetscSection
+    this->add_dofs_to_section(system, section, node_map, elem_map, scalar_map);
+
+    // Final setup of PetscSection
+    // Until Matt Knepley finishes implementing the commented out function
+    // below, the PetscSection will be assuming node-major ordering
+    // so let's throw an error if the user tries to use this without
+    // node-major order
+    if (!libMesh::on_command_line("--node-major-dofs"))
+      libmesh_error_msg("ERROR: Must use --node-major-dofs with PetscSection!");
+
+    //else if (!system.identify_variable_groups())
+    //  ierr = PetscSectionSetUseFieldOffsets(section,PETSC_TRUE);LIBMESH_CHKERR(ierr);
+    //else
+    //  {
+    //    std::string msg = "ERROR: Only node-major or var-major ordering supported for PetscSection!\n";
+    //    msg += "       var-group-major ordering not supported!\n";
+    //    msg += "       Must use --node-major-dofs or set System::identify_variable_groups() = false!\n";
+    //    libmesh_error_msg(msg);
+    //  }
+
+    ierr = PetscSectionSetUp(section);LIBMESH_CHKERR(ierr);
+
+    // Sanity checking at least that local_n_dofs match
+    libmesh_assert_equal_to(system.n_local_dofs(),this->check_section_n_dofs(section));
+
+    STOP_LOG ("build_section()", "PetscDMWrapper");
+  }
+
+  void PetscDMWrapper::build_sf( const System & system, PetscSF & star_forest )
+  {
+    START_LOG ("build_sf()", "PetscDMWrapper");
+
+    const DofMap & dof_map = system.get_dof_map();
+
+    const std::vector<dof_id_type> & send_list = dof_map.get_send_list();
+
+    // Number of ghost dofs that send information to this processor
+    const PetscInt n_leaves = cast_int<PetscInt>(send_list.size());
+
+    // Number of local dofs, including ghosts dofs
+    const PetscInt n_roots = dof_map.n_local_dofs() + n_leaves;
+
+    // This is the vector of dof indices coming from other processors
+    // We need to give this to the PetscSF
+    // We'll be extra paranoid about this ugly double cast
+    static_assert(sizeof(PetscInt) == sizeof(dof_id_type),"PetscInt is not a dof_id_type!");
+    PetscInt * local_dofs = reinterpret_cast<PetscInt *>(const_cast<dof_id_type *>(send_list.data()));
+
+    // This is the vector of PetscSFNode's for the local_dofs.
+    // For each entry in local_dof, we have to supply the rank from which
+    // that dof stems and its local index on that rank.
+    // PETSc documentation here:
+    // http://www.mcs.anl.gov/petsc/petsc-current/docs/manualpages/PetscSF/PetscSFNode.html
+    std::vector<PetscSFNode> sf_nodes(send_list.size());
+
+    for( unsigned int i = 0; i < send_list.size(); i++ )
+      {
+        dof_id_type incoming_dof = send_list[i];
+
+        const processor_id_type rank = dof_map.dof_owner(incoming_dof);
+
+        // Dofs are sorted and continuous on the processor so local index
+        // is counted up from the first dof on the processor.
+        PetscInt index = incoming_dof - dof_map.first_dof(rank);
+
+        sf_nodes[i].rank  = rank; /* Rank of owner */
+        sf_nodes[i].index = index;/* Index of dof on rank */
+      }
+
+    PetscSFNode * remote_dofs = sf_nodes.data();
+
+    PetscErrorCode ierr;
+    ierr = PetscSFCreate(system.comm().get(), &star_forest);LIBMESH_CHKERR(ierr);
+
+    // TODO: We should create pointers to arrays so we don't have to copy
+    //       and then can use PETSC_OWN_POINTER where PETSc will take ownership
+    //       and delete the memory for us. But then we'd have to use PetscMalloc.
+    ierr = PetscSFSetGraph(star_forest,
+                           n_roots,
+                           n_leaves,
+                           local_dofs,
+                           PETSC_COPY_VALUES,
+                           remote_dofs,
+                           PETSC_COPY_VALUES);
+    LIBMESH_CHKERR(ierr);
+
+    STOP_LOG ("build_sf()", "PetscDMWrapper");
+  }
+
+  void PetscDMWrapper::set_point_range_in_section (const System & system,
+                                                   PetscSection & section,
+                                                   std::unordered_map<dof_id_type,dof_id_type> & node_map,
+                                                   std::unordered_map<dof_id_type,dof_id_type> & elem_map,
+                                                   std::map<dof_id_type,unsigned int> & scalar_map)
+  {
+    // We're expecting this to be empty coming in
+    libmesh_assert(node_map.empty());
+
+    // We need to count up the number of active "points" on this processor.
+    // Nominally, a "point" in PETSc parlance is a geometric object that can
+    // hold DoFs, i.e node, edge, face, elem. Since we handle the mesh and are only
+    // interested in solvers, then the only thing PETSc needs is a unique *local* number
+    // for each "point" that has active DoFs; note however this local numbering
+    // we construct must be continuous.
+    //
+    // In libMesh, for most finite elements, we just associate those DoFs with the
+    // geometric nodes. So can we loop over the nodes on this processor and check
+    // if any of the fields are have active DoFs on that node.
+    // If so, then we tell PETSc about that "point". At this stage, we just need
+    // to count up how many active "points" we have and cache the local number to global id
+    // mapping.
+
+
+    // These will be our local counters. pstart should always be zero.
+    // pend will track our local "point" count.
+    // If we're on a processor who coarsened the mesh to have no local elements,
+    // we should make an empty PetscSection. An empty PetscSection is specified
+    // by passing [0,0) to the PetscSectionSetChart call at the end. So, if we
+    // have nothing on this processor, these are the correct values to pass to
+    // PETSc.
+    dof_id_type pstart = 0;
+    dof_id_type pend = 0;
+
+    const MeshBase & mesh = system.get_mesh();
+
+    const DofMap & dof_map = system.get_dof_map();
+
+    // If we don't have any local dofs, then there's nothing to tell to the PetscSection
+    if (dof_map.n_local_dofs() > 0)
+      {
+        // Conservative estimate of space needed so we don't thrash
+        node_map.reserve(mesh.n_local_nodes());
+        elem_map.reserve(mesh.n_active_local_elem());
+
+        // We loop over active elements and then cache the global/local node mapping to make sure
+        // we only count active nodes. For example, if we're calling this function and we're
+        // not the finest level in the Mesh tree, we don't want to include nodes of child elements
+        // that aren't active on this level.
+        for (const auto & elem : mesh.active_local_element_ptr_range())
+          {
+            for (unsigned int n = 0; n < elem->n_nodes(); n++)
+              {
+                // get the global id number of local node n
+                const Node & node = elem->node_ref(n);
+
+                // Only register nodes with the PetscSection if they have dofs that belong to
+                // this processor. Even though we're active local elements, the dofs associated
+                // with the node may belong to a different processor. The processor who owns
+                // those dofs will register that node with the PetscSection on that processor.
+                std::vector<dof_id_type> node_dof_indices;
+                dof_map.dof_indices( &node, node_dof_indices );
+                if( !node_dof_indices.empty() && dof_map.local_index(node_dof_indices[0]) )
+                  {
 #ifndef NDEBUG
-                  // We're assuming that if the first dof for this node belongs to this processor,
-                  // then all of them do.
-                  for( auto dof : node_dof_indices )
-                    libmesh_assert(dof_map.local_index(dof));
+                    // We're assuming that if the first dof for this node belongs to this processor,
+                    // then all of them do.
+                    for( auto dof : node_dof_indices )
+                      libmesh_assert(dof_map.local_index(dof));
 #endif
-                  // Cache the global/local mapping if we haven't already
-                  // Then increment our local count
-                  dof_id_type node_id = node.id();
-                  if( node_map.count(node_id) == 0 )
-                    {
-                      node_map.insert(std::make_pair(node_id,pend));
-                      pend++;
-                    }
-                }
-            }
+                    // Cache the global/local mapping if we haven't already
+                    // Then increment our local count
+                    dof_id_type node_id = node.id();
+                    if( node_map.count(node_id) == 0 )
+                      {
+                        node_map.insert(std::make_pair(node_id,pend));
+                        pend++;
+                      }
+                  }
+              }
 
-          // Some finite elements, e.g. Hierarchic, associate element interior DoFs with the element
-          // rather than the node (since we ought to be able to use Hierachic elements on a QUAD4,
-          // which has no interior node). Thus, we also need to check element interiors for DoFs
-          // as well and, if the finite element has them, we also need to count the Elem in our
-          // "point" accounting.
-          if( elem->n_dofs(system.number()) > 0 )
-            {
-              dof_id_type elem_id = elem->id();
-              elem_map.insert(std::make_pair(elem_id,pend));
-              pend++;
-            }
-        }
+            // Some finite elements, e.g. Hierarchic, associate element interior DoFs with the element
+            // rather than the node (since we ought to be able to use Hierachic elements on a QUAD4,
+            // which has no interior node). Thus, we also need to check element interiors for DoFs
+            // as well and, if the finite element has them, we also need to count the Elem in our
+            // "point" accounting.
+            if( elem->n_dofs(system.number()) > 0 )
+              {
+                dof_id_type elem_id = elem->id();
+                elem_map.insert(std::make_pair(elem_id,pend));
+                pend++;
+              }
+          }
 
-      // SCALAR dofs live on the "last" processor, so only work there if there are any
-      if( dof_map.n_SCALAR_dofs() > 0 && (system.processor_id() == (system.n_processors()-1)) )
-        {
-          // Loop through all the variables and cache the scalar ones. We cache the
-          // SCALAR variable index along with the local point to make it easier when
-          // we have to register dofs with the PetscSection
-          for( unsigned int v = 0; v < system.n_vars(); v++ )
-            {
-              if( system.variable(v).type().family == SCALAR )
-                {
-                  scalar_map.insert(std::make_pair(pend,v));
-                  pend++;
-                }
-            }
-        }
+        // SCALAR dofs live on the "last" processor, so only work there if there are any
+        if( dof_map.n_SCALAR_dofs() > 0 && (system.processor_id() == (system.n_processors()-1)) )
+          {
+            // Loop through all the variables and cache the scalar ones. We cache the
+            // SCALAR variable index along with the local point to make it easier when
+            // we have to register dofs with the PetscSection
+            for( unsigned int v = 0; v < system.n_vars(); v++ )
+              {
+                if( system.variable(v).type().family == SCALAR )
+                  {
+                    scalar_map.insert(std::make_pair(pend,v));
+                    pend++;
+                  }
+              }
+          }
 
-    }
+      }
 
-  PetscErrorCode ierr = PetscSectionSetChart(section, pstart, pend);
-  LIBMESH_CHKERR(ierr);
-}
+    PetscErrorCode ierr = PetscSectionSetChart(section, pstart, pend);
+    LIBMESH_CHKERR(ierr);
+  }
 
-void PetscDMWrapper::add_dofs_to_section (const System & system,
-                                          PetscSection & section,
-                                          const std::unordered_map<dof_id_type,dof_id_type> & node_map,
-                                          const std::unordered_map<dof_id_type,dof_id_type> & elem_map,
-                                          const std::map<dof_id_type,unsigned int> & scalar_map)
-{
-  const MeshBase & mesh = system.get_mesh();
+  void PetscDMWrapper::add_dofs_to_section (const System & system,
+                                            PetscSection & section,
+                                            const std::unordered_map<dof_id_type,dof_id_type> & node_map,
+                                            const std::unordered_map<dof_id_type,dof_id_type> & elem_map,
+                                            const std::map<dof_id_type,unsigned int> & scalar_map)
+  {
+    const MeshBase & mesh = system.get_mesh();
 
-  PetscErrorCode ierr;
+    PetscErrorCode ierr;
 
-  // Now we go through and add dof information for each "point".
-  //
-  // In libMesh, for most finite elements, we just associate those DoFs with the
-  // geometric nodes. So can we loop over the nodes we cached in the node_map and
-  // the DoFs for each field for that node. We need to give PETSc the local id
-  // we built up in the node map.
-  for (const auto & nmap : node_map )
-    {
-      const dof_id_type global_node_id = nmap.first;
-      const dof_id_type local_node_id = nmap.second;
+    // Now we go through and add dof information for each "point".
+    //
+    // In libMesh, for most finite elements, we just associate those DoFs with the
+    // geometric nodes. So can we loop over the nodes we cached in the node_map and
+    // the DoFs for each field for that node. We need to give PETSc the local id
+    // we built up in the node map.
+    for (const auto & nmap : node_map )
+      {
+        const dof_id_type global_node_id = nmap.first;
+        const dof_id_type local_node_id = nmap.second;
 
-      libmesh_assert( mesh.query_node_ptr(global_node_id) );
+        libmesh_assert( mesh.query_node_ptr(global_node_id) );
 
-      const Node & node = mesh.node_ref(global_node_id);
+        const Node & node = mesh.node_ref(global_node_id);
 
-      this->add_dofs_helper(system,node,local_node_id,section);
-    }
+        this->add_dofs_helper(system,node,local_node_id,section);
+      }
 
-  // Some finite element types associate dofs with the element. So now we go through
-  // any of those with the Elem as the point we add to the PetscSection with accompanying
-  // dofs
-  for (const auto & emap : elem_map )
-    {
-      const dof_id_type global_elem_id = emap.first;
-      const dof_id_type local_elem_id = emap.second;
+    // Some finite element types associate dofs with the element. So now we go through
+    // any of those with the Elem as the point we add to the PetscSection with accompanying
+    // dofs
+    for (const auto & emap : elem_map )
+      {
+        const dof_id_type global_elem_id = emap.first;
+        const dof_id_type local_elem_id = emap.second;
 
-      libmesh_assert( mesh.query_elem_ptr(global_elem_id) );
+        libmesh_assert( mesh.query_elem_ptr(global_elem_id) );
 
-      const Elem & elem = mesh.elem_ref(global_elem_id);
+        const Elem & elem = mesh.elem_ref(global_elem_id);
 
-      this->add_dofs_helper(system,elem,local_elem_id,section);
-    }
+        this->add_dofs_helper(system,elem,local_elem_id,section);
+      }
 
-  // Now add any SCALAR dofs to the PetscSection
-  // SCALAR dofs live on the "last" processor, so only work there if there are any
-  if (system.processor_id() == (system.n_processors()-1))
-    {
-      for (const auto & smap : scalar_map )
-        {
-          const dof_id_type local_id = smap.first;
-          const unsigned int scalar_var = smap.second;
+    // Now add any SCALAR dofs to the PetscSection
+    // SCALAR dofs live on the "last" processor, so only work there if there are any
+    if (system.processor_id() == (system.n_processors()-1))
+      {
+        for (const auto & smap : scalar_map )
+          {
+            const dof_id_type local_id = smap.first;
+            const unsigned int scalar_var = smap.second;
 
-          // The number of SCALAR dofs comes from the variable order
-          const int n_dofs = system.variable(scalar_var).type().order.get_order();
+            // The number of SCALAR dofs comes from the variable order
+            const int n_dofs = system.variable(scalar_var).type().order.get_order();
 
-          ierr = PetscSectionSetFieldDof( section, local_id, scalar_var, n_dofs );
-          LIBMESH_CHKERR(ierr);
+            ierr = PetscSectionSetFieldDof( section, local_id, scalar_var, n_dofs );
+            LIBMESH_CHKERR(ierr);
 
-          // In the SCALAR case, there are no other variables associate with the "point"
-          // the total number of dofs on the point is the same as that for the field
-          ierr = PetscSectionSetDof( section, local_id, n_dofs );
-          LIBMESH_CHKERR(ierr);
-        }
-    }
+            // In the SCALAR case, there are no other variables associate with the "point"
+            // the total number of dofs on the point is the same as that for the field
+            ierr = PetscSectionSetDof( section, local_id, n_dofs );
+            LIBMESH_CHKERR(ierr);
+          }
+      }
 
-}
+  }
 
-void PetscDMWrapper::add_dofs_helper (const System & system,
-                                      const DofObject & dof_object,
-                                      dof_id_type local_id,
-                                      PetscSection & section)
-{
-  unsigned int total_n_dofs_at_dofobject = 0;
+  void PetscDMWrapper::add_dofs_helper (const System & system,
+                                        const DofObject & dof_object,
+                                        dof_id_type local_id,
+                                        PetscSection & section)
+  {
+    unsigned int total_n_dofs_at_dofobject = 0;
 
-  // We are assuming variables are also numbered 0 to n_vars()-1
-  for( unsigned int v = 0; v < system.n_vars(); v++ )
-    {
-      unsigned int n_dofs_at_dofobject = dof_object.n_dofs(system.number(), v);
+    // We are assuming variables are also numbered 0 to n_vars()-1
+    for( unsigned int v = 0; v < system.n_vars(); v++ )
+      {
+        unsigned int n_dofs_at_dofobject = dof_object.n_dofs(system.number(), v);
 
-      if( n_dofs_at_dofobject > 0 )
-        {
-          PetscErrorCode ierr = PetscSectionSetFieldDof( section,
-                                                         local_id,
-                                                         v,
-                                                         n_dofs_at_dofobject );
+        if( n_dofs_at_dofobject > 0 )
+          {
+            PetscErrorCode ierr = PetscSectionSetFieldDof( section,
+                                                           local_id,
+                                                           v,
+                                                           n_dofs_at_dofobject );
 
-          LIBMESH_CHKERR(ierr);
+            LIBMESH_CHKERR(ierr);
 
-          total_n_dofs_at_dofobject += n_dofs_at_dofobject;
-        }
-    }
+            total_n_dofs_at_dofobject += n_dofs_at_dofobject;
+          }
+      }
 
-  libmesh_assert_equal_to(total_n_dofs_at_dofobject, dof_object.n_dofs(system.number()));
+    libmesh_assert_equal_to(total_n_dofs_at_dofobject, dof_object.n_dofs(system.number()));
 
-  PetscErrorCode ierr =
-    PetscSectionSetDof( section, local_id, total_n_dofs_at_dofobject );
-  LIBMESH_CHKERR(ierr);
-}
+    PetscErrorCode ierr =
+      PetscSectionSetDof( section, local_id, total_n_dofs_at_dofobject );
+    LIBMESH_CHKERR(ierr);
+  }
 
 
-dof_id_type PetscDMWrapper::check_section_n_dofs( PetscSection & section )
-{
-  PetscInt n_local_dofs = 0;
+  dof_id_type PetscDMWrapper::check_section_n_dofs( PetscSection & section )
+  {
+    PetscInt n_local_dofs = 0;
 
-  // Grap the starting and ending points from the section
-  PetscInt pstart, pend;
-  PetscErrorCode ierr = PetscSectionGetChart(section, &pstart, &pend);
-  LIBMESH_CHKERR(ierr);
+    // Grap the starting and ending points from the section
+    PetscInt pstart, pend;
+    PetscErrorCode ierr = PetscSectionGetChart(section, &pstart, &pend);
+    LIBMESH_CHKERR(ierr);
 
-  // Count up the n_dofs for each point from the section
-  for( PetscInt p = pstart; p < pend; p++ )
-    {
-      PetscInt n_dofs;
-      ierr = PetscSectionGetDof(section,p,&n_dofs);LIBMESH_CHKERR(ierr);
-      n_local_dofs += n_dofs;
-    }
+    // Count up the n_dofs for each point from the section
+    for( PetscInt p = pstart; p < pend; p++ )
+      {
+        PetscInt n_dofs;
+        ierr = PetscSectionGetDof(section,p,&n_dofs);LIBMESH_CHKERR(ierr);
+        n_local_dofs += n_dofs;
+      }
 
-  static_assert(sizeof(PetscInt) == sizeof(dof_id_type),"PetscInt is not a dof_id_type!");
-  return n_local_dofs;
-}
+    static_assert(sizeof(PetscInt) == sizeof(dof_id_type),"PetscInt is not a dof_id_type!");
+    return n_local_dofs;
+  }
 
-void PetscDMWrapper::init_dm_data(unsigned int n_levels, const Parallel::Communicator & comm)
-{
-  _dms.resize(n_levels);
-  _sections.resize(n_levels);
-  _star_forests.resize(n_levels);
-  _ctx_vec.resize(n_levels);
-  _pmtx_vec.resize(n_levels);
-  _subpmtx_vec.resize(n_levels);
-  _vec_vec.resize(n_levels);
-  _mesh_dof_sizes.resize(n_levels);
-  _mesh_dof_loc_sizes.resize(n_levels);
+  void PetscDMWrapper::init_dm_data(unsigned int n_levels, const Parallel::Communicator & comm)
+  {
+    _dms.resize(n_levels);
+    _sections.resize(n_levels);
+    _star_forests.resize(n_levels);
+    _ctx_vec.resize(n_levels);
+    _pmtx_vec.resize(n_levels);
+    _subpmtx_vec.resize(n_levels);
+    _vec_vec.resize(n_levels);
+    _mesh_dof_sizes.resize(n_levels);
+    _mesh_dof_loc_sizes.resize(n_levels);
 
-  for( unsigned int i = 0; i < n_levels; i++ )
-    {
-      _dms[i] = libmesh_make_unique<DM>();
-      _sections[i] = libmesh_make_unique<PetscSection>();
-      _star_forests[i] = libmesh_make_unique<PetscSF>();
-      _ctx_vec[i] = libmesh_make_unique<PetscDMContext>();
-      _pmtx_vec[i]= libmesh_make_unique<PetscMatrix<Number>>(comm);
-      _subpmtx_vec[i]= libmesh_make_unique<PetscMatrix<Number>>(comm);
-      _vec_vec[i] = libmesh_make_unique<PetscVector<Number>>(comm);
-    }
-}
+    for( unsigned int i = 0; i < n_levels; i++ )
+      {
+        _dms[i] = libmesh_make_unique<DM>();
+        _sections[i] = libmesh_make_unique<PetscSection>();
+        _star_forests[i] = libmesh_make_unique<PetscSF>();
+        _ctx_vec[i] = libmesh_make_unique<PetscDMContext>();
+        _pmtx_vec[i]= libmesh_make_unique<PetscMatrix<Number>>(comm);
+        _subpmtx_vec[i]= libmesh_make_unique<PetscMatrix<Number>>(comm);
+        _vec_vec[i] = libmesh_make_unique<PetscVector<Number>>(comm);
+      }
+  }
 
 } // end namespace libMesh
 

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -20,7 +20,7 @@
 
 #ifdef LIBMESH_HAVE_PETSC
 #if !PETSC_VERSION_LESS_THAN(3,7,3)
-#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_METAPHYSICL)
 
 #include "libmesh/ignore_warnings.h"
 #include <petscsf.h>
@@ -1031,6 +1031,6 @@ void PetscDMWrapper::init_dm_data(unsigned int n_levels, const Parallel::Communi
 
 } // end namespace libMesh
 
-#endif // #if LIBMESH_ENABLE_AMR && LIBMESH_HAVE_METAPHYSICL && !LIBMESH_USE_COMPLEX_NUMBERS
+#endif // #if LIBMESH_ENABLE_AMR && LIBMESH_HAVE_METAPHYSICL
 #endif // PETSC_VERSION
 #endif // LIBMESH_HAVE_PETSC

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -1023,9 +1023,9 @@ void PetscDMWrapper::init_dm_data(unsigned int n_levels, const Parallel::Communi
       _sections[i] = libmesh_make_unique<PetscSection>();
       _star_forests[i] = libmesh_make_unique<PetscSF>();
       _ctx_vec[i] = libmesh_make_unique<PetscDMContext>();
-      _pmtx_vec[i]= libmesh_make_unique<PetscMatrix<Real>>(comm);
-      _subpmtx_vec[i]= libmesh_make_unique<PetscMatrix<Real>>(comm);
-      _vec_vec[i] = libmesh_make_unique<PetscVector<Real>>(comm);
+      _pmtx_vec[i]= libmesh_make_unique<PetscMatrix<Number>>(comm);
+      _subpmtx_vec[i]= libmesh_make_unique<PetscMatrix<Number>>(comm);
+      _vec_vec[i] = libmesh_make_unique<PetscVector<Number>>(comm);
     }
 }
 

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -56,7 +56,7 @@ namespace libMesh
 #if PETSC_VERSION_LESS_THAN(3,9,0)
     PetscErrorCode libmesh_petsc_DMCreateSubDM(DM dm, PetscInt numFields, PetscInt fields[], IS *is, DM *subdm)
 #else
-      PetscErrorCode libmesh_petsc_DMCreateSubDM(DM dm, PetscInt numFields, const PetscInt fields[], IS *is, DM *subdm)
+    PetscErrorCode libmesh_petsc_DMCreateSubDM(DM dm, PetscInt numFields, const PetscInt fields[], IS *is, DM *subdm)
 #endif
     {
       PetscErrorCode ierr;

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -24,7 +24,7 @@
 
 #include "libmesh/ignore_warnings.h"
 #include <petscsf.h>
-#if PETSC_VERSION_LESS_THAN(3,11,0)
+#if PETSC_VERSION_LESS_THAN(3,12,0)
 #include <petsc/private/dmimpl.h>
 #endif
 #include <petscdmshell.h>
@@ -83,10 +83,10 @@ namespace libMesh
           LIBMESH_CHKERR(ierr);
 
           // Now set the function pointers for the subDM
-          // Some DMShellGet* functions only exist with PETSc >= 3.11.1.
+          // Some DMShellGet* functions only exist with PETSc >= 3.12.0.
 
           // Set Coarsen function pointer
-#if PETSC_VERSION_LESS_THAN(3,11,0)
+#if PETSC_VERSION_LESS_THAN(3,12,0)
           if (dm->ops->coarsen)
             {
               ierr = DMShellSetCoarsen(*subdm, dm->ops->coarsen);
@@ -104,7 +104,7 @@ namespace libMesh
 #endif
 
           // Set Refine function pointer
-#if PETSC_VERSION_LESS_THAN(3,11,0)
+#if PETSC_VERSION_LESS_THAN(3,12,0)
           if (dm->ops->refine)
             {
               ierr = DMShellSetRefine(*subdm, dm->ops->refine);
@@ -121,7 +121,7 @@ namespace libMesh
 #endif
 
           // Set Interpolation function pointer
-#if PETSC_VERSION_LESS_THAN(3,11,0)
+#if PETSC_VERSION_LESS_THAN(3,12,0)
           if (dm->ops->createinterpolation)
             {
               ierr = DMShellSetCreateInterpolation(*subdm, dm->ops->createinterpolation);
@@ -139,7 +139,7 @@ namespace libMesh
 #endif
 
           // Set Restriction function pointer
-#if PETSC_VERSION_LESS_THAN(3,11,0)
+#if PETSC_VERSION_LESS_THAN(3,12,0)
           if (dm->ops->createrestriction)
             {
               ierr = DMShellSetCreateRestriction(*subdm, dm->ops->createrestriction);
@@ -157,7 +157,7 @@ namespace libMesh
 #endif
 
           // Set CreateSubDM function pointer
-#if PETSC_VERSION_LESS_THAN(3,11,0)
+#if PETSC_VERSION_LESS_THAN(3,12,0)
           if (dm->ops->createsubdm)
             {
               ierr = DMShellSetCreateSubDM(*subdm, dm->ops->createsubdm);


### PR DESCRIPTION
Hi all. Here's a PR with various fixup's to things I had discovered in the recent past. While some things are minor and cosmetic, there are a few changes worth outlining.

- Previously fieldsplit without GMG had a bug in it, this is now fixed and tested against with a couple more fem_system_ex1 runs. I also added a tiny transient case as we had no earlier coverage of the teardown/resetting up process.
- Some API changes from PETSc's side were already merged (as @fdkong noticed and fixed in #2147 ; thanks!) while others are still pending an official PETSc release. I checked with PETSc developers and was notified that we can get rid of the remaining PETSc private dependency in 3.12.0, so I've preemptively included these updates.
- Fieldsplit with GMG didnt work earlier in cases where we wanted to use GMG on more than one  subblock. This is fixed now, and I will be creating coverage for this shortly in GRINS with a thermally coupled flow example.

As always, please let me know if theres something I can improve or needs fixing, and thanks in advance for the review!