### PR TITLE
Add new warning to ignore in 3rd party code

### DIFF
--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -85,6 +85,7 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #if (__GNUC__ > 7)
 #pragma GCC diagnostic ignored "-Wparentheses"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif // GCC > 7
 #endif // GCC > 6
 #endif // GCC > 5


### PR DESCRIPTION
On Ubuntu 19.04 the use of g++ 8.3 and OpenMPI 3.1.3 together trigger
this warning for me.

Judging by https://github.com/open-mpi/ompi/issues/5157 there isn't an
underlying bug here, the overzealous warning isn't going to be fixable
upstream, and even if it was there'd still be users on the existing
releases, so let's just make sure we ignore it.