### PR TITLE
Generalize subdomain comparison for var groups

### DIFF
--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -1085,7 +1085,9 @@ public:
 
   /**
    * Adds the variable \p var to the list of variables
-   * for this system.
+   * for this system. If \p active_subdomains is either \p nullptr
+   * (the default) or points to an empty set, then it will be assumed that
+   * \p var has no subdomain restrictions
    *
    * \returns The index number for the new variable.
    */
@@ -1096,7 +1098,9 @@ public:
   /**
    * Adds the variable \p var to the list of variables
    * for this system.  Same as before, but assumes \p LAGRANGE
-   * as default value for \p FEType.family.
+   * as default value for \p FEType.family. If \p active_subdomains is either
+   * \p nullptr (the default) or points to an empty set, then it will be assumed
+   * that \p var has no subdomain restrictions
    */
   unsigned int add_variable (const std::string & var,
                              const Order order = FIRST,
@@ -1105,7 +1109,9 @@ public:
 
   /**
    * Adds the variable \p var to the list of variables
-   * for this system.
+   * for this system. If \p active_subdomains is either \p nullptr
+   * (the default) or points to an empty set, then it will be assumed that
+   * \p var has no subdomain restrictions
    *
    * \returns The index number for the new variable.
    */
@@ -1116,7 +1122,9 @@ public:
   /**
    * Adds the variable \p var to the list of variables
    * for this system.  Same as before, but assumes \p LAGRANGE
-   * as default value for \p FEType.family.
+   * as default value for \p FEType.family. If \p active_subdomains is either
+   * \p nullptr (the default) or points to an empty set, then it will be assumed that
+   * \p var has no subdomain restrictions
    */
   unsigned int add_variables (const std::vector<std::string> & vars,
                               const Order order = FIRST,

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -1121,11 +1121,12 @@ unsigned int System::add_variable (const std::string & var,
         should_be_in_vg = false;
 
       // they are restricted, we aren't?
-      if (their_active_subdomains && !active_subdomains)
+      if (their_active_subdomains &&
+          (!active_subdomains || (active_subdomains && active_subdomains->empty())))
         should_be_in_vg = false;
 
       // they aren't restricted, we are?
-      if (!their_active_subdomains && active_subdomains)
+      if (!their_active_subdomains && (active_subdomains && !active_subdomains->empty()))
         should_be_in_vg = false;
 
       if (their_active_subdomains && active_subdomains)


### PR DESCRIPTION
This allows user code to be more general. They can create
a std::set instance in all cases and pass it in; if the set
is empty then this code will do the right thing and
recognize that there are no restrictions. The
their_active_subdomains was already doing the right thing
because it is a nullptr if the previously added subdomain
set was empty (e.g. see Variable::implicity_active())