### PR TITLE
Check for exactly zero rhs norm.

### DIFF
--- a/src/reduced_basis/rb_construction.C
+++ b/src/reduced_basis/rb_construction.C
@@ -1098,6 +1098,9 @@ void RBConstruction::enrich_basis_from_rhs_terms(const bool resize_rb_eval_data)
     {
       libMesh::out << std::endl << "Performing truth solve with rhs from rhs term " << q_f << std::endl;
 
+      if (rhs->l2_norm() == 0)
+        libmesh_error_msg("RHS norm should be non-zero");
+
       *rhs = *get_Fq(q_f);
 
       // truth_assembly assembles into matrix and rhs, so use those for the solve


### PR DESCRIPTION
It's better to get this error ASAP rather than at some later stage of the execution.