### PR TITLE
MeshBase::add_elem/node_datum APIs

### DIFF
--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -403,7 +403,7 @@ public:
    * Returns how many extra integers are associated to the \p DofObject
    *
    * If non-integer data has been associated, each datum of type T
-   * counts for * sizeof(T)/sizeof(dof_id_type) times in the return
+   * counts for sizeof(T)/sizeof(dof_id_type) times in the return
    * value.
    */
   unsigned int n_extra_integers () const;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -770,8 +770,29 @@ public:
   /*
    * \returns The number of extra element integers for which space is
    * being reserved on this mesh.
+   *
+   * If non-integer data has been associated, each datum of type T
+   * counts for sizeof(T)/sizeof(dof_id_type) times in the return
+   * value.
    */
   unsigned int n_elem_integers() const { return _elem_integer_names.size(); }
+
+  /**
+   * Register a datum (of type T) to be added to each element in the
+   * mesh.
+   *
+   * \returns The starting index number for the new datum, or for the
+   * existing datum if one by the same name has already been added.
+   *
+   * If type T is larger than dof_id_type, its data will end up
+   * spanning multiple index values, but will be queried with the
+   * starting index number.
+   *
+   * No type checking is done with this function!  If you add data of
+   * type T, don't try to access it with a call specifying type U.
+   */
+  template <typename T>
+  unsigned int add_elem_datum(const std::string & name);
 
   /**
    * Register an integer datum (of type dof_id_type) to be added to
@@ -803,8 +824,29 @@ public:
   /*
    * \returns The number of extra node integers for which space is
    * being reserved on this mesh.
+   *
+   * If non-integer data has been associated, each datum of type T
+   * counts for sizeof(T)/sizeof(dof_id_type) times in the return
+   * value.
    */
   unsigned int n_node_integers() const { return _node_integer_names.size(); }
+
+  /**
+   * Register a datum (of type T) to be added to each node in the
+   * mesh.
+   *
+   * \returns The starting index number for the new datum, or for the
+   * existing datum if one by the same name has already been added.
+   *
+   * If type T is larger than dof_id_type, its data will end up
+   * spanning multiple index values, but will be queried with the
+   * starting index number.
+   *
+   * No type checking is done with this function!  If you add data of
+   * type T, don't try to access it with a call specifying type U.
+   */
+  template <typename T>
+  unsigned int add_node_datum(const std::string & name);
 
   /**
    * Prepare a newly ecreated (or read) mesh for use.
@@ -1767,6 +1809,30 @@ MeshBase::const_node_iterator : variant_filter_iterator<MeshBase::Predicate,
   const_node_iterator (const MeshBase::node_iterator & rhs) :
     variant_filter_iterator<Predicate, Node * const, Node * const &, Node * const *>(rhs) {}
 };
+
+
+template <typename T>
+inline
+unsigned int MeshBase::add_elem_datum(const std::string & name)
+{
+  unsigned int start_idx = this->add_elem_integer(name);
+  unsigned int n_more_integers = (sizeof(T)-1)/sizeof(dof_id_type);
+  for (unsigned int i=0; i != n_more_integers; ++i)
+    this->add_elem_integer(name+"__"+std::to_string(i));
+  return start_idx;
+}
+
+
+template <typename T>
+inline
+unsigned int MeshBase::add_node_datum(const std::string & name)
+{
+  unsigned int start_idx = this->add_node_integer(name);
+  unsigned int n_more_integers = (sizeof(T)-1)/sizeof(dof_id_type);
+  for (unsigned int i=0; i != n_more_integers; ++i)
+    this->add_node_integer(name+"__"+std::to_string(i));
+  return start_idx;
+}
 
 
 } // namespace libMesh

--- a/tests/base/dof_object_test.h
+++ b/tests/base/dof_object_test.h
@@ -12,7 +12,7 @@
   CPPUNIT_TEST( testInvalidateProcId );         \
   CPPUNIT_TEST( testSetNSystems );              \
   CPPUNIT_TEST( testSetNVariableGroups );       \
-  CPPUNIT_TEST( testAddExtraInts );             \
+  CPPUNIT_TEST( testAddExtraData );             \
   CPPUNIT_TEST( testAddSystemExtraInts );       \
   CPPUNIT_TEST( testSetNSystemsExtraInts );     \
   CPPUNIT_TEST( testSetNVariableGroupsExtraInts ); \
@@ -125,7 +125,7 @@ public:
       }
   }
 
-  void testAddExtraInts()
+  void testAddExtraData()
   {
     DofObject aobject(*instance);
 
@@ -135,11 +135,24 @@ public:
 
     CPPUNIT_ASSERT_EQUAL( (unsigned int) 9, aobject.n_extra_integers() );
 
+    unsigned int ints_per_Real = (sizeof(Real)-1)/sizeof(dof_id_type) + 1;
+
+    for (unsigned int i=0; i != 9; ++i)
+      CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
+
     for (unsigned int i=0; i != 9; ++i)
       {
-        CPPUNIT_ASSERT_EQUAL( DofObject::invalid_id, aobject.get_extra_integer(i) );
-        aobject.set_extra_integer(i, i);
-        CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+        // Try out a char at i=1
+        if (i == 1)
+          aobject.set_extra_datum<char>(i, '1');
+        // Try out an extra Real at i=2 if we'll have room
+        if (i == 2 && ints_per_Real <= 4)
+          aobject.set_extra_datum<Real>(i, pi);
+        if (i < 1 || i >= (2 + ints_per_Real))
+          {
+            aobject.set_extra_integer(i, i);
+            CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+          }
       }
 
     aobject.add_extra_integers (6);
@@ -149,7 +162,14 @@ public:
     CPPUNIT_ASSERT_EQUAL( (unsigned int) 6, aobject.n_extra_integers() );
 
     for (unsigned int i=0; i != 6; ++i)
-      CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      {
+        if (i == 1)
+          CPPUNIT_ASSERT_EQUAL(aobject.get_extra_datum<char>(i), '1');
+        if (i == 2 && ints_per_Real <= 4)
+          CPPUNIT_ASSERT_EQUAL(aobject.get_extra_datum<Real>(i), pi);
+        if (i < 1 || i >= (2 + ints_per_Real))
+          CPPUNIT_ASSERT_EQUAL( dof_id_type(i), aobject.get_extra_integer(i) );
+      }
   }
 
   void testAddSystemExtraInts()


### PR DESCRIPTION
This is one step closer from #2095 toward #1439 - we can now add arbitrary POD data types to elements and/or nodes, not just dof_id_type integers, and if we want to add something larger than those integers then at least the gory memcpy details are encapsulated.  This should be zero overhead for people who don't use it, since it reuses the code paths from #2102.

This functionality isn't completely supported (no CheckpointIO saves!) yet, but I'm planning on making use of just the basic feature for now for #2179 work.