### PR TITLE
Disabled glibc++ debug defines by default.

### DIFF
--- a/configure
+++ b/configure
@@ -1937,9 +1937,9 @@ Optional Features:
   --enable-cxx11-required Error if compiler does not support C++11
   --enable-sanitize="opt dbg devel prof oprof"
                           turn on sanitizer flags for the given methods
-  --disable-glibcxx-debugging
-                          omit -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC even
-                          in dbg mode
+  --enable-glibcxx-debugging
+                          enable -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC in
+                          dbg mode
   --enable-glibcxx-debugging-cppunit
                           Use GLIBCXX debugging flags for unit tests
   --enable-coverage       configure code coverage analysis tools
@@ -7778,7 +7778,8 @@ fi
 fi
 
   # in the case blocks below we may add GLIBCXX-specific pedantic debugging preprocessor
-  # definitions. however, allow the knowing user to preclude that if they need to.
+  # definitions. Should only be used by a knowing user, because these options break
+  # ABI compatibility.
   # Check whether --enable-glibcxx-debugging was given.
 if test "${enable_glibcxx_debugging+set}" = set; then :
   enableval=$enable_glibcxx_debugging; case "${enableval}" in #(
@@ -7790,7 +7791,7 @@ if test "${enable_glibcxx_debugging+set}" = set; then :
     as_fn_error $? "bad value ${enableval} for --enable-glibcxx-debugging" "$LINENO" 5 ;;
 esac
 else
-  enableglibcxxdebugging=yes
+  enableglibcxxdebugging=no
 fi
 
 
@@ -46438,6 +46439,22 @@ fi
 fi
 
 fi
+$as_echo
+if test "x$enableglibcxxdebugging" = "xyes"; then :
+
+        $as_echo  \
+"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" \
+"! WARNING: You used --enable-glibcxx-debugging. This setting breaks ABI !" \
+"!          compatibility. You need to make sure that when you link C++  !" \
+"!          libraries in combination with the debug version of libMesh   !" \
+"!          that ALL OF THESE LIBRARIES are compiled with the            !" \
+"!            -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC                 !" \
+"!          flags.                                                       !" \
+"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        $as_echo
+
+fi
+
 $as_echo "-------------------------------------------------------------------------------"
 $as_echo "Configure complete, now type 'make' and then 'make install'."
 $as_echo

--- a/m4/compiler.m4
+++ b/m4/compiler.m4
@@ -419,15 +419,16 @@ AC_DEFUN([LIBMESH_SET_CXX_FLAGS],
         ])
 
   # in the case blocks below we may add GLIBCXX-specific pedantic debugging preprocessor
-  # definitions. however, allow the knowing user to preclude that if they need to.
+  # definitions. Should only be used by a knowing user, because these options break
+  # ABI compatibility.
   AC_ARG_ENABLE(glibcxx-debugging,
-                [AS_HELP_STRING([--disable-glibcxx-debugging],
-                                [omit -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC even in dbg mode])],
+                [AS_HELP_STRING([--enable-glibcxx-debugging],
+                                [enable -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC in dbg mode])],
                 [AS_CASE("${enableval}",
                          [yes], [enableglibcxxdebugging=yes],
                          [no],  [enableglibcxxdebugging=no],
                          [AC_MSG_ERROR(bad value ${enableval} for --enable-glibcxx-debugging)])],
-                [enableglibcxxdebugging=yes])
+                [enableglibcxxdebugging=no])
 
   # GLIBCXX debugging causes untold woes on mac machines - so disable it
   AS_IF([test `uname` = "Darwin"],

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -179,6 +179,21 @@ AS_IF([test "x$enableoptional" = "xyes"],
                 AS_ECHO([])
               ])
       ])
+AS_ECHO([])
+AS_IF([test "x$enableglibcxxdebugging" = "xyes"],
+      [
+        AS_ECHO([ \
+"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" \
+"! WARNING: You used --enable-glibcxx-debugging. This setting breaks ABI !" \
+"!          compatibility. You need to make sure that when you link C++  !" \
+"!          libraries in combination with the debug version of libMesh   !" \
+"!          that ALL OF THESE LIBRARIES are compiled with the            !" \
+"!            -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC                 !" \
+"!          flags.                                                       !" \
+"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"])
+        AS_ECHO([])
+      ])
+
 AS_ECHO(["-------------------------------------------------------------------------------"])
 AS_ECHO(["Configure complete, now type 'make' and then 'make install'."])
 AS_ECHO([])


### PR DESCRIPTION
By default libMesh enables the flags -D_GLIBCXX_DEBUG and -D_GLIBCXX_DEBUG_PEDANTIC for the debug version of the library. These flags are dangerous.

These flags require that all C++ libraries that are linked together with the debug version of libMesh are also compiled with these flags. When a user combines libMesh with a library that was compiled without these flags, no warning or error message is shown. The resulting application will however segfault in various places, which makes it hard to trace back the origin of the error. (It just took me two hours to do so.)

I would suggest, to disable these flags by default and to show an prominent warning message when using them. I am aware that these flags can be very useful for debugging and also for running unit tests. Since they require special care and proper treatment by users, however, they should only be used by users that know what they are doing.