### PR TITLE
Add inline Utility::map_find() helper function

### DIFF
--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -23,6 +23,7 @@
 #include "libmesh/libmesh_common.h"
 #include "libmesh/mesh_input.h"
 #include "libmesh/mesh_output.h"
+#include "libmesh/utility.h"
 
 #ifdef LIBMESH_HAVE_VTK
 // Ignore "deprecated...header" warning from strstream
@@ -194,23 +195,13 @@ private:
     // Find an entry in the writing map, or throw an error.
     vtkIdType find(ElemType libmesh_type)
     {
-      std::map<ElemType, vtkIdType>::iterator it = writing_map.find(libmesh_type);
-
-      if (it == writing_map.end())
-        libmesh_error_msg("Element type " << libmesh_type << " not available in VTK.");
-
-      return it->second;
+      return Utility::map_find(writing_map, libmesh_type);
     }
 
     // Find an entry in the reading map, or throw an error.
     ElemType find(vtkIdType vtk_type)
     {
-      std::map<vtkIdType, ElemType>::iterator it = reading_map.find(vtk_type);
-
-      if (it == reading_map.end())
-        libmesh_error_msg("Element type " << vtk_type << " not available in libMesh.");
-
-      return it->second;
+      return Utility::map_find(reading_map, vtk_type);
     }
 
     std::map<ElemType, vtkIdType> writing_map;

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -45,6 +45,41 @@ namespace Utility
 std::string system_info();
 
 
