### PR TITLE
ExodusII: Read and write sideset data

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -695,8 +695,8 @@ public:
    * (elem-id, side-id, bc-id) triplets and returns it to the user,
    * taking advantage of guaranteed RVO.
    */
-  std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>>
-  build_side_list() const;
+  typedef std::tuple<dof_id_type, unsigned short int, boundary_id_type> BCTuple;
+  std::vector<BCTuple> build_side_list() const;
 
   /**
    * Creates a list of active element numbers, sides, and ids for those sides.

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -266,6 +266,31 @@ public:
                        const std::set<std::string> * system_names=nullptr);
 
   /**
+   * FIXME: This tuple should be defined in the BoundaryInfo class/header file
+   * since it is convenient to have wherever BoundaryInfo functions are called...
+   */
+  typedef std::tuple<dof_id_type, unsigned short int, boundary_id_type> BCTuple;
+
+  /**
+   * The Exodus format can also store values on sidesets. This can be
+   * thought of as an alternative to defining an elemental variable
+   * field on lower-dimensional elements making up a part of the
+   * boundary. The inputs to the function are:
+   * .) var_names[i] is the name of the ith sideset variable to be written to file.
+   * .) side_ids[i] is a set of side_ids where var_names[i] is active.
+   * .) bc_vals[i] is a map from (elem,side,id) BCTuple objects to the
+   *    corresponding real-valued data.
+   *
+   * \note You must have already written the mesh by calling
+   * e.g. write() before calling this function, because it uses the
+   * existing ordering of the Exodus sidesets.
+   */
+  void write_sideset_data (int timestep,
+                           const std::vector<std::string> & var_names,
+                           const std::vector<std::set<boundary_id_type>> & side_ids,
+                           const std::vector<std::map<BCTuple, Real>> & bc_vals);
+
+  /**
    * Sets the list of variable names to be included in the output.
    * This is _optional_.  If this is never called then all variables
    * will be present. If this is called and an empty vector is supplied

--- a/include/mesh/exodusII_io.h
+++ b/include/mesh/exodusII_io.h
@@ -26,8 +26,7 @@
 #include "libmesh/mesh_input.h"
 #include "libmesh/mesh_output.h"
 #include "libmesh/parallel_object.h"
-
-// C++ includes
+#include "libmesh/boundary_info.h" // BoundaryInfo::BCTuple
 
 namespace libMesh
 {
@@ -266,12 +265,6 @@ public:
                        const std::set<std::string> * system_names=nullptr);
 
   /**
-   * FIXME: This tuple should be defined in the BoundaryInfo class/header file
-   * since it is convenient to have wherever BoundaryInfo functions are called...
-   */
-  typedef std::tuple<dof_id_type, unsigned short int, boundary_id_type> BCTuple;
-
-  /**
    * The Exodus format can also store values on sidesets. This can be
    * thought of as an alternative to defining an elemental variable
    * field on lower-dimensional elements making up a part of the
@@ -285,10 +278,23 @@ public:
    * e.g. write() before calling this function, because it uses the
    * existing ordering of the Exodus sidesets.
    */
-  void write_sideset_data (int timestep,
-                           const std::vector<std::string> & var_names,
-                           const std::vector<std::set<boundary_id_type>> & side_ids,
-                           const std::vector<std::map<BCTuple, Real>> & bc_vals);
+  void
+  write_sideset_data (int timestep,
+                      const std::vector<std::string> & var_names,
+                      const std::vector<std::set<boundary_id_type>> & side_ids,
+                      const std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals);
+
+  /**
+   * Similar to write_sideset_data(), this function is used to read
+   * the data at a particular timestep. TODO: currently _all_ the
+   * sideset variables are read, but we might want to change this to
+   * only read the requested ones.
+   */
+  void
+  read_sideset_data (int timestep,
+                     std::vector<std::string> & var_names,
+                     std::vector<std::set<boundary_id_type>> & side_ids,
+                     std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals);
 
   /**
    * Sets the list of variable names to be included in the output.

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -324,6 +324,17 @@ public:
   void write_timestep(int timestep, Real time);
 
   /**
+   * Writes sideset data time for the timestep
+   */
+  typedef std::tuple<dof_id_type, unsigned short int, boundary_id_type> BCTuple;
+  void write_sideset_data
+  /**/(const MeshBase & mesh,
+       int timestep,
+       const std::vector<std::string> & var_names,
+       const std::vector<std::set<boundary_id_type>> & side_ids,
+       const std::vector<std::map<BCTuple, Real>> & bc_vals);
+
+  /**
    * Writes the vector of values to the element variables.
    *
    * The 'values' vector is assumed to be in the order:
@@ -471,6 +482,9 @@ public:
 
   // Number of global variables
   int num_global_vars;
+
+  // Number of sideset variables
+  int num_sideset_vars;
 
   // Total number of nodes in the mesh
   int num_nodes;
@@ -643,7 +657,7 @@ public:
    * ELEMENTAL: num_elem_vars   elem_var_names
    * GLOBAL:    num_global_vars global_var_names
    */
