### PR TITLE
Call newer ex_{put,get}_num_map() Exodus APIs.

### DIFF
--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -575,8 +575,12 @@ void ExodusII_IO_Helper::read_node_num_map ()
 {
   node_num_map.resize(num_nodes);
 
-  ex_err = exII::ex_get_node_num_map (ex_id,
-                                      node_num_map.empty() ? nullptr : node_num_map.data());
+  // Note: we cannot use the exII::ex_get_num_map() here because it
+  // (apparently) does not behave like ex_get_node_num_map() when
+  // there is no node number map in the file: it throws an error
+  // instead of returning a default identity array (1,2,3,...).
+  ex_err = exII::ex_get_node_num_map
+    (ex_id, node_num_map.empty() ? nullptr : node_num_map.data());
 
   EX_CHECK_ERR(ex_err, "Error retrieving nodal number map.");
   message("Nodal numbering map retrieved successfully.");
@@ -725,8 +729,12 @@ void ExodusII_IO_Helper::read_elem_num_map ()
 {
   elem_num_map.resize(num_elem);
 
-  ex_err = exII::ex_get_elem_num_map (ex_id,
-                                      elem_num_map.empty() ? nullptr : elem_num_map.data());
+  // Note: we cannot use the exII::ex_get_num_map() here because it
+  // (apparently) does not behave like ex_get_elem_num_map() when
+  // there is no elem number map in the file: it throws an error
+  // instead of returning a default identity array (1,2,3,...).
+  ex_err = exII::ex_get_elem_num_map
+    (ex_id, elem_num_map.empty() ? nullptr : elem_num_map.data());
 
   EX_CHECK_ERR(ex_err, "Error retrieving element number map.");
   message("Element numbering map retrieved successfully.");


### PR DESCRIPTION
It turns out that we rely on a special behavior of `ex_get_{node,elem}_num_map()`. In cases where there is no node or elem number map defined in the Exodus file, these functions automatically return 1-based identity arrays. The more generic `ex_get_num_map()` function does not do this, it just throws an error if a required mapping array is not found. This PR now documents that official behavior a bit better.
