### PR TITLE
Reduce header dependencies

### DIFF
--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -58,6 +58,7 @@
 #include "libmesh/vtk_io.h"
 #include "libmesh/exodusII_io.h"
 #include "libmesh/enum_solver_package.h"
+#include "libmesh/parallel.h"
 
 // These are the include files typically needed for subdivision elements.
 #include "libmesh/face_tri3_subdivision.h"

--- a/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
+++ b/examples/miscellaneous/miscellaneous_ex12/miscellaneous_ex12.C
@@ -56,6 +56,7 @@
 #include "libmesh/getpot.h"
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/enum_solver_type.h"
+#include "libmesh/parallel.h"
 
 // Eigen includes
 #ifdef LIBMESH_HAVE_EIGEN

--- a/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
+++ b/examples/miscellaneous/miscellaneous_ex13/miscellaneous_ex13.C
@@ -58,6 +58,7 @@
 #include "libmesh/getpot.h"
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/enum_solver_type.h"
+#include "libmesh/parallel.h"
 
 // Eigen includes
 #ifdef LIBMESH_HAVE_EIGEN

--- a/examples/optimization/optimization_ex2/optimization_ex2.C
+++ b/examples/optimization/optimization_ex2/optimization_ex2.C
@@ -49,6 +49,7 @@
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/optimization_system.h"
 #include "libmesh/optimization_solver.h"
+#include "libmesh/parallel.h"
 
 // Bring in everything from the libMesh namespace
 using namespace libMesh;

--- a/include/base/dirichlet_boundaries.h
+++ b/include/base/dirichlet_boundaries.h
@@ -25,7 +25,6 @@
 #ifdef LIBMESH_ENABLE_DIRICHLET
 
 // Local Includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/id_types.h"
 #include "libmesh/vector_value.h"
 

--- a/include/base/dof_map.h
+++ b/include/base/dof_map.h
@@ -22,7 +22,6 @@
 
 // Local Includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h" // libMesh::invalid_uint
 #include "libmesh/variable.h"

--- a/include/base/dof_object.h
+++ b/include/base/dof_object.h
@@ -29,6 +29,7 @@
 
 // C++ includes
 #include <cstddef>
+#include <cstring>
 #include <vector>
 
 namespace libMesh
@@ -1048,7 +1049,7 @@ DofObject::set_extra_datum(const unsigned int index,
   const unsigned int start_idx_i = this->start_idx_ints();
 
   libmesh_assert_less(start_idx_i+index+n_more_integers, _idx_buf.size());
-  memcpy(&_idx_buf[start_idx_i+index], &value, sizeof(T));
+  std::memcpy(&_idx_buf[start_idx_i+index], &value, sizeof(T));
 }
 
 
@@ -1068,7 +1069,7 @@ DofObject::get_extra_datum (const unsigned int index) const
 
   libmesh_assert_less(start_idx_i+index+n_more_integers, _idx_buf.size());
   T returnval;
-  memcpy(&returnval, &_idx_buf[start_idx_i+index], sizeof(T));
+  std::memcpy(&returnval, &_idx_buf[start_idx_i+index], sizeof(T));
   return returnval;
 }
 

--- a/include/base/libmesh.h
+++ b/include/base/libmesh.h
@@ -24,7 +24,6 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh_base.h"
-#include "libmesh/parallel.h"
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS
 namespace libMesh