-  enum ExodusVarType {NODAL=0, ELEMENTAL=1, GLOBAL=2};
+  enum ExodusVarType {NODAL=0, ELEMENTAL=1, GLOBAL=2, SIDESET=3};
   void read_var_names(ExodusVarType type);
 
 protected:
@@ -658,7 +672,7 @@ protected:
    * The enumeration controls whether nodal, elemental, or global
    * variable names are read and which class members are filled in.
    */
-  void write_var_names(ExodusVarType type, std::vector<std::string> & names);
+  void write_var_names(ExodusVarType type, const std::vector<std::string> & names);
 
   // If true, whenever there is an I/O operation, only perform if if we are on processor 0.
   bool _run_only_on_proc0;
@@ -720,7 +734,7 @@ private:
    */
   void write_var_names_impl(const char * var_type,
                             int & count,
-                            std::vector<std::string> & names);
+                            const std::vector<std::string> & names);
 };
 
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -25,6 +25,7 @@
 // Local includes
 #include "libmesh/parallel_object.h"
 #include "libmesh/point.h"
+#include "libmesh/boundary_info.h" // BoundaryInfo::BCTuple
 
 #ifdef LIBMESH_FORWARD_DECLARE_ENUMS
 namespace libMesh
@@ -324,15 +325,24 @@ public:
   void write_timestep(int timestep, Real time);
 
   /**
-   * Writes sideset data time for the timestep
+   * Write sideset data for the requested timestep.
    */
-  typedef std::tuple<dof_id_type, unsigned short int, boundary_id_type> BCTuple;
-  void write_sideset_data
-  /**/(const MeshBase & mesh,
-       int timestep,
-       const std::vector<std::string> & var_names,
-       const std::vector<std::set<boundary_id_type>> & side_ids,
-       const std::vector<std::map<BCTuple, Real>> & bc_vals);
+  void
+  write_sideset_data (const MeshBase & mesh,
+                      int timestep,
+                      const std::vector<std::string> & var_names,
+                      const std::vector<std::set<boundary_id_type>> & side_ids,
+                      const std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals);
+
+  /**
+   * Read sideset variables, if any, into the provided data structures.
+   */
+  void
+  read_sideset_data (const MeshBase & mesh,
+                     int timestep,
+                     std::vector<std::string> & var_names,
+                     std::vector<std::set<boundary_id_type>> & side_ids,
+                     std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals);
 
   /**
    * Writes the vector of values to the element variables.
@@ -623,6 +633,9 @@ public:
   // The names of the global variables stored in the Exodus file
   std::vector<std::string> global_var_names;
 
+  // The names of the sideset variables stored in the Exodus file
+  std::vector<std::string> sideset_var_names;
+
   // Maps of Ids to named entities
   std::map<int, std::string> id_to_block_names;
   std::map<int, std::string> id_to_ss_names;
@@ -653,9 +666,10 @@ public:
    * Wraps calls to exII::ex_get_var_names() and exII::ex_get_var_param().
    * The enumeration controls whether nodal, elemental, or global
    * variable names are read and which class members are filled in.
-   * NODAL:     num_nodal_vars  nodal_var_names
-   * ELEMENTAL: num_elem_vars   elem_var_names
-   * GLOBAL:    num_global_vars global_var_names
+   * NODAL:     num_nodal_vars   nodal_var_names
+   * ELEMENTAL: num_elem_vars    elem_var_names
+   * GLOBAL:    num_global_vars  global_var_names
+   * SIDESET:   num_sideset_vars sideset_var_names
    */
   enum ExodusVarType {NODAL=0, ELEMENTAL=1, GLOBAL=2, SIDESET=3};
   void read_var_names(ExodusVarType type);

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -374,8 +374,8 @@ void ExodusII_IO::read (const std::string & fname)
                                                cast_int<unsigned short>(mapped_side),
                                                cast_int<boundary_id_type>(exio_helper->id_list[e]));
           }
