### PR TITLE
GCC 9.0 warning fixes

### DIFF
--- a/include/geom/point.h
+++ b/include/geom/point.h
@@ -64,6 +64,11 @@ public:
   {}
 
   /**
+   * Copy-assignment operator.
+   */
+  Point& operator=(const Point & p) = default;
+
+  /**
    * Disambiguate constructing from non-Real scalars
    */
   template <typename T,

--- a/include/utils/ignore_warnings.h
+++ b/include/utils/ignore_warnings.h
@@ -86,6 +86,9 @@
 #if (__GNUC__ > 7)
 #pragma GCC diagnostic ignored "-Wparentheses"
 #pragma GCC diagnostic ignored "-Wcast-function-type"
+#if (__GNUC__ > 8)
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif // GCC > 8
 #endif // GCC > 7
 #endif // GCC > 6
 #endif // GCC > 5


### PR DESCRIPTION
- explicitly declare used ctors and methods if they are implicitly being called
- ignore this same warning for contribs.