### PR TITLE
Assert real parents

### DIFF
--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -287,42 +287,42 @@ extern bool warned_about_auto_ptr;
 
 #define libmesh_assert_equal_to_msg(expr1,expr2, msg)                   \
   do {                                                                  \
-    if (!(expr1 == expr2)) {                                            \
+    if (!((expr1) == (expr2))) {                                        \
       libMesh::err << "Assertion `" #expr1 " == " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_not_equal_to_msg(expr1,expr2, msg)               \
   do {                                                                  \
-    if (!(expr1 != expr2)) {                                            \
+    if (!((expr1) != (expr2))) {                                        \
       libMesh::err << "Assertion `" #expr1 " != " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_less_msg(expr1,expr2, msg)                       \
   do {                                                                  \
-    if (!(expr1 < expr2)) {                                             \
+    if (!((expr1) < (expr2))) {                                         \
       libMesh::err << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_msg(expr1,expr2, msg)                    \
   do {                                                                  \
-    if (!(expr1 > expr2)) {                                             \
+    if (!((expr1) > (expr2))) {                                         \
       libMesh::err << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_less_equal_msg(expr1,expr2, msg)                 \
   do {                                                                  \
-    if (!(expr1 <= expr2)) {                                            \
+    if (!((expr1) <= (expr2))) {                                        \
       libMesh::err << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_equal_msg(expr1,expr2, msg)              \
   do {                                                                  \
-    if (!(expr1 >= expr2)) {                                            \
+    if (!((expr1) >= (expr2))) {                                        \
       libMesh::err << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2468,6 +2468,8 @@ Elem * Elem::parent ()
 inline
 void Elem::set_parent (Elem * p)
 {
+  // We no longer support using parent() as interior_parent()
+  libmesh_assert_equal_to(this->dim(), p ? p->dim() : this->dim());
   _elemlinks[0] = p;
 }
 


### PR DESCRIPTION
We long ago added interior_parent() and removed any old support for the previous parent()-really-returning-interior_parent() hack, so let's add a few more assertions to make debugging any old third party code easier, and that should completely resolve #1047.