### PR TITLE
Nonblocking packed range push

### DIFF
--- a/include/parallel/communicator.h
+++ b/include/parallel/communicator.h
@@ -464,7 +464,7 @@ public:
    *
    * @param src_processor_id The pid to receive from or "any".
    * will be set to the actual src being receieved from
-   * @param buf THe buffer to receive into
+   * @param buf The buffer to receive into
    * @param type The intrinsic datatype to receive
    * @param req The request to use
    * @param tag The tag to use
@@ -475,6 +475,38 @@ public:
                          const DataType & type,
                          Request & req,
                          const MessageTag & tag) const;
+
+ /**
+  * Nonblocking packed range receive from one processor with
+  * user-defined type.
+  *
+  * Checks to see if a message can be received from the
+  * src_processor_id .  If so, it starts a nonblocking
+  * packed range receive using the passed in request and
+  * returns true
+  *
+  * Otherwise - if there is no message to receive it returns false
+  *
+  * void Parallel::unpack(const T *, OutputIter data, const Context *)
+  * is used to unserialize type T
+  *
+  * @param src_processor_id The pid to receive from or "any".
+  * will be set to the actual src being receieved from
+  * @param context Context pointer that will be passed into
+  * the unpack functions
+  * @param out The output iterator
+  * @param buf The buffer to receive into
+  * @param type The intrinsic datatype to receive
+  * @param req The request to use
+  * @param tag The tag to use
+  */
+  template <typename Context, typename OutputIter, typename T>
+  bool possibly_receive_packed_range (unsigned int & src_processor_id,
+                                      Context * context,
+                                      OutputIter out,
+                                      const T * output_type,
+                                      Request & req,
+                                      const MessageTag & tag) const;
 
   /**
    * Blocking-send range-of-pointers to one processor.  This

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -100,6 +100,34 @@ void pull_parallel_vector_data(const Communicator & comm,
                                ActionFunctor & act_on_data,
                                const datum * example);
 
+/**
+* Send and receive and act on vectors of data. Similar to
+* push_parallel_vector_data, except the vectors are packed and unpacked
+* using the Parallel::Packing routines.
+*
+* The \p data map is indexed by processor ids as keys, and for each
+* processor id in the map there should be a vector of data to send.
+*
+* Data which is received from other processors will be operated on by
+* act_on_data(processor_id_type pid, const std::vector<datum> & data)
+*
+* No guarantee about operation ordering is made - this function will
+* attempt to act on data in the order in which it is received.
+*
+* All receives and actions are completed before this function
+* returns.
+*
+* Note: it is very important that the message tag be completely
+* unique to each invocation
+*/
+template <typename MapToVectors,
+          typename ActionFunctor,
+          typename ReceiveContext>
+void push_parallel_packed_range(const Communicator & comm,
+                                const MapToVectors & data,
+                                ReceiveContext * receive_context,
+                                const ActionFunctor & act_on_data);
+
 //------------------------------------------------------------------------
 // Parallel function overloads
 //
