### PR TITLE
Add ExodusII_IO_Helper::MappedOutputVector

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -734,6 +734,26 @@ protected:
 
   std::map<const std::vector<Real> *, void *> mapped_vectors;
 
+  // RAII-enabled version of the {create,move}_{input,output}_buffer() stuff.
+  struct MappedOutputVector
+  {
+    // Does the float copy if necessary, as in create_output_buffer()
+    MappedOutputVector(const std::vector<Real> & vec_in,
+                       bool single_precision_in);
+
+    // Deletes anything allocated, as in remove_output_buffer()
+    ~MappedOutputVector();
+
+    // returns void * pointer to the float-mapped data or the original
+    // data, as necessary
+    void * data();
+
+  private:
+    const std::vector<Real> & our_data;
+    bool single_precision;
+    void * mapped_vec;
+  };
+
 private:
 
   /**

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -724,14 +724,6 @@ protected:
   // Exodus.
   void move_input_buffer_data(std::vector<Real> & our_data);
 
-  // Mapping of vector<Real> to vector<whatever-the-file-uses> data,
-  // which may just be the original vector
-  void * create_output_buffer(const std::vector<Real> & our_data);
-
-  // If our data buffer wasn't the original vector, then we need to
-  // free it after we've written it via Exodus.
-  void remove_output_buffer(const std::vector<Real> & our_data);
-
   std::map<const std::vector<Real> *, void *> mapped_vectors;
 
   // RAII-enabled version of the {create,move}_{input,output}_buffer() stuff.

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -460,69 +460,6 @@ ExodusII_IO_Helper::MappedOutputVector::data()
   return const_cast<void *>(static_cast<const void *>(our_data.data()));
 }
 
-void * ExodusII_IO_Helper::create_output_buffer(const std::vector<Real> & our_data)
-{
-  // We should never do this multiple times at once
-  libmesh_assert(!mapped_vectors.count(&our_data));
-
-  if (_single_precision)
-    {
-      if (sizeof(Real) != sizeof(float))
-        {
-          std::vector<float> * vec =
-            new std::vector<float>(our_data.begin(), our_data.end());
-          void * vec_ptr = static_cast<void *>(vec);
-          mapped_vectors[&our_data] = vec_ptr;
-          return static_cast<void *>(vec->data());
-        }
-    }
-  else
-    {
-      if (sizeof(Real) != sizeof(double))
-        {
-          std::vector<double> * vec =
-            new std::vector<double>(our_data.begin(), our_data.end());
-          void * vec_ptr = static_cast<void *>(vec);
-          mapped_vectors[&our_data] = vec_ptr;
-          return static_cast<void *>(vec->data());
-        }
-    }
-  return const_cast<void *>(static_cast<const void *>(our_data.data()));
-}
-
-void ExodusII_IO_Helper::remove_output_buffer(const std::vector<Real> & our_data)
-{
-  if (_single_precision)
-    {
-      if (sizeof(Real) != sizeof(float))
-        {
-          libmesh_assert(mapped_vectors.count(&our_data));
-          auto it = mapped_vectors.find(&our_data);
-          void * vec_ptr = it->second;
-          std::vector<float> * vec =
-            static_cast<std::vector<float> *>(vec_ptr);
-          mapped_vectors.erase(it);
-          delete vec;
-        }
-    }
-  else
-    {
-      if (sizeof(Real) != sizeof(double))
-        {
-          libmesh_assert(mapped_vectors.count(&our_data));
-          auto it = mapped_vectors.find(&our_data);
-          void * vec_ptr = it->second;
-          std::vector<double> * vec =
-            static_cast<std::vector<double> *>(vec_ptr);
-          mapped_vectors.erase(it);
-          delete vec;
-        }
-    }
-  libmesh_assert(!mapped_vectors.count(&our_data));
-}
-
-
-
 void ExodusII_IO_Helper::open(const char * filename, bool read_only)
 {
   // Version of Exodus you are using


### PR DESCRIPTION
As discussed with @roystgnr over IM, this makes the temporary-conversion-to-float code in `ExodusII_IO` a bit cleaner/easier to use. The refactoring is not yet complete as I'd also like to replace the `create_input_buffer()` and `move_input_buffer_data()` APIs with something similar, but before I go on I want to be sure that nothing got broken.
