### PR TITLE
Change macro name MAP_FIND -> libmesh_map_find

### DIFF
--- a/include/mesh/vtk_io.h
+++ b/include/mesh/vtk_io.h
@@ -195,13 +195,13 @@ private:
     // Find an entry in the writing map, or throw an error.
     vtkIdType find(ElemType libmesh_type)
     {
-      return MAP_FIND(writing_map, libmesh_type);
+      return libmesh_map_find(writing_map, libmesh_type);
     }
 
     // Find an entry in the reading map, or throw an error.
     ElemType find(vtkIdType vtk_type)
     {
-      return MAP_FIND(reading_map, vtk_type);
+      return libmesh_map_find(reading_map, vtk_type);
     }
 
     std::map<ElemType, vtkIdType> writing_map;

--- a/include/utils/utility.h
+++ b/include/utils/utility.h
@@ -35,7 +35,7 @@ namespace libMesh
  * idiom, which is similar to calling map.at(), but gives a more
  * useful error message with a line number.
  */
-#define MAP_FIND(map, key) Utility::map_find((map), (key), __FILE__, __LINE__)
+#define libmesh_map_find(map, key) Utility::map_find((map), (key), __FILE__, __LINE__)
 
 // ------------------------------------------------------------
 // The Utility namespace is for functions
