### PR TITLE
Add FEMContext::set_jacobian_tolerance().

### DIFF
--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -457,6 +457,7 @@ public:
    * \returns The mapping object
    */
   const FEMap & get_fe_map() const { return *_fe_map.get(); }
+  FEMap & get_fe_map() { return *_fe_map.get(); }
 
   /**
    * Prints the Jacobian times the weight for each quadrature point.

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -976,6 +976,12 @@ public:
   { _custom_solution = custom_sol; }
 
   /**
+   * Calls set_jacobian_tolerance() on all the FE objects controlled
+   * by this class. (Actually, it calls this on the underlying)
+   */
+  void set_jacobian_tolerance(Real tol);
+
+  /**
    * System from which to acquire moving mesh information
    */
   System * _mesh_sys;

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1477,6 +1477,22 @@ void FEMContext::elem_position_get()
 
 
 
+void FEMContext::set_jacobian_tolerance(Real tol)
+{
+  for (auto & m : _element_fe)
+    for (auto & pr : m)
+      pr.second->get_fe_map().set_jacobian_tolerance(tol);
+
+  for (auto & m : _side_fe)
+    for (auto & pr : m)
+      pr.second->get_fe_map().set_jacobian_tolerance(tol);
+
+  for (auto & pr : _edge_fe)
+    pr.second->get_fe_map().set_jacobian_tolerance(tol);
+}
+
+
+
 // We can ignore the theta argument in the current use of this
 // function, because elem_subsolutions will already have been set to
 // the theta value.


### PR DESCRIPTION
This requires us to add a non-const accessor for the underlying FEMap
object, or add an FEAbstract interface for changing the tolerance on
the underlying FEMap object. The former seems like a more general
solution, but if it's unsafe for some reason we could fall back on the
latter...