### PR TITLE
Explicit SubFunctor::join in SortAndCopy::join()

### DIFF
--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -1628,6 +1628,8 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::SortAndCopy
   merge_multimaps(vertices, other.vertices);
   merge_multimaps(edges, other.edges);
   merge_multimaps(sides, other.sides);
+
+  SubFunctor::join(other);
 }
 
 


### PR DESCRIPTION
Otherwise we end up *overriding* the subfunctor join, and then we lose
other threads' list of saved ids, and then we can't figure out how to
do subsequent projection stages properly.

Thanks to @lindsayad for helping catch this bug, but wow it should never have made it into master in the first place.  I'll start using --n_threads habitually myself, but perhaps we should make hybrid-parallel runs standard when running the libMesh "make check" through CI?