-      }
-  }
+      } // end for (elem_list)
+  } // end read sideset info
 
   // Read nodeset info
   {
@@ -1274,15 +1274,31 @@ void ExodusII_IO::write_timestep (const std::string & fname,
 
 
 void
-ExodusII_IO::write_sideset_data
-/**/(int timestep,
-     const std::vector<std::string> & var_names,
-     const std::vector<std::set<boundary_id_type>> & side_ids,
-     const std::vector<std::map<BCTuple, Real>> & bc_vals)
+ExodusII_IO::
+write_sideset_data(int timestep,
+                   const std::vector<std::string> & var_names,
+                   const std::vector<std::set<boundary_id_type>> & side_ids,
+                   const std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
 {
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
   exio_helper->write_sideset_data(mesh, timestep, var_names, side_ids, bc_vals);
 }
+
+
+
+void
+ExodusII_IO::
+read_sideset_data(int timestep,
+                  std::vector<std::string> & var_names,
+                  std::vector<std::set<boundary_id_type>> & side_ids,
+                  std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
+{
+  const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
+  exio_helper->read_sideset_data(mesh, timestep, var_names, side_ids, bc_vals);
+}
+
+
+
 
 void ExodusII_IO::write (const std::string & fname)
 {

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1280,6 +1280,10 @@ write_sideset_data(int timestep,
                    const std::vector<std::set<boundary_id_type>> & side_ids,
                    const std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
 {
+  if (!exio_helper->opened_for_writing)
+    libmesh_error_msg("ERROR, ExodusII file must be opened for writing "
+                      "before calling ExodusII_IO::write_sideset_data()!");
+
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
   exio_helper->write_sideset_data(mesh, timestep, var_names, side_ids, bc_vals);
 }
@@ -1293,6 +1297,10 @@ read_sideset_data(int timestep,
                   std::vector<std::set<boundary_id_type>> & side_ids,
                   std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
 {
+  if (!exio_helper->opened_for_reading)
+    libmesh_error_msg("ERROR, ExodusII file must be opened for reading "
+                      "before calling ExodusII_IO::read_sideset_data()!");
+
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
   exio_helper->read_sideset_data(mesh, timestep, var_names, side_ids, bc_vals);
 }

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1625,6 +1625,30 @@ void ExodusII_IO::write_timestep (const std::string &,
 
 
 
+void
+ExodusII_IO::
+write_sideset_data (int,
+                    const std::vector<std::string> &,
+                    const std::vector<std::set<boundary_id_type>> &,
+                    const std::vector<std::map<BoundaryInfo::BCTuple, Real>> &)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+
+
+void
+ExodusII_IO::
+read_sideset_data (int,
+                   std::vector<std::string> &,
+                   std::vector<std::set<boundary_id_type>> &,
+                   std::vector<std::map<BoundaryInfo::BCTuple, Real>> &)
+{
+  libmesh_error_msg("ERROR, ExodusII API is not defined.");
+}
+
+
+
 void ExodusII_IO::write (const std::string &)
 {
   libmesh_error_msg("ERROR, ExodusII API is not defined.");

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1273,6 +1273,17 @@ void ExodusII_IO::write_timestep (const std::string & fname,
 
 
 
+void
+ExodusII_IO::write_sideset_data
+/**/(int timestep,
+     const std::vector<std::string> & var_names,
+     const std::vector<std::set<boundary_id_type>> & side_ids,
+     const std::vector<std::map<BCTuple, Real>> & bc_vals)
+{
+  const MeshBase & mesh = MeshOutput<MeshBase>::mesh();
+  exio_helper->write_sideset_data(mesh, timestep, var_names, side_ids, bc_vals);
+}
+
 void ExodusII_IO::write (const std::string & fname)
 {
   const MeshBase & mesh = MeshOutput<MeshBase>::mesh();

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2174,6 +2174,9 @@ write_sideset_data(const MeshBase & mesh,
                    const std::vector<std::set<boundary_id_type>> & side_ids,
                    const std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
 {
+  if ((_run_only_on_proc0) && (this->processor_id() != 0))
+    return;
+
   // Write the sideset variable names to file. This function should
   // only be called once for SIDESET variables, repeated calls to
   // write_var_names overwrites/changes the order of names that were

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -277,6 +277,7 @@ ExodusII_IO_Helper::ExodusII_IO_Helper(const ParallelObject & parent,
   ex_err(0),
   num_dim(0),
   num_global_vars(0),
+  num_sideset_vars(0),
   num_nodes(0),
   num_elem(0),
   num_elem_blk(0),
@@ -523,6 +524,9 @@ void ExodusII_IO_Helper::read_header()
 
   ex_err = exII::ex_get_var_param(ex_id, "g", &num_global_vars);
   EX_CHECK_ERR(ex_err, "Error reading number of global variables.");
+
+  ex_err = exII::ex_get_var_param(ex_id, "s", &num_sideset_vars);
+  EX_CHECK_ERR(ex_err, "Error reading number of sideset variables.");
 
   message("Exodus header info retrieved successfully.");
 }
@@ -1166,7 +1170,9 @@ void ExodusII_IO_Helper::read_var_names_impl(const char * var_type,
 
 
 
-void ExodusII_IO_Helper::write_var_names(ExodusVarType type, std::vector<std::string> & names)
+void
+ExodusII_IO_Helper::write_var_names(ExodusVarType type,
+                                    const std::vector<std::string> & names)
 {
   switch (type)
     {
@@ -1179,6 +1185,14 @@ void ExodusII_IO_Helper::write_var_names(ExodusVarType type, std::vector<std::st
     case GLOBAL:
       this->write_var_names_impl("g", num_global_vars, names);
       break;
+    case SIDESET:
+      {
+        // Note: calling this function *sets* num_sideset_vars to the
+        // number of entries in the 'names' vector, num_sideset_vars
+        // does not already need to be set before calling this.
+        this->write_var_names_impl("s", num_sideset_vars, names);
+        break;
+      }
     default:
       libmesh_error_msg("Unrecognized ExodusVarType " << type);
     }
@@ -1186,7 +1200,10 @@ void ExodusII_IO_Helper::write_var_names(ExodusVarType type, std::vector<std::st
 
 
 
-void ExodusII_IO_Helper::write_var_names_impl(const char * var_type, int & count, std::vector<std::string> & names)
+void
+ExodusII_IO_Helper::write_var_names_impl(const char * var_type,
+                                         int & count,
+                                         const std::vector<std::string> & names)
 {
   // Update the count variable so that it's available to other parts of the class.
   count = cast_int<int>(names.size());
@@ -2141,6 +2158,165 @@ void ExodusII_IO_Helper::write_timestep(int timestep, Real time)
 
   ex_err = exII::ex_update(ex_id);
   EX_CHECK_ERR(ex_err, "Error flushing buffers to file.");
+}
+
+
+
+void
+ExodusII_IO_Helper::write_sideset_data
+/**/(const MeshBase & mesh,
+     int timestep,
+     const std::vector<std::string> & var_names,
+     const std::vector<std::set<boundary_id_type>> & side_ids,
+     const std::vector<std::map<BCTuple, Real>> & bc_vals)
+{
+  // Write the sideset variable names to file. This function should
+  // only be called once for SIDESET variables, repeated calls to
+  // write_var_names overwrites/changes the order of names that were
+  // there previously, and will mess up any data that has already been
+  // written.
+  this->write_var_names(SIDESET, var_names);
+
+  // I hope that we are allowed to call read_sideset_info() even
+  // though we are in the middle of writing? It seems to work provided
+  // that you have already written the mesh itself... read_sideset_info()
+  // fills in the following data members:
+  // .) num_side_sets
+  // .) ss_ids
+  this->read_sideset_info();
+
+  // Debugging:
+  // libMesh::out << "File has " << num_side_sets << " side sets." << std::endl;
+
+  // We'll use this object to map Exodus side ids to libmesh side ids.
+  ExodusII_IO_Helper::ElementMaps em;
+
+  // Write "truth" table for sideset variables.  The function
+  // exII::ex_put_var_param() must be called before
+  // exII::ex_put_sset_var_tab() For us, this happens during the call
+  // to ExodusII_IO_Helper::write_var_names(). sset_var_tab is a logically
+  // (num_side_sets x num_sset_var) integer array of 0s and 1s
+  // indicating which sidesets a given sideset variable is defined on.
+  std::vector<int> sset_var_tab(num_side_sets * var_names.size());
+
+  // We now call read_sideset() once per sideset and write any sideset
+  // variable values which are defined there.
+  int offset=0;
+  for (int ss=0; ss<num_side_sets; ++ss)
+    {
+      // We don't know num_sides_per_set for each set until we call
+      // read_sideset(). The values for each sideset are stored (using
+      // the offsets) into the 'elem_list' and 'side_list' arrays of
+      // this class.
+      offset += (ss > 0 ? num_sides_per_set[ss-1] : 0);
+      this->read_sideset(ss, offset);
+
+      // Debugging:
+      // libMesh::out << "Sideset " << ss_ids[ss]
+      //              << " has " << num_sides_per_set[ss]
+      //              << " entries."
+      //              << std::endl;
+
+      // For each variable in var_names, write the values for the
+      // current sideset, if any.
+      for (unsigned int var=0; var<var_names.size(); ++var)
+        {
+          // If this var has no values on this sideset, go to the next one.
+          if (!side_ids[var].count(ss_ids[ss]))
+            continue;
+
+          // Otherwise, fill in this entry of the sideset truth table.
+          sset_var_tab[ss*var_names.size() + var] = 1;
+
+          // Data vector that will eventually be passed to exII::ex_put_sset_var().
+          std::vector<Real> sset_var_vals(num_sides_per_set[ss]);
+
+          // Get reference to the BCTuple -> Real map for this variable.
+          const auto & data_map = bc_vals[var];
+
+          // Loop over elem_list, side_list entries in current sideset.
+          for (int i=0; i<num_sides_per_set[ss]; ++i)
+            {
+              // Get elem_id and side_id from the respective lists that
+              // are filled in by calling read_sideset().
+              //
+              // Note: these are Exodus-specific ids, so we have to convert them
+              // to libmesh ids, as that is what will be in the bc_tuples.
+              //
+              // TODO: we should probably consult the exodus_elem_num_to_libmesh
+              // mapping in order to figure out which libmesh element id 'elem_id'
+              // actually corresponds to here, instead of just assuming it will be
+              // off by one. Unfortunately that data structure does not seemed to
+              // be used at the moment. If we assume that write_sideset_data() is
+              // always called following write(), then this should be a fairly safe
+              // assumption...
+              dof_id_type elem_id = elem_list[i + offset] - 1;
+              unsigned int side_id = side_list[i + offset] - 1;
+
+              // Sanity check: make sure that the "off by one"
+              // assumption we used above to set 'elem_id' is valid.
+              auto check_it = libmesh_elem_num_to_exodus.find(elem_id);
+              if (check_it == libmesh_elem_num_to_exodus.end() ||
+                  check_it->second != elem_list[i + offset])
+                libmesh_error_msg("Error mapping Exodus elem id to libmesh elem id.");
+
+              // Map from Exodus side ids to libmesh side ids.
+              ExodusII_IO_Helper::Conversion conv =
+                em.assign_conversion(mesh.elem_ptr(elem_id)->type());
+
+              // Map from Exodus side ids to libmesh side ids.
+              unsigned int converted_side_id = conv.get_side_map(side_id);
+
+              // Debugging:
+              // libMesh::out << "side_id=" << side_id
+              //              << ", converted_side_id=" << converted_side_id
+              //              << std::endl;
+
+              // Construct a key so we can quickly see whether there is any
+              // data for this variable in the map.
+              BCTuple key = std::make_tuple
+                (elem_id,
+                 converted_side_id,
+                 ss_ids[ss]);
+
+              // Find the data for this (elem,side,id) tuple. Throw an
+              // error if not found.
+              auto it = data_map.find(key);
+
+              if (it == data_map.end())
+                libmesh_error_msg("Error: could not find data for variable "
+                                  << var_names[var] << ", elem " << elem_id
+                                  << ", side " << converted_side_id
+                                  << ", b_id " << ss_ids[ss]);
+
+              // Store value in vector which will be passed to Exodus.
+              sset_var_vals[i] = it->second;
+            } // end for (i)
+
+          // As far as I can tell, there is no "concat" version of writing
+          // sideset data, you have to call ex_put_sset_var() once per (variable,
+          // sideset) pair.
+          if (sset_var_vals.size() > 0)
+            {
+              ex_err = exII::ex_put_sset_var
+                (ex_id,
+                 timestep,
+                 var + 1, // 1-based variable index of current variable
+                 ss_ids[ss],
+                 num_sides_per_set[ss],
+                 sset_var_vals.data());
+              EX_CHECK_ERR(ex_err, "Error writing sideset vars.");
+            }
+        } // end for (var)
+    } // end for (ss)
+
+  // Finally, write the sideset truth table.
+  ex_err =
+    exII::ex_put_sset_var_tab(ex_id,
+                              num_side_sets,
+                              cast_int<int>(var_names.size()),
+                              sset_var_tab.data());
+  EX_CHECK_ERR(ex_err, "Error writing sideset var truth table.");
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -63,6 +63,7 @@ unit_tests_sources = \
   mesh/spatial_dimension_test.C \
   mesh/mapped_subdomain_partitioner_test.C \
   mesh/mesh_function_dfem.C \
+  mesh/write_sideset_data.C \
   mesh/write_vec_and_scalar.C \
   numerics/composite_function_test.C \
   numerics/coupling_matrix_test.C \
@@ -217,7 +218,8 @@ CLEANFILES = cube_mesh.xda \
              slit_mesh.xda slit_solution.xda \
 	     out.e \
 	     mesh_with_soln.e \
-	     elemental_from_nodal.e
+	     elemental_from_nodal.e \
+             write_sideset_data.e
 
 # CLEANFILES only applies to files, handle directories separately
 clean-local:

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -202,8 +202,8 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -273,6 +273,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_function_dfem.$(OBJEXT) \
+	mesh/unit_tests_dbg-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_dbg-write_vec_and_scalar.$(OBJEXT) \
 	numerics/unit_tests_dbg-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-coupling_matrix_test.$(OBJEXT) \
@@ -337,8 +338,8 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -407,6 +408,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_function_dfem.$(OBJEXT) \
+	mesh/unit_tests_devel-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_devel-write_vec_and_scalar.$(OBJEXT) \
 	numerics/unit_tests_devel-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_devel-coupling_matrix_test.$(OBJEXT) \
@@ -468,8 +470,8 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -538,6 +540,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_function_dfem.$(OBJEXT) \
+	mesh/unit_tests_oprof-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_oprof-write_vec_and_scalar.$(OBJEXT) \
 	numerics/unit_tests_oprof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-coupling_matrix_test.$(OBJEXT) \
@@ -599,8 +602,8 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -669,6 +672,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_function_dfem.$(OBJEXT) \
+	mesh/unit_tests_opt-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_opt-write_vec_and_scalar.$(OBJEXT) \
 	numerics/unit_tests_opt-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_opt-coupling_matrix_test.$(OBJEXT) \
@@ -729,8 +733,8 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -799,6 +803,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mapped_subdomain_partitioner_test.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_function_dfem.$(OBJEXT) \
+	mesh/unit_tests_prof-write_sideset_data.$(OBJEXT) \
 	mesh/unit_tests_prof-write_vec_and_scalar.$(OBJEXT) \
 	numerics/unit_tests_prof-composite_function_test.$(OBJEXT) \
 	numerics/unit_tests_prof-coupling_matrix_test.$(OBJEXT) \
@@ -997,6 +1002,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po \
+	mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po \
@@ -1015,6 +1021,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po \
+	mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po \
@@ -1033,6 +1040,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po \
+	mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po \
@@ -1051,6 +1059,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po \
+	mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-all_tri.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po \
@@ -1069,6 +1078,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po \
+	mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po \
@@ -1663,8 +1673,8 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
 	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
-	mesh/mesh_function_dfem.C mesh/write_vec_and_scalar.C \
-	numerics/composite_function_test.C \
+	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
+	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
 	numerics/coupling_matrix_test.C \
 	numerics/distributed_vector_test.C \
 	numerics/eigen_sparse_vector_test.C \
@@ -1713,7 +1723,8 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 @LIBMESH_ENABLE_CPPUNIT_TRUE@@LIBMESH_OPT_MODE_TRUE@unit_tests_opt_LDADD = $(top_builddir)/libmesh_opt.la
 @LIBMESH_ENABLE_CPPUNIT_TRUE@TESTS = run_unit_tests.sh
 CLEANFILES = cube_mesh.xda slit_mesh.xda slit_solution.xda out.e \
-	mesh_with_soln.e elemental_from_nodal.e $(am__append_12)
+	mesh_with_soln.e elemental_from_nodal.e write_sideset_data.e \
+	$(am__append_12)
 all: all-am
 
 .SUFFIXES:
@@ -1870,6 +1881,8 @@ mesh/unit_tests_dbg-spatial_dimension_test.$(OBJEXT):  \
 mesh/unit_tests_dbg-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_function_dfem.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-write_vec_and_scalar.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2079,6 +2092,8 @@ mesh/unit_tests_devel-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-write_sideset_data.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-write_vec_and_scalar.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-composite_function_test.$(OBJEXT):  \
@@ -2238,6 +2253,8 @@ mesh/unit_tests_oprof-spatial_dimension_test.$(OBJEXT):  \
 mesh/unit_tests_oprof-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_function_dfem.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-write_vec_and_scalar.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2399,6 +2416,8 @@ mesh/unit_tests_opt-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_function_dfem.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-write_sideset_data.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-write_vec_and_scalar.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-composite_function_test.$(OBJEXT):  \
@@ -2558,6 +2577,8 @@ mesh/unit_tests_prof-spatial_dimension_test.$(OBJEXT):  \
 mesh/unit_tests_prof-mapped_subdomain_partitioner_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_function_dfem.$(OBJEXT):  \
+	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-write_sideset_data.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-write_vec_and_scalar.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2800,6 +2821,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po@am__quote@ # am--include-marker
@@ -2818,6 +2840,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po@am__quote@ # am--include-marker
@@ -2836,6 +2859,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po@am__quote@ # am--include-marker
@@ -2854,6 +2878,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-all_tri.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po@am__quote@ # am--include-marker
@@ -2872,6 +2897,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po@am__quote@ # am--include-marker
@@ -3637,6 +3663,20 @@ mesh/unit_tests_dbg-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_dbg-mesh_function_dfem.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
+
+mesh/unit_tests_dbg-write_sideset_data.o: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Tpo -c -o mesh/unit_tests_dbg-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_dbg-write_sideset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+
+mesh/unit_tests_dbg-write_sideset_data.obj: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-write_sideset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Tpo -c -o mesh/unit_tests_dbg-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_dbg-write_sideset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
 
 mesh/unit_tests_dbg-write_vec_and_scalar.o: mesh/write_vec_and_scalar.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-write_vec_and_scalar.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Tpo -c -o mesh/unit_tests_dbg-write_vec_and_scalar.o `test -f 'mesh/write_vec_and_scalar.C' || echo '$(srcdir)/'`mesh/write_vec_and_scalar.C
@@ -4688,6 +4728,20 @@ mesh/unit_tests_devel-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
 
+mesh/unit_tests_devel-write_sideset_data.o: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Tpo -c -o mesh/unit_tests_devel-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_devel-write_sideset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+
+mesh/unit_tests_devel-write_sideset_data.obj: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-write_sideset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Tpo -c -o mesh/unit_tests_devel-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_devel-write_sideset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+
 mesh/unit_tests_devel-write_vec_and_scalar.o: mesh/write_vec_and_scalar.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-write_vec_and_scalar.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Tpo -c -o mesh/unit_tests_devel-write_vec_and_scalar.o `test -f 'mesh/write_vec_and_scalar.C' || echo '$(srcdir)/'`mesh/write_vec_and_scalar.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Tpo mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po
@@ -5737,6 +5791,20 @@ mesh/unit_tests_oprof-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function_dfem.C' object='mesh/unit_tests_oprof-mesh_function_dfem.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
+
+mesh/unit_tests_oprof-write_sideset_data.o: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Tpo -c -o mesh/unit_tests_oprof-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_oprof-write_sideset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+
+mesh/unit_tests_oprof-write_sideset_data.obj: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-write_sideset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Tpo -c -o mesh/unit_tests_oprof-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_oprof-write_sideset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
 
 mesh/unit_tests_oprof-write_vec_and_scalar.o: mesh/write_vec_and_scalar.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-write_vec_and_scalar.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Tpo -c -o mesh/unit_tests_oprof-write_vec_and_scalar.o `test -f 'mesh/write_vec_and_scalar.C' || echo '$(srcdir)/'`mesh/write_vec_and_scalar.C
@@ -6788,6 +6856,20 @@ mesh/unit_tests_opt-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
 
+mesh/unit_tests_opt-write_sideset_data.o: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Tpo -c -o mesh/unit_tests_opt-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_opt-write_sideset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+
+mesh/unit_tests_opt-write_sideset_data.obj: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-write_sideset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Tpo -c -o mesh/unit_tests_opt-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_opt-write_sideset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+
 mesh/unit_tests_opt-write_vec_and_scalar.o: mesh/write_vec_and_scalar.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-write_vec_and_scalar.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Tpo -c -o mesh/unit_tests_opt-write_vec_and_scalar.o `test -f 'mesh/write_vec_and_scalar.C' || echo '$(srcdir)/'`mesh/write_vec_and_scalar.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Tpo mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po
@@ -7838,6 +7920,20 @@ mesh/unit_tests_prof-mesh_function_dfem.obj: mesh/mesh_function_dfem.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_function_dfem.obj `if test -f 'mesh/mesh_function_dfem.C'; then $(CYGPATH_W) 'mesh/mesh_function_dfem.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function_dfem.C'; fi`
 
+mesh/unit_tests_prof-write_sideset_data.o: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-write_sideset_data.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Tpo -c -o mesh/unit_tests_prof-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_prof-write_sideset_data.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-write_sideset_data.o `test -f 'mesh/write_sideset_data.C' || echo '$(srcdir)/'`mesh/write_sideset_data.C
+
+mesh/unit_tests_prof-write_sideset_data.obj: mesh/write_sideset_data.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-write_sideset_data.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Tpo -c -o mesh/unit_tests_prof-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Tpo mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/write_sideset_data.C' object='mesh/unit_tests_prof-write_sideset_data.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-write_sideset_data.obj `if test -f 'mesh/write_sideset_data.C'; then $(CYGPATH_W) 'mesh/write_sideset_data.C'; else $(CYGPATH_W) '$(srcdir)/mesh/write_sideset_data.C'; fi`
+
 mesh/unit_tests_prof-write_vec_and_scalar.o: mesh/write_vec_and_scalar.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-write_vec_and_scalar.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Tpo -c -o mesh/unit_tests_prof-write_vec_and_scalar.o `test -f 'mesh/write_vec_and_scalar.C' || echo '$(srcdir)/'`mesh/write_vec_and_scalar.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Tpo mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po
@@ -8707,6 +8803,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po
@@ -8725,6 +8822,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po
@@ -8743,6 +8841,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po
@@ -8761,6 +8860,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-all_tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po
@@ -8779,6 +8879,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po
@@ -9127,6 +9228,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-all_tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-boundary_info.Po
@@ -9145,6 +9247,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-all_tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-boundary_info.Po
@@ -9163,6 +9266,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-all_tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-boundary_info.Po
@@ -9181,6 +9285,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-write_vec_and_scalar.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-all_tri.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-boundary_info.Po
@@ -9199,6 +9304,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-spatial_dimension_test.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_sideset_data.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-write_vec_and_scalar.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po

--- a/tests/mesh/write_sideset_data.C
+++ b/tests/mesh/write_sideset_data.C
@@ -1,0 +1,113 @@
+// Basic include files
+#include "libmesh/equation_systems.h"
+#include "libmesh/exodusII_io.h"
+#include "libmesh/mesh.h"
+#include "libmesh/mesh_generation.h"
+#include "libmesh/string_to_enum.h"
+#include "libmesh/boundary_info.h"
+
+#include "test_comm.h"
+#include "libmesh_cppunit.h"
+
+
+// Bring in everything from the libMesh namespace
+using namespace libMesh;
+
+class WriteSidesetData : public CppUnit::TestCase
+{
+  /**
+   * This test ensures you can write both vector and scalar variables
+   */
+public:
+  CPPUNIT_TEST_SUITE(WriteSidesetData);
+
+#if LIBMESH_DIM > 1
+  CPPUNIT_TEST(testWrite);
+#endif
+
+  CPPUNIT_TEST_SUITE_END();
+
+  void testWrite()
+  {
+    Mesh mesh(*TestCommWorld);
+
+    // We set our initial conditions based on build_square node ids
+    mesh.allow_renumbering(false);
+
+    MeshTools::Generation::build_square(mesh,
+                                        /*nx=*/5, /*ny=*/5,
+                                        -1., 1.,
+                                        -1., 1.,
+                                        QUAD4);
+
+    // Get list of all (elem, side, id) tuples
+    std::vector<BoundaryInfo::BCTuple> all_bc_tuples =
+      mesh.get_boundary_info().build_side_list();
+
+    // Data structures to be passed to ExodusII_IO::write_sideset_data
+    std::vector<std::string> var_names = {"var1", "var2"};
+    std::vector<std::set<boundary_id_type>> side_ids =
+      {
+        {0, 2}, // var1 is defined on sidesets 0 and 2
+        {1, 3}  // var2 is defined on sidesets 1 and 3
+      };
+
+    // Data structure mapping (elem, side, id) tuples to Real values that
+    // will be passed to Exodus.
+    std::vector<std::map<BoundaryInfo::BCTuple, Real>> bc_vals(var_names.size());
+
+    // For each var_names[i], construct bc_vals[i]
+    for (unsigned int i=0; i<var_names.size(); ++i)
+      {
+        // const auto & var_name = var_names[i];
+        auto & vals = bc_vals[i];
+
+        for (const auto & t : all_bc_tuples)
+          {
+            // dof_id_type elem_id = std::get<0>(t);
+            // unsigned int side_id = std::get<1>(t);
+            boundary_id_type b_id = std::get<2>(t);
+
+            if (side_ids[i].count(b_id))
+              {
+                // Compute a value. This could in theory depend on
+                // var_name, elem_id, side_id, and/or b_id.
+                Real val = static_cast<Real>(b_id);
+
+                // Insert into the vals map.
+                vals.insert(std::make_pair(t, val));
+              }
+          }
+      } // done constructing bc_vals
+
+#ifdef LIBMESH_HAVE_EXODUS_API
+
+    // We write the file in the ExodusII format.
+    ExodusII_IO writer(mesh);
+    writer.write("write_sideset_data.e");
+    writer.write_sideset_data (/*timestep=*/1, var_names, side_ids, bc_vals);
+
+    // Make sure that the writing is done before the reading starts.
+    TestCommWorld->barrier();
+
+    // Now read it back in
+    Mesh read_mesh(*TestCommWorld);
+    ExodusII_IO reader(read_mesh);
+    reader.read("write_sideset_data.e");
+
+    std::vector<std::string> read_in_var_names;
+    std::vector<std::set<boundary_id_type>> read_in_side_ids;
+    std::vector<std::map<BoundaryInfo::BCTuple, Real>> read_in_bc_vals;
+    reader.read_sideset_data
+      (/*timestep=*/1, read_in_var_names, read_in_side_ids, read_in_bc_vals);
+
+    // Assert that we got back out what we put in.
+    CPPUNIT_ASSERT(read_in_var_names == var_names);
+    CPPUNIT_ASSERT(read_in_side_ids == side_ids);
+    CPPUNIT_ASSERT(read_in_bc_vals == bc_vals);
+
+#endif // #ifdef LIBMESH_HAVE_EXODUS_API
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(WriteSidesetData);

--- a/tests/mesh/write_sideset_data.C
+++ b/tests/mesh/write_sideset_data.C
@@ -83,9 +83,11 @@ public:
 #ifdef LIBMESH_HAVE_EXODUS_API
 
     // We write the file in the ExodusII format.
-    ExodusII_IO writer(mesh);
-    writer.write("write_sideset_data.e");
-    writer.write_sideset_data (/*timestep=*/1, var_names, side_ids, bc_vals);
+    {
+      ExodusII_IO writer(mesh);
+      writer.write("write_sideset_data.e");
+      writer.write_sideset_data (/*timestep=*/1, var_names, side_ids, bc_vals);
+    }
 
     // Make sure that the writing is done before the reading starts.
     TestCommWorld->barrier();


### PR DESCRIPTION
Variables (data) on sidesets are conceptually similar to elemental data fields defined on lower-dimensional subdomains of elements.  They can be useful for defining boundary condition data, such as e.g. piecewise-constant normal forces on each face of a sideset.
