### PR TITLE
Provide two functions to inquire the existence of mesh integers

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -756,6 +756,11 @@ public:
   unsigned int get_elem_integer_index(const std::string & name) const;
 
   /*
+   * \returns Whether or not the mesh has an element integer with its name.
+   */
+  bool has_elem_integer(const std::string & name) const;
+
+  /*
    * \returns The name for the indexed extra element integer
    * datum, which must have already been added.
    */
@@ -782,6 +787,11 @@ public:
    * datum, which must have already been added.
    */
   unsigned int get_node_integer_index(const std::string & name) const;
+
+  /*
+   * \returns Whether or not the mesh has a node integer with its name.
+   */
+  bool has_node_integer(const std::string & name) const;
 
   /*
    * \returns The name for the indexed extra node integer

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -192,6 +192,17 @@ unsigned int MeshBase::get_elem_integer_index(const std::string & name) const
 
 
 
+bool MeshBase::has_elem_integer(const std::string & name) const
+{
+  for (auto & entry : _elem_integer_names)
+    if (entry == name)
+      return true;
+
+  return false;
+}
+
+
+
 unsigned int MeshBase::add_node_integer(const std::string & name)
 {
   for (auto i : index_range(_node_integer_names))
@@ -212,6 +223,17 @@ unsigned int MeshBase::get_node_integer_index(const std::string & name) const
 
   libmesh_error_msg("Unknown node integer " << name);
   return libMesh::invalid_uint;
+}
+
+
+
+bool MeshBase::has_node_integer(const std::string & name) const
+{
+  for (auto & entry : _node_integer_names)
+    if (entry == name)
+      return true;
+
+  return false;
 }
 
 


### PR DESCRIPTION
It is typically the adder and the getter are in different places, and the getter can fail when the adder has not been called. These functions provide users the way to gracefully handle the case of missing integers.