### PR TITLE
FEMap refactor

### DIFF
--- a/examples/fem_system/fem_system_ex1/naviersystem.C
+++ b/examples/fem_system/fem_system_ex1/naviersystem.C
@@ -494,7 +494,7 @@ bool NavierSystem::side_constraint (bool request_jacobian,
 
       unsigned int dim = get_mesh().mesh_dimension();
       FEType fe_type = p_elem_fe->get_fe_type();
-      Point p_master = FEInterface::inverse_map(dim, fe_type, &c.get_elem(), zero);
+      Point p_master = FEMap::inverse_map(dim, &c.get_elem(), zero);
 
       std::vector<Real> point_phi(n_p_dofs);
       for (unsigned int i=0; i != n_p_dofs; i++)

--- a/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
+++ b/examples/miscellaneous/miscellaneous_ex5/miscellaneous_ex5.C
@@ -364,11 +364,9 @@ void assemble_ellipticdg(EquationSystems & es,
                                                 qface.get_points(),
                                                 qface_neighbor_point);
                   else
-                    FEInterface::inverse_map (elem->dim(),
-                                              fe->get_fe_type(),
-                                              neighbor,
-                                              qface_point,
-                                              qface_neighbor_point);
+                    FEMap::inverse_map (elem->dim(), neighbor,
+                                        qface_point,
+                                        qface_neighbor_point);
 
                   // Calculate the neighbor element shape functions at those locations
                   fe_neighbor_face->reinit(neighbor, &qface_neighbor_point);

--- a/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
+++ b/examples/miscellaneous/miscellaneous_ex9/miscellaneous_ex9.C
@@ -297,8 +297,9 @@ void assemble_poisson(EquationSystems & es,
                   const Elem * neighbor = ltu_it->second;
 
                   std::vector<Point> qface_neighbor_points;
-                  FEInterface::inverse_map (elem->dim(), fe->get_fe_type(),
-                                            neighbor, qface_points, qface_neighbor_points);
+                  FEMap::inverse_map (elem->dim(), neighbor,
+                                      qface_points,
+                                      qface_neighbor_points);
                   fe_neighbor_face->reinit(neighbor, &qface_neighbor_points);
 
                   std::vector<dof_id_type> neighbor_dof_indices;

--- a/examples/vector_fe/vector_fe_ex5/assembly.C
+++ b/examples/vector_fe/vector_fe_ex5/assembly.C
@@ -247,8 +247,8 @@ compute_residual(const NumericVector<Number> & X,
 
           // Make sure we have the matching quadrature points on face and neighbor
           std::vector<Point> neighbor_xyz;
-          FEInterface::inverse_map(
-              elem->dim(), fe->get_fe_type(), neighbor, face_xyz, neighbor_xyz);
+          FEMap::inverse_map(elem->dim(), neighbor, face_xyz,
+                             neighbor_xyz);
 
           fe_neighbor_face->reinit(neighbor, &neighbor_xyz);
 
@@ -481,8 +481,8 @@ compute_jacobian(const NumericVector<Number> &,
 
           // Make sure we have the matching quadrature points on face and neighbor
           std::vector<Point> neighbor_xyz;
-          FEInterface::inverse_map(
-              elem->dim(), fe->get_fe_type(), neighbor, face_xyz, neighbor_xyz);
+          FEMap::inverse_map(elem->dim(), neighbor, face_xyz,
+                             neighbor_xyz);
 
           fe_neighbor_face->reinit(neighbor, &neighbor_xyz);
 

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -679,6 +679,7 @@ include_HEADERS = \
         fe/inf_fe_instantiate_2D.h \
         fe/inf_fe_instantiate_3D.h \
         fe/inf_fe_macro.h \
+        fe/inf_fe_map.h \
         geom/bounding_box.h \
         geom/cell.h \
         geom/cell_hex.h \

--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -295,39 +295,23 @@ public:
                            unsigned int e,
                            std::vector<unsigned int> & di);
 
-  /**
-   * \returns The location (on the reference element) of the
-   * point \p p located in physical space.  This function requires
-   * inverting the (possibly nonlinear) transformation map, so
-   * it is not trivial. The optional parameter \p tolerance defines
-   * how close is "good enough."  The map inversion iteration
-   * computes the sequence \f$ \{ p_n \} \f$, and the iteration is
-   * terminated when \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
-   * The parameter secure (always assumed false in non-debug mode)
-   * switches on integrity-checks on the mapped points.
-   */
   static Point inverse_map (const Elem * elem,
                             const Point & p,
                             const Real tolerance = TOLERANCE,
-                            const bool secure = true);
+                            const bool secure = true) {
+    // libmesh_deprecated(); // soon
+    return FEMap::inverse_map(Dim, elem, p, tolerance, secure);
+  }
 
-  /**
-   * Takes a number points in physical space (in the \p
-   * physical_points vector) and finds their location on the reference
-   * element for the input element \p elem.  The values on the
-   * reference element are returned in the vector \p
-   * reference_points. The optional parameter \p tolerance defines how
-   * close is "good enough."  The map inversion iteration computes the
-   * sequence \f$ \{ p_n \} \f$, and the iteration is terminated when
-   * \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
-   * The parameter secure (always assumed false in non-debug mode)
-   * switches on integrity-checks on the mapped points.
-   */
   static void inverse_map (const Elem * elem,
                            const std::vector<Point> & physical_points,
                            std::vector<Point> &       reference_points,
                            const Real tolerance = TOLERANCE,
-                           const bool secure = true);
+                           const bool secure = true) {
+    // libmesh_deprecated(); // soon
+    FEMap::inverse_map(Dim, elem, physical_points, reference_points,
+                       tolerance, secure);
+  }
 
   /**
    * This is at the core of this class. Use this for each
@@ -418,33 +402,29 @@ public:
    */
   virtual bool shapes_need_reinit() const override;
 
-  /**
-   * \returns The location (in physical space) of the point
-   * \p p located on the reference element.
-   */
   static Point map (const Elem * elem,
-                    const Point & reference_point);
+                    const Point & reference_point) {
+    // libmesh_deprecated(); // soon
+    return FEMap::map(Dim, elem, reference_point);
+  }
 
-  /**
-   * \returns d(xyz)/dxi (in physical space) of the point
-   * \p p located on the reference element.
-   */
   static Point map_xi (const Elem * elem,
-                       const Point & reference_point);
+                       const Point & reference_point) {
+    // libmesh_deprecated(); // soon
+    return FEMap::map_deriv(Dim, elem, 0, reference_point);
+  }
 
-  /**
-   * \returns d(xyz)/deta (in physical space) of the point
-   * \p p located on the reference element.
-   */
   static Point map_eta (const Elem * elem,
-                        const Point & reference_point);
+                        const Point & reference_point) {
+    // libmesh_deprecated(); // soon
+    return FEMap::map_deriv(Dim, elem, 1, reference_point);
+  }
 
