### PR TITLE
Real literals

### DIFF
--- a/src/quadrature/quadrature_gauss_lobatto_1D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_1D.C
@@ -102,7 +102,7 @@ void QGaussLobatto::init_1D(const ElemType, unsigned int)
         _points[ 3]    = -_points[1];
         _points[ 4]    = -_points[0];
 
-        _weights[ 0]   = 0.1;
+        _weights[ 0]   = 1/Real(10);
         _weights[ 1]   = Real(49)/90;
         _weights[ 2]   = Real(32)/45;
         _weights[ 3]   = _weights[1];

--- a/src/quadrature/quadrature_trap_2D.C
+++ b/src/quadrature/quadrature_trap_2D.C
@@ -73,9 +73,9 @@ void QTrap::init_2D(const ElemType, unsigned int)
         _points[2](1) = 1.;
 
 
-        _weights[0] = 1./6.;
-        _weights[1] = 1./6.;
-        _weights[2] = 1./6.;
+        _weights[0] = 1/Real(6);
+        _weights[1] = 1/Real(6);
+        _weights[2] = 1/Real(6);
 
         return;
       }

--- a/src/quadrature/quadrature_trap_3D.C
+++ b/src/quadrature/quadrature_trap_3D.C
@@ -76,7 +76,7 @@ void QTrap::init_3D(const ElemType, unsigned int)
 
 
 
-        _weights[0] = .0416666666666666666666666666666666666666666667;
+        _weights[0] = 1/Real(24);
         _weights[1] = _weights[0];
         _weights[2] = _weights[0];
         _weights[3] = _weights[0];

--- a/tests/solvers/second_order_unsteady_solver_test.C
+++ b/tests/solvers/second_order_unsteady_solver_test.C
@@ -121,7 +121,7 @@ public:
     // For \beta = 1/6, we have the "linear acceleration method" for which
     // we should be able to exactly integrate linear (in time) acceleration
     // functions.
-    this->set_beta(1.0/6.0);
+    this->set_beta(Real(1)/Real(6));
     this->run_test_with_exact_soln<LinearTimeSecondOrderODE<SecondOrderScalarSystemSecondOrderTimeSolverBase>>(0.5,10);
   }
 
@@ -135,7 +135,7 @@ public:
     // For \beta = 1/6, we have the "linear acceleration method" for which
     // we should be able to exactly integrate linear (in time) acceleration
     // functions.
-    this->set_beta(1.0/6.0);
+    this->set_beta(Real(1)/Real(6));
     this->run_test_with_exact_soln<LinearTimeSecondOrderODE<SecondOrderScalarSystemFirstOrderTimeSolverBase>>(0.5,10);
   }
 


### PR DESCRIPTION
Some of our double-precision literals cause us to lose accuracy when testing (or with some quadrature rules, running!) with higher precision Real.

Commits extracted from #2185 since this is an independent change - it fixes triple precision problems too and it doesn't depend on any float128 modifications.