+/**
+ * Encapsulates the common "get value from map, otherwise error"
+ * idiom, which is similar to calling map.at(), but gives a more
+ * useful error message with a line number. Templated on the type
+ * of map, so this will work with both std::map and std::unordered_map.
+ */
+template<typename Map>
+inline
+typename Map::mapped_type &
+map_find(Map & map,
+         const typename Map::key_type & key)
+{
+  auto it = map.find(key);
+  if (it == map.end())
+    libmesh_error_msg("map_find() error: required key not found.");
+  return it->second;
+}
+
+/**
+ * A const version of the function above. It would be better if we
+ * only needed one version of the function that would work with const
+ * and non-const, but I don't think that's possible.
+ */
+template<typename Map>
+inline
+const typename Map::mapped_type &
+map_find(const Map & map,
+         const typename Map::key_type & key)
+{
+  auto it = map.find(key);
+  if (it == map.end())
+    libmesh_error_msg("map_find() error: required key not found.");
+  return it->second;
+}
+
 
 /**
  * \p Utility::iota is a duplication of the SGI STL extension

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -32,6 +32,7 @@
 #include "libmesh/raw_accessor.h"
 #include "libmesh/tensor_tools.h"
 #include "libmesh/enum_norm_type.h"
+#include "libmesh/utility.h"
 
 namespace libMesh
 {
@@ -208,25 +209,10 @@ void ExactSolution::attach_exact_hessian (unsigned int sys_num,
 std::vector<Real> & ExactSolution::_check_inputs(const std::string & sys_name,
                                                  const std::string & unknown_name)
 {
-  // If no exact solution function or fine grid solution has been
-  // attached, we now just compute the solution norm (i.e. the
-  // difference from an "exact solution" of zero
-
-  // Make sure the requested sys_name exists.
-  std::map<std::string, SystemErrorMap>::iterator sys_iter =
-    _errors.find(sys_name);
-
-  if (sys_iter == _errors.end())
-    libmesh_error_msg("Sorry, couldn't find the requested system '" << sys_name << "'.");
-
-  // Make sure the requested unknown_name exists.
-  SystemErrorMap::iterator var_iter = (*sys_iter).second.find(unknown_name);
-
-  if (var_iter == (*sys_iter).second.end())
-    libmesh_error_msg("Sorry, couldn't find the requested variable '" << unknown_name << "'.");
-
-  // Return a reference to the proper error entry
-  return (*var_iter).second;
+  // Return a reference to the proper error entry, or throw an error
+  // if it doesn't exist.
+  auto & system_error_map = Utility::map_find(_errors, sys_name);
+  return Utility::map_find(system_error_map, unknown_name);
 }
 
 

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -27,6 +27,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/int_range.h"
+#include "libmesh/utility.h" // map_find
 
 // C++ includes
 #include <sstream>
@@ -230,12 +231,10 @@ void EnsightIO::write_geometry_ascii()
   for (const auto & pr : ensight_parts_map)
     {
       // Look up this ElemType in the map, error if not present.
-      auto name_it = _element_map.find(pr.first);
-      if (name_it == _element_map.end())
-        libmesh_error_msg("Error: Unsupported ElemType " << pr.first << " for EnsightIO.");
+      std::string name = Utility::map_find(_element_map, pr.first);
 
       // Write element type
-      mesh_stream << "\n" << name_it->second << "\n";
+      mesh_stream << "\n" << name << "\n";
 
       const std::vector<const Elem *> & elem_ref = pr.second;
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -38,6 +38,7 @@
 #include "libmesh/parallel_mesh.h"
 #include "libmesh/dof_map.h"
 #include "libmesh/parallel.h"
+#include "libmesh/utility.h"
 
 namespace libMesh
 {
@@ -923,13 +924,13 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
   for (auto derived_var_id : index_range(derived_var_names))
     {
       const auto & derived_name = derived_var_names[derived_var_id];
-      auto it = derived_name_to_orig_name_and_node_id.find(derived_name);
-      if (it == derived_name_to_orig_name_and_node_id.end())
-        libmesh_error_msg("Unmapped derived variable name: " << derived_name);
+      const auto & name_and_id =
+        Utility::map_find (derived_name_to_orig_name_and_node_id,
+                           derived_name);
 
       // Convenience variables for the map entry's contents.
-      const std::string & orig_name = it->second.first;
-      const unsigned int node_id = it->second.second;
+      const std::string & orig_name = name_and_id.first;
+      const unsigned int node_id = name_and_id.second;
 
       // For each subdomain, determine whether the current variable
       // should be active on that subdomain.
@@ -990,12 +991,12 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
   for (auto & derived_var_name : derived_var_names)
     {
       // Get the original name associated with this derived name.
-      auto it = derived_name_to_orig_name_and_node_id.find(derived_var_name);
-      if (it == derived_name_to_orig_name_and_node_id.end())
-        libmesh_error_msg("Unmapped derived variable name: " << derived_var_name);
+      const auto & name_and_id =
+        Utility::map_find (derived_name_to_orig_name_and_node_id,
+                           derived_var_name);
 
       // Convenience variables for the map entry's contents.
-      const std::string & orig_name = it->second.first;
+      const std::string & orig_name = name_and_id.first;
 
       // Was the original name a constant monomial?
       if (std::count(monomial_var_names.begin(),

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -33,6 +33,7 @@
 #include "libmesh/enum_io_package.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/int_range.h"
+#include "libmesh/utility.h"
 
 // Wrap everything in a GMVLib namespace and
 // use extern "C" to avoid name mangling.
@@ -1043,11 +1044,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
           for (const auto & elem : mesh.active_element_ptr_range())
             {
               // Find the unique index for elem->subdomain_id(), print that to file
-              auto map_iter = sbdid_map.find(elem->subdomain_id());
-
-              libmesh_assert_msg(map_iter != sbdid_map.end(), "Entry for subdomain " << elem->subdomain_id() << " not found.");
-
-              unsigned gmv_mat_number = (*map_iter).second;
+              unsigned gmv_mat_number = Utility::map_find(sbdid_map, elem->subdomain_id());
 
               if (this->subdivide_second_order())
                 for (unsigned int se=0; se<elem->n_sub_elem(); se++)
@@ -2153,14 +2150,7 @@ ElemType GMVIO::gmv_elem_to_libmesh_elem(std::string elemname)
 {
   // Erase any whitespace padding in name coming from gmv before performing comparison.
   elemname.erase(std::remove_if(elemname.begin(), elemname.end(), isspace), elemname.end());
-
-  // Look up the string in our string->ElemType name.
-  auto it = _reading_element_map.find(elemname);
-
-  if (it == _reading_element_map.end())
-    libmesh_error_msg("Unknown/unsupported element: " << elemname << " was read.");
-
-  return it->second;
+  return Utility::map_find(_reading_element_map, elemname);
 }
 
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -32,6 +32,7 @@
 #include "libmesh/string_to_enum.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/int_range.h"
+#include "libmesh/utility.h"
 
 #ifdef DEBUG
 #  include "libmesh/remote_elem.h"
@@ -917,24 +918,16 @@ void MeshTools::find_nodal_neighbors(const MeshBase &,
   // user in a std::vector.
   std::set<const Node *> neighbor_set;
 
-  // Iterators to iterate through the elements that include this node
-  auto my_elems_it = nodes_to_elem_map.find(global_id);
-  libmesh_assert(my_elems_it != nodes_to_elem_map.end());
-
-  std::vector<const Elem *>::const_iterator
-    el = my_elems_it->second.begin(),
-    end_el = my_elems_it->second.end();
+  // List of Elems attached to this node.
+  const auto & elem_vec = Utility::map_find(nodes_to_elem_map, global_id);
 
   // Look through the elements that contain this node
   // find the local node id... then find the side that
   // node lives on in the element
   // next, look for the _other_ node on that side
   // That other node is a "nodal_neighbor"... save it
-  for (; el != end_el; ++el)
+  for (const auto & elem : elem_vec)
     {
-      // Grab an Elem pointer to use in the subsequent loop
-      const Elem * elem = *el;
-
       // We only care about active elements...
       if (elem->active())
         {

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -32,6 +32,7 @@
 #include "libmesh/cell_hex20.h"
 #include "libmesh/cell_tet10.h"
 #include "libmesh/cell_prism6.h"
+#include "libmesh/utility.h"
 
 // C++ includes
 #include <array>
@@ -844,11 +845,10 @@ void UNVIO::elements_in (std::istream & in_file)
       for (dof_id_type j=1; j<=n_nodes; j++)
         {
           // Map the UNV node ID to the libmesh node ID
-          auto it = _unv_node_id_to_libmesh_node_ptr.find(node_labels[j]);
-          if (it != _unv_node_id_to_libmesh_node_ptr.end())
-            elem->set_node(assign_elem_nodes[j]) = it->second;
-          else
-            libmesh_error_msg("ERROR: UNV node " << node_labels[j] << " not found!");
+          auto & node_ptr =
+            Utility::map_find(_unv_node_id_to_libmesh_node_ptr, node_labels[j]);
+
+          elem->set_node(assign_elem_nodes[j]) = node_ptr;
         }
 
       elems_of_dimension[elem->dim()] = true;
@@ -1307,16 +1307,14 @@ void UNVIO::read_dataset(std::string file_name)
                 } // end loop data_cnt
 
               // Get a pointer to the Node associated with the UNV node id.
-              auto it = _unv_node_id_to_libmesh_node_ptr.find(f_n_id);
-
-              if (it == _unv_node_id_to_libmesh_node_ptr.end())
-                libmesh_error_msg("UNV node id " << f_n_id << " was not found.");
+              auto & node_ptr = Utility::map_find
+                (_unv_node_id_to_libmesh_node_ptr, f_n_id);
 
               // Store the nodal values in our map which uses the
               // libMesh Node* as the key.  We use operator[] here
               // because we want to create an empty vector if the
               // entry does not already exist.
-              _node_data[it->second] = values;
+              _node_data[node_ptr] = values;
             } // end while (true)
         } // end if (news == "2414")
     } // end while (true)

--- a/src/partitioning/mapped_subdomain_partitioner.C
+++ b/src/partitioning/mapped_subdomain_partitioner.C
@@ -22,6 +22,7 @@
 #include "libmesh/mapped_subdomain_partitioner.h"
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/elem.h"
+#include "libmesh/utility.h"
 
 namespace libMesh
 {
@@ -50,15 +51,7 @@ void MappedSubdomainPartitioner::partition_range(MeshBase & /*mesh*/,
       subdomain_id_type sbd_id = elem->subdomain_id();
 
       // Find which processor id corresponds to this element's subdomain id.
