### PR TITLE
Odd config fixes

### DIFF
--- a/examples/fem_system/fem_system_ex3/elasticity_system.C
+++ b/examples/fem_system/fem_system_ex3/elasticity_system.C
@@ -27,6 +27,9 @@
 
 using namespace libMesh;
 
+
+#if LIBMESH_DIM > 2
+
 void ElasticitySystem::init_data()
 {
   _u_var = this->add_variable ("Ux", FIRST, LAGRANGE);
@@ -324,6 +327,7 @@ bool ElasticitySystem::mass_residual(bool request_jacobian,
   // If the Jacobian was requested, we computed it. Otherwise, we didn't.
   return request_jacobian;
 }
+#endif // LIBMESH_DIM > 2
 
 Real ElasticitySystem::elasticity_tensor(unsigned int i, unsigned int j, unsigned int k, unsigned int l)
 {

--- a/examples/fem_system/fem_system_ex3/elasticity_system.h
+++ b/examples/fem_system/fem_system_ex3/elasticity_system.h
@@ -44,6 +44,7 @@ public:
       _rho(1.0)
   {}
 
+#if LIBMESH_DIM > 2
   // System initialization
   virtual void init_data ();
 
@@ -61,6 +62,7 @@ public:
   // Mass matrix part
   virtual bool mass_residual (bool request_jacobian,
                               DiffContext & context);
+#endif // LIBMESH_DIM > 2
 
 private:
 

--- a/examples/fem_system/fem_system_ex3/fem_system_ex3.C
+++ b/examples/fem_system/fem_system_ex3/fem_system_ex3.C
@@ -66,6 +66,9 @@ int main (int argc, char ** argv)
   libmesh_example_requires(libMesh::default_solver_package() != INVALID_SOLVER_PACKAGE,
                            "--enable-petsc, --enable-trilinos, or --enable-eigen");
 
+  // This example requires 3D calculations
+  libmesh_example_requires(LIBMESH_DIM > 2, "3D support");
+
   // Parse the input file
   GetPot infile("fem_system_ex3.in");
 

--- a/examples/fem_system/fem_system_ex4/fem_system_ex4.C
+++ b/examples/fem_system/fem_system_ex4/fem_system_ex4.C
@@ -312,12 +312,12 @@ int main (int argc, char ** argv)
   exact_sol.attach_exact_value(0, &exact_func);
   exact_sol.compute_error("Heat", "T");
 
-  Number err = exact_sol.l2_error("Heat", "T");
+  Real err = exact_sol.l2_error("Heat", "T");
 
   // Print out the error value
   libMesh::out << "L2-Error is: " << err << std::endl;
 
-  libmesh_assert_less(libmesh_real(err), 2e-3);
+  libmesh_assert_less(err, 2e-3);
 
 #endif // #ifdef LIBMESH_HAVE_FPARSER
 

--- a/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
+++ b/examples/miscellaneous/miscellaneous_ex11/miscellaneous_ex11.C
@@ -67,7 +67,7 @@
 // Bring in everything from the libMesh namespace
 using namespace libMesh;
 
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+#if defined(LIBMESH_ENABLE_SECOND_DERIVATIVES) && LIBMESH_DIM > 2
 // Function prototype.  This is the function that will assemble
 // the stiffness matrix and the right-hand-side vector ready
 // for solution.
@@ -101,7 +101,7 @@ int main (int argc, char ** argv)
   // Skip this example without --enable-second; requires d2phi
 #ifndef LIBMESH_ENABLE_SECOND_DERIVATIVES
   libmesh_example_requires(false, "--enable-second");
-#else
+#elif LIBMESH_DIM > 2
 
   // Create a 2D mesh distributed across the default MPI communicator.
   // Subdivision surfaces do not appear to work with DistributedMesh yet.
@@ -241,7 +241,7 @@ int main (int argc, char ** argv)
   libMesh::out << "z-displacement of the center point: " << w << std::endl;
   libMesh::out << "Analytic solution for pure bending: " << w_analytic << std::endl;
 
-#endif // #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES, LIBMESH_DIM > 2
 
 #endif // #ifdef LIBMESH_ENABLE_AMR
 
@@ -249,7 +249,7 @@ int main (int argc, char ** argv)
   return 0;
 }
 
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
+#if defined(LIBMESH_ENABLE_SECOND_DERIVATIVES) && LIBMESH_DIM > 2
 
 // We now define the matrix and rhs vector assembly function
 // for the shell system.  This function implements the
@@ -634,4 +634,4 @@ void assemble_shell (EquationSystems & es,
     } // end of ghost element loop
 }
 
