### PR TITLE
Add missing array header include

### DIFF
--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -26,6 +26,8 @@
 #include "libmesh/enum_elem_quality.h"
 #include "libmesh/tensor_value.h"
 
+#include <array>
+
 namespace libMesh
 {
 


### PR DESCRIPTION
I don't know why this has never been an issue before, but I'm getting compile errors now on my workstation and it's failing on CIVET mac tests as well: https://civet.inl.gov/job/387911/.

This header should definitely be here though.