### PR TITLE
Add DiagonalMatrix

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -809,6 +809,7 @@ include_HEADERS = \
         numerics/dense_subvector.h \
         numerics/dense_vector.h \
         numerics/dense_vector_base.h \
+        numerics/diagonal_matrix.h \
         numerics/distributed_vector.h \
         numerics/eigen_core_support.h \
         numerics/eigen_preconditioner.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -230,6 +230,7 @@ include_HEADERS =  \
         numerics/dense_subvector.h \
         numerics/dense_vector.h \
         numerics/dense_vector_base.h \
+        numerics/diagonal_matrix.h \
         numerics/distributed_vector.h \
         numerics/eigen_core_support.h \
         numerics/eigen_preconditioner.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -221,6 +221,7 @@ BUILT_SOURCES = \
         dense_subvector.h \
         dense_vector.h \
         dense_vector_base.h \
+        diagonal_matrix.h \
         distributed_vector.h \
         eigen_core_support.h \
         eigen_preconditioner.h \
@@ -1185,6 +1186,9 @@ dense_vector.h: $(top_srcdir)/include/numerics/dense_vector.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 dense_vector_base.h: $(top_srcdir)/include/numerics/dense_vector_base.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+diagonal_matrix.h: $(top_srcdir)/include/numerics/diagonal_matrix.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 distributed_vector.h: $(top_srcdir)/include/numerics/distributed_vector.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -560,7 +560,7 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	coupling_matrix.h dense_matrix.h dense_matrix_base.h \
 	dense_matrix_base_impl.h dense_matrix_impl.h dense_submatrix.h \
 	dense_subvector.h dense_vector.h dense_vector_base.h \
-	distributed_vector.h eigen_core_support.h \
+	diagonal_matrix.h distributed_vector.h eigen_core_support.h \
 	eigen_preconditioner.h eigen_sparse_matrix.h \
 	eigen_sparse_vector.h fem_function_base.h function_base.h \
 	laspack_matrix.h laspack_vector.h numeric_vector.h \
@@ -1530,6 +1530,9 @@ dense_vector.h: $(top_srcdir)/include/numerics/dense_vector.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 dense_vector_base.h: $(top_srcdir)/include/numerics/dense_vector_base.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+diagonal_matrix.h: $(top_srcdir)/include/numerics/diagonal_matrix.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 distributed_vector.h: $(top_srcdir)/include/numerics/distributed_vector.h

--- a/include/numerics/dense_matrix_base.h
+++ b/include/numerics/dense_matrix_base.h
@@ -31,6 +31,7 @@ namespace libMesh
 
 // Forward declarations
 template <typename T> class DenseVectorBase;
+template <typename T> class DenseVector;
 
 /**
  * Defines an abstract dense matrix base class for use in Finite Element-type
@@ -138,6 +139,11 @@ public:
     ScalarTraits<T2>::value, void >::type
   add (const T2 factor,
        const DenseMatrixBase<T3> & mat);
+
+  /**
+   * Return the matrix diagonal
+   */
+  DenseVector<T> diagonal() const;
 
 protected:
 

--- a/include/numerics/dense_matrix_base_impl.h
+++ b/include/numerics/dense_matrix_base_impl.h
@@ -23,6 +23,7 @@
 // Local Includes
 #include "libmesh/dense_matrix.h"
 #include "libmesh/dense_vector_base.h"
+#include "libmesh/dense_vector.h"
 
 // C++ includes
 #include <iomanip> // for std::setw()
