### PR TITLE
Split string_to_enum.h into separate headers

### DIFF
--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -1010,6 +1010,7 @@ include_HEADERS = \
         systems/system_subset_by_subdomain.h \
         systems/transient_system.h \
         utils/compare_types.h \
+        utils/enum_to_string.h \
         utils/error_vector.h \
         utils/hashword.h \
         utils/ignore_warnings.h \

--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -431,6 +431,7 @@ include_HEADERS =  \
         systems/system_subset_by_subdomain.h \
         systems/transient_system.h \
         utils/compare_types.h \
+        utils/enum_to_string.h \
         utils/error_vector.h \
         utils/hashword.h \
         utils/ignore_warnings.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -427,6 +427,7 @@ BUILT_SOURCES = \
         system_subset_by_subdomain.h \
         transient_system.h \
         compare_types.h \
+        enum_to_string.h \
         error_vector.h \
         hashword.h \
         ignore_warnings.h \
@@ -1805,6 +1806,9 @@ transient_system.h: $(top_srcdir)/include/systems/transient_system.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 compare_types.h: $(top_srcdir)/include/utils/compare_types.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+enum_to_string.h: $(top_srcdir)/include/utils/enum_to_string.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 error_vector.h: $(top_srcdir)/include/utils/error_vector.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -636,11 +636,11 @@ BUILT_SOURCES = auto_ptr.h default_coupling.h dirichlet_boundaries.h \
 	parameter_pointer.h parameter_vector.h qoi_set.h \
 	sensitivity_data.h steady_system.h system.h system_norm.h \
 	system_subset.h system_subset_by_subdomain.h \
-	transient_system.h compare_types.h error_vector.h hashword.h \
-	ignore_warnings.h int_range.h jacobi_polynomials.h \
-	libmesh_nullptr.h location_maps.h mapvector.h \
-	null_output_iterator.h number_lookups.h ostream_proxy.h \
-	parameters.h perf_log.h perfmon.h plt_loader.h \
+	transient_system.h compare_types.h enum_to_string.h \
+	error_vector.h hashword.h ignore_warnings.h int_range.h \
+	jacobi_polynomials.h libmesh_nullptr.h location_maps.h \
+	mapvector.h null_output_iterator.h number_lookups.h \
+	ostream_proxy.h parameters.h perf_log.h perfmon.h plt_loader.h \
 	point_locator_base.h point_locator_tree.h \
 	pointer_to_pointer_iter.h pool_allocator.h restore_warnings.h \
 	simple_range.h statistics.h string_to_enum.h timestamp.h \
@@ -2148,6 +2148,9 @@ transient_system.h: $(top_srcdir)/include/systems/transient_system.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 compare_types.h: $(top_srcdir)/include/utils/compare_types.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+enum_to_string.h: $(top_srcdir)/include/utils/enum_to_string.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 error_vector.h: $(top_srcdir)/include/utils/error_vector.h

--- a/include/utils/enum_to_string.h
+++ b/include/utils/enum_to_string.h
@@ -17,8 +17,8 @@
 
 
 
-#ifndef LIBMESH_STRING_TO_ENUM_H
-#define LIBMESH_STRING_TO_ENUM_H
+#ifndef LIBMESH_ENUM_TO_STRING_H
+#define LIBMESH_ENUM_TO_STRING_H
 
 
 
@@ -32,13 +32,13 @@ namespace Utility
 {
 
 /**
- * \returns the enumeration of type \p T which matches the string \p s.
+ * \returns the \p string which matches the enumeration \p e of type \p T.
  */
 template <typename T>
-T string_to_enum (const std::string & s);
+std::string enum_to_string (const T e);
 
 } // namespace Utility
 } // namespace libMesh
 
 
-#endif // LIBMESH_STRING_TO_ENUM_H
+#endif // LIBMESH_ENUM_TO_STRING_H

--- a/include/utils/string_to_enum.h
+++ b/include/utils/string_to_enum.h
@@ -22,6 +22,9 @@
 
 
 
+// libMesh includes
+ #include "libmesh/enum_to_string.h" // backwards compatibility
+
 // C++ includes
 #include <string>
 

