### PR TITLE
Add component-wise *= operator to NumericVector

### DIFF
--- a/include/numerics/distributed_vector.h
+++ b/include/numerics/distributed_vector.h
@@ -166,6 +166,8 @@ public:
 
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) override;
 
+  virtual NumericVector<T> & operator *= (const NumericVector<T> & v) override;
+
   virtual NumericVector<T> & operator /= (const NumericVector<T> & v) override;
 
   virtual void reciprocal() override;

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -168,6 +168,8 @@ public:
 
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) override;
 
+  virtual NumericVector<T> & operator *= (const NumericVector<T> & v_in) override;
+
   virtual NumericVector<T> & operator /= (const NumericVector<T> & v_in) override;
 
   virtual void reciprocal() override;

--- a/include/numerics/laspack_vector.h
+++ b/include/numerics/laspack_vector.h
@@ -169,6 +169,8 @@ public:
 
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) override;
 
+  virtual NumericVector<T> & operator *= (const NumericVector<T> & v) override;
+
   virtual NumericVector<T> & operator /= (const NumericVector<T> & v) override;
 
   virtual void reciprocal() override;

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -409,7 +409,7 @@ public:
   NumericVector<T> & operator /= (const T a) { this->scale(1./a); return *this; }
 
   /**
-   * Computes the pointwise division of this vector's entries by another's,
+   * Computes the component-wise division of this vector's entries by another's,
    * \f$ u_i \leftarrow \frac{u_i}{v_i} \, \forall i\f$
    *
    * \returns A reference to *this.
@@ -417,7 +417,7 @@ public:
   virtual NumericVector<T> & operator /= (const NumericVector<T> & v) = 0;
 
   /**
-   * Computes the pointwise reciprocal,
+   * Computes the component-wise reciprocal,
    * \f$ u_i \leftarrow \frac{1}{u_i} \, \forall i\f$
    */
   virtual void reciprocal() = 0;

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -391,6 +391,15 @@ public:
   NumericVector<T> & operator *= (const T a) { this->scale(a); return *this; }
 
   /**
+   * Computes the component-wise multiplication of this vector's entries by
+   * another's,
+   * \f$ u_i \leftarrow u_i v_i \, \forall i\f$
+   *
+   * \returns A reference to *this.
+   */
+  virtual NumericVector<T> & operator *= (const NumericVector<T> & v) = 0;
+
+  /**
    * Scales the vector by \p 1/a,
    * \f$ \vec{u} \leftarrow \frac{1}{a}\vec{u} \f$.
    * Equivalent to \p u.scale(1./a)
@@ -405,7 +414,7 @@ public:
    *
    * \returns A reference to *this.
    */