-  /**
-   * \returns d(xyz)/dzeta (in physical space) of the point
-   * \p p located on the reference element.
-   */
   static Point map_zeta (const Elem * elem,
-                         const Point & reference_point);
+                         const Point & reference_point) {
+    // libmesh_deprecated(); // soon
+    return FEMap::map_deriv(Dim, elem, 2, reference_point);
+  }
 
 #ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
   /**

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -190,8 +190,7 @@ public:
                          std::vector<Number> & nodal_soln);
 
   /**
-   * \returns The point in physical space corresponding to the
-   * reference point \p p which is passed in.
+   * This is now deprecated; use FEMap::map instead.
    */
   static Point map(unsigned int dim,
                    const FEType & fe_t,
@@ -199,13 +198,7 @@ public:
                    const Point & p);
 
   /**
-   * \returns The location (on the reference element) of the
-   * point \p p located in physical space.  This function requires
-   * inverting the (probably nonlinear) transformation map, so
-   * it is not trivial. The optional parameter \p tolerance defines
-   * how close is "good enough."  The map inversion iteration
-   * computes the sequence \f$ \{ p_n \} \f$, and the iteration is
-   * terminated when \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
+   * This is now deprecated; use FEMap::inverse_map instead.
    */
   static Point inverse_map (const unsigned int dim,
                             const FEType & fe_t,
@@ -215,15 +208,7 @@ public:
                             const bool secure = true);
 
   /**
-   * \returns The location (on the reference element) of the points \p
-   * physical_points located in physical space.  This function
-   * requires inverting the (probably nonlinear) transformation map,
-   * so it is not trivial. The location of each point on the reference
-   * element is returned in the vector \p reference_points. The
-   * optional parameter \p tolerance defines how close is "good
-   * enough."  The map inversion iteration computes the sequence \f$
-   * \{ p_n \} \f$, and the iteration is terminated when \f$ \|p -
-   * p_n\| < \mbox{\texttt{tolerance}} \f$
+   * This is now deprecated; use FEMap::inverse_map instead.
    */
   static void  inverse_map (const unsigned int dim,
                             const FEType & fe_t,

--- a/include/fe/fe_map.h
+++ b/include/fe/fe_map.h
@@ -134,6 +134,59 @@ public:
                                  const Elem * edge);
 
   /**
+   * \returns The location (in physical space) of the point
+   * \p p located on the reference element.
+   */
+  static Point map (const unsigned int dim,
+                    const Elem * elem,
+                    const Point & reference_point);
+
+  /**
+   * \returns component \p j of d(xyz)/d(xi eta zeta) (in physical
+   * space) of the point \p p located on the reference element.
+   */
+  static Point map_deriv (const unsigned int dim,
+                          const Elem * elem,
+                          const unsigned int j,
+                          const Point & reference_point);
+
+  /**
+   * \returns The location (on the reference element) of the
+   * point \p p located in physical space.  This function requires
+   * inverting the (possibly nonlinear) transformation map, so
+   * it is not trivial. The optional parameter \p tolerance defines
+   * how close is "good enough."  The map inversion iteration
+   * computes the sequence \f$ \{ p_n \} \f$, and the iteration is
+   * terminated when \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
+   * The parameter secure (always assumed false in non-debug mode)
+   * switches on integrity-checks on the mapped points.
+   */
+  static Point inverse_map (const unsigned int dim,
+                            const Elem * elem,
+                            const Point & p,
+                            const Real tolerance = TOLERANCE,
+                            const bool secure = true);
+
+  /**
+   * Takes a number points in physical space (in the \p
+   * physical_points vector) and finds their location on the reference
+   * element for the input element \p elem.  The values on the
+   * reference element are returned in the vector \p
+   * reference_points. The optional parameter \p tolerance defines how
+   * close is "good enough."  The map inversion iteration computes the
+   * sequence \f$ \{ p_n \} \f$, and the iteration is terminated when
+   * \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$
+   * The parameter secure (always assumed false in non-debug mode)
+   * switches on integrity-checks on the mapped points.
+   */
+  static void inverse_map (unsigned int dim,
+                           const Elem * elem,
+                           const std::vector<Point> & physical_points,
+                           std::vector<Point> &       reference_points,
+                           const Real tolerance = TOLERANCE,
+                           const bool secure = true);
+
+  /**
    * \returns The \p xyz spatial locations of the quadrature
    * points on the element.
    */

--- a/include/fe/inf_fe_map.h
+++ b/include/fe/inf_fe_map.h
@@ -1,0 +1,130 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+
+#ifndef LIBMESH_INF_FE_MAP_H
+#define LIBMESH_INF_FE_MAP_H
+
+#include "libmesh/libmesh_config.h"
+
+#ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+// Local includes
+#include "libmesh/fe_type.h"
+#include "libmesh/point.h"
+
+// C++ includes
+#include <vector>
+
+namespace libMesh
+{
+
+// forward declarations
+class Elem;
+class FEComputeData;
+
+
+
+/**
+ * Class that encapsulates mapping (i.e. from physical space to
+ * reference space and vice-versa) operations on infinite elements.
+ */
+class InfFEMap
+{
+public:
+  /**
+   * \returns The location (in physical space) of the point
+   * \p p located on the reference element.
+   */
+  static Point map (const unsigned int dim,
+                    const Elem * inf_elem,
+                    const Point & reference_point);
+
+  /**
+   * \returns The location (on the reference element) of the
+   * point \p p located in physical space.  First, the location
+   * in the base face is computed. This requires inverting the
+   * (possibly nonlinear) transformation map in the base, so it is
+   * not trivial. The optional parameter \p tolerance defines
+   * how close is "good enough."  The map inversion iteration
+   * computes the sequence \f$ \{ p_n \} \f$, and the iteration is
+   * terminated when \f$ \|p - p_n\| < \mbox{\texttt{tolerance}} \f$.
+   * Once the base face point is determined, the radial local
+   * coordinate is directly evaluated.
+   * If \p interpolated is true, the interpolated distance from the
+   * base element to the infinite element origin is used for the map
+   * in radial direction.
+   */
+  static Point inverse_map (const unsigned int dim,
+                            const Elem * elem,
+                            const Point & p,
+                            const Real tolerance = TOLERANCE,
+                            const bool secure = true);
+
+
+  /**
+   * Takes a number points in physical space (in the \p physical_points
+   * vector) and finds their location on the reference element for the
+   * input element \p elem.  The values on the reference element are
+   * returned in the vector \p reference_points
+   */
+  static void inverse_map (const unsigned int dim,
+                           const Elem * elem,
+                           const std::vector<Point> & physical_points,
+                           std::vector<Point> &       reference_points,
+                           const Real tolerance = TOLERANCE,
+                           const bool secure = true);
+
+  /**
+   * \returns The value of the \f$ i^{th} \f$ polynomial evaluated
+   * at \p v.  This method provides the approximation
+   * in radial direction for the overall shape functions,
+   * which is defined in \p InfFE::shape().
+   * This method is allowed to be static, since it is independent
+   * of dimension and base_family.  It is templated, though,
+   * w.r.t. to radial \p FEFamily.
+   *
+   * \returns The value of the \f$ i^{th} \f$ mapping shape function
+   * in radial direction evaluated at \p v when T_radial ==
+   * INFINITE_MAP.  Currently, only one specific mapping shape is
+   * used.  Namely the one by Marques JMMC, Owen DRJ: Infinite
+   * elements in quasi-static materially nonlinear problems, Computers
+   * and Structures, 1984.
+   */
+  static Real eval(Real v,
+                   Order o,
+                   unsigned int i);
+
+  /**
+   * \returns The value of the first derivative of the
+   * \f$ i^{th} \f$ polynomial at coordinate \p v.
+   * See \p eval for details.
+   */
+  static Real eval_deriv(Real v,
+                         Order o,
+                         unsigned int i);
+};
+
+
+} // namespace libMesh
+
+
+#endif // ifdef LIBMESH_ENABLE_INFINITE_ELEMENTS
+
+
+#endif // LIBMESH_INF_FE_MAP_H

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -100,6 +100,7 @@ include_HEADERS =  \
         fe/inf_fe_instantiate_2D.h \
         fe/inf_fe_instantiate_3D.h \
         fe/inf_fe_macro.h \
+        fe/inf_fe_map.h \
         geom/bounding_box.h \
         geom/cell.h \
         geom/cell_hex.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -90,6 +90,7 @@ BUILT_SOURCES = \
         inf_fe_instantiate_2D.h \
         inf_fe_instantiate_3D.h \
         inf_fe_macro.h \
+        inf_fe_map.h \
         bounding_box.h \
         cell.h \
         cell_hex.h \
