### PR TITLE
Bugfix for PointLocatorTree in definition of is_planar_xy

### DIFF
--- a/src/utils/point_locator_tree.C
+++ b/src/utils/point_locator_tree.C
@@ -144,7 +144,10 @@ void PointLocatorTree::init (Trees::BuildType build_type)
                   Dx = bbox.second(0) - bbox.first(0),
                   Dz = bbox.second(2) - bbox.first(2);
 
-                if (std::abs(Dz/(Dx + 1.e-20)) < 1e-10)
+                // In order to satisfy is_planar_xy the mesh should be planar and should
+                // also be in the z=0 plane, since otherwise it is incorrect to use a
+                // QuadTree since QuadTrees assume z=0.
+                if ( (std::abs(Dz/(Dx + 1.e-20)) < 1e-10) && (std::abs(bbox.second(2)) < 1.e-10) )
                   is_planar_xy = true;
               }
 


### PR DESCRIPTION
The bounding box code requires the mesh to be in the z=0 plane if we treat it as xy-planar, so need to set is_planar_xy based on this requirement. This prevents assertion failure when setting up the Tree in the case that we have an xy-planar mesh that is not in the z=0 plane.