@@ -30,7 +31,15 @@
 namespace libMesh
 {
 
-
+  template <typename T>
+  DenseVector<T>
+  DenseMatrixBase<T>::diagonal() const
+  {
+    DenseVector<T> ret;
+    for (decltype(_m) i = 0; i < _m; ++i)
+      ret(i) = el(i, i);
+    return ret;
+  }
 
   template<typename T>
   void DenseMatrixBase<T>::multiply (DenseMatrixBase<T> & M1,

--- a/include/numerics/dense_matrix_base_impl.h
+++ b/include/numerics/dense_matrix_base_impl.h
@@ -35,7 +35,7 @@ namespace libMesh
   DenseVector<T>
   DenseMatrixBase<T>::diagonal() const
   {
-    DenseVector<T> ret;
+    DenseVector<T> ret(_m);
     for (decltype(_m) i = 0; i < _m; ++i)
       ret(i) = el(i, i);
     return ret;

--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -1,0 +1,134 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#ifndef LIBMESH_DIAGONAL_MATRIX_H
+#define LIBMESH_DIAGONAL_MATRIX_H
+
+#include "libmesh/id_types.h"
+#include "libmesh/sparse_matrix.h"
+
+#include <memory>
+
+namespace libMesh
+{
+template <typename>
+class NumericVector;
+namespace Parallel
+{
+class Communicator;
+}
+
+/**
+ * Diagonal matrix class whose underlying storage is a vector
+ *
+ * \author Alexander D. Lindsay
+ * \date 2019
+ */
+template <typename T>
+class DiagonalMatrix : public SparseMatrix<T>
+{
+public:
+  /**
+   * Constructor; initializes the matrix to be empty, without any
+   * structure, i.e.  the matrix is not usable at all. This
+   * constructor is therefore only useful for matrices which are
+   * members of a class. All other matrices should be created at a
+   * point in the data flow where all necessary information is
+   * available.
+   *
+   * You have to initialize the matrix before usage with
+   * \p init(...).
+   */
+  explicit DiagonalMatrix(const Parallel::Communicator & comm);
+
+  /**
+   * unique pointers can be moved but not copied
+   */
+  DiagonalMatrix(DiagonalMatrix &&) = default;
+  DiagonalMatrix & operator=(DiagonalMatrix &&) = default;
+
+  /**
+   * Copy contents from vec into underlying diagonal storage
+   */
+  DiagonalMatrix & operator=(const NumericVector<T> & vec);
+
+  /**
+   * Move contents from vec into underlying diagonal storage
+   */
+  DiagonalMatrix & operator=(NumericVector<T> && vec);
+
+
+  void init(const numeric_index_type m,
+            const numeric_index_type n,
+            const numeric_index_type m_l,
+            const numeric_index_type n_l,
+            const numeric_index_type nnz = 30,
+            const numeric_index_type noz = 10,
+            const numeric_index_type blocksize = 1) override;
+
+  void init() override;
+
+  void clear() override;
+
+  void zero() override;
+
+  void close() override;
+
+  numeric_index_type m() const override;
+
+  numeric_index_type n() const override;
+
+  numeric_index_type row_start() const override;
+
+  numeric_index_type row_stop() const override;
+
+  void set(const numeric_index_type i, const numeric_index_type j, const T value) override;
+
+  void add(const numeric_index_type i, const numeric_index_type j, const T value) override;
+
+  void add_matrix(const DenseMatrix<T> & dm,
+                  const std::vector<numeric_index_type> & rows,
+                  const std::vector<numeric_index_type> & cols) override;
+
+  void add_matrix(const DenseMatrix<T> & dm,
+                  const std::vector<numeric_index_type> & dof_indices) override;
+
+  void add(const T a, const SparseMatrix<T> & X) override;
+
+  T operator()(const numeric_index_type i, const numeric_index_type j) const override;
+
+  Real l1_norm() const override;
+
+  Real linfty_norm() const override;
+
+  bool closed() const override;
+
+  void print_personal(std::ostream & os = libMesh::out) const override;
+
+  void get_diagonal(NumericVector<T> & dest) const override;
+
+  void get_transpose(SparseMatrix<T> & dest) const override;
+
+  void zero_rows(std::vector<numeric_index_type> & rows, T val = 0) override;
+
+protected:
+  /// Underlying diagonal matrix storage
+  std::unique_ptr<NumericVector<T>> _diagonal;
+};
+} // namespace libMesh
+
+#endif // LIBMESH_DIAGONAL_MATRIX_H

--- a/include/numerics/diagonal_matrix.h
+++ b/include/numerics/diagonal_matrix.h
@@ -82,6 +82,19 @@ public:
 
   void init() override;
 
+  /**
+   * Initialize with a NumericVector \p other, e.g. duplicate the storage
+   * allocation of \p other. This in general DOES NOT copy the vector entires
+   */
+  virtual void init(const NumericVector<T> & other, const bool fast = false);
+
+  /**
+   * Initialize with DiagonalMatrix \p other, e.g. duplicate the storage
+   * allocation of the underlying NumericVector in \p other. This in general
+   * DOES NOT copy the vector entires
+   */
+  virtual void init(const DiagonalMatrix<T> & other, const bool fast = false);
+
   void clear() override;
 
   void zero() override;
@@ -124,6 +137,8 @@ public:
   void get_transpose(SparseMatrix<T> & dest) const override;
 
   void zero_rows(std::vector<numeric_index_type> & rows, T val = 0) override;
+
+  const NumericVector<T> & diagonal() const;
 
 protected:
   /// Underlying diagonal matrix storage

--- a/include/numerics/eigen_sparse_vector.h
+++ b/include/numerics/eigen_sparse_vector.h
@@ -323,9 +323,7 @@ void EigenSparseVector<T>::init (const numeric_index_type n,
   _vec.resize(n);
 
   this->_is_initialized = true;
-#ifndef NDEBUG
   this->_is_closed = true;
-#endif
 
   // Optionally zero out all components
   if (fast == false)
@@ -377,9 +375,7 @@ void EigenSparseVector<T>::close ()
 {
   libmesh_assert (this->initialized());
 
-#ifndef NDEBUG
   this->_is_closed = true;
-#endif
 }
 
 
@@ -391,9 +387,7 @@ void EigenSparseVector<T>::clear ()
   _vec.resize(0);
 
   this->_is_initialized = false;
-#ifndef NDEBUG
   this->_is_closed = false;
-#endif
 }
 
 
@@ -485,9 +479,7 @@ void EigenSparseVector<T>::set (const numeric_index_type i, const T value)
 
   _vec[static_cast<eigen_idx_type>(i)] = value;
 
-#ifndef NDEBUG
   this->_is_closed = false;
-#endif
 }
 
 
@@ -501,9 +493,7 @@ void EigenSparseVector<T>::add (const numeric_index_type i, const T value)
 
   _vec[static_cast<eigen_idx_type>(i)] += value;
 
-#ifndef NDEBUG
   this->_is_closed = false;
-#endif
 }
 
 

--- a/include/numerics/numeric_vector.h
+++ b/include/numerics/numeric_vector.h
@@ -133,6 +133,12 @@ public:
   NumericVector & operator= (NumericVector &&) = default;
 
   /**
+   * While this class doesn't manage any memory, the derived class might and
+   * users may be deleting through a pointer to this base class
+   */
+  virtual ~NumericVector() = default;
+
+  /**
    * Builds a \p NumericVector on the processors in communicator
    * \p comm using the linear solver package specified by
    * \p solver_package

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -235,6 +235,7 @@ libmesh_SOURCES =  \
         src/numerics/dense_subvector.C \
         src/numerics/dense_vector.C \
         src/numerics/dense_vector_base.C \
+        src/numerics/diagonal_matrix.C \
         src/numerics/distributed_vector.C \
         src/numerics/eigen_preconditioner.C \
         src/numerics/eigen_sparse_matrix.C \

--- a/src/numerics/diagonal_matrix.C
+++ b/src/numerics/diagonal_matrix.C
@@ -1,0 +1,237 @@
+// The libMesh Finite Element Library.
+// Copyright (C) 2002-2019 Benjamin S. Kirk, John W. Peterson, Roy H. Stogner
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+#include "libmesh/diagonal_matrix.h"
+#include "libmesh/numeric_vector.h"
+#include "libmesh/dense_matrix.h"
+#include "libmesh/dof_map.h"
+#include "libmesh/libmesh_common.h"
+
+namespace libMesh
+{
+template <typename T>
+DiagonalMatrix<T>::DiagonalMatrix(const Parallel::Communicator & comm_in) : SparseMatrix<T>(comm_in)
+{
+  _diagonal = NumericVector<T>::build(comm_in);
+}
+
+template <typename T>
+DiagonalMatrix<T> &
+DiagonalMatrix<T>::operator=(const NumericVector<T> & vec)
+{
+  *_diagonal = vec;
+  return *this;
+}
+
+template <typename T>
+DiagonalMatrix<T> &
+DiagonalMatrix<T>::operator=(NumericVector<T> && vec)
+{
+  *_diagonal = vec;
+  return *this;
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::init(const numeric_index_type m,
+                        const numeric_index_type /*n*/,
+                        const numeric_index_type m_l,
+                        const numeric_index_type /*n_l*/,
+                        const numeric_index_type /*nnz*/,
+                        const numeric_index_type /*noz*/,
+                        const numeric_index_type /*blocksize*/)
+{
+  _diagonal->init(m, m_l);
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::init()
+{
+  libmesh_assert(this->_dof_map);
+
+  _diagonal->init(this->_dof_map->n_dofs());
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::clear()
+{
+  _diagonal->clear();
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::zero()
+{
+  _diagonal->zero();
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::close()
+{
+  _diagonal->close();
+}
+
+template <typename T>
+numeric_index_type
+DiagonalMatrix<T>::m() const
+{
+  return _diagonal->size();
+}
+
+template <typename T>
+numeric_index_type
+DiagonalMatrix<T>::n() const
+{
+  return _diagonal->size();
+}
+
+template <typename T>
+numeric_index_type
+DiagonalMatrix<T>::row_start() const
+{
+  return _diagonal->first_local_index();
+}
+
+template <typename T>
+numeric_index_type
+DiagonalMatrix<T>::row_stop() const
+{
+  return _diagonal->last_local_index();
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::set(const numeric_index_type i, const numeric_index_type j, const T value)
+{
+  if (i == j)
+    _diagonal->set(i, value);
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::add(const numeric_index_type i, const numeric_index_type j, const T value)
+{
+  if (i == j)
+    _diagonal->add(i, value);
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
+                              const std::vector<numeric_index_type> & rows,
+                              const std::vector<numeric_index_type> & cols)
+{
+  auto m = dm.m();
+  auto n = dm.n();
+
+  for (decltype(m) i = 0; i < m; ++i)
+    for (decltype(n) j = 0; j < n; ++j)
+    {
+      auto global_i = rows[i];
+      auto global_j = cols[j];
+      if (global_i == global_j)
+        _diagonal->add(global_i, dm(i, j));
+    }
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::add_matrix(const DenseMatrix<T> & dm,
+                              const std::vector<numeric_index_type> & dof_indices)
+{
+  _diagonal->add_vector(dm.diagonal(), dof_indices);
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::add(const T a, const SparseMatrix<T> & X)
+{
+  auto & x_diagonal = *_diagonal->zero_clone();
+  X.get_diagonal(x_diagonal);
+  _diagonal->add(a, x_diagonal);
+}
+
+template <typename T>
+T
+DiagonalMatrix<T>::operator()(const numeric_index_type i, const numeric_index_type j) const
+{
+  if (i == j)
+    return (*_diagonal)(i);
+  else
+    return 0;
+}
+
+template <typename T>
+Real
+DiagonalMatrix<T>::l1_norm() const
+{
+  return _diagonal->l1_norm();
+}
+
+template <typename T>
+Real
+DiagonalMatrix<T>::linfty_norm() const
+{
+  return _diagonal->linfty_norm();
+}
+
+template <typename T>
+bool
+DiagonalMatrix<T>::closed() const
+{
+  return _diagonal->closed();
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::print_personal(std::ostream & os) const
+{
+  _diagonal->print(os);
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::get_diagonal(NumericVector<T> & dest) const
+{
+  dest = *_diagonal;
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::get_transpose(SparseMatrix<T> & dest) const
+{
+  auto diagonal_dest = dynamic_cast<DiagonalMatrix<T> *>(&dest);
+  if (diagonal_dest)
+    *diagonal_dest = *_diagonal;
+  else
+    libmesh_error_msg("DenseMatrix<T>::get_transpose currently only accepts another DenseMatrix<T> "
+                      "as its argument");
+}
+
+template <typename T>
+void
+DiagonalMatrix<T>::zero_rows(std::vector<numeric_index_type> & rows, T val/*=0*/)
+{
+  for (auto row : rows)
+    _diagonal->set(row, val);
+}
+
+template class DiagonalMatrix<Number>;
+}

--- a/src/numerics/eigen_sparse_vector.C
+++ b/src/numerics/eigen_sparse_vector.C
@@ -166,9 +166,7 @@ void EigenSparseVector<T>::add (const T v)
 {
   _vec += EigenSV::Constant(this->size(), v);
 
-#ifndef NDEBUG
   this->_is_closed = false;
-#endif
 }
 
 
@@ -308,9 +306,7 @@ EigenSparseVector<T>::operator = (const EigenSparseVector<T> & v)
 
   _vec = v._vec;
 
-#ifndef NDEBUG
   this->_is_closed = true;
-#endif
 
   return *this;
 }
@@ -389,9 +385,7 @@ void EigenSparseVector<T>::localize (const numeric_index_type libmesh_dbg_var(fi
 
   libmesh_assert_less_equal (send_list.size(), this->size());
 
-#ifndef NDEBUG
   this->_is_closed = true;
-#endif
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -79,6 +79,7 @@ unit_tests_sources = \
   numerics/vector_value_test.C \
   numerics/type_tensor_test.C \
   numerics/dense_matrix_test.C \
+  numerics/diagonal_matrix_test.C \
   parallel/message_tag.C \
   parallel/packed_range_test.C \
   parallel/parallel_sort_test.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -213,10 +213,10 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/diagonal_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -287,6 +287,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	numerics/unit_tests_dbg-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_dbg-dense_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_dbg-diagonal_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-message_tag.$(OBJEXT) \
 	parallel/unit_tests_dbg-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_dbg-parallel_sort_test.$(OBJEXT) \
@@ -349,10 +350,10 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/diagonal_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -422,6 +423,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	numerics/unit_tests_devel-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_devel-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_devel-dense_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_devel-diagonal_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_devel-message_tag.$(OBJEXT) \
 	parallel/unit_tests_devel-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_devel-parallel_sort_test.$(OBJEXT) \
@@ -481,10 +483,10 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/diagonal_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -554,6 +556,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	numerics/unit_tests_oprof-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_oprof-dense_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_oprof-diagonal_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-message_tag.$(OBJEXT) \
 	parallel/unit_tests_oprof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_oprof-parallel_sort_test.$(OBJEXT) \
@@ -613,10 +616,10 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/diagonal_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -686,6 +689,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	numerics/unit_tests_opt-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_opt-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_opt-dense_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_opt-diagonal_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_opt-message_tag.$(OBJEXT) \
 	parallel/unit_tests_opt-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_opt-parallel_sort_test.$(OBJEXT) \
@@ -744,10 +748,10 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/diagonal_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -817,6 +821,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	numerics/unit_tests_prof-vector_value_test.$(OBJEXT) \
 	numerics/unit_tests_prof-type_tensor_test.$(OBJEXT) \
 	numerics/unit_tests_prof-dense_matrix_test.$(OBJEXT) \
+	numerics/unit_tests_prof-diagonal_matrix_test.$(OBJEXT) \
 	parallel/unit_tests_prof-message_tag.$(OBJEXT) \
 	parallel/unit_tests_prof-packed_range_test.$(OBJEXT) \
 	parallel/unit_tests_prof-parallel_sort_test.$(OBJEXT) \
@@ -1083,6 +1088,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po \
+	numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po \
@@ -1095,6 +1101,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-dense_matrix_test.Po \
+	numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po \
@@ -1107,6 +1114,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-dense_matrix_test.Po \
+	numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po \
@@ -1119,6 +1127,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-dense_matrix_test.Po \
+	numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po \
@@ -1131,6 +1140,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-dense_matrix_test.Po \
+	numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po \
 	numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po \
@@ -1684,10 +1694,10 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	numerics/trilinos_epetra_vector_test.C \
 	numerics/type_vector_test.h numerics/vector_value_test.C \
 	numerics/type_tensor_test.C numerics/dense_matrix_test.C \
-	parallel/message_tag.C parallel/packed_range_test.C \
-	parallel/parallel_sort_test.C parallel/parallel_sync_test.C \
-	parallel/parallel_test.C parallel/parallel_point_test.C \
-	partitioning/partitioner_test.h \
+	numerics/diagonal_matrix_test.C parallel/message_tag.C \
+	parallel/packed_range_test.C parallel/parallel_sort_test.C \
+	parallel/parallel_sync_test.C parallel/parallel_test.C \
+	parallel/parallel_point_test.C partitioning/partitioner_test.h \
 	partitioning/centroid_partitioner_test.C \
 	partitioning/hilbert_sfc_partitioner_test.C \
 	partitioning/linear_partitioner_test.C \
@@ -1916,6 +1926,8 @@ numerics/unit_tests_dbg-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_dbg-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_dbg-diagonal_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/$(am__dirstamp):
 	@$(MKDIR_P) parallel
 	@: > parallel/$(am__dirstamp)
@@ -2120,6 +2132,8 @@ numerics/unit_tests_devel-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_devel-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_devel-diagonal_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_devel-packed_range_test.$(OBJEXT):  \
@@ -2281,6 +2295,8 @@ numerics/unit_tests_oprof-vector_value_test.$(OBJEXT):  \
 numerics/unit_tests_oprof-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_oprof-dense_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_oprof-diagonal_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_oprof-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -2444,6 +2460,8 @@ numerics/unit_tests_opt-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_opt-dense_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_opt-diagonal_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_opt-packed_range_test.$(OBJEXT):  \
@@ -2605,6 +2623,8 @@ numerics/unit_tests_prof-vector_value_test.$(OBJEXT):  \
 numerics/unit_tests_prof-type_tensor_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 numerics/unit_tests_prof-dense_matrix_test.$(OBJEXT):  \
+	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
+numerics/unit_tests_prof-diagonal_matrix_test.$(OBJEXT):  \
 	numerics/$(am__dirstamp) numerics/$(DEPDIR)/$(am__dirstamp)
 parallel/unit_tests_prof-message_tag.$(OBJEXT):  \
 	parallel/$(am__dirstamp) parallel/$(DEPDIR)/$(am__dirstamp)
@@ -2902,6 +2922,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po@am__quote@ # am--include-marker
@@ -2914,6 +2935,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-dense_matrix_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po@am__quote@ # am--include-marker
@@ -2926,6 +2948,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-dense_matrix_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po@am__quote@ # am--include-marker
@@ -2938,6 +2961,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-dense_matrix_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po@am__quote@ # am--include-marker
@@ -2950,6 +2974,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-dense_matrix_test.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po@am__quote@ # am--include-marker
@@ -3859,6 +3884,20 @@ numerics/unit_tests_dbg-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/dense_matrix_test.C' object='numerics/unit_tests_dbg-dense_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
+
+numerics/unit_tests_dbg-diagonal_matrix_test.o: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-diagonal_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_dbg-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_dbg-diagonal_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+
+numerics/unit_tests_dbg-diagonal_matrix_test.obj: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_dbg-diagonal_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_dbg-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_dbg-diagonal_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_dbg-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
 
 parallel/unit_tests_dbg-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_dbg-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_dbg-message_tag.Tpo -c -o parallel/unit_tests_dbg-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
@@ -4924,6 +4963,20 @@ numerics/unit_tests_devel-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+numerics/unit_tests_devel-diagonal_matrix_test.o: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-diagonal_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_devel-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_devel-diagonal_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+
+numerics/unit_tests_devel-diagonal_matrix_test.obj: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_devel-diagonal_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_devel-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_devel-diagonal_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_devel-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+
 parallel/unit_tests_devel-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_devel-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo -c -o parallel/unit_tests_devel-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_devel-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_devel-message_tag.Po
@@ -5987,6 +6040,20 @@ numerics/unit_tests_oprof-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/dense_matrix_test.C' object='numerics/unit_tests_oprof-dense_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
+
+numerics/unit_tests_oprof-diagonal_matrix_test.o: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-diagonal_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_oprof-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_oprof-diagonal_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+
+numerics/unit_tests_oprof-diagonal_matrix_test.obj: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_oprof-diagonal_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_oprof-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_oprof-diagonal_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_oprof-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
 
 parallel/unit_tests_oprof-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_oprof-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_oprof-message_tag.Tpo -c -o parallel/unit_tests_oprof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
@@ -7052,6 +7119,20 @@ numerics/unit_tests_opt-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+numerics/unit_tests_opt-diagonal_matrix_test.o: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-diagonal_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_opt-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_opt-diagonal_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+
+numerics/unit_tests_opt-diagonal_matrix_test.obj: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_opt-diagonal_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_opt-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_opt-diagonal_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_opt-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+
 parallel/unit_tests_opt-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_opt-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo -c -o parallel/unit_tests_opt-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_opt-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_opt-message_tag.Po
@@ -8116,6 +8197,20 @@ numerics/unit_tests_prof-dense_matrix_test.obj: numerics/dense_matrix_test.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-dense_matrix_test.obj `if test -f 'numerics/dense_matrix_test.C'; then $(CYGPATH_W) 'numerics/dense_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/dense_matrix_test.C'; fi`
 
+numerics/unit_tests_prof-diagonal_matrix_test.o: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-diagonal_matrix_test.o -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_prof-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_prof-diagonal_matrix_test.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-diagonal_matrix_test.o `test -f 'numerics/diagonal_matrix_test.C' || echo '$(srcdir)/'`numerics/diagonal_matrix_test.C
+
+numerics/unit_tests_prof-diagonal_matrix_test.obj: numerics/diagonal_matrix_test.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT numerics/unit_tests_prof-diagonal_matrix_test.obj -MD -MP -MF numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Tpo -c -o numerics/unit_tests_prof-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Tpo numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='numerics/diagonal_matrix_test.C' object='numerics/unit_tests_prof-diagonal_matrix_test.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o numerics/unit_tests_prof-diagonal_matrix_test.obj `if test -f 'numerics/diagonal_matrix_test.C'; then $(CYGPATH_W) 'numerics/diagonal_matrix_test.C'; else $(CYGPATH_W) '$(srcdir)/numerics/diagonal_matrix_test.C'; fi`
+
 parallel/unit_tests_prof-message_tag.o: parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT parallel/unit_tests_prof-message_tag.o -MD -MP -MF parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo -c -o parallel/unit_tests_prof-message_tag.o `test -f 'parallel/message_tag.C' || echo '$(srcdir)/'`parallel/message_tag.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) parallel/$(DEPDIR)/unit_tests_prof-message_tag.Tpo parallel/$(DEPDIR)/unit_tests_prof-message_tag.Po
@@ -8884,6 +8979,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po
@@ -8896,6 +8992,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po
@@ -8908,6 +9005,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po
@@ -8920,6 +9018,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po
@@ -8932,6 +9031,7 @@ distclean: distclean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po
@@ -9309,6 +9409,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_dbg-laspack_vector_test.Po
@@ -9321,6 +9422,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_devel-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_devel-laspack_vector_test.Po
@@ -9333,6 +9435,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_oprof-laspack_vector_test.Po
@@ -9345,6 +9448,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_opt-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_opt-laspack_vector_test.Po
@@ -9357,6 +9461,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-composite_function_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-coupling_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-dense_matrix_test.Po
+	-rm -f numerics/$(DEPDIR)/unit_tests_prof-diagonal_matrix_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-distributed_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-eigen_sparse_vector_test.Po
 	-rm -f numerics/$(DEPDIR)/unit_tests_prof-laspack_vector_test.Po

--- a/tests/numerics/diagonal_matrix_test.C
+++ b/tests/numerics/diagonal_matrix_test.C
@@ -40,7 +40,7 @@ public:
   void setUp()
   {
     _comm = TestCommWorld;
-    _matrix = libmesh_make_unique<DiagonalMatrix<Real>>(*_comm);
+    _matrix = libmesh_make_unique<DiagonalMatrix<Number>>(*_comm);
 
     numeric_index_type root_block_size = 2;
     _local_size = root_block_size + static_cast<numeric_index_type>(_comm->rank());
@@ -82,8 +82,8 @@ public:
     _matrix->set(beginning_index + 1, beginning_index, 1);
 
     // Test that off-diagonal elements are always zero
-    LIBMESH_ASSERT_FP_EQUAL((*_matrix)(beginning_index, beginning_index + 1), 0, _tolerance);
-    LIBMESH_ASSERT_FP_EQUAL((*_matrix)(beginning_index + 1, beginning_index), 0, _tolerance);
+    LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(beginning_index, beginning_index + 1)), 0, _tolerance);
+    LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(beginning_index + 1, beginning_index)), 0, _tolerance);
 
     // Test add
     {
@@ -101,9 +101,9 @@ public:
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
       {
         if (i)
-          LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), i, _tolerance);
+          LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), i, _tolerance);
         else
-          LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), _comm->size(), _tolerance);
+          LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), _comm->size(), _tolerance);
       }
     }
 
