### PR TITLE
Allow TRI3SUBDIVISION elements in more quadrature rules.

### DIFF
--- a/src/quadrature/quadrature_conical_2D.C
+++ b/src/quadrature/quadrature_conical_2D.C
@@ -30,6 +30,8 @@ void QConical::init_2D(const ElemType, unsigned int)
   switch (_type)
     {
     case TRI3:
+    case TRISHELL3:
+    case TRI3SUBDIVISION:
     case TRI6:
       {
         this->conical_product_tri();

--- a/src/quadrature/quadrature_gm_2D.C
+++ b/src/quadrature/quadrature_gm_2D.C
@@ -37,6 +37,8 @@ void QGrundmann_Moller::init_2D(const ElemType, unsigned int)
   switch (_type)
     {
     case TRI3:
+    case TRISHELL3:
+    case TRI3SUBDIVISION:
     case TRI6:
       {
         switch(get_order())

--- a/src/quadrature/quadrature_grid_2D.C
+++ b/src/quadrature/quadrature_grid_2D.C
@@ -53,6 +53,7 @@ void QGrid::init_2D(const ElemType, unsigned int)
       // Triangle quadrature rules
     case TRI3:
     case TRISHELL3:
+    case TRI3SUBDIVISION:
     case TRI6:
       {
         const unsigned int np = (_order + 1)*(_order + 2)/2;

--- a/src/quadrature/quadrature_simpson_2D.C
+++ b/src/quadrature/quadrature_simpson_2D.C
@@ -55,6 +55,7 @@ void QSimpson::init_2D(const ElemType, unsigned int)
       // Triangle quadrature rules
     case TRI3:
     case TRISHELL3:
+    case TRI3SUBDIVISION:
     case TRI6:
       {
         // I'm not sure if you would call this Simpson's

--- a/src/quadrature/quadrature_trap_2D.C
+++ b/src/quadrature/quadrature_trap_2D.C
@@ -58,6 +58,7 @@ void QTrap::init_2D(const ElemType, unsigned int)
       // Triangle quadrature rules
     case TRI3:
     case TRISHELL3:
+    case TRI3SUBDIVISION:
     case TRI6:
       {
         _points.resize(3);


### PR DESCRIPTION
This was just an oversight, I think you can do any kind of quadrature
on these elements that you could do on TRI3 elements. Also add missing
TRISHELL3 cases while we are at it.

There was a mailing list [thread](https://sourceforge.net/p/libmesh/mailman/message/36750631/) on this.
