### PR TITLE
Fix PETSc deprecation warnings.

### DIFF
--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -517,7 +517,11 @@ namespace libMesh
 
         // Build the PetscSection and attach it to the DM
         this->build_section(system, section);
+#if PETSC_VERSION_LESS_THAN(3,9,0)
         ierr = DMSetDefaultSection(dm, section);
+#else
+        ierr = DMSetSection(dm, section);
+#endif
         CHKERRABORT(system.comm().get(),ierr);
 
         // We only need to build the star forest if we're in a parallel environment
@@ -525,7 +529,11 @@ namespace libMesh
           {
             // Build the PetscSF and attach it to the DM
             this->build_sf(system, star_forest);
+#if PETSC_VERSION_LESS_THAN(3,12,0)
             ierr = DMSetDefaultSF(dm, star_forest);
+#else
+            ierr = DMSetSectionSF(dm, star_forest);
+#endif
             CHKERRABORT(system.comm().get(),ierr);
           }
 


### PR DESCRIPTION
I did not test this with older PETSc yet, just going with the versions recommended in the PETSc deprecation messages:
```
PETSC_STATIC_INLINE PETSC_DEPRECATED_FUNCTION("Use DMSetSection() (since v3.9)")
PetscErrorCode DMSetDefaultSection(DM dm, PetscSection s) {return DMSetSection(dm,s);}
```
```
PETSC_STATIC_INLINE PETSC_DEPRECATED_FUNCTION("Use DMSetSectionSF() (since v3.12)") 
PetscErrorCode DMSetDefaultSF(DM dm, PetscSF s) {return DMSetSectionSF(dm,s);}
```
