### PR TITLE
Missing array include in extra integers test

### DIFF
--- a/tests/mesh/extra_integers.C
+++ b/tests/mesh/extra_integers.C
@@ -7,6 +7,7 @@
 #include "test_comm.h"
 #include "libmesh_cppunit.h"
 
+#include <array>
 
 using namespace libMesh;
 


### PR DESCRIPTION
This error is only triggered with Mac headers and with
cppunit available, which is why we haven't seen it with
any CIVET testing