### PR TITLE
Fixes to get libmesh compiling with PETSc master as of late July 2019.

### DIFF
--- a/src/solvers/petsc_diff_solver.C
+++ b/src/solvers/petsc_diff_solver.C
@@ -267,7 +267,12 @@ DiffSolver::SolveResult convert_solve_result(SNESConvergedReason r)
 #endif
       return DiffSolver::CONVERGED_RELATIVE_STEP;
     case SNES_CONVERGED_ITS:
+      // SNES_CONVERGED_TR_DELTA was changed to a diverged condition,
+      // SNES_DIVERGED_TR_DELTA, in PETSc 1c6b2ff8df. This change will
+      // likely be in 3.12 and later releases.
+#if PETSC_RELEASE_LESS_THAN(3,12,0)
     case SNES_CONVERGED_TR_DELTA:
+#endif
       return DiffSolver::CONVERGED_NO_REASON;
     case SNES_DIVERGED_FUNCTION_DOMAIN:
     case SNES_DIVERGED_FUNCTION_COUNT:

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -1192,8 +1192,17 @@ PetscErrorCode  DMCreate_libMesh(DM dm)
 
   dm->ops->refine             = 0; // DMRefine_libMesh;
   dm->ops->coarsen            = 0; // DMCoarsen_libMesh;
+
+  // * dm->ops->getinjection was renamed to dm->ops->createinjection in PETSc 5a84ad338 (5 Jul 2019)
+  // * dm->ops-getaggregates was removed in PETSc 97779f9a (5 Jul 2019)
+  // * Both changes were merged into PETSc master in 94aad3ce (7 Jul 2019).
+#if PETSC_RELEASE_LESS_THAN(3,12,0)
   dm->ops->getinjection       = 0; // DMGetInjection_libMesh;
   dm->ops->getaggregates      = 0; // DMGetAggregates_libMesh;
+#else
+  dm->ops->createinjection = 0;
+#endif
+
 
 #if PETSC_RELEASE_LESS_THAN(3,3,1)
   dm->ops->createfielddecompositiondm  = DMCreateFieldDecompositionDM_libMesh;


### PR DESCRIPTION
* Fix for SNES_CONVERGED_TR_DELTA.
* Fix for dm->ops->getinjection.
* Fix for dm->ops->getaggregates.

All of these changes are currently in PETSc master but not yet in any
PETSc release.  For example, the SNES_CONVERGED_TR_DELTA was merged
into PETSc master 16 Jul 2019 in: c1c6be5a2e, and the latest PETSc
release is v3.11.3 (26 Jun 2019).  These changes are therefore likely
to be in 3.12 but not in any 3.11.x release. Also, this change will
break anyone who is using libmesh with an older version of PETSc
master, but there is basically nothing we can do about that, they just
have to update.