### PR TITLE
Fix missing includes in --disable-optional builds

### DIFF
--- a/include/numerics/parsed_function.h
+++ b/include/numerics/parsed_function.h
@@ -20,6 +20,7 @@
 
 #include "libmesh/libmesh_config.h"
 #include "libmesh/function_base.h"
+#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 #ifdef LIBMESH_HAVE_FPARSER
 
@@ -27,7 +28,6 @@
 #include "libmesh/dense_vector.h"
 #include "libmesh/vector_value.h"
 #include "libmesh/point.h"
-#include "libmesh/auto_ptr.h" // libmesh_make_unique
 
 // FParser includes
 #include "libmesh/fparser_ad.hh"

--- a/include/reduced_basis/rb_assembly_expansion.h
+++ b/include/reduced_basis/rb_assembly_expansion.h
@@ -25,7 +25,7 @@
 
 // C++ includes
 #include <vector>
-
+#include <memory>
 
 namespace libMesh
 {

--- a/include/reduced_basis/rb_theta_expansion.h
+++ b/include/reduced_basis/rb_theta_expansion.h
@@ -26,7 +26,7 @@
 
 // C++ includes
 #include <vector>
-
+#include <memory>
 
 namespace libMesh
 {

--- a/include/systems/system.h
+++ b/include/systems/system.h
@@ -47,6 +47,15 @@ enum FEMNormType : int;
 #include <vector>
 #include <memory>
 
+// This define may be useful in --disable-optional builds when it is
+// possible that libmesh will not have any solvers available.
+#if defined(LIBMESH_HAVE_PETSC) || \
+  defined(LIBMESH_HAVE_EIGEN)   || \
+  defined(LIBMESH_HAVE_LASPACK) || \
+  defined(LIBMESH_TRILINOS_HAVE_AZTECOO)
+#define LIBMESH_HAVE_SOLVER 1
+#endif
+
 namespace libMesh
 {
 

--- a/src/base/default_coupling.C
+++ b/src/base/default_coupling.C
@@ -24,6 +24,7 @@
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/remote_elem.h"
 #include "libmesh/int_range.h"
+#include "libmesh/libmesh_logging.h"
 
 // C++ Includes
 #include <unordered_set>

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -27,6 +27,7 @@
 #include "libmesh/threads.h"
 #include "libmesh/print_trace.h"
 #include "libmesh/enum_solver_package.h"
+#include "libmesh/perf_log.h"
 
 // C/C++ includes
 #include <iostream>

--- a/src/base/point_neighbor_coupling.C
+++ b/src/base/point_neighbor_coupling.C
@@ -23,6 +23,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/remote_elem.h"
+#include "libmesh/libmesh_logging.h"
 
 // C++ Includes
 #include <unordered_set>

--- a/src/base/sibling_coupling.C
+++ b/src/base/sibling_coupling.C
@@ -21,6 +21,7 @@
 #include "libmesh/sibling_coupling.h"
 #include "libmesh/elem.h"
 #include "libmesh/remote_elem.h"
+#include "libmesh/libmesh_logging.h"
 
 namespace libMesh
 {

--- a/src/utils/topology_map.C
+++ b/src/utils/topology_map.C
@@ -24,6 +24,7 @@
 #include "libmesh/node.h"
 #include "libmesh/parallel_only.h"
 #include "libmesh/remote_elem.h"
+#include "libmesh/libmesh_logging.h"
 
 // C++ Includes
 #include <limits>

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -359,12 +359,14 @@ public:
 
   CPPUNIT_TEST_SUITE( OverlappingFunctorTest );
 
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( checkCouplingFunctorQuad );
   CPPUNIT_TEST( checkCouplingFunctorQuadUnifRef );
   CPPUNIT_TEST( checkCouplingFunctorTri );
   CPPUNIT_TEST( checkCouplingFunctorTriUnifRef );
   CPPUNIT_TEST( checkOverlappingPartitioner );
   CPPUNIT_TEST( checkOverlappingPartitionerUnifRef );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -414,17 +416,18 @@ private:
 
   // This is basically to sanity check the coupling functor
   // with the supplied mesh to make sure all the assumptions
-  // are kosher.
+  // are kosher. This test requires AMR and some kind of a
+  // linear solver, so let's only run it if we have PETSc.
   void run_coupling_functor_test(unsigned int n_refinements)
   {
-#ifdef LIBMESH_ENABLE_AMR
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_PETSC)
     if( n_refinements > 0 )
       {
         MeshRefinement refine(*_mesh);
         refine.uniformly_refine(n_refinements);
         _es->reinit();
       }
-#endif // LIBMESH_ENABLE_AMR
+#endif
 
     System & system = _es->get_system("SimpleSystem");
 

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -359,7 +359,7 @@ public:
 
   CPPUNIT_TEST_SUITE( OverlappingFunctorTest );
 
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( checkCouplingFunctorQuad );
   CPPUNIT_TEST( checkCouplingFunctorQuadUnifRef );
   CPPUNIT_TEST( checkCouplingFunctorTri );
@@ -420,7 +420,7 @@ private:
   // linear solver, so let's only run it if we have PETSc.
   void run_coupling_functor_test(unsigned int n_refinements)
   {
-#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_PETSC)
+#if defined(LIBMESH_ENABLE_AMR) && defined(LIBMESH_HAVE_SOLVER)
     if( n_refinements > 0 )
       {
         MeshRefinement refine(*_mesh);

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -26,7 +26,7 @@ public:
 
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testMesh );
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testDofOrdering );
 #endif
   CPPUNIT_TEST( testPointLocatorTree );
@@ -210,7 +210,7 @@ public:
 
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testMesh );
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testDofOrdering );
 #endif
 #endif
@@ -353,7 +353,7 @@ public:
 
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testMesh );
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testDofOrdering );
 #endif
 #endif