@@ -124,9 +124,9 @@ public:
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
       {
         if (i != _global_size - 1)
-          LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), i, _tolerance);
+          LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), i, _tolerance);
         else
-          LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), 0, _tolerance);
+          LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), 0, _tolerance);
       }
     }
 
@@ -135,7 +135,7 @@ public:
 
     // Test dense matrix add, get diagonal, SparseMatrix add, get transpose
     {
-      DenseMatrix<Real> dense(_local_size, _local_size);
+      DenseMatrix<Number> dense(_local_size, _local_size);
 
       for (numeric_index_type local_index = 0, global_index = beginning_index;
            local_index < _local_size;
@@ -152,17 +152,17 @@ public:
       _matrix->close();
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), i, _tolerance);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), i, _tolerance);
 
       // Build
-      auto diagonal = NumericVector<Real>::build(*_comm);
+      auto diagonal = NumericVector<Number>::build(*_comm);
       // Allocate storage
       diagonal->init(_matrix->diagonal());
       // Fill entries
       _matrix->get_diagonal(*diagonal);
 
       // Build
-      DiagonalMatrix<Real> copy(*_comm);
+      DiagonalMatrix<Number> copy(*_comm);
       // Allocate storage
       copy.init(*_matrix);
       // Fill entries from diagonal
