### PR TITLE
Changed libMesh configuration to support --download-selpc in PETSc

### DIFF
--- a/configure
+++ b/configure
@@ -35870,76 +35870,70 @@ fi
 
   if test "$enableslepc" !=  no; then :
 
-                              if test "x$SLEPC_DIR" = x; then :
+                                                  if test "x$SLEPC_DIR" = "x" && test "x$PETSC_DIR" != "x"; then :
   export SLEPC_DIR=$PETSC_DIR
 fi
 
-                              if test "x$SLEPC_DIR" = "x" || test "x$petscversion" = "x"; then :
+          # It doesn't seem likely that we would find a /usr/lib/slepc
+          # when we already didn't find a /usr/lib/petsc (otherwise,
+          # PETSC_DIR would be set!)  so let's rule that case out just
+          # to be safe.
+          if test "x$SLEPC_DIR" = "x"; then :
 
-                                                         ac_fn_cxx_check_header_mongrel "$LINENO" "/usr/lib/slepc/slepcversion.h" "ac_cv_header__usr_lib_slepc_slepcversion_h" "$ac_includes_default"
-if test "x$ac_cv_header__usr_lib_slepc_slepcversion_h" = xyes; then :
-
-                                   export SLEPC_DIR=/usr/lib/slepc
-                                   SLEPC_INCLUDE="-I$SLEPC_DIR/include"
-
-else
-
-                                    enableslepc=no
-                                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< SLEPc disabled.  Please set your \"\$SLEPC_DIR\" environment variable correctly to enable SLEPc. >>>" >&5
-$as_echo "<<< SLEPc disabled.  Please set your \"\$SLEPC_DIR\" environment variable correctly to enable SLEPc. >>>" >&6; }
+                                                                                          enableslepc=no
+                  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Could not infer SLEPC_DIR from PETSC_DIR, SLEPc disabled. >>>" >&5
+$as_echo "<<< Could not infer SLEPC_DIR from PETSC_DIR, SLEPc disabled. >>>" >&6; }
 
 fi
 
+                    if test "x$SLEPC_DIR" != "x"; then :
 
+                                                                        slepc_standalone=no
+                  slepc_in_petsc_arch=no
+                  slepc_in_usr_lib=no
 
-else
-
-                  as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/include/slepcversion.h" | $as_tr_sh`
+                                    as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/include/slepcversion.h" | $as_tr_sh`
 ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/include/slepcversion.h" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   SLEPC_INCLUDE="-I$SLEPC_DIR/include"
-                                   slepc_in_petsc_arch=no
-else
-  as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h" | $as_tr_sh`
+                                   slepc_standalone=yes
+fi
+
+
+
+                                    if test "x$slepc_standalone" != "xyes" && test "x$PETSC_ARCH" != "x"; then :
+
+                          as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h" | $as_tr_sh`
 ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   SLEPC_INCLUDE="-I$SLEPC_DIR/$PETSC_ARCH/include"
-                                                    slepc_in_petsc_arch=yes
-else
-  ac_fn_cxx_check_header_mongrel "$LINENO" "/usr/lib/slepc/slepcversion.h" "ac_cv_header__usr_lib_slepc_slepcversion_h" "$ac_includes_default"
+                                          slepc_in_petsc_arch=yes
+fi
+
+
+
+fi
+
+                                    if test "x$slepc_standalone" != "xyes" && test "x$slepc_in_petsc_arch" != "xyes"; then :
+
+                          ac_fn_cxx_check_header_mongrel "$LINENO" "/usr/lib/slepc/slepcversion.h" "ac_cv_header__usr_lib_slepc_slepcversion_h" "$ac_includes_default"
 if test "x$ac_cv_header__usr_lib_slepc_slepcversion_h" = xyes; then :
 
-                                                                     export SLEPC_DIR=/usr/lib/slepc
-                                                                     SLEPC_INCLUDE="-I$SLEPC_DIR/include"
+                                            export SLEPC_DIR=/usr/lib/slepc
+                                            SLEPC_INCLUDE="-I$SLEPC_DIR/include"
 
 else
 
-                                                                     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Invalid \"\$SLEPC_DIR\" detected (slepcversion.h not found). SLEPc disabled. >>>" >&5
-$as_echo "<<< Invalid \"\$SLEPC_DIR\" detected (slepcversion.h not found). SLEPc disabled. >>>" >&6; }
-                                                                      unset SLEPC_DIR
-                                                                      enableslepc=no
-
-fi
-
-
-
-
-fi
-
+                                            { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< No valid SLEPC installation found, SLEPc disabled. >>>" >&5
+$as_echo "<<< No valid SLEPC installation found, SLEPc disabled. >>>" >&6; }
+                                            unset SLEPC_DIR
+                                            enableslepc=no
 
 fi
 
 
 
 fi
