### PR TITLE
Fix OOB array access in miscellaneous_ex14

### DIFF
--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -275,9 +275,11 @@ void InfFE<Dim,T_radial,T_base>::init_face_shape_functions(const std::vector<Poi
       {
         psi_map[i].resize         (n_total_qp);
         dpsidxi_map[i].resize     (n_total_qp);
-        dpsideta_map[i].resize     (n_total_qp);
+        dpsideta_map[i].resize    (n_total_qp);
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
         d2psidxi2_map[i].resize   (n_total_qp);
+        d2psidxideta_map[i].resize(n_total_qp);
+        d2psideta2_map[i].resize  (n_total_qp);
 #endif
       }
 


### PR DESCRIPTION
This appears to have been broken for half a year or more.  I don't
imagine we'll be putting a SLEPc+IFEM+Complex build into CI any time
soon, though.