### PR TITLE
Add QNodal quadrature class

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -902,6 +902,7 @@ include_HEADERS = \
         quadrature/quadrature_grid.h \
         quadrature/quadrature_jacobi.h \
         quadrature/quadrature_monomial.h \
+        quadrature/quadrature_nodal.h \
         quadrature/quadrature_simpson.h \
         quadrature/quadrature_trap.h \
         reduced_basis/rb_assembly_expansion.h \

--- a/include/enums/enum_quadrature_type.h
+++ b/include/enums/enum_quadrature_type.h
@@ -43,6 +43,7 @@ enum QuadratureType : int {
                      QGAUSS_LOBATTO    = 9,
                      QCLOUGH           = 21,
                      QCOMPOSITE        = 31,
+                     QNODAL            = 32,
                      // Invalid
                      INVALID_Q_RULE    = 127};
 }

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -325,6 +325,7 @@ include_HEADERS =  \
         quadrature/quadrature_grid.h \
         quadrature/quadrature_jacobi.h \
         quadrature/quadrature_monomial.h \
+        quadrature/quadrature_nodal.h \
         quadrature/quadrature_simpson.h \
         quadrature/quadrature_trap.h \
         reduced_basis/rb_assembly_expansion.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -320,6 +320,7 @@ BUILT_SOURCES = \
         quadrature_grid.h \
         quadrature_jacobi.h \
         quadrature_monomial.h \
+        quadrature_nodal.h \
         quadrature_simpson.h \
         quadrature_trap.h \
         rb_assembly_expansion.h \
@@ -1478,6 +1479,9 @@ quadrature_jacobi.h: $(top_srcdir)/include/quadrature/quadrature_jacobi.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 quadrature_monomial.h: $(top_srcdir)/include/quadrature/quadrature_monomial.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+quadrature_nodal.h: $(top_srcdir)/include/quadrature/quadrature_nodal.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 quadrature_simpson.h: $(top_srcdir)/include/quadrature/quadrature_simpson.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -592,17 +592,17 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	diff_qoi.h fem_physics.h quadrature.h quadrature_clough.h \
 	quadrature_composite.h quadrature_conical.h quadrature_gauss.h \
 	quadrature_gauss_lobatto.h quadrature_gm.h quadrature_grid.h \
-	quadrature_jacobi.h quadrature_monomial.h quadrature_simpson.h \
-	quadrature_trap.h rb_assembly_expansion.h rb_construction.h \
-	rb_construction_base.h rb_data_deserialization.h \
-	rb_data_serialization.h rb_eim_assembly.h \
-	rb_eim_construction.h rb_eim_evaluation.h rb_eim_theta.h \
-	rb_evaluation.h rb_parameters.h rb_parametrized.h \
-	rb_parametrized_function.h rb_scm_construction.h \
-	rb_scm_evaluation.h rb_temporal_discretization.h rb_theta.h \
-	rb_theta_expansion.h transient_rb_assembly_expansion.h \
-	transient_rb_construction.h transient_rb_evaluation.h \
-	transient_rb_theta_expansion.h \
+	quadrature_jacobi.h quadrature_monomial.h quadrature_nodal.h \
+	quadrature_simpson.h quadrature_trap.h rb_assembly_expansion.h \
+	rb_construction.h rb_construction_base.h \
+	rb_data_deserialization.h rb_data_serialization.h \
+	rb_eim_assembly.h rb_eim_construction.h rb_eim_evaluation.h \
+	rb_eim_theta.h rb_evaluation.h rb_parameters.h \
+	rb_parametrized.h rb_parametrized_function.h \
+	rb_scm_construction.h rb_scm_evaluation.h \
+	rb_temporal_discretization.h rb_theta.h rb_theta_expansion.h \
+	transient_rb_assembly_expansion.h transient_rb_construction.h \
+	transient_rb_evaluation.h transient_rb_theta_expansion.h \
 	boundary_volume_solution_transfer.h direct_solution_transfer.h \
 	dtk_adapter.h dtk_evaluator.h dtk_solution_transfer.h \
 	meshfree_interpolation.h meshfree_solution_transfer.h \
@@ -1824,6 +1824,9 @@ quadrature_jacobi.h: $(top_srcdir)/include/quadrature/quadrature_jacobi.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 quadrature_monomial.h: $(top_srcdir)/include/quadrature/quadrature_monomial.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+quadrature_nodal.h: $(top_srcdir)/include/quadrature/quadrature_nodal.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 quadrature_simpson.h: $(top_srcdir)/include/quadrature/quadrature_simpson.h

