### PR TITLE
Fix compile error with newer eigen versions.

### DIFF
--- a/include/numerics/dense_vector.h
+++ b/include/numerics/dense_vector.h
@@ -275,7 +275,7 @@ private:
 template<typename T>
 inline
 DenseVector<T>::DenseVector(const unsigned int n) :
-  _val (n, T(0.))
+  _val (n, T{})
 {
 }
 
@@ -380,7 +380,7 @@ void DenseVector<T>::zero()
 {
   std::fill (_val.begin(),
              _val.end(),
-             T(0.));
+             T{});
 }
 
 


### PR DESCRIPTION
Newer versions of eigen has some static asserts that get triggered by
types that MOOSE tries to use with libmesh DenseVector.  It looks
something like this:

```
Compiling C++ (in opt mode) /home/foo/MOOSE/moose/framework/build/unity_src/ics_Unity.C...
In file included from /usr/include/eigen3/Eigen/Core:347,
                 from /home/foo/MOOSE/moose/framework/build/header_symlinks/MooseTypes.h:26,
                 from /home/foo/MOOSE/moose/framework/build/header_symlinks/InputParameters.h:15,
                 from /home/foo/MOOSE/moose/framework/build/header_symlinks/MooseObject.h:13,
                 from /home/foo/MOOSE/moose/framework/build/header_symlinks/InitialConditionBase.h:12,
                 from /home/foo/MOOSE/moose/framework/build/header_symlinks/InitialConditionTempl.h:12,
                 from /home/foo/MOOSE/moose/framework/build/header_symlinks/ArrayInitialCondition.h:12,
                 from /home/foo/MOOSE/moose/framework/build/header_symlinks/ArrayConstantIC.h:12,
                 from /home/foo/MOOSE/moose/framework/src/ics/ArrayConstantIC.C:10,
                 from /home/foo/MOOSE/moose/framework/build/unity_src/ics_Unity.C:2:
/usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h: In instantiation of ‘void Eigen::PlainObjectBase<Derived>::_init1(Eigen::Index, typename Eigen::internal::enable_if<(((typename Eigen::internal::dense_xpr_base<Derived>::type::SizeAtCompileTime != 1) || (! Eigen::internal::is_convertible<T, typename Eigen::internal::traits<T>::Scalar>::value)) && ((! Eigen::internal::is_same<typename Eigen::internal::traits<T>::XprKind, Eigen::ArrayXpr>::value) || (typename Eigen::internal::dense_xpr_base<Derived>::type::SizeAtCompileTime == Eigen::Dynamic))), T>::type*) [with T = double; Derived = Eigen::Matrix<double, -1, 1>; Eigen::Index = long int; typename Eigen::internal::enable_if<(((typename Eigen::internal::dense_xpr_base<Derived>::type::SizeAtCompileTime != 1) || (! Eigen::internal::is_convertible<T, typename Eigen::internal::traits<T>::Scalar>::value)) && ((! Eigen::internal::is_same<typename Eigen::internal::traits<T>::XprKind, Eigen::ArrayXpr>::value) || (typename Eigen::internal::dense_xpr_base<Derived>::type::SizeAtCompileTime == Eigen::Dynamic))), T>::type = double]’:
/usr/include/eigen3/Eigen/src/Core/Matrix.h:296:31:   required from ‘Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>::Matrix(const T&) [with T = double; _Scalar = double; int _Rows = -1; int _Cols = 1; int _Options = 0; int _MaxRows = -1; int _MaxCols = 1]’
/opt/libmesh_gcc8_openmpi/include/libmesh/dense_vector.h:278:12:   required from ‘libMesh::DenseVector<T>::DenseVector(unsigned int) [with T = Eigen::Matrix<double, -1, 1>]’
/home/foo/MOOSE/moose/framework/src/ics/InitialConditionTempl.C:52:27:   required from ‘InitialConditionTempl< <template-parameter-1-1> >::InitialConditionTempl(const InputParameters&) [with T = Eigen::Matrix<double, -1, 1>]’
/home/foo/MOOSE/moose/framework/src/ics/ArrayConstantIC.C:27:81:   required from here
/usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:774:27: error: static assertion failed: FLOATING_POINT_ARGUMENT_PASSED__INTEGER_WAS_EXPECTED
       EIGEN_STATIC_ASSERT(is_integer,
                           ^~~~~~~~~~
/usr/include/eigen3/Eigen/src/Core/util/StaticAssert.h:32:54: note: in definition of macro ‘EIGEN_STATIC_ASSERT’
     #define EIGEN_STATIC_ASSERT(X,MSG) static_assert(X,#MSG);
```

This was originally reported in the MOOSE users list here:
https://groups.google.com/forum/#!topic/moose-users/5zNET5wl_Tk
I was able to reproduce it on my workstation as well.