### PR TITLE
Re-enable misc ex9 on non-PETSc builds

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -105,9 +105,6 @@ int main (int argc, char ** argv)
   libmesh_example_requires(false, "--enable-exodus");
 #endif
 
-  // The sparsity augmentation code requires PETSc
-  libmesh_example_requires(libMesh::default_solver_package() == PETSC_SOLVERS, "--enable-petsc");
-
   // Skip this 3D example if libMesh was compiled as 1D or 2D-only.
   libmesh_example_requires(3 <= LIBMESH_DIM, "3D support");
 


### PR DESCRIPTION
In #1064 we converted the sparsity augmentation code here to use
GhostingFunctor, and in doing so we managed to fix #116 in passing; at
least that's what my current Eigen and Laspack tests claim.