-
-                                                            if test "x$PETSC_ARCH" != "x"; then :
-  as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/$PETSC_ARCH/include/slepcconf.h" | $as_tr_sh`
-ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/$PETSC_ARCH/include/slepcconf.h" "$as_ac_Header" "$ac_includes_default"
-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
-  SLEPC_INCLUDE="$SLEPC_INCLUDE -I$SLEPC_DIR/$PETSC_ARCH/include"
-fi
-
 
 fi
 
@@ -35947,20 +35941,14 @@ fi
 
     if test "x$enableslepc" = "xyes"; then :
 
-                                    if test "x$slepc_in_petsc_arch" != "xyes"; then :
-
-                               slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
-                               slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
-                               slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
-
-else
-
-                               slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
-                               slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
-                               slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
-
-
+                                    slepc_version_header=$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h
+            if test "x$slepc_in_petsc_arch" != "xyes"; then :
+  slepc_version_header=$SLEPC_DIR/include/slepcversion.h
 fi
+
+            slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $slepc_version_header | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
+            slepcminor=`grep "define SLEPC_VERSION_MINOR" $slepc_version_header | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
+            slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $slepc_version_header | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
 
             slepcversion=$slepcmajor.$slepcminor.$slepcsubminor
                         oldpetsc=no

--- a/configure
+++ b/configure
@@ -35871,14 +35871,26 @@ fi
   if test "$enableslepc" !=  no; then :
 
                               if test "x$SLEPC_DIR" = x; then :
-  export SLEPC_DIR=/usr/lib/slepc
+  export SLEPC_DIR=$PETSC_DIR
 fi
 
                               if test "x$SLEPC_DIR" = "x" || test "x$petscversion" = "x"; then :
 
-                  enableslepc=no
-                  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< SLEPc disabled.  Please set your \"\$SLEPC_DIR\" environment variable correctly to enable SLEPc. >>>" >&5
+                                                         ac_fn_cxx_check_header_mongrel "$LINENO" "/usr/lib/slepc/slepcversion.h" "ac_cv_header__usr_lib_slepc_slepcversion_h" "$ac_includes_default"
+if test "x$ac_cv_header__usr_lib_slepc_slepcversion_h" = xyes; then :
+
+                                   export SLEPC_DIR=/usr/lib/slepc
+                                   SLEPC_INCLUDE="-I$SLEPC_DIR/include"
+
+else
+
+                                    enableslepc=no
+                                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< SLEPc disabled.  Please set your \"\$SLEPC_DIR\" environment variable correctly to enable SLEPc. >>>" >&5
 $as_echo "<<< SLEPc disabled.  Please set your \"\$SLEPC_DIR\" environment variable correctly to enable SLEPc. >>>" >&6; }
+
+fi
+
+
 
 else
 
@@ -35886,16 +35898,31 @@ else
 ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/include/slepcversion.h" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   SLEPC_INCLUDE="-I$SLEPC_DIR/include"
+                                   slepc_in_petsc_arch=no
 else
   as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h" | $as_tr_sh`
 ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   SLEPC_INCLUDE="-I$SLEPC_DIR/$PETSC_ARCH/include"
+                                                    slepc_in_petsc_arch=yes
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Invalid \"\$SLEPC_DIR\" detected (slepcversion.h not found). SLEPc disabled. >>>" >&5
+  ac_fn_cxx_check_header_mongrel "$LINENO" "/usr/lib/slepc/slepcversion.h" "ac_cv_header__usr_lib_slepc_slepcversion_h" "$ac_includes_default"
+if test "x$ac_cv_header__usr_lib_slepc_slepcversion_h" = xyes; then :
+
+                                                                     export SLEPC_DIR=/usr/lib/slepc
+                                                                     SLEPC_INCLUDE="-I$SLEPC_DIR/include"
+
+else
+
+                                                                     { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Invalid \"\$SLEPC_DIR\" detected (slepcversion.h not found). SLEPc disabled. >>>" >&5
 $as_echo "<<< Invalid \"\$SLEPC_DIR\" detected (slepcversion.h not found). SLEPc disabled. >>>" >&6; }
-                                                    unset SLEPC_DIR
-                                                    enableslepc=no
+                                                                      unset SLEPC_DIR
+                                                                      enableslepc=no
+
+fi
+
+
+
 
 fi
 