-      std::map<subdomain_id_type, processor_id_type>::iterator
-        s2p_it = subdomain_to_proc.find(sbd_id);
-
-      // If an element has a subdomain we don't know how to
-      // partition, throw an error.
-      if (s2p_it == subdomain_to_proc.end())
-        libmesh_error_msg("Could not find processor id corresponding to subdomain id " << sbd_id);
-
-      elem->processor_id() = s2p_it->second;
+      elem->processor_id() = Utility::map_find(subdomain_to_proc, sbd_id);
     }
 }
 

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -28,6 +28,7 @@
 #include "libmesh/vectormap.h"
 #include "libmesh/metis_csr_graph.h"
 #include "libmesh/parallel.h"
+#include "libmesh/utility.h"
 
 #ifdef LIBMESH_HAVE_METIS
 // MIPSPro 7.4.2 gets confused about these nested namespaces
@@ -385,18 +386,8 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                     // Compare the neighbor and the queried_elem
                     // pointers, make sure they are the same.
                     if (queried_elem && queried_elem == neighbor)
-                      {
-                        vectormap<dof_id_type, dof_id_type>::iterator global_index_map_it =
-                          global_index_map.find(neighbor->id());
-
-                        // If the interior_neighbor is in the Mesh but
-                        // not in the global_index_map, we have other issues.
-                        if (global_index_map_it == global_index_map.end())
-                          libmesh_error_msg("Interior neighbor with id " << neighbor->id() << " not found in global_index_map.");
-
-                        else
-                          csr_graph(elem_global_index, connection++) = global_index_map_it->second;
-                      }
+                      csr_graph(elem_global_index, connection++) =
+                        Utility::map_find(global_index_map, neighbor->id());
                   }
               }
 

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -20,10 +20,9 @@
 // C++ includes
 #include <sstream>
 