--- a/src/base/dof_map.C
+++ b/src/base/dof_map.C
@@ -38,10 +38,10 @@
 #include "libmesh/periodic_boundaries.h"
 #include "libmesh/sparse_matrix.h"
 #include "libmesh/sparsity_pattern.h"
-#include "libmesh/string_to_enum.h"
 #include "libmesh/threads.h"
 #include "libmesh/mesh_subdivision_support.h"
 #include "libmesh/int_range.h"
+#include "libmesh/enum_to_string.h"
 
 // C++ Includes
 #include <set>

--- a/src/fe/fe_bernstein.C
+++ b/src/fe/fe_bernstein.C
@@ -19,12 +19,13 @@
 
 // Local includes
 #include "libmesh/libmesh_config.h"
+
 #ifdef LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
 
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/fe/fe_clough.C
+++ b/src/fe/fe_clough.C
@@ -21,8 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/string_to_enum.h"
-
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/fe/fe_hermite.C
+++ b/src/fe/fe_hermite.C
@@ -21,7 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/fe/fe_hierarchic.C
+++ b/src/fe/fe_hierarchic.C
@@ -21,7 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/fe/fe_interface.C
+++ b/src/fe/fe_interface.C
@@ -26,7 +26,7 @@
 #include "libmesh/enum_fe_family.h"
 #include "libmesh/enum_order.h"
 #include "libmesh/enum_elem_type.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/fe/fe_l2_hierarchic.C
+++ b/src/fe/fe_l2_hierarchic.C
@@ -21,7 +21,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/fe/fe_l2_lagrange.C
+++ b/src/fe/fe_l2_lagrange.C
@@ -22,7 +22,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/elem.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/fe/fe_lagrange.C
+++ b/src/fe/fe_lagrange.C
@@ -24,14 +24,10 @@
 #include "libmesh/elem.h"
 #include "libmesh/remote_elem.h"
 #include "libmesh/threads.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