@@ -53,7 +53,7 @@ std::string system_info();
 
 /**
  * This function should not be called directly (although it can be),
- * instead see the MAP_FIND() macro.
+ * instead see the libmesh_map_find() macro.
  *
  * Calls find(key), and checks the result against end(). Returns the
  * corresponding value if found, throws an error otherwise. Templated

--- a/src/error_estimation/exact_solution.C
+++ b/src/error_estimation/exact_solution.C
@@ -211,8 +211,8 @@ std::vector<Real> & ExactSolution::_check_inputs(const std::string & sys_name,
 {
   // Return a reference to the proper error entry, or throw an error
   // if it doesn't exist.
-  auto & system_error_map = MAP_FIND(_errors, sys_name);
-  return MAP_FIND(system_error_map, unknown_name);
+  auto & system_error_map = libmesh_map_find(_errors, sys_name);
+  return libmesh_map_find(system_error_map, unknown_name);
 }
 
 

--- a/src/mesh/ensight_io.C
+++ b/src/mesh/ensight_io.C
@@ -231,7 +231,7 @@ void EnsightIO::write_geometry_ascii()
   for (const auto & pr : ensight_parts_map)
     {
       // Look up this ElemType in the map, error if not present.
-      std::string name = MAP_FIND(_element_map, pr.first);
+      std::string name = libmesh_map_find(_element_map, pr.first);
 
       // Write element type
       mesh_stream << "\n" << name << "\n";

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -925,7 +925,7 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
     {
       const auto & derived_name = derived_var_names[derived_var_id];
       const auto & name_and_id =
-        MAP_FIND (derived_name_to_orig_name_and_node_id,
+        libmesh_map_find (derived_name_to_orig_name_and_node_id,
                   derived_name);
 
       // Convenience variables for the map entry's contents.
@@ -992,7 +992,7 @@ ExodusII_IO::write_element_data_from_discontinuous_nodal_data
     {
       // Get the original name associated with this derived name.
       const auto & name_and_id =
-        MAP_FIND (derived_name_to_orig_name_and_node_id,
+        libmesh_map_find (derived_name_to_orig_name_and_node_id,
                   derived_var_name);
 
       // Convenience variables for the map entry's contents.

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1669,15 +1669,15 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
                   // this libmesh node number to the connectivity
                   // array, or throw an error if it's not found.
                   connect[connect_index] =
-                    MAP_FIND(libmesh_node_num_to_exodus,
-                             cast_int<int>(libmesh_node_id));
+                    libmesh_map_find(libmesh_node_num_to_exodus,
+                                     cast_int<int>(libmesh_node_id));
                 }
               else
                 {
                   // Look up the (elem_id, elem_node_index) pair in the map.
                   connect[connect_index] =
-                    MAP_FIND(discontinuous_node_indices,
-                             std::make_pair(elem_id, elem_node_index));
+                    libmesh_map_find(discontinuous_node_indices,
+                                     std::make_pair(elem_id, elem_node_index));
                 }
             }
         }
@@ -2190,7 +2190,7 @@ write_sideset_data(const MeshBase & mesh,
 
               // Sanity check: make sure that the "off by one"
               // assumption we used above to set 'elem_id' is valid.
-              if (MAP_FIND(libmesh_elem_num_to_exodus, cast_int<int>(elem_id))
+              if (libmesh_map_find(libmesh_elem_num_to_exodus, cast_int<int>(elem_id))
                   != elem_list[i + offset])
                 libmesh_error_msg("Error mapping Exodus elem id to libmesh elem id.");
 
@@ -2216,7 +2216,7 @@ write_sideset_data(const MeshBase & mesh,
               // Find the data for this (elem,side,id) tuple. Throw an
               // error if not found. Then store value in vector which
               // will be passed to Exodus.
-              sset_var_vals[i] = MAP_FIND(data_map, key);
+              sset_var_vals[i] = libmesh_map_find(data_map, key);
             } // end for (i)
 
           // As far as I can tell, there is no "concat" version of writing
@@ -2757,7 +2757,7 @@ ExodusII_IO_Helper::Conversion ExodusII_IO_Helper::ElementMaps::assign_conversio
 
   // Do only upper-case comparisons
   std::transform(type_str.begin(), type_str.end(), type_str.begin(), ::toupper);
-  return assign_conversion (MAP_FIND(element_equivalence_map, type_str));
+  return assign_conversion (libmesh_map_find(element_equivalence_map, type_str));
 }
 
 

--- a/src/mesh/gmsh_io.C
+++ b/src/mesh/gmsh_io.C
@@ -502,7 +502,7 @@ void GmshIO::read_mesh(std::istream & in)
 
                 // Get a reference to the ElementDefinition, throw an error if not found.
                 const GmshIO::ElementDefinition & eletype =
-                  MAP_FIND(_element_maps.in, type);
+                  libmesh_map_find(_element_maps.in, type);
 
                 // If we read nnodes, make sure it matches the number in eletype.nnodes
                 if (nnodes != 0 && nnodes != eletype.nnodes)
@@ -600,7 +600,7 @@ void GmshIO::read_mesh(std::istream & in)
 
                 // Get a reference to the ElementDefinition
                 const GmshIO::ElementDefinition & eletype =
-                  MAP_FIND(_element_maps.in, element_type);
+                  libmesh_map_find(_element_maps.in, element_type);
 
                 // Don't add 0-dimensional "point" elements to the
                 // Mesh.  They should *always* be treated as boundary
@@ -899,7 +899,7 @@ void GmshIO::write_mesh (std::ostream & out_stream)
       {
         // Get a reference to the ElementDefinition object
         const ElementDefinition & eletype =
-          MAP_FIND(_element_maps.out, elem->type());
+          libmesh_map_find(_element_maps.out, elem->type());
 
         // The element mapper better not require any more nodes
         // than are present in the current element!
@@ -957,7 +957,7 @@ void GmshIO::write_mesh (std::ostream & out_stream)
 
             // consult the export element table
             const GmshIO::ElementDefinition & eletype =
-              MAP_FIND(_element_maps.out, side->type());
+              libmesh_map_find(_element_maps.out, side->type());
 
             // The element mapper better not require any more nodes
             // than are present in the current element!

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -1044,7 +1044,7 @@ void GMVIO::write_ascii_old_impl (const std::string & fname,
           for (const auto & elem : mesh.active_element_ptr_range())
             {
               // Find the unique index for elem->subdomain_id(), print that to file
-              unsigned gmv_mat_number = MAP_FIND(sbdid_map, elem->subdomain_id());
+              unsigned gmv_mat_number = libmesh_map_find(sbdid_map, elem->subdomain_id());
 
               if (this->subdivide_second_order())
                 for (unsigned int se=0; se<elem->n_sub_elem(); se++)
@@ -2150,7 +2150,7 @@ ElemType GMVIO::gmv_elem_to_libmesh_elem(std::string elemname)
 {
   // Erase any whitespace padding in name coming from gmv before performing comparison.
   elemname.erase(std::remove_if(elemname.begin(), elemname.end(), isspace), elemname.end());
-  return MAP_FIND(_reading_element_map, elemname);
+  return libmesh_map_find(_reading_element_map, elemname);
 }
 
 

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -919,7 +919,7 @@ void MeshTools::find_nodal_neighbors(const MeshBase &,
   std::set<const Node *> neighbor_set;
 
   // List of Elems attached to this node.
-  const auto & elem_vec = MAP_FIND(nodes_to_elem_map, global_id);
+  const auto & elem_vec = libmesh_map_find(nodes_to_elem_map, global_id);
 
   // Look through the elements that contain this node
   // find the local node id... then find the side that

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -978,13 +978,13 @@ void Nemesis_IO_Helper::compute_element_maps()
   {
     unsigned cnt = 0;
     for (const auto & id : this->internal_elem_ids)
-      this->elem_mapi[cnt++] = MAP_FIND(libmesh_elem_num_to_exodus, id);
+      this->elem_mapi[cnt++] = libmesh_map_find(libmesh_elem_num_to_exodus, id);
   }
 
   {
     unsigned cnt = 0;
     for (const auto & id : this->border_elem_ids)
-      this->elem_mapb[cnt++] = MAP_FIND(libmesh_elem_num_to_exodus, id);
+      this->elem_mapb[cnt++] = libmesh_map_find(libmesh_elem_num_to_exodus, id);
   }
 }
 
@@ -1025,7 +1025,8 @@ void Nemesis_IO_Helper::compute_elem_communication_maps()
         // Pack the vectors with elem IDs, side IDs, and processor IDs.
         for (std::size_t j=0; j<this->elem_cmap_elem_ids[cnt].size(); ++j, ++elem_set_iter)
           {
-            this->elem_cmap_elem_ids[cnt][j] = MAP_FIND(libmesh_elem_num_to_exodus, elem_set_iter->first);
+            this->elem_cmap_elem_ids[cnt][j] =
+              libmesh_map_find(libmesh_elem_num_to_exodus, elem_set_iter->first);
             this->elem_cmap_side_ids[cnt][j] = elem_set_iter->second;     // Side ID, this has already been converted above
             this->elem_cmap_proc_ids[cnt][j] = it->first; // All have the same processor ID
           }
@@ -1055,13 +1056,13 @@ void Nemesis_IO_Helper::compute_node_maps()
   {
     unsigned cnt = 0;
     for (const auto & id : this->internal_node_ids)
-      this->node_mapi[cnt++] = MAP_FIND(libmesh_node_num_to_exodus, id);
+      this->node_mapi[cnt++] = libmesh_map_find(libmesh_node_num_to_exodus, id);
   }
 
   {
     unsigned cnt=0;
     for (const auto & id : this->border_node_ids)
-      this->node_mapb[cnt++] = MAP_FIND(libmesh_node_num_to_exodus, id);
+      this->node_mapb[cnt++] = libmesh_map_find(libmesh_node_num_to_exodus, id);
   }
 }
 
@@ -1106,7 +1107,7 @@ void Nemesis_IO_Helper::compute_node_communication_maps()
         for (std::size_t j=0; j<this->node_cmap_node_ids[cnt].size(); ++j, ++node_set_iter)
           {
             this->node_cmap_node_ids[cnt][j] =
-              MAP_FIND(libmesh_node_num_to_exodus, *node_set_iter);
+              libmesh_map_find(libmesh_node_num_to_exodus, *node_set_iter);
             this->node_cmap_proc_ids[cnt][j] = it->first;
           }
 
@@ -1803,8 +1804,8 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
               const unsigned int elem_node_index = conv.get_node_map(j);
 
               current_block_connectivity[connect_index] =
-                MAP_FIND(libmesh_node_num_to_exodus,
-                         elem.node_id(elem_node_index));
+                libmesh_map_find(libmesh_node_num_to_exodus,
+                                 elem.node_id(elem_node_index));
             }
         } // End loop over elems in this subdomain
     } // end loop over subdomain_map
@@ -2138,7 +2139,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
               //
               // We know the parent element is local, but let's be absolutely sure that all the children have been
               // actually mapped to Exodus IDs before we blindly try to add them...
-              local_elem_boundary_id_lists[ std::get<2>(t) ].push_back( MAP_FIND(libmesh_elem_num_to_exodus, f_id) );
+              local_elem_boundary_id_lists[ std::get<2>(t) ].push_back( libmesh_map_find(libmesh_elem_num_to_exodus, f_id) );
               local_elem_boundary_id_side_lists[ std::get<2>(t) ].push_back(conv.get_inverse_side_map( std::get<1>(t) ));
             }
         }
@@ -2196,8 +2197,8 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
 
               // Get reference to the vector of side IDs
               std::vector<int> & current_sideset_side_ids =
-                MAP_FIND(local_elem_boundary_id_side_lists,
-                         cast_int<boundary_id_type>(exodus_id));
+                libmesh_map_find(local_elem_boundary_id_side_lists,
+                                 cast_int<boundary_id_type>(exodus_id));
 
               // Call the Exodus interface to write the parameters of this side set
               this->ex_err = exII::ex_put_side_set_param(this->ex_id,

--- a/src/mesh/ucd_io.C
+++ b/src/mesh/ucd_io.C
@@ -202,7 +202,7 @@ void UCDIO::read_implementation (std::istream & in)
            >> type;        // string describing cell type
 
         // Convert the UCD type string to a libmesh ElemType
-        ElemType et = MAP_FIND(_reading_element_map, type);
+        ElemType et = libmesh_map_find(_reading_element_map, type);
 
         // Build the required type and release it into our custody.
         Elem * elem = Elem::build(et).release();
@@ -320,7 +320,7 @@ void UCDIO::write_interior_elems(std::ostream & out_stream,
       libmesh_assert (out_stream.good());
 
       // Look up the corresponding UCD element type in the static map.
-      std::string elem_string = MAP_FIND(_writing_element_map, elem->type());
+      std::string elem_string = libmesh_map_find(_writing_element_map, elem->type());
 
       // Write the element's subdomain ID as the UCD "material_id".
       out_stream << e++ << " " << elem->subdomain_id() << " " << elem_string << "\t";

--- a/src/mesh/unv_io.C
+++ b/src/mesh/unv_io.C
@@ -846,7 +846,7 @@ void UNVIO::elements_in (std::istream & in_file)
         {
           // Map the UNV node ID to the libmesh node ID
           auto & node_ptr =
-            MAP_FIND(_unv_node_id_to_libmesh_node_ptr, node_labels[j]);
+            libmesh_map_find(_unv_node_id_to_libmesh_node_ptr, node_labels[j]);
 
           elem->set_node(assign_elem_nodes[j]) = node_ptr;
         }
@@ -1307,7 +1307,7 @@ void UNVIO::read_dataset(std::string file_name)
                 } // end loop data_cnt
 
               // Get a pointer to the Node associated with the UNV node id.
-              auto & node_ptr = MAP_FIND(_unv_node_id_to_libmesh_node_ptr, f_n_id);
+              auto & node_ptr = libmesh_map_find(_unv_node_id_to_libmesh_node_ptr, f_n_id);
 
               // Store the nodal values in our map which uses the
               // libMesh Node* as the key.  We use operator[] here

--- a/src/partitioning/mapped_subdomain_partitioner.C
+++ b/src/partitioning/mapped_subdomain_partitioner.C
@@ -51,7 +51,7 @@ void MappedSubdomainPartitioner::partition_range(MeshBase & /*mesh*/,
       subdomain_id_type sbd_id = elem->subdomain_id();
 
       // Find which processor id corresponds to this element's subdomain id.