@@ -791,6 +792,9 @@ inf_fe_instantiate_3D.h: $(top_srcdir)/include/fe/inf_fe_instantiate_3D.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 inf_fe_macro.h: $(top_srcdir)/include/fe/inf_fe_macro.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+inf_fe_map.h: $(top_srcdir)/include/fe/inf_fe_map.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 bounding_box.h: $(top_srcdir)/include/geom/bounding_box.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -523,24 +523,24 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	fe_transformation_base.h fe_type.h fe_xyz_map.h \
 	h1_fe_transformation.h hcurl_fe_transformation.h inf_fe.h \
 	inf_fe_instantiate_1D.h inf_fe_instantiate_2D.h \
-	inf_fe_instantiate_3D.h inf_fe_macro.h bounding_box.h cell.h \
-	cell_hex.h cell_hex20.h cell_hex27.h cell_hex8.h cell_inf.h \
-	cell_inf_hex.h cell_inf_hex16.h cell_inf_hex18.h \
-	cell_inf_hex8.h cell_inf_prism.h cell_inf_prism12.h \
-	cell_inf_prism6.h cell_prism.h cell_prism15.h cell_prism18.h \
-	cell_prism6.h cell_pyramid.h cell_pyramid13.h cell_pyramid14.h \
-	cell_pyramid5.h cell_tet.h cell_tet10.h cell_tet4.h \
-	compare_elems_by_level.h edge.h edge_edge2.h edge_edge3.h \
-	edge_edge4.h edge_inf_edge2.h elem.h elem_cutter.h elem_hash.h \
-	elem_internal.h elem_quality.h elem_range.h face.h \
-	face_inf_quad.h face_inf_quad4.h face_inf_quad6.h face_quad.h \
-	face_quad4.h face_quad4_shell.h face_quad8.h \
-	face_quad8_shell.h face_quad9.h face_tri.h face_tri3.h \
-	face_tri3_shell.h face_tri3_subdivision.h face_tri6.h node.h \
-	node_elem.h node_range.h plane.h point.h reference_elem.h \
-	remote_elem.h side.h sphere.h stored_range.h surface.h \
-	abaqus_io.h boundary_info.h boundary_mesh.h checkpoint_io.h \
-	distributed_mesh.h ensight_io.h exodusII_io.h \
+	inf_fe_instantiate_3D.h inf_fe_macro.h inf_fe_map.h \
+	bounding_box.h cell.h cell_hex.h cell_hex20.h cell_hex27.h \
+	cell_hex8.h cell_inf.h cell_inf_hex.h cell_inf_hex16.h \
+	cell_inf_hex18.h cell_inf_hex8.h cell_inf_prism.h \
+	cell_inf_prism12.h cell_inf_prism6.h cell_prism.h \
+	cell_prism15.h cell_prism18.h cell_prism6.h cell_pyramid.h \
+	cell_pyramid13.h cell_pyramid14.h cell_pyramid5.h cell_tet.h \
+	cell_tet10.h cell_tet4.h compare_elems_by_level.h edge.h \
+	edge_edge2.h edge_edge3.h edge_edge4.h edge_inf_edge2.h elem.h \
+	elem_cutter.h elem_hash.h elem_internal.h elem_quality.h \
+	elem_range.h face.h face_inf_quad.h face_inf_quad4.h \
+	face_inf_quad6.h face_quad.h face_quad4.h face_quad4_shell.h \
+	face_quad8.h face_quad8_shell.h face_quad9.h face_tri.h \
+	face_tri3.h face_tri3_shell.h face_tri3_subdivision.h \
+	face_tri6.h node.h node_elem.h node_range.h plane.h point.h \
+	reference_elem.h remote_elem.h side.h sphere.h stored_range.h \
+	surface.h abaqus_io.h boundary_info.h boundary_mesh.h \
+	checkpoint_io.h distributed_mesh.h ensight_io.h exodusII_io.h \
 	exodusII_io_helper.h fro_io.h gmsh_io.h gmv_io.h gnuplot_io.h \
 	inf_elem_builder.h matlab_io.h medit_io.h mesh.h mesh_base.h \
 	mesh_communication.h mesh_function.h mesh_generation.h \
@@ -1137,6 +1137,9 @@ inf_fe_instantiate_3D.h: $(top_srcdir)/include/fe/inf_fe_instantiate_3D.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 inf_fe_macro.h: $(top_srcdir)/include/fe/inf_fe_macro.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+inf_fe_map.h: $(top_srcdir)/include/fe/inf_fe_map.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 bounding_box.h: $(top_srcdir)/include/geom/bounding_box.h

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -2014,8 +2014,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectEdge
                 }
 
               std::vector<Point> fine_qp;
-              FEInterface::inverse_map (dim, base_fe_type, &elem,
-                                        fine_points, fine_qp);
+              FEMap::inverse_map (dim, &elem, fine_points, fine_qp);
 
               context.elem_fe_reinit(&fine_qp);
             }
@@ -2176,8 +2175,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectSide
                 }
 
               std::vector<Point> fine_qp;
-              FEInterface::inverse_map (dim, base_fe_type, &elem,
-                                        fine_points, fine_qp);
+              FEMap::inverse_map (dim, &elem, fine_points, fine_qp);
 
               context.elem_fe_reinit(&fine_qp);
             }
@@ -2295,8 +2293,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectInte
                 }
 
               std::vector<Point> fine_qp;
-              FEInterface::inverse_map (dim, base_fe_type, elem,
-                                        fine_points, fine_qp);
+              FEMap::inverse_map (dim, elem, fine_points, fine_qp);
 
               context.elem_fe_reinit(&fine_qp);
             }

