### PR TITLE
Ignore -Wstack-protector in 3rd party code

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -66,8 +66,9 @@
 #pragma GCC diagnostic ignored "-Wredundant-decls"
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #pragma GCC diagnostic ignored "-Wswitch-default"
-// And this for Eigen
+// And these are for Eigen
 #pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wstack-protector"
 // And this for VTK
 #pragma GCC diagnostic ignored "-Wlogical-op"
 // Ignore warnings from code that uses deprecated members of std, like std::auto_ptr.


### PR DESCRIPTION
My Eigen install is setting it off if I turn on Werror and paranoid
warnings, giving "stack protector not protecting local variables:
variable length buffer", but this doesn't actually mean it has an
error, just that the function can't get runtime protection when the
stack-protector options are turned on.