-      elem->processor_id() = MAP_FIND(subdomain_to_proc, sbd_id);
+      elem->processor_id() = libmesh_map_find(subdomain_to_proc, sbd_id);
     }
 }
 

--- a/src/partitioning/metis_partitioner.C
+++ b/src/partitioning/metis_partitioner.C
@@ -387,7 +387,7 @@ void MetisPartitioner::partition_range(MeshBase & mesh,
                     // pointers, make sure they are the same.
                     if (queried_elem && queried_elem == neighbor)
                       csr_graph(elem_global_index, connection++) =
-                        MAP_FIND(global_index_map, neighbor->id());
+                        libmesh_map_find(global_index_map, neighbor->id());
                   }
               }
 

--- a/src/reduced_basis/rb_parameters.C
+++ b/src/reduced_basis/rb_parameters.C
@@ -41,7 +41,7 @@ void RBParameters::clear()
 Real RBParameters::get_value(const std::string & param_name) const
 {
   // find the parameter value, throwing an error if it doesn't exist.
-  return MAP_FIND(_parameters, param_name);
+  return libmesh_map_find(_parameters, param_name);
 }
 
 void RBParameters::set_value(const std::string & param_name, Real value)
@@ -52,7 +52,7 @@ void RBParameters::set_value(const std::string & param_name, Real value)
 Real RBParameters::get_extra_value(const std::string & param_name) const
 {
   // find the parameter value, throwing an error if it doesn't exist.
-  return MAP_FIND(_extra_parameters, param_name);
+  return libmesh_map_find(_extra_parameters, param_name);
 }
 
 void RBParameters::set_extra_value(const std::string & param_name, Real value)

