### PR TITLE
Slepc $PETSC_ARCH fix

### DIFF
--- a/configure
+++ b/configure
@@ -36010,6 +36010,16 @@ fi
 
 fi
 
+                        if test "x$PETSC_ARCH" != "x"; then :
+  as_ac_Header=`$as_echo "ac_cv_header_$SLEPC_DIR/$PETSC_ARCH/include/slepcconf.h" | $as_tr_sh`
+ac_fn_cxx_check_header_mongrel "$LINENO" "$SLEPC_DIR/$PETSC_ARCH/include/slepcconf.h" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  SLEPC_INCLUDE="$SLEPC_INCLUDE -I$SLEPC_DIR/$PETSC_ARCH/include"
+fi
+
+
+fi
+
 fi
 
     if test "x$enableslepc" = "xyes"; then :

--- a/m4/slepc.m4
+++ b/m4/slepc.m4
@@ -75,6 +75,11 @@ AC_DEFUN([CONFIGURE_SLEPC],
                                           ])
                         ])
                 ])
+
+            dnl With a separate $PETSC_ARCH we have a separate configuration-specific directory
+            AS_IF([test "x$PETSC_ARCH" != "x"],
+                  [AC_CHECK_HEADER([$SLEPC_DIR/$PETSC_ARCH/include/slepcconf.h],
+                                   [SLEPC_INCLUDE="$SLEPC_INCLUDE -I$SLEPC_DIR/$PETSC_ARCH/include"])])
         ])
 
     AS_IF([test "x$enableslepc" = "xyes"],


### PR DESCRIPTION
This was mistakenly deleted by #2178, which broke SLEPc configuration
for installs with a separate $PETSC_ARCH subdirectory.