### PR TITLE
QNodal update

### DIFF
--- a/src/quadrature/quadrature_nodal_2D.C
+++ b/src/quadrature/quadrature_nodal_2D.C
@@ -61,10 +61,10 @@ void QNodal::init_2D(const ElemType, unsigned int)
         // vertex (wv), and edge (we) weights are obtained by:
         // 1.) Requiring that they sum to the reference element volume.
         // 2.) Minimizing the Frobenius norm of the difference between
-        //     the resulting nodal quadrature (diagonal) mass matrix
+        //     the suitably scaled nodal quadrature (diagonal) mass matrix
         //     and the true mass matrix for the reference element.
-        Real wv = Real(19) / 90;
-        Real we = Real(71) / 90;
+        Real wv = Real(12) / 79;
+        Real we = Real(67) / 79;
 
         _weights = {wv, wv, wv, wv, we, we, we, we};
 

--- a/src/quadrature/quadrature_nodal_3D.C
+++ b/src/quadrature/quadrature_nodal_3D.C
@@ -62,11 +62,11 @@ void QNodal::init_3D(const ElemType, unsigned int)
         // obtained by:
         // 1.) Requiring that they sum to the reference element volume.
         // 2.) Minimizing the Frobenius norm of the difference between
-        //     the resulting nodal quadrature (diagonal) mass matrix
+        //     the suitably scaled nodal quadrature (diagonal) mass matrix
         //     and the true mass matrix for the reference element.
-        Real wv = Real(26) / 675;
-        Real wt = Real(17) / 225;
-        Real wq = Real(71) / 675;
+        Real wv = Real(1) / 34;
+        Real wt = Real(4) / 51;
+        Real wq = Real(2) / 17;
 
         _weights = {wv, wv, wv, wv, wv, wv,
                     wt, wt, wt,
@@ -94,10 +94,10 @@ void QNodal::init_3D(const ElemType, unsigned int)
         // vertex (wv), and edge (we) weights are obtained by:
         // 1.) Requiring that they sum to the reference element volume.
         // 2.) Minimizing the Frobenius norm of the difference between
-        //     the resulting nodal quadrature (diagonal) mass matrix
+        //     the suitably scaled quadrature (diagonal) mass matrix
         //     and the true mass matrix for the reference element.
-        Real wv = Real(136) / 585;
-        Real we = Real(898) / 1755;
+        Real wv = Real(7) / 31;
+        Real we = Real(16) / 31;
 
         _weights = {wv, wv, wv, wv, wv, wv, wv, wv,
                     we, we, we, we, we, we, we, we, we, we, we, we};

--- a/src/quadrature/quadrature_nodal_3D.C
+++ b/src/quadrature/quadrature_nodal_3D.C
@@ -59,11 +59,8 @@ void QNodal::init_3D(const ElemType, unsigned int)
           };
 
         // vertex (wv), tri edge (wt), and quad edge (wq) weights are
-        // obtained by:
-        // 1.) Requiring that they sum to the reference element volume.
-        // 2.) Minimizing the Frobenius norm of the difference between
-        //     the suitably scaled nodal quadrature (diagonal) mass matrix
-        //     and the true mass matrix for the reference element.
+        // obtained using the same approach that was used for the Quad8,
+        // see quadrature_nodal_2D.C for details.
         Real wv = Real(1) / 34;
         Real wt = Real(4) / 51;
         Real wq = Real(2) / 17;
@@ -91,11 +88,9 @@ void QNodal::init_3D(const ElemType, unsigned int)
             Point(0.,-1,+1), Point(+1,0.,+1), Point(0.,+1,+1), Point(-1,0.,+1)
           };
 
-        // vertex (wv), and edge (we) weights are obtained by:
-        // 1.) Requiring that they sum to the reference element volume.
-        // 2.) Minimizing the Frobenius norm of the difference between
-        //     the suitably scaled quadrature (diagonal) mass matrix
-        //     and the true mass matrix for the reference element.
+        // vertex (wv), and edge (we) weights are obtained using the
+        // same approach that was used for the Quad8, see
+        // quadrature_nodal_2D.C for details.
         Real wv = Real(7) / 31;
         Real we = Real(16) / 31;
 

--- a/tests/quadrature/quadrature_test.C
+++ b/tests/quadrature/quadrature_test.C
@@ -78,7 +78,7 @@ public:
   TEST_ONE_ORDER(QTRAP, FIRST, 1);
   TEST_ALL_ORDERS(QGRID, 1);
 
-  // In genreal, QNodal rules (e.g. QTRAP) are only exact for linears.
+  // In general, QNodal rules (e.g. QTRAP) are only exact for linears.
   // QSIMPSON is a special case of a nodal quadrature which obtains
   // higher accuracy.
   TEST_ONE_ORDER(QNODAL, /*ignored*/FIRST, /*max order=*/1);

--- a/tests/quadrature/quadrature_test.C
+++ b/tests/quadrature/quadrature_test.C
@@ -78,6 +78,11 @@ public:
   TEST_ONE_ORDER(QTRAP, FIRST, 1);
   TEST_ALL_ORDERS(QGRID, 1);
 
+  // In genreal, QNodal rules (e.g. QTRAP) are only exact for linears.
+  // QSIMPSON is a special case of a nodal quadrature which obtains
+  // higher accuracy.
+  TEST_ONE_ORDER(QNODAL, /*ignored*/FIRST, /*max order=*/1);
+
   // The TEST_ALL_ORDERS macro only goes up to 9th-order
   TEST_ALL_ORDERS(QGAUSS_LOBATTO, 9);
 


### PR DESCRIPTION
I changed the metric for computing the optimal weights slightly. These rules, which are for serendipity elements, are only exact for linears. Their main purpose is to guarantee an SPD approximation to the true mass matrix when nodal quadarture is employed, so the weights are simply chosen to be as closely proportional to the true mass matrix values as possible.