@@ -35920,9 +35947,7 @@ fi
 
     if test "x$enableslepc" = "xyes"; then :
 
-                                    as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/include/slepcversion.h" | $as_tr_sh`
-ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/include/slepcversion.h" "$as_ac_Header" "$ac_includes_default"
-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+                                    if test "x$slepc_in_petsc_arch" != "xyes"; then :
 
                                slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
                                slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
@@ -35936,8 +35961,6 @@ else
 
 
 fi
-
-
 
             slepcversion=$slepcmajor.$slepcminor.$slepcsubminor
                         oldpetsc=no

--- a/configure
+++ b/configure
@@ -35887,11 +35887,18 @@ ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/include/slepcversion.h" "$a
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   SLEPC_INCLUDE="-I$SLEPC_DIR/include"
 else
-
-                                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Invalid \"\$SLEPC_DIR\" detected (slepcversion.h not found). SLEPc disabled. >>>" >&5
+  as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h" | $as_tr_sh`
+ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  SLEPC_INCLUDE="-I$SLEPC_DIR/$PETSC_ARCH/include"
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< Invalid \"\$SLEPC_DIR\" detected (slepcversion.h not found). SLEPc disabled. >>>" >&5
 $as_echo "<<< Invalid \"\$SLEPC_DIR\" detected (slepcversion.h not found). SLEPc disabled. >>>" >&6; }
-                                    unset SLEPC_DIR
-                                    enableslepc=no
+                                                    unset SLEPC_DIR
+                                                    enableslepc=no
+
+fi
+
 
 fi
 
@@ -35913,11 +35920,26 @@ fi
 
     if test "x$enableslepc" = "xyes"; then :
 
-                                    slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
-            slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
-            slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
-            slepcversion=$slepcmajor.$slepcminor.$slepcsubminor
+                                    as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/include/slepcversion.h" | $as_tr_sh`
+ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/include/slepcversion.h" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
 
+                               slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
+                               slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
+                               slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
+
+else
+
+                               slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
+                               slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
+                               slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
+
+
+fi
+
+
+
+            slepcversion=$slepcmajor.$slepcminor.$slepcsubminor
                         oldpetsc=no
 
             if test $petscmajor -lt 3; then :
@@ -35947,8 +35969,10 @@ elif test -r ${SLEPC_DIR}/conf/slepc_variables; then :
   includefile=${SLEPC_DIR}/conf/slepc_variables
 elif test -r ${SLEPC_DIR}/lib/slepc/conf/slepc_variables; then :
   includefile=${SLEPC_DIR}/lib/slepc/conf/slepc_variables
+elif                   test -r ${SLEPC_DIR}/${PETSC_ARCH}/lib/slepc/conf/slepc_variables; then :
+  includefile=${SLEPC_DIR}/${PETSC_ARCH}/lib/slepc/conf/slepc_variables
 else
-                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< SLEPc configuration failed.  Could not find slepcconf/slepc_variables file. >>>" >&5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: <<< SLEPc configuration failed.  Could not find slepcconf/slepc_variables file. >>>" >&5
 $as_echo "<<< SLEPc configuration failed.  Could not find slepcconf/slepc_variables file. >>>" >&6; }
                    enableslepc=no
 fi

--- a/m4/slepc.m4
+++ b/m4/slepc.m4
@@ -31,11 +31,12 @@ AC_DEFUN([CONFIGURE_SLEPC],
                 [
                   AC_CHECK_HEADER([$SLEPC_DIR/include/slepcversion.h],
                                   [SLEPC_INCLUDE="-I$SLEPC_DIR/include"],
-                                  [
-                                    AC_MSG_RESULT(<<< Invalid "\$SLEPC_DIR" detected (slepcversion.h not found). SLEPc disabled. >>>)
-                                    unset SLEPC_DIR
-                                    enableslepc=no
-                                  ])
+                                  [AC_CHECK_HEADER([$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h],
+                                                   [SLEPC_INCLUDE="-I$SLEPC_DIR/$PETSC_ARCH/include"],
+                                                   [AC_MSG_RESULT(<<< Invalid "\$SLEPC_DIR" detected (slepcversion.h not found). SLEPc disabled. >>>)
+                                                    unset SLEPC_DIR
+                                                    enableslepc=no]
+                                  )])
                 ])
 
             dnl I didn't check this code branch since I don't use a
