### PR TITLE
Include libmesh_logging.h to define LOG_SCOPE

### DIFF
--- a/src/solvers/petsc_nonlinear_solver.C
+++ b/src/solvers/petsc_nonlinear_solver.C
@@ -24,6 +24,7 @@
 // C++ includes
 
 // Local Includes
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/nonlinear_implicit_system.h"
 #include "libmesh/petsc_nonlinear_solver.h"
 #include "libmesh/petsc_linear_solver.h"

--- a/src/solvers/tao_optimization_solver.C
+++ b/src/solvers/tao_optimization_solver.C
@@ -25,6 +25,7 @@
 // C++ includes
 
 // Local Includes
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/dof_map.h"


### PR DESCRIPTION
Otherwise we aren't guaranteed to get it included indirectly, not with
threads disabled at least, not since the #2219 header refactoring.

This fixes the compile failure I managed to replicate; Hopefully this fixes #2228 for @boyceg too.