### PR TITLE
Why are you always failing?

### DIFF
--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -513,6 +513,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
+                    failing = false;
                     if (calculate_xyz)
                       {
                         libmesh_error_msg("ERROR: negative Jacobian " \
@@ -589,6 +590,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
+                    failing = false;
                     libmesh_error_msg("Encountered invalid 1D element!");
                   }
                 else
@@ -635,6 +637,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
+                    failing = false;
                     libmesh_error_msg("Encountered invalid 1D element!");
                   }
                 else
@@ -758,6 +761,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
+                    failing = false;
                     if (calculate_xyz)
                       {
                         libmesh_error_msg("ERROR: negative Jacobian " \
@@ -858,6 +862,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
+                    failing = false;
                     if (calculate_xyz)
                       {
                         libmesh_error_msg("ERROR: negative Jacobian " \
@@ -1092,6 +1097,7 @@ void FEMap::compute_single_point_map(const unsigned int dim,
                   {
                     failing = true;
                     elem->print_info(libMesh::err);
+                    failing = false;
                     if (calculate_xyz)
                       {
                         libmesh_error_msg("ERROR: negative Jacobian " \


### PR DESCRIPTION
This fixes an issue where, after the first time you catch a negative Jacobian exception and keep going, you no longer get exceptions for subsequent negative Jacobians. Instead, the code just returns with incomplete results whenever a negative Jacobian occurs since `failing==true` from then on.

`¯\_(ツ)_/¯`