@@ -55,6 +54,11 @@ class vtkMPIController;
  */
 namespace libMesh
 {
+
+// Forward declarations
+namespace Parallel {
+  class Communicator;
+}
 
 /**
  * The \p LibMeshInit class, when constructed, initializes
@@ -115,12 +119,12 @@ public:
    * for the user-input MPI_Comm if we were constructed with one, or a
    * wrapper for MPI_COMM_WORLD by default.
    */
-  const Parallel::Communicator & comm() const { return _comm; }
+  const Parallel::Communicator & comm() const { return *_comm; }
 
-  Parallel::Communicator & comm() { return _comm; }
+  Parallel::Communicator & comm() { return *_comm; }
 
 private:
-  Parallel::Communicator _comm;
+  Parallel::Communicator * _comm;
 
 #if defined(LIBMESH_HAVE_MPI) && defined(LIBMESH_HAVE_VTK)
   // VTK object for dealing with MPI stuff in VTK.

--- a/include/base/periodic_boundary_base.h
+++ b/include/base/periodic_boundary_base.h
@@ -25,7 +25,6 @@
 
 // Local Includes
 #include "libmesh/point.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/dense_matrix.h"
 
 // C++ Includes

--- a/include/error_estimation/adjoint_residual_error_estimator.h
+++ b/include/error_estimation/adjoint_residual_error_estimator.h
@@ -21,7 +21,6 @@
 #define LIBMESH_ADJOINT_RESIDUAL_ERROR_ESTIMATOR_H
 
 // Local Includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/error_estimator.h"
 #include "libmesh/qoi_set.h"
 

--- a/include/error_estimation/error_estimator.h
+++ b/include/error_estimation/error_estimator.h
@@ -22,7 +22,6 @@
 
 // Local Includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/parallel.h"
 #include "libmesh/system_norm.h"
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS
@@ -48,6 +47,10 @@ class ErrorVector;
 class EquationSystems;
 class System;
 template <typename T> class NumericVector;
+
+namespace Parallel {
+  class Communicator;
+}
 
 /**
  * This class holds functions that will estimate the error

--- a/include/error_estimation/hp_coarsentest.h
+++ b/include/error_estimation/hp_coarsentest.h
@@ -21,7 +21,6 @@
 #define LIBMESH_HP_COARSENTEST_H
 
 // Local Includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
 #include "libmesh/hp_selector.h"

--- a/include/error_estimation/jump_error_estimator.h
+++ b/include/error_estimation/jump_error_estimator.h
@@ -21,7 +21,6 @@
 #define LIBMESH_JUMP_ERROR_ESTIMATOR_H
 
 // Local Includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/dense_vector.h"
 #include "libmesh/error_estimator.h"
 #include "libmesh/fem_context.h"

--- a/include/error_estimation/weighted_patch_recovery_error_estimator.h
+++ b/include/error_estimation/weighted_patch_recovery_error_estimator.h
@@ -29,7 +29,6 @@
 #include "libmesh/fem_function_base.h"
 #include "libmesh/patch_recovery_error_estimator.h"
 #include "libmesh/patch.h"
-#include "libmesh/point.h"
 
 
 namespace libMesh

--- a/include/fe/fe_abstract.h
+++ b/include/fe/fe_abstract.h
@@ -25,7 +25,6 @@
 #include "libmesh/point.h"
 #include "libmesh/vector_value.h"
 #include "libmesh/fe_type.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/fe_map.h"
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 #include "libmesh/tensor_value.h"

--- a/include/fe/fe_base.h
+++ b/include/fe/fe_base.h
@@ -22,7 +22,6 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/compare_types.h"
 #include "libmesh/fe_abstract.h"
 #include "libmesh/fe_transformation_base.h"

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -25,7 +25,6 @@
 #include "libmesh/point.h"
 #include "libmesh/vector_value.h"
 #include "libmesh/fe_type.h"
-#include "libmesh/auto_ptr.h" // deprecated
 
 // C++ includes
 #include <memory>

--- a/include/fe/fe_type.h
+++ b/include/fe/fe_type.h
@@ -21,7 +21,6 @@
 #define LIBMESH_FE_TYPE_H
 
 // Local includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/compare_types.h"
 #include "libmesh/libmesh_config.h"
 #include "libmesh/enum_order.h"

--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -28,7 +28,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/node.h"
 #include "libmesh/enum_elem_type.h" // INVALID_ELEM
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/multi_predicates.h"
 #include "libmesh/pointer_to_pointer_iter.h"
 #include "libmesh/int_range.h"

--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -28,7 +28,7 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/point.h"
 #include "libmesh/auto_ptr.h" // deprecated
-#include "libmesh/parallel.h"
+#include "libmesh/communicator.h"
 
 // C++ includes
 #include <vector>

--- a/include/geom/elem_cutter.h
+++ b/include/geom/elem_cutter.h
@@ -27,7 +27,6 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/point.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/communicator.h"
 
 // C++ includes

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -55,21 +55,12 @@ enum ElemType : int;
       libmesh_exceptionless_error();            \
     } } while (0)
 
-
-
-// Through several subsequent levels of includes, the exodusII.h
-// header includes <errno.h>.  On very specific system/compiler combinations
-// (currently GCC 5.2.0+ OSX Yosemite, El Capitan, possibly others) errno.h
-// cannot be included while wrapped in a namespace (as we do with the exII
-// namespace below).  A workaround for this is to simply include errno.h
-// not in any namespace prior to including exodusII.h.
-//
-// The same is also true for string.h.
-#ifdef LIBMESH_COMPILER_HAS_BROKEN_ERRNO_T
+// Before we include a header wrapped in a namespace, we'd better make
+// sure none of its dependencies end up in that namespace
 #include <errno.h>
-#include <string.h>
-#endif
-
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdint.h>
 
 #include <libmesh/ignore_warnings.h>
 namespace exII {

--- a/include/mesh/mesh.h
+++ b/include/mesh/mesh.h
@@ -22,7 +22,6 @@
 #include "libmesh/libmesh_config.h"
 
 #ifdef LIBMESH_ENABLE_PARMESH
-#include "libmesh/auto_ptr.h" // libmesh_make_unique
 #include "libmesh/distributed_mesh.h"
 namespace libMesh {
 typedef DistributedMesh DefaultMesh;

--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -21,7 +21,6 @@
 #define LIBMESH_MESH_BASE_H
 
 // Local Includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/boundary_info.h"
 #include "libmesh/dof_object.h" // for invalid_processor_id
 #include "libmesh/libmesh_common.h"

--- a/include/mesh/mesh_inserter_iterator.h
+++ b/include/mesh/mesh_inserter_iterator.h
@@ -21,15 +21,18 @@
 #define LIBMESH_MESH_INSERTER_ITERATOR_H
 
 // Local includes
-#include "libmesh/elem.h"
 #include "libmesh/mesh_base.h"
-#include "libmesh/node.h"
 
 // C++ includes
 #include <iterator>
 
 namespace libMesh
 {
+
+// Forward declarations
+class Elem;
+class Node;
+class Point;
 
 /**
  * A class for templated methods that expect output iterator

--- a/include/mesh/mesh_subdivision_support.h
+++ b/include/mesh/mesh_subdivision_support.h
@@ -23,7 +23,6 @@
 // Local Includes
 #include "libmesh/libmesh.h"
 #include "libmesh/face_tri3_subdivision.h"
-#include "libmesh/elem.h"
 
 namespace libMesh
 {

--- a/include/mesh/mesh_tetgen_wrapper.h
+++ b/include/mesh/mesh_tetgen_wrapper.h
@@ -21,9 +21,6 @@
 #include "libmesh/libmesh_config.h"
 #ifdef LIBMESH_HAVE_TETGEN
 
-// libMesh includes
-#include "libmesh/auto_ptr.h" // deprecated
-
 // TetGen include file
 #include "tetgen.h"  // Defines REAL and other Tetgen types
 

--- a/include/numerics/fem_function_base.h
+++ b/include/numerics/fem_function_base.h
@@ -23,7 +23,6 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/dense_vector.h" // required to instantiate a DenseVector<> below
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/fem_context.h"
 
 // C++ includes

--- a/include/numerics/function_base.h
+++ b/include/numerics/function_base.h
@@ -23,7 +23,6 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/dense_vector.h" // required to instantiate a DenseVector<> below
-#include "libmesh/auto_ptr.h" // deprecated
 
 // C++ includes
 #include <cstddef>

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -22,7 +22,6 @@
 
 // Local includes
 #include "libmesh/libmesh_common.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/enum_parallel_type.h"
 #include "libmesh/id_types.h"
 #include "libmesh/reference_counted_object.h"

--- a/include/numerics/petsc_matrix.h
+++ b/include/numerics/petsc_matrix.h
@@ -27,7 +27,6 @@
 // Local includes
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/petsc_macro.h"
-#include "libmesh/parallel.h"
 
 // C++ includes
 #include <algorithm>

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -31,7 +31,7 @@
 #include "libmesh/petsc_macro.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/petsc_solver_exception.h"
-#include "libmesh/parallel.h" // parallel_object_only
+#include "libmesh/parallel_only.h"
 
 // PETSc include files.
 #ifdef I

--- a/include/numerics/petsc_vector.h
+++ b/include/numerics/petsc_vector.h
@@ -31,6 +31,7 @@
 #include "libmesh/petsc_macro.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/petsc_solver_exception.h"
+#include "libmesh/parallel.h" // parallel_object_only
 
 // PETSc include files.
 #ifdef I

--- a/include/numerics/sparse_matrix.h
+++ b/include/numerics/sparse_matrix.h
@@ -24,7 +24,6 @@
 // Local includes
 #include "libmesh/libmesh.h"
 #include "libmesh/libmesh_common.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/id_types.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/parallel_object.h"

--- a/include/numerics/trilinos_preconditioner.h
+++ b/include/numerics/trilinos_preconditioner.h
@@ -29,7 +29,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
-#include "libmesh/auto_ptr.h" // deprecated
 
 // Trilinos includes.  Ignore many unused parameter warnings coming
 // from these headers.

--- a/include/parallel/communicator.h
+++ b/include/parallel/communicator.h
@@ -24,7 +24,6 @@
 #include "libmesh/message_tag.h"
 #include "libmesh/request.h"
 #include "libmesh/status.h"
-#include "libmesh/post_wait_dereference_shared_ptr.h"
 
 // libMesh Includes
 #include "libmesh/libmesh_common.h"

--- a/include/parallel/communicator.h
+++ b/include/parallel/communicator.h
@@ -252,6 +252,7 @@ public:
    * Containers must have the same value in every entry.
    */
   template <typename T>
+  inline
   bool verify(const T & r) const;
 
   /**
@@ -260,6 +261,7 @@ public:
    * Containers must have the same value in every entry.
    */
   template <typename T>
+  inline
   bool semiverify(const T * r) const;
 
   /**
@@ -267,6 +269,7 @@ public:
    * on all processors.  Containers are replaced element-wise.
    */
   template <typename T>
+  inline
   void min(T & r) const;
 
   /**
@@ -275,6 +278,7 @@ public:
    * which originally held the minimum value.
    */
   template <typename T>
+  inline
   void minloc(T & r,
               unsigned int & min_id) const;
 
@@ -284,6 +288,7 @@ public:
    * the minimum rank where a corresponding minimum was found.
    */
   template <typename T, typename A1, typename A2>
+  inline
   void minloc(std::vector<T,A1> & r,
               std::vector<unsigned int,A2> & min_id) const;
 
@@ -292,6 +297,7 @@ public:
    * on all processors.  Containers are replaced element-wise.
    */
   template <typename T>
+  inline
   void max(T & r) const;
 
   /**
@@ -300,6 +306,7 @@ public:
    * which originally held the maximum value.
    */
   template <typename T>
+  inline
   void maxloc(T & r,
               unsigned int & max_id) const;
 
@@ -309,6 +316,7 @@ public:
    * the minimum rank where a corresponding maximum was found.
    */
   template <typename T, typename A1, typename A2>
+  inline
   void maxloc(std::vector<T,A1> & r,
               std::vector<unsigned int,A2> & max_id) const;
 
@@ -317,6 +325,7 @@ public:
    * on all processors.  Containers are replaced element-wise.
    */
   template <typename T>
+  inline
   void sum(T & r) const;
 
   /**
@@ -325,6 +334,7 @@ public:
    * processor 0.
    */
   template <typename T>
+  inline
   void set_union(T & data, const unsigned int root_id) const;
 
   /**
@@ -332,6 +342,7 @@ public:
    * replace it with their union over all processors.
    */
   template <typename T>
+  inline
   void set_union(T & data) const;
 
   /**
@@ -354,6 +365,7 @@ public:
    * \param flag Output.  True if a message exists.  False otherwise.
    */
   template <typename T>
+  inline
   Status packed_range_probe (const unsigned int src_processor_id,
                              const MessageTag & tag,
                              bool & flag) const;
@@ -362,6 +374,7 @@ public:
    * Blocking-send to one processor with data-defined type.
    */
   template <typename T>
+  inline
   void send (const unsigned int dest_processor_id,
              const T & buf,
              const MessageTag & tag=no_tag) const;
@@ -370,6 +383,7 @@ public:
    * Nonblocking-send to one processor with data-defined type.
    */
   template <typename T>
+  inline
   void send (const unsigned int dest_processor_id,
              const T & buf,
              Request & req,
@@ -383,6 +397,7 @@ public:
    * entries in the container(s).
    */
   template <typename T>
+  inline
   void send (const unsigned int dest_processor_id,
              const T & buf,
              const DataType & type,
@@ -396,6 +411,7 @@ public:
    * entries in the container(s).
    */
   template <typename T>
+  inline
   void send (const unsigned int dest_processor_id,
              const T & buf,
              const DataType & type,
@@ -406,6 +422,7 @@ public:
    * Blocking-receive from one processor with data-defined type.
    */
   template <typename T>
+  inline
   Status receive (const unsigned int dest_processor_id,
                   T & buf,
                   const MessageTag & tag=any_tag) const;
@@ -414,6 +431,7 @@ public:
    * Nonblocking-receive from one processor with data-defined type.
    */
   template <typename T>
+  inline
   void receive (const unsigned int dest_processor_id,
                 T & buf,
                 Request & req,
@@ -427,6 +445,7 @@ public:
    * entries in the container(s).
    */
   template <typename T>
+  inline
   Status receive (const unsigned int dest_processor_id,
                   T & buf,
                   const DataType & type,
@@ -440,6 +459,7 @@ public:
    * entries in the container(s).
    */
   template <typename T>
+  inline
   void receive (const unsigned int dest_processor_id,
                 T & buf,
                 const DataType & type,
@@ -470,6 +490,7 @@ public:
    * @param tag The tag to use
    */
   template <typename T, typename A>
+  inline
   bool possibly_receive (unsigned int & src_processor_id,
                          std::vector<T,A> & buf,
                          const DataType & type,
@@ -490,6 +511,7 @@ public:
    * error checking
    */
   template <typename Context, typename Iter>
+  inline
   void send_packed_range (const unsigned int dest_processor_id,
                           const Context * context,
                           Iter range_begin,
@@ -510,6 +532,7 @@ public:
    * error checking
    */
   template <typename Context, typename Iter>
+  inline
   void send_packed_range (const unsigned int dest_processor_id,
                           const Context * context,
                           Iter range_begin,
@@ -526,6 +549,7 @@ public:
    * 4. The message must be received by Communicator::nonblocking_receive_packed_range()
    */
   template <typename Context, typename Iter>
+  inline
   void nonblocking_send_packed_range (const unsigned int dest_processor_id,
                                       const Context * context,
                                       Iter range_begin,
@@ -543,6 +567,7 @@ public:
    * 4. The message must be received by Communicator::nonblocking_receive_packed_range()
    */
   template <typename Context, typename Iter>
+  inline
   void nonblocking_send_packed_range (const unsigned int dest_processor_id,
                                       const Context * context,
                                       Iter range_begin,
@@ -578,6 +603,7 @@ public:
    * is used to advance to the beginning of the next object's data.
    */
   template <typename Context, typename OutputIter, typename T>
+  inline
   void receive_packed_range (const unsigned int dest_processor_id,
                              Context * context,
                              OutputIter out,
@@ -597,6 +623,7 @@ public:
    * Communicator::packed_range_probe.
    */
   template <typename Context, typename OutputIter, typename T>
+  inline
   void nonblocking_receive_packed_range (const unsigned int src_processor_id,
                                          Context * context,
                                          OutputIter out,
@@ -618,6 +645,7 @@ public:
    * Communicator::packed_range_probe.
    */
   template <typename Context, typename OutputIter, typename T>
+  inline
   void nonblocking_receive_packed_range (const unsigned int src_processor_id,
                                          Context * context,
                                          OutputIter out,
@@ -633,6 +661,7 @@ public:
    * other data \p recv from a (potentially different) processor.
    */
   template <typename T1, typename T2>
+  inline
   void send_receive(const unsigned int dest_processor_id,
                     const T1 & send,
                     const unsigned int source_processor_id,
@@ -678,6 +707,7 @@ public:
    */
   template <typename Context1, typename RangeIter, typename Context2,
             typename OutputIter, typename T>
+  inline
   void send_receive_packed_range(const unsigned int dest_processor_id,
                                  const Context1 * context1,
                                  RangeIter send_begin,
@@ -695,6 +725,7 @@ public:
    * a user-specified MPI Dataype.
    */
   template <typename T1, typename T2>
+  inline
   void send_receive(const unsigned int dest_processor_id,
                     const T1 & send,
                     const DataType & type1,

--- a/include/parallel/parallel.h
+++ b/include/parallel/parallel.h
@@ -30,6 +30,7 @@
 #include "libmesh/parallel_only.h"
 #include "libmesh/post_wait_copy_buffer.h"
 #include "libmesh/post_wait_delete_buffer.h"
+#include "libmesh/post_wait_dereference_shared_ptr.h"
 #include "libmesh/post_wait_dereference_tag.h"
 #include "libmesh/post_wait_free_buffer.h"
 #include "libmesh/post_wait_unpack_buffer.h"

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -26,7 +26,6 @@
 
 // Local Includes
 #include "libmesh/libmesh_config.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/op_function.h"
 #include "libmesh/standard_type.h"
 #include "libmesh/point.h"

--- a/include/parallel/parallel_algebra.h
+++ b/include/parallel/parallel_algebra.h
@@ -27,7 +27,8 @@
 // Local Includes
 #include "libmesh/libmesh_config.h"
 #include "libmesh/auto_ptr.h" // deprecated
-#include "libmesh/parallel.h"
+#include "libmesh/op_function.h"
+#include "libmesh/standard_type.h"
 #include "libmesh/point.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/vector_value.h"

--- a/include/parallel/parallel_communicator_specializations
+++ b/include/parallel/parallel_communicator_specializations
@@ -4,102 +4,130 @@
 
 // Some of these specializations are defined in an MPI-independent way
 
+    inline
     bool verify(const std::string & r) const;
 
+    inline
     bool verify(const bool & r) const;
 
     template <typename T, typename A>
+    inline
     bool semiverify(const std::vector<T,A> * r) const;
 
+    inline
     bool semiverify(const std::string * r) const;
 
+    inline
     bool semiverify(const bool * r) const;
 
+    inline
     void min(bool &r) const;
 
     template <typename T, typename A>
+    inline
     void min(std::vector<T,A> &r) const;
 
     template <typename A>
+    inline
     void min(std::vector<bool,A> &r) const;
 
+    inline
     void minloc(bool &r,
                 unsigned int &min_id) const;
 
     template <typename A1, typename A2>
+    inline
     void minloc(std::vector<bool,A1> &r,
                 std::vector<unsigned int,A2> &min_id) const;
 
+    inline
     void max(bool &r) const;
 
     template <typename T, typename A>
+    inline
     void max(std::vector<T,A> &r) const;
 
     template <typename A>
+    inline
     void max(std::vector<bool,A> &r) const;
 
+    inline
     void maxloc(bool &r,
                 unsigned int &max_id) const;
 
     template <typename A1, typename A2>
+    inline
     void maxloc(std::vector<bool,A1> &r,
                 std::vector<unsigned int,A2> &max_id) const;
 
     template <typename T, typename A>
+    inline
     void sum(std::vector<T,A> &r) const;
 
     template <typename T>
+    inline
     void sum(std::complex<T> &r) const;
 
     template <typename T, typename A>
+    inline
     void sum(std::vector<std::complex<T>,A> &r) const;
 
     template <typename T, typename C, typename A>
+    inline
     void set_union(std::set<T,C,A> &data,
                    const unsigned int root_id) const;
 
     template <typename T, typename C, typename A>
+    inline
     void set_union(std::set<T,C,A> &data) const;
 
     template <typename T1, typename T2, typename C, typename A>
+    inline
     void set_union(std::map<T1,T2,C,A> &data,
                    const unsigned int root_id) const;
 
     template <typename T1, typename T2, typename C, typename A>
+    inline
     void set_union(std::map<T1,T2,C,A> &data) const;
 
 // We only need to bother with many of these specializations if we're
 // actually in parallel.
 #ifdef LIBMESH_HAVE_MPI
     template<typename T>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::basic_string<T> & buf,
                const MessageTag &tag=no_tag) const;
  
     template<typename T>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::basic_string<T> & buf,
                Request &req,
                const MessageTag &tag=no_tag) const;
  
     template <typename T, typename C, typename A>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::set<T,C,A> & buf,
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename C, typename A>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::set<T,C,A> & buf,
                Request &req,
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename C, typename A>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::set<T,C,A> & buf,
                const DataType &type,
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename C, typename A>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::set<T,C,A> & buf,
                const DataType &type,
@@ -107,23 +135,27 @@
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
                Request &req,
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
                const DataType &type,
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::vector<T,A> & buf,
                const DataType &type,
@@ -131,23 +163,27 @@
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A1, typename A2>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::vector<std::vector<T,A1>,A2> & buf,
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A1, typename A2>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::vector<std::vector<T,A1>,A2> & buf,
                Request &req,
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A1, typename A2>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::vector<std::vector<T,A1>,A2> & buf,
                const DataType &type,
                const MessageTag &tag=no_tag) const;
 
     template <typename T, typename A1, typename A2>
+    inline
     void send (const unsigned int dest_processor_id,
                const std::vector<std::vector<T,A1>,A2> & buf,
                const DataType &type,
@@ -155,34 +191,40 @@
                const MessageTag &tag=no_tag) const;
 
     template<typename T>
+    inline
     Status receive (const unsigned int src_processor_id,
                     std::basic_string<T> &buf,
                     const MessageTag &tag=any_tag) const;
 
     template<typename T>
+    inline
     void receive (const unsigned int src_processor_id,
                   std::basic_string<T> &buf,
                   Request &req,
                   const MessageTag &tag=any_tag) const;
 
     template <typename T, typename C, typename A>
+    inline
     Status receive (const unsigned int src_processor_id,
                     std::set<T,C,A> &buf,
                     const MessageTag &tag=any_tag) const;
 
     template <typename T, typename C, typename A>
+    inline
     void receive (const unsigned int src_processor_id,
                   std::set<T,C,A> &buf,
                   Request &req,
                   const MessageTag &tag=any_tag) const;
 
     template <typename T, typename C, typename A>
+    inline
     Status receive (const unsigned int src_processor_id,
                     std::set<T,C,A> &buf,
                     const DataType &type,
                     const MessageTag &tag=any_tag) const;
 
     template <typename T, typename C, typename A>
+    inline
     void receive (const unsigned int src_processor_id,
                   std::set<T,C,A> &buf,
                   const DataType &type,
@@ -190,23 +232,27 @@
                   const MessageTag &tag=any_tag) const;
  
     template <typename T, typename A>
+    inline
     Status receive (const unsigned int src_processor_id,
                     std::vector<T,A> &buf,
                     const MessageTag &tag=any_tag) const;
 
     template <typename T, typename A>
+    inline
     void receive (const unsigned int src_processor_id,
                   std::vector<T,A> &buf,
                   Request &req,
                   const MessageTag &tag=any_tag) const;
 
     template <typename T, typename A>
+    inline
     Status receive (const unsigned int src_processor_id,
                     std::vector<T,A> &buf,
                     const DataType &type,
                     const MessageTag &tag=any_tag) const;
 
     template <typename T, typename A>
+    inline
     void receive (const unsigned int src_processor_id,
                   std::vector<T,A> &buf,
                   const DataType &type,
@@ -214,17 +260,20 @@
                   const MessageTag &tag=any_tag) const;
 
     template <typename T, typename A1, typename A2>
+    inline
     Status receive (const unsigned int src_processor_id,
                     std::vector<std::vector<T,A1>,A2> &buf,
                     const MessageTag &tag=any_tag) const;
 
     template<typename T, typename A1, typename A2>
+    inline
     void receive (const unsigned int src_processor_id,
                   std::vector<std::vector<T,A1>,A2> &buf,
                   Request &req,
                   const MessageTag &tag=any_tag) const;
 
     template <typename T, typename A1, typename A2>
+    inline
     Status receive (const unsigned int src_processor_id,
                     std::vector<std::vector<T,A1>,A2> &buf,
                     const DataType &type,
@@ -233,6 +282,7 @@
 // FIXME - non-blocking receive of vector-of-vectors is currently unimplemented
 /*
     template <typename T, typename A1, typename A2>
+    inline
     void receive (const unsigned int src_processor_id,
                   std::vector<std::vector<T,A1>,A2> &buf,
                   const DataType &type,
@@ -241,28 +291,34 @@
 */
 
     template <typename T>
+    inline
     void broadcast(std::basic_string<T> &data,
                    const unsigned int root_id=0) const;
 
     template <typename T, typename A>
+    inline
     void broadcast(std::vector<T,A> &data,
                    const unsigned int root_id=0) const;
 
     template <typename T, typename A>
+    inline
     void broadcast(std::vector<std::basic_string<T>,A> &data,
                    const unsigned int root_id=0) const;
 
     template <typename T, typename C, typename A>
+    inline
     void broadcast(std::set<T,C,A> &data,
                    const unsigned int root_id=0) const;
 
     template <typename T1, typename T2, typename C, typename A>
+    inline
     void broadcast(std::map<T1,T2,C,A> &data,
                    const unsigned int root_id=0) const;
 
     // In new overloaded function template entries we have to
     // re-specify the default arguments
     template <typename T1, typename T2, typename A1, typename A2>
+    inline
     void send_receive(const unsigned int dest_processor_id,
                       const std::vector<T1,A1> & send,
                       const DataType &type1,
@@ -273,6 +329,7 @@
                       const MessageTag &recv_tag = any_tag) const;
 
     template <typename T1, typename T2, typename A1, typename A2>
+    inline
     void send_receive(const unsigned int dest_processor_id,
                       const std::vector<T1,A1> & send,
                       const unsigned int source_processor_id,
@@ -284,6 +341,7 @@
     // send_receive-to-self with a plain copy rather than going through
     // MPI.
     template <typename T, typename A>
+    inline
     void send_receive(const unsigned int dest_processor_id,
                       const std::vector<T,A> & send,
                       const unsigned int source_processor_id,
@@ -292,6 +350,7 @@
                       const MessageTag &recv_tag = any_tag) const;
 
     template <typename T1, typename T2, typename A1, typename A2, typename A3, typename A4>
+    inline
     void send_receive(const unsigned int dest_processor_id,
                       const std::vector<std::vector<T1,A1>,A2> & send,
                       const unsigned int source_processor_id,
@@ -300,6 +359,7 @@
                       const MessageTag &recv_tag = any_tag) const;
 
     template <typename T, typename A1, typename A2>
+    inline
     void send_receive(const unsigned int dest_processor_id,
                       const std::vector<std::vector<T,A1>,A2> & send,
                       const unsigned int source_processor_id,

--- a/include/parallel/parallel_communicator_specializations
+++ b/include/parallel/parallel_communicator_specializations
@@ -4,23 +4,18 @@
 
 // Some of these specializations are defined in an MPI-independent way
 
-    inline
     bool verify(const std::string & r) const;
 
-    inline
     bool verify(const bool & r) const;
 
     template <typename T, typename A>
     inline
     bool semiverify(const std::vector<T,A> * r) const;
 
-    inline
     bool semiverify(const std::string * r) const;
 
-    inline
     bool semiverify(const bool * r) const;
 
-    inline
     void min(bool &r) const;
 
     template <typename T, typename A>
@@ -31,7 +26,6 @@
     inline
     void min(std::vector<bool,A> &r) const;
 
-    inline
     void minloc(bool &r,
                 unsigned int &min_id) const;
 
@@ -40,7 +34,6 @@
     void minloc(std::vector<bool,A1> &r,
                 std::vector<unsigned int,A2> &min_id) const;
 
-    inline
     void max(bool &r) const;
 
     template <typename T, typename A>
@@ -51,7 +44,6 @@
     inline
     void max(std::vector<bool,A> &r) const;
 
-    inline
     void maxloc(bool &r,
                 unsigned int &max_id) const;
 

--- a/include/parallel/parallel_elem.h
+++ b/include/parallel/parallel_elem.h
@@ -22,11 +22,15 @@
 // Local Includes
 #include "libmesh/libmesh_config.h"
 
-#include "libmesh/elem.h"
 #include "libmesh/id_types.h"
+#include "libmesh/packing.h"
 
 namespace libMesh
 {
+
+// Forward declarations
+class Elem;
+
 namespace Parallel
 {
 

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -22,10 +22,10 @@
 
 // Local Includes
 #include "libmesh/auto_ptr.h" // deprecated
+#include "libmesh/communicator.h"
 #include "libmesh/elem.h"
 #include "libmesh/location_maps.h"
 #include "libmesh/mesh_base.h"
-#include "libmesh/parallel.h"
 #include "libmesh/parallel_algebra.h"
 #include "libmesh/parallel_sync.h"
 

--- a/include/parallel/parallel_ghost_sync.h
+++ b/include/parallel/parallel_ghost_sync.h
@@ -21,7 +21,6 @@
 #define LIBMESH_PARALLEL_GHOST_SYNC_H
 
 // Local Includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/communicator.h"
 #include "libmesh/elem.h"
 #include "libmesh/location_maps.h"

--- a/include/parallel/parallel_hilbert.h
+++ b/include/parallel/parallel_hilbert.h
@@ -32,7 +32,8 @@
 #include "libmesh/ignore_warnings.h"
 #include "hilbert.h"
 #include "libmesh/restore_warnings.h"
-#include "libmesh/parallel.h"
+
+#include "libmesh/standard_type.h"
 
 // C++ includes
 #include <cstddef>

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -1449,7 +1449,7 @@ inline void Communicator::allgather(const std::basic_string<T> & sendval,
     return;
 
   // monolithic receive buffer
-  std::string r(globalsize, 0);
+  std::basic_string<T> r(globalsize, 0);
 
   // and get the data from the remote processors.
   libmesh_call_mpi
@@ -1514,7 +1514,7 @@ inline void Communicator::broadcast (std::basic_string<T> & data,
 
   std::vector<T> data_c(data_size);
 #ifndef NDEBUG
-  std::string orig(data);
+  std::basic_string<T> orig(data);
 #endif
 
   if (this->rank() == root_id)
@@ -1613,7 +1613,7 @@ inline void Communicator::broadcast (std::vector<std::basic_string<T>,A> & data,
       while (iter != temp.end())
         {
           std::size_t curr_len = *iter++;
-          data.push_back(std::string(iter, iter+curr_len));
+          data.push_back(std::basic_string<T>(iter, iter+curr_len));
           iter += curr_len;
         }
     }
@@ -2607,7 +2607,7 @@ inline void Communicator::gather(const unsigned int root_id,
         }
 
       // monolithic receive buffer
-      std::string r;
+      std::basic_string<T> r;
       if (this->rank() == root_id)
         r.resize(globalsize, 0);
 

--- a/include/parallel/parallel_implementation.h
+++ b/include/parallel/parallel_implementation.h
@@ -26,7 +26,6 @@
 // C++ includes
 #include <complex>
 #include <cstddef>
-#include <cstring> // memcpy
 #include <iterator>
 #include <limits>
 #include <map>

--- a/include/parallel/parallel_node.h
+++ b/include/parallel/parallel_node.h
@@ -22,11 +22,15 @@
 // Local Includes
 #include "libmesh/libmesh_config.h"
 
-#include "libmesh/node.h"
 #include "libmesh/id_types.h"
+#include "libmesh/packing.h"
 
 namespace libMesh
 {
+
+// Forward declarations
+class Node;
+
 namespace Parallel
 {
 

--- a/include/parallel/parallel_object.h
+++ b/include/parallel/parallel_object.h
@@ -22,7 +22,7 @@
 
 
 // Local includes
-#include "libmesh/parallel.h"
+#include "libmesh/communicator.h"
 
 // Macro to identify and debug functions which should only be called in
 // parallel on every processor at once

--- a/include/parallel/parallel_object.h
+++ b/include/parallel/parallel_object.h
@@ -23,6 +23,7 @@
 
 // Local includes
 #include "libmesh/communicator.h"
+#include "libmesh/parallel_only.h"
 
 // Macro to identify and debug functions which should only be called in
 // parallel on every processor at once

--- a/include/parallel/parallel_only.h
+++ b/include/parallel/parallel_only.h
@@ -19,6 +19,12 @@
 #ifndef LIBMESH_PARALLEL_ONLY_H
 #define LIBMESH_PARALLEL_ONLY_H
 
+// libMesh includes
+#include <libmesh/communicator.h>
+
+// C++ includes
+#include <string>
+
 // Macro to identify and debug functions which should only be called in
 // parallel on every processor at once
 
@@ -27,9 +33,8 @@
 #ifndef NDEBUG
 #define parallel_only() do {                                            \
     libmesh_deprecated();                                               \
-    libmesh_assert(CommWorld.verify(std::string(__FILE__).size()));     \
     libmesh_assert(CommWorld.verify(std::string(__FILE__)));            \
-    libmesh_assert(CommWorld.verify(__LINE__)); } while (0)
+    libmesh_assert(CommWorld.verify(std::to_string(__LINE__))); } while (0)
 #else
 #define parallel_only()  ((void) 0)
 #endif
@@ -38,9 +43,8 @@
 #undef libmesh_parallel_only
 #ifndef NDEBUG
 #define libmesh_parallel_only(comm_obj) do {                            \
-    libmesh_assert((comm_obj).verify(std::string(__FILE__).size()));    \
     libmesh_assert((comm_obj).verify(std::string(__FILE__)));           \
-    libmesh_assert((comm_obj).verify(__LINE__)); } while (0)
+    libmesh_assert((comm_obj).verify(std::to_string(__LINE__))); } while (0)
 #else
 #define libmesh_parallel_only(comm_obj)  ((void) 0)
 #endif
@@ -53,9 +57,8 @@
 #ifndef NDEBUG
 #define parallel_only_on(comm_arg) do {                                 \
     libmesh_deprecated();                                               \
-    libmesh_assert(CommWorld.verify(std::string(__FILE__).size(), comm_arg)); \
     libmesh_assert(CommWorld.verify(std::string(__FILE__), comm_arg));  \
-    libmesh_assert(CommWorld.verify(__LINE__), comm_arg); } while (0)
+    libmesh_assert(CommWorld.verify(std::to_string(__LINE__), comm_arg)); } while (0)
 #else
 #define parallel_only_on(comm_arg)  ((void) 0)
 #endif
@@ -64,9 +67,8 @@
 #undef libmesh_parallel_only_on
 #ifndef NDEBUG
 #define libmesh_parallel_only_on(comm_obj,comm_arg) do {                \
-    libmesh_assert(comm_obj.verify(std::string(__FILE__).size(), comm_arg)); \
     libmesh_assert(comm_obj.verify(std::string(__FILE__), comm_arg));   \
-    libmesh_assert(comm_obj.verify(__LINE__), comm_arg); } while (0)
+    libmesh_assert(comm_obj.verify(std::to_string(__LINE__), comm_arg)); } while (0)
 #else
 #define libmesh_parallel_only_on(comm_obj,comm_arg)  ((void) 0)
 #endif

--- a/include/parallel/parallel_sort.h
+++ b/include/parallel/parallel_sort.h
@@ -20,7 +20,6 @@
 #define LIBMESH_PARALLEL_SORT_H
 
 // Local Includes
-#include "libmesh/parallel.h"
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parallel_object.h"
 
@@ -30,9 +29,12 @@
 namespace libMesh
 {
 
-
 namespace Parallel
 {
+
+// Forward declarations
+class Communicator;
+
 /**
  * The parallel sorting method is templated on the
  * type of data which is to be sorted.  It may later

--- a/include/partitioning/parmetis_helper.h
+++ b/include/partitioning/parmetis_helper.h
@@ -24,9 +24,14 @@
 // C++ Includes
 #include <vector>
 
+#ifdef LIBMESH_HAVE_PARMETIS
+
+// Before we include a header wrapped in a namespace, we'd better make
+// sure none of its dependencies end up in that namespace
+#include <mpi.h>
+
 // Include the ParMETIS header files.  We need this so we can use
 // ParMetis' idx_t and real_t types directly.
-#ifdef LIBMESH_HAVE_PARMETIS
 namespace Parmetis {
 extern "C" {
 #     include "libmesh/ignore_warnings.h"

--- a/include/physics/diff_physics.h
+++ b/include/physics/diff_physics.h
@@ -25,8 +25,9 @@
 #include "libmesh/auto_ptr.h" // deprecated
 
 // C++ includes
-#include <vector>
 #include <memory>
+#include <set>
+#include <vector>
 
 namespace libMesh
 {

--- a/include/physics/diff_physics.h
+++ b/include/physics/diff_physics.h
@@ -24,6 +24,7 @@
 #include "libmesh/libmesh.h"
 
 // C++ includes
+#include <map>
 #include <memory>
 #include <set>
 #include <vector>

--- a/include/physics/diff_physics.h
+++ b/include/physics/diff_physics.h
@@ -22,7 +22,6 @@
 
 // Local Includes
 #include "libmesh/libmesh.h"
-#include "libmesh/auto_ptr.h" // deprecated
 
 // C++ includes
 #include <memory>

--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -22,7 +22,6 @@
 
 // Local Includes
 #include "libmesh/auto_ptr.h" // deprecated
-#include "libmesh/parallel.h"
 #include "libmesh/diff_context.h"
 
 // C++ includes
@@ -34,6 +33,10 @@ namespace libMesh
 // Forward declarations
 class DiffContext;
 class QoISet;
+
+namespace Parallel {
+  class Communicator;
+}
 
 /**
  * This class provides a specific system class.  It aims

--- a/include/physics/diff_qoi.h
+++ b/include/physics/diff_qoi.h
@@ -21,7 +21,6 @@
 #define LIBMESH_DIFF_QOI_H
 
 // Local Includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/diff_context.h"
 
 // C++ includes

--- a/include/quadrature/quadrature.h
+++ b/include/quadrature/quadrature.h
@@ -26,7 +26,6 @@
 #include "libmesh/point.h"
 #include "libmesh/enum_elem_type.h" // INVALID_ELEM
 #include "libmesh/enum_order.h" // INVALID_ORDER
-#include "libmesh/auto_ptr.h" // deprecated
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS
 namespace libMesh

--- a/include/quadrature/quadrature_composite.h
+++ b/include/quadrature/quadrature_composite.h
@@ -28,7 +28,6 @@
 #include "libmesh/quadrature.h"
 #include "libmesh/elem_cutter.h"
 #include "libmesh/fe_base.h"
-#include "libmesh/auto_ptr.h" // deprecated
 
 // C++ includes
 #include <memory>

--- a/include/reduced_basis/rb_eim_assembly.h
+++ b/include/reduced_basis/rb_eim_assembly.h
@@ -24,7 +24,6 @@
 #include "libmesh/elem_assembly.h"
 
 // libMesh includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/numeric_vector.h"
 #include "libmesh/point.h"
 #include "libmesh/fe.h"

--- a/include/reduced_basis/rb_eim_evaluation.h
+++ b/include/reduced_basis/rb_eim_evaluation.h
@@ -21,7 +21,6 @@
 #define LIBMESH_RB_EIM_EVALUATION_H
 
 // libMesh includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/point.h"
 #include "libmesh/rb_evaluation.h"
 #include "libmesh/replicated_mesh.h"

--- a/include/reduced_basis/rb_evaluation.h
+++ b/include/reduced_basis/rb_evaluation.h
@@ -26,7 +26,6 @@
 // libMesh includes
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/parallel_object.h"
 
 // C++ includes

--- a/include/solution_transfer/meshfree_interpolation.h
+++ b/include/solution_transfer/meshfree_interpolation.h
@@ -23,7 +23,6 @@
 // Local includes
 #include "libmesh/libmesh_config.h"
 #include "libmesh/libmesh_common.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/point.h"
 #include "libmesh/parallel_object.h"
 #ifdef LIBMESH_HAVE_NANOFLANN

--- a/include/solvers/diff_solver.h
+++ b/include/solvers/diff_solver.h
@@ -21,7 +21,6 @@
 #define LIBMESH_DIFF_SOLVER_H
 
 // Local includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/libmesh_common.h"
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/parallel_object.h"

--- a/include/solvers/eigen_solver.h
+++ b/include/solvers/eigen_solver.h
@@ -29,7 +29,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/enum_solver_package.h" // SLEPC_SOLVERS
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS

--- a/include/solvers/linear_solver.h
+++ b/include/solvers/linear_solver.h
@@ -26,7 +26,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
-#include "libmesh/auto_ptr.h" // deprecated
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS
 namespace libMesh

--- a/include/solvers/nonlinear_solver.h
+++ b/include/solvers/nonlinear_solver.h
@@ -26,7 +26,6 @@
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
-#include "libmesh/auto_ptr.h" // deprecated
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS
 namespace libMesh

--- a/include/solvers/optimization_solver.h
+++ b/include/solvers/optimization_solver.h
@@ -25,7 +25,6 @@
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/parallel_object.h"
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/optimization_system.h"
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS

--- a/include/solvers/time_solver.h
+++ b/include/solvers/time_solver.h
@@ -21,7 +21,6 @@
 #define LIBMESH_TIME_SOLVER_H
 
 // Local includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/libmesh_common.h"
 #include "libmesh/linear_solver.h"
 #include "libmesh/numeric_vector.h"

--- a/include/solvers/unsteady_solver.h
+++ b/include/solvers/unsteady_solver.h
@@ -21,7 +21,6 @@
 #define LIBMESH_UNSTEADY_SOLVER_H
 
 // Local includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/libmesh_common.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/time_solver.h"

--- a/include/systems/diff_system.h
+++ b/include/systems/diff_system.h
@@ -21,7 +21,6 @@
 #define LIBMESH_DIFF_SYSTEM_H
 
 // Local Includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/diff_context.h"
 #include "libmesh/diff_physics.h"
 #include "libmesh/diff_qoi.h"

--- a/include/systems/fem_context.h
+++ b/include/systems/fem_context.h
@@ -33,6 +33,7 @@
 
 // C++ includes
 #include <map>
+#include <set>
 
 namespace libMesh
 {

--- a/include/systems/parameter_accessor.h
+++ b/include/systems/parameter_accessor.h
@@ -24,7 +24,6 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/compare_types.h" // remove_const
-#include "libmesh/auto_ptr.h" // deprecated
 
 // C++ includes
 #include <memory>

--- a/include/systems/parameter_vector.h
+++ b/include/systems/parameter_vector.h
@@ -24,7 +24,6 @@
 // Local Includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/parameter_accessor.h"
-#include "libmesh/auto_ptr.h" // deprecated
 
 // C++ Includes
 #include <vector>

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -21,7 +21,6 @@
 #define LIBMESH_SYSTEM_H
 
 // Local Includes
-#include "libmesh/auto_ptr.h" // deprecated
 #include "libmesh/elem_range.h"
 #include "libmesh/enum_subset_solve_mode.h" // SUBSET_ZERO
 #include "libmesh/enum_parallel_type.h" // PARALLEL

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -23,7 +23,6 @@
 // Local Includes
 #include "libmesh/reference_counted_object.h"
 #include "libmesh/libmesh_common.h"
-#include "libmesh/auto_ptr.h" // deprecated
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS
 namespace libMesh

--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -36,8 +36,9 @@ enum PointLocatorType : int;
 
 // C++ includes
 #include <cstddef>
-#include <vector>
 #include <memory>
+#include <set>
+#include <vector>
 
 namespace libMesh
 {

--- a/include/utils/xdr_cxx.h
+++ b/include/utils/xdr_cxx.h
@@ -24,7 +24,6 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/libmesh.h"
 #include "libmesh/enum_xdr_mode.h" // READ, WRITE, etc.
-#include "libmesh/auto_ptr.h" // deprecated
 
 // C++ includes
 #include <memory>

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -430,7 +430,7 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
       // Duplicate the input communicator for internal use
       // And get a Parallel::Communicator copy too, to use
       // as a default for that API
-      this->_comm = COMM_WORLD_IN;
+      this->_comm = new Parallel::Communicator(COMM_WORLD_IN);
 
       libMesh::GLOBAL_COMM_WORLD = COMM_WORLD_IN;
 
@@ -774,7 +774,8 @@ LibMeshInit::~LibMeshInit()
   // Allow the user to bypass MPI finalization
   if (!libMesh::on_command_line ("--disable-mpi"))
     {
-      this->_comm.clear();
+      this->comm().clear();
+      delete this->_comm;
 
       if (libmesh_initialized_mpi)
         {

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -18,8 +18,9 @@
 
 // Local includes
 #include "libmesh/libmesh.h"
+
+#include "libmesh/communicator.h"
 #include "libmesh/getpot.h"
-#include "libmesh/parallel.h"
 #include "libmesh/reference_counter.h"
 #include "libmesh/libmesh_singleton.h"
 #include "libmesh/remote_elem.h"

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -463,6 +463,8 @@ LibMeshInit::LibMeshInit (int argc, const char * const * argv,
   // Let's be sure we properly initialize on every processor at once:
   libmesh_parallel_only(this->comm());
 
+#else
+  this->_comm = new Parallel::Communicator(); // So comm() doesn't dereference null
 #endif
 
 #if defined(LIBMESH_HAVE_PETSC)
@@ -789,6 +791,8 @@ LibMeshInit::~LibMeshInit()
             }
         }
     }
+#else
+  delete this->_comm;
 #endif
 }
 

--- a/src/base/periodic_boundary_base.C
+++ b/src/base/periodic_boundary_base.C
@@ -20,8 +20,10 @@
 
 #ifdef LIBMESH_ENABLE_PERIODIC
 
-#include "libmesh/boundary_info.h" // BoundaryInfo::invalid_id
 #include "libmesh/periodic_boundary_base.h"
+
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
+#include "libmesh/boundary_info.h" // BoundaryInfo::invalid_id
 
 namespace libMesh
 {

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -25,6 +25,7 @@
 #include "libmesh/sparsity_pattern.h"
 #include "libmesh/communicator.h"
 #include "libmesh/parallel_algebra.h"
+#include "libmesh/parallel.h"
 
 
 namespace libMesh

--- a/src/fe/fe_l2_lagrange.C
+++ b/src/fe/fe_l2_lagrange.C
@@ -22,7 +22,6 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/elem.h"
-#include "libmesh/threads.h"
 #include "libmesh/string_to_enum.h"
 
 namespace libMesh

--- a/src/fe/fe_lagrange_vec.C
+++ b/src/fe/fe_lagrange_vec.C
@@ -22,7 +22,6 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/elem.h"
-#include "libmesh/threads.h"
 #include "libmesh/tensor_value.h"
 
 namespace libMesh

--- a/src/fe/fe_monomial_vec.C
+++ b/src/fe/fe_monomial_vec.C
@@ -20,7 +20,6 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/elem.h"
-#include "libmesh/threads.h"
 #include "libmesh/tensor_value.h"
 
 namespace libMesh

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -22,7 +22,6 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/elem.h"
-#include "libmesh/threads.h"
 #include "libmesh/tensor_value.h"
 #include "libmesh/string_to_enum.h"
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -37,6 +37,7 @@
 #include "libmesh/mesh_communication.h"
 #include "libmesh/parallel_mesh.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/parallel.h"
 
 namespace libMesh
 {

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -53,6 +53,7 @@
 #include "libmesh/function_base.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/int_range.h"
+#include "libmesh/parallel.h"
 
 namespace libMesh
 {

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -20,7 +20,6 @@
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/mesh_output.h"
-#include "libmesh/parallel.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/numeric_vector.h"
 

--- a/src/mesh/mesh_serializer.C
+++ b/src/mesh/mesh_serializer.C
@@ -19,7 +19,7 @@
 // Local includes
 #include "libmesh/mesh_serializer.h"
 #include "libmesh/mesh_base.h"
-#include "libmesh/parallel.h" // parallel_only() macro
+#include "libmesh/parallel_only.h"
 
 namespace libMesh
 {

--- a/src/mesh/namebased_io.C
+++ b/src/mesh/namebased_io.C
@@ -48,6 +48,8 @@
 #include "libmesh/equation_systems.h"
 #include "libmesh/enum_xdr_mode.h"
 
+#include "libmesh/parallel.h" // broadcast
+
 
 namespace libMesh
 {

--- a/src/mesh/replicated_mesh.C
+++ b/src/mesh/replicated_mesh.C
@@ -24,6 +24,7 @@
 #include "libmesh/metis_partitioner.h"
 #include "libmesh/replicated_mesh.h"
 #include "libmesh/utility.h"
+#include "libmesh/parallel.h"
 #include "libmesh/point.h"
 #ifdef LIBMESH_HAVE_NANOFLANN
 #include "libmesh/nanoflann.hpp"

--- a/src/mesh/tecplot_io.C
+++ b/src/mesh/tecplot_io.C
@@ -28,7 +28,6 @@
 #include "libmesh/tecplot_io.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/elem.h"
-#include "libmesh/parallel.h"
 #include "libmesh/enum_io_package.h"
 #include "libmesh/int_range.h"
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -29,6 +29,7 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/dense_matrix.h"
 #include "libmesh/petsc_vector.h"
+#include "libmesh/parallel.h"
 
 
 // For some reason, the blocked matrix API calls below seem to break with PETSC 3.2 & presumably earlier.

--- a/src/parallel/communicator.C
+++ b/src/parallel/communicator.C
@@ -390,7 +390,7 @@ void Communicator::minloc(bool & r,
       libmesh_ignore(data_in); // unused ifndef LIBMESH_HAVE_MPI
       data_in.val = r;
       data_in.rank = this->rank();
-      DataPlusInt<int> data_out;
+      DataPlusInt<int> data_out = data_in;
 
       libmesh_call_mpi
         (MPI_Allreduce (&data_in, &data_out, 1,
@@ -432,7 +432,7 @@ void Communicator::maxloc(bool & r,
       libmesh_ignore(data_in); // unused ifndef LIBMESH_HAVE_MPI
       data_in.val = r;
       data_in.rank = this->rank();
-      DataPlusInt<int> data_out;
+      DataPlusInt<int> data_out = data_in;
 
       libmesh_call_mpi
         (MPI_Allreduce (&data_in, &data_out, 1,

--- a/src/parallel/communicator.C
+++ b/src/parallel/communicator.C
@@ -276,12 +276,13 @@ MessageTag Communicator::get_unique_tag(int tagvalue) const
 
 
 status Communicator::probe (const unsigned int src_processor_id,
-                                   const MessageTag & tag) const
+                            const MessageTag & tag) const
 {
   LOG_SCOPE("probe()", "Parallel");
 
 #ifndef LIBMESH_HAVE_MPI
   libmesh_not_implemented();
+  libmesh_ignore(src_processor_id, tag);
 #endif
 
   status stat;

--- a/src/parallel/communicator.C
+++ b/src/parallel/communicator.C
@@ -21,7 +21,7 @@
 
 // libMesh includes
 #include "libmesh/libmesh_logging.h"
-#include "libmesh/parallel_implementation.h" // for inline max(int)
+#include "libmesh/parallel.h" // for inline max(int)
 
 namespace libMesh
 {
@@ -273,6 +273,178 @@ MessageTag Communicator::get_unique_tag(int tagvalue) const
 
   return MessageTag(tagvalue, this);
 }
+
+
+status Communicator::probe (const unsigned int src_processor_id,
+                                   const MessageTag & tag) const
+{
+  LOG_SCOPE("probe()", "Parallel");
+
+#ifndef LIBMESH_HAVE_MPI
+  libmesh_not_implemented();
+#endif
+
+  status stat;
+
+  libmesh_assert(src_processor_id < this->size() ||
+                 src_processor_id == any_source);
+
+  libmesh_call_mpi
+    (MPI_Probe (src_processor_id, tag.value(), this->get(), &stat));
+
+  return stat;
+}
+
+
+bool Communicator::verify(const bool & r) const
+{
+  const unsigned char rnew = r;
+  return this->verify(rnew);
+}
+
+
+bool Communicator::semiverify(const bool * r) const
+{
+  if (r)
+    {
+      const unsigned char rnew = *r;
+      return this->semiverify(&rnew);
+    }
+
+  const unsigned char * rptr = nullptr;
+  return this->semiverify(rptr);
+}
+
+
+bool Communicator::verify(const std::string & r) const
+{
+  if (this->size() > 1)
+    {
+      // Cannot use <char> since MPI_MIN is not
+      // strictly defined for chars!
+      std::vector<short int> temp; temp.reserve(r.size());
+      for (std::size_t i=0; i != r.size(); ++i)
+        temp.push_back(r[i]);
+      return this->verify(temp);
+    }
+  return true;
+}
+
+
+bool Communicator::semiverify(const std::string * r) const
+{
+  if (this->size() > 1)
+    {
+      std::size_t rsize = r ? r->size() : 0;
+      std::size_t * psize = r ? &rsize : nullptr;
+
+      if (!this->semiverify(psize))
+        return false;
+
+      this->max(rsize);
+
+      // Cannot use <char> since MPI_MIN is not
+      // strictly defined for chars!
+      std::vector<short int> temp (rsize);
+      if (r)
+        {
+          temp.reserve(rsize);
+          for (std::size_t i=0; i != rsize; ++i)
+            temp.push_back((*r)[i]);
+        }
+
+      std::vector<short int> * ptemp = r ? &temp: nullptr;
+
+      return this->semiverify(ptemp);
+    }
+  return true;
+}
+
+
+void Communicator::min(bool & r) const
+{
+  if (this->size() > 1)
+    {
+      LOG_SCOPE("min(bool)", "Parallel");
+
+      unsigned int temp = r;
+      libmesh_call_mpi
+        (MPI_Allreduce (MPI_IN_PLACE, &temp, 1,
+                        StandardType<unsigned int>(),
+                        OpFunction<unsigned int>::min(),
+                        this->get()));
+      r = temp;
+    }
+}
+
+
+void Communicator::minloc(bool & r,
+                          unsigned int & min_id) const
+{
+  if (this->size() > 1)
+    {
+      LOG_SCOPE("minloc(bool)", "Parallel");
+
+      DataPlusInt<int> data_in;
+      libmesh_ignore(data_in); // unused ifndef LIBMESH_HAVE_MPI
+      data_in.val = r;
+      data_in.rank = this->rank();
+      DataPlusInt<int> data_out;
+
+      libmesh_call_mpi
+        (MPI_Allreduce (&data_in, &data_out, 1,
+                        dataplusint_type_acquire<int>().first,
+                        OpFunction<int>::min_location(), this->get()));
+      r = data_out.val;
+      min_id = data_out.rank;
+    }
+  else
+    min_id = this->rank();
+}
+
+
+void Communicator::max(bool & r) const
+{
+  if (this->size() > 1)
+    {
+      LOG_SCOPE("max(bool)", "Parallel");
+
+      unsigned int temp = r;
+      libmesh_call_mpi
+        (MPI_Allreduce (MPI_IN_PLACE, &temp, 1,
+                        StandardType<unsigned int>(),
+                        OpFunction<unsigned int>::max(),
+                        this->get()));
+      r = temp;
+    }
+}
+
+
+void Communicator::maxloc(bool & r,
+                          unsigned int & max_id) const
+{
+  if (this->size() > 1)
+    {
+      LOG_SCOPE("maxloc(bool)", "Parallel");
+
+      DataPlusInt<int> data_in;
+      libmesh_ignore(data_in); // unused ifndef LIBMESH_HAVE_MPI
+      data_in.val = r;
+      data_in.rank = this->rank();
+      DataPlusInt<int> data_out;
+
+      libmesh_call_mpi
+        (MPI_Allreduce (&data_in, &data_out, 1,
+                        dataplusint_type_acquire<int>().first,
+                        OpFunction<int>::max_location(),
+                        this->get()));
+      r = data_out.val;
+      max_id = data_out.rank;
+    }
+  else
+    max_id = this->rank();
+}
+
 
 
 } // namespace Parallel

--- a/src/parallel/parallel_elem.C
+++ b/src/parallel/parallel_elem.C
@@ -24,7 +24,7 @@
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/elem.h"
 #include "libmesh/mesh_base.h"
-#include "libmesh/parallel.h"
+#include "libmesh/parallel_elem.h"
 #include "libmesh/parallel_mesh.h"
 #include "libmesh/remote_elem.h"
 
@@ -53,7 +53,6 @@ namespace libMesh
 namespace Parallel
 {
 
-template <>
 template <>
 unsigned int
 Packing<const Elem *>::packed_size (std::vector<largest_id_type>::const_iterator in)
@@ -130,7 +129,6 @@ Packing<const Elem *>::packed_size (std::vector<largest_id_type>::const_iterator
 
 
 template <>
-template <>
 unsigned int
 Packing<const Elem *>::packed_size (std::vector<largest_id_type>::iterator in)
 {
@@ -139,7 +137,6 @@ Packing<const Elem *>::packed_size (std::vector<largest_id_type>::iterator in)
 
 
 
-template <>
 template <>
 unsigned int
 Packing<const Elem *>::packable_size (const Elem * const & elem,
@@ -178,7 +175,6 @@ Packing<const Elem *>::packable_size (const Elem * const & elem,
 
 
 template <>
-template <>
 unsigned int
 Packing<const Elem *>::packable_size (const Elem * const & elem,
                                       const DistributedMesh * mesh)
@@ -189,7 +185,6 @@ Packing<const Elem *>::packable_size (const Elem * const & elem,
 
 
 template <>
-template <>
 unsigned int
 Packing<const Elem *>::packable_size (const Elem * const & elem,
                                       const ParallelMesh * mesh)
@@ -199,7 +194,6 @@ Packing<const Elem *>::packable_size (const Elem * const & elem,
 
 
 
-template <>
 template <>
 void
 Packing<const Elem *>::pack (const Elem * const & elem,
@@ -324,7 +318,6 @@ Packing<const Elem *>::pack (const Elem * const & elem,
 
 
 template <>
-template <>
 void
 Packing<const Elem *>::pack (const Elem * const & elem,
                              std::back_insert_iterator<std::vector<largest_id_type>> data_out,
@@ -335,7 +328,6 @@ Packing<const Elem *>::pack (const Elem * const & elem,
 
 
 
-template <>
 template <>
 void
 Packing<const Elem *>::pack (const Elem * const & elem,
@@ -348,7 +340,6 @@ Packing<const Elem *>::pack (const Elem * const & elem,
 
 
 // FIXME - this needs serious work to be 64-bit compatible
-template <>
 template <>
 Elem *
 Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
@@ -803,7 +794,6 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
 
 
 template <>
-template <>
 Elem *
 Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
                          DistributedMesh * mesh)
@@ -813,7 +803,6 @@ Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,
 
 
 
-template <>
 template <>
 Elem *
 Packing<Elem *>::unpack (std::vector<largest_id_type>::const_iterator in,

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -151,7 +151,7 @@ Packing<const Node *>::pack (const Node * const & node,
     {
       const Real node_i = (*node)(i);
       largest_id_type Real_as_idtypes[idtypes_per_Real];
-      memcpy(Real_as_idtypes, &node_i, sizeof(Real));
+      std::memcpy(Real_as_idtypes, &node_i, sizeof(Real));
       for (unsigned int j=0; j != idtypes_per_Real; ++j)
         *data_out++ =(Real_as_idtypes[j]);
     }
@@ -233,7 +233,7 @@ Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,
       for (unsigned int i=0; i != LIBMESH_DIM; ++i)
         {
           Real idtypes_as_Real;
-          memcpy(&idtypes_as_Real, &(*in), sizeof(Real));
+          std::memcpy(&idtypes_as_Real, &(*in), sizeof(Real));
           in += idtypes_per_Real;
           libmesh_assert_less_equal ((*node)(i), idtypes_as_Real + (std::max(Real(1),idtypes_as_Real)*TOLERANCE*TOLERANCE));
           libmesh_assert_greater_equal ((*node)(i), idtypes_as_Real - (std::max(Real(1),idtypes_as_Real)*TOLERANCE*TOLERANCE));
@@ -264,7 +264,7 @@ Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,
       for (unsigned int i=0; i != LIBMESH_DIM; ++i)
         {
           Real idtypes_as_Real;
-          memcpy(&idtypes_as_Real, &(*in), sizeof(Real));
+          std::memcpy(&idtypes_as_Real, &(*in), sizeof(Real));
           (*node)(i) = idtypes_as_Real;
           in += idtypes_per_Real;
         }

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -17,8 +17,6 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/boundary_info.h"
 #include "libmesh/distributed_mesh.h"
@@ -26,6 +24,9 @@
 #include "libmesh/node.h"
 #include "libmesh/parallel_mesh.h"
 #include "libmesh/parallel_node.h"
+
+// C++ includes
+#include <cstring> // memcpy
 
 // Helper functions in anonymous namespace
 

--- a/src/parallel/parallel_node.C
+++ b/src/parallel/parallel_node.C
@@ -24,8 +24,8 @@
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/node.h"
-#include "libmesh/parallel.h"
 #include "libmesh/parallel_mesh.h"
+#include "libmesh/parallel_node.h"
 
 // Helper functions in anonymous namespace
 
@@ -57,7 +57,6 @@ namespace Parallel
 {
 
 template <>
-template <>
 unsigned int
 Packing<const Node *>::packable_size (const Node * const & node,
                                       const MeshBase * mesh)
@@ -73,7 +72,6 @@ Packing<const Node *>::packable_size (const Node * const & node,
 
 
 
-template <>
 template <>
 unsigned int
 Packing<const Node *>::packed_size (const std::vector<largest_id_type>::const_iterator in)
@@ -97,7 +95,6 @@ Packing<const Node *>::packed_size (const std::vector<largest_id_type>::const_it
 
 
 template <>
-template <>
 unsigned int
 Packing<const Node *>::packed_size (const std::vector<largest_id_type>::iterator in)
 {
@@ -106,7 +103,6 @@ Packing<const Node *>::packed_size (const std::vector<largest_id_type>::iterator
 
 
 
-template <>
 template <>
 unsigned int
 Packing<const Node *>::packable_size (const Node * const & node,
@@ -118,7 +114,6 @@ Packing<const Node *>::packable_size (const Node * const & node,
 
 
 template <>
-template <>
 unsigned int
 Packing<const Node *>::packable_size (const Node * const & node,
                                       const ParallelMesh * mesh)
@@ -128,7 +123,6 @@ Packing<const Node *>::packable_size (const Node * const & node,
 
 
 
-template <>
 template <>
 void
 Packing<const Node *>::pack (const Node * const & node,
@@ -179,7 +173,6 @@ Packing<const Node *>::pack (const Node * const & node,
 
 
 template <>
-template <>
 void
 Packing<const Node *>::pack (const Node * const & node,
                              std::back_insert_iterator<std::vector<largest_id_type>> data_out,
@@ -191,7 +184,6 @@ Packing<const Node *>::pack (const Node * const & node,
 
 
 template <>
-template <>
 void
 Packing<const Node *>::pack (const Node * const & node,
                              std::back_insert_iterator<std::vector<largest_id_type>> data_out,
@@ -202,7 +194,6 @@ Packing<const Node *>::pack (const Node * const & node,
 
 
 
-template <>
 template <>
 Node *
 Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,
@@ -312,7 +303,6 @@ Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,
 
 
 template <>
-template <>
 Node *
 Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,
                          DistributedMesh * mesh)
@@ -322,7 +312,6 @@ Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,
 
 
 
-template <>
 template <>
 Node *
 Packing<Node *>::unpack (std::vector<largest_id_type>::const_iterator in,

--- a/src/partitioning/linear_partitioner.C
+++ b/src/partitioning/linear_partitioner.C
@@ -21,6 +21,7 @@
 #include "libmesh/linear_partitioner.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/elem.h"
+#include "libmesh/parallel.h"
 
 namespace libMesh
 {

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -27,6 +27,7 @@
 #include "libmesh/error_vector.h"
 #include "libmesh/vectormap.h"
 #include "libmesh/metis_csr_graph.h"
+#include "libmesh/parallel.h"
 
 #ifdef LIBMESH_HAVE_METIS
 // MIPSPro 7.4.2 gets confused about these nested namespaces

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -34,6 +34,10 @@
 // Include the ParMETIS header file.
 #ifdef LIBMESH_HAVE_PARMETIS
 
+// Before we include a header wrapped in a namespace, we'd better make
+// sure none of its dependencies end up in that namespace
+#include <mpi.h>
+
 namespace Parmetis {
 extern "C" {
 #     include "libmesh/ignore_warnings.h"

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -20,7 +20,7 @@
 // Local Includes
 #include "libmesh/libmesh_config.h"
 #include "libmesh/mesh_base.h"
-#include "libmesh/parallel.h"    // also includes mpi.h
+#include "libmesh/communicator.h"    // also includes mpi.h
 #include "libmesh/mesh_serializer.h"
 #include "libmesh/mesh_tools.h"
 #include "libmesh/mesh_communication.h"

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -26,7 +26,7 @@
 #include "libmesh/mesh_communication.h"
 #include "libmesh/parmetis_partitioner.h"
 #include "libmesh/metis_partitioner.h"
-#include "libmesh/parallel_ghost_sync.h"
+#include "libmesh/parallel_only.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/elem.h"
 #include "libmesh/parmetis_helper.h"

--- a/src/physics/diff_qoi.C
+++ b/src/physics/diff_qoi.C
@@ -18,6 +18,7 @@
 
 #include "libmesh/diff_qoi.h"
 #include "libmesh/int_range.h"
+#include "libmesh/parallel.h"
 
 namespace libMesh
 {

--- a/src/physics/fem_physics.C
+++ b/src/physics/fem_physics.C
@@ -26,7 +26,6 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/parallel.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/time_solver.h"

--- a/src/reduced_basis/rb_evaluation.C
+++ b/src/reduced_basis/rb_evaluation.C
@@ -22,10 +22,10 @@
 #include "libmesh/rb_theta_expansion.h"
 
 // libMesh includes
+#include "libmesh/communicator.h"
 #include "libmesh/libmesh_version.h"
 #include "libmesh/system.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/parallel.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/xdr_cxx.h"
 #include "libmesh/mesh_tools.h"

--- a/src/reduced_basis/rb_scm_construction.C
+++ b/src/reduced_basis/rb_scm_construction.C
@@ -33,7 +33,6 @@
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/getpot.h"
-#include "libmesh/parallel.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/enum_eigen_solver_type.h"
 

--- a/src/reduced_basis/rb_scm_evaluation.C
+++ b/src/reduced_basis/rb_scm_evaluation.C
@@ -35,7 +35,6 @@
 #include "libmesh/int_range.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/parallel.h"
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/xdr_cxx.h"
 

--- a/src/reduced_basis/transient_rb_construction.C
+++ b/src/reduced_basis/transient_rb_construction.C
@@ -36,7 +36,7 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/xdr_cxx.h"
 #include "libmesh/timestamp.h"
-#include "libmesh/parallel.h"
+#include "libmesh/communicator.h"
 
 // For checking for the existence of files
 #include <sys/stat.h>

--- a/src/reduced_basis/transient_rb_evaluation.C
+++ b/src/reduced_basis/transient_rb_evaluation.C
@@ -26,7 +26,6 @@
 #include "libmesh/int_range.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/parallel.h"
 #include "libmesh/xdr_cxx.h"
 
 // C++ includes

--- a/src/solvers/petscdmlibmeshimpl.C
+++ b/src/solvers/petscdmlibmeshimpl.C
@@ -40,6 +40,7 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/preconditioner.h"
 #include "libmesh/elem.h"
+#include "libmesh/parallel.h"
 
 
 using namespace libMesh;

--- a/src/systems/fem_system.C
+++ b/src/systems/fem_system.C
@@ -26,7 +26,6 @@
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/parallel.h"
 #include "libmesh/parallel_algebra.h"
 #include "libmesh/parallel_ghost_sync.h"
 #include "libmesh/quadrature.h"

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -22,7 +22,7 @@
 #include "libmesh/topology_map.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/node.h"
-#include "libmesh/parallel.h"
+#include "libmesh/parallel_only.h"
 #include "libmesh/remote_elem.h"
 
 // C++ Includes

--- a/tests/mesh/boundary_info.C
+++ b/tests/mesh/boundary_info.C
@@ -7,6 +7,7 @@
 #include <libmesh/zero_function.h>
 #include <libmesh/dirichlet_boundaries.h>
 #include <libmesh/dof_map.h>
+#include <libmesh/parallel.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"

--- a/tests/mesh/checkpoint.C
+++ b/tests/mesh/checkpoint.C
@@ -2,6 +2,7 @@
 #include "libmesh/replicated_mesh.h"
 #include "libmesh/checkpoint_io.h"
 #include "libmesh/mesh_generation.h"
+#include "libmesh/parallel.h"
 #include "libmesh/partitioner.h"
 
 #include "test_comm.h"

--- a/tests/parallel/parallel_sort_test.C
+++ b/tests/parallel/parallel_sort_test.C
@@ -1,4 +1,5 @@
 #include <libmesh/parallel_sort.h>
+#include <libmesh/parallel.h>
 
 #include <algorithm>
 

--- a/tests/solvers/time_solver_test_common.h
+++ b/tests/solvers/time_solver_test_common.h
@@ -3,6 +3,7 @@
 #include <libmesh/newton_solver.h>
 #include <libmesh/enum_solver_type.h>
 #include <libmesh/enum_preconditioner_type.h>
+#include <libmesh/parallel.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -20,6 +20,7 @@
 #include <libmesh/enum_solver_type.h>
 #include <libmesh/enum_preconditioner_type.h>
 #include <libmesh/linear_solver.h>
+#include <libmesh/parallel.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"

--- a/tests/utils/point_locator_test.C
+++ b/tests/utils/point_locator_test.C
@@ -2,6 +2,7 @@
 #include <libmesh/mesh_generation.h>
 #include <libmesh/elem.h>
 #include <libmesh/node.h>
+#include <libmesh/parallel.h>
 
 #include "test_comm.h"
 #include "libmesh_cppunit.h"


### PR DESCRIPTION
This greatly reduces the number of unnecessary inclusions of the huge parallel.h swath of headers, among some more minor improvements.

As usual for this sort of refactoring, this can break codes which use Foo but rely on including "bar.h" to include "foo.h", but the MOOSE fixes in https://github.com/idaholab/moose/pull/13919 weren't bad.