@@ -51,11 +52,20 @@ AC_DEFUN([CONFIGURE_SLEPC],
           [
             dnl Similar to petsc, we need the slepc version number.
             dnl Note slepc will most likely only work with the corresponding version of petsc
-            slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
-            slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
-            slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
-            slepcversion=$slepcmajor.$slepcminor.$slepcsubminor
+            AC_CHECK_HEADER([$SLEPC_DIR/include/slepcversion.h],
+                            [
+                               slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
+                               slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
+                               slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
+                             ],
+                             [
+                               slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
+                               slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
+                               slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
+                             ]
+            )
 
+            slepcversion=$slepcmajor.$slepcminor.$slepcsubminor
             dnl Older PETSc (3.3 and earlier) might not work if the version numbers don't match exactly.
             oldpetsc=no
 
@@ -78,6 +88,7 @@ AC_DEFUN([CONFIGURE_SLEPC],
                   [test -r ${SLEPC_DIR}/conf/slepc_common_variables],    [includefile=${SLEPC_DIR}/conf/slepc_common_variables],
                   [test -r ${SLEPC_DIR}/conf/slepc_variables],           [includefile=${SLEPC_DIR}/conf/slepc_variables],
                   [test -r ${SLEPC_DIR}/lib/slepc/conf/slepc_variables], [includefile=${SLEPC_DIR}/lib/slepc/conf/slepc_variables], dnl 3.6.0
+                  [test -r ${SLEPC_DIR}/${PETSC_ARCH}/lib/slepc/conf/slepc_variables], [includefile=${SLEPC_DIR}/${PETSC_ARCH}/lib/slepc/conf/slepc_variables],
                   [AC_MSG_RESULT([<<< SLEPc configuration failed.  Could not find slepcconf/slepc_variables file. >>>])
                    enableslepc=no])
 

--- a/m4/slepc.m4
+++ b/m4/slepc.m4
@@ -72,18 +72,13 @@ AC_DEFUN([CONFIGURE_SLEPC],
           [
             dnl Similar to petsc, we need the slepc version number.
             dnl Note slepc will most likely only work with the corresponding version of petsc
+            slepc_version_header=$SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h
             AS_IF([test "x$slepc_in_petsc_arch" != "xyes"],
-                            [
-                               slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
-                               slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
-                               slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
-                             ],
-                             [
-                               slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
-                               slepcminor=`grep "define SLEPC_VERSION_MINOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
-                               slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $SLEPC_DIR/$PETSC_ARCH/include/slepcversion.h | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
-                             ]
-            )
+                  [slepc_version_header=$SLEPC_DIR/include/slepcversion.h])
+
+            slepcmajor=`grep "define SLEPC_VERSION_MAJOR" $slepc_version_header | sed -e "s/#define SLEPC_VERSION_MAJOR[ ]*//g"`
+            slepcminor=`grep "define SLEPC_VERSION_MINOR" $slepc_version_header | sed -e "s/#define SLEPC_VERSION_MINOR[ ]*//g"`
+            slepcsubminor=`grep "define SLEPC_VERSION_SUBMINOR" $slepc_version_header | sed -e "s/#define SLEPC_VERSION_SUBMINOR[ ]*//g"`
 
             slepcversion=$slepcmajor.$slepcminor.$slepcsubminor
             dnl Older PETSc (3.3 and earlier) might not work if the version numbers don't match exactly.


### PR DESCRIPTION
There are a couple of SLEPc use cases:

(1) Use prefix, and SLEPc will be installed to $prefix, and SLEPC_DIR=$prefix. PETSC_ARCH most likely is empty. $SLEPC_DIR/include has `slepcversion.h `

(2) Install SLEPc in place, SLEPC_DIR and PETSC_ARCH will be set properly. $SLEPC_DIR/include has 
`slepcversion.h`

(3) Let PETSc configuration --download-slepc, and make a prefix installation.  PETSC_DIR=$prefix, SLEPC_DIR=$PETSC_DIR and PETSC_ARCH should be empty.  $SLEPC_DIR/include has 
`slepcversion.h`

(4) PETSc configure with --download-slepc, and make an in-place installation. I would like to set SLEPC_DIR=$PETSC_DIR, and PETSC_ARCH is NOT empty. And then $SLEPC_DIR/include does not have  `slepcversion.h`. Instead, `slepcversion.h` lives in $SLEPC_DIR/$PETSC_ARCH.

libMesh was able to support (1), (2) and (3). The current PR is trying to support (4) that is what I usually use.

Not sure is it a reasonable use case or not?