-  virtual NumericVector<T> & operator /= (const NumericVector<T> & /*v*/) = 0;
+  virtual NumericVector<T> & operator /= (const NumericVector<T> & v) = 0;
 
   /**
    * Computes the pointwise reciprocal,

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -274,6 +274,8 @@ public:
 
   virtual void scale (const T factor) override;
 
+  virtual NumericVector<T> & operator *= (const NumericVector<T> & v) override;
+
   virtual NumericVector<T> & operator /= (const NumericVector<T> & v) override;
 
   virtual void abs() override;

--- a/include/numerics/trilinos_epetra_vector.h
+++ b/include/numerics/trilinos_epetra_vector.h
@@ -179,6 +179,8 @@ public:
 
   virtual NumericVector<T> & operator -= (const NumericVector<T> & v) override;
 
+  virtual NumericVector<T> & operator *= (const NumericVector<T> & v) override;
+
   virtual NumericVector<T> & operator /= (const NumericVector<T> & v) override;
 
   virtual void reciprocal() override;

--- a/src/numerics/distributed_vector.C
+++ b/src/numerics/distributed_vector.C
@@ -163,6 +163,21 @@ NumericVector<T> & DistributedVector<T>::operator -= (const NumericVector<T> & v
 
 
 template <typename T>
+NumericVector<T> & DistributedVector<T>::operator *= (const NumericVector<T> & v)
+{
+  libmesh_assert_equal_to(size(), v.size());
+
+  const DistributedVector<T> & v_vec = cast_ref<const DistributedVector<T> &>(v);
+
+  for (auto i : index_range(_values))
+    _values[i] *= v_vec._values[i];
+
+  return *this;
+}
+
+
+
+template <typename T>
 NumericVector<T> & DistributedVector<T>::operator /= (const NumericVector<T> & v)
 {
   libmesh_assert_equal_to(size(), v.size());

--- a/src/numerics/eigen_sparse_vector.C
+++ b/src/numerics/eigen_sparse_vector.C
@@ -107,6 +107,21 @@ NumericVector<T> & EigenSparseVector<T>::operator -= (const NumericVector<T> & v
 
 
 template <typename T>
+NumericVector<T> & EigenSparseVector<T>::operator *= (const NumericVector<T> & v_in)
+{
+  libmesh_assert (this->closed());
+  libmesh_assert_equal_to(size(), v_in.size());
+
+  const EigenSparseVector<T> & v = cast_ref<const EigenSparseVector<T> &>(v_in);
+
+  _vec = _vec.cwiseProduct(v._vec);
+
+  return *this;
+}
+
+
+
+template <typename T>
 NumericVector<T> & EigenSparseVector<T>::operator /= (const NumericVector<T> & v_in)
 {
   libmesh_assert (this->closed());

--- a/src/numerics/laspack_vector.C
+++ b/src/numerics/laspack_vector.C
@@ -106,6 +106,21 @@ NumericVector<T> & LaspackVector<T>::operator -= (const NumericVector<T> & v)
 
 
 template <typename T>
+NumericVector<T> & LaspackVector<T>::operator *= (const NumericVector<T> & v)
+{
+  libmesh_assert_equal_to(size(), v.size());
+
+  const numeric_index_type n = this->size();
+
+  for (numeric_index_type i=0; i<n; i++)
+    this->set(i, (*this)(i) * v(i));
+
+  return *this;
+}
+
+
+
+template <typename T>
 NumericVector<T> & LaspackVector<T>::operator /= (const NumericVector<T> & v)
 {
   libmesh_assert_equal_to(size(), v.size());

--- a/src/numerics/petsc_vector.C
+++ b/src/numerics/petsc_vector.C
@@ -425,6 +425,19 @@ void PetscVector<T>::scale (const T factor_in)
 }
 
 template <typename T>
+NumericVector<T> & PetscVector<T>::operator *= (const NumericVector<T> & v)
+{
+  PetscErrorCode ierr = 0;
+
+  const PetscVector<T> * v_vec = cast_ptr<const PetscVector<T> *>(&v);
+
+  ierr = VecPointwiseMult(_vec, _vec, v_vec->_vec);
+  LIBMESH_CHKERR(ierr);
+
+  return *this;
+}
+
+template <typename T>
 NumericVector<T> & PetscVector<T>::operator /= (const NumericVector<T> & v)
 {
   PetscErrorCode ierr = 0;

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -128,6 +128,21 @@ EpetraVector<T>::operator -= (const NumericVector<T> & v)
 
 template <typename T>
 NumericVector<T> &
+EpetraVector<T>::operator *= (const NumericVector<T> & v)
+{
+  libmesh_assert(this->closed());
+  libmesh_assert_equal_to(size(), v.size());
+
+  const EpetraVector<T> & v_vec = cast_ref<const EpetraVector<T> &>(v);
+
+  _vec->Multiply(1.0, *v_vec._vec, *_vec, 0.0);
+
+  return *this;
+}
+
+
+template <typename T>
+NumericVector<T> &
 EpetraVector<T>::operator /= (const NumericVector<T> & v)
 {
   libmesh_assert(this->closed());


### PR DESCRIPTION
Also removed optional flag for `v` [here](https://github.com/loganharbour/libmesh/blob/6a1cadac908c43b5ca76c85ac09bc12ccbfd9e55/include/numerics/numeric_vector.h#L416)