### PR TITLE
Hiding second derivatives in macro 2

### DIFF
--- a/include/fe/fe.h
+++ b/include/fe/fe.h
@@ -157,6 +157,7 @@ public:
                                  const unsigned int j,
                                  const Point & p);
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
    * \returns The second \f$ j^{th} \f$ derivative of the \f$ i^{th} \f$
    * shape function at the point \p p.
@@ -209,6 +210,7 @@ public:
                                         const unsigned int j,
                                         const Point & p);
 
+#endif //LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
    * Build the nodal soln from the element soln.
    * This is the solution that will be plotted.
@@ -519,11 +521,13 @@ public:
     FE<Dim,HERMITE> (fet)
   {}
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
    * 1D hermite functions on unit interval
    */
   static Real hermite_raw_shape_second_deriv(const unsigned int basis_num,
                                              const Real xi);
+#endif
   static Real hermite_raw_shape_deriv(const unsigned int basis_num,
                                       const Real xi);
   static Real hermite_raw_shape(const unsigned int basis_num,
@@ -551,6 +555,7 @@ Real FE<2,SUBDIVISION>::shape_deriv(const Elem * elem,
                                     const unsigned int j,
                                     const Point & p);
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 template <>
 Real FE<2,SUBDIVISION>::shape_second_deriv(const Elem * elem,
                                            const Order order,
@@ -558,6 +563,7 @@ Real FE<2,SUBDIVISION>::shape_second_deriv(const Elem * elem,
                                            const unsigned int j,
                                            const Point & p);
 
+#endif
 
 class FESubdivision : public FE<2,SUBDIVISION>
 {
@@ -633,6 +639,7 @@ public:
                                   const Real v,
                                   const Real w);
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
    * \returns The second \f$ j^{th} \f$ derivative of the
    * \f$ i^{th} \f$ of the 12 quartic box splines interpolating
@@ -645,6 +652,7 @@ public:
                                          const Real w);
 
 
+#endif // LIBMESH_ENABLE_SECOND_DERIVATIVE
   /**
    * Fills the vector \p weights with the weight coefficients
    * of the Loop subdivision mask for evaluating the limit surface

--- a/include/fe/fe_interface.h
+++ b/include/fe/fe_interface.h
@@ -327,6 +327,7 @@ public:
                            const unsigned int j,
                            const Point & p);
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   /**
    * \returns The second \f$ j^{th} \f$ derivative of the \f$ i^{th} \f$
    * shape function at the point \p p.
@@ -374,6 +375,8 @@ public:
                                   const unsigned int i,
                                   const unsigned int j,
                                   const Point & p);
+
+#endif
 
   /**
    * Lets the appropriate child of \p FEBase compute the requested

--- a/src/fe/fe_hermite_shape_3D.C
+++ b/src/fe/fe_hermite_shape_3D.C
@@ -646,6 +646,6 @@ Real FE<3,HERMITE>::shape_second_deriv(const Elem * elem,
     }
 }
 
-#endif
+#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 } // namespace libMesh

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -902,6 +902,7 @@ Real FEInterface::shape_deriv(const unsigned int dim,
   return 0;
 }
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 Real FEInterface::shape_second_deriv(const unsigned int dim,
                                      const FEType & fe_t,
@@ -966,6 +967,7 @@ Real FEInterface::shape_second_deriv(const unsigned int dim,
   return 0;
 }
 
+#endif //LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template<>
 void FEInterface::shape<RealGradient>(const unsigned int dim,

--- a/src/fe/fe_subdivision_2D.C
+++ b/src/fe/fe_subdivision_2D.C
@@ -276,6 +276,7 @@ Real FESubdivision::regular_shape_deriv(const unsigned int i,
 
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 Real FESubdivision::regular_shape_second_deriv(const unsigned int i,
                                                const unsigned int j,
                                                const Real v,
@@ -387,6 +388,7 @@ Real FESubdivision::regular_shape_second_deriv(const unsigned int i,
     }
 }
 
+#endif //LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 
 void FESubdivision::loop_subdivision_mask(std::vector<Real> & weights,
@@ -773,6 +775,7 @@ Real FE<2,SUBDIVISION>::shape_deriv(const Elem * elem,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 Real FE<2,SUBDIVISION>::shape_second_deriv(const ElemType type,
@@ -812,7 +815,7 @@ Real FE<2,SUBDIVISION>::shape_second_deriv(const Elem * elem,
   return FE<2,SUBDIVISION>::shape_second_deriv(elem->type(), order, i, j, p);
 }
 
-
+#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 template <>
 void FE<2,SUBDIVISION>::nodal_soln(const Elem * elem,


### PR DESCRIPTION
Hi, 
by updating, in addition to issue #2240, I had some compile-problems of the form
```
./.libs/libmesh_dbg.so: undefined reference to `libMesh::FE<3u, ...>:: shape_second_deriv( ElemType ,FEOrder<,3u ,unsigned int22,>
shape_second_deriv:(Point, const &ElemType),'
./.libs/libmesh_dbg.so: undefined reference to `libMesh::FE<3u, (libMesh.::/FEFamily.)libs22/>libmesh_dbg.so::: shape_second_derivundefined( libMeshreference: :toElemType ,` libMeshlibMesh::::FEOrder<,3u ,unsigned  (intlibMesh,: :unsignedFEFamily )int22,> :libMesh::shape_second_deriv:(PointlibMesh :const:&ElemType),'
libMesh.:/:.Orderlibs,/ libmesh_dbg.sounsigned:  intundefined,  referenceunsigned  toint ,` libMeshlibMesh::::FEPoint< 2uconst,& )('libMesh
:.:/FEFamily.)libs2/>libmesh_dbg.so::: shape_second_derivundefined( libMeshreference: :toElem  `constlibMesh*:,: FElibMesh<:2u:,Order ,( libMeshunsigned: :intFEFamily,) 2unsigned> :int:,shape_second_deriv (libMeshlibMesh::::PointElem  constconst&*),'
```
(using ``--disable-second``). For some reason, they showed up only now, and I must have forgotten them in #1983.

I hope, not to introduce some problems for some other configs by this...