@@ -613,7 +613,7 @@ public:
 
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testMesh );
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testDofOrdering );
 #endif
 #endif
@@ -876,7 +876,7 @@ public:
 
 #if LIBMESH_DIM > 2
   CPPUNIT_TEST( testMesh );
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testDofOrdering );
 #endif
 #endif

--- a/tests/mesh/mixed_dim_mesh_test.C
+++ b/tests/mesh/mixed_dim_mesh_test.C
@@ -26,7 +26,9 @@ public:
 
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testMesh );
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testDofOrdering );
+#endif
   CPPUNIT_TEST( testPointLocatorTree );
 #endif
 
@@ -208,7 +210,9 @@ public:
 
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testMesh );
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testDofOrdering );
+#endif
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -349,7 +353,9 @@ public:
 
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testMesh );
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testDofOrdering );
+#endif
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -607,7 +613,9 @@ public:
 
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testMesh );
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testDofOrdering );
+#endif
 #endif
 
   CPPUNIT_TEST_SUITE_END();
@@ -868,7 +876,9 @@ public:
 
 #if LIBMESH_DIM > 2
   CPPUNIT_TEST( testMesh );
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testDofOrdering );
+#endif
 #endif
 
   CPPUNIT_TEST_SUITE_END();

--- a/tests/solvers/first_order_unsteady_solver_test.C
+++ b/tests/solvers/first_order_unsteady_solver_test.C
@@ -75,8 +75,10 @@ class EulerSolverTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( EulerSolverTest );
 
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testEulerSolverConstantFirstOrderODE );
   CPPUNIT_TEST( testEulerSolverLinearTimeFirstOrderODE );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -106,8 +108,10 @@ class Euler2SolverTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( Euler2SolverTest );
 
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testEuler2SolverConstantFirstOrderODE );
   CPPUNIT_TEST( testEuler2SolverLinearTimeFirstOrderODE );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 

--- a/tests/solvers/first_order_unsteady_solver_test.C
+++ b/tests/solvers/first_order_unsteady_solver_test.C
@@ -75,7 +75,7 @@ class EulerSolverTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( EulerSolverTest );
 
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testEulerSolverConstantFirstOrderODE );
   CPPUNIT_TEST( testEulerSolverLinearTimeFirstOrderODE );
 #endif
@@ -108,7 +108,7 @@ class Euler2SolverTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( Euler2SolverTest );
 
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testEuler2SolverConstantFirstOrderODE );
   CPPUNIT_TEST( testEuler2SolverLinearTimeFirstOrderODE );
 #endif