@@ -173,18 +173,18 @@ public:
       _matrix->close();
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), 2 * i, _tolerance);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), 2 * i, _tolerance);
 
       // SparseMatrix add
       _matrix->add(-1, copy);
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), i, _tolerance);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, i)), i, _tolerance);
 
       _matrix->get_transpose(copy);
 
       for (numeric_index_type i = beginning_index; i < end_index; ++i)
-        LIBMESH_ASSERT_FP_EQUAL(copy(i, i), i, _tolerance);
+        LIBMESH_ASSERT_FP_EQUAL(libmesh_real(copy(i, i)), i, _tolerance);
     }
 
     // Test norms
@@ -200,9 +200,9 @@ public:
         for (numeric_index_type j = beginning_index; j < end_index; ++j)
         {
           if (i == j)
-            LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, j), 1, _tolerance);
+            LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, j)), 1, _tolerance);
           else
-            LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, j), 0, _tolerance);
+            LIBMESH_ASSERT_FP_EQUAL(libmesh_real((*_matrix)(i, j)), 0, _tolerance);
         }
     }
   }
@@ -210,7 +210,7 @@ public:
 private:
 
   Parallel::Communicator * _comm;
-  std::unique_ptr<DiagonalMatrix<Real>> _matrix;
+  std::unique_ptr<DiagonalMatrix<Number>> _matrix;
   numeric_index_type _local_size, _global_size;
   std::vector<numeric_index_type> _i;
   const Real _tolerance = TOLERANCE * TOLERANCE;