-// rbOOmit includes
+// libmesh includes
 #include "libmesh/rb_parameters.h"
-
-
+#include "libmesh/utility.h"
 
 namespace libMesh
 {
@@ -41,14 +40,8 @@ void RBParameters::clear()
 
 Real RBParameters::get_value(const std::string & param_name) const
 {
-  // find the parameter value
-  const_iterator it = _parameters.find(param_name);
-
-  // throw and error if the parameter doesn't exist
-  if (it == _parameters.end())
-    libmesh_error_msg("Error: parameter " << param_name << " does not exist in RBParameters object.");
-
-  return it->second;
+  // find the parameter value, throwing an error if it doesn't exist.
+  return Utility::map_find(_parameters, param_name);
 }
 
 void RBParameters::set_value(const std::string & param_name, Real value)
@@ -58,14 +51,8 @@ void RBParameters::set_value(const std::string & param_name, Real value)
 
 Real RBParameters::get_extra_value(const std::string & param_name) const
 {
-  // find the parameter value
-  const_iterator it = _extra_parameters.find(param_name);
-
-  // throw and error if the parameter doesn't exist
-  if (it == _extra_parameters.end())
-    libmesh_error_msg("Error: parameter " << param_name << " does not exist in extra parameters.");
-
-  return it->second;
+  // find the parameter value, throwing an error if it doesn't exist.
+  return Utility::map_find(_extra_parameters, param_name);
 }
 
 void RBParameters::set_extra_value(const std::string & param_name, Real value)

--- a/src/solvers/nlopt_optimization_solver.C
+++ b/src/solvers/nlopt_optimization_solver.C
@@ -22,14 +22,13 @@
 #if defined(LIBMESH_HAVE_NLOPT) && !defined(LIBMESH_USE_COMPLEX_NUMBERS)
 
 
-// C++ includes
-
 // Local Includes
 #include "libmesh/dof_map.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/nlopt_optimization_solver.h"
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/int_range.h"
+#include "libmesh/utility.h"
 
 namespace libMesh
 {
@@ -326,13 +325,8 @@ void NloptOptimizationSolver<T>::init ()
                                                            nlopt_algorithm_name);
 
       // Convert string to an nlopt algorithm type
-      auto it = _nlopt_algorithms.find(nlopt_algorithm_name);
-
-      if (it == _nlopt_algorithms.end())
-        libmesh_error_msg("Invalid nlopt algorithm requested on command line: " \
-                          << nlopt_algorithm_name);
-
-      _opt = nlopt_create(it->second, this->system().solution->size());
+      _opt = nlopt_create(Utility::map_find(_nlopt_algorithms, nlopt_algorithm_name),
+                          this->system().solution->size());
     }
 }
 

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -17,8 +17,6 @@
 
 
 