--- a/tests/solvers/second_order_unsteady_solver_test.C
+++ b/tests/solvers/second_order_unsteady_solver_test.C
@@ -85,7 +85,7 @@ class NewmarkSolverTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( NewmarkSolverTest );
 
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testNewmarkSolverConstantSecondOrderODESecondOrderStyle );
   CPPUNIT_TEST( testNewmarkSolverLinearTimeSecondOrderODESecondOrderStyle );
   CPPUNIT_TEST( testNewmarkSolverConstantSecondOrderODEFirstOrderStyle );
@@ -152,7 +152,7 @@ class EulerSolverSecondOrderTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( EulerSolverSecondOrderTest );
 
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testEulerSolverConstantSecondOrderODE );
 #endif
 
@@ -174,7 +174,7 @@ class Euler2SolverSecondOrderTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( Euler2SolverSecondOrderTest );
 
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testEuler2SolverConstantSecondOrderODE );
 #endif
 

--- a/tests/solvers/second_order_unsteady_solver_test.C
+++ b/tests/solvers/second_order_unsteady_solver_test.C
@@ -85,10 +85,12 @@ class NewmarkSolverTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( NewmarkSolverTest );
 
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testNewmarkSolverConstantSecondOrderODESecondOrderStyle );
   CPPUNIT_TEST( testNewmarkSolverLinearTimeSecondOrderODESecondOrderStyle );
   CPPUNIT_TEST( testNewmarkSolverConstantSecondOrderODEFirstOrderStyle );
   CPPUNIT_TEST( testNewmarkSolverLinearTimeSecondOrderODEFirstOrderStyle );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -150,7 +152,9 @@ class EulerSolverSecondOrderTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( EulerSolverSecondOrderTest );
 
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testEulerSolverConstantSecondOrderODE );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 
@@ -170,7 +174,9 @@ class Euler2SolverSecondOrderTest : public CppUnit::TestCase,
 public:
   CPPUNIT_TEST_SUITE( Euler2SolverSecondOrderTest );
 
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testEuler2SolverConstantSecondOrderODE );
+#endif
 
   CPPUNIT_TEST_SUITE_END();
 

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -421,7 +421,7 @@ public:
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testProjectHierarchicQuad9 );
   CPPUNIT_TEST( testProjectHierarchicTri6 );
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testBlockRestrictedVarNDofs );
 #endif
 #endif // LIBMESH_DIM > 1
@@ -429,13 +429,14 @@ public:
   CPPUNIT_TEST( testProjectHierarchicHex27 );
   CPPUNIT_TEST( testProjectMeshFunctionHex27 );
   CPPUNIT_TEST( testBoundaryProjectCube );
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testAssemblyWithDgFemContext );
 #endif
 #endif // LIBMESH_DIM > 2
-#ifdef LIBMESH_HAVE_PETSC
+#ifdef LIBMESH_HAVE_SOLVER
   CPPUNIT_TEST( testDofCouplingWithVarGroups );
 #endif
+
 #ifdef LIBMESH_ENABLE_AMR
 #ifdef LIBMESH_HAVE_METAPHYSICL
 #ifdef LIBMESH_HAVE_PETSC

--- a/tests/systems/systems_test.C
+++ b/tests/systems/systems_test.C
@@ -421,16 +421,21 @@ public:
 #if LIBMESH_DIM > 1
   CPPUNIT_TEST( testProjectHierarchicQuad9 );
   CPPUNIT_TEST( testProjectHierarchicTri6 );
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testBlockRestrictedVarNDofs );
+#endif
 #endif // LIBMESH_DIM > 1
 #if LIBMESH_DIM > 2
   CPPUNIT_TEST( testProjectHierarchicHex27 );
   CPPUNIT_TEST( testProjectMeshFunctionHex27 );
   CPPUNIT_TEST( testBoundaryProjectCube );
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testAssemblyWithDgFemContext );
+#endif
 #endif // LIBMESH_DIM > 2
+#ifdef LIBMESH_HAVE_PETSC
   CPPUNIT_TEST( testDofCouplingWithVarGroups );
-
+#endif
 #ifdef LIBMESH_ENABLE_AMR
 #ifdef LIBMESH_HAVE_METAPHYSICL
 #ifdef LIBMESH_HAVE_PETSC


### PR DESCRIPTION
The libmesh_make_unique macro is still required even with fparser disabled.