--- a/src/error_estimation/hp_coarsentest.C
+++ b/src/error_estimation/hp_coarsentest.C
@@ -60,9 +60,6 @@ void HPCoarsenTest::add_projection(const System & system,
   // The DofMap for this system
   const DofMap & dof_map = system.get_dof_map();
 
-  // The type of finite element to use for this variable
-  const FEType & fe_type = dof_map.variable_type (var);
-
   const FEContinuity cont = fe->get_continuity();
 
   fe->reinit(elem);
@@ -72,8 +69,8 @@ void HPCoarsenTest::add_projection(const System & system,
   const unsigned int n_dofs =
     cast_int<unsigned int>(dof_indices.size());
 
-  FEInterface::inverse_map (system.get_mesh().mesh_dimension(),
-                            fe_type, coarse, *xyz_values, coarse_qpoints);
+  FEMap::inverse_map (system.get_mesh().mesh_dimension(), coarse,
+                      *xyz_values, coarse_qpoints);
 
   fe_coarse->reinit(coarse, &coarse_qpoints);
 
@@ -425,8 +422,8 @@ void HPCoarsenTest::select_refinement (System & system)
             }
           else
             {
-              FEInterface::inverse_map (dim, fe_type, coarse,
-                                        *xyz_values, coarse_qpoints);
+              FEMap::inverse_map (dim, coarse, *xyz_values,
+                                  coarse_qpoints);
 
               unsigned int old_parent_level = coarse->p_level();
               coarse->hack_p_level(elem->p_level());

--- a/src/error_estimation/jump_error_estimator.C
+++ b/src/error_estimation/jump_error_estimator.C
@@ -440,9 +440,9 @@ JumpErrorEstimator::reinit_sides ()
 
   std::vector<Point> qp_coarse;
 
-  FEInterface::inverse_map
-    (coarse_context->get_elem().dim(), fe_coarse->get_fe_type(),
-     &coarse_context->get_elem(), qface_point, qp_coarse);
+  FEMap::inverse_map (coarse_context->get_elem().dim(),
+                      &coarse_context->get_elem(), qface_point,
+                      qp_coarse);
 
   // The number of variables in the system
   const unsigned int n_vars = fine_context->n_vars();

--- a/src/fe/fe_abstract.C
+++ b/src/fe/fe_abstract.C
@@ -907,9 +907,9 @@ void FEAbstract::compute_node_constraints (NodeConstraints & constraints,
               const Point & support_point = *my_node;
 
               // Figure out where my node lies on their reference element.
-              const Point mapped_point = FEInterface::inverse_map(Dim-1, fe_type,
-                                                                  parent_side.get(),
-                                                                  support_point);
+              const Point mapped_point = FEMap::inverse_map(Dim-1,
+                                                            parent_side.get(),
+                                                            support_point);
 
               // Compute the parent's side shape function values.
               for (unsigned int their_side_n=0;
@@ -1077,9 +1077,9 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
                       // Figure out where my node lies on their reference element.
                       const Point neigh_point = periodic->get_corresponding_pos(*my_node);
 
-                      const Point mapped_point = FEInterface::inverse_map(Dim-1, fe_type,
-                                                                          neigh_side.get(),
-                                                                          neigh_point);
+                      const Point mapped_point =
+                        FEMap::inverse_map(Dim-1, neigh_side.get(),
+                                           neigh_point);
 
                       // If we've already got a constraint on this
                       // node, then the periodic constraint is
@@ -1145,9 +1145,9 @@ void FEAbstract::compute_periodic_node_constraints (NodeConstraints & constraint
                       const Point neigh_point = periodic->get_corresponding_pos(*my_node);
 
                       // Figure out where my node lies on their reference element.
-                      const Point mapped_point = FEInterface::inverse_map(Dim-1, fe_type,
-                                                                          neigh_side.get(),
-                                                                          neigh_point);
+                      const Point mapped_point =
+                        FEMap::inverse_map(Dim-1, neigh_side.get(),
+                                           neigh_point);
 
                       for (unsigned int their_side_n=0;
                            their_side_n < n_side_nodes;

--- a/src/fe/fe_base.C
+++ b/src/fe/fe_base.C
@@ -1009,8 +1009,8 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
             fe->edge_reinit (child, e);
             const unsigned int n_qp = qedgerule->n_points();
 
-            FEInterface::inverse_map (dim, fe_type, elem,
-                                      xyz_values, coarse_qpoints);
+            FEMap::inverse_map (dim, elem, xyz_values,
+                                coarse_qpoints);
 
             fe_coarse->reinit(elem, &coarse_qpoints);
 
@@ -1149,8 +1149,8 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
             fe->reinit (child, s);
             const unsigned int n_qp = qsiderule->n_points();
 
-            FEInterface::inverse_map (dim, fe_type, elem,
-                                      xyz_values, coarse_qpoints);
+            FEMap::inverse_map (dim, elem, xyz_values,
+                                coarse_qpoints);
 
             fe_coarse->reinit(elem, &coarse_qpoints);
 
@@ -1267,8 +1267,7 @@ FEGenericBase<OutputType>::coarsened_dof_values(const NumericVector<Number> & ol
       fe->reinit (&child);
       const unsigned int n_qp = qrule->n_points();
 
-      FEInterface::inverse_map (dim, fe_type, elem,
-                                xyz_values, coarse_qpoints);
+      FEMap::inverse_map (dim, elem, xyz_values, coarse_qpoints);
 
       fe_coarse->reinit(elem, &coarse_qpoints);
 
@@ -1511,8 +1510,7 @@ FEGenericBase<OutputType>::compute_proj_constraints (DofConstraints & constraint
 
           const unsigned int n_qp = my_qface.n_points();
 
-          FEInterface::inverse_map (Dim, base_fe_type, neigh,
-                                    q_point, neigh_qface);
+          FEMap::inverse_map (Dim, neigh, q_point, neigh_qface);
 
           neigh_fe->reinit(neigh, &neigh_qface);
 
@@ -1853,8 +1851,8 @@ compute_periodic_constraints (DofConstraints & constraints,
                   for (auto i : index_range(neigh_point))
                     neigh_point[i] = periodic->get_corresponding_pos(q_point[i]);
 
-                  FEInterface::inverse_map (Dim, base_fe_type, neigh,
-                                            neigh_point, neigh_qface);
+                  FEMap::inverse_map (Dim, neigh, neigh_point,
+                                      neigh_qface);
 
                   neigh_fe->reinit(neigh, &neigh_qface);
 

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -349,7 +349,7 @@ void FE<Dim,T>::edge_reinit(const Elem * elem,
   // Find where the integration points are located on the
   // full element.
   std::vector<Point> qp;
-  this->inverse_map (elem, this->_fe_map->get_xyz(), qp, tolerance);
+  FEMap::inverse_map (Dim, elem, this->_fe_map->get_xyz(), qp, tolerance);
 
   // compute the shape function and derivative values
   // at the points qp
@@ -761,11 +761,11 @@ void FEMap::compute_face_map(int dim, const std::vector<Real> & qw,
                 libmesh_assert(elem);
 
                 // Inverse map xyz[p] to a reference point on the parent...
-                Point reference_point = FE<2,LAGRANGE>::inverse_map(elem, this->xyz[p]);
+                Point reference_point = FEMap::inverse_map(2, elem, this->xyz[p]);
 
                 // Get dxyz/dxi and dxyz/deta from the parent map.
-                Point dx_dxi  = FE<2,LAGRANGE>::map_xi (elem, reference_point);
-                Point dx_deta = FE<2,LAGRANGE>::map_eta(elem, reference_point);
+                Point dx_dxi  = FEMap::map_deriv (2, elem, 0, reference_point);
+                Point dx_deta = FEMap::map_deriv (2, elem, 1, reference_point);
 
                 // The second tangent vector is formed by crossing these vectors.
                 tangents[p][1] = dx_dxi.cross(dx_deta).unit();

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -774,9 +774,9 @@ void lagrange_compute_constraints (DofConstraints & constraints,
               const Point & support_point = my_side->point(my_dof);
 
               // Figure out where my node lies on their reference element.
-              const Point mapped_point = FEInterface::inverse_map(Dim-1, fe_type,
-                                                                  parent_side.get(),
-                                                                  support_point);
+              const Point mapped_point = FEMap::inverse_map(Dim-1,
+                                                            parent_side.get(),
+                                                            support_point);
 
               // Compute the parent's side shape function values.
               for (unsigned int their_dof=0;

--- a/src/fe/inf_fe_base_radial.C
+++ b/src/fe/inf_fe_base_radial.C
@@ -31,9 +31,8 @@ namespace libMesh
 
 
 // ------------------------------------------------------------
-// InfFE::Base class members
-template <unsigned int Dim, FEFamily T_radial, InfMapType T_base>
-Elem * InfFE<Dim,T_radial,T_base>::Base::build_elem (const Elem * inf_elem)
+// InfFEBase class members
+Elem * InfFEBase::build_elem (const Elem * inf_elem)
 {
   std::unique_ptr<const Elem> ape(inf_elem->build_side_ptr(0));
 
@@ -47,8 +46,7 @@ Elem * InfFE<Dim,T_radial,T_base>::Base::build_elem (const Elem * inf_elem)
 
 
 
-template <unsigned int Dim, FEFamily T_radial, InfMapType T_base>
-ElemType InfFE<Dim,T_radial,T_base>::Base::get_elem_type (const ElemType type)
+ElemType InfFEBase::get_elem_type (const ElemType type)
 {
   switch (type)
     {
@@ -94,23 +92,21 @@ ElemType InfFE<Dim,T_radial,T_base>::Base::get_elem_type (const ElemType type)
 
 
 
-template <unsigned int Dim, FEFamily T_radial, InfMapType T_base>
-unsigned int InfFE<Dim,T_radial,T_base>::Base::n_base_mapping_sf (const ElemType base_elem_type,
-                                                                  const Order base_mapping_order)
+unsigned int InfFEBase::n_base_mapping_sf (const Elem & base_elem,
+                                           const Order base_mapping_order)
 {
-  if (Dim == 1)
-    return 1;
-
-  else if (Dim == 2)
-    return FE<1,LAGRANGE>::n_shape_functions (base_elem_type,
-                                              base_mapping_order);
-  else if (Dim == 3)
-    return FE<2,LAGRANGE>::n_shape_functions (base_elem_type,
-                                              base_mapping_order);
-  else
+  switch (base_elem.dim())
     {
-      libmesh_error_msg("Unsupported Dim = " << Dim);
-      return 0;
+    case 0:
+      return 1;
+    case 1:
+      return FE<1,LAGRANGE>::n_shape_functions (base_elem.type(),
+                                                base_mapping_order);
+    case 2:
+      return FE<2,LAGRANGE>::n_shape_functions (base_elem.type(),
+                                                base_mapping_order);
+    default:
+      libmesh_error_msg("Unsupported base_elem dim = " << base_elem.dim());
     }
 }
 
@@ -119,10 +115,9 @@ unsigned int InfFE<Dim,T_radial,T_base>::Base::n_base_mapping_sf (const ElemType
 
 
 // ------------------------------------------------------------
-// InfFE::Radial class members
-template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
-unsigned int InfFE<Dim,T_radial,T_map>::Radial::n_dofs_at_node (const Order o_radial,
-                                                                const unsigned int n_onion)
+// InfFERadial class members
+unsigned int InfFERadial::n_dofs_at_node (const Order o_radial,
+                                          const unsigned int n_onion)
 {
   libmesh_assert_less (n_onion, 2);
 
@@ -140,25 +135,6 @@ unsigned int InfFE<Dim,T_radial,T_map>::Radial::n_dofs_at_node (const Order o_ra
     return static_cast<unsigned int>(o_radial);
 }
 
-
-
-
-
-
-//--------------------------------------------------------------
-// Explicit instantiations
-INSTANTIATE_INF_FE_MBRF(1,CARTESIAN,Elem *,Base::build_elem(const Elem *));
-INSTANTIATE_INF_FE_MBRF(2,CARTESIAN,Elem *,Base::build_elem(const Elem *));
-INSTANTIATE_INF_FE_MBRF(3,CARTESIAN,Elem *,Base::build_elem(const Elem *));
-INSTANTIATE_INF_FE_MBRF(1,CARTESIAN,ElemType,Base::get_elem_type(const ElemType type));
-INSTANTIATE_INF_FE_MBRF(2,CARTESIAN,ElemType,Base::get_elem_type(const ElemType type));
-INSTANTIATE_INF_FE_MBRF(3,CARTESIAN,ElemType,Base::get_elem_type(const ElemType type));
-INSTANTIATE_INF_FE_MBRF(1,CARTESIAN,unsigned int,Base::n_base_mapping_sf(const ElemType,const Order));
-INSTANTIATE_INF_FE_MBRF(2,CARTESIAN,unsigned int,Base::n_base_mapping_sf(const ElemType,const Order));
-INSTANTIATE_INF_FE_MBRF(3,CARTESIAN,unsigned int,Base::n_base_mapping_sf(const ElemType,const Order));
-INSTANTIATE_INF_FE_MBRF(1,CARTESIAN,unsigned int,Radial::n_dofs_at_node (const Order,const unsigned int));
-INSTANTIATE_INF_FE_MBRF(2,CARTESIAN,unsigned int,Radial::n_dofs_at_node (const Order,const unsigned int));
-INSTANTIATE_INF_FE_MBRF(3,CARTESIAN,unsigned int,Radial::n_dofs_at_node (const Order,const unsigned int));
 
 } // namespace libMesh
 

--- a/src/fe/inf_fe_boundary.C
+++ b/src/fe/inf_fe_boundary.C
@@ -212,15 +212,14 @@ void InfFE<Dim,T_radial,T_base>::init_face_shape_functions(const std::vector<Poi
 
     // The element type and order to use in the base map
     const Order    base_mapping_order     ( base_elem->default_order() );
-    const ElemType base_mapping_elem_type ( base_elem->type()          );
 
     // the number of mapping shape functions. For base side it is 1.
     // (Lagrange shape functions are used for mapping in the base)
     const unsigned int n_radial_mapping_sf =
       inf_side->infinite() ? cast_int<unsigned int>(radial_map.size()) : 1;
 
-    const unsigned int n_base_mapping_shape_functions = Base::n_base_mapping_sf(base_mapping_elem_type,
-                                                                                base_mapping_order);
+    const unsigned int n_base_mapping_shape_functions =
+      InfFEBase::n_base_mapping_sf(*base_elem, base_mapping_order);
 
     const unsigned int n_total_mapping_shape_functions =
       n_radial_mapping_sf * n_base_mapping_shape_functions;

--- a/src/fe/inf_fe_map_eval.C
+++ b/src/fe/inf_fe_map_eval.C
@@ -24,10 +24,7 @@
 namespace libMesh
 {
 
-// Anonymous namespace for local helper functions
-namespace {
-
-Real infinite_map_eval(Real v, unsigned i)
+Real InfFEMap::eval(Real v, Order, unsigned i)
 {
   libmesh_assert (-1.-1.e-5 <= v && v < 1.);
 
@@ -45,7 +42,7 @@ Real infinite_map_eval(Real v, unsigned i)
 
 
 
-Real infinite_map_eval_deriv(Real v, unsigned i)
+Real InfFEMap::eval_deriv(Real v, Order, unsigned i)
 {
   libmesh_assert (-1.-1.e-5 <= v && v < 1.);
 
@@ -61,20 +58,18 @@ Real infinite_map_eval_deriv(Real v, unsigned i)
     }
 }
 
-} // anonymous namespace
-
-
-  // Specialize the eval() function for 1, 2, and 3 dimensions and the CARTESIAN mapping type
-  // to call the local helper function from the anonymous namespace.
-template <> Real InfFE<1,INFINITE_MAP,CARTESIAN>::eval(Real v, Order, unsigned i) { return infinite_map_eval(v, i); }
-template <> Real InfFE<2,INFINITE_MAP,CARTESIAN>::eval(Real v, Order, unsigned i) { return infinite_map_eval(v, i); }
-template <> Real InfFE<3,INFINITE_MAP,CARTESIAN>::eval(Real v, Order, unsigned i) { return infinite_map_eval(v, i); }
+// Specialize the eval() function for 1, 2, and 3 dimensions and the CARTESIAN mapping type
+// to call the local helper function from the anonymous namespace.
+template <> Real InfFE<1,INFINITE_MAP,CARTESIAN>::eval(Real v, Order o, unsigned i) { return InfFEMap::eval(v, o, i); }
+template <> Real InfFE<2,INFINITE_MAP,CARTESIAN>::eval(Real v, Order o, unsigned i) { return InfFEMap::eval(v, o, i); }
+template <> Real InfFE<3,INFINITE_MAP,CARTESIAN>::eval(Real v, Order o, unsigned i) { return InfFEMap::eval(v, o, i); }
 
 // Specialize the eval_deriv() function for 1, 2, and 3 dimensions and the CARTESIAN mapping type
 // to call the local helper function from the anonymous namespace.
-template <> Real InfFE<1,INFINITE_MAP,CARTESIAN>::eval_deriv(Real v, Order, unsigned i) { return infinite_map_eval_deriv(v, i); }
-template <> Real InfFE<2,INFINITE_MAP,CARTESIAN>::eval_deriv(Real v, Order, unsigned i) { return infinite_map_eval_deriv(v, i); }
-template <> Real InfFE<3,INFINITE_MAP,CARTESIAN>::eval_deriv(Real v, Order, unsigned i) { return infinite_map_eval_deriv(v, i); }
+template <> Real InfFE<1,INFINITE_MAP,CARTESIAN>::eval_deriv(Real v, Order o, unsigned i) { return InfFEMap::eval_deriv(v, o, i); }
+template <> Real InfFE<2,INFINITE_MAP,CARTESIAN>::eval_deriv(Real v, Order o, unsigned i) { return InfFEMap::eval_deriv(v, o, i); }
+template <> Real InfFE<3,INFINITE_MAP,CARTESIAN>::eval_deriv(Real v, Order o, unsigned i) { return InfFEMap::eval_deriv(v, o, i); }
+
 
 } // namespace libMesh
 

--- a/src/fe/inf_fe_static.C
+++ b/src/fe/inf_fe_static.C
@@ -58,12 +58,13 @@ template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 unsigned int InfFE<Dim,T_radial,T_map>::n_dofs (const FEType & fet,
                                                 const ElemType inf_elem_type)
 {
-  const ElemType base_et (Base::get_elem_type(inf_elem_type));
+  const ElemType base_et (InfFEBase::get_elem_type(inf_elem_type));
 
   if (Dim > 1)
-    return FEInterface::n_dofs(Dim-1, fet, base_et) * Radial::n_dofs(fet.radial_order);
+    return FEInterface::n_dofs(Dim-1, fet, base_et) *
+      InfFERadial::n_dofs(fet.radial_order);
   else
-    return Radial::n_dofs(fet.radial_order);
+    return InfFERadial::n_dofs(fet.radial_order);
 }
 
 
@@ -76,7 +77,7 @@ unsigned int InfFE<Dim,T_radial,T_map>::n_dofs_at_node (const FEType & fet,
                                                         const ElemType inf_elem_type,
                                                         const unsigned int n)
 {
-  const ElemType base_et (Base::get_elem_type(inf_elem_type));
+  const ElemType base_et (InfFEBase::get_elem_type(inf_elem_type));
 
   unsigned int n_base, n_radial;
   compute_node_indices(inf_elem_type, n, n_base, n_radial);
@@ -90,9 +91,9 @@ unsigned int InfFE<Dim,T_radial,T_map>::n_dofs_at_node (const FEType & fet,
 
   if (Dim > 1)
     return FEInterface::n_dofs_at_node(Dim-1, fet, base_et, n_base)
-      * Radial::n_dofs_at_node(fet.radial_order, n_radial);
+      * InfFERadial::n_dofs_at_node(fet.radial_order, n_radial);
   else
-    return Radial::n_dofs_at_node(fet.radial_order, n_radial);
+    return InfFERadial::n_dofs_at_node(fet.radial_order, n_radial);
 }
 
 
@@ -104,13 +105,13 @@ template <unsigned int Dim, FEFamily T_radial, InfMapType T_map>
 unsigned int InfFE<Dim,T_radial,T_map>::n_dofs_per_elem (const FEType & fet,
                                                          const ElemType inf_elem_type)
 {
-  const ElemType base_et (Base::get_elem_type(inf_elem_type));
+  const ElemType base_et (InfFEBase::get_elem_type(inf_elem_type));
 
   if (Dim > 1)
     return FEInterface::n_dofs_per_elem(Dim-1, fet, base_et)
-      * Radial::n_dofs_per_elem(fet.radial_order);
+      * InfFERadial::n_dofs_per_elem(fet.radial_order);
   else
-    return Radial::n_dofs_per_elem(fet.radial_order);
+    return InfFERadial::n_dofs_per_elem(fet.radial_order);
 }
 
 
@@ -173,7 +174,7 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType & fet,
     }
 #endif
 
-  const ElemType     base_et  (Base::get_elem_type(inf_elem_type));
+  const ElemType     base_et  (InfFEBase::get_elem_type(inf_elem_type));
   const Order        o_radial (fet.radial_order);
   const Real         v        (p(Dim-1));
 
@@ -186,10 +187,10 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType & fet,
   if (Dim > 1)
     return FEInterface::shape(Dim-1, fet, base_et, i_base, p)
       * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
-      * InfFE<Dim,T_radial,T_map>::Radial::decay(v);
+      * InfFERadial::decay(Dim,v);
   else
     return InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
-      * InfFE<Dim,T_radial,T_map>::Radial::decay(v);
+      * InfFERadial::decay(Dim,v);
 }
 
 
@@ -228,10 +229,10 @@ Real InfFE<Dim,T_radial,T_map>::shape(const FEType & fet,
   if (Dim > 1)
     return FEInterface::shape(Dim-1, fet, base_el.get(), i_base, p)
       * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
-      * InfFE<Dim,T_radial,T_map>::Radial::decay(v);
+      * InfFERadial::decay(Dim,v);
   else
     return InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
-      * InfFE<Dim,T_radial,T_map>::Radial::decay(v);
+      * InfFERadial::decay(Dim,v);
 }
 
 
@@ -256,7 +257,7 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
     }
 #endif
 
-  const ElemType     base_et  (Base::get_elem_type(inf_elem_type));
+  const ElemType     base_et  (InfFEBase::get_elem_type(inf_elem_type));
   const Order o_radial (fe_t.radial_order);
   const Real v (p(Dim-1));
 
@@ -266,16 +267,16 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
   if (j== Dim -1)
     {
       Real RadialDeriv = InfFE<Dim,T_radial,T_map>::eval_deriv(v, o_radial, i_radial)
-        * InfFE<Dim,T_radial,T_map>::Radial::decay(v)
+        * InfFERadial::decay(Dim,v)
         + InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
-        * InfFE<Dim,T_radial,T_map>::Radial::decay_deriv(v);
+        * InfFERadial::decay_deriv(v);
 
       return FEInterface::shape(Dim-1, fe_t, base_et, i_base, p)*RadialDeriv;
     }
 
   return FEInterface::shape_deriv(Dim-1, fe_t, base_et, i_base, j, p)
     * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
-    * InfFE<Dim,T_radial,T_map>::Radial::decay(v);
+    * InfFERadial::decay(Dim,v);
 }
 
 
@@ -317,15 +318,15 @@ Real InfFE<Dim,T_radial,T_map>::shape_deriv (const FEType & fe_t,
   if (j== Dim -1)
     {
       Real RadialDeriv = InfFE<Dim,T_radial,T_map>::eval_deriv(v, o_radial, i_radial)
-        * InfFE<Dim,T_radial,T_map>::Radial::decay(v)
+        * InfFERadial::decay(Dim,v)
         + InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
-        * InfFE<Dim,T_radial,T_map>::Radial::decay_deriv(v);
+        * InfFERadial::decay_deriv(v);
 
       return FEInterface::shape(Dim-1, fe_t, base_el.get(), i_base, p)*RadialDeriv;
     }
   return FEInterface::shape_deriv(Dim-1, fe_t, base_el.get(), i_base, j, p)
     * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
-    * InfFE<Dim,T_radial,T_map>::Radial::decay(v);
+    * InfFERadial::decay(Dim,v);
 }
 
 
@@ -341,7 +342,7 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
   libmesh_assert_not_equal_to (Dim, 0);
 
   const Order        o_radial             (fet.radial_order);
-  const Order        radial_mapping_order (Radial::mapping_order());
+  const Order        radial_mapping_order (InfFERadial::mapping_order());
   const Point &      p                    (data.p);
   const Real         v                    (p(Dim-1));
   std::unique_ptr<const Elem> base_el (inf_elem->build_side_ptr(0));
@@ -467,7 +468,7 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
           unsigned int i_base, i_radial;
           compute_shape_indices(fet, inf_elem->type(), i, i_base, i_radial);
 
-          data.shape[i] = (InfFE<Dim,T_radial,T_map>::Radial::decay(v)                  /* (1.-v)/2. in 3D          */
+          data.shape[i] = (InfFERadial::decay(Dim,v)                                    /* (1.-v)/2. in 3D          */
                            * FEInterface::shape(Dim-1, fet, base_el.get(), i_base, p)   /* S_n(s,t)                 */
                            * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial))    /* L_n(v)                   */
                            * time_harmonic;                                             /* e^(i*k*phase(s,t,v)      */
@@ -475,21 +476,21 @@ void InfFE<Dim,T_radial,T_map>::compute_data(const FEType & fet,
           // use differentiation of the above equation
           if (data.need_derivative())
             {
-              data.dshape[i](0)     = (InfFE<Dim,T_radial,T_map>::Radial::decay(v)
+              data.dshape[i](0)     = (InfFERadial::decay(Dim,v)
                                        * FEInterface::shape_deriv(Dim-1, fet, base_el.get(), i_base, 0, p)
                                        * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial))
                                        * time_harmonic;
 
               if (Dim > 2)
                 {
-                  data.dshape[i](1)   = (InfFE<Dim,T_radial,T_map>::Radial::decay(v)
+                  data.dshape[i](1)   = (InfFERadial::decay(Dim,v)
                                          * FEInterface::shape_deriv(Dim-1, fet, base_el.get(), i_base, 1, p)
                                          * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial))
                                          * time_harmonic;
 
                 }
-              data.dshape[i](Dim-1)  = (InfFE<Dim,T_radial,T_map>::Radial::decay_deriv(v) * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
-                                        +InfFE<Dim,T_radial,T_map>::Radial::decay(v) * InfFE<Dim,T_radial,T_map>::eval_deriv(v, o_radial, i_radial))
+              data.dshape[i](Dim-1)  = (InfFERadial::decay_deriv(v) * InfFE<Dim,T_radial,T_map>::eval(v, o_radial, i_radial)
+                                        +InfFERadial::decay(Dim,v) * InfFE<Dim,T_radial,T_map>::eval_deriv(v, o_radial, i_radial))
                                         * FEInterface::shape(Dim-1, fet, base_el.get(), i_base, p) * time_harmonic;
 
 #ifdef LIBMESH_USE_COMPLEX_NUMBERS
@@ -870,7 +871,7 @@ void InfFE<Dim,T_radial,T_map>::compute_shape_indices (const FEType & fet,
   const unsigned int radial_order       = static_cast<unsigned int>(fet.radial_order.get_order()); // 4
   const unsigned int radial_order_p_one = radial_order+1;                                          // 5
 
-  const ElemType base_elem_type           (Base::get_elem_type(inf_elem_type));                    // QUAD9
+  const ElemType base_elem_type           (InfFEBase::get_elem_type(inf_elem_type));               // QUAD9
 
   // assume that the number of dof is the same for all vertices
   unsigned int n_base_vertices         = libMesh::invalid_uint;                                    // 4

--- a/src/geom/cell_inf_hex.C
+++ b/src/geom/cell_inf_hex.C
@@ -31,6 +31,7 @@
 #include "libmesh/face_inf_quad4.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/inf_fe_map.h"
 #include "libmesh/enum_elem_quality.h"
 
 namespace libMesh
@@ -449,7 +450,7 @@ bool InfHex::contains_point (const Point & p, Real tol) const
   // envelope may be non-spherical, the physical point may lie
   // inside the envelope, outside the envelope, or even inside
   // this infinite element.  Therefore if this fails,
-  // fall back to the FEInterface::inverse_map()
+  // fall back to the inverse_map()
   const Point my_origin (this->origin());
 
   // determine the minimal distance of the base from the origin
@@ -511,12 +512,8 @@ bool InfHex::contains_point (const Point & p, Real tol) const
   // and something else (not important) in radial direction.
   FEType fe_type(default_order());
 
-  const Point mapped_point = FEInterface::inverse_map(dim(),
-                                                      fe_type,
-                                                      this,
-                                                      p,
-                                                      tol,
-                                                      false);
+  const Point mapped_point = InfFEMap::inverse_map(dim(), this, p,
+                                                   tol, false);
 
   return FEInterface::on_reference_element(mapped_point, this->type(), tol);
 }

--- a/src/geom/cell_inf_prism.C
+++ b/src/geom/cell_inf_prism.C
@@ -26,6 +26,7 @@
 #include "libmesh/face_inf_quad4.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/inf_fe_map.h"
 #include "libmesh/enum_order.h"
 
 namespace libMesh
@@ -212,7 +213,7 @@ bool InfPrism::contains_point (const Point & p, Real tol) const
   // envelope may be non-spherical, the physical point may lie
   // inside the envelope, outside the envelope, or even inside
   // this infinite element.  Therefore if this fails,
-  // fall back to the FEInterface::inverse_map()
+  // fall back to the inverse_map()
   const Point my_origin (this->origin());
 
   // determine the minimal distance of the base from the origin
@@ -270,12 +271,8 @@ bool InfPrism::contains_point (const Point & p, Real tol) const
   // and something else (not important) in radial direction.
   FEType fe_type(default_order());
 
-  const Point mapped_point = FEInterface::inverse_map(dim(),
-                                                      fe_type,
-                                                      this,
-                                                      p,
-                                                      tol,
-                                                      false);
+  const Point mapped_point = InfFEMap::inverse_map(dim(), this, p,
+                                                   tol, false);
 
   return FEInterface::on_reference_element(mapped_point, this->type(), tol);
 }

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -2185,12 +2185,11 @@ bool Elem::point_test(const Point & p, Real box_tol, Real map_tol) const
   // To be on the safe side, we converge the inverse_map() iteration
   // to a slightly tighter tolerance than that requested by the
   // user...
-  const Point mapped_point = FEInterface::inverse_map(this->dim(),
-                                                      fe_type,
-                                                      this,
-                                                      p,
-                                                      0.1*map_tol, // <- this is |dx| tolerance, the Newton residual should be ~ |dx|^2
-                                                      /*secure=*/ false);
+  const Point mapped_point = FEMap::inverse_map(this->dim(),
+                                                this,
+                                                p,
+                                                0.1*map_tol, // <- this is |dx| tolerance, the Newton residual should be ~ |dx|^2
+                                                /*secure=*/ false);
 
   // Check that the refspace point maps back to p!  This is only necessary
   // for 1D and 2D elements, 3D elements always live in 3D.
@@ -2200,10 +2199,7 @@ bool Elem::point_test(const Point & p, Real box_tol, Real map_tol) const
   // the linear element types.
   if (this->dim() < 3)
     {
-      Point xyz = FEInterface::map(this->dim(),
-                                   fe_type,
-                                   this,
-                                   mapped_point);
+      Point xyz = FEMap::map(this->dim(), this, mapped_point);
 
       // Compute the distance between the original point and the re-mapped point.
       // They should be in the same place.
@@ -2212,7 +2208,7 @@ bool Elem::point_test(const Point & p, Real box_tol, Real map_tol) const
 
       // If dist is larger than some fraction of the tolerance, then return false.
       // This can happen when e.g. a 2D element is living in 3D, and
-      // FEInterface::inverse_map() maps p onto the projection of the element,
+      // FEMap::inverse_map() maps p onto the projection of the element,
       // effectively "tricking" FEInterface::on_reference_element().
       if (dist > this->hmax() * map_tol)
         return false;

--- a/src/geom/face_inf_quad4.C
+++ b/src/geom/face_inf_quad4.C
@@ -30,6 +30,7 @@
 #include "libmesh/edge_inf_edge2.h"
 #include "libmesh/enum_io_package.h"
 #include "libmesh/enum_order.h"
+#include "libmesh/inf_fe_map.h"
 
 namespace libMesh
 {
@@ -126,7 +127,7 @@ bool InfQuad4::contains_point (const Point & p, Real tol) const
    * this is not exclusive: the point may be outside
    * the envelope, but contained in another infinite element.
    * Therefore, if the distance is greater, do fall back
-   * to the scheme of using FEInterface::inverse_map().
+   * to the scheme of using inverse_map().
    */
   const Point my_origin (this->origin());
 
@@ -154,19 +155,15 @@ bool InfQuad4::contains_point (const Point & p, Real tol) const
   else
     {
       /*
-       * cannot say anything, fall back to the FEInterface::inverse_map()
+       * cannot say anything, fall back to the inverse_map()
        *
        * Declare a basic FEType.  Will use default in the base,
        * and something else (not important) in radial direction.
        */
       FEType fe_type(default_order());
 
-      const Point mapped_point = FEInterface::inverse_map(dim(),
-                                                          fe_type,
-                                                          this,
-                                                          p,
-                                                          tol,
-                                                          false);
+      const Point mapped_point = InfFEMap::inverse_map(dim(), this, p,
+                                                       tol, false);
 
       return FEInterface::on_reference_element(mapped_point, this->type(), tol);
     }

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -272,10 +272,8 @@ void MeshFunction::operator() (const Point & p,
          * Note that the fe_type can safely be used from the 0-variable,
          * since the inverse mapping is the same for all FEFamilies
          */
-        const Point mapped_point (FEInterface::inverse_map (dim,
-                                                            this->_dof_map.variable_type(0),
-                                                            element,
-                                                            p));
+        const Point mapped_point (FEMap::inverse_map (dim, element,
+                                                      p));
 
         // loop over all vars
         for (auto index : index_range(this->_system_vars))
@@ -363,10 +361,7 @@ void MeshFunction::discontinuous_value (const Point & p,
        * Note that the fe_type can safely be used from the 0-variable,
        * since the inverse mapping is the same for all FEFamilies
        */
-      const Point mapped_point (FEInterface::inverse_map (dim,
-                                                          this->_dof_map.variable_type(0),
-                                                          element,
-                                                          p));
+      const Point mapped_point (FEMap::inverse_map (dim, element, p));
 
       // loop over all vars
       for (auto index : index_range(this->_system_vars))
@@ -451,10 +446,8 @@ void MeshFunction::gradient (const Point & p,
          * Note that the fe_type can safely be used from the 0-variable,
          * since the inverse mapping is the same for all FEFamilies
          */
-        const Point mapped_point (FEInterface::inverse_map (dim,
-                                                            this->_dof_map.variable_type(0),
-                                                            element,
-                                                            p));
+        const Point mapped_point (FEMap::inverse_map (dim, element,
+                                                      p));
 
         std::vector<Point> point_list (1, mapped_point);
 
@@ -565,10 +558,7 @@ void MeshFunction::discontinuous_gradient (const Point & p,
        * Note that the fe_type can safely be used from the 0-variable,
        * since the inverse mapping is the same for all FEFamilies
        */
-      const Point mapped_point (FEInterface::inverse_map (dim,
-                                                          this->_dof_map.variable_type(0),
-                                                          element,
-                                                          p));
+      const Point mapped_point (FEMap::inverse_map (dim, element, p));
 
 
       // loop over all vars
@@ -687,10 +677,8 @@ void MeshFunction::hessian (const Point & p,
          * Note that the fe_type can safely be used from the 0-variable,
          * since the inverse mapping is the same for all FEFamilies
          */
-        const Point mapped_point (FEInterface::inverse_map (dim,
-                                                            this->_dof_map.variable_type(0),
-                                                            element,
-                                                            p));
+        const Point mapped_point (FEMap::inverse_map (dim, element,
+                                                      p));
 
         std::vector<Point> point_list (1, mapped_point);
 

--- a/src/solution_transfer/dtk_evaluator.C
+++ b/src/solution_transfer/dtk_evaluator.C
@@ -61,7 +61,7 @@ DTKEvaluator::evaluate(const Teuchos::ArrayRCP<int> & elements,
       for (unsigned int j=0; j<dim; j++)
         p(j) = coords[(j*num_values)+i];
 
-      const Point mapped_point(FEInterface::inverse_map(dim, dof_map.variable_type(0), elem, p));
+      const Point mapped_point(FEMap::inverse_map(dim, elem, p));
 
       FEComputeData data (es, mapped_point);
       FEInterface::compute_data (dim, fe_type, elem, data);

--- a/src/systems/dg_fem_context.C
+++ b/src/systems/dg_fem_context.C
@@ -97,11 +97,8 @@ void DGFEMContext::neighbor_side_fe_reinit ()
       FEAbstract * side_fe = _side_fe[this->get_dim()][neighbor_side_fe_type].get();
       qface_side_points = side_fe->get_xyz();
 
-      FEInterface::inverse_map (this->get_dim(),
-                                neighbor_side_fe_type,
-                                &get_neighbor(),
-                                qface_side_points,
-                                qface_neighbor_points);
+      FEMap::inverse_map (this->get_dim(), &get_neighbor(),
+                          qface_side_points, qface_neighbor_points);
 
       pr.second->reinit(&get_neighbor(), &qface_neighbor_points);
     }

--- a/src/systems/fem_context.C
+++ b/src/systems/fem_context.C
@@ -1913,11 +1913,8 @@ FEMContext::build_new_fe( const FEGenericBase<OutputShape>* fe,
   // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h
   // Build a vector of point co-ordinates to send to reinit
   Point master_point = this->has_elem() ?
-    FEInterface::inverse_map (elem_dim,
-                              fe_type,
-                              &this->get_elem(),
-                              p,
-                              tolerance) : Point(0);
+    FEMap::inverse_map (elem_dim, &this->get_elem(), p, tolerance) :
+    Point(0);
 
   std::vector<Point> coor(1, master_point);
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -2084,7 +2084,7 @@ Number System::point_value(unsigned int var,
   FEType fe_type = dof_map.variable_type(var);
 
   // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h.
-  Point coor = FEInterface::inverse_map(e.dim(), fe_type, &e, p);
+  Point coor = FEMap::inverse_map(e.dim(), &e, p);
 
   // get the shape function value via the FEInterface to also handle the case
   // of infinite elements correcly, the shape function is not fe->phi().
@@ -2217,7 +2217,7 @@ Gradient System::point_gradient(unsigned int var,
   FEType fe_type = dof_map.variable_type(var);
 
   // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h.
-  Point coor = FEInterface::inverse_map(dim, fe_type, &e, p);
+  Point coor = FEMap::inverse_map(dim, &e, p);
 
   // get the shape function value via the FEInterface to also handle the case
   // of infinite elements correcly, the shape function is not fe->phi().
@@ -2366,7 +2366,7 @@ Tensor System::point_hessian(unsigned int var,
 
   // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h
   // Build a vector of point co-ordinates to send to reinit
-  std::vector<Point> coor(1, FEInterface::inverse_map(e.dim(), fe_type, &e, p));
+  std::vector<Point> coor(1, FEMap::inverse_map(e.dim(), &e, p));
 
   // Get the values of the shape function derivatives
   const std::vector<std::vector<RealTensor>> &  d2phi = fe->get_d2phi();

--- a/tests/fe/fe_test.h
+++ b/tests/fe/fe_test.h
@@ -251,7 +251,7 @@ public:
               continue;
 
             std::vector<Point> master_points
-              (1, FEInterface::inverse_map(_dim, _fe->get_fe_type(), _elem, p));
+              (1, FEMap::inverse_map(_dim, _elem, p));
 
             _fe->reinit(_elem, &master_points);
 
@@ -300,7 +300,7 @@ public:
               continue;
 
             std::vector<Point> master_points
-              (1, FEInterface::inverse_map(_dim, _fe->get_fe_type(), _elem, p));
+              (1, FEMap::inverse_map(_dim, _elem, p));
 
             _fe->reinit(_elem, &master_points);
 
@@ -367,7 +367,7 @@ public:
               continue;
 
             std::vector<Point> master_points
-              (1, FEInterface::inverse_map(_dim, _fe->get_fe_type(), _elem, p));
+              (1, FEMap::inverse_map(_dim, _elem, p));
 
             _fe->reinit(_elem, &master_points);
 


### PR DESCRIPTION
```
// TODO: PB: We should consider moving this to the FEMap class
```

// TADA: All moved to the FEMap class.

Clearing out those years-old TODOs should make a few things infinitesimally more efficient, but more urgently it's a clean up that should make implementing the next tick box in #2179 cleaner too.

Begging @BalticPinguin to try this on his own infinite element codes; doing this cleanly required me to do an analogous refactoring on the InfFE class at the same time, but I'm much less confident about that part of it, and we don't have as much test coverage there as we should.