### PR TITLE
Refactor ExodusII_IO_Helper classes

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -801,28 +801,18 @@ public:
    * Constructor.  Initializes the const private member
    * variables.
    */
-  Conversion(const int * nm,       // node_map
-             size_t nm_size,
-             const int * inm,      // inverse_node_map
-             size_t inm_size,
-             const int * sm,       // side_map
-             size_t sm_size,
-             const int * ism,      // inverse_side_map
-             size_t ism_size,
+  Conversion(const std::vector<int> * nm,
+             const std::vector<int> * inm,
+             const std::vector<int> * sm,
+             const std::vector<int> * ism,
              const ElemType ct,   // "canonical" aka libmesh element type
              std::string ex_type) // string representing the Exodus element type
     : node_map(nm),
-      node_map_size(nm_size),
       inverse_node_map(inm),
-      inverse_node_map_size(inm_size),
       side_map(sm),
-      side_map_size(sm_size),
       inverse_side_map(ism),
-      inverse_side_map_size(ism_size),
       shellface_map(nullptr),
-      shellface_map_size(0),
       inverse_shellface_map(nullptr),
-      inverse_shellface_map_size(0),
       shellface_index_offset(0),
       canonical_type(ct),
       exodus_type(ex_type)
@@ -832,45 +822,25 @@ public:
    * Constructor.  Initializes the const private member
    * variables.  In this case we also initialize shellface data.
    */
-  Conversion(const int * nm,       // node_map
-             size_t nm_size,
-             const int * inm,      // inverse_node_map
-             size_t inm_size,
-             const int * sm,       // side_map
-             size_t sm_size,
-             const int * ism,      // inverse_side_map
-             size_t ism_size,
-             const int * sfm,      // shellface_map
-             size_t sfm_size,
-             const int * isfm,     // inverse_shellface_map
-             size_t isfm_size,
+  Conversion(const std::vector<int> * nm,
+             const std::vector<int> * inm,
+             const std::vector<int> * sm,
+             const std::vector<int> * ism,
+             const std::vector<int> * sfm,
+             const std::vector<int> * isfm,
              size_t sfi_offset,
              const ElemType ct,   // "canonical" aka libmesh element type
              std::string ex_type) // string representing the Exodus element type
     : node_map(nm),
-      node_map_size(nm_size),
       inverse_node_map(inm),
-      inverse_node_map_size(inm_size),
       side_map(sm),
-      side_map_size(sm_size),
       inverse_side_map(ism),
-      inverse_side_map_size(ism_size),
       shellface_map(sfm),
-      shellface_map_size(sfm_size),
       inverse_shellface_map(isfm),
-      inverse_shellface_map_size(isfm_size),
       shellface_index_offset(sfi_offset),
       canonical_type(ct),
       exodus_type(ex_type)
-  {
-    // libmesh_ignore variables that are only used in asserts to avoid
-    // compiler warnings.
-    libmesh_ignore(node_map_size,
-                   inverse_node_map_size,
-                   inverse_side_map_size,
-                   shellface_map_size,
-                   inverse_shellface_map_size);
-  }
+  {}
 
   /**
    * \returns The ith component of the node map for this element.
@@ -880,8 +850,8 @@ public:
    */
   int get_node_map(int i) const
   {
-    libmesh_assert_less (i, node_map_size);
-    return node_map[i];
+    libmesh_assert_less (i, node_map->size());
+    return (*node_map)[i];
   }
 
   /**
@@ -896,8 +866,8 @@ public:
    */
   int get_inverse_node_map(int i) const
   {
-    libmesh_assert_less (i, inverse_node_map_size);
-    return inverse_node_map[i];
+    libmesh_assert_less (i, inverse_node_map->size());
+    return (*inverse_node_map)[i];
   }
 
   /**
@@ -916,8 +886,8 @@ public:
    */
   int get_inverse_side_map(int i) const
   {
-    libmesh_assert_less (i, inverse_side_map_size);
-    return inverse_side_map[i];
+    libmesh_assert_less (i, inverse_side_map->size());
+    return (*inverse_side_map)[i];
   }
 
   /**
@@ -926,8 +896,8 @@ public:
    */
   int get_shellface_map(int i) const
   {
-    libmesh_assert_less (i, shellface_map_size);
-    return shellface_map[i];
+    libmesh_assert_less (i, shellface_map->size());
+    return (*shellface_map)[i];
   }
 
   /**
@@ -935,8 +905,8 @@ public:
    */
   int get_inverse_shellface_map(int i) const
   {
-    libmesh_assert_less (i, inverse_shellface_map_size);
-    return inverse_shellface_map[i];
+    libmesh_assert_less (i, inverse_shellface_map->size());
+    return (*inverse_shellface_map)[i];
   }
 
   /**
@@ -967,71 +937,36 @@ private:
   /**
    * Pointer to the node map for this element.
    */
-  const int * node_map;
-
-  /**
-   * The size of the node map array, this helps with bounds checking
-   * and is only used in asserts.
-   */
-  size_t node_map_size;
+  const std::vector<int> * node_map;
 
   /**
    * Pointer to the inverse node map for this element.
    * For all elements except for the Hex27, this is the same
    * as the node map.
    */
-  const int * inverse_node_map;
-
-  /**
-   * The size of the inverse node map array, this helps with bounds
-   * checking and is only used in asserts.
-   */
-  size_t inverse_node_map_size;
+  const std::vector<int> * inverse_node_map;
 
   /**
    * Pointer to the side map for this element.
    */
-  const int * side_map;
-
-  /**
-   * The size of the side map array, this helps with bounds checking...
-   */
-  size_t side_map_size;
+  const std::vector<int> * side_map;
 
   /**
    * Pointer to the inverse side map for this element.
    */
-  const int * inverse_side_map;
-
-  /**
-   * The size of the inverse side map array, this helps with bounds
-   * checking and is only used in asserts.
-   */
-  size_t inverse_side_map_size;
+  const std::vector<int> * inverse_side_map;
 
   /**
    * Pointer to the shellface map for this element. Only the inverse
    * is actually used currently, this one is provided for completeness
    * and libmesh_ingore()d to avoid warnings.
    */
-  const int * shellface_map;
-
-  /**
-   * The size of the shellface map array, this helps with bounds
-   * checking and is only used in asserts.
-   */
-  size_t shellface_map_size;
+  const std::vector<int> * shellface_map;
 
   /**
    * Pointer to the inverse shellface map for this element.
    */
-  const int * inverse_shellface_map;
-
-  /**
-   * The size of the inverse shellface map array, this helps with
-   * bounds checking and is only used in asserts.
-   */
-  size_t inverse_shellface_map_size;
+  const std::vector<int> * inverse_shellface_map;
 
   /**
    * The shellface index offset defines the offset due to a difference between libMesh
@@ -1062,12 +997,14 @@ class ExodusII_IO_Helper::ElementMaps
 public:
 
   /**
-   * Constructor.  Takes a const reference to an ExodusII_IO_Helper
-   * helper object.  The functionality of ElementMaps should probably
-   * just be moved into the Helper, I have no idea why it's separate
-   * currently.
+   * Constructor and special functions are all defaulted.
    */
-  ElementMaps() {}
+  ElementMaps() = default;
+  ElementMaps (const ElementMaps &) = default;
+  ElementMaps (ElementMaps &&) = default;
+  ElementMaps & operator= (const ElementMaps &) = default;
+  ElementMaps & operator= (ElementMaps &&) = default;
+  ~ElementMaps() = default;
 
 public:
 
@@ -1079,7 +1016,7 @@ public:
   /**
    * The NodeElem node map.
    */
-  static const int nodeelem_node_map[1];
+  static const std::vector<int> nodeelem_node_map;
 
   /**
    * 1D node maps.  These define mappings from ExodusII-formatted
@@ -1089,12 +1026,12 @@ public:
   /**
    * The Edge2 node map.  Use this map for linear elements in 1D.
    */
-  static const int edge2_node_map[2];
+  static const std::vector<int> edge2_node_map;
 
   /**
    * The Edge3 node map.  Use this map for quadratic elements in 1D.
    */
-  static const int edge3_node_map[3];
+  static const std::vector<int> edge3_node_map;
 
   /**
    * 1D edge maps
@@ -1105,13 +1042,13 @@ public:
    * Maps the Exodus edge numbering for line elements.  Useful for
    * reading sideset information.
    */
-  static const int edge_edge_map[2];
+  static const std::vector<int> edge_edge_map;
 
   /**
    * Maps the Exodus edge numbering for line elements.
    * Useful for writing sideset information.
    */
-  static const int edge_inverse_edge_map[2];
+  static const std::vector<int> edge_inverse_edge_map;
 
   /**
    * 2D node maps.  These define mappings from ExodusII-formatted
@@ -1122,30 +1059,30 @@ public:
    * The Quad4 node map.  Use this map for bi-linear quadrilateral
    * elements in 2D.
    */
-  static const int quad4_node_map[4];
+  static const std::vector<int> quad4_node_map;
 
   /**
    * The Quad8 node map.  Use this map for serendipity quadrilateral
    * elements in 2D.
    */
-  static const int quad8_node_map[8];
+  static const std::vector<int> quad8_node_map;
 
   /**
    * The Quad9 node map.  Use this map for bi-quadratic quadrilateral
    * elements in 2D.
    */
-  static const int quad9_node_map[9];
+  static const std::vector<int> quad9_node_map;
 
   /**
    * The Tri3 node map.  Use this map for linear triangles in 2D.
    */
-  static const int tri3_node_map[3];
+  static const std::vector<int> tri3_node_map;
 
   /**
    * The Tri6 node map.  Use this map for quadratic triangular
    * elements in 2D.
    */
-  static const int tri6_node_map[6];
+  static const std::vector<int> tri6_node_map;
 
   /**
    * 2D edge maps
@@ -1155,7 +1092,7 @@ public:
    * Maps the Exodus edge numbering for triangles.  Useful for reading
    * sideset information.
    */
-  static const int tri_edge_map[3];
+  static const std::vector<int> tri_edge_map;
 
   /**
    * Maps the Exodus edge numbering for "shell triangles". In this case
@@ -1163,14 +1100,14 @@ public:
    * the triangle faces and are mapped to "shell face" boundary conditions.
    * The remaining three sides are mapped to edge boundary conditions.
    */
-  static const int trishell3_edge_map[3];
-  static const int trishell3_inverse_edge_map[3];
+  static const std::vector<int> trishell3_edge_map;
+  static const std::vector<int> trishell3_inverse_edge_map;
 
   /**
    * Maps the Exodus edge numbering for quadrilaterals.  Useful for
    * reading sideset information.
    */
-  static const int quad_edge_map[4];
+  static const std::vector<int> quad_edge_map;
 
   /**
    * Maps the Exodus edge numbering for "shell quads". In this case
@@ -1178,20 +1115,20 @@ public:
    * the quad faces and are mapped to "shell face" boundary conditions.
    * The remaining four sides are mapped to edge boundary conditions.
    */
-  static const int quadshell4_edge_map[4];
-  static const int quadshell4_inverse_edge_map[4];
+  static const std::vector<int> quadshell4_edge_map;
+  static const std::vector<int> quadshell4_inverse_edge_map;
 
   /**
    * Maps the Exodus edge numbering for triangles.  Useful for writing
    * sideset information.
    */
-  static const int tri_inverse_edge_map[3];
+  static const std::vector<int> tri_inverse_edge_map;
 
   /**
    * Maps the Exodus edge numbering for quadrilaterals.  Useful for
    * writing sideset information.
    */
-  static const int quad_inverse_edge_map[4];
+  static const std::vector<int> quad_inverse_edge_map;
 
   /**
    * 3D maps.  These define mappings from ExodusII-formatted element
@@ -1202,71 +1139,71 @@ public:
    * The Hex8 node map.  Use this map for bi-linear hexahedral
    * elements in 3D.
    */
-  static const int hex8_node_map[8];
+  static const std::vector<int> hex8_node_map;
 
   /**
    * The Hex20 node map.  Use this map for serendipity hexahedral
    * elements in 3D.
    */
-  static const int hex20_node_map[20];
+  static const std::vector<int> hex20_node_map;
 
   /**
    * The Hex27 node map.  Use this map for reading tri-quadratic
    * hexahedral elements in 3D.
    */
-  static const int hex27_node_map[27];
+  static const std::vector<int> hex27_node_map;
 
   /**
    * The Hex27 inverse node map.  Use this map for writing
    * tri-quadratic hexahedral elements in 3D.
    */
-  static const int hex27_inverse_node_map[27];
+  static const std::vector<int> hex27_inverse_node_map;
 
   /**
    * The Tet4 node map.  Use this map for linear tetrahedral elements
    * in 3D.
    */
-  static const int tet4_node_map[4];
+  static const std::vector<int> tet4_node_map;
 
   /**
    * The Tet10 node map.  Use this map for quadratic tetrahedral
    * elements in 3D.
    */
-  static const int tet10_node_map[10];
+  static const std::vector<int> tet10_node_map;
 
   /**
    * The Prism6 node map.
    */
-  static const int prism6_node_map[6];
+  static const std::vector<int> prism6_node_map;
 
   /**
    * The Prism15 node map.  Use this map for "serendipity" prisms in
    * 3D.
    */
-  static const int prism15_node_map[15];
+  static const std::vector<int> prism15_node_map;
 
   /**
    * The Prism18 node map.
    */
-  static const int prism18_node_map[18];
+  static const std::vector<int> prism18_node_map;
 
   /**
    * The Pyramid5 node map.  Use this map for linear pyramid elements
    * in 3D.
    */
-  static const int pyramid5_node_map[5];
+  static const std::vector<int> pyramid5_node_map;
 
   /**
    * The Pyramid13 node map.  Use this map for "serendipity" pyramid elements
    * in 3D.
    */
-  static const int pyramid13_node_map[13];
+  static const std::vector<int> pyramid13_node_map;
 
   /**
    * The Pyramid14 node map.  Use this map for biquadratic pyramid elements
    * in 3D.
    */
-  static const int pyramid14_node_map[14];
+  static const std::vector<int> pyramid14_node_map;
 
 
   /**
@@ -1277,15 +1214,15 @@ public:
    * Maps the Exodus shell face numbering for triangles.  Useful for reading
    * sideset information.
    */
-  static const int trishell3_shellface_map[2];
-  static const int trishell3_inverse_shellface_map[2];
+  static const std::vector<int> trishell3_shellface_map;
+  static const std::vector<int> trishell3_inverse_shellface_map;
 
   /**
    * Maps the Exodus shell face numbering for quads.  Useful for reading
    * sideset information.
    */
-  static const int quadshell4_shellface_map[2];
-  static const int quadshell4_inverse_shellface_map[2];
+  static const std::vector<int> quadshell4_shellface_map;
+  static const std::vector<int> quadshell4_inverse_shellface_map;
 
   /**
    * 3D face maps.
@@ -1295,61 +1232,61 @@ public:
    * Maps the Exodus face numbering for general hexahedra.
    * Useful for reading sideset information.
    */
-  static const int hex_face_map[6];
+  static const std::vector<int> hex_face_map;
 
   /**
    * Maps the Exodus face numbering for 27-noded hexahedra.
    * Useful for reading sideset information.
    */
-  static const int hex27_face_map[6];
+  static const std::vector<int> hex27_face_map;
 
   /**
    * Maps the Exodus face numbering for general tetrahedra.
    * Useful for reading sideset information.
    */
-  static const int tet_face_map[4];
+  static const std::vector<int> tet_face_map;
 
   /**
    * Maps the Exodus face numbering for general prisms.
    * Useful for reading sideset information.
    */
-  static const int prism_face_map[5];
+  static const std::vector<int> prism_face_map;
 
   /**
    * Maps the Exodus face numbering for general pyramids.
    * Useful for reading sideset information.
    */
-  static const int pyramid_face_map[5];
+  static const std::vector<int> pyramid_face_map;
 
   /**
    * Maps the Exodus face numbering for general hexahedra.
    * Useful for writing sideset information.
    */
-  static const int hex_inverse_face_map[6];
+  static const std::vector<int> hex_inverse_face_map;
 
   /**
    * Maps the Exodus face numbering for 27-noded hexahedra.
    * Useful for writing sideset information.
    */
-  static const int hex27_inverse_face_map[6];
+  static const std::vector<int> hex27_inverse_face_map;
 
   /**
    * Maps the Exodus face numbering for general tetrahedra.
    * Useful for writing sideset information.
    */
-  static const int tet_inverse_face_map[4];
+  static const std::vector<int> tet_inverse_face_map;
 
   /**
    * Maps the Exodus face numbering for general prisms.
    * Useful for writing sideset information.
    */
-  static const int prism_inverse_face_map[5];
+  static const std::vector<int> prism_inverse_face_map;
 
   /**
    * Maps the Exodus face numbering for general pyramids.
    * Useful for writing sideset information.
    */
-  static const int pyramid_inverse_face_map[5];
+  static const std::vector<int> pyramid_inverse_face_map;
 
   /**
    * \returns A conversion object given an element type name.

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -159,48 +159,46 @@ namespace libMesh
 // ExodusII_IO_Helper::ElementMaps static data
 
 // 0D node map definitions
-const int ExodusII_IO_Helper::ElementMaps::nodeelem_node_map[1] = {0};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::nodeelem_node_map = {0};
 
 // 1D node map definitions
-const int ExodusII_IO_Helper::ElementMaps::edge2_node_map[2] = {0, 1};
-const int ExodusII_IO_Helper::ElementMaps::edge3_node_map[3] = {0, 1, 2};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::edge2_node_map = {0, 1};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::edge3_node_map = {0, 1, 2};
 
 // 1D edge maps
 // FIXME: This notion may or may not be defined in ExodusII
-const int ExodusII_IO_Helper::ElementMaps::edge_edge_map[2] = {0, 1};
-const int ExodusII_IO_Helper::ElementMaps::edge_inverse_edge_map[2] = {1, 2};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::edge_edge_map = {0, 1};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::edge_inverse_edge_map = {1, 2};
 
 // 2D node map definitions
-const int ExodusII_IO_Helper::ElementMaps::quad4_node_map[4] = {0, 1, 2, 3};
-const int ExodusII_IO_Helper::ElementMaps::quad8_node_map[8] = {0, 1, 2, 3, 4, 5, 6, 7};
-const int ExodusII_IO_Helper::ElementMaps::quad9_node_map[9] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
-const int ExodusII_IO_Helper::ElementMaps::tri3_node_map[3]  = {0, 1, 2};
-const int ExodusII_IO_Helper::ElementMaps::tri6_node_map[6]  = {0, 1, 2, 3, 4, 5};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad4_node_map = {0, 1, 2, 3};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad8_node_map = {0, 1, 2, 3, 4, 5, 6, 7};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad9_node_map = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::tri3_node_map = {0, 1, 2};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::tri6_node_map = {0, 1, 2, 3, 4, 5};
 
 // 2D edge map definitions
-const int ExodusII_IO_Helper::ElementMaps::tri_edge_map[3] = {0, 1, 2};
-const int ExodusII_IO_Helper::ElementMaps::quad_edge_map[4] = {0, 1, 2, 3};
-const int ExodusII_IO_Helper::ElementMaps::trishell3_edge_map[3] = {0, 1, 2};
-const int ExodusII_IO_Helper::ElementMaps::quadshell4_edge_map[4] = {0, 1, 2, 3};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::tri_edge_map = {0, 1, 2};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad_edge_map = {0, 1, 2, 3};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::trishell3_edge_map = {0, 1, 2};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::quadshell4_edge_map = {0, 1, 2, 3};
 
-//These take a libMesh ID and turn it into an Exodus ID
-const int ExodusII_IO_Helper::ElementMaps::tri_inverse_edge_map[3] = {1, 2, 3};
-const int ExodusII_IO_Helper::ElementMaps::quad_inverse_edge_map[4] = {1, 2, 3, 4};
-const int ExodusII_IO_Helper::ElementMaps::trishell3_inverse_edge_map[3] = {3, 4, 5};
-const int ExodusII_IO_Helper::ElementMaps::quadshell4_inverse_edge_map[4] = {3, 4, 5, 6};
+// 2D inverse face map definitions.
+// These take a libMesh ID and turn it into an Exodus ID
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::tri_inverse_edge_map = {1, 2, 3};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad_inverse_edge_map = {1, 2, 3, 4};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::trishell3_inverse_edge_map = {3, 4, 5};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::quadshell4_inverse_edge_map = {3, 4, 5, 6};
 
 // 3D node map definitions
-const int ExodusII_IO_Helper::ElementMaps::hex8_node_map[8]   = {0, 1, 2, 3, 4, 5, 6, 7};
-const int ExodusII_IO_Helper::ElementMaps::hex20_node_map[20] = { 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
-                                                                  10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex8_node_map = {0, 1, 2, 3, 4, 5, 6, 7};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex20_node_map
+= { 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
 
-// Perhaps an older Hex27 node numbering?  This no longer works.
-//const int ExodusII_IO_Helper::ElementMaps::hex27_node_map[27] = { 1,  5,  6,  2,  0,  4,  7,  3, 13, 17, 14,  9,  8, 16,
-//  18, 10, 12, 19, 15, 11, 24, 25, 22, 26, 21, 23, 20};
-
-//DRG: Using the newest exodus documentation available on sourceforge and using Table 2 to see
+// DRG: Using the newest exodus documentation available on sourceforge and using Table 2 to see
 // where all of the nodes over 21 are supposed to go... we come up with:
-const int ExodusII_IO_Helper::ElementMaps::hex27_node_map[27] = {
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_node_map = {
   // Vertex and mid-edge nodes
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
   // Mid-face nodes and centroid
@@ -210,58 +208,47 @@ const int ExodusII_IO_Helper::ElementMaps::hex27_node_map[27] = {
 // The hex27 appears to be the only element without a 1:1 map between its
 // node numbering and libmesh's.  Therefore when writing out hex27's we need
 // to invert this map...
-const int ExodusII_IO_Helper::ElementMaps::hex27_inverse_node_map[27] = {
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_inverse_node_map = {
   // Vertex and mid-edge nodes
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
   // Mid-face nodes and centroid
   26, 20, 25, 24, 22, 21, 23};
 //20  21  22  23  24  25  26
-
-
-const int ExodusII_IO_Helper::ElementMaps::tet4_node_map[4]   = {0, 1, 2, 3};
-const int ExodusII_IO_Helper::ElementMaps::tet10_node_map[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-
-const int ExodusII_IO_Helper::ElementMaps::prism6_node_map[6]   = {0, 1, 2, 3, 4, 5};
-const int ExodusII_IO_Helper::ElementMaps::prism15_node_map[15]   = {0, 1, 2, 3, 4, 5, 6,  7,  8,  9,
-                                                                     10, 11, 12, 13, 14};
-const int ExodusII_IO_Helper::ElementMaps::prism18_node_map[18]   = {0, 1, 2, 3, 4, 5, 6,  7,  8,  9,
-                                                                     10, 11, 12, 13, 14, 15, 16, 17};
-const int ExodusII_IO_Helper::ElementMaps::pyramid5_node_map[5] = {0, 1, 2, 3, 4};
-const int ExodusII_IO_Helper::ElementMaps::pyramid13_node_map[13] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-const int ExodusII_IO_Helper::ElementMaps::pyramid14_node_map[14] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet4_node_map = {0, 1, 2, 3};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet10_node_map =
+  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism6_node_map = {0, 1, 2, 3, 4, 5};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism15_node_map =
+  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism18_node_map =
+  {0, 1, 2, 3, 4, 5, 6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid5_node_map = {0, 1, 2, 3, 4};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid13_node_map =
+  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid14_node_map =
+  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
 
 // Shell element face maps
-const int ExodusII_IO_Helper::ElementMaps::trishell3_shellface_map[2] = {0, 1};
-const int ExodusII_IO_Helper::ElementMaps::quadshell4_shellface_map[2] = {0, 1};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::trishell3_shellface_map = {0, 1};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::quadshell4_shellface_map = {0, 1};
 
-//These take a libMesh ID and turn it into an Exodus ID
-const int ExodusII_IO_Helper::ElementMaps::trishell3_inverse_shellface_map[2] = {1, 2};
-const int ExodusII_IO_Helper::ElementMaps::quadshell4_inverse_shellface_map[2] = {1, 2};
+// These take a libMesh ID and turn it into an Exodus ID
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::trishell3_inverse_shellface_map = {1, 2};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::quadshell4_inverse_shellface_map = {1, 2};
 
 // 3D face map definitions
-const int ExodusII_IO_Helper::ElementMaps::tet_face_map[4]     = {1, 2, 3, 0};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet_face_map = {1, 2, 3, 0};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex_face_map = {1, 2, 3, 4, 0, 5};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_face_map = {1, 2, 3, 4, 0, 5};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism_face_map = {1, 2, 3, 0, 4};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid_face_map = {0, 1, 2, 3, 4};
 
-const int ExodusII_IO_Helper::ElementMaps::hex_face_map[6]     = {1, 2, 3, 4, 0, 5};
-const int ExodusII_IO_Helper::ElementMaps::hex27_face_map[6]   = {1, 2, 3, 4, 0, 5};
-//const int ExodusII_IO_Helper::ElementMaps::hex27_face_map[6]   = {1, 0, 3, 5, 4, 2};
-const int ExodusII_IO_Helper::ElementMaps::prism_face_map[5]   = {1, 2, 3, 0, 4};
-
-// Pyramids are not included in the ExodusII specification. The ordering below matches
-// the sideset ordering that CUBIT generates.
-const int ExodusII_IO_Helper::ElementMaps::pyramid_face_map[5] = {0, 1, 2, 3, 4};
-
-//These take a libMesh ID and turn it into an Exodus ID
-const int ExodusII_IO_Helper::ElementMaps::tet_inverse_face_map[4]     = {4, 1, 2, 3};
-const int ExodusII_IO_Helper::ElementMaps::hex_inverse_face_map[6]     = {5, 1, 2, 3, 4, 6};
-const int ExodusII_IO_Helper::ElementMaps::hex27_inverse_face_map[6]   = {5, 1, 2, 3, 4, 6};
-//const int ExodusII_IO_Helper::ElementMaps::hex27_inverse_face_map[6]   = {2, 1, 6, 3, 5, 4};
-const int ExodusII_IO_Helper::ElementMaps::prism_inverse_face_map[5]   = {4, 1, 2, 3, 5};
-
-// Pyramids are not included in the ExodusII specification. The ordering below matches
-// the sideset ordering that CUBIT generates.
-const int ExodusII_IO_Helper::ElementMaps::pyramid_inverse_face_map[5] = {1, 2, 3, 4, 5};
-
-
+// These take a libMesh ID and turn it into an Exodus ID
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet_inverse_face_map = {4, 1, 2, 3};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex_inverse_face_map = {5, 1, 2, 3, 4, 6};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_inverse_face_map = {5, 1, 2, 3, 4, 6};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism_inverse_face_map = {4, 1, 2, 3, 5};
+const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid_inverse_face_map = {1, 2, 3, 4, 5};
 
 // ExodusII_IO_Helper::Conversion static data
 const int ExodusII_IO_Helper::Conversion::invalid_id = std::numeric_limits<int>::max();
@@ -2768,353 +2755,216 @@ ExodusII_IO_Helper::Conversion ExodusII_IO_Helper::ElementMaps::assign_conversio
     {
     case NODEELEM:
       {
-        const Conversion conv(nodeelem_node_map,
-                              ARRAY_LENGTH(nodeelem_node_map),
-                              nodeelem_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(nodeelem_node_map),
-                              nullptr, // NODELEM doesn't have any edges
-                              0,
-                              nullptr,
-                              0,
-                              NODEELEM, "SPHERE");
-        return conv;
+        return Conversion(&nodeelem_node_map,
+                          &nodeelem_node_map, // inverse node map same as forward node map
+                          nullptr, // NODELEM doesn't have any edges
+                          nullptr, // We also don't inverse map NODEELEM edges
+                          NODEELEM, "SPHERE");
       }
 
     case EDGE2:
       {
-        const Conversion conv(edge2_node_map,
-                              ARRAY_LENGTH(edge2_node_map),
-                              edge2_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(edge2_node_map),
-                              edge_edge_map,
-                              ARRAY_LENGTH(edge_edge_map),
-                              edge_inverse_edge_map,
-                              ARRAY_LENGTH(edge_inverse_edge_map),
-                              EDGE2, "EDGE2");
-        return conv;
+        return Conversion(&edge2_node_map,
+                          &edge2_node_map, // inverse node map same as forward node map
+                          &edge_edge_map,
+                          &edge_inverse_edge_map,
+                          EDGE2, "EDGE2");
       }
     case EDGE3:
       {
-        const Conversion conv(edge3_node_map,
-                              ARRAY_LENGTH(edge3_node_map),
-                              edge3_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(edge3_node_map),
-                              edge_edge_map,
-                              ARRAY_LENGTH(edge_edge_map),
-                              edge_inverse_edge_map,
-                              ARRAY_LENGTH(edge_inverse_edge_map),
-                              EDGE3, "EDGE3");
-        return conv;
+        return Conversion(&edge3_node_map,
+                          &edge3_node_map, // inverse node map same as forward node map
+                          &edge_edge_map,
+                          &edge_inverse_edge_map,
+                          EDGE3, "EDGE3");
       }
     case QUAD4:
       {
-        const Conversion conv(quad4_node_map,
-                              ARRAY_LENGTH(quad4_node_map),
-                              quad4_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(quad4_node_map),
-                              quad_edge_map,
-                              ARRAY_LENGTH(quad_edge_map),
-                              quad_inverse_edge_map,
-                              ARRAY_LENGTH(quad_inverse_edge_map),
-                              QUAD4,
-                              "QUAD4");
-        return conv;
+        return Conversion(&quad4_node_map,
+                          &quad4_node_map, // inverse node map same as forward node map
+                          &quad_edge_map,
+                          &quad_inverse_edge_map,
+                          QUAD4, "QUAD4");
       }
 
     case QUADSHELL4:
       {
-        return Conversion(quad4_node_map,
-                          ARRAY_LENGTH(quad4_node_map), // node mapping is the same as for quad4
-                          quad4_node_map,
-                          ARRAY_LENGTH(quad4_node_map),
-                          quadshell4_edge_map,
-                          ARRAY_LENGTH(quadshell4_edge_map),
-                          quadshell4_inverse_edge_map,
-                          ARRAY_LENGTH(quadshell4_inverse_edge_map),
-                          quadshell4_shellface_map,
-                          ARRAY_LENGTH(quadshell4_shellface_map),
-                          quadshell4_inverse_shellface_map,
-                          ARRAY_LENGTH(quadshell4_inverse_shellface_map),
+        return Conversion(&quad4_node_map, // node mapping is the same as for quad4
+                          &quad4_node_map,
+                          &quadshell4_edge_map,
+                          &quadshell4_inverse_edge_map,
+                          &quadshell4_shellface_map,
+                          &quadshell4_inverse_shellface_map,
                           2, // the side index offset for QUADSHELL4 is 2
-                          QUADSHELL4,
-                          "SHELL4");
+                          QUADSHELL4, "SHELL4");
       }
 
     case QUAD8:
       {
-        const Conversion conv(quad8_node_map,
-                              ARRAY_LENGTH(quad8_node_map),
-                              quad8_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(quad8_node_map),
-                              quad_edge_map,
-                              ARRAY_LENGTH(quad_edge_map),
-                              quad_inverse_edge_map,
-                              ARRAY_LENGTH(quad_inverse_edge_map),
-                              QUAD8,
-                              "QUAD8");
-        return conv;
+        return Conversion(&quad8_node_map,
+                          &quad8_node_map, // inverse node map same as forward node map
+                          &quad_edge_map,
+                          &quad_inverse_edge_map,
+                          QUAD8, "QUAD8");
       }
 
     case QUADSHELL8:
       {
-        return Conversion(quad8_node_map,
-                          ARRAY_LENGTH(quad8_node_map), // node mapping is the same as for quad8
-                          quad8_node_map,
-                          ARRAY_LENGTH(quad8_node_map),
-                          quadshell4_edge_map,
-                          ARRAY_LENGTH(quadshell4_edge_map),
-                          quadshell4_inverse_edge_map,
-                          ARRAY_LENGTH(quadshell4_inverse_edge_map),
-                          quadshell4_shellface_map,
-                          ARRAY_LENGTH(quadshell4_shellface_map),
-                          quadshell4_inverse_shellface_map,
-                          ARRAY_LENGTH(quadshell4_inverse_shellface_map),
+        return Conversion(&quad8_node_map, // node mapping is the same as for quad8
+                          &quad8_node_map,
+                          &quadshell4_edge_map,
+                          &quadshell4_inverse_edge_map,
+                          &quadshell4_shellface_map,
+                          &quadshell4_inverse_shellface_map,
                           2, // the side index offset for QUADSHELL8 is 2
-                          QUADSHELL8,
-                          "SHELL8");
+                          QUADSHELL8, "SHELL8");
       }
 
     case QUAD9:
       {
-        const Conversion conv(quad9_node_map,
-                              ARRAY_LENGTH(quad9_node_map),
-                              quad9_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(quad9_node_map),
-                              quad_edge_map,
-                              ARRAY_LENGTH(quad_edge_map),
-                              quad_inverse_edge_map,
-                              ARRAY_LENGTH(quad_inverse_edge_map),
-                              QUAD9,
-                              "QUAD9");
-        return conv;
+        return Conversion(&quad9_node_map,
+                          &quad9_node_map, // inverse node map same as forward node map
+                          &quad_edge_map,
+                          &quad_inverse_edge_map,
+                          QUAD9, "QUAD9");
       }
 
     case TRI3:
       {
-        return Conversion(tri3_node_map,
-                          ARRAY_LENGTH(tri3_node_map),
-                          tri3_node_map, // inverse node map same as forward node map
-                          ARRAY_LENGTH(tri3_node_map),
-                          tri_edge_map,
-                          ARRAY_LENGTH(tri_edge_map),
-                          tri_inverse_edge_map,
-                          ARRAY_LENGTH(tri_inverse_edge_map),
-                          TRI3,
-                          "TRI3");
+        return Conversion(&tri3_node_map,
+                          &tri3_node_map, // inverse node map same as forward node map
+                          &tri_edge_map,
+                          &tri_inverse_edge_map,
+                          TRI3, "TRI3");
       }
 
     case TRISHELL3:
       {
-        return Conversion(tri3_node_map,
-                          ARRAY_LENGTH(tri3_node_map), // node mapping is the same as for tri3
-                          tri3_node_map,
-                          ARRAY_LENGTH(tri3_node_map),
-                          trishell3_edge_map,
-                          ARRAY_LENGTH(trishell3_edge_map),
-                          trishell3_inverse_edge_map,
-                          ARRAY_LENGTH(trishell3_inverse_edge_map),
-                          trishell3_shellface_map,
-                          ARRAY_LENGTH(trishell3_shellface_map),
-                          trishell3_inverse_shellface_map,
-                          ARRAY_LENGTH(trishell3_inverse_shellface_map),
+        return Conversion(&tri3_node_map, // node mapping is the same as for tri3
+                          &tri3_node_map,
+                          &trishell3_edge_map,
+                          &trishell3_inverse_edge_map,
+                          &trishell3_shellface_map,
+                          &trishell3_inverse_shellface_map,
                           2, // the side index offset for TRISHELL4 is 2
-                          TRISHELL3,
-                          "TRISHELL3");
+                          TRISHELL3, "TRISHELL3");
       }
 
     case TRI3SUBDIVISION:
       {
-        const Conversion conv(tri3_node_map,
-                              ARRAY_LENGTH(tri3_node_map),
-                              tri3_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(tri3_node_map),
-                              tri_edge_map,
-                              ARRAY_LENGTH(tri_edge_map),
-                              tri_inverse_edge_map,
-                              ARRAY_LENGTH(tri_inverse_edge_map),
-                              TRI3SUBDIVISION,
-                              "TRI3");
-        return conv;
+        return Conversion(&tri3_node_map,
+                          &tri3_node_map, // inverse node map same as forward node map
+                          &tri_edge_map,
+                          &tri_inverse_edge_map,
+                          TRI3SUBDIVISION, "TRI3");
       }
 
     case TRI6:
       {
-        const Conversion conv(tri6_node_map,
-                              ARRAY_LENGTH(tri6_node_map),
-                              tri6_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(tri6_node_map),
-                              tri_edge_map,
-                              ARRAY_LENGTH(tri_edge_map),
-                              tri_inverse_edge_map,
-                              ARRAY_LENGTH(tri_inverse_edge_map),
-                              TRI6,
-                              "TRI6");
-        return conv;
+        return Conversion(&tri6_node_map,
+                          &tri6_node_map, // inverse node map same as forward node map
+                          &tri_edge_map,
+                          &tri_inverse_edge_map,
+                          TRI6, "TRI6");
       }
 
     case HEX8:
       {
-        const Conversion conv(hex8_node_map,
-                              ARRAY_LENGTH(hex8_node_map),
-                              hex8_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(hex8_node_map),
-                              hex_face_map,
-                              ARRAY_LENGTH(hex_face_map),
-                              hex_inverse_face_map,
-                              ARRAY_LENGTH(hex_inverse_face_map),
-                              HEX8,
-                              "HEX8");
-        return conv;
+        return Conversion(&hex8_node_map,
+                          &hex8_node_map, // inverse node map same as forward node map
+                          &hex_face_map,
+                          &hex_inverse_face_map,
+                          HEX8, "HEX8");
       }
 
     case HEX20:
       {
-        const Conversion conv(hex20_node_map,
-                              ARRAY_LENGTH(hex20_node_map),
-                              hex20_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(hex20_node_map),
-                              hex_face_map,
-                              ARRAY_LENGTH(hex_face_map),
-                              hex_inverse_face_map,
-                              ARRAY_LENGTH(hex_inverse_face_map),
-                              HEX20,
-                              "HEX20");
-        return conv;
+        return Conversion(&hex20_node_map,
+                          &hex20_node_map, // inverse node map same as forward node map
+                          &hex_face_map,
+                          &hex_inverse_face_map,
+                          HEX20, "HEX20");
       }
 
     case HEX27:
       {
-        const Conversion conv(hex27_node_map,
-                              ARRAY_LENGTH(hex27_node_map),
-                              hex27_inverse_node_map, // different inverse node map for Hex27!
-                              ARRAY_LENGTH(hex27_inverse_node_map),
-                              hex27_face_map,
-                              ARRAY_LENGTH(hex27_face_map),
-                              hex27_inverse_face_map,
-                              ARRAY_LENGTH(hex27_inverse_face_map),
-                              HEX27,
-                              "HEX27");
-        return conv;
+        return Conversion(&hex27_node_map,
+                          &hex27_inverse_node_map, // different inverse node map for Hex27!
+                          &hex27_face_map,
+                          &hex27_inverse_face_map,
+                          HEX27, "HEX27");
       }
 
     case TET4:
       {
-        const Conversion conv(tet4_node_map,
-                              ARRAY_LENGTH(tet4_node_map),
-                              tet4_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(tet4_node_map),
-                              tet_face_map,
-                              ARRAY_LENGTH(tet_face_map),
-                              tet_inverse_face_map,
-                              ARRAY_LENGTH(tet_inverse_face_map),
-                              TET4,
-                              "TETRA4");
-        return conv;
+        return Conversion(&tet4_node_map,
+                          &tet4_node_map, // inverse node map same as forward node map
+                          &tet_face_map,
+                          &tet_inverse_face_map,
+                          TET4, "TETRA4");
       }
 
     case TET10:
       {
-        const Conversion conv(tet10_node_map,
-                              ARRAY_LENGTH(tet10_node_map),
-                              tet10_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(tet10_node_map),
-                              tet_face_map,
-                              ARRAY_LENGTH(tet_face_map),
-                              tet_inverse_face_map,
-                              ARRAY_LENGTH(tet_inverse_face_map),
-                              TET10,
-                              "TETRA10");
-        return conv;
+        return Conversion(&tet10_node_map,
+                          &tet10_node_map, // inverse node map same as forward node map
+                          &tet_face_map,
+                          &tet_inverse_face_map,
+                          TET10, "TETRA10");
       }
 
     case PRISM6:
       {
-        const Conversion conv(prism6_node_map,
-                              ARRAY_LENGTH(prism6_node_map),
-                              prism6_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(prism6_node_map),
-                              prism_face_map,
-                              ARRAY_LENGTH(prism_face_map),
-                              prism_inverse_face_map,
-                              ARRAY_LENGTH(prism_inverse_face_map),
-                              PRISM6,
-                              "WEDGE");
-        return conv;
+        return Conversion(&prism6_node_map,
+                          &prism6_node_map, // inverse node map same as forward node map
+                          &prism_face_map,
+                          &prism_inverse_face_map,
+                          PRISM6, "WEDGE");
       }
 
     case PRISM15:
       {
-        const Conversion conv(prism15_node_map,
-                              ARRAY_LENGTH(prism15_node_map),
-                              prism15_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(prism15_node_map),
-                              prism_face_map,
-                              ARRAY_LENGTH(prism_face_map),
-                              prism_inverse_face_map,
-                              ARRAY_LENGTH(prism_inverse_face_map),
-                              PRISM15,
-                              "WEDGE15");
-        return conv;
+        return Conversion(&prism15_node_map,
+                          &prism15_node_map, // inverse node map same as forward node map
+                          &prism_face_map,
+                          &prism_inverse_face_map,
+                          PRISM15, "WEDGE15");
       }
 
     case PRISM18:
       {
-        const Conversion conv(prism18_node_map,
-                              ARRAY_LENGTH(prism18_node_map),
-                              prism18_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(prism18_node_map),
-                              prism_face_map,
-                              ARRAY_LENGTH(prism_face_map),
-                              prism_inverse_face_map,
-                              ARRAY_LENGTH(prism_inverse_face_map),
-                              PRISM18,
-                              "WEDGE18");
-        return conv;
+        return Conversion(&prism18_node_map,
+                          &prism18_node_map, // inverse node map same as forward node map
+                          &prism_face_map,
+                          &prism_inverse_face_map,
+                          PRISM18, "WEDGE18");
       }
 
     case PYRAMID5:
       {
-        const Conversion conv(pyramid5_node_map,
-                              ARRAY_LENGTH(pyramid5_node_map),
-                              pyramid5_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(pyramid5_node_map),
-                              pyramid_face_map,
-                              ARRAY_LENGTH(pyramid_face_map),
-                              pyramid_inverse_face_map,
-                              ARRAY_LENGTH(pyramid_inverse_face_map),
-                              PYRAMID5,
-                              "PYRAMID5");
-        return conv;
+        return Conversion(&pyramid5_node_map,
+                          &pyramid5_node_map, // inverse node map same as forward node map
+                          &pyramid_face_map,
+                          &pyramid_inverse_face_map,
+                          PYRAMID5, "PYRAMID5");
       }
 
     case PYRAMID13:
       {
-        const Conversion conv(pyramid13_node_map,
-                              ARRAY_LENGTH(pyramid13_node_map),
-                              pyramid13_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(pyramid13_node_map),
-                              pyramid_face_map,
-                              ARRAY_LENGTH(pyramid_face_map),
-                              pyramid_inverse_face_map,
-                              ARRAY_LENGTH(pyramid_inverse_face_map),
-                              PYRAMID13,
-                              "PYRAMID13");
-        return conv;
+        return Conversion(&pyramid13_node_map,
+                          &pyramid13_node_map, // inverse node map same as forward node map
+                          &pyramid_face_map,
+                          &pyramid_inverse_face_map,
+                          PYRAMID13, "PYRAMID13");
       }
 
     case PYRAMID14:
       {
-        const Conversion conv(pyramid14_node_map,
-                              ARRAY_LENGTH(pyramid14_node_map),
-                              pyramid14_node_map, // inverse node map same as forward node map
-                              ARRAY_LENGTH(pyramid14_node_map),
-                              pyramid_face_map,
-                              ARRAY_LENGTH(pyramid_face_map),
-                              pyramid_inverse_face_map,
-                              ARRAY_LENGTH(pyramid_inverse_face_map),
-                              PYRAMID14,
-                              "PYRAMID14");
-        return conv;
+        return Conversion(&pyramid14_node_map,
+                          &pyramid14_node_map, // inverse node map same as forward node map
+                          &pyramid_face_map,
+                          &pyramid_inverse_face_map,
+                          PYRAMID14, "PYRAMID14");
       }
 
     default:
@@ -3128,10 +2978,10 @@ int ExodusII_IO_Helper::Conversion::get_side_map(int i) const
 {
   // If we asked for a side that doesn't exist, return an invalid_id
   // and allow higher-level code to handle it.
-  if (static_cast<size_t>(i) >= side_map_size)
+  if (static_cast<size_t>(i) >= side_map->size())
     return invalid_id;
 
-  return side_map[i];
+  return (*side_map)[i];
 }
 
 


### PR DESCRIPTION
Primarily the ElementMaps and Conversion classes are updated. This is
in preparation for adding support for reading/writing edgesets and
associated data fields to Exodus files. When this code was originally
written, we used C arrays because std::vectors could not be
initialized using initializer lists (indeed, no such thing existed at
the time). This required us to pass array sizes to several different
interfaces, which made them bloated and ugly. This refactoring gets
ride of some of that ugliness.