--- a/include/quadrature/quadrature_nodal.h
+++ b/include/quadrature/quadrature_nodal.h
@@ -1,0 +1,90 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_QUADRATURE_NODAL_H
+#define LIBMESH_QUADRATURE_NODAL_H
+
+// Local includes
+#include "libmesh/quadrature.h"
+
+namespace libMesh
+{
+
+/**
+ * This class implements nodal quadrature rules for various element
+ * types. For some element types, this corresponds to well-known
+ * quadratures such as the trapezoidal rule and Simpson's rule. For
+ * other element types (e.g. the serendipity QUAD8/HEX20/PRISM15) it
+ * implements a lower-order-accurate nodal quadrature which still
+ * generates a strictly positive definite (diagonal) mass matrix.
+ * Since the main purpose of this class is provide appropriate nodal
+ * quadrature rules, "order" arguments passed during initialization
+ * are ignored.
+ *
+ * \author John W. Peterson
+ * \date 2019
+ * \brief Implements nodal quadrature for various element types.
+ */
+class QNodal : public QBase
+{
+public:
+
+  /**
+   * Constructor.  Declares the order of the quadrature rule.  We
+   * explicitly call the \p init function in 1D since the other
+   * tensor-product rules require this one.
+   *
+   * \note The element type, EDGE2, will not be used internally,
+   * however if we called the function with INVALID_ELEM it would try
+   * to be smart and return, thinking it had already done the work.
+   */
+  explicit
+  QNodal (unsigned int dim,
+         Order order=FIRST) :
+    QBase(dim,order)
+  {
+    if (_dim == 1)
+      init(EDGE2);
+  }
+
+  /**
+   * Copy/move ctor, copy/move assignment operator, and destructor are
+   * all explicitly defaulted for this simple class.
+   */
+  QNodal (const QNodal &) = default;
+  QNodal (QNodal &&) = default;
+  QNodal & operator= (const QNodal &) = default;
+  QNodal & operator= (QNodal &&) = default;
+  virtual ~QNodal() = default;
+
+  /**
+   * \returns \p QNODAL.
+   */
+  virtual QuadratureType type() const override;
+
+private:
+
+  virtual void init_1D (const ElemType, unsigned int) override;
+  virtual void init_2D (const ElemType, unsigned int) override;
+  virtual void init_3D (const ElemType, unsigned int) override;
+};
+
+} // namespace libMesh
+
+#endif // LIBMESH_QUADRATURE_NODAL_H

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -303,6 +303,10 @@ libmesh_SOURCES =  \
         src/quadrature/quadrature_monomial_1D.C \
         src/quadrature/quadrature_monomial_2D.C \
         src/quadrature/quadrature_monomial_3D.C \
+        src/quadrature/quadrature_nodal.C \
+        src/quadrature/quadrature_nodal_1D.C \
+        src/quadrature/quadrature_nodal_2D.C \
+        src/quadrature/quadrature_nodal_3D.C \
         src/quadrature/quadrature_simpson.C \
         src/quadrature/quadrature_simpson_1D.C \
         src/quadrature/quadrature_simpson_2D.C \

--- a/src/quadrature/quadrature_build.C
+++ b/src/quadrature/quadrature_build.C
@@ -27,6 +27,7 @@
 #include "libmesh/quadrature_trap.h"
 #include "libmesh/quadrature_gauss_lobatto.h"
 #include "libmesh/quadrature_conical.h"
+#include "libmesh/quadrature_nodal.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/auto_ptr.h" // libmesh_make_unique
 #include "libmesh/enum_quadrature_type.h"
@@ -164,6 +165,9 @@ std::unique_ptr<QBase> QBase::build(const QuadratureType _qt,
 
     case QCONICAL:
       return libmesh_make_unique<QConical>(_dim, _order);
+
+    case QNODAL:
+      return libmesh_make_unique<QNodal>(_dim, _order);
 
     default:
       libmesh_error_msg("ERROR: Bad qt=" << _qt);

--- a/src/quadrature/quadrature_nodal.C
+++ b/src/quadrature/quadrature_nodal.C
@@ -1,0 +1,37 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+// libMesh includes
+#include "libmesh/quadrature_nodal.h"
+#include "libmesh/enum_quadrature_type.h"
+
+namespace libMesh
+{
+
+QuadratureType QNodal::type() const
+{
+  return QNODAL;
+}
+
+// See the files:
+// quadrature_nodal_1D.C
+// quadrature_nodal_2D.C
+// quadrature_nodal_3D.C
+// for implementation.
+
+}

--- a/src/quadrature/quadrature_nodal_1D.C
+++ b/src/quadrature/quadrature_nodal_1D.C
@@ -1,0 +1,66 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+// Local includes
+#include "libmesh/quadrature_nodal.h"
+#include "libmesh/quadrature_trap.h"
+#include "libmesh/quadrature_simpson.h"
+#include "libmesh/string_to_enum.h"
+
+namespace libMesh
+{
+
+void QNodal::init_1D(const ElemType, unsigned int)
+{
+  switch (_type)
+    {
+    case EDGE2:
+      {
+        // Nodal quadrature on an Edge2 is QTrap
+        QTrap rule(/*dim=*/1, /*ignored*/_order);
+        rule.init(_type, /*ignored*/_p_level);
+        _points.swap (rule.get_points());
+        _weights.swap(rule.get_weights());
+        return;
+      }
+    case EDGE3:
+      {
+        // Nodal quadrature on an Edge3 is QSimpson
+        QSimpson rule(/*dim=*/1, /*ignored*/_order);
+        rule.init(_type, /*ignored*/_p_level);
+        _points.swap (rule.get_points());
+        _weights.swap(rule.get_weights());
+        return;
+      }
+    case EDGE4:
+      {
+        // The 4-point variant of Simpson's rule. The quadrature
+        // points are in the same order as the reference element
+        // nodes.
+        _points = {Point(-1,0.,0.), Point(+1,0.,0.),
+                   Point(-Real(1)/3,0.,0.), Point(Real(1)/3,0.,0.)};
+        _weights = {0.25, 0.25, 0.75, 0.75};
+        return;
+      }
+    default:
+      libmesh_error_msg("Element type not supported:" << Utility::enum_to_string(_type));
+    }
+}
+
+} // namespace libMesh

--- a/src/quadrature/quadrature_nodal_2D.C
+++ b/src/quadrature/quadrature_nodal_2D.C
@@ -1,0 +1,90 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+// Local includes
+#include "libmesh/quadrature_nodal.h"
+#include "libmesh/quadrature_trap.h"
+#include "libmesh/quadrature_simpson.h"
+#include "libmesh/string_to_enum.h"
+
+namespace libMesh
+{
+
+void QNodal::init_2D(const ElemType, unsigned int)
+{
+#if LIBMESH_DIM > 1
+
+  switch (_type)
+    {
+
+    case QUAD4:
+    case QUADSHELL4:
+    case TRI3:
+    case TRISHELL3:
+      {
+        QTrap rule(/*dim=*/2, /*ignored*/_order);
+        rule.init(_type, /*ignored*/_p_level);
+        _points.swap (rule.get_points());
+        _weights.swap(rule.get_weights());
+        return;
+      }
+
+    case QUAD8:
+    case QUADSHELL8:
+      {
+        // A rule with 8 points which is exact for linears, and
+        // naturally produces a lumped approximation to the mass
+        // matrix. The quadrature points are numbered the same way as
+        // the reference element nodes.
+        _points =
+          {
+            Point(-1,-1), Point(+1,-1), Point(+1,+1), Point(-1,+1),
+            Point(0.,-1), Point(+1,0.), Point(0.,+1), Point(-1,0.)
+          };
+
+        // vertex (wv), and edge (we) weights are obtained by:
+        // 1.) Requiring that they sum to the reference element volume.
+        // 2.) Minimizing the Frobenius norm of the difference between
+        //     the resulting nodal quadrature (diagonal) mass matrix
+        //     and the true mass matrix for the reference element.
+        Real wv = Real(19) / 90;
+        Real we = Real(71) / 90;
+
+        _weights = {wv, wv, wv, wv, we, we, we, we};
+
+        return;
+      }
+
+    case QUAD9:
+    case TRI6:
+      {
+        QSimpson rule(/*dim=*/2, /*ignored*/_order);
+        rule.init(_type, /*ignored*/_p_level);
+        _points.swap (rule.get_points());
+        _weights.swap(rule.get_weights());
+        return;
+      }
+
+    default:
+      libmesh_error_msg("Element type not supported!:" << Utility::enum_to_string(_type));
+    }
+#endif
+}
+
+} // namespace libMesh

--- a/src/quadrature/quadrature_nodal_3D.C
+++ b/src/quadrature/quadrature_nodal_3D.C
@@ -1,0 +1,125 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+// Local includes
+#include "libmesh/quadrature_nodal.h"
+#include "libmesh/quadrature_trap.h"
+#include "libmesh/quadrature_simpson.h"
+#include "libmesh/string_to_enum.h"
+
+namespace libMesh
+{
+
+void QNodal::init_3D(const ElemType, unsigned int)
+{
+#if LIBMESH_DIM == 3
+
+  switch (_type)
+    {
+    case TET4:
+    case PRISM6:
+    case HEX8:
+      {
+        QTrap rule(/*dim=*/3, /*ignored*/_order);
+        rule.init(_type, /*ignored*/_p_level);
+        _points.swap (rule.get_points());
+        _weights.swap(rule.get_weights());
+        return;
+      }
+
+    case PRISM15:
+      {
+        // A rule with 15 points which is exact for linears, and
+        // naturally produces a lumped approximation to the mass
+        // matrix. The quadrature points are numbered the same way as
+        // the reference element nodes.
+        _points =
+          {
+            Point(0.,0.,-1), Point(+1,0.,-1), Point(0.,+1,-1),
+            Point(0.,0.,+1), Point(+1,0.,+1), Point(0.,+1,+1),
+            Point(.5,0.,-1), Point(.5,.5,-1), Point(0.,.5,-1),
+            Point(0.,0.,0.), Point(+1,0.,0.), Point(0.,+1,0.),
+            Point(.5,0.,+1), Point(.5,.5,+1), Point(0.,.5,+1),
+          };
+
+        // vertex (wv), tri edge (wt), and quad edge (wq) weights are
+        // obtained by:
+        // 1.) Requiring that they sum to the reference element volume.
+        // 2.) Minimizing the Frobenius norm of the difference between
+        //     the resulting nodal quadrature (diagonal) mass matrix
+        //     and the true mass matrix for the reference element.
+        Real wv = Real(26) / 675;
+        Real wt = Real(17) / 225;
+        Real wq = Real(71) / 675;
+
+        _weights = {wv, wv, wv, wv, wv, wv,
+                    wt, wt, wt,
+                    wq, wq, wq,
+                    wt, wt, wt};
+
+        return;
+      }
+
+    case HEX20:
+      {
+        // A rule with 20 points which is exact for linears, and
+        // naturally produces a lumped approximation to the mass
+        // matrix. The quadrature points are numbered the same way as
+        // the reference element nodes.
+        _points =
+          {
+            Point(-1,-1,-1), Point(+1,-1,-1), Point(+1,+1,-1), Point(-1,+1,-1),
+            Point(-1,-1,+1), Point(+1,-1,+1), Point(+1,+1,+1), Point(-1,+1,+1),
+            Point(0.,-1,-1), Point(+1,0.,-1), Point(0.,+1,-1), Point(-1,0.,-1),
+            Point(-1,-1,0.), Point(+1,-1,0.), Point(+1,+1,0.), Point(-1,+1,0.),
+            Point(0.,-1,+1), Point(+1,0.,+1), Point(0.,+1,+1), Point(-1,0.,+1)
+          };
+
+        // vertex (wv), and edge (we) weights are obtained by:
+        // 1.) Requiring that they sum to the reference element volume.
+        // 2.) Minimizing the Frobenius norm of the difference between
+        //     the resulting nodal quadrature (diagonal) mass matrix
+        //     and the true mass matrix for the reference element.
+        Real wv = Real(136) / 585;
+        Real we = Real(898) / 1755;
+
+        _weights = {wv, wv, wv, wv, wv, wv, wv, wv,
+                    we, we, we, we, we, we, we, we, we, we, we, we};
+
+        return;
+      }
+
+    case TET10:
+    case PRISM18:
+    case HEX27:
+      {
+        QSimpson rule(/*dim=*/3, /*ignored*/_order);
+        rule.init(_type, /*ignored*/_p_level);
+        _points.swap (rule.get_points());
+        _weights.swap(rule.get_weights());
+        return;
+      }
+
+    default:
+      libmesh_error_msg("ERROR: Unsupported type: " << Utility::enum_to_string(_type));
+    }
+#endif
+}
+
+} // namespace libMesh

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -285,6 +285,7 @@ void init_quadrature_type_to_enum ()
       quadrature_type_to_enum["QGRID"      ]=QGRID;
       quadrature_type_to_enum["QCLOUGH"    ]=QCLOUGH;
       quadrature_type_to_enum["QGAUSS_LOBATTO"    ]=QGAUSS_LOBATTO;
+      quadrature_type_to_enum["QNODAL"]=QNODAL;
     }
 }
 


### PR DESCRIPTION
After a [recent discussion on the libmesh-users mailing list](https://sourceforge.net/p/libmesh/mailman/message/36685739/), I realized that we did not have nodal quadrature rules for the various "serendipity" elements (QUAD8, HEX20, PRISM15) and therefore we were not getting e.g. diagonal approximations to the mass matrix while using `QSimpson` quadrature on such elements. The new `QNodal` class is a hybrid of `QSimpson`, `QTrap`, and custom quadrature rules, depending on the element type for which it is initialized. 

It's not possible to derive a SECOND-order accurate nodal quadrature rule on serendipity elements without using negative weights. Using negative weights in turn would produce an indefinite approximation to the mass matrix which I felt was bad, so instead I went with lower-order accurate rules which also guarantee positivity.