-#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
+#endif // defined(LIBMESH_ENABLE_SECOND_DERIVATIVES) && LIBMESH_DIM > 2

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
@@ -184,6 +184,8 @@ void Biharmonic::JR::residual_and_jacobian(const NumericVector<Number> & u,
                                            SparseMatrix<Number> * J,
                                            NonlinearImplicitSystem &)
 {
+  libmesh_ignore(u, R, J);  // if we don't use --enable-second
+
 #ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   if (!R && !J)
     return;

--- a/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
+++ b/examples/miscellaneous/miscellaneous_ex7/biharmonic_jr.C
@@ -145,7 +145,11 @@ Number Biharmonic::JR::InitialDensityRod(const Point & p,
   // Initialize with a rod in the middle so that we have a z-homogeneous system to model the 2D disk.
   Point center = parameters.get<Point>("center");
   Real width = parameters.get<Real>("width");
-  Real r = sqrt((p(0)-center(0))*(p(0)-center(0)) + (p(1)-center(1))*(p(1)-center(1)));
+  Point pc = p-center;
+#if LIBMESH_DIM > 2
+  pc(2) = 0;
+#endif
+  Real r = pc.norm();
   return (r < width) ? 1.0 : -0.5;
 }
 

--- a/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
+++ b/examples/systems_of_equations/systems_of_equations_ex2/systems_of_equations_ex2.C
@@ -341,6 +341,7 @@ void assemble_stokes (EquationSystems & es,
   // the proper system.
   libmesh_assert_equal_to (system_name, "Navier-Stokes");
 
+#if LIBMESH_DIM > 1
   // Get a constant reference to the mesh object.
   const MeshBase & mesh = es.get_mesh();
 
@@ -656,6 +657,9 @@ void assemble_stokes (EquationSystems & es,
       navier_stokes_system.matrix->add_matrix (Ke, dof_indices);
       navier_stokes_system.rhs->add_vector    (Fe, dof_indices);
     } // end of element loop
+#else
+  libmesh_ignore(es);
+#endif
 }
 
 

--- a/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
+++ b/examples/systems_of_equations/systems_of_equations_ex3/systems_of_equations_ex3.C
@@ -336,6 +336,7 @@ void assemble_stokes (EquationSystems & es,
   // the proper system.
   libmesh_assert_equal_to (system_name, "Navier-Stokes");
 
+#if LIBMESH_DIM > 1
   // Get a constant reference to the mesh object.
   const MeshBase & mesh = es.get_mesh();
 
@@ -641,6 +642,9 @@ void assemble_stokes (EquationSystems & es,
   // We can set the mean of the pressure by setting Falpha.  Typically
   // a value of zero is chosen, but the value should be arbitrary.
   navier_stokes_system.rhs->add(navier_stokes_system.rhs->size()-1, 10.);
+#else
+  libmesh_ignore(es);
+#endif
 }
 
 

--- a/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
+++ b/examples/systems_of_equations/systems_of_equations_ex9/systems_of_equations_ex9.C
@@ -360,6 +360,10 @@ int main (int argc, char ** argv)
   // Make sure libMesh was compiled for 3D
   libmesh_example_requires(dim == LIBMESH_DIM, "3D support");
 
+  // Make sure libMesh has normal boundary id sizes
+  libmesh_example_requires(sizeof(boundary_id_type) > 1, "boundary_id_size > 1");
+
+#if LIBMESH_BOUNDARY_ID_BYTES > 1
   // Create a 3D mesh distributed across the default MPI communicator.
   Mesh mesh(init.comm());
 
@@ -440,6 +444,7 @@ int main (int argc, char ** argv)
                                             equation_systems);
 
 #endif // #ifdef LIBMESH_HAVE_EXODUS_API
+#endif // #if LIBMESH_BOUNDARY_ID_BYTES > 1
 
   // All done.
   return 0;

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -279,6 +279,10 @@ extern bool warned_about_auto_ptr;
 
 #else
 
+#define libmesh_assertion_types(expr1,expr2)                            \
+  typedef typename std::decay<decltype(expr1)>::type libmesh_type1;  \
+  typedef typename std::decay<decltype(expr2)>::type libmesh_type2
+
 #define libmesh_assert_msg(asserted, msg)                               \
   do {                                                                  \
     if (!(asserted)) {                                                  \
@@ -309,28 +313,36 @@ extern bool warned_about_auto_ptr;
 
 #define libmesh_assert_less_msg(expr1,expr2, msg)                       \
   do {                                                                  \
-    if (!((expr1) < (expr2))) {                                         \
+    libmesh_assertion_types(expr1, expr2);                              \
+    if (!((static_cast<libmesh_type2>(expr1) < expr2) &&                \
+          (expr1 < static_cast<libmesh_type1>(expr2)))) {               \
       libMesh::err << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_msg(expr1,expr2, msg)                    \
   do {                                                                  \
-    if (!((expr1) > (expr2))) {                                         \
+    libmesh_assertion_types(expr1, expr2);                              \
+    if (!((static_cast<libmesh_type2>(expr1) > expr2) &&                \
+          (expr1 > static_cast<libmesh_type1>(expr2)))) {               \
       libMesh::err << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_less_equal_msg(expr1,expr2, msg)                 \
   do {                                                                  \
-    if (!((expr1) <= (expr2))) {                                        \
+    libmesh_assertion_types(expr1, expr2);                              \
+    if (!((static_cast<libmesh_type2>(expr1) <= expr2) &&               \
+          (expr1 <= static_cast<libmesh_type1>(expr2)))) {              \
       libMesh::err << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)
 
 #define libmesh_assert_greater_equal_msg(expr1,expr2, msg)              \
   do {                                                                  \
-    if (!((expr1) >= (expr2))) {                                        \
+    libmesh_assertion_types(expr1, expr2);                              \
+    if (!((static_cast<libmesh_type2>(expr1) >= expr2) &&               \
+          (expr1 >= static_cast<libmesh_type1>(expr2)))) {              \
       libMesh::err << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; \
       libmesh_error();                                                  \
     } } while (0)

--- a/include/base/libmesh_common.h
+++ b/include/base/libmesh_common.h
@@ -45,6 +45,7 @@
 #endif
 #include <complex>
 #include <typeinfo> // std::bad_cast
+#include <type_traits> // std::decay
 
 
 // Include the MPI definition

--- a/include/geom/sphere.h
+++ b/include/geom/sphere.h
@@ -200,6 +200,7 @@ private:
 inline
 Point Sphere::surface_coords (const Point & cart) const
 {
+#if LIBMESH_DIM > 2
   // constant translation in the origin
   const Point c (cart-this->center());
 
@@ -209,6 +210,10 @@ Point Sphere::surface_coords (const Point & cart) const
   return Point(/* radius */ c.norm(),
                /* theta  */ std::atan2( std::sqrt( c(0)*c(0) + c(1)*c(1) ), c(2) ),
                /* phi    */ ( (phi < 0)  ?  2.*libMesh::pi+phi  :  phi ) );
+#else
+  libmesh_ignore(cart);
+  libmesh_not_implemented();
+#endif
 }
 
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -880,7 +880,7 @@ public:
    */
   int get_node_map(int i) const
   {
-    libmesh_assert_less (static_cast<size_t>(i), node_map_size);
+    libmesh_assert_less (i, node_map_size);
     return node_map[i];
   }
 
@@ -896,7 +896,7 @@ public:
    */
   int get_inverse_node_map(int i) const
   {
-    libmesh_assert_less (static_cast<size_t>(i), inverse_node_map_size);
+    libmesh_assert_less (i, inverse_node_map_size);
     return inverse_node_map[i];
   }
 
@@ -916,7 +916,7 @@ public:
    */
   int get_inverse_side_map(int i) const
   {
-    libmesh_assert_less (static_cast<size_t>(i), inverse_side_map_size);
+    libmesh_assert_less (i, inverse_side_map_size);
     return inverse_side_map[i];
   }
 
@@ -926,7 +926,7 @@ public:
    */
   int get_shellface_map(int i) const
   {
-    libmesh_assert_less (static_cast<size_t>(i), shellface_map_size);
+    libmesh_assert_less (i, shellface_map_size);
     return shellface_map[i];
   }
 
@@ -935,7 +935,7 @@ public:
    */
   int get_inverse_shellface_map(int i) const
   {
-    libmesh_assert_less (static_cast<size_t>(i), inverse_shellface_map_size);
+    libmesh_assert_less (i, inverse_shellface_map_size);
     return inverse_shellface_map[i];
   }
 

--- a/include/mesh/mesh_generation.h
+++ b/include/mesh/mesh_generation.h
@@ -129,7 +129,7 @@ void build_extrusion (UnstructuredMesh & mesh,
                       RealVectorValue extrusion_vector,
                       QueryElemSubdomainIDBase * elem_subdomain = nullptr);
 
-#ifdef LIBMESH_HAVE_TRIANGLE
+#if defined(LIBMESH_HAVE_TRIANGLE) && LIBMESH_DIM > 1
 /**
  * Meshes a rectangular (2D) region (with or without holes) with a
  * Delaunay triangulation.  This function internally calls the
@@ -142,7 +142,7 @@ void build_delaunay_square(UnstructuredMesh & mesh,
                            const Real ymin, const Real ymax,
                            const ElemType type,
                            const std::vector<TriangleInterface::Hole*> * holes=nullptr);
-#endif // #define LIBMESH_HAVE_TRIANGLE
+#endif // LIBMESH_HAVE_TRIANGLE && LIBMESH_DIM > 1
 
 /**
  * Class for receiving the callback during extrusion generation and providing user-defined

--- a/include/mesh/mesh_smoother_vsmoother.h
+++ b/include/mesh/mesh_smoother_vsmoother.h
@@ -21,7 +21,7 @@
 #define LIBMESH_MESH_SMOOTHER_VSMOOTHER_H
 
 #include "libmesh/libmesh_config.h"
-#ifdef LIBMESH_ENABLE_VSMOOTHER
+#if defined(LIBMESH_ENABLE_VSMOOTHER) && LIBMESH_DIM > 1
 
 // Local Includes
 #include "libmesh/libmesh_common.h"
@@ -440,6 +440,6 @@ private:
 
 } // namespace libMesh
 
-#endif // LIBMESH_ENABLE_VSMOOTHER
+#endif // defined(LIBMESH_ENABLE_VSMOOTHER) && LIBMESH_DIM > 1
 
 #endif // LIBMESH_MESH_SMOOTHER_VSMOOTHER_H

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -680,10 +680,14 @@ TypeTensor<T>::TypeTensor(const TypeVector<T2> & vx,
                           const TypeVector<T2> & vy)
 {
   libmesh_assert_equal_to (LIBMESH_DIM, 2);
+#if LIBMESH_DIM > 2
   _coords[0] = vx(0);
   _coords[1] = vx(1);
   _coords[2] = vy(0);
   _coords[3] = vy(1);
+#else
+  libmesh_ignore(vx, vy);
+#endif
 }
 
 template <typename T>
@@ -693,6 +697,7 @@ TypeTensor<T>::TypeTensor(const TypeVector<T2> & vx,
                           const TypeVector<T2> & vz)
 {
   libmesh_assert_equal_to (LIBMESH_DIM, 3);
+#if LIBMESH_DIM > 2
   _coords[0] = vx(0);
   _coords[1] = vx(1);
   _coords[2] = vx(2);
@@ -702,6 +707,9 @@ TypeTensor<T>::TypeTensor(const TypeVector<T2> & vx,
   _coords[6] = vz(0);
   _coords[7] = vz(1);
   _coords[8] = vz(2);
+#else
+  libmesh_ignore(vx, vy, vz);
+#endif
 }
 
 

--- a/include/numerics/type_tensor.h
+++ b/include/numerics/type_tensor.h
@@ -583,6 +583,7 @@ TypeTensor<T>::TypeTensor (const T & xx,
   libmesh_assert_equal_to (xy, 0);
   libmesh_assert_equal_to (yx, 0);
   libmesh_assert_equal_to (yy, 0);
+  libmesh_ignore(xy, yx, yy);
 #endif
 
 #if LIBMESH_DIM == 3
@@ -600,6 +601,7 @@ TypeTensor<T>::TypeTensor (const T & xx,
   libmesh_assert_equal_to (zx, 0);
   libmesh_assert_equal_to (zy, 0);
   libmesh_assert_equal_to (zz, 0);
+  libmesh_ignore(xz, yz, zx, zy, zz);
 #endif
 }
 
@@ -625,6 +627,11 @@ TypeTensor<T>::TypeTensor (const Scalar & xx,
   _coords[1] = xy;
   _coords[2] = yx;
   _coords[3] = yy;
+#elif LIBMESH_DIM == 1
+  libmesh_assert_equal_to (xy, 0);
+  libmesh_assert_equal_to (yx, 0);
+  libmesh_assert_equal_to (yy, 0);
+  libmesh_ignore(xy, yx, yy);
 #endif
 
 #if LIBMESH_DIM == 3
@@ -636,6 +643,13 @@ TypeTensor<T>::TypeTensor (const Scalar & xx,
   _coords[6] = zx;
   _coords[7] = zy;
   _coords[8] = zz;
+#else
+  libmesh_assert_equal_to (xz, 0);
+  libmesh_assert_equal_to (yz, 0);
+  libmesh_assert_equal_to (zx, 0);
+  libmesh_assert_equal_to (zy, 0);
+  libmesh_assert_equal_to (zz, 0);
+  libmesh_ignore(xz, yz, zx, zy, zz);
 #endif
 }
 

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -480,12 +480,14 @@ TypeVector<T>::TypeVector (const T & x,
 #if LIBMESH_DIM > 1
   _coords[1] = y;
 #else
+  libmesh_ignore(y);
   libmesh_assert_equal_to (y, 0);
 #endif
 
 #if LIBMESH_DIM > 2
   _coords[2] = z;
 #else
+  libmesh_ignore(z);
   libmesh_assert_equal_to (z, 0);
 #endif
 }
@@ -1106,6 +1108,7 @@ T triple_product(const TypeVector<T> & a,
     a(1)*(b(0)*c(2) - b(2)*c(0)) +
     a(2)*(b(0)*c(1) - b(1)*c(0));
 #else
+  libmesh_ignore(a, b, c);
   return 0;
 #endif
 }

--- a/include/numerics/type_vector.h
+++ b/include/numerics/type_vector.h
@@ -926,9 +926,14 @@ TypeVector<T>::cross(const TypeVector<T2> & p) const
   // |(*this)(0) (*this)(1) (*this)(2)|
   // |   p(0)       p(1)       p(2)   |
 
+#if LIBMESH_DIM == 3
   return TypeVector<TS>( _coords[1]*p._coords[2] - _coords[2]*p._coords[1],
                          -_coords[0]*p._coords[2] + _coords[2]*p._coords[0],
                          _coords[0]*p._coords[1] - _coords[1]*p._coords[0]);
+#else
+  libmesh_ignore(p);
+  return TypeVector<TS>(0);
+#endif
 }
 
 

--- a/include/solution_transfer/meshfree_interpolation.h
+++ b/include/solution_transfer/meshfree_interpolation.h
@@ -259,7 +259,7 @@ protected:
      */
     inline coord_t kdtree_get_pt(const size_t idx, int dim) const
     {
-      libmesh_assert_less (dim, (int) PLDim);
+      libmesh_assert_less (dim, PLDim);
       libmesh_assert_less (idx, _pts.size());
       libmesh_assert_less (dim, 3);
 

--- a/include/systems/generic_projector.h
+++ b/include/systems/generic_projector.h
@@ -1756,6 +1756,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectVert
                   // x derivative
                   insert_id(first_id+1, grad(0),
                             vertex.processor_id());
+#if LIBMESH_DIM > 1
                   if (dim > 1)
                     {
                       // We'll finite difference mixed derivatives
@@ -1783,6 +1784,7 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectVert
                         (gxplus(1) - gxminus(1)) / 2. / delta_x,
                         vertex.processor_id());
 
+#if LIBMESH_DIM > 2
                       if (dim > 2)
                         {
                           // z derivative
@@ -1854,7 +1856,9 @@ void GenericProjector<FFunctor, GFunctor, FValue, ProjectionAction>::ProjectVert
                             (gxzplus - gxzminus) / 2. / delta_x,
                             vertex.processor_id());
                         }
+#endif // LIBMESH_DIM > 2
                     }
+#endif // LIBMESH_DIM > 1
                 }
               else
                 {

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -622,7 +622,7 @@ void DofMap::reinit(MeshBase & mesh)
           if (elem->p_level() + base_fe_type.order >
               FEInterface::max_order(base_fe_type, type))
             {
-              libmesh_assert_less_msg(static_cast<unsigned int>(base_fe_type.order.get_order()),
+              libmesh_assert_less_msg(base_fe_type.order.get_order(),
                                       FEInterface::max_order(base_fe_type,type),
                                       "ERROR: Finite element "
                                       << Utility::enum_to_string(base_fe_type.family)

--- a/src/base/libmesh.C
+++ b/src/base/libmesh.C
@@ -1039,8 +1039,10 @@ SolverPackage default_solver_package ()
 
 
 //-------------------------------------------------------------------------------
+template unsigned char  command_line_value<unsigned char>  (const std::string &, unsigned char);
 template unsigned short command_line_value<unsigned short> (const std::string &, unsigned short);
 template unsigned int   command_line_value<unsigned int>   (const std::string &, unsigned int);
+template char           command_line_value<char>           (const std::string &, char);
 template short          command_line_value<short>          (const std::string &, short);
 template int            command_line_value<int>            (const std::string &, int);
 template float          command_line_value<float>          (const std::string &, float);
@@ -1048,8 +1050,10 @@ template double         command_line_value<double>         (const std::string &,
 template long double    command_line_value<long double>    (const std::string &, long double);
 template std::string    command_line_value<std::string>    (const std::string &, std::string);
 
+template unsigned char  command_line_value<unsigned char>  (const std::vector<std::string> &, unsigned char);
 template unsigned short command_line_value<unsigned short> (const std::vector<std::string> &, unsigned short);
 template unsigned int   command_line_value<unsigned int>   (const std::vector<std::string> &, unsigned int);
+template char           command_line_value<char>           (const std::vector<std::string> &, char);
 template short          command_line_value<short>          (const std::vector<std::string> &, short);
 template int            command_line_value<int>            (const std::vector<std::string> &, int);
 template float          command_line_value<float>          (const std::vector<std::string> &, float);
@@ -1057,8 +1061,10 @@ template double         command_line_value<double>         (const std::vector<st
 template long double    command_line_value<long double>    (const std::vector<std::string> &, long double);
 template std::string    command_line_value<std::string>    (const std::vector<std::string> &, std::string);
 
+template unsigned char  command_line_next<unsigned char>   (std::string, unsigned char);
 template unsigned short command_line_next<unsigned short>  (std::string, unsigned short);
 template unsigned int   command_line_next<unsigned int>    (std::string, unsigned int);
+template char           command_line_next<char>            (std::string, char);
 template short          command_line_next<short>           (std::string, short);
 template int            command_line_next<int>             (std::string, int);
 template float          command_line_next<float>           (std::string, float);
@@ -1066,8 +1072,10 @@ template double         command_line_next<double>          (std::string, double)
 template long double    command_line_next<long double>     (std::string, long double);
 template std::string    command_line_next<std::string>     (std::string, std::string);
 
+template void           command_line_vector<unsigned char> (const std::string &, std::vector<unsigned char> &);
 template void           command_line_vector<unsigned short>(const std::string &, std::vector<unsigned short> &);
 template void           command_line_vector<unsigned int>  (const std::string &, std::vector<unsigned int> &);
+template void           command_line_vector<char>          (const std::string &, std::vector<char> &);
 template void           command_line_vector<short>         (const std::string &, std::vector<short> &);
 template void           command_line_vector<int>           (const std::string &, std::vector<int> &);
 template void           command_line_vector<float>         (const std::string &, std::vector<float> &);

--- a/src/error_estimation/patch_recovery_error_estimator.C
+++ b/src/error_estimation/patch_recovery_error_estimator.C
@@ -509,6 +509,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                           Fx(i) += JxW[qp]*grad_u_h(0)*psi[i];
                         }
                     }
+#if LIBMESH_DIM > 1
                   else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
@@ -525,6 +526,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                           Fy(i) += JxW[qp]*grad_u_h(1)*psi[i];
                         }
                     }
+#endif // LIBMESH_DIM > 1
+#if LIBMESH_DIM > 2
                   else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
@@ -541,6 +544,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
                           Fz(i) += JxW[qp]*grad_u_h(2)*psi[i];
                         }
                     }
+#endif // LIBMESH_DIM > 2
                   else if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
                            error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
                     {
@@ -781,6 +785,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
 
                       temperr[0] -= grad_u_h(0);
                     }
+#if LIBMESH_DIM > 1
                   else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
@@ -799,6 +804,8 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
 
                       temperr[1] -= grad_u_h(1);
                     }
+#endif // LIBMESH_DIM > 1
+#if LIBMESH_DIM > 2
                   else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
@@ -817,6 +824,7 @@ void PatchRecoveryErrorEstimator::EstimateError::operator()(const ConstElemRange
 
                       temperr[2] -= grad_u_h(2);
                     }
+#endif // LIBMESH_DIM > 2
                   else if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
                            error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
                     {

--- a/src/error_estimation/weighted_patch_recovery_error_estimator.C
+++ b/src/error_estimation/weighted_patch_recovery_error_estimator.C
@@ -415,6 +415,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                           Fx(i) += JxW[qp]*grad_u_h(0)*psi[i];
                         }
                     }
+#if LIBMESH_DIM > 1
                   else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
@@ -433,6 +434,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                           Fy(i) += JxW[qp]*grad_u_h(1)*psi[i];
                         }
                     }
+#endif // LIBMESH_DIM > 1
+#if LIBMESH_DIM > 2
                   else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
                     {
                       // Compute the gradient on the current patch element
@@ -451,6 +454,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
                           Fz(i) += JxW[qp]*grad_u_h(2)*psi[i];
                         }
                     }
+#endif // LIBMESH_DIM > 2
                   else if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
                            error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
                     {
@@ -701,6 +705,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
                       temperr[0] -= grad_u_h(0);
                     }
+#if LIBMESH_DIM > 1
                   else if (error_estimator.error_norm.type(var) == H1_Y_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
@@ -719,6 +724,8 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
                       temperr[1] -= grad_u_h(1);
                     }
+#endif // LIBMESH_DIM > 1
+#if LIBMESH_DIM > 2
                   else if (error_estimator.error_norm.type(var) == H1_Z_SEMINORM)
                     {
                       // Compute the gradient at the current sample point
@@ -737,6 +744,7 @@ void WeightedPatchRecoveryErrorEstimator::EstimateError::operator()(const ConstE
 
                       temperr[2] -= grad_u_h(2);
                     }
+#endif // LIBMESH_DIM > 2
                   else if (error_estimator.error_norm.type(var) == H2_SEMINORM ||
                            error_estimator.error_norm.type(var) == W2_INF_SEMINORM)
                     {

--- a/src/fe/fe_bernstein_shape_3D.C
+++ b/src/fe/fe_bernstein_shape_3D.C
@@ -1373,7 +1373,9 @@ Real FE<3,BERNSTEIN>::shape(const Elem * elem,
     default:
       libmesh_error_msg("Invalid totalorder = " << totalorder);
     }
-
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, p, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -2960,6 +2962,9 @@ Real FE<3,BERNSTEIN>::shape_deriv(const Elem * elem,
       libmesh_error_msg("Invalid totalorder = " << totalorder);
     }
 
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, j, p, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_boundary.C
+++ b/src/fe/fe_boundary.C
@@ -436,8 +436,10 @@ void FEMap::init_face_shape_functions(const std::vector<Point> & qp,
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
     FEInterface::shape_deriv_function(Dim-1, map_fe_type);
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   FEInterface::shape_second_deriv_ptr shape_second_deriv_ptr =
     FEInterface::shape_second_deriv_function(Dim-1, map_fe_type);
+#endif
 
   for (unsigned int i=0; i<n_mapping_shape_functions; i++)
     {
@@ -546,8 +548,10 @@ void FEMap::init_edge_shape_functions(const std::vector<Point> & qp,
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
     FEInterface::shape_deriv_function(1, map_fe_type);
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   FEInterface::shape_second_deriv_ptr shape_second_deriv_ptr =
     FEInterface::shape_second_deriv_function(1, map_fe_type);
+#endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   for (unsigned int i=0; i<n_mapping_shape_functions; i++)
     {

--- a/src/fe/fe_hierarchic_shape_3D.C
+++ b/src/fe/fe_hierarchic_shape_3D.C
@@ -52,6 +52,7 @@ Real fe_hierarchic_3D_shape_second_deriv(const Elem * elem,
 
 #endif // LIBMESH_ENABLE_SECOND_DERIVATIVES
 
+#if LIBMESH_DIM > 2
 Point get_min_point(const Elem * elem,
                     unsigned int a,
                     unsigned int b,
@@ -658,6 +659,7 @@ void cube_indices(const Elem * elem,
       i2 = cube_number_page[basisnum] + 2;
     }
 }
+#endif // LIBMESH_DIM > 2
 
 } // end anonymous namespace
 
@@ -869,6 +871,9 @@ Real fe_hierarchic_3D_shape(const Elem * elem,
       libmesh_error_msg("Invalid element type = " << type);
     }
 
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, p, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -922,6 +927,9 @@ Real fe_hierarchic_3D_shape_deriv(const Elem * elem,
 
   return (FE<3,HIERARCHIC>::shape(elem, order, i, pp, add_p_level) -
           FE<3,HIERARCHIC>::shape(elem, order, i, pm, add_p_level))/2./eps;
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, j, p, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -911,7 +911,6 @@ Real FEInterface::shape_deriv(const unsigned int dim,
   return 0;
 }
 
-#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 FEInterface::shape_deriv_ptr
 FEInterface::shape_deriv_function(const unsigned int dim,
@@ -921,6 +920,7 @@ FEInterface::shape_deriv_function(const unsigned int dim,
 }
 
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 Real FEInterface::shape_second_deriv(const unsigned int dim,
                                      const FEType & fe_t,
                                      const ElemType t,
@@ -984,7 +984,6 @@ Real FEInterface::shape_second_deriv(const unsigned int dim,
   return 0;
 }
 
-#endif //LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 FEInterface::shape_second_deriv_ptr
 FEInterface::shape_second_deriv_function(const unsigned int dim,
@@ -992,6 +991,7 @@ FEInterface::shape_second_deriv_function(const unsigned int dim,
 {
   fe_switch(shape_second_deriv);
 }
+#endif //LIBMESH_ENABLE_SECOND_DERIVATIVES
 
 
 template<>

--- a/src/fe/fe_lagrange_shape_2D.C
+++ b/src/fe/fe_lagrange_shape_2D.C
@@ -401,7 +401,8 @@ Real fe_lagrange_2D_shape(const ElemType type,
       libmesh_error_msg("ERROR: Unsupported 2D FE order: " << order);
     }
 #else // LIBMESH_DIM > 1
-  return 0.;
+  libmesh_ignore(type, order, i, p);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -727,7 +728,8 @@ Real fe_lagrange_2D_shape_deriv(const ElemType type,
       libmesh_error_msg("ERROR: Unsupported 2D FE order: " << order);
     }
 #else // LIBMESH_DIM > 1
-  return 0.;
+  libmesh_ignore(type, order, i, j, p);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -1067,7 +1069,8 @@ Real fe_lagrange_2D_shape_second_deriv(const ElemType type,
     } // end switch (order)
 
 #else // LIBMESH_DIM > 1
-  return 0.;
+  libmesh_ignore(type, order, i, j, p);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_lagrange_shape_3D.C
+++ b/src/fe/fe_lagrange_shape_3D.C
@@ -745,8 +745,9 @@ Real fe_lagrange_3D_shape(const ElemType type,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << order);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(type, order, i, p);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -2085,8 +2086,9 @@ Real fe_lagrange_3D_shape_deriv(const ElemType type,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << order);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(type, order, i, j, p);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -3802,8 +3804,9 @@ Real fe_lagrange_3D_shape_second_deriv(const ElemType type,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << order);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(type, order, i, j, p);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -206,8 +206,10 @@ void FEMap::init_reference_to_physical_map(const std::vector<Point> & qp,
   FEInterface::shape_deriv_ptr shape_deriv_ptr =
     FEInterface::shape_deriv_function(Dim, map_fe_type);
 
+#ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
   FEInterface::shape_second_deriv_ptr shape_second_deriv_ptr =
     FEInterface::shape_second_deriv_function(Dim, map_fe_type);
+#endif // ifdef LIBMESH_ENABLE_SECOND_DERIVATIVES
 
   switch (Dim)
     {

--- a/src/fe/fe_monomial_shape_2D.C
+++ b/src/fe/fe_monomial_shape_2D.C
@@ -107,8 +107,10 @@ Real FE<2,MONOMIAL>::shape(const ElemType,
       return val;
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM == 1
+  libmesh_ignore(i, p);
+  libmesh_assert(order);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -294,8 +296,10 @@ Real FE<2,MONOMIAL>::shape_deriv(const ElemType,
       libmesh_error_msg("Invalid shape function derivative j = " << j);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM == 1
+  libmesh_ignore(i, j, p);
+  libmesh_assert(order);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -530,8 +534,10 @@ Real FE<2,MONOMIAL>::shape_second_deriv(const ElemType,
       libmesh_error_msg("Invalid shape function derivative j = " << j);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM == 1
+  libmesh_assert(order);
+  libmesh_ignore(i, j, p);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_monomial_shape_3D.C
+++ b/src/fe/fe_monomial_shape_3D.C
@@ -175,8 +175,10 @@ Real FE<3,MONOMIAL>::shape(const ElemType,
       return val;
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM != 3
+  libmesh_assert(order);
+  libmesh_ignore(i, p);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -628,8 +630,10 @@ Real FE<3,MONOMIAL>::shape_deriv(const ElemType,
       libmesh_error_msg("Invalid shape function derivative j = " << j);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM != 3
+  libmesh_assert(order);
+  libmesh_ignore(i, j, p);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -1293,8 +1297,10 @@ Real FE<3,MONOMIAL>::shape_second_deriv(const ElemType,
       libmesh_error_msg("Invalid j = " << j);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM != 3
+  libmesh_assert(order);
+  libmesh_ignore(i, j, p);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -156,7 +156,8 @@ RealGradient FE<2,NEDELEC_ONE>::shape(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported 2D FE order!: " << total_order);
     }
 #else // LIBMESH_DIM > 1
-  return RealGradient();
+  libmesh_ignore(elem, order, i, p, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -321,7 +322,8 @@ RealGradient FE<2,NEDELEC_ONE>::shape_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported 2D FE order!: " << total_order);
     }
 #else // LIBMESH_DIM > 1
-  return RealGradient();
+  libmesh_ignore(elem, order, i, j, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -395,7 +397,8 @@ RealGradient FE<2,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
     } // end switch (order)
 
 #else // LIBMESH_DIM > 1
-  return RealGradient();
+  libmesh_ignore(elem, order, i, j, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_nedelec_one_shape_2D.C
+++ b/src/fe/fe_nedelec_one_shape_2D.C
@@ -397,7 +397,8 @@ RealGradient FE<2,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
     } // end switch (order)
 
 #else // LIBMESH_DIM > 1
-  libmesh_ignore(elem, order, i, j, add_p_level);
+  libmesh_assert(true || i || j);
+  libmesh_ignore(elem, order, add_p_level);
   libmesh_not_implemented();
 #endif
 }

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -183,8 +183,9 @@ RealGradient FE<3,NEDELEC_ONE>::shape(const Elem * elem,
     default:
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << totalorder);
     }
-#else
-  return RealGradient();
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, p, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -482,8 +483,9 @@ RealGradient FE<3,NEDELEC_ONE>::shape_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << totalorder);
     }
 
-#else
-  return RealGradient();
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, j, p, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -742,8 +744,9 @@ RealGradient FE<3,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("ERROR: Unsupported 3D FE order!: " << totalorder);
     }
 
-#else
-  return RealGradient();
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, j, p, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_nedelec_one_shape_3D.C
+++ b/src/fe/fe_nedelec_one_shape_3D.C
@@ -745,7 +745,8 @@ RealGradient FE<3,NEDELEC_ONE>::shape_second_deriv(const Elem * elem,
     }
 
 #else // LIBMESH_DIM != 3
-  libmesh_ignore(elem, order, i, j, p, add_p_level);
+  libmesh_assert(true || p(0));
+  libmesh_ignore(elem, order, i, j, add_p_level);
   libmesh_not_implemented();
 #endif
 }

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -143,7 +143,8 @@ Real FE<2,XYZ>::shape(const Elem * elem,
     }
 
 #else // LIBMESH_DIM <= 1
-  libmesh_ignore(elem, order, i, point_in, add_p_level);
+  libmesh_assert(true || order || add_p_level);
+  libmesh_ignore(elem, i, point_in);
   libmesh_not_implemented();
 #endif
 }
@@ -349,7 +350,8 @@ Real FE<2,XYZ>::shape_deriv(const Elem * elem,
     }
 
 #else // LIBMESH_DIM <= 1
-  libmesh_ignore(elem, order, i, j, point_in, add_p_level);
+  libmesh_assert(true || order || add_p_level);
+  libmesh_ignore(elem, i, j, point_in);
   libmesh_not_implemented();
 #endif
 }
@@ -603,7 +605,8 @@ Real FE<2,XYZ>::shape_second_deriv(const Elem * elem,
     }
 
 #else // LIBMESH_DIM <= 1
-  libmesh_ignore(elem, order, i, j, point_in, add_p_level);
+  libmesh_assert(true || order || add_p_level);
+  libmesh_ignore(elem, i, j, point_in);
   libmesh_not_implemented();
 #endif
 }

--- a/src/fe/fe_xyz_shape_2D.C
+++ b/src/fe/fe_xyz_shape_2D.C
@@ -142,8 +142,9 @@ Real FE<2,XYZ>::shape(const Elem * elem,
       return val;
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM <= 1
+  libmesh_ignore(elem, order, i, point_in, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -347,8 +348,9 @@ Real FE<2,XYZ>::shape_deriv(const Elem * elem,
       libmesh_error_msg("Invalid j = " << j);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM <= 1
+  libmesh_ignore(elem, order, i, j, point_in, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -600,8 +602,9 @@ Real FE<2,XYZ>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("Invalid shape function derivative j = " << j);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM <= 1
+  libmesh_ignore(elem, order, i, j, point_in, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -213,7 +213,8 @@ Real FE<3,XYZ>::shape(const Elem * elem,
     }
 
 #else // LIBMESH_DIM != 3
-  libmesh_ignore(elem, order, i, point_in, add_p_level);
+  libmesh_assert(true || order || add_p_level);
+  libmesh_ignore(elem, i, point_in);
   libmesh_not_implemented();
 #endif
 }
@@ -689,7 +690,8 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
     }
 
 #else // LIBMESH_DIM != 3
-  libmesh_ignore(elem, order, i, j, point_in, add_p_level);
+  libmesh_assert(true || order || add_p_level);
+  libmesh_ignore(elem, i, j, point_in);
   libmesh_not_implemented();
 #endif
 }
@@ -1384,7 +1386,8 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
     }
 
 #else // LIBMESH_DIM != 3
-  libmesh_ignore(elem, order, i, j, point_in, add_p_level);
+  libmesh_assert(true || order || add_p_level);
+  libmesh_ignore(elem, i, j, point_in);
   libmesh_not_implemented();
 #endif
 }

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -212,8 +212,9 @@ Real FE<3,XYZ>::shape(const Elem * elem,
       return val;
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, point_in, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -687,8 +688,9 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
       libmesh_error_msg("Invalid j = " << j);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, j, point_in, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 
@@ -1381,8 +1383,9 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
       libmesh_error_msg("Invalid j = " << j);
     }
 
-#else
-  return 0.;
+#else // LIBMESH_DIM != 3
+  libmesh_ignore(elem, order, i, j, point_in, add_p_level);
+  libmesh_not_implemented();
 #endif
 }
 

--- a/src/fe/fe_xyz_shape_3D.C
+++ b/src/fe/fe_xyz_shape_3D.C
@@ -77,9 +77,8 @@ Real FE<3,XYZ>::shape(const Elem * elem,
   // we avoid declaring it when asserts are not active.
   const unsigned int totalorder = order + add_p_level * elem->p_level();
 #endif
-  libmesh_assert_less (i, (static_cast<unsigned int>(totalorder)+1)*
-                       (static_cast<unsigned int>(totalorder)+2)*
-                       (static_cast<unsigned int>(totalorder)+3)/6);
+  libmesh_assert_less (i, (totalorder+1) * (totalorder+2) *
+                       (totalorder+3)/6);
 
   // monomials. since they are hierarchic we only need one case block.
   switch (i)
@@ -274,9 +273,8 @@ Real FE<3,XYZ>::shape_deriv(const Elem * elem,
   // we avoid declaring it when asserts are not active.
   const unsigned int totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
 #endif
-  libmesh_assert_less (i, (static_cast<unsigned int>(totalorder)+1)*
-                       (static_cast<unsigned int>(totalorder)+2)*
-                       (static_cast<unsigned int>(totalorder)+3)/6);
+  libmesh_assert_less (i, (totalorder+1) * (totalorder+2) *
+                       (totalorder+3)/6);
 
   switch (j)
     {
@@ -758,9 +756,8 @@ Real FE<3,XYZ>::shape_second_deriv(const Elem * elem,
   // we avoid declaring it when asserts are not active.
   const unsigned int totalorder = static_cast<Order>(order + add_p_level * elem->p_level());
 #endif
-  libmesh_assert_less (i, (static_cast<unsigned int>(totalorder)+1)*
-                       (static_cast<unsigned int>(totalorder)+2)*
-                       (static_cast<unsigned int>(totalorder)+3)/6);
+  libmesh_assert_less (i, (totalorder+1) * (totalorder+2) *
+                       (totalorder+3)/6);
 
   // monomials. since they are hierarchic we only need one case block.
   switch (j)

--- a/src/geom/cell_hex.C
+++ b/src/geom/cell_hex.C
@@ -198,6 +198,7 @@ Real Hex::quality (const ElemQuality q) const
   switch (q)
     {
 
+#if LIBMESH_DIM >= 3
       /**
        * Compute the min/max diagonal ratio.
        * Source: CUBIT User's Manual.
@@ -406,6 +407,7 @@ Real Hex::quality (const ElemQuality q) const
             return (den == 0.) ? 0 : (8. / den);
           }
       }
+#endif // LIBMESH_DIM >= 3
 
       /**
        * I don't know what to do for this metric.

--- a/src/geom/face_tri6.C
+++ b/src/geom/face_tri6.C
@@ -383,6 +383,9 @@ Real Tri6::volume () const
   if (this->mapping_type() != LAGRANGE_MAP)
     return this->Elem::volume();
 
+  Real vol=0.;
+
+#if LIBMESH_DIM > 1
   // Make copies of our points.  It makes the subsequent calculations a bit
   // shorter and avoids dereferencing the same pointer multiple times.
   Point
@@ -421,10 +424,10 @@ Real Tri6::volume () const
   const static Real wts[N] = {Real(9)/80, w1, w1,     w1,     w2, w2,     w2};
 
   // Approximate the area with quadrature
-  Real vol=0.;
   for (unsigned int q=0; q<N; ++q)
     vol += wts[q] * cross_norm(xi[q]*a1 + eta[q]*b1 + c1,
                                xi[q]*b1 + eta[q]*b2 + c2);
+#endif // LIBMESH_DIM > 1
 
   return vol;
 }

--- a/src/geom/sphere.C
+++ b/src/geom/sphere.C
@@ -64,6 +64,7 @@ Sphere::Sphere(const Point & pa,
                const Point & pc,
                const Point & pd)
 {
+#if LIBMESH_DIM > 2
   Point pad = pa - pd;
   Point pbd = pb - pd;
   Point pcd = pc - pd;
@@ -98,6 +99,10 @@ Sphere::Sphere(const Point & pa,
   Real r = (c-pa).norm();
 
   this->create_from_center_radius(c,r);
+#else // LIBMESH_DIM > 2
+  libmesh_ignore(pa, pb, pc, pd);
+  libmesh_not_implemented();
+#endif
 }
 
 

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1061,8 +1061,8 @@ DistributedMesh::renumber_dof_objects(mapvector<T *, dof_id_type> & objects)
   std::vector<dof_id_type> objects_on_proc(this->n_processors(), 0);
   auto this_it = ghost_objects_from_proc.find(this->processor_id());
   this->comm().allgather
-    ((this_it == ghost_objects_from_proc.end()) ? 0 : this_it->second,
-     objects_on_proc);
+    ((this_it == ghost_objects_from_proc.end()) ?
+     dof_id_type(0) : this_it->second, objects_on_proc);
 
 #ifndef NDEBUG
   libmesh_assert(this->comm().verify(unpartitioned_objects));

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -624,7 +624,7 @@ void ExodusII_IO_Helper::read_block_info()
 
 int ExodusII_IO_Helper::get_block_id(int index)
 {
-  libmesh_assert_less (static_cast<unsigned int>(index), block_ids.size());
+  libmesh_assert_less (index, block_ids.size());
 
   return block_ids[index];
 }
@@ -633,7 +633,7 @@ int ExodusII_IO_Helper::get_block_id(int index)
 
 std::string ExodusII_IO_Helper::get_block_name(int index)
 {
-  libmesh_assert_less (static_cast<unsigned int>(index), block_ids.size());
+  libmesh_assert_less (index, block_ids.size());
 
   return id_to_block_names[block_ids[index]];
 }
@@ -642,7 +642,7 @@ std::string ExodusII_IO_Helper::get_block_name(int index)
 
 int ExodusII_IO_Helper::get_side_set_id(int index)
 {
-  libmesh_assert_less (static_cast<unsigned int>(index), ss_ids.size());
+  libmesh_assert_less (index, ss_ids.size());
 
   return ss_ids[index];
 }
@@ -651,7 +651,7 @@ int ExodusII_IO_Helper::get_side_set_id(int index)
 
 std::string ExodusII_IO_Helper::get_side_set_name(int index)
 {
-  libmesh_assert_less (static_cast<unsigned int>(index), ss_ids.size());
+  libmesh_assert_less (index, ss_ids.size());
 
   return id_to_ss_names[ss_ids[index]];
 }
@@ -660,7 +660,7 @@ std::string ExodusII_IO_Helper::get_side_set_name(int index)
 
 int ExodusII_IO_Helper::get_node_set_id(int index)
 {
-  libmesh_assert_less (static_cast<unsigned int>(index), nodeset_ids.size());
+  libmesh_assert_less (index, nodeset_ids.size());
 
   return nodeset_ids[index];
 }
@@ -669,7 +669,7 @@ int ExodusII_IO_Helper::get_node_set_id(int index)
 
 std::string ExodusII_IO_Helper::get_node_set_name(int index)
 {
-  libmesh_assert_less (static_cast<unsigned int>(index), nodeset_ids.size());
+  libmesh_assert_less (index, nodeset_ids.size());
 
   return id_to_ns_names[nodeset_ids[index]];
 }
@@ -679,7 +679,7 @@ std::string ExodusII_IO_Helper::get_node_set_name(int index)
 
 void ExodusII_IO_Helper::read_elem_in_block(int block)
 {
-  libmesh_assert_less (static_cast<unsigned int>(block), block_ids.size());
+  libmesh_assert_less (block, block_ids.size());
 
   ex_err = exII::ex_get_elem_block(ex_id,
                                    block_ids[block],
@@ -803,11 +803,11 @@ void ExodusII_IO_Helper::read_nodeset_info()
 
 void ExodusII_IO_Helper::read_sideset(int id, int offset)
 {
-  libmesh_assert_less (static_cast<unsigned int>(id), ss_ids.size());
-  libmesh_assert_less (static_cast<unsigned int>(id), num_sides_per_set.size());
-  libmesh_assert_less (static_cast<unsigned int>(id), num_df_per_set.size());
-  libmesh_assert_less_equal (static_cast<unsigned int>(offset), elem_list.size());
-  libmesh_assert_less_equal (static_cast<unsigned int>(offset), side_list.size());
+  libmesh_assert_less (id, ss_ids.size());
+  libmesh_assert_less (id, num_sides_per_set.size());
+  libmesh_assert_less (id, num_df_per_set.size());
+  libmesh_assert_less_equal (offset, elem_list.size());
+  libmesh_assert_less_equal (offset, side_list.size());
 
   ex_err = exII::ex_get_side_set_param(ex_id,
                                        ss_ids[id],
@@ -846,9 +846,9 @@ void ExodusII_IO_Helper::read_sideset(int id, int offset)
 
 void ExodusII_IO_Helper::read_nodeset(int id)
 {
-  libmesh_assert_less (static_cast<unsigned int>(id), nodeset_ids.size());
-  libmesh_assert_less (static_cast<unsigned int>(id), num_nodes_per_set.size());
-  libmesh_assert_less (static_cast<unsigned int>(id), num_node_df_per_set.size());
+  libmesh_assert_less (id, nodeset_ids.size());
+  libmesh_assert_less (id, num_nodes_per_set.size());
+  libmesh_assert_less (id, num_node_df_per_set.size());
 
   ex_err = exII::ex_get_node_set_param(ex_id,
                                        nodeset_ids[id],

--- a/src/mesh/inf_elem_builder.C
+++ b/src/mesh/inf_elem_builder.C
@@ -108,10 +108,14 @@ const Point InfElemBuilder::build_inf_elem (const InfElemOriginValue & origin_x,
       // override default values, if necessary
       if (!origin_x.first)
         origin(0) = auto_origin(0);
+#if LIBMESH_DIM > 1
       if (!origin_y.first)
         origin(1) = auto_origin(1);
+#endif
+#if LIBMESH_DIM > 2
       if (!origin_z.first)
         origin(2) = auto_origin(2);
+#endif
 
       if (be_verbose)
         {

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -704,11 +704,11 @@ void MeshBase::cache_elem_dims()
   // If the mesh is x-aligned or x-y planar, we will end up checking
   // every node's coordinates and not breaking out of the loop
   // early...
+#if LIBMESH_DIM > 1
   if (_spatial_dimension < 3)
     {
       for (const auto & node : this->node_ptr_range())
         {
-#if LIBMESH_DIM > 1
           // Note: the exact floating point comparison is intentional,
           // we don't want to get tripped up by tolerances.
           if ((*node)(1) != 0.)
@@ -721,7 +721,6 @@ void MeshBase::cache_elem_dims()
               break;
 #endif
             }
-#endif
 
 #if LIBMESH_DIM > 2
           if ((*node)(2) != 0.)
@@ -734,6 +733,7 @@ void MeshBase::cache_elem_dims()
 #endif
         }
     }
+#endif // LIBMESH_DIM > 1
 }
 
 void MeshBase::detect_interior_parents()

--- a/src/mesh/mesh_generation.C
+++ b/src/mesh/mesh_generation.C
@@ -2315,7 +2315,7 @@ void MeshTools::Generation::build_extrusion (UnstructuredMesh & mesh,
 
 
 
-#ifdef LIBMESH_HAVE_TRIANGLE
+#if defined(LIBMESH_HAVE_TRIANGLE) && LIBMESH_DIM > 1
 
 // Triangulates a 2D rectangular region with or without holes
 void MeshTools::Generation::build_delaunay_square(UnstructuredMesh & mesh,
@@ -2425,7 +2425,7 @@ void MeshTools::Generation::build_delaunay_square(UnstructuredMesh & mesh,
 
 } // end build_delaunay_square
 
-#endif // LIBMESH_HAVE_TRIANGLE
+#endif // LIBMESH_HAVE_TRIANGLE && LIBMESH_DIM > 1
 
 
 

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -226,6 +226,7 @@ void MeshTools::Modification::rotate (MeshBase & mesh,
                     ( sp*st)*x          + (-cp*st)*y          + (ct)*z   );
     }
 #else
+  libmesh_ignore(mesh, phi, theta, psi);
   libmesh_error_msg("MeshTools::Modification::rotate() requires libMesh to be compiled with LIBMESH_DIM==3");
 #endif
 }

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -113,10 +113,14 @@ void MeshTools::Modification::distort (MeshBase & mesh,
                      ((mesh.mesh_dimension() == 3) ? static_cast<Real>(std::rand())/static_cast<Real>(RAND_MAX) : 0.));
 
           dir(0) = (dir(0)-.5)*2.;
+#if LIBMESH_DIM > 1
           if (mesh.mesh_dimension() > 1)
             dir(1) = (dir(1)-.5)*2.;
+#endif
+#if LIBMESH_DIM > 2
           if (mesh.mesh_dimension() == 3)
             dir(2) = (dir(2)-.5)*2.;
+#endif
 
           dir = dir.unit();
 
@@ -125,10 +129,14 @@ void MeshTools::Modification::distort (MeshBase & mesh,
             continue;
 
           (*node)(0) += dir(0)*factor*hmin[n];
+#if LIBMESH_DIM > 1
           if (mesh.mesh_dimension() > 1)
             (*node)(1) += dir(1)*factor*hmin[n];
+#endif
+#if LIBMESH_DIM > 2
           if (mesh.mesh_dimension() == 3)
             (*node)(2) += dir(2)*factor*hmin[n];
+#endif
         }
   }
 }

--- a/src/mesh/mesh_smoother_vsmoother.C
+++ b/src/mesh/mesh_smoother_vsmoother.C
@@ -16,7 +16,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "libmesh/libmesh_config.h"
-#ifdef LIBMESH_ENABLE_VSMOOTHER
+#if defined(LIBMESH_ENABLE_VSMOOTHER) && LIBMESH_DIM > 1
 
 // Local includes
 #include "libmesh/mesh_smoother_vsmoother.h"
@@ -4146,6 +4146,7 @@ void VariationalMeshSmoother::metr_data_gen(std::string grid,
               } // end QUAD case
           } // end _dim==2
 
+#if LIBMESH_DIM > 2
         if (_dim == 3)
           {
             // 3D - tetr and hex
@@ -4305,6 +4306,7 @@ void VariationalMeshSmoother::metr_data_gen(std::string grid,
                   } // end for ni
               } // end hex
           } // end dim==3
+#endif // LIBMESH_DIM > 2
       }
 
   // Done with the metric file
@@ -4374,4 +4376,4 @@ void VariationalMeshSmoother::metr_data_gen(std::string grid,
 
 } // namespace libMesh
 
-#endif // LIBMESH_ENABLE_VSMOOTHER
+#endif // defined(LIBMESH_ENABLE_VSMOOTHER) && LIBMESH_DIM > 1

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -1790,8 +1790,8 @@ void libmesh_assert_parallel_consistent_procids<Elem>(const MeshBase & mesh)
   // along and just figure out new max ids ourselves.
   dof_id_type parallel_max_elem_id = 0;
   for (const auto & elem : mesh.element_ptr_range())
-    parallel_max_elem_id = std::max(parallel_max_elem_id,
-                                    elem->id()+1);
+    parallel_max_elem_id = std::max<dof_id_type>(parallel_max_elem_id,
+                                                 elem->id()+1);
   mesh.comm().max(parallel_max_elem_id);
 
   // Check processor ids for consistency between processors
@@ -1843,8 +1843,8 @@ void libmesh_assert_topology_consistent_procids<Node>(const MeshBase & mesh)
   // ourselves.
   dof_id_type parallel_max_node_id = 0;
   for (const auto & node : mesh.node_ptr_range())
-    parallel_max_node_id = std::max(parallel_max_node_id,
-                                    node->id()+1);
+    parallel_max_node_id = std::max<dof_id_type>(parallel_max_node_id,
+                                                 node->id()+1);
   mesh.comm().max(parallel_max_node_id);
 
 
@@ -1932,8 +1932,8 @@ void libmesh_assert_parallel_consistent_procids<Node>(const MeshBase & mesh)
   // ourselves.
   dof_id_type parallel_max_node_id = 0;
   for (const auto & node : mesh.node_ptr_range())
-    parallel_max_node_id = std::max(parallel_max_node_id,
-                                    node->id()+1);
+    parallel_max_node_id = std::max<dof_id_type>(parallel_max_node_id,
+                                                 node->id()+1);
   mesh.comm().max(parallel_max_node_id);
 
   std::vector<bool> node_touched_by_anyone(parallel_max_node_id, false);

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -269,7 +269,7 @@ void Nemesis_IO::read (const std::string & base_filename)
     // mark each processor id we reference with a node cmap
     for (unsigned int cmap=0; cmap<to_uint(nemhelper->num_node_cmaps); cmap++)
       {
-        libmesh_assert_less (to_uint(nemhelper->node_cmap_ids[cmap]), this->n_processors());
+        libmesh_assert_less (nemhelper->node_cmap_ids[cmap], this->n_processors());
 
         pid_send_partner[nemhelper->node_cmap_ids[cmap]] = 1;
       }
@@ -347,7 +347,7 @@ void Nemesis_IO::read (const std::string & base_filename)
       num_nodes_i_must_number++;
 
   // more error checking...
-  libmesh_assert_greater_equal (num_nodes_i_must_number, to_uint(nemhelper->num_internal_nodes));
+  libmesh_assert_greater_equal (num_nodes_i_must_number, nemhelper->num_internal_nodes);
   libmesh_assert (num_nodes_i_must_number <= to_uint(nemhelper->num_internal_nodes +
                                                      nemhelper->num_border_nodes));
   if (_verbose)
@@ -454,7 +454,7 @@ void Nemesis_IO::read (const std::string & base_filename)
 
       // an internal node we do not own? huh??
       libmesh_assert_equal_to (owning_pid_idx, this->processor_id());
-      libmesh_assert_less (my_next_node, to_uint(nemhelper->num_nodes_global));
+      libmesh_assert_less (my_next_node, nemhelper->num_nodes_global);
 
       // "Catch" the node pointer after addition, make sure the
       // ID matches the requested value.

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1880,7 +1880,7 @@ void Nemesis_IO_Helper::compute_border_node_ids(const MeshBase & pmesh)
 
     // We can't be connecting to more processors than exist outside
     // ourselves
-    libmesh_assert_less (static_cast<unsigned>(this->num_node_cmaps), this->n_processors());
+    libmesh_assert_less (this->num_node_cmaps, this->n_processors());
 
     if (verbose)
       {

--- a/src/mesh/tetgen_io.C
+++ b/src/mesh/tetgen_io.C
@@ -16,14 +16,15 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-#include <fstream>
-
 // Local includes
 #include "libmesh/tetgen_io.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/cell_tet4.h"
 #include "libmesh/cell_tet10.h"
+
+// C++ includes
+#include <array>
+#include <fstream>
 
 namespace libMesh
 {
@@ -126,7 +127,6 @@ void TetGenIO::node_in (std::istream & node_stream)
 
   // Read the nodal coordinates from the node_stream (*.node file).
   unsigned int node_lab=0;
-  Point xyz;
   Real dummy;
 
   // If present, make room for node attributes to be stored.
@@ -140,10 +140,12 @@ void TetGenIO::node_in (std::istream & node_stream)
       // Check input buffer
       libmesh_assert (node_stream.good());
 
+      std::array<Real, 3> xyz;
+
       node_stream >> node_lab  // node number
-                  >> xyz(0)    // x-coordinate value
-                  >> xyz(1)    // y-coordinate value
-                  >> xyz(2);   // z-coordinate value
+                  >> xyz[0]    // x-coordinate value
+                  >> xyz[1]    // y-coordinate value
+                  >> xyz[2];   // z-coordinate value
 
       // Read and store attributes from the stream.
       for (unsigned int j=0; j<nAttributes; j++)
@@ -158,8 +160,20 @@ void TetGenIO::node_in (std::istream & node_stream)
       //_assign_nodes.insert (std::make_pair(node_lab,i));
       _assign_nodes[node_lab] = i;
 
+      Point p(xyz[0]);
+#if LIBMESH_DIM > 1
+      p(1) = xyz[1];
+#else
+      libmesh_assert_equal_to(xyz[1], 0);
+#endif
+#if LIBMESH_DIM > 2
+      p(2) = xyz[2];
+#else
+      libmesh_assert_equal_to(xyz[2], 0);
+#endif
+
       // Add this point to the Mesh.
-      mesh.add_point(xyz, i);
+      mesh.add_point(p, i);
     }
 }
 

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -16,9 +16,6 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-// C++ includes
-#include <fstream>
-
 // Local includes
 #include "libmesh/libmesh_config.h"
 #include "libmesh/ucd_io.h"
@@ -37,6 +34,10 @@
 # include "gzstream.h" // For reading/writing compressed streams
 # include "libmesh/restore_warnings.h"
 #endif
+
+// C++ includes
+#include <array>
+#include <fstream>
 
 
 namespace libMesh
@@ -153,19 +154,31 @@ void UCDIO::read_implementation (std::istream & in)
   // however.  So, we read in x,y,z for each node and make a point
   // in the proper way based on what dimension we're in
   {
-    Point xyz;
-
     for (unsigned int i=0; i<nNodes; i++)
       {
         libmesh_assert (in.good());
 
+        std::array<Real, 3> xyz;
+
         in >> dummy   // Point number
-           >> xyz(0)  // x-coordinate value
-           >> xyz(1)  // y-coordinate value
-           >> xyz(2); // z-coordinate value
+           >> xyz[0]  // x-coordinate value
+           >> xyz[1]  // y-coordinate value
+           >> xyz[2]; // z-coordinate value
+
+        Point p(xyz[0]);
+#if LIBMESH_DIM > 1
+        p(1) = xyz[1];
+#else
+        libmesh_assert_equal_to(xyz[1], 0);
+#endif
+#if LIBMESH_DIM > 2
+        p(2) = xyz[2];
+#else
+        libmesh_assert_equal_to(xyz[2], 0);
+#endif
 
         // Build the node
-        mesh.add_point (xyz, i);
+        mesh.add_point (p, i);
       }
   }
 

--- a/src/numerics/petsc_matrix.C
+++ b/src/numerics/petsc_matrix.C
@@ -1243,7 +1243,7 @@ T PetscMatrix<T>::operator () (const numeric_index_type i_in,
         std::distance (const_cast<PetscInt *>(petsc_cols),
                        const_cast<PetscInt *>(p.first));
 
-      libmesh_assert_less (static_cast<PetscInt>(j), ncols);
+      libmesh_assert_less (j, ncols);
       libmesh_assert_equal_to (petsc_cols[j], j_val);
 
       value = static_cast<T> (petsc_row[j]);

--- a/src/partitioning/parmetis_partitioner.C
+++ b/src/partitioning/parmetis_partitioner.C
@@ -379,7 +379,7 @@ void ParmetisPartitioner::initialize (const MeshBase & mesh,
                          std::lower_bound(subdomain_bounds.begin(),
                                           subdomain_bounds.end(),
                                           global_index)));
-        libmesh_assert_less (subdomain_id, static_cast<unsigned int>(_pmetis->nparts));
+        libmesh_assert_less (subdomain_id, _pmetis->nparts);
         libmesh_assert_less (local_index, _pmetis->part.size());
 
         _pmetis->part[local_index] = subdomain_id;

--- a/src/partitioning/partitioner.C
+++ b/src/partitioning/partitioner.C
@@ -42,7 +42,8 @@ namespace libMesh
 
 // ------------------------------------------------------------
 // Partitioner static data
-const dof_id_type Partitioner::communication_blocksize = 1000000;
+const dof_id_type Partitioner::communication_blocksize =
+  dof_id_type(1000000);
 
 
 

--- a/src/partitioning/sfc_partitioner.C
+++ b/src/partitioning/sfc_partitioner.C
@@ -166,7 +166,7 @@ void SFCPartitioner::partition_range(MeshBase & mesh,
 
     for (dof_id_type i=0; i<n_range_elem; i++)
       {
-        libmesh_assert_less (static_cast<unsigned int>(table[i] - 1), reverse_map.size());
+        libmesh_assert_less (table[i] - 1, reverse_map.size());
 
         Elem * elem = reverse_map[table[i] - 1];
 

--- a/src/systems/system_projection.C
+++ b/src/systems/system_projection.C
@@ -1550,6 +1550,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                   Ue(current_dof) = grad(0);
                   dof_is_fixed[current_dof] = true;
                   current_dof++;
+#if LIBMESH_DIM > 1
                   if (dim > 1)
                     {
                       // We'll finite difference mixed derivatives
@@ -1573,6 +1574,7 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                       dof_is_fixed[current_dof] = true;
                       current_dof++;
 
+#if LIBMESH_DIM > 2
                       if (dim > 2)
                         {
                           // z derivative
@@ -1635,7 +1637,9 @@ void BoundaryProjectSolution::operator()(const ConstElemRange & range) const
                           dof_is_fixed[current_dof] = true;
                           current_dof++;
                         }
+#endif // LIBMESH_DIM > 2
                     }
+#endif // LIBMESH_DIM > 1
                 }
               // Assume that other C_ONE elements have a single nodal
               // value shape function and nodal gradient component

--- a/tests/base/overlapping_coupling_test.C
+++ b/tests/base/overlapping_coupling_test.C
@@ -450,7 +450,7 @@ private:
                                                        _mesh->active_subdomain_elements_end(2) );
 
     CPPUNIT_ASSERT_EQUAL( n_elems_subdomain_two, (dof_id_type) subdomain_one_couplings.size() );
-    CPPUNIT_ASSERT_EQUAL( 2*n_elems_subdomain_two, (dof_id_type) subdomain_two_couplings.size() );
+    CPPUNIT_ASSERT_EQUAL( dof_id_type(2*n_elems_subdomain_two), (dof_id_type) subdomain_two_couplings.size() );
   }
 
   void run_partitioner_test(unsigned int n_refinements)

--- a/tests/mesh/write_sideset_data.C
+++ b/tests/mesh/write_sideset_data.C
@@ -3,6 +3,7 @@
 #include "libmesh/exodusII_io.h"
 #include "libmesh/mesh.h"
 #include "libmesh/mesh_generation.h"
+#include "libmesh/parallel.h" // set_union
 #include "libmesh/string_to_enum.h"
 #include "libmesh/boundary_info.h"
 
@@ -78,6 +79,12 @@ public:
                 vals.insert(std::make_pair(t, val));
               }
           }
+
+        // If we have a distributed mesh, write_sideset_data wants our
+        // ghost data too; we'll just serialize everything here.
+        if (!mesh.is_serial())
+          TestCommWorld->set_union(vals);
+
       } // done constructing bc_vals
 
 #ifdef LIBMESH_HAVE_EXODUS_API

--- a/tests/numerics/diagonal_matrix_test.C
+++ b/tests/numerics/diagonal_matrix_test.C
@@ -72,7 +72,7 @@ public:
     numeric_index_type beginning_index = _matrix->row_start();
     numeric_index_type end_index = _matrix->row_stop();
 
-    CPPUNIT_ASSERT_EQUAL(_local_size, _matrix->row_stop() - _matrix->row_start());
+    CPPUNIT_ASSERT_EQUAL(_local_size, numeric_index_type(_matrix->row_stop() - _matrix->row_start()));
 
     _matrix->zero();
 


### PR DESCRIPTION
This branch was *originally* supposed to be for finding and fixing any 1.5.0 errors in little-used libMesh configurations, but it turned out that I caught a couple recent (post-1.5.0 branch) outright errors in an actually-used configuration too.  If there are any disagreements about something in the bulk of these commits then I can cherry-pick out the handful that are actually important and submit those separately.

Unlike the errors, most of the warnings fixes apply to 1.5.0 code, but IMHO none of them are important enough to bother backporting; any users who try ```--enable-werror --enable-paranoid-warnings --disable-something-everyone-uses``` can pick and settle for two out of three.