@@ -233,6 +261,182 @@ void push_parallel_vector_data(const Communicator & comm,
 
     // Check if there is a message and start receiving it
     if (comm.possibly_receive(current_src_proc, *current_incoming_data, datatype, *current_request, tag))
+    {
+      receive_reqs.emplace_back(current_src_proc, current_request);
+      current_request = std::make_shared<Request>();
+
+      // current_src_proc will now hold the src pid for this receive
+      incoming_data.emplace(current_src_proc, current_incoming_data);
+      current_incoming_data = std::make_shared<std::vector<nonconst_nonref_type>>();
+    }
+
+    // Clean up outstanding receive requests
+    receive_reqs.remove_if([&act_on_data, &incoming_data](std::pair<unsigned int, std::shared_ptr<Request>> & pid_req_pair)
+                           {
+                             auto & pid = pid_req_pair.first;
+                             auto & req = pid_req_pair.second;
+
+                             // If it's finished - let's act on it
+                             if (req->test())
+                             {
+                               // Do any post-wait work
+                               req->wait();
+
+                               auto it = incoming_data.find(pid);
+                               libmesh_assert(it != incoming_data.end());
+
+                               act_on_data(pid, *it->second);
+
+                               // Don't need this data anymore
+                               incoming_data.erase(it);
+
+                               // This removes it from the list
+                               return true;
+                             }
+
+                             // Not finished yet
+                             return false;
+                           });
+
+    reqs.remove_if([](Request & req)
+                   {
+                     if (req.test())
+                     {
+                       // Do Post-Wait work
+                       req.wait();
+
+                       return true;
+                     }
+
+                     // Not finished yet
+                     return false;
+                   });
+
+
+    // See if all of the sends are finished
+    if (reqs.empty())
+      sends_complete = true;
+
+    // If they've all completed then we can start the barrier
+    if (sends_complete && !started_barrier)
+    {
+      started_barrier = true;
+      comm.nonblocking_barrier(barrier_request);
+    }
+
+    // Must fully receive everything before being allowed to move on!
+    if (receive_reqs.empty())
+      // See if all proessors have finished all sends (i.e. _done_!)
+      if (started_barrier)
+        if (barrier_request.test())
+          break; // Done!
+  }
+
+  // Reset the send mode
+  const_cast<Communicator &>(comm).send_mode(old_send_mode);
+}
+
+
+template <typename MapToVectors,
+          typename ActionFunctor,
+          typename ReceiveContext>
+void push_parallel_packed_range(const Communicator & comm,
+                                const MapToVectors & data,
+                                ReceiveContext * receive_context,
+                                const ActionFunctor & act_on_data)
+{
+  // This function must be run on all processors at once
+  libmesh_parallel_only(comm);
+
+  // This function implements the "NBX" algorithm from
+  // https://htor.inf.ethz.ch/publications/img/hoefler-dsde-protocols.pdf
+
+  // This function only works for "flat" data that we can pre-size
+  // receive buffers for: a map to vectors-of-standard-types, not e.g.
+  // vectors-of-vectors.
+  //
+  // Trying to instantiate a StandardType<T> gives us a compiler error
+  // where otherwise we would have had a runtime error.
+  //
+  // Creating a StandardType<T> manually also saves our APIs from
+  // having to do a bunch of automatic creations later.
+  //
+  // This object will be free'd before all non-blocking communications
+  // complete, but the MPI standard for MPI_Type_free specifies "Any
+  // communication that is currently using this datatype will
+  // complete normally." so we're cool.
+  typedef decltype(data.begin()->second.front()) ref_type;
+  typedef typename std::remove_reference<ref_type>::type nonref_type;
+  typedef typename std::remove_const<nonref_type>::type nonconst_nonref_type;
+
+  // We'll grab a tag so we can overlap request sends and receives
+  // without confusing one for the other
+  auto tag = comm.get_unique_tag();
+
+  MapToVectors received_data;
+
+  // Post all of the sends, non-blocking and synchronous
+
+  // Save off the old send_mode so we can restore it after this
+  auto old_send_mode = comm.send_mode();
+
+  // Set the sending to synchronous - this is so that we can know when
+  // the sends are complete
+  const_cast<Communicator &>(comm).send_mode(Communicator::SYNCHRONOUS);
+
+  // The send requests
+  std::list<Request> reqs;
+
+  processor_id_type num_procs = comm.size();
+
+  for (auto & datapair : data)
+    {
+      // In the case of data partitioned into more processors than we
+      // have ranks, we "wrap around"
+      processor_id_type destid = datapair.first % num_procs;
+      auto & datum = datapair.second;
+
+      // Just act on data if the user requested a send-to-self
+      if (destid == comm.rank())
+        act_on_data(destid, datum);
+      else
+        {
+          Request sendreq;
+          comm.nonblocking_send_packed_range(destid, &datum, datum.begin(), datum.end(), sendreq, tag);
+          reqs.push_back(sendreq);
+        }
+    }
+
+  bool sends_complete = reqs.empty();
+  bool started_barrier = false;
+  Request barrier_request;
+
+  // Receive
+
+  // The pair of src_pid and requests
+  std::list<std::pair<unsigned int, std::shared_ptr<Request>>> receive_reqs;
+  auto current_request = std::make_shared<Request>();
+
+  std::multimap<processor_id_type, std::shared_ptr<std::vector<nonconst_nonref_type>>> incoming_data;
+  auto current_incoming_data = std::make_shared<std::vector<nonconst_nonref_type>>();
+
+  nonconst_nonref_type * output_type;
+
+  unsigned int current_src_proc = 0;
+
+  // Keep looking for receives
+  while (true)
+  {
+    // Look for data from anywhere
+    current_src_proc = Parallel::any_source;
+
+    // Check if there is a message and start receiving it
+    if (comm.possibly_receive_packed_range(current_src_proc,
+                                           receive_context,
+                                           std::back_inserter(*current_incoming_data),
+                                           output_type,
+                                           *current_request,
+                                           tag))
     {
       receive_reqs.emplace_back(current_src_proc, current_request);
       current_request = std::make_shared<Request>();

--- a/include/parallel/parallel_sync.h
+++ b/include/parallel/parallel_sync.h
@@ -351,20 +351,6 @@ void push_parallel_packed_range(const Communicator & comm,
   // This function implements the "NBX" algorithm from
   // https://htor.inf.ethz.ch/publications/img/hoefler-dsde-protocols.pdf
 
-  // This function only works for "flat" data that we can pre-size
-  // receive buffers for: a map to vectors-of-standard-types, not e.g.
-  // vectors-of-vectors.
-  //
-  // Trying to instantiate a StandardType<T> gives us a compiler error
-  // where otherwise we would have had a runtime error.
-  //
-  // Creating a StandardType<T> manually also saves our APIs from
-  // having to do a bunch of automatic creations later.
-  //
-  // This object will be free'd before all non-blocking communications
-  // complete, but the MPI standard for MPI_Type_free specifies "Any
-  // communication that is currently using this datatype will
-  // complete normally." so we're cool.
   typedef decltype(data.begin()->second.front()) ref_type;
   typedef typename std::remove_reference<ref_type>::type nonref_type;
   typedef typename std::remove_const<nonref_type>::type nonconst_nonref_type;


### PR DESCRIPTION
@friedmud has already used something very similar, I just cleaned it up to match `Parallel::push_parallel_vector_data`. There's quite a bit of duplication and I'm not sure if there's a way to cleanly avoid it.

I'll work on some unit tests in a bit, but would like your input @roystgnr on this so far.