--- a/src/solvers/nlopt_optimization_solver.C
+++ b/src/solvers/nlopt_optimization_solver.C
@@ -325,7 +325,7 @@ void NloptOptimizationSolver<T>::init ()
                                                            nlopt_algorithm_name);
 
       // Convert string to an nlopt algorithm type
-      _opt = nlopt_create(MAP_FIND(_nlopt_algorithms, nlopt_algorithm_name),
+      _opt = nlopt_create(libmesh_map_find(_nlopt_algorithms, nlopt_algorithm_name),
                           this->system().solution->size());
     }
 }

--- a/src/systems/implicit_system.C
+++ b/src/systems/implicit_system.C
@@ -261,14 +261,14 @@ SparseMatrix<Number> * ImplicitSystem::request_matrix (const std::string & mat_n
 
 const SparseMatrix<Number> & ImplicitSystem::get_matrix (const std::string & mat_name) const
 {
-  return *(MAP_FIND(_matrices, mat_name));
+  return *(libmesh_map_find(_matrices, mat_name));
 }
 
 
 
 SparseMatrix<Number> & ImplicitSystem::get_matrix (const std::string & mat_name)
 {
-  return *(MAP_FIND(_matrices, mat_name));
+  return *(libmesh_map_find(_matrices, mat_name));
 }
 
 

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -772,14 +772,14 @@ NumericVector<Number> * System::request_vector (const unsigned int vec_num)
 
 const NumericVector<Number> & System::get_vector (const std::string & vec_name) const
 {
-  return *(MAP_FIND(_vectors, vec_name));
+  return *(libmesh_map_find(_vectors, vec_name));
 }
 
 
 
 NumericVector<Number> & System::get_vector (const std::string & vec_name)
 {
-  return *(MAP_FIND(_vectors, vec_name));
+  return *(libmesh_map_find(_vectors, vec_name));
 }
 
 
@@ -1230,7 +1230,7 @@ bool System::has_variable (const std::string & var) const
 
 unsigned short int System::variable_number (const std::string & var) const
 {
-  auto var_num = MAP_FIND(_variable_numbers, var);
+  auto var_num = libmesh_map_find(_variable_numbers, var);
   libmesh_assert_equal_to (_variables[var_num].name(), var);
   return var_num;
 }


### PR DESCRIPTION
As @roystgnr pointed out, the previous name risked colliding with other code/apps/libraries, so we employ the usual "fake namespacing" that we use for other macro names.