-// C++ includes
-
 // Local includes
 #include "libmesh/dof_map.h"
 #include "libmesh/equation_systems.h"
@@ -33,6 +31,7 @@
 #include "libmesh/qoi_set.h"
 #include "libmesh/sensitivity_data.h"
 #include "libmesh/sparse_matrix.h"
+#include "libmesh/utility.h"
 
 namespace libMesh
 {
@@ -262,26 +261,14 @@ SparseMatrix<Number> * ImplicitSystem::request_matrix (const std::string & mat_n
 
 const SparseMatrix<Number> & ImplicitSystem::get_matrix (const std::string & mat_name) const
 {
-  // Make sure the matrix exists
-  const_matrices_iterator pos = _matrices.find (mat_name);
-
-  if (pos == _matrices.end())
-    libmesh_error_msg("ERROR: matrix " << mat_name << " does not exist in this system!");
-
-  return *(pos->second);
+  return *(Utility::map_find(_matrices, mat_name));
 }
 
 
 
 SparseMatrix<Number> & ImplicitSystem::get_matrix (const std::string & mat_name)
 {
-  // Make sure the matrix exists
-  matrices_iterator pos = _matrices.find (mat_name);
-
-  if (pos == _matrices.end())
-    libmesh_error_msg("ERROR: matrix " << mat_name << " does not exist in this system!");
-
-  return *(pos->second);
+  return *(Utility::map_find(_matrices, mat_name));
 }
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -20,7 +20,6 @@
 // C++ includes
 #include <sstream>   // for std::ostringstream
 
-
 // Local includes
 #include "libmesh/dof_map.h"
 #include "libmesh/equation_systems.h"
@@ -773,26 +772,14 @@ NumericVector<Number> * System::request_vector (const unsigned int vec_num)
 
 const NumericVector<Number> & System::get_vector (const std::string & vec_name) const
 {
-  // Make sure the vector exists
-  const_vectors_iterator pos = _vectors.find(vec_name);
-
-  if (pos == _vectors.end())
-    libmesh_error_msg("ERROR: vector " << vec_name << " does not exist in this system!");
-
-  return *(pos->second);
+  return *(Utility::map_find(_vectors, vec_name));
 }
 
 
 
 NumericVector<Number> & System::get_vector (const std::string & vec_name)
 {
-  // Make sure the vector exists
-  vectors_iterator pos = _vectors.find(vec_name);
-
-  if (pos == _vectors.end())
-    libmesh_error_msg("ERROR: vector " << vec_name << " does not exist in this system!");
-
-  return *(pos->second);
+  return *(Utility::map_find(_vectors, vec_name));
 }
 
 
@@ -1243,16 +1230,9 @@ bool System::has_variable (const std::string & var) const
 
 unsigned short int System::variable_number (const std::string & var) const
 {
-  // Make sure the variable exists
-  std::map<std::string, unsigned short int>::const_iterator
-    pos = _variable_numbers.find(var);
-
-  if (pos == _variable_numbers.end())
-    libmesh_error_msg("ERROR: variable " << var << " does not exist in this system!");
-
-  libmesh_assert_equal_to (_variables[pos->second].name(), var);
-
-  return pos->second;
+  auto var_num = Utility::map_find(_variable_numbers, var);
+  libmesh_assert_equal_to (_variables[var_num].name(), var);
+  return var_num;
 }
 
 


### PR DESCRIPTION
I seem to always be writing the same "find; error-if-end; use value" lines of code with maps, so I wrote a templated helper function that simplifies this process. It's similar to using `map::at()`, but it throws a `libmesh_error_msg()` with relevant filename and line numbers instead of a generic `std::out_of_range` exception when the value is not found. The new function works with `std::map`, `std::unordered_map`, and even map-like things such as `vectormap`, and allowed me to get rid of several lines of boilerplate code.
