### PR TITLE
Make mallocs uniformly an error in PetscMatrix

### DIFF
--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -333,6 +333,14 @@ void PetscMatrix<T>::init (const numeric_index_type m_in,
 
     }
 
+  // Make it an error for PETSc to allocate new nonzero entries during assembly
+#if PETSC_VERSION_LESS_THAN(3,0,0)
+  ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR);
+#else
+  ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+#endif
+  LIBMESH_CHKERR(ierr);
+
   // Is prefix information available somewhere? Perhaps pass in the system name?
   ierr = MatSetOptionsPrefix(_mat, "");
   LIBMESH_CHKERR(ierr);
@@ -453,6 +461,14 @@ void PetscMatrix<T>::init ()
         default: libmesh_error_msg("Unsupported petsc matrix type");
       }
     }
+
+  // Make it an error for PETSc to allocate new nonzero entries during assembly
+#if PETSC_VERSION_LESS_THAN(3,0,0)
+  ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR);
+#else
+  ierr = MatSetOption(_mat, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_TRUE);
+#endif
+  LIBMESH_CHKERR(ierr);
 
   // Is prefix information available somewhere? Perhaps pass in the system name?
   ierr = MatSetOptionsPrefix(_mat, "");


### PR DESCRIPTION
This adds the setting to the other two init methods that
if a new malloc occurs during MatSetValues then it is an
error. I think this is an improvement because it establishes
uniformity across our init methods and it can prevent users
from running extremely slow simulations. They might hate
it at first, but it would force them to correct their sparsity,
which would definitely be a win for them in the long run.

I fully expect this to cause failures in MOOSE, but they can
manually override if they need to (e.g. I will make those
changes in MOOSE before this gets merged).