### PR TITLE
Improve quality of Legendre polynomial implementation

### DIFF
--- a/src/fe/inf_fe_legendre_eval.C
+++ b/src/fe/inf_fe_legendre_eval.C
@@ -22,300 +22,108 @@
 #include "libmesh/inf_fe.h"
 #include "libmesh/inf_fe_macro.h"
 
-namespace libMesh
-{
+using namespace libMesh;
 
 // Anonymous namespace for local helper functions
 namespace {
 
-Real legendre_eval(Real v,  unsigned i)
+// Evaluate P_n(x) using the three term recurrence relation.  Note
+// that using the three term recurrence is more accurate than the
+// unrolled Horner scheme that was used here previously and requires a
+// lot less code.
+// TODO: C++17 will have std::legendre() in <cmath>, so eventually we
+// can just use that.
+Real legendre_eval(unsigned int n, Real x)
 {
-  libmesh_assert (-1.-1.e-5 <= v && v < 1.);
+  Real p0 = 1;
+  Real p1 = x;
+  if (n == 0)
+    return p0;
 
-  switch (i)
+  unsigned int i = 1;
+  while (i < n)
     {
-    case 0:
-      return 1.;
-
-    case 1:
-      return v+1.;
-
-    case 2:
-      return 1.5*v*v-1.5;
-
-    case 3:
-      return 1.+(-1.5+2.5*v*v)*v;
-
-    case 4:
-      return -.625+(-3.75+4.375*v*v)*v*v;
-
-    case 5:
-      return 1.+(1.875+(-8.75+7.875*v*v)*v*v)*v;
-
-    case 6:
-      return -1.3125+
-        (6.5625+
-         (-19.6875+14.4375*v*v)*v*v)*v*v;
-
-    case 7:
-      return 1.+
-        (-2.1875+
-         (19.6875+
-          (-43.3125+26.8125*v*v)*v*v)*v*v)*v;
-
-    case 8:
-      return -.7265625+
-        (-9.84375+
-         (54.140625+
-          (-93.84375+50.2734375*v*v)*v*v)*v*v)*v*v;
-
-    case 9:
-      return 1.+
-        (2.4609375+
-         (-36.09375+
-          (140.765625+
-           (-201.09375+94.9609375*v*v)*v*v)*v*v)*v*v)*v;
-
-    case 10:
-      return -1.24609375+
-        (13.53515625+
-         (-117.3046875+
-          (351.9140625+
-           (-427.32421875+180.42578125*v*v)*v*v)*v*v)*v*v)*v*v;
-
-    case 11:
-      return 1.+
-        (-2.70703125+
-         (58.65234375+
-          (-351.9140625+
-           (854.6484375+
-            (-902.12890625+344.44921875*v*v)*v*v)*v*v)*v*v)*v*v)*v;
-
-    case 12:
-      return -.7744140625+
-        (-17.595703125+
-         (219.9462890625+
-          (-997.08984375+
-           (2029.7900390625+
-            (-1894.470703125+660.1943359375*v*v)*v*v)*v*v)*v*v)*v*v)*v*v;
-
-    case 13:
-      return 1.+
-        (2.9326171875+
-         (-87.978515625+
-          (747.8173828125+
-           (-2706.38671875+
-            (4736.1767578125+
-             (-3961.166015625+1269.6044921875*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v;
-
-    case 14:
-      return -1.20947265625+
-        (21.99462890625+
-         (-373.90869140625+
-          (2368.08837890625+
-           (-7104.26513671875+
-            (10893.20654296875+
-             (-8252.42919921875+2448.52294921875*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v;
-
-    case 15:
-      return 1.+
-        (-3.14208984375+
-         (124.63623046875+
-          (-1420.85302734375+
-           (7104.26513671875+
-            (-18155.34423828125+
-             (24757.28759765625+
-              (-17139.66064453125+4733.81103515625*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v;
-
-    case 16:
-      return -.803619384765625+
-        (-26.707763671875+
-         (592.0220947265625+
-          (-4972.985595703125+
-           (20424.76226806641+
-            (-45388.36059570313+
-             (55703.89709472656+
-              (-35503.58276367188+9171.758880615234*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v;
-
-    case 17:
-      return 1.+
-        (3.338470458984375+
-         (-169.149169921875+
-          (2486.492797851563+
-           (-16339.80981445313+
-            (56735.45074462891+
-             (-111407.7941894531+
-              (124262.5396728516+
-               (-73374.07104492188+17804.00253295898*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v;
-
-    case 18:
-      return -1.185470581054688+
-        (31.71546936035156+
-         (-888.0331420898438+
-          (9531.555725097656+
-           (-51061.90567016602+
-            (153185.717010498+
-             (-269235.5026245117+
-              (275152.766418457+
-               (-151334.0215301514+34618.89381408691*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v;
-
-
-    default:
-      libmesh_error_msg("bad index i = " << i);
+      // Swapping saves a temporary, since this immediately updates p0
+      // and then p1 is updated on the next line. Note that p0 and p1
+      // appear in opposite positions than is usual in the update
+      // formula because of this swap!
+      std::swap(p0, p1);
+      p1 = ((2*i + 1) * x * p0 - i * p1) / (i + 1);
+      ++i;
     }
-} // legendre_eval()
+
+  // To match the original implementation, we add 1 to the result for
+  // n odd, and subtract 1 for n even. I'm not sure why this is done
+  // as it is not part of the "standard" Legendre polynomial definition.
+  return p1 + (n % 2 == 0 ? -1 : +1);
+}
 
 
 
-
-Real legendre_eval_deriv(Real v, unsigned i)
+// Evaluate d/dx P_n(x) using a recurrence relation.
+// To evaluate the derivatives, we also need to evaluate the values,
+// so this function duplicates some of legendre_eval(). That seems OK to me
+// though since it is so simple. The recurrence relation we are using
+// is from Wikipedia:
+// (2n+1) * P_n = d/dx (P_{n+1} - P_{n-1})
+// There are no plans for Legendre function derivatives to be in
+// C++17, so we will need our own implementation for the forseeable
+// future.  Finally, note that the shift which is applied to the
+// values does not affect the derivatives, so it does not show up
+// here.
+Real legendre_eval_deriv(unsigned int n, Real x)
 {
-  libmesh_assert (-1.-1.e-5 <= v && v < 1.);
+  if (n == 0)
+    return 0;
 
-  switch (i)
+  Real p0 = 1;
+  Real p1 = x;
+
+  // The recurrence relation we're using only requires one previous
+  // derivative value, but it is from two iterations ago, so we still
+  // need to keep track of two values.
+  Real dp0 = 0;
+  Real dp1 = 1;
+
+  unsigned int i = 1;
+  while (i < n)
     {
-    case 0:
-      return 0.;
+      // Swapping saves a temporary, since this immediately updates p0
+      // and then p1 is updated on the next line. Note that p0 and p1
+      // appear in opposite positions than is usual in the update
+      // formula because of this swap!
+      std::swap(p0, p1);
+      p1 = ((2*i + 1) * x * p0 - i * p1) / (i + 1);
 
-    case 1:
-      return 1.;
-
-    case 2:
-      return 3.*v;
-
-    case 3:
-      return 7.5*v*v-1.5;
-
-    case 4:
-      return (-7.5+17.5*v*v)*v;
-
-    case 5:
-      return 1.875+(-26.25+39.375*v*v)*v*v;
-
-    case 6:
-      return
-        (13.125+
-         (-78.75+86.625*v*v)*v*v)*v;
-
-    case 7:
-      return -2.1875+
-        (59.0625+
-         (-216.5625+187.6875*v*v)*v*v)*v*v;
-
-    case 8:
-      return
-        (-19.6875+
-         (216.5625+
-          (-563.0625+402.1875*v*v)*v*v)*v*v)*v;
-
-    case 9:
-      return 2.4609375+
-        (-108.28125+
-         (703.828125+
-          (-1407.65625+854.6484375*v*v)*v*v)*v*v)*v*v;
-
-    case 10:
-      return
-        (27.0703125+
-         (-469.21875+
-          (2111.484375+
-           (-3418.59375+1804.2578125*v*v)*v*v)*v*v)*v*v)*v;
-
-    case 11:
-      return -2.70703125+
-        (175.95703125+
-         (-1759.5703125+
-          (5982.5390625+
-           (-8119.16015625+3788.94140625*v*v)*v*v)*v*v)*v*v)*v*v;
-
-    case 12:
-      return
-        (-35.19140625+
-         (879.78515625+
-          (-5982.5390625+
-           (16238.3203125+
-            (-18944.70703125+7922.33203125*v*v)*v*v)*v*v)*v*v)*v*v)*v;
-
-    case 13:
-      return 2.9326171875+
-        (-263.935546875+
-         (3739.0869140625+
-          (-18944.70703125+
-           (42625.5908203125+
-            (-43572.826171875+16504.8583984375*v*v)*v*v)*v*v)*v*v)*v*v)*v*v;
-
-    case 14:
-      return
-        (43.9892578125+
-         (-1495.634765625+
-          (14208.5302734375+
-           (-56834.12109375+
-            (108932.0654296875+
-             (-99029.150390625+34279.3212890625*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v;
-
-    case 15:
-      return -3.14208984375+
-        (373.90869140625+
-         (-7104.26513671875+
-          (49729.85595703125+
-           (-163398.0981445313+
-            (272330.1635742188+
-             (-222815.5883789063+71007.16552734375*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v;
-
-    case 16:
-      return
-        (-53.41552734375+
-         (2368.08837890625+
-          (-29837.91357421875+
-           (163398.0981445313+
-            (-453883.6059570313+
-             (668446.7651367188+
-              (-497050.1586914063+146748.1420898438*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v;
-
-    case 17:
-      return 3.338470458984375+
-        (-507.447509765625+
-         (12432.46398925781+
-          (-114378.6687011719+
-           (510619.0567016602+
-            (-1225485.736083984+
-             (1615413.01574707+
-              (-1100611.065673828+302668.0430603027*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v;
-
-    case 18:
-      return
-        (63.43093872070313+
-         (-3552.132568359375+
-          (57189.33435058594+
-           (-408495.2453613281+
-            (1531857.17010498+
-             (-3230826.031494141+
-              (3852138.729858398+
-               (-2421344.344482422+623140.0886535645*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v*v)*v;
-
-
-    default:
-      libmesh_error_msg("bad index i = " << i);
+      // Note that dp1 appears in the formula below, but because we
+      // swapped, it's really dp0. Also, we have already updated the
+      // values, so:
+      // p1 is now P_{i+1}(x)
+      // p0 is now P_{i}(x)
+      std::swap(dp0, dp1);
+      dp1 = (2*i + 1) * p0 + dp1;
+      ++i;
     }
-} // legendre_eval_deriv()
+  return dp1;
+}
 
 } // anonymous namespace
 
 
+namespace libMesh
+{
 
-
-
-  // Specialize the eval() function for 1, 2, and 3 dimensions and the CARTESIAN mapping type
-  // to call the local helper function from the anonymous namespace.
-template <> Real InfFE<1,LEGENDRE,CARTESIAN>::eval(Real v, Order, unsigned i) { return legendre_eval(v, i); }
-template <> Real InfFE<2,LEGENDRE,CARTESIAN>::eval(Real v, Order, unsigned i) { return legendre_eval(v, i); }
-template <> Real InfFE<3,LEGENDRE,CARTESIAN>::eval(Real v, Order, unsigned i) { return legendre_eval(v, i); }
+// Specialize the eval() function for 1, 2, and 3 dimensions and the CARTESIAN mapping type
+// to call the local helper function from the anonymous namespace.
+template <> Real InfFE<1,LEGENDRE,CARTESIAN>::eval(Real x, Order, unsigned n) { return legendre_eval(n, x); }
+template <> Real InfFE<2,LEGENDRE,CARTESIAN>::eval(Real x, Order, unsigned n) { return legendre_eval(n, x); }
+template <> Real InfFE<3,LEGENDRE,CARTESIAN>::eval(Real x, Order, unsigned n) { return legendre_eval(n, x); }
 
 // Specialize the eval_deriv() function for 1, 2, and 3 dimensions and the CARTESIAN mapping type
 // to call the local helper function from the anonymous namespace.
-template <> Real InfFE<1,LEGENDRE,CARTESIAN>::eval_deriv(Real v, Order, unsigned i) { return legendre_eval_deriv(v, i); }
-template <> Real InfFE<2,LEGENDRE,CARTESIAN>::eval_deriv(Real v, Order, unsigned i) { return legendre_eval_deriv(v, i); }
-template <> Real InfFE<3,LEGENDRE,CARTESIAN>::eval_deriv(Real v, Order, unsigned i) { return legendre_eval_deriv(v, i); }
+template <> Real InfFE<1,LEGENDRE,CARTESIAN>::eval_deriv(Real x, Order, unsigned n) { return legendre_eval_deriv(n, x); }
+template <> Real InfFE<2,LEGENDRE,CARTESIAN>::eval_deriv(Real x, Order, unsigned n) { return legendre_eval_deriv(n, x); }
+template <> Real InfFE<3,LEGENDRE,CARTESIAN>::eval_deriv(Real x, Order, unsigned n) { return legendre_eval_deriv(n, x); }
 
 } // namespace libMesh
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,6 +29,7 @@ unit_tests_sources = \
   fe/fe_clough_test.C \
   fe/fe_hermite_test.C \
   fe/fe_hierarchic_test.C \
+  fe/inf_fe_legendre_test.C \
   fe/fe_l2_hierarchic_test.C \
   fe/fe_l2_lagrange_test.C \
   fe/fe_lagrange_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -188,13 +188,14 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C test_comm.h \
 	base/point_neighbor_coupling_test.C \
 	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/bbox_test.C geom/elem_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	geom/side_test.C geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	fe/fe_hierarchic_test.C fe/inf_fe_legendre_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/bbox_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h geom/side_test.C \
+	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_input.C mesh/mesh_function.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
@@ -241,6 +242,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_hermite_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_hierarchic_test.$(OBJEXT) \
+	fe/unit_tests_dbg-inf_fe_legendre_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_l2_hierarchic_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_l2_lagrange_test.$(OBJEXT) \
 	fe/unit_tests_dbg-fe_lagrange_test.$(OBJEXT) \
@@ -320,13 +322,14 @@ am__unit_tests_devel_SOURCES_DIST = driver.C test_comm.h \
 	base/point_neighbor_coupling_test.C \
 	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/bbox_test.C geom/elem_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	geom/side_test.C geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	fe/fe_hierarchic_test.C fe/inf_fe_legendre_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/bbox_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h geom/side_test.C \
+	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_input.C mesh/mesh_function.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
@@ -372,6 +375,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	fe/unit_tests_devel-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_hermite_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_hierarchic_test.$(OBJEXT) \
+	fe/unit_tests_devel-inf_fe_legendre_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_l2_hierarchic_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_l2_lagrange_test.$(OBJEXT) \
 	fe/unit_tests_devel-fe_lagrange_test.$(OBJEXT) \
@@ -448,13 +452,14 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C test_comm.h \
 	base/point_neighbor_coupling_test.C \
 	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/bbox_test.C geom/elem_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	geom/side_test.C geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	fe/fe_hierarchic_test.C fe/inf_fe_legendre_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/bbox_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h geom/side_test.C \
+	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_input.C mesh/mesh_function.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
@@ -500,6 +505,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_hermite_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_hierarchic_test.$(OBJEXT) \
+	fe/unit_tests_oprof-inf_fe_legendre_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_l2_hierarchic_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_l2_lagrange_test.$(OBJEXT) \
 	fe/unit_tests_oprof-fe_lagrange_test.$(OBJEXT) \
@@ -576,13 +582,14 @@ am__unit_tests_opt_SOURCES_DIST = driver.C test_comm.h \
 	base/point_neighbor_coupling_test.C \
 	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/bbox_test.C geom/elem_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	geom/side_test.C geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	fe/fe_hierarchic_test.C fe/inf_fe_legendre_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/bbox_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h geom/side_test.C \
+	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_input.C mesh/mesh_function.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
@@ -628,6 +635,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	fe/unit_tests_opt-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_hermite_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_hierarchic_test.$(OBJEXT) \
+	fe/unit_tests_opt-inf_fe_legendre_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_l2_hierarchic_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_l2_lagrange_test.$(OBJEXT) \
 	fe/unit_tests_opt-fe_lagrange_test.$(OBJEXT) \
@@ -703,13 +711,14 @@ am__unit_tests_prof_SOURCES_DIST = driver.C test_comm.h \
 	base/point_neighbor_coupling_test.C \
 	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/bbox_test.C geom/elem_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	geom/side_test.C geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	fe/fe_hierarchic_test.C fe/inf_fe_legendre_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/bbox_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h geom/side_test.C \
+	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_input.C mesh/mesh_function.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
@@ -755,6 +764,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	fe/unit_tests_prof-fe_clough_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_hermite_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_hierarchic_test.$(OBJEXT) \
+	fe/unit_tests_prof-inf_fe_legendre_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_l2_hierarchic_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_l2_lagrange_test.$(OBJEXT) \
 	fe/unit_tests_prof-fe_lagrange_test.$(OBJEXT) \
@@ -880,6 +890,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	fe/$(DEPDIR)/unit_tests_dbg-fe_monomial_test.Po \
 	fe/$(DEPDIR)/unit_tests_dbg-fe_szabab_test.Po \
 	fe/$(DEPDIR)/unit_tests_dbg-fe_xyz_test.Po \
+	fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Po \
 	fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Po \
 	fe/$(DEPDIR)/unit_tests_devel-fe_clough_test.Po \
 	fe/$(DEPDIR)/unit_tests_devel-fe_hermite_test.Po \
@@ -890,6 +901,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	fe/$(DEPDIR)/unit_tests_devel-fe_monomial_test.Po \
 	fe/$(DEPDIR)/unit_tests_devel-fe_szabab_test.Po \
 	fe/$(DEPDIR)/unit_tests_devel-fe_xyz_test.Po \
+	fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Po \
 	fe/$(DEPDIR)/unit_tests_oprof-fe_bernstein_test.Po \
 	fe/$(DEPDIR)/unit_tests_oprof-fe_clough_test.Po \
 	fe/$(DEPDIR)/unit_tests_oprof-fe_hermite_test.Po \
@@ -900,6 +912,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	fe/$(DEPDIR)/unit_tests_oprof-fe_monomial_test.Po \
 	fe/$(DEPDIR)/unit_tests_oprof-fe_szabab_test.Po \
 	fe/$(DEPDIR)/unit_tests_oprof-fe_xyz_test.Po \
+	fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Po \
 	fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Po \
 	fe/$(DEPDIR)/unit_tests_opt-fe_clough_test.Po \
 	fe/$(DEPDIR)/unit_tests_opt-fe_hermite_test.Po \
@@ -910,6 +923,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	fe/$(DEPDIR)/unit_tests_opt-fe_monomial_test.Po \
 	fe/$(DEPDIR)/unit_tests_opt-fe_szabab_test.Po \
 	fe/$(DEPDIR)/unit_tests_opt-fe_xyz_test.Po \
+	fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Po \
 	fe/$(DEPDIR)/unit_tests_prof-fe_bernstein_test.Po \
 	fe/$(DEPDIR)/unit_tests_prof-fe_clough_test.Po \
 	fe/$(DEPDIR)/unit_tests_prof-fe_hermite_test.Po \
@@ -920,6 +934,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	fe/$(DEPDIR)/unit_tests_prof-fe_monomial_test.Po \
 	fe/$(DEPDIR)/unit_tests_prof-fe_szabab_test.Po \
 	fe/$(DEPDIR)/unit_tests_prof-fe_xyz_test.Po \
+	fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Po \
 	fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Po \
 	fparser/$(DEPDIR)/unit_tests_devel-autodiff.Po \
 	fparser/$(DEPDIR)/unit_tests_oprof-autodiff.Po \
@@ -1622,13 +1637,14 @@ unit_tests_sources = driver.C test_comm.h stream_redirector.h \
 	base/point_neighbor_coupling_test.C \
 	base/overlapping_coupling_test.C fe/fe_bernstein_test.C \
 	fe/fe_clough_test.C fe/fe_hermite_test.C \
-	fe/fe_hierarchic_test.C fe/fe_l2_hierarchic_test.C \
-	fe/fe_l2_lagrange_test.C fe/fe_lagrange_test.C \
-	fe/fe_monomial_test.C fe/fe_szabab_test.C fe/fe_test.h \
-	fe/fe_xyz_test.C geom/bbox_test.C geom/elem_test.C \
-	geom/node_test.C geom/point_test.C geom/point_test.h \
-	geom/side_test.C geom/which_node_am_i_test.C mesh/all_tri.C \
-	mesh/distort.C mesh/boundary_mesh.C mesh/boundary_info.C \
+	fe/fe_hierarchic_test.C fe/inf_fe_legendre_test.C \
+	fe/fe_l2_hierarchic_test.C fe/fe_l2_lagrange_test.C \
+	fe/fe_lagrange_test.C fe/fe_monomial_test.C \
+	fe/fe_szabab_test.C fe/fe_test.h fe/fe_xyz_test.C \
+	geom/bbox_test.C geom/elem_test.C geom/node_test.C \
+	geom/point_test.C geom/point_test.h geom/side_test.C \
+	geom/which_node_am_i_test.C mesh/all_tri.C mesh/distort.C \
+	mesh/boundary_mesh.C mesh/boundary_info.C \
 	mesh/boundary_points.C mesh/checkpoint.C mesh/contains_point.C \
 	mesh/extra_integers.C mesh/mesh_input.C mesh/mesh_function.C \
 	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
@@ -1768,6 +1784,8 @@ fe/unit_tests_dbg-fe_clough_test.$(OBJEXT): fe/$(am__dirstamp) \
 fe/unit_tests_dbg-fe_hermite_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_dbg-fe_hierarchic_test.$(OBJEXT): fe/$(am__dirstamp) \
+	fe/$(DEPDIR)/$(am__dirstamp)
+fe/unit_tests_dbg-inf_fe_legendre_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_dbg-fe_l2_hierarchic_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
@@ -1985,6 +2003,8 @@ fe/unit_tests_devel-fe_hermite_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_devel-fe_hierarchic_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
+fe/unit_tests_devel-inf_fe_legendre_test.$(OBJEXT):  \
+	fe/$(am__dirstamp) fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_devel-fe_l2_hierarchic_test.$(OBJEXT):  \
 	fe/$(am__dirstamp) fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_devel-fe_l2_lagrange_test.$(OBJEXT): fe/$(am__dirstamp) \
@@ -2141,6 +2161,8 @@ fe/unit_tests_oprof-fe_hermite_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_oprof-fe_hierarchic_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
+fe/unit_tests_oprof-inf_fe_legendre_test.$(OBJEXT):  \
+	fe/$(am__dirstamp) fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_oprof-fe_l2_hierarchic_test.$(OBJEXT):  \
 	fe/$(am__dirstamp) fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_oprof-fe_l2_lagrange_test.$(OBJEXT): fe/$(am__dirstamp) \
@@ -2297,6 +2319,8 @@ fe/unit_tests_opt-fe_hermite_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_opt-fe_hierarchic_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
+fe/unit_tests_opt-inf_fe_legendre_test.$(OBJEXT): fe/$(am__dirstamp) \
+	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_opt-fe_l2_hierarchic_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_opt-fe_l2_lagrange_test.$(OBJEXT): fe/$(am__dirstamp) \
@@ -2452,6 +2476,8 @@ fe/unit_tests_prof-fe_clough_test.$(OBJEXT): fe/$(am__dirstamp) \
 fe/unit_tests_prof-fe_hermite_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_prof-fe_hierarchic_test.$(OBJEXT): fe/$(am__dirstamp) \
+	fe/$(DEPDIR)/$(am__dirstamp)
+fe/unit_tests_prof-inf_fe_legendre_test.$(OBJEXT): fe/$(am__dirstamp) \
 	fe/$(DEPDIR)/$(am__dirstamp)
 fe/unit_tests_prof-fe_l2_hierarchic_test.$(OBJEXT):  \
 	fe/$(am__dirstamp) fe/$(DEPDIR)/$(am__dirstamp)
@@ -2650,6 +2676,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-fe_monomial_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-fe_szabab_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-fe_xyz_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_devel-fe_clough_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_devel-fe_hermite_test.Po@am__quote@ # am--include-marker
@@ -2660,6 +2687,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_devel-fe_monomial_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_devel-fe_szabab_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_devel-fe_xyz_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_oprof-fe_bernstein_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_oprof-fe_clough_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_oprof-fe_hermite_test.Po@am__quote@ # am--include-marker
@@ -2670,6 +2698,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_oprof-fe_monomial_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_oprof-fe_szabab_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_oprof-fe_xyz_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_opt-fe_clough_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_opt-fe_hermite_test.Po@am__quote@ # am--include-marker
@@ -2680,6 +2709,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_opt-fe_monomial_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_opt-fe_szabab_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_opt-fe_xyz_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_prof-fe_bernstein_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_prof-fe_clough_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_prof-fe_hermite_test.Po@am__quote@ # am--include-marker
@@ -2690,6 +2720,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_prof-fe_monomial_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_prof-fe_szabab_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_prof-fe_xyz_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_devel-autodiff.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@fparser/$(DEPDIR)/unit_tests_oprof-autodiff.Po@am__quote@ # am--include-marker
@@ -3145,6 +3176,20 @@ fe/unit_tests_dbg-fe_hierarchic_test.obj: fe/fe_hierarchic_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/fe_hierarchic_test.C' object='fe/unit_tests_dbg-fe_hierarchic_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_dbg-fe_hierarchic_test.obj `if test -f 'fe/fe_hierarchic_test.C'; then $(CYGPATH_W) 'fe/fe_hierarchic_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_hierarchic_test.C'; fi`
+
+fe/unit_tests_dbg-inf_fe_legendre_test.o: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_dbg-inf_fe_legendre_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_dbg-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_dbg-inf_fe_legendre_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_dbg-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+
+fe/unit_tests_dbg-inf_fe_legendre_test.obj: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_dbg-inf_fe_legendre_test.obj -MD -MP -MF fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_dbg-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_dbg-inf_fe_legendre_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_dbg-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
 
 fe/unit_tests_dbg-fe_l2_hierarchic_test.o: fe/fe_l2_hierarchic_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_dbg-fe_l2_hierarchic_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_dbg-fe_l2_hierarchic_test.Tpo -c -o fe/unit_tests_dbg-fe_l2_hierarchic_test.o `test -f 'fe/fe_l2_hierarchic_test.C' || echo '$(srcdir)/'`fe/fe_l2_hierarchic_test.C
@@ -4168,6 +4213,20 @@ fe/unit_tests_devel-fe_hierarchic_test.obj: fe/fe_hierarchic_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_devel-fe_hierarchic_test.obj `if test -f 'fe/fe_hierarchic_test.C'; then $(CYGPATH_W) 'fe/fe_hierarchic_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_hierarchic_test.C'; fi`
 
+fe/unit_tests_devel-inf_fe_legendre_test.o: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_devel-inf_fe_legendre_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_devel-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_devel-inf_fe_legendre_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_devel-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+
+fe/unit_tests_devel-inf_fe_legendre_test.obj: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_devel-inf_fe_legendre_test.obj -MD -MP -MF fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_devel-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_devel-inf_fe_legendre_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_devel-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
+
 fe/unit_tests_devel-fe_l2_hierarchic_test.o: fe/fe_l2_hierarchic_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_devel-fe_l2_hierarchic_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_devel-fe_l2_hierarchic_test.Tpo -c -o fe/unit_tests_devel-fe_l2_hierarchic_test.o `test -f 'fe/fe_l2_hierarchic_test.C' || echo '$(srcdir)/'`fe/fe_l2_hierarchic_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_devel-fe_l2_hierarchic_test.Tpo fe/$(DEPDIR)/unit_tests_devel-fe_l2_hierarchic_test.Po
@@ -5189,6 +5248,20 @@ fe/unit_tests_oprof-fe_hierarchic_test.obj: fe/fe_hierarchic_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/fe_hierarchic_test.C' object='fe/unit_tests_oprof-fe_hierarchic_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_oprof-fe_hierarchic_test.obj `if test -f 'fe/fe_hierarchic_test.C'; then $(CYGPATH_W) 'fe/fe_hierarchic_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_hierarchic_test.C'; fi`
+
+fe/unit_tests_oprof-inf_fe_legendre_test.o: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_oprof-inf_fe_legendre_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_oprof-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_oprof-inf_fe_legendre_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_oprof-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+
+fe/unit_tests_oprof-inf_fe_legendre_test.obj: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_oprof-inf_fe_legendre_test.obj -MD -MP -MF fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_oprof-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_oprof-inf_fe_legendre_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_oprof-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
 
 fe/unit_tests_oprof-fe_l2_hierarchic_test.o: fe/fe_l2_hierarchic_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_oprof-fe_l2_hierarchic_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_oprof-fe_l2_hierarchic_test.Tpo -c -o fe/unit_tests_oprof-fe_l2_hierarchic_test.o `test -f 'fe/fe_l2_hierarchic_test.C' || echo '$(srcdir)/'`fe/fe_l2_hierarchic_test.C
@@ -6212,6 +6285,20 @@ fe/unit_tests_opt-fe_hierarchic_test.obj: fe/fe_hierarchic_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_opt-fe_hierarchic_test.obj `if test -f 'fe/fe_hierarchic_test.C'; then $(CYGPATH_W) 'fe/fe_hierarchic_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_hierarchic_test.C'; fi`
 
+fe/unit_tests_opt-inf_fe_legendre_test.o: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_opt-inf_fe_legendre_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_opt-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_opt-inf_fe_legendre_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_opt-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+
+fe/unit_tests_opt-inf_fe_legendre_test.obj: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_opt-inf_fe_legendre_test.obj -MD -MP -MF fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_opt-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_opt-inf_fe_legendre_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_opt-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
+
 fe/unit_tests_opt-fe_l2_hierarchic_test.o: fe/fe_l2_hierarchic_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_opt-fe_l2_hierarchic_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_opt-fe_l2_hierarchic_test.Tpo -c -o fe/unit_tests_opt-fe_l2_hierarchic_test.o `test -f 'fe/fe_l2_hierarchic_test.C' || echo '$(srcdir)/'`fe/fe_l2_hierarchic_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_opt-fe_l2_hierarchic_test.Tpo fe/$(DEPDIR)/unit_tests_opt-fe_l2_hierarchic_test.Po
@@ -7233,6 +7320,20 @@ fe/unit_tests_prof-fe_hierarchic_test.obj: fe/fe_hierarchic_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/fe_hierarchic_test.C' object='fe/unit_tests_prof-fe_hierarchic_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_prof-fe_hierarchic_test.obj `if test -f 'fe/fe_hierarchic_test.C'; then $(CYGPATH_W) 'fe/fe_hierarchic_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/fe_hierarchic_test.C'; fi`
+
+fe/unit_tests_prof-inf_fe_legendre_test.o: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_prof-inf_fe_legendre_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_prof-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_prof-inf_fe_legendre_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_prof-inf_fe_legendre_test.o `test -f 'fe/inf_fe_legendre_test.C' || echo '$(srcdir)/'`fe/inf_fe_legendre_test.C
+
+fe/unit_tests_prof-inf_fe_legendre_test.obj: fe/inf_fe_legendre_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_prof-inf_fe_legendre_test.obj -MD -MP -MF fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Tpo -c -o fe/unit_tests_prof-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Tpo fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='fe/inf_fe_legendre_test.C' object='fe/unit_tests_prof-inf_fe_legendre_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o fe/unit_tests_prof-inf_fe_legendre_test.obj `if test -f 'fe/inf_fe_legendre_test.C'; then $(CYGPATH_W) 'fe/inf_fe_legendre_test.C'; else $(CYGPATH_W) '$(srcdir)/fe/inf_fe_legendre_test.C'; fi`
 
 fe/unit_tests_prof-fe_l2_hierarchic_test.o: fe/fe_l2_hierarchic_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT fe/unit_tests_prof-fe_l2_hierarchic_test.o -MD -MP -MF fe/$(DEPDIR)/unit_tests_prof-fe_l2_hierarchic_test.Tpo -c -o fe/unit_tests_prof-fe_l2_hierarchic_test.o `test -f 'fe/fe_l2_hierarchic_test.C' || echo '$(srcdir)/'`fe/fe_l2_hierarchic_test.C
@@ -8407,6 +8508,7 @@ distclean: distclean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_clough_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_hermite_test.Po
@@ -8417,6 +8519,7 @@ distclean: distclean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_clough_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_hermite_test.Po
@@ -8427,6 +8530,7 @@ distclean: distclean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_clough_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_hermite_test.Po
@@ -8437,6 +8541,7 @@ distclean: distclean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_clough_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_hermite_test.Po
@@ -8447,6 +8552,7 @@ distclean: distclean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Po
 	-rm -f fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Po
 	-rm -f fparser/$(DEPDIR)/unit_tests_devel-autodiff.Po
 	-rm -f fparser/$(DEPDIR)/unit_tests_oprof-autodiff.Po
@@ -8817,6 +8923,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_dbg-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_dbg-inf_fe_legendre_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_clough_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_hermite_test.Po
@@ -8827,6 +8934,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_devel-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_devel-inf_fe_legendre_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_clough_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_hermite_test.Po
@@ -8837,6 +8945,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_oprof-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_oprof-inf_fe_legendre_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_clough_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_hermite_test.Po
@@ -8847,6 +8956,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_opt-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_opt-inf_fe_legendre_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_bernstein_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_clough_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_hermite_test.Po
@@ -8857,6 +8967,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_monomial_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_szabab_test.Po
 	-rm -f fe/$(DEPDIR)/unit_tests_prof-fe_xyz_test.Po
+	-rm -f fe/$(DEPDIR)/unit_tests_prof-inf_fe_legendre_test.Po
 	-rm -f fparser/$(DEPDIR)/unit_tests_dbg-autodiff.Po
 	-rm -f fparser/$(DEPDIR)/unit_tests_devel-autodiff.Po
 	-rm -f fparser/$(DEPDIR)/unit_tests_oprof-autodiff.Po

--- a/tests/fe/inf_fe_legendre_test.C
+++ b/tests/fe/inf_fe_legendre_test.C
@@ -1,0 +1,241 @@
+// Ignore unused parameter warnings coming from cppunit headers
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+// libmesh includes
+#include "libmesh/libmesh.h"
+#include "libmesh/replicated_mesh.h"
+#include "libmesh/mesh_generation.h"
+#include "libmesh/inf_elem_builder.h"
+#include "libmesh/fe_type.h"
+#include "libmesh/quadrature_gauss.h"
+#include "libmesh/elem.h"
+#include "libmesh/inf_fe.h"
+
+// unit test includes
+#include "test_comm.h"
+
+// C++ includes
+#include <tuple>
+
+// THE CPPUNIT_TEST_SUITE_END macro expands to code that involves
+// std::auto_ptr, which in turn produces -Wdeprecated-declarations
+// warnings.  These can be ignored in GCC as long as we wrap the
+// offending code in appropriate pragmas.  We can't get away with a
+// single ignore_warnings.h inclusion at the beginning of this file,
+// since the libmesh headers pull in a restore_warnings.h at some
+// point.  We also don't bother restoring warnings at the end of this
+// file since it's not a header.
+#include <libmesh/ignore_warnings.h>
+
+using namespace libMesh;
+
+class InfFELegendreTest : public CppUnit::TestCase
+{
+public:
+  CPPUNIT_TEST_SUITE( InfFELegendreTest );
+  CPPUNIT_TEST( testDifferentOrders );
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  typedef std::vector<std::tuple<unsigned, unsigned, Real>> TabulatedVals;
+  typedef std::vector<std::tuple<unsigned, unsigned, Point>> TabulatedGrads;
+
+  void testDifferentOrders ()
+  {
+    // std::cout << "Called testDifferentOrders." << std::endl;
+
+    // Arbitrarily selected (i, qp, phi) sample values for FIRST-order case.
+    TabulatedVals first_vals =
+      {
+        {0,9,0.0550016}, {1,5,0.41674},   {2,8,0.0147376}, {3,7,0.111665},
+        {4,6,0.0737011}, {5,1,0.0803773}, {6,11,0.275056}, {7,15,0.021537}
+      };
+
+    // Arbitrarily selected (i, qp, dphi) sample values for FIRST-order case.
+    TabulatedGrads first_grads =
+      {
+        {0,9,Point(-0.0429458, -0.0115073, 0.)},
+        {1,5,Point(0.177013, -0.177013, -0.483609)},
+        {2,8,Point(0.0115073, 0.0115073, 0.00842393)},
+        {3,7,Point(-0.177013, 0.0474305, 0.)},
+        {4,6,Point(-0.031305, -0.116832,  0.10025)},
+        {5,1,Point(0.0474191, -0.0474191, 0.872917)},
+        {6,11,Point(0.0575466, 0.0575466, -0.11251)},
+        {7,15,Point(-0.00353805, 0.000948017, 0.000111572)}
+      };
+
+    testSingleOrder(FIRST, first_vals, first_grads);
+
+    // Arbitrarily selected (i, qp, phi) sample values for SECOND-order case.
+    TabulatedVals second_vals =
+      {
+        {0,3,0.0425633}, {1,6,0.0343526}, {2,2,0.158848}, {3,7,0.128206},
+        {4,12,0.220829}, {5,5,-0.136549}, {6,0,0.0149032}, {7,10,-0.0334936},
+        {8,16,0.00399329}, {9,18,-0.00209733}, {10,2,0.0556194}, {11,17,-0.000561977}
+      };
+
+    // Arbitrarily selected (i, qp, dphi) sample values for SECOND-order case.
+    TabulatedGrads second_grads =
+      {
+        {0,3,Point(-0.0959817, -0.0959817, 0.0702635)},
+        {1,6,Point(0.0625228, -0.0625228, 0.0457699)},
+        {2,2,Point(0.358209, 0.0959817, -2.77556e-17)},
+        {3,7,Point(-0.233338, 0.0625228, -6.93889e-17)},
+        {4,12,Point(-0.0323071, -0.0323071, -0.0729771)},
+        {5,5,Point(0.248523, 0.0665915, -0.245097)},
+        {6,0,Point(0.0336072, -0.00900502, 0.288589)},
+        {7,10,Point(-0.0396234, 0.0396234, -0.0290064)},
+        {8,16,Point(0.000443217, 0.000443217, 0.000333678)},
+        {9,18,Point(-0.000232783, -6.23741e-05, 9.35433e-05)},
+        {10,2,Point(-0.0336072, 0.0336072, 0.985214)},
+        {11,17,Point(6.23741e-05, -6.23741e-05, -2.05961e-05)},
+      };
+
+    testSingleOrder(SECOND, second_vals, second_grads);
+
+    // Arbitrarily selected (i, qp, phi) sample values for THIRD-order case.
+    TabulatedVals third_vals =
+      {
+        {12,9,0.136657},
+        {13,6,0.175034},
+        {14,20,-0.0011016},
+        {15,15,0.0428935}
+      };
+
+    // Arbitrarily selected (i, qp, dphi) sample values for THIRD-order case.
+    TabulatedGrads third_grads =
+      {
+        {12,9,Point(0.0536552, 0.200244, -0.0849541)},
+        {13,6,Point(-0.0921697, 0.0921697, 0.461056)},
+        {14,20,Point(2.35811e-05, -8.80059e-05, 3.58959e-05)},
+        {15,15,Point(-0.0386352, 0.0103523, -0.0197323)},
+      };
+
+    testSingleOrder(THIRD, third_vals, third_grads);
+
+    // Arbitrarily selected (i, qp, phi) sample values for FOURTH-order case.
+    TabulatedVals fourth_vals =
+      {
+        {16,3,0.00826618},
+        {17,10,-0.547813},
+        {18,14,0.311004},
+        {19,27,-0.00192085}
+      };
+
+    // Arbitrarily selected (i, qp, dphi) sample values for FOURTH-order case.
+    TabulatedGrads fourth_grads =
+      {
+        {16,3,Point(-0.0190603, 0.0051072, 0.308529)},
+        {17,10,Point(0.244125, -0.244125, 0.140907)},
+        {18,14,Point(-0.0985844, 0.0985844, -0.502591)},
+        {19,27,Point(0.000115647, -3.09874e-05, 4.30775e-05)}
+      };
+
+    testSingleOrder(FOURTH, fourth_vals, fourth_grads);
+  }
+
+  void testSingleOrder (Order radial_order,
+                        const TabulatedVals & val_table,
+                        const TabulatedGrads & grad_table)
+  {
+    // Avoid warnings when not compiled with infinite element support.
+    libmesh_ignore(radial_order, val_table, grad_table);
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+    // std::cout << "Called testSingleOrder with radial_order = "
+    //           << radial_order
+    //           << std::endl;
+
+    ReplicatedMesh mesh(*TestCommWorld);
+    MeshTools::Generation::build_cube
+      (mesh,
+       /*nx=*/1, /*ny=*/1, /*nz=*/1,
+       /*xmin=*/-1., /*xmax=*/1.,
+       /*ymin=*/-1., /*ymax=*/1.,
+       /*zmin=*/-1., /*zmax=*/1.,
+       HEX8);
+
+    // Add infinite elements to the mesh. The optional verbose flag only
+    // prints extra information in non-optimized mode.
+    InfElemBuilder builder(mesh);
+    builder.build_inf_elem(/*verbose=true*/);
+
+    // Get pointer to the last infinite Elem. I originally intended to
+    // get a pointer to the *first* infinite Elem but then I computed
+    // all the reference values on the last Elem, so that's the one we
+    // are using now...
+    const Elem * infinite_elem = mesh.elem_ptr(mesh.n_elem() - 1);
+    if (!infinite_elem || !infinite_elem->infinite())
+      libmesh_error_msg("Error setting Elem pointer.");
+
+    // We will construct FEs, etc. of the same dimension as the mesh elements.
+    auto dim = mesh.mesh_dimension();
+
+    FEType fe_type(/*Order*/FIRST,
+                   /*FEFamily*/LAGRANGE,
+                   radial_order,
+                   /*radial_family*/LEGENDRE,
+                   /*inf_map*/CARTESIAN);
+
+    // Construct FE, quadrature rule, etc.
+    std::unique_ptr<FEBase> inf_fe (FEBase::build_InfFE(dim, fe_type));
+    QGauss qrule (dim, fe_type.default_quadrature_order());
+    inf_fe->attach_quadrature_rule(&qrule);
+    const std::vector<std::vector<Real>> & phi = inf_fe->get_phi();
+    const std::vector<std::vector<RealGradient>> & dphi = inf_fe->get_dphi();
+
+    // Reinit on infinite elem
+    inf_fe->reinit(infinite_elem);
+
+    // Check phi values against reference values. The number of
+    // quadrature points and shape functions seem to both increase by
+    // 4 as the radial_order is increased.
+    //
+    // radial_order | n_qp | n_sf
+    // --------------------------
+    // FIRST        | 16   | 8
+    // SECOND       | 20   | 12
+    // THIRD        | 24   | 16
+    // FOURTH       | 28   | 20
+    // FIFTH        | 32   | 24
+
+    // Debugging print values so we can tabulate them
+    // auto n_qp = inf_fe->n_quadrature_points();
+    // auto n_sf = inf_fe->n_shape_functions();
+    // for (unsigned int i=0; i<n_sf; ++i)
+    //   for (unsigned qp=0; qp<n_qp; ++qp)
+    //     {
+    //       libMesh::out << "phi[" << i << "][" << qp << "]=" << phi[i][qp] << std::endl;
+    //       libMesh::out << "dphi[" << i << "][" << qp << "]=" << dphi[i][qp] << std::endl;
+    //     }
+
+    // Test whether the computed values match the tabulated values to
+    // the specified accuracy.
+    for (const auto & t : val_table)
+      {
+        unsigned int i = std::get<0>(t);
+        unsigned int qp = std::get<1>(t);
+        Real val = std::get<2>(t);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(phi[i][qp], val, 1.e-4);
+      }
+    for (const auto & t : grad_table)
+      {
+        unsigned int i = std::get<0>(t);
+        unsigned int qp = std::get<1>(t);
+        Point grad = std::get<2>(t);
+        // std::cout << "grad " << grad << std::endl;
+        // std::cout << "dphi[" << i << "][" << qp << "] " << dphi[i][qp] << std::endl;
+        CPPUNIT_ASSERT_DOUBLES_EQUAL((dphi[i][qp] - grad).norm_sq(), 0., 1.e-4);
+      }
+
+#endif // LIBMESH_ENABLE_INFINITE_ELEMENTS
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( InfFELegendreTest );

--- a/tests/geom/node_test.C
+++ b/tests/geom/node_test.C
@@ -25,9 +25,12 @@ class NodeTest : public PointTestBase<Node>, public DofObjectTest<Node> {
 public:
   CPPUNIT_TEST_SUITE( NodeTest );
 
+  // These tests currently use the Node copy constructor, which is marked
+  // as deprecated, so only instantiate them if deprecated code is allowed.
+#ifdef LIBMESH_ENABLE_DEPRECATED
   POINTTEST
-
   DOFOBJECTTEST
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
My long term goal is to have have some Legendre-polynomial-based elements available for DG. We currently only optionally use Legendre polynomials in the infinite elements (there they are the so-called "radial" basis functions). The previous formulation was based on [Horner's method](https://en.wikipedia.org/wiki/Horner%27s_method) with hard-coded coefficients, but this was both difficult to verify and somewhat inaccurate at higher p levels, at least based on my tests which compared it to C++17's `std::legendre()` and analytic values computed via Wolfram alpha. 

This PR adds a unit test for Legendre infinite elements and replaces the Horner method with an implementation based on Legendre polynomial recurrence relations which is shorter, simpler, and more numerically stable. In a later PR, I plan to add the corresponding 1D (and 2D/3D tensor product) DG elements, which will share this implementation.