-
-// ------------------------------------------------------------
-// Lagrange-specific implementations
-
 
 // Anonymous namespace for local helper functions
 namespace {

--- a/src/fe/fe_monomial.C
+++ b/src/fe/fe_monomial.C
@@ -21,14 +21,10 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
-
-// ------------------------------------------------------------
-// Monomials-specific implementations
-
 
 // Anonymous namespace for local helper functions
 namespace {

--- a/src/fe/fe_nedelec_one.C
+++ b/src/fe/fe_nedelec_one.C
@@ -23,14 +23,10 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/elem.h"
 #include "libmesh/tensor_value.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {
-
-// ------------------------------------------------------------
-// Nedelec first kind specific implementations
-
 
 // Anonymous namespace for local helper functions
 namespace {

--- a/src/fe/fe_rational.C
+++ b/src/fe/fe_rational.C
@@ -24,7 +24,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 // Anonymous namespace for local helper functions
 namespace {

--- a/src/fe/fe_szabab.C
+++ b/src/fe/fe_szabab.C
@@ -24,7 +24,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/fe/fe_xyz.C
+++ b/src/fe/fe_xyz.C
@@ -22,7 +22,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/int_range.h"
 
 namespace libMesh

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -67,7 +67,7 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/remote_elem.h"
 #include "libmesh/reference_elem.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/threads.h"
 #include "libmesh/enum_elem_quality.h"
 #include "libmesh/enum_io_package.h"

--- a/src/geom/reference_elem.C
+++ b/src/geom/reference_elem.C
@@ -23,7 +23,7 @@
 #include "libmesh/reference_elem.h"
 #include "libmesh/libmesh_singleton.h"
 #include "libmesh/threads.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/enum_elem_type.h"
 
 // C++ includes

--- a/src/mesh/abaqus_io.C
+++ b/src/mesh/abaqus_io.C
@@ -25,7 +25,7 @@
 #include "libmesh/abaqus_io.h"
 #include "libmesh/point.h"
 #include "libmesh/elem.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/utility.h"
 #include <unordered_map>

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -33,7 +33,7 @@
 #include "libmesh/system.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/exodusII_io_helper.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/mesh_communication.h"
 #include "libmesh/parallel_mesh.h"
 #include "libmesh/dof_map.h"

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -31,7 +31,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/system.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/int_range.h"
 #include "libmesh/utility.h"

--- a/src/mesh/gmv_io.C
+++ b/src/mesh/gmv_io.C
@@ -29,7 +29,7 @@
 #include "libmesh/elem.h"
 #include "libmesh/equation_systems.h"
 #include "libmesh/numeric_vector.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/enum_io_package.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/int_range.h"

--- a/src/mesh/mesh_modification.C
+++ b/src/mesh/mesh_modification.C
@@ -37,7 +37,7 @@
 #include "libmesh/mesh_tools.h"
 #include "libmesh/parallel.h"
 #include "libmesh/remote_elem.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/unstructured_mesh.h"
 
 namespace

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -29,7 +29,7 @@
 #include "libmesh/parallel_ghost_sync.h"
 #include "libmesh/sphere.h"
 #include "libmesh/threads.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/int_range.h"
 #include "libmesh/utility.h"

--- a/src/quadrature/quadrature_clough_2D.C
+++ b/src/quadrature/quadrature_clough_2D.C
@@ -20,7 +20,7 @@
 // Local includes
 #include "libmesh/quadrature_clough.h"
 #include "libmesh/quadrature_gauss.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_clough_3D.C
+++ b/src/quadrature/quadrature_clough_3D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_clough.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_conical_2D.C
+++ b/src/quadrature/quadrature_conical_2D.C
@@ -18,7 +18,7 @@
 
 // Local includes
 #include "libmesh/quadrature_conical.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_conical_3D.C
+++ b/src/quadrature/quadrature_conical_3D.C
@@ -18,7 +18,7 @@
 
 // Local includes
 #include "libmesh/quadrature_conical.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_gauss_2D.C
+++ b/src/quadrature/quadrature_gauss_2D.C
@@ -20,7 +20,7 @@
 // Local includes
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/quadrature_conical.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_gauss_3D.C
+++ b/src/quadrature/quadrature_gauss_3D.C
@@ -21,7 +21,7 @@
 #include "libmesh/quadrature_gauss.h"
 #include "libmesh/quadrature_conical.h"
 #include "libmesh/quadrature_gm.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_gauss_lobatto_2D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_2D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_gauss_lobatto.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_gauss_lobatto_3D.C
+++ b/src/quadrature/quadrature_gauss_lobatto_3D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_gauss_lobatto.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_gm_2D.C
+++ b/src/quadrature/quadrature_gm_2D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_gm.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_gm_3D.C
+++ b/src/quadrature/quadrature_gm_3D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_gm.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_grid_2D.C
+++ b/src/quadrature/quadrature_grid_2D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_grid.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_grid_3D.C
+++ b/src/quadrature/quadrature_grid_3D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_grid.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_nodal_1D.C
+++ b/src/quadrature/quadrature_nodal_1D.C
@@ -21,7 +21,7 @@
 #include "libmesh/quadrature_nodal.h"
 #include "libmesh/quadrature_trap.h"
 #include "libmesh/quadrature_simpson.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_nodal_2D.C
+++ b/src/quadrature/quadrature_nodal_2D.C
@@ -21,7 +21,7 @@
 #include "libmesh/quadrature_nodal.h"
 #include "libmesh/quadrature_trap.h"
 #include "libmesh/quadrature_simpson.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_nodal_3D.C
+++ b/src/quadrature/quadrature_nodal_3D.C
@@ -21,7 +21,7 @@
 #include "libmesh/quadrature_nodal.h"
 #include "libmesh/quadrature_trap.h"
 #include "libmesh/quadrature_simpson.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_simpson_2D.C
+++ b/src/quadrature/quadrature_simpson_2D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_simpson.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_simpson_3D.C
+++ b/src/quadrature/quadrature_simpson_3D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_simpson.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_trap_2D.C
+++ b/src/quadrature/quadrature_trap_2D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_trap.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/quadrature/quadrature_trap_3D.C
+++ b/src/quadrature/quadrature_trap_3D.C
@@ -19,7 +19,7 @@
 
 // Local includes
 #include "libmesh/quadrature_trap.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 
 namespace libMesh
 {

--- a/src/reduced_basis/rb_data_serialization.C
+++ b/src/reduced_basis/rb_data_serialization.C
@@ -20,10 +20,10 @@
 #include "libmesh/libmesh_config.h"
 #if defined(LIBMESH_HAVE_CAPNPROTO)
 
-//libMesh includes
+// libMesh includes
 #include "libmesh/rb_data_serialization.h"
 #include "libmesh/rb_eim_evaluation.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/transient_rb_theta_expansion.h"
 #include "libmesh/rb_evaluation.h"
 #include "libmesh/transient_rb_evaluation.h"

--- a/src/solvers/eigen_sparse_linear_solver.C
+++ b/src/solvers/eigen_sparse_linear_solver.C
@@ -25,7 +25,7 @@
 // Local Includes
 #include "libmesh/eigen_sparse_linear_solver.h"
 #include "libmesh/libmesh_logging.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/solver_configuration.h"
 #include "libmesh/enum_preconditioner_type.h"
 #include "libmesh/enum_solver_type.h"

--- a/src/solvers/laspack_linear_solver.C
+++ b/src/solvers/laspack_linear_solver.C
@@ -25,7 +25,7 @@
 // Local Includes
 #include "libmesh/laspack_linear_solver.h"
 #include "libmesh/libmesh_logging.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/enum_solver_type.h"
 #include "libmesh/enum_preconditioner_type.h"
 #include "libmesh/enum_convergence_flags.h"

--- a/src/solvers/linear_solver.C
+++ b/src/solvers/linear_solver.C
@@ -27,7 +27,7 @@
 #include "libmesh/trilinos_aztec_linear_solver.h"
 #include "libmesh/preconditioner.h"
 #include "libmesh/sparse_matrix.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/solver_configuration.h"
 #include "libmesh/enum_solver_package.h"
 #include "libmesh/enum_preconditioner_type.h"

--- a/src/solvers/petsc_linear_solver.C
+++ b/src/solvers/petsc_linear_solver.C
@@ -31,7 +31,7 @@
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/petsc_preconditioner.h"
 #include "libmesh/petsc_vector.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/system.h"
 #include "libmesh/petsc_auto_fieldsplit.h"
 #include "libmesh/solver_configuration.h"

--- a/src/solvers/slepc_eigen_solver.C
+++ b/src/solvers/slepc_eigen_solver.C
@@ -21,16 +21,13 @@
 
 #if defined(LIBMESH_HAVE_SLEPC) && defined(LIBMESH_HAVE_PETSC)
 
-
-// C++ includes
-
 // Local Includes
 #include "libmesh/libmesh_logging.h"
 #include "libmesh/petsc_matrix.h"
 #include "libmesh/petsc_vector.h"
 #include "libmesh/slepc_eigen_solver.h"
 #include "libmesh/shell_matrix.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/solver_configuration.h"
 #include "libmesh/enum_eigen_solver_type.h"
 

--- a/src/solvers/trilinos_aztec_linear_solver.C
+++ b/src/solvers/trilinos_aztec_linear_solver.C
@@ -24,7 +24,7 @@
 
 // Local Includes
 #include "libmesh/libmesh_logging.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/trilinos_aztec_linear_solver.h"
 #include "libmesh/trilinos_epetra_matrix.h"
 #include "libmesh/trilinos_epetra_vector.h"

--- a/src/systems/system.C
+++ b/src/systems/system.C
@@ -31,7 +31,7 @@
 #include "libmesh/point.h"              // For point_value
 #include "libmesh/point_locator_base.h" // For point_value
 #include "libmesh/qoi_set.h"
-#include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/system.h"
 #include "libmesh/system_norm.h"
 #include "libmesh/utility.h"

--- a/src/utils/string_to_enum.C
+++ b/src/utils/string_to_enum.C
@@ -24,6 +24,7 @@
 // Local includes
 #include "libmesh/libmesh_common.h"
 #include "libmesh/string_to_enum.h"
+#include "libmesh/enum_to_string.h"
 #include "libmesh/enum_convergence_flags.h"
 #include "libmesh/enum_elem_quality.h"
 #include "libmesh/enum_elem_type.h"


### PR DESCRIPTION
This fixes a minor annoyance of mine where you had to remember to include "string_to_enum.h" when you were using the `enum_to_string()` function. The new header is included in the old for backwards compatibility, and the library src files have been updated as necessary.
