### PR TITLE
Switch signs of on-diagonal and off-diagonal entries for constraints

### DIFF
--- a/src/base/dof_map_constraints.C
+++ b/src/base/dof_map_constraints.C
@@ -2219,8 +2219,8 @@ void DofMap::enforce_constraints_on_residual (const NonlinearImplicitSystem & sy
 
       Number exact_value = 0;
       for (const auto & j : constraint_row)
-        exact_value += j.second * (*solution_local)(j.first);
-      exact_value -= (*solution_local)(constrained_dof);
+        exact_value -= j.second * (*solution_local)(j.first);
+      exact_value += (*solution_local)(constrained_dof);
       if (!homogeneous)
         {
           DofConstraintValueMap::const_iterator rhsit =
@@ -2255,8 +2255,8 @@ void DofMap::enforce_constraints_on_jacobian (const NonlinearImplicitSystem & sy
       const DofConstraintRow constraint_row = pr.second;
 
       for (const auto & j : constraint_row)
-        jac->set(constrained_dof, j.first, j.second);
-      jac->set(constrained_dof, constrained_dof, -1);
+        jac->set(constrained_dof, j.first, -j.second);
+      jac->set(constrained_dof, constrained_dof, 1);
     }
 }
 


### PR DESCRIPTION
Previously, we were putting a negative on the diagonal and positive values
on the off-diagonal which is generally inconsistent with the structure
of the rest of the matrix. Pretty silly.

I want to throw up some SLEPc results comparing eigenvalues for the different
constraint structures...

@friedmud 