--- a/tests/numerics/diagonal_matrix_test.C
+++ b/tests/numerics/diagonal_matrix_test.C
@@ -1,0 +1,213 @@
+// libmesh includes
+#include <libmesh/diagonal_matrix.h>
+#include <libmesh/parallel.h>
+#include <libmesh/auto_ptr.h>
+#include <libmesh/dense_matrix.h>
+#include <libmesh/id_types.h>
+#include <libmesh/numeric_vector.h>
+
+#include "libmesh_cppunit.h"
+
+#include <memory>
+#include <numeric>
+
+#define UNUSED 0
+
+using namespace libMesh;
+
+namespace
+{
+template <typename T>
+T
+termial(T n)
+{
+  if (n == 0)
+    return 1;
+  return n * termial(n - 1);
+}
+}
+
+class DiagonalMatrixTest : public CppUnit::TestCase
+{
+public:
+  void setUp()
+  {
+    _comm = TestCommWorld;
+    _matrix = libmesh_make_unique<DiagonalMatrix<Real>>(*_comm);
+
+    numeric_index_type root_block_size = 2;
+    _local_size = root_block_size + static_cast<numeric_index_type>(_comm->rank());
+    _global_size = 0;
+    _i.push_back(0);
+
+    for (processor_id_type p = 0; p < _comm->size(); ++p)
+    {
+      numeric_index_type block_size = root_block_size + static_cast<numeric_index_type>(p);
+      _global_size += block_size;
+      _i.push_back(block_size);
+    }
+
+    _matrix->init(global_size, UNUSED, local_size, UNUSED);
+  }
+
+  void tearDown() {}
+
+  CPPUNIT_TEST_SUITE(DiagonalMatrixTest);
+
+  CPPUNIT_TEST(testSizes);
+  CPPUNIT_TEST(testNumerics);
+
+  CPPUNIT_TEST_SUITE_END();
+
+private:
+  void testSizes()
+  {
+    CPPUNIT_ASSERT_EQUAL(_global_size, _matrix->m());
+    CPPUNIT_ASSERT_EQUAL(_global_size, _matrix->n());
+    CPPUNIT_ASSERT_EQUAL(_i[_comm->rank()], _matrix->row_start());
+    CPPUNIT_ASSERT_EQUAL(_i[_comm->rank() + 1], _matrix->row_stop());
+  }
+
+  void testNumerics()
+  {
+    numeric_index_type beginning_index = _matrix->row_start();
+    numeric_index_type end_index = _matrix->row_stop();
+
+    CPPUNIT_ASSERT_EQUAL(_local_size, _matrix->row_stop() - _matrix->row_start());
+
+    _matrix->zero();
+
+    // In general we don't want to mix these calls without an intervening close(), but since these
+    // calls are not actually doing anything for this matrix type it's ok here
+    _matrix->add(beginning_index, beginning_index + 1, 1);
+    _matrix->set(beginning_index + 1, beginning_index, 1);
+
+    // Test that off-diagonal elements are always zero
+    LIBMESH_ASSERT_FP_EQUAL((*_matrix)(beginning_index, beginning_index + 1), 0, _tolerance);
+    LIBMESH_ASSERT_FP_EQUAL((*_matrix)(beginning_index + 1, beginning_index), 0, _tolerance);
+
+    // Test add
+    {
+      for (numeric_index_type i = beginning_index; i < end_index; ++i)
+        _matrix->add(i, i, i);
+
+      // Also add to rank 0
+      _matrix->add(0, 0, 1);
+
+      CPPUNIT_ASSERT(!_matrix->closed())
+
+      _matrix->close();
+      CPPUNIT_ASSERT(_matrix->closed())
+
+      for (numeric_index_type i = beginning_index; i < end_index; ++i)
+      {
+        if (i)
+          LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), i, _tolerance);
+        else
+          LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), _comm->size(), _tolerance);
+      }
+    }
+
+    // Test set
+    {
+      for (numeric_index_type i = beginning_index; i < end_index; ++i)
+        if (i != _global_size - 1)
+          _matrix->set(i, i, i);
+
+      if (_comm->rank() == 0)
+        _matrix->set(_global_size - 1, _global_size - 1, 0);
+
+      CPPUNIT_ASSERT(!_matrix->closed())
+
+      _matrix->close();
+      CPPUNIT_ASSERT(_matrix->closed())
+
+      for (numeric_index_type i = beginning_index; i < end_index; ++i)
+      {
+        if (i != _global_size - 1)
+          LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), i, _tolerance);
+        else
+          LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), 0, _tolerance);
+      }
+    }
+
+    std::vector<numeric_index_type> rows(_local_size);
+    std::iota(rows.begin(), rows.end(), beginning_index);
+
+    // Test dense matrix add, get diagonal, SparseMatrix add, get transpose
+    {
+      DenseMatrix<Real> dense(_local_size);
+
+      for (numeric_index_type local_index = 0, global_index = beginning_index;
+           local_index < _local_size;
+           ++local_index, ++global_index)
+        dense(local_index, local_index) = global_index;
+
+      _matrix->zero();
+
+      // rows-columns overload for DenseMatrix add
+      _matrix->add_matrix(dense, rows, rows);
+
+      // Close not really necessary here because we didn't do anything off-process but still good
+      // practice
+      _matrix->close();
+
+      for (numeric_index_type i = beginning_index; i < end_index; ++i)
+        LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), i, _tolerance);
+
+      auto diagonal = *NumericVector<Real>::build(*_comm);
+      _matrix->get_diagonal(vector);
+
+      DiagonalMatrix<Real> copy(*_comm);
+
+      // Move assignment from NumericVector
+      copy = std::move(diagonal);
+
+      // Single dof-indices overload for DenseMatrix add
+      _matrix->add_matrix(dense, rows);
+      _matrix->close();
+
+      for (numeric_index_type i = beginning_index; i < end_index; ++i)
+        LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), 2 * i, _tolerance);
+
+      // SparseMatrix add
+      _matrix->add(-1, copy);
+
+      for (numeric_index_type i = beginning_index; i < end_index; ++i)
+        LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, i), i, _tolerance);
+
+      copy.clear();
+      _matrix->get_transpose(copy);
+
+      for (numeric_index_type i = beginning_index; i < end_index; ++i)
+        LIBMESH_ASSERT_FP_EQUAL(copy(i, i), i, _tolerance);
+    }
+
+    // Test norms
+    {
+      LIBMESH_ASSERT_FP_EQUAL(_matrix->l1_norm(), termial(_global_size - 1), _tolerance);
+      LIBMESH_ASSERT_FP_EQUAL(_matrix->linfty_norm(), _global_size - 1, _tolerance);
+    }
+
+    // Test zero_rows
+    {
+      _matrix->zero_rows(rows, 1);
+      for (numeric_index_type i = beginning_index; i < end_index; ++i)
+        for (numeric_index_type j = beginning_index; j < end_index; ++j)
+        {
+          if (i == j)
+            LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, j), 1, _tolerance);
+          else
+            LIBMESH_ASSERT_FP_EQUAL((*_matrix)(i, j), 0, _tolerance);
+        }
+    }
+  }
+
+  Parallel::Communicator * _comm;
+  std::unique_ptr<DiagonalMatrix<Real>> _matrix;
+  numeric_index_type _local_size, _global_size;
+  std::vector<numeric_index_type> _i;
+  const Real _tolerance = TOLERANCE * TOLERANCE;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(DiagonalMatrixTest);

--- a/tests/numerics/diagonal_matrix_test.C
+++ b/tests/numerics/diagonal_matrix_test.C
@@ -22,14 +22,20 @@ template <typename T>
 T
 termial(T n)
 {
-  if (n == 1)
-    return 1;
-  return n + termial(n - 1);
+  return n * (n + 1) / 2;
 }
 }
 
 class DiagonalMatrixTest : public CppUnit::TestCase
 {
+public:
+  CPPUNIT_TEST_SUITE(DiagonalMatrixTest);
+
+  CPPUNIT_TEST(testSizes);
+  CPPUNIT_TEST(testNumerics);
+
+  CPPUNIT_TEST_SUITE_END();
+
 public:
   void setUp()
   {
@@ -45,7 +51,7 @@ public:
     {
       numeric_index_type block_size = root_block_size + static_cast<numeric_index_type>(p);
       _global_size += block_size;
-      _i.push_back(block_size);
+      _i.push_back(_global_size);
     }
 
     _matrix->init(_global_size, UNUSED, _local_size, UNUSED);
@@ -53,14 +59,6 @@ public:
 
   void tearDown() {}
 
-  CPPUNIT_TEST_SUITE(DiagonalMatrixTest);
-
-  CPPUNIT_TEST(testSizes);
-  CPPUNIT_TEST(testNumerics);
-
-  CPPUNIT_TEST_SUITE_END();
-
-private:
   void testSizes()
   {
     CPPUNIT_ASSERT_EQUAL(_global_size, _matrix->m());
@@ -208,6 +206,8 @@ private:
         }
     }
   }
+
+private:
 
   Parallel::Communicator * _comm;
   std::unique_ptr<DiagonalMatrix<Real>> _matrix;

--- a/tests/parallel/parallel_test.C
+++ b/tests/parallel/parallel_test.C
@@ -689,10 +689,11 @@ public:
   {
     Parallel::Communicator subcomm;
     unsigned int rank = TestCommWorld->rank();
-    Parallel::info i;
+    Parallel::info i = 0;
     int type = 0;
 #ifdef LIBMESH_HAVE_MPI
     type = MPI_COMM_TYPE_SHARED;
+    i = MPI_INFO_NULL;
 #endif
     TestCommWorld->split_by_type(type, rank, i, subcomm);
 


### PR DESCRIPTION
`DiagonalMatrix` holds its data in an underlying `NumericVector` data member, and shims all its methods down into it.

Also:
- add a templated `add_matrix` method to `ImplicitSystem` that allows a user to specify the type of matrix they want to add, since I may want to simultaneously have a `PetscMatrix` and `DiagonalMatrix` held by the system (and because `DiagonalMatrix` itself is not associated with a solver package (although its underlying `NumericVector` is))

Closes #2168 
