### PR TITLE
Clear up the old SLEPc solver before we start calling SLEPc EPS.

### DIFF
--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -108,6 +108,8 @@ SlepcEigenSolver<T>::solve_standard (SparseMatrix<T> & matrix_A_in,
 {
   LOG_SCOPE("solve_standard()", "SlepcEigenSolver");
 
+  this->clear ();
+
   this->init ();
 
   // Make sure the SparseMatrix passed in is really a PetscMatrix
@@ -132,6 +134,8 @@ SlepcEigenSolver<T>::solve_standard (ShellMatrix<T> & shell_matrix,
                                      const double tol,         // solver tolerance
                                      const unsigned int m_its) // maximum number of iterations
 {
+  this->clear ();
+
   this->init ();
 
   PetscErrorCode ierr=0;
@@ -294,6 +298,8 @@ SlepcEigenSolver<T>::solve_generalized (SparseMatrix<T> & matrix_A_in,
                                         const double tol,         // solver tolerance
                                         const unsigned int m_its) // maximum number of iterations
 {
+  this->clear ();
+
   this->init ();
 
   // Make sure the data passed in are really of Petsc types
@@ -322,6 +328,8 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
                                         const double tol,         // solver tolerance
                                         const unsigned int m_its) // maximum number of iterations
 {
+  this->clear();
+
   this->init ();
 
   PetscErrorCode ierr=0;
@@ -366,6 +374,8 @@ SlepcEigenSolver<T>::solve_generalized (SparseMatrix<T> & matrix_A_in,
                                         const double tol,         // solver tolerance
                                         const unsigned int m_its) // maximum number of iterations
 {
+  this->clear();
+
   this->init ();
 
   PetscErrorCode ierr=0;
@@ -411,6 +421,8 @@ SlepcEigenSolver<T>::solve_generalized (ShellMatrix<T> & shell_matrix_A,
                                         const double tol,         // solver tolerance
                                         const unsigned int m_its) // maximum number of iterations
 {
+  this->clear();
+
   this->init ();
 
   PetscErrorCode ierr=0;


### PR DESCRIPTION
If we call `solve() `of `slepc_eigen_solver` multiple times, we should obtain the same answer.


If we do not clear up the old EPS, it looks like there are messing things in EPS. And then we will 
get a different answer when we have the second call to EPS. 