### PR TITLE
Simplify Exodus Conversion class

### DIFF
--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -965,70 +965,18 @@ public:
   ExodusII_IO_Helper::Conversion assign_conversion(const ElemType type);
 
   /**
-   * 0D element node maps. The trivial map {0}.
-   */
-  static const std::vector<int> nodeelem_node_map;
-
-  /**
-   * 1D element node maps. These map from 0-based Exodus node ids
-   * to libmesh node ids, and in all cases use the identity mapping.
-   */
-  static const std::vector<int> edge2_node_map;
-  static const std::vector<int> edge3_node_map;
-
-  /**
-   * 1D element edge maps. The "edges" of 1D elements are nodes.
-   */
-  static const std::vector<int> edge_edge_map;
-  static const std::vector<int> edge_inverse_edge_map;
-
-  /**
-   * 2D element node maps. These map from 0-based Exodus node ids to
-   * libmesh node ids.
-   */
-  static const std::vector<int> quad4_node_map;
-  static const std::vector<int> quad8_node_map;
-  static const std::vector<int> quad9_node_map;
-  static const std::vector<int> tri3_node_map;
-  static const std::vector<int> tri6_node_map;
-
-  /**
-   * 2D element edge maps. These are used to map from 0-based Exodus
-   * edge ids to libmesh edge ids. For "shell" elements, the first two
-   * "sides" correspond to the 2D "front" and "back" faces of the
-   * element and are used for "shell face" boundary conditions.  The
-   * remaining three sides are used for standard BCs.
-   */
-  static const std::vector<int> tri_edge_map;
-  static const std::vector<int> quad_edge_map;
-  static const std::vector<int> trishell3_edge_map;
-  static const std::vector<int> quadshell4_edge_map;
-
-  /**
    * 2D element inverse edge maps. These are used to map from libmesh
    * edge ids to 1-based Exodus ids. For shell elements, these maps
    * always start with "3" because the first two sides are shellfaces.
    */
-  static const std::vector<int> tri_inverse_edge_map;
-  static const std::vector<int> quad_inverse_edge_map;
   static const std::vector<int> trishell3_inverse_edge_map;
   static const std::vector<int> quadshell4_inverse_edge_map;
 
   /**
-   * 3D element node maps. These are used to map from 0-based Exodus
-   * node ids to libmesh node ids.
+   * 3D element node maps. Only the Hex27 has a non-trivial forward
+   * and inverse node mapping.
    */
-  static const std::vector<int> hex8_node_map;
-  static const std::vector<int> hex20_node_map;
   static const std::vector<int> hex27_node_map;
-  static const std::vector<int> tet4_node_map;
-  static const std::vector<int> tet10_node_map;
-  static const std::vector<int> prism6_node_map;
-  static const std::vector<int> prism15_node_map;
-  static const std::vector<int> prism18_node_map;
-  static const std::vector<int> pyramid5_node_map;
-  static const std::vector<int> pyramid13_node_map;
-  static const std::vector<int> pyramid14_node_map;
 
   /**
    * 3D element inverse node maps. These are used to map from libmesh
@@ -1039,28 +987,12 @@ public:
   static const std::vector<int> hex27_inverse_node_map;
 
   /**
-   * Shell element face maps. These are used to map from 0-based
-   * exodus shellface ids to shell face ids.
-   */
-  static const std::vector<int> trishell3_shellface_map;
-  static const std::vector<int> quadshell4_shellface_map;
-
-  /**
-   * Shell element inverse face maps. These are used to map from
-   * libmesh shellface ids to 1-based Exodus ids.
-   */
-  static const std::vector<int> trishell3_inverse_shellface_map;
-  static const std::vector<int> quadshell4_inverse_shellface_map;
-
-  /**
    * 3D element face maps. These are used to map from 0-based exodus side
    * ids to libmesh side ids.
    */
   static const std::vector<int> hex_face_map;
-  static const std::vector<int> hex27_face_map;
   static const std::vector<int> tet_face_map;
   static const std::vector<int> prism_face_map;
-  static const std::vector<int> pyramid_face_map;
 
   /**
    * 3D element inverse face maps. These are used to map from libmesh
@@ -1069,10 +1001,8 @@ public:
    * the value you get out of the inverse face maps before using it.
    */
   static const std::vector<int> hex_inverse_face_map;
-  static const std::vector<int> hex27_inverse_face_map;
   static const std::vector<int> tet_inverse_face_map;
   static const std::vector<int> prism_inverse_face_map;
-  static const std::vector<int> pyramid_inverse_face_map;
 
   /**
    * 3D element edge maps. These are used to map from 0-based Exodus

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -453,14 +453,6 @@ public:
   class Conversion;
 
   /**
-   * This is the \p ExodusII_IO_Helper ElementMap class.
-   * It contains constant maps between the \p ExodusII naming/numbering
-   * schemes and the canonical schemes used in this code.  It's defined
-   * below.
-   */
-  class ElementMaps;
-
-  /**
    * This is the \p ExodusII_IO_Helper NamesData class.
    * It manages the C data structure necessary for writing out named
    * entities to ExodusII files.
@@ -673,6 +665,12 @@ public:
   enum ExodusVarType {NODAL=0, ELEMENTAL=1, GLOBAL=2, SIDESET=3};
   void read_var_names(ExodusVarType type);
 
+  ExodusII_IO_Helper::Conversion
+  assign_conversion(const ElemType type);
+
+  ExodusII_IO_Helper::Conversion
+  assign_conversion(std::string type_str);
+
 protected:
   /**
    * When appending: during initialization, check that variable names
@@ -783,6 +781,20 @@ private:
   void write_var_names_impl(const char * var_type,
                             int & count,
                             const std::vector<std::string> & names);
+
+  /**
+   * Defines equivalence classes of Exodus element types that map to
+   * libmesh ElemTypes.
+   */
+  std::map<std::string, ElemType> element_equivalence_map;
+  void init_element_equivalence_map();
+
+  /**
+   * Associates libMesh ElemTypes with node/face/edge/etc. mappings
+   * of the corresponding Exodus element types.
+   */
+  std::map<ElemType, ExodusII_IO_Helper::Conversion> conversion_map;
+  void init_conversion_map();
 };
 
 
@@ -933,88 +945,6 @@ public:
    * The string corresponding to the Exodus type for this element
    */
   std::string exodus_type;
-};
-
-
-
-
-
-
-class ExodusII_IO_Helper::ElementMaps
-{
-public:
-
-  /**
-   * Constructor and special functions are all defaulted.
-   */
-  ElementMaps() = default;
-  ElementMaps (const ElementMaps &) = default;
-  ElementMaps (ElementMaps &&) = default;
-  ElementMaps & operator= (const ElementMaps &) = default;
-  ElementMaps & operator= (ElementMaps &&) = default;
-  ~ElementMaps() = default;
-
-  /**
-   * \returns A conversion object given an element type name.
-   */
-  ExodusII_IO_Helper::Conversion assign_conversion(std::string type_str);
-
-  /**
-   * \returns A conversion object given an element type.
-   */
-  ExodusII_IO_Helper::Conversion assign_conversion(const ElemType type);
-
-  /**
-   * 2D element inverse edge maps. These are used to map from libmesh
-   * edge ids to 1-based Exodus ids. For shell elements, these maps
-   * always start with "3" because the first two sides are shellfaces.
-   */
-  static const std::vector<int> trishell3_inverse_edge_map;
-  static const std::vector<int> quadshell4_inverse_edge_map;
-
-  /**
-   * 3D element node maps. Only the Hex27 has a non-trivial forward
-   * and inverse node mapping.
-   */
-  static const std::vector<int> hex27_node_map;
-
-  /**
-   * 3D element inverse node maps. These are used to map from libmesh
-   * node ids to 0-based Exodus node ids. The Hex27 is the only
-   * element that has a non-trivial inverse node map, all the other
-   * elements simply reuse the forward mapping.
-   */
-  static const std::vector<int> hex27_inverse_node_map;
-
-  /**
-   * 3D element face maps. These are used to map from 0-based exodus side
-   * ids to libmesh side ids.
-   */
-  static const std::vector<int> hex_face_map;
-  static const std::vector<int> tet_face_map;
-  static const std::vector<int> prism_face_map;
-
-  /**
-   * 3D element inverse face maps. These are used to map from libmesh
-   * side ids to 1-based Exodus ids. Note: this is a bit different
-   * from how the inverse node maps work: you don't have to add 1 to
-   * the value you get out of the inverse face maps before using it.
-   */
-  static const std::vector<int> hex_inverse_face_map;
-  static const std::vector<int> tet_inverse_face_map;
-  static const std::vector<int> prism_inverse_face_map;
-
-  /**
-   * 3D element edge maps. These are used to map from 0-based Exodus
-   * edge ids to libmesh edge ids.
-   */
-  static const std::vector<int> hex_edge_map;
-
-  /**
-   * 3D element inverse edge maps. These are used to map from libmesh
-   * edge ids to 1-based Exodus edge ids.
-   */
-  static const std::vector<int> hex_inverse_edge_map;
 };
 
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -665,11 +665,11 @@ public:
   enum ExodusVarType {NODAL=0, ELEMENTAL=1, GLOBAL=2, SIDESET=3};
   void read_var_names(ExodusVarType type);
 
-  ExodusII_IO_Helper::Conversion
-  assign_conversion(const ElemType type);
+  const ExodusII_IO_Helper::Conversion &
+  get_conversion(const ElemType type) const;
 
-  ExodusII_IO_Helper::Conversion
-  assign_conversion(std::string type_str);
+  const ExodusII_IO_Helper::Conversion &
+  get_conversion(std::string type_str) const;
 
 protected:
   /**
@@ -819,7 +819,7 @@ public:
       shellface_map(nullptr),
       inverse_shellface_map(nullptr),
       shellface_index_offset(0),
-      canonical_type(INVALID_ELEM),
+      libmesh_type(INVALID_ELEM),
       exodus_type("")
   {}
 
@@ -876,7 +876,7 @@ public:
    * The canonical element type is the standard element type
    * understood by this library.
    */
-  ElemType get_canonical_type() const;
+  ElemType libmesh_elem_type() const;
 
   /**
    * \returns The string corresponding to the Exodus type for this element.
@@ -939,7 +939,7 @@ public:
    * The canonical (i.e. standard for this library)
    * element type.
    */
-  ElemType canonical_type;
+  ElemType libmesh_type;
 
   /**
    * The string corresponding to the Exodus type for this element

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -26,15 +26,7 @@
 #include "libmesh/parallel_object.h"
 #include "libmesh/point.h"
 #include "libmesh/boundary_info.h" // BoundaryInfo::BCTuple
-
-#ifdef LIBMESH_FORWARD_DECLARE_ENUMS
-namespace libMesh
-{
-enum ElemType : int;
-}
-#else
-#include "libmesh/enum_elem_type.h"
-#endif
+#include "libmesh/enum_elem_type.h" // INVALID_ELEM
 
 // C++ includes
 #include <iostream>
@@ -805,48 +797,18 @@ class ExodusII_IO_Helper::Conversion
 public:
 
   /**
-   * Constructor.  Initializes the const private member
-   * variables.
+   * Constructor. Zero initializes all variables.
    */
-  Conversion(const std::vector<int> * nm,
-             const std::vector<int> * inm,
-             const std::vector<int> * sm,
-             const std::vector<int> * ism,
-             const ElemType ct,   // "canonical" aka libmesh element type
-             std::string ex_type) // string representing the Exodus element type
-    : node_map(nm),
-      inverse_node_map(inm),
-      side_map(sm),
-      inverse_side_map(ism),
+  Conversion()
+    : node_map(nullptr),
+      inverse_node_map(nullptr),
+      side_map(nullptr),
+      inverse_side_map(nullptr),
       shellface_map(nullptr),
       inverse_shellface_map(nullptr),
       shellface_index_offset(0),
-      canonical_type(ct),
-      exodus_type(ex_type)
-  {}
-
-  /**
-   * Constructor.  Initializes the const private member
-   * variables.  In this case we also initialize shellface data.
-   */
-  Conversion(const std::vector<int> * nm,
-             const std::vector<int> * inm,
-             const std::vector<int> * sm,
-             const std::vector<int> * ism,
-             const std::vector<int> * sfm,
-             const std::vector<int> * isfm,
-             size_t sfi_offset,
-             const ElemType ct,   // "canonical" aka libmesh element type
-             std::string ex_type) // string representing the Exodus element type
-    : node_map(nm),
-      inverse_node_map(inm),
-      side_map(sm),
-      inverse_side_map(ism),
-      shellface_map(sfm),
-      inverse_shellface_map(isfm),
-      shellface_index_offset(sfi_offset),
-      canonical_type(ct),
-      exodus_type(ex_type)
+      canonical_type(INVALID_ELEM),
+      exodus_type("")
   {}
 
   /**
@@ -855,11 +817,7 @@ public:
    * The node map maps the exodusII node numbering format to this
    * library's format.
    */
-  int get_node_map(int i) const
-  {
-    libmesh_assert_less (i, node_map->size());
-    return (*node_map)[i];
-  }
+  int get_node_map(int i) const;
 
   /**
    * \returns The ith component of the inverse node map for this
@@ -871,11 +829,7 @@ public:
    * \note All elements except Hex27 currently have the same node
    * numbering as libmesh elements.
    */
-  int get_inverse_node_map(int i) const
-  {
-    libmesh_assert_less (i, inverse_node_map->size());
-    return (*inverse_node_map)[i];
-  }
+  int get_inverse_node_map(int i) const;
 
   /**
    * \returns The ith component of the side map for this element.
@@ -891,30 +845,18 @@ public:
    * The side map maps the libMesh side numbering format to this
    * exodus's format.
    */
-  int get_inverse_side_map(int i) const
-  {
-    libmesh_assert_less (i, inverse_side_map->size());
-    return (*inverse_side_map)[i];
-  }
+  int get_inverse_side_map(int i) const;
 
   /**
    * \returns The ith component of the shellface map for this element.
    * \note Nothing is currently using this.
    */
-  int get_shellface_map(int i) const
-  {
-    libmesh_assert_less (i, shellface_map->size());
-    return (*shellface_map)[i];
-  }
+  int get_shellface_map(int i) const;
 
   /**
    * \returns The ith component of the inverse shellface map for this element.
    */
-  int get_inverse_shellface_map(int i) const
-  {
-    libmesh_assert_less (i, inverse_shellface_map->size());
-    return (*inverse_shellface_map)[i];
-  }
+  int get_inverse_shellface_map(int i) const;
 
   /**
    * \returns The canonical element type for this element.
@@ -922,17 +864,17 @@ public:
    * The canonical element type is the standard element type
    * understood by this library.
    */
-  ElemType get_canonical_type()    const { return canonical_type; }
+  ElemType get_canonical_type() const;
 
   /**
    * \returns The string corresponding to the Exodus type for this element.
    */
-  std::string exodus_elem_type() const { return exodus_type; }
+  std::string exodus_elem_type() const;
 
   /**
    * \returns The shellface index offset.
    */
-  std::size_t get_shellface_index_offset() const { return shellface_index_offset; }
+  std::size_t get_shellface_index_offset() const;
 
   /**
    * An invalid_id that can be returned to signal failure in case
@@ -940,7 +882,6 @@ public:
    */
   static const int invalid_id;
 
-private:
   /**
    * Pointer to the node map for this element.
    */
@@ -986,12 +927,12 @@ private:
    * The canonical (i.e. standard for this library)
    * element type.
    */
-  const ElemType canonical_type;
+  ElemType canonical_type;
 
   /**
    * The string corresponding to the Exodus type for this element
    */
-  const std::string exodus_type;
+  std::string exodus_type;
 };
 
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -151,9 +151,6 @@ void ExodusII_IO::read (const std::string & fname)
   elems_of_dimension.clear();
   elems_of_dimension.resize(4, false);
 
-  // Instantiate the ElementMaps interface
-  ExodusII_IO_Helper::ElementMaps em;
-
   // Open the exodus file in EX_READ mode
   exio_helper->open(fname.c_str(), /*read_only=*/true);
 
@@ -230,7 +227,7 @@ void ExodusII_IO::read (const std::string & fname)
 
       // Set any relevant node/edge maps for this element
       const std::string type_str (exio_helper->get_elem_type());
-      const ExodusII_IO_Helper::Conversion conv = em.assign_conversion(type_str);
+      const ExodusII_IO_Helper::Conversion conv = exio_helper->assign_conversion(type_str);
 
       // Loop over all the faces in this block
       int jmax = nelem_last_block+exio_helper->num_elem_this_blk;
@@ -335,7 +332,8 @@ void ExodusII_IO::read (const std::string & fname)
         // Set any relevant node/edge maps for this element
         Elem & elem = mesh.elem_ref(libmesh_elem_id);
 
-        const ExodusII_IO_Helper::Conversion conv = em.assign_conversion(elem.type());
+        const ExodusII_IO_Helper::Conversion conv =
+          exio_helper->assign_conversion(elem.type());
 
         // Map the zero-based Exodus side numbering to the libmesh side numbering
         unsigned int raw_side_index = exio_helper->side_list[e]-1;

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -227,13 +227,13 @@ void ExodusII_IO::read (const std::string & fname)
 
       // Set any relevant node/edge maps for this element
       const std::string type_str (exio_helper->get_elem_type());
-      const ExodusII_IO_Helper::Conversion conv = exio_helper->assign_conversion(type_str);
+      const auto & conv = exio_helper->get_conversion(type_str);
 
       // Loop over all the faces in this block
       int jmax = nelem_last_block+exio_helper->num_elem_this_blk;
       for (int j=nelem_last_block; j<jmax; j++)
         {
-          Elem * elem = Elem::build (conv.get_canonical_type()).release();
+          Elem * elem = Elem::build (conv.libmesh_elem_type()).release();
           libmesh_assert (elem);
           elem->subdomain_id() = static_cast<subdomain_id_type>(subdomain_id) ;
 
@@ -332,8 +332,7 @@ void ExodusII_IO::read (const std::string & fname)
         // Set any relevant node/edge maps for this element
         Elem & elem = mesh.elem_ref(libmesh_elem_id);
 
-        const ExodusII_IO_Helper::Conversion conv =
-          exio_helper->assign_conversion(elem.type());
+        const auto & conv = exio_helper->get_conversion(elem.type());
 
         // Map the zero-based Exodus side numbering to the libmesh side numbering
         unsigned int raw_side_index = exio_helper->side_list[e]-1;

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -158,46 +158,14 @@ namespace libMesh
 // ------------------------------------------------------------
 // ExodusII_IO_Helper::ElementMaps static data
 
-// 0D node map definitions
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::nodeelem_node_map = {0};
-
-// 1D node map definitions
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::edge2_node_map = {0, 1};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::edge3_node_map = {0, 1, 2};
-
-// 1D edge maps
-// FIXME: This notion may or may not be defined in ExodusII
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::edge_edge_map = {0, 1};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::edge_inverse_edge_map = {1, 2};
-
-// 2D node map definitions
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad4_node_map = {0, 1, 2, 3};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad8_node_map = {0, 1, 2, 3, 4, 5, 6, 7};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad9_node_map = {0, 1, 2, 3, 4, 5, 6, 7, 8};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::tri3_node_map = {0, 1, 2};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::tri6_node_map = {0, 1, 2, 3, 4, 5};
-
-// 2D edge map definitions
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::tri_edge_map = {0, 1, 2};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad_edge_map = {0, 1, 2, 3};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::trishell3_edge_map = {0, 1, 2};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::quadshell4_edge_map = {0, 1, 2, 3};
-
 // 2D inverse face map definitions.
 // These take a libMesh ID and turn it into an Exodus ID
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::tri_inverse_edge_map = {1, 2, 3};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::quad_inverse_edge_map = {1, 2, 3, 4};
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::trishell3_inverse_edge_map = {3, 4, 5};
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::quadshell4_inverse_edge_map = {3, 4, 5, 6};
 
 // 3D node map definitions
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex8_node_map = {0, 1, 2, 3, 4, 5, 6, 7};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex20_node_map
-= { 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
-    10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
-
-// DRG: Using the newest exodus documentation available on sourceforge and using Table 2 to see
-// where all of the nodes over 21 are supposed to go... we come up with:
+// The hex27 appears to be the only element without an identity mapping between its
+// node numbering and libmesh's.
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_node_map = {
   // Vertex and mid-edge nodes
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
@@ -205,50 +173,22 @@ const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_node_map = {
   21, 25, 24, 26, 23, 22, 20};
 //20  21  22  23  24  25  26 // LibMesh indices
 
-// The hex27 appears to be the only element without a 1:1 map between its
-// node numbering and libmesh's.  Therefore when writing out hex27's we need
-// to invert this map...
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_inverse_node_map = {
   // Vertex and mid-edge nodes
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
   // Mid-face nodes and centroid
   26, 20, 25, 24, 22, 21, 23};
 //20  21  22  23  24  25  26
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet4_node_map = {0, 1, 2, 3};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet10_node_map =
-  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism6_node_map = {0, 1, 2, 3, 4, 5};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism15_node_map =
-  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism18_node_map =
-  {0, 1, 2, 3, 4, 5, 6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid5_node_map = {0, 1, 2, 3, 4};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid13_node_map =
-  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid14_node_map =
-  {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
-
-// Shell element face maps
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::trishell3_shellface_map = {0, 1};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::quadshell4_shellface_map = {0, 1};
-
-// These take a libMesh ID and turn it into an Exodus ID
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::trishell3_inverse_shellface_map = {1, 2};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::quadshell4_inverse_shellface_map = {1, 2};
 
 // 3D face map definitions
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet_face_map = {1, 2, 3, 0};
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex_face_map = {1, 2, 3, 4, 0, 5};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_face_map = {1, 2, 3, 4, 0, 5};
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism_face_map = {1, 2, 3, 0, 4};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid_face_map = {0, 1, 2, 3, 4};
 
 // These take a libMesh ID and turn it into an Exodus ID
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet_inverse_face_map = {4, 1, 2, 3};
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex_inverse_face_map = {5, 1, 2, 3, 4, 6};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_inverse_face_map = {5, 1, 2, 3, 4, 6};
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism_inverse_face_map = {4, 1, 2, 3, 5};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::pyramid_inverse_face_map = {1, 2, 3, 4, 5};
 
 // 3D element edge maps. Map 0-based Exodus id -> libMesh id.
 const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex_edge_map =
@@ -2834,50 +2774,31 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
     {
     case NODEELEM:
       {
-        conv.node_map = &nodeelem_node_map;
-        conv.inverse_node_map = &nodeelem_node_map;
         conv.canonical_type = NODEELEM;
         conv.exodus_type = "SPHERE";
         return conv;
       }
     case EDGE2:
       {
-        conv.node_map = &edge2_node_map;
-        conv.inverse_node_map = &edge2_node_map;
-        conv.side_map = &edge_edge_map;
-        conv.inverse_side_map = &edge_edge_map;
         conv.canonical_type = EDGE2;
         conv.exodus_type = "EDGE2";
         return conv;
       }
     case EDGE3:
       {
-        conv.node_map = &edge3_node_map;
-        conv.inverse_node_map = &edge3_node_map;
-        conv.side_map = &edge_edge_map;
-        conv.inverse_side_map = &edge_edge_map;
         conv.canonical_type = EDGE3;
         conv.exodus_type = "EDGE3";
         return conv;
       }
     case QUAD4:
       {
-        conv.node_map = &quad4_node_map;
-        conv.inverse_node_map = &quad4_node_map;
-        conv.side_map = &quad_edge_map;
-        conv.inverse_side_map = &quad_inverse_edge_map;
         conv.canonical_type = QUAD4;
         conv.exodus_type = "QUAD4";
         return conv;
       }
     case QUADSHELL4:
       {
-        conv.node_map = &quad4_node_map;
-        conv.inverse_node_map = &quad4_node_map;
-        conv.side_map = &quadshell4_edge_map;
         conv.inverse_side_map = &quadshell4_inverse_edge_map;
-        conv.shellface_map = &quadshell4_shellface_map;
-        conv.inverse_shellface_map = &quadshell4_inverse_shellface_map;
         conv.shellface_index_offset = 2;
         conv.canonical_type = QUADSHELL4;
         conv.exodus_type = "SHELL4";
@@ -2885,22 +2806,13 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
       }
     case QUAD8:
       {
-        conv.node_map = &quad8_node_map;
-        conv.inverse_node_map = &quad8_node_map;
-        conv.side_map = &quad_edge_map;
-        conv.inverse_side_map = &quad_inverse_edge_map;
         conv.canonical_type = QUAD8;
         conv.exodus_type = "QUAD8";
         return conv;
       }
     case QUADSHELL8:
       {
-        conv.node_map = &quad8_node_map;
-        conv.inverse_node_map = &quad8_node_map;
-        conv.side_map = &quadshell4_edge_map;
         conv.inverse_side_map = &quadshell4_inverse_edge_map;
-        conv.shellface_map = &quadshell4_shellface_map;
-        conv.inverse_shellface_map = &quadshell4_inverse_shellface_map;
         conv.shellface_index_offset = 2;
         conv.canonical_type = QUADSHELL8;
         conv.exodus_type = "SHELL8";
@@ -2908,32 +2820,19 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
       }
     case QUAD9:
       {
-        conv.node_map = &quad9_node_map;
-        conv.inverse_node_map = &quad9_node_map;
-        conv.side_map = &quad_edge_map;
-        conv.inverse_side_map = &quad_inverse_edge_map;
         conv.canonical_type = QUAD9;
         conv.exodus_type = "QUAD9";
         return conv;
       }
     case TRI3:
       {
-        conv.node_map = &tri3_node_map;
-        conv.inverse_node_map = &tri3_node_map;
-        conv.side_map = &tri_edge_map;
-        conv.inverse_side_map = &tri_inverse_edge_map;
         conv.canonical_type = TRI3;
         conv.exodus_type = "TRI3";
         return conv;
       }
     case TRISHELL3:
       {
-        conv.node_map = &tri3_node_map;
-        conv.inverse_node_map = &tri3_node_map;
-        conv.side_map = &trishell3_edge_map;
         conv.inverse_side_map = &trishell3_inverse_edge_map;
-        conv.shellface_map = &trishell3_shellface_map;
-        conv.inverse_shellface_map = &trishell3_inverse_shellface_map;
         conv.shellface_index_offset = 2;
         conv.canonical_type = TRISHELL3;
         conv.exodus_type = "TRISHELL3";
@@ -2941,28 +2840,18 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
       }
     case TRI3SUBDIVISION:
       {
-        conv.node_map = &tri3_node_map;
-        conv.inverse_node_map = &tri3_node_map;
-        conv.side_map = &tri_edge_map;
-        conv.inverse_side_map = &tri_inverse_edge_map;
         conv.canonical_type = TRI3SUBDIVISION;
         conv.exodus_type = "TRI3";
         return conv;
       }
     case TRI6:
       {
-        conv.node_map = &tri6_node_map;
-        conv.inverse_node_map = &tri6_node_map;
-        conv.side_map = &tri_edge_map;
-        conv.inverse_side_map = &tri_inverse_edge_map;
         conv.canonical_type = TRI6;
         conv.exodus_type = "TRI6";
         return conv;
       }
     case HEX8:
       {
-        conv.node_map = &hex8_node_map;
-        conv.inverse_node_map = &hex8_node_map;
         conv.side_map = &hex_face_map;
         conv.inverse_side_map = &hex_inverse_face_map;
         conv.canonical_type = HEX8;
@@ -2971,8 +2860,6 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
       }
     case HEX20:
       {
-        conv.node_map = &hex20_node_map;
-        conv.inverse_node_map = &hex20_node_map;
         conv.side_map = &hex_face_map;
         conv.inverse_side_map = &hex_inverse_face_map;
         conv.canonical_type = HEX20;
@@ -2983,16 +2870,14 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
       {
         conv.node_map = &hex27_node_map;
         conv.inverse_node_map = &hex27_inverse_node_map;
-        conv.side_map = &hex27_face_map;
-        conv.inverse_side_map = &hex27_inverse_face_map;
+        conv.side_map = &hex_face_map;
+        conv.inverse_side_map = &hex_inverse_face_map;
         conv.canonical_type = HEX27;
         conv.exodus_type = "HEX27";
         return conv;
       }
     case TET4:
       {
-        conv.node_map = &tet4_node_map;
-        conv.inverse_node_map = &tet4_node_map;
         conv.side_map = &tet_face_map;
         conv.inverse_side_map = &tet_inverse_face_map;
         conv.canonical_type = TET4;
@@ -3001,8 +2886,6 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
     }
     case TET10:
       {
-        conv.node_map = &tet10_node_map;
-        conv.inverse_node_map = &tet10_node_map;
         conv.side_map = &tet_face_map;
         conv.inverse_side_map = &tet_inverse_face_map;
         conv.canonical_type = TET10;
@@ -3011,8 +2894,6 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
     }
     case PRISM6:
       {
-        conv.node_map = &prism6_node_map;
-        conv.inverse_node_map = &prism6_node_map;
         conv.side_map = &prism_face_map;
         conv.inverse_side_map = &prism_inverse_face_map;
         conv.canonical_type = PRISM6;
@@ -3021,8 +2902,6 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
       }
     case PRISM15:
       {
-        conv.node_map = &prism15_node_map;
-        conv.inverse_node_map = &prism15_node_map;
         conv.side_map = &prism_face_map;
         conv.inverse_side_map = &prism_inverse_face_map;
         conv.canonical_type = PRISM15;
@@ -3031,8 +2910,6 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
       }
     case PRISM18:
       {
-        conv.node_map = &prism18_node_map;
-        conv.inverse_node_map = &prism18_node_map;
         conv.side_map = &prism_face_map;
         conv.inverse_side_map = &prism_inverse_face_map;
         conv.canonical_type = PRISM18;
@@ -3041,30 +2918,18 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
       }
     case PYRAMID5:
       {
-        conv.node_map = &pyramid5_node_map;
-        conv.inverse_node_map = &pyramid5_node_map;
-        conv.side_map = &pyramid_face_map;
-        conv.inverse_side_map = &pyramid_inverse_face_map;
         conv.canonical_type = PYRAMID5;
         conv.exodus_type = "PYRAMID5";
         return conv;
       }
     case PYRAMID13:
       {
-        conv.node_map = &pyramid13_node_map;
-        conv.inverse_node_map = &pyramid13_node_map;
-        conv.side_map = &pyramid_face_map;
-        conv.inverse_side_map = &pyramid_inverse_face_map;
         conv.canonical_type = PYRAMID13;
         conv.exodus_type = "PYRAMID13";
         return conv;
       }
     case PYRAMID14:
       {
-        conv.node_map = &pyramid14_node_map;
-        conv.inverse_node_map = &pyramid14_node_map;
-        conv.side_map = &pyramid_face_map;
-        conv.inverse_side_map = &pyramid_inverse_face_map;
         conv.canonical_type = PYRAMID14;
         conv.exodus_type = "PYRAMID14";
         return conv;
@@ -3079,7 +2944,9 @@ ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
 
 int ExodusII_IO_Helper::Conversion::get_node_map(int i) const
 {
-  libmesh_assert(node_map);
+  if (!node_map)
+    return i;
+
   libmesh_assert_less (i, node_map->size());
   return (*node_map)[i];
 }
@@ -3088,7 +2955,9 @@ int ExodusII_IO_Helper::Conversion::get_node_map(int i) const
 
 int ExodusII_IO_Helper::Conversion::get_inverse_node_map(int i) const
 {
-  libmesh_assert(inverse_node_map);
+  if (!inverse_node_map)
+    return i;
+
   libmesh_assert_less (i, inverse_node_map->size());
   return (*inverse_node_map)[i];
 }
@@ -3097,7 +2966,8 @@ int ExodusII_IO_Helper::Conversion::get_inverse_node_map(int i) const
 
 int ExodusII_IO_Helper::Conversion::get_side_map(int i) const
 {
-  libmesh_assert(side_map);
+  if (!side_map)
+    return i;
 
   // If we asked for a side that doesn't exist, return an invalid_id
   // and allow higher-level code to handle it.
@@ -3111,7 +2981,10 @@ int ExodusII_IO_Helper::Conversion::get_side_map(int i) const
 
 int ExodusII_IO_Helper::Conversion::get_inverse_side_map(int i) const
 {
-  libmesh_assert(inverse_side_map);
+  // For identity side mappings, we our convention is to return a 1-based index.
+  if (!inverse_side_map)
+    return i + 1;
+
   libmesh_assert_less (i, inverse_side_map->size());
   return (*inverse_side_map)[i];
 }
@@ -3124,7 +2997,9 @@ int ExodusII_IO_Helper::Conversion::get_inverse_side_map(int i) const
  */
 int ExodusII_IO_Helper::Conversion::get_shellface_map(int i) const
 {
-  libmesh_assert(shellface_map);
+  if (!shellface_map)
+    return i;
+
   libmesh_assert_less (i, shellface_map->size());
   return (*shellface_map)[i];
 }
@@ -3133,7 +3008,9 @@ int ExodusII_IO_Helper::Conversion::get_shellface_map(int i) const
 
 int ExodusII_IO_Helper::Conversion::get_inverse_shellface_map(int i) const
 {
-  libmesh_assert(inverse_shellface_map);
+  if (!inverse_shellface_map)
+    return i + 1;
+
   libmesh_assert_less (i, inverse_shellface_map->size());
   return (*inverse_shellface_map)[i];
 }

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -43,132 +43,24 @@
 // Anonymous namespace for file local data
 namespace
 {
-using namespace libMesh;
 
-// Define equivalence classes of Cubit/Exodus element types that map to
-// libmesh ElemTypes
-std::map<std::string, ElemType> element_equivalence_map;
-
-// This function initializes the element_equivalence_map the first time it
-// is called, and returns early all other times.
-void init_element_equivalence_map()
-{
-  if (element_equivalence_map.empty())
-    {
-      // We use an ExodusII SPHERE element to represent a NodeElem
-      element_equivalence_map["SPHERE"] = NODEELEM;
-
-      // EDGE2 equivalences
-      element_equivalence_map["EDGE"]   = EDGE2;
-      element_equivalence_map["EDGE2"]  = EDGE2;
-      element_equivalence_map["TRUSS"]  = EDGE2;
-      element_equivalence_map["BEAM"]   = EDGE2;
-      element_equivalence_map["BAR"]    = EDGE2;
-      element_equivalence_map["TRUSS2"] = EDGE2;
-      element_equivalence_map["BEAM2"]  = EDGE2;
-      element_equivalence_map["BAR2"]   = EDGE2;
-
-      // EDGE3 equivalences
-      element_equivalence_map["EDGE3"]  = EDGE3;
-      element_equivalence_map["TRUSS3"] = EDGE3;
-      element_equivalence_map["BEAM3"]  = EDGE3;
-      element_equivalence_map["BAR3"]   = EDGE3;
-
-      // QUAD4 equivalences
-      element_equivalence_map["QUAD"]   = QUAD4;
-      element_equivalence_map["QUAD4"]  = QUAD4;
-
-      // QUADSHELL4 equivalences
-      element_equivalence_map["SHELL"]  = QUADSHELL4;
-      element_equivalence_map["SHELL4"] = QUADSHELL4;
-
-      // QUAD8 equivalences
-      element_equivalence_map["QUAD8"]  = QUAD8;
-
-      // QUADSHELL8 equivalences
-      element_equivalence_map["SHELL8"] = QUADSHELL8;
-
-      // QUAD9 equivalences
-      element_equivalence_map["QUAD9"]  = QUAD9;
-      // element_equivalence_map["SHELL9"] = QUAD9;
-
-      // TRI3 equivalences
-      element_equivalence_map["TRI"]       = TRI3;
-      element_equivalence_map["TRI3"]      = TRI3;
-      element_equivalence_map["TRIANGLE"]  = TRI3;
-
-      // TRISHELL3 equivalences
-      element_equivalence_map["TRISHELL"]  = TRISHELL3;
-      element_equivalence_map["TRISHELL3"] = TRISHELL3;
-
-      // TRI6 equivalences
-      element_equivalence_map["TRI6"]      = TRI6;
-      // element_equivalence_map["TRISHELL6"] = TRI6;
-
-      // HEX8 equivalences
-      element_equivalence_map["HEX"]  = HEX8;
-      element_equivalence_map["HEX8"] = HEX8;
-
-      // HEX20 equivalences
-      element_equivalence_map["HEX20"] = HEX20;
-
-      // HEX27 equivalences
-      element_equivalence_map["HEX27"] = HEX27;
-
-      // TET4 equivalences
-      element_equivalence_map["TETRA"]  = TET4;
-      element_equivalence_map["TETRA4"] = TET4;
-
-      // TET10 equivalences
-      element_equivalence_map["TETRA10"] = TET10;
-
-      // PRISM6 equivalences
-      element_equivalence_map["WEDGE"] = PRISM6;
-
-      // PRISM15 equivalences
-      element_equivalence_map["WEDGE15"] = PRISM15;
-
-      // PRISM18 equivalences
-      element_equivalence_map["WEDGE18"] = PRISM18;
-
-      // PYRAMID5 equivalences
-      element_equivalence_map["PYRAMID"]  = PYRAMID5;
-      element_equivalence_map["PYRAMID5"] = PYRAMID5;
-
-      // PYRAMID13 equivalences
-      element_equivalence_map["PYRAMID13"] = PYRAMID13;
-
-      // PYRAMID14 equivalences
-      element_equivalence_map["PYRAMID14"] = PYRAMID14;
-    }
-}
-
-}
-
-
-
-namespace libMesh
-{
-
-// ------------------------------------------------------------
-// ExodusII_IO_Helper::ElementMaps static data
-
+// File scope constant node/edge/face mapping arrays.
 // 2D inverse face map definitions.
 // These take a libMesh ID and turn it into an Exodus ID
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::trishell3_inverse_edge_map = {3, 4, 5};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::quadshell4_inverse_edge_map = {3, 4, 5, 6};
+const std::vector<int> trishell3_inverse_edge_map = {3, 4, 5};
+const std::vector<int> quadshell4_inverse_edge_map = {3, 4, 5, 6};
 
 // 3D node map definitions
 // The hex27 appears to be the only element without an identity mapping between its
 // node numbering and libmesh's.
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_node_map = {
+const std::vector<int> hex27_node_map = {
   // Vertex and mid-edge nodes
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
   // Mid-face nodes and centroid
   21, 25, 24, 26, 23, 22, 20};
 //20  21  22  23  24  25  26 // LibMesh indices
 
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_inverse_node_map = {
+const std::vector<int> hex27_inverse_node_map = {
   // Vertex and mid-edge nodes
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
   // Mid-face nodes and centroid
@@ -176,28 +68,32 @@ const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex27_inverse_node_map =
 //20  21  22  23  24  25  26
 
 // 3D face map definitions
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet_face_map = {1, 2, 3, 0};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex_face_map = {1, 2, 3, 4, 0, 5};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism_face_map = {1, 2, 3, 0, 4};
+const std::vector<int> tet_face_map = {1, 2, 3, 0};
+const std::vector<int> hex_face_map = {1, 2, 3, 4, 0, 5};
+const std::vector<int> prism_face_map = {1, 2, 3, 0, 4};
 
 // These take a libMesh ID and turn it into an Exodus ID
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::tet_inverse_face_map = {4, 1, 2, 3};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex_inverse_face_map = {5, 1, 2, 3, 4, 6};
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::prism_inverse_face_map = {4, 1, 2, 3, 5};
+const std::vector<int> tet_inverse_face_map = {4, 1, 2, 3};
+const std::vector<int> hex_inverse_face_map = {5, 1, 2, 3, 4, 6};
+const std::vector<int> prism_inverse_face_map = {4, 1, 2, 3, 5};
 
 // 3D element edge maps. Map 0-based Exodus id -> libMesh id.
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex_edge_map =
+const std::vector<int> hex_edge_map =
   {0,1,2,3,8,9,10,11,4,5,7,6};
 
 // 3D inverse element edge maps. Map libmesh edge ids to 1-based Exodus edge ids.
-const std::vector<int> ExodusII_IO_Helper::ElementMaps::hex_inverse_edge_map =
+const std::vector<int> hex_inverse_edge_map =
   {1,2,3,4,9,10,12,11,5,6,7,8};
+
+} // end anonymous namespace
+
+
+
+namespace libMesh
+{
 
 // ExodusII_IO_Helper::Conversion static data
 const int ExodusII_IO_Helper::Conversion::invalid_id = std::numeric_limits<int>::max();
-
-// ------------------------------------------------------------
-// ExodusII_IO_Helper class members
 
 ExodusII_IO_Helper::ExodusII_IO_Helper(const ParallelObject & parent,
                                        bool v,
@@ -234,6 +130,8 @@ ExodusII_IO_Helper::ExodusII_IO_Helper(const ParallelObject & parent,
 {
   title.resize(MAX_LINE_LENGTH+1);
   elem_type.resize(MAX_STR_LENGTH);
+  init_element_equivalence_map();
+  init_conversion_map();
 }
 
 
@@ -241,6 +139,257 @@ ExodusII_IO_Helper::ExodusII_IO_Helper(const ParallelObject & parent,
 ExodusII_IO_Helper::~ExodusII_IO_Helper() = default;
 
 
+
+// Initialization function for conversion_map object
+void ExodusII_IO_Helper::init_conversion_map()
+{
+  {
+    auto & conv = conversion_map[NODEELEM];
+    conv.canonical_type = NODEELEM;
+    conv.exodus_type = "SPHERE";
+  }
+  {
+    auto & conv = conversion_map[EDGE2];
+    conv.canonical_type = EDGE2;
+    conv.exodus_type = "EDGE2";
+  }
+  {
+    auto & conv = conversion_map[EDGE3];
+    conv.canonical_type = EDGE3;
+    conv.exodus_type = "EDGE3";
+  }
+  {
+    auto & conv = conversion_map[QUAD4];
+    conv.canonical_type = QUAD4;
+    conv.exodus_type = "QUAD4";
+  }
+  {
+    auto & conv = conversion_map[QUADSHELL4];
+    conv.inverse_side_map = &quadshell4_inverse_edge_map;
+    conv.shellface_index_offset = 2;
+    conv.canonical_type = QUADSHELL4;
+    conv.exodus_type = "SHELL4";
+  }
+  {
+    auto & conv = conversion_map[QUAD8];
+    conv.canonical_type = QUAD8;
+    conv.exodus_type = "QUAD8";
+  }
+  {
+    auto & conv = conversion_map[QUADSHELL8];
+    conv.inverse_side_map = &quadshell4_inverse_edge_map;
+    conv.shellface_index_offset = 2;
+    conv.canonical_type = QUADSHELL8;
+    conv.exodus_type = "SHELL8";
+  }
+  {
+    auto & conv = conversion_map[QUAD9];
+    conv.canonical_type = QUAD9;
+    conv.exodus_type = "QUAD9";
+  }
+  {
+    auto & conv = conversion_map[TRI3];
+    conv.canonical_type = TRI3;
+    conv.exodus_type = "TRI3";
+  }
+  {
+    auto & conv = conversion_map[TRISHELL3];
+    conv.inverse_side_map = &trishell3_inverse_edge_map;
+    conv.shellface_index_offset = 2;
+    conv.canonical_type = TRISHELL3;
+    conv.exodus_type = "TRISHELL3";
+  }
+  {
+    auto & conv = conversion_map[TRI3SUBDIVISION];
+    conv.canonical_type = TRI3SUBDIVISION;
+    conv.exodus_type = "TRI3";
+  }
+  {
+    auto & conv = conversion_map[TRI6];
+    conv.canonical_type = TRI6;
+    conv.exodus_type = "TRI6";
+  }
+  {
+    auto & conv = conversion_map[HEX8];
+    conv.side_map = &hex_face_map;
+    conv.inverse_side_map = &hex_inverse_face_map;
+    conv.canonical_type = HEX8;
+    conv.exodus_type = "HEX8";
+  }
+  {
+    auto & conv = conversion_map[HEX20];
+    conv.side_map = &hex_face_map;
+    conv.inverse_side_map = &hex_inverse_face_map;
+    conv.canonical_type = HEX20;
+    conv.exodus_type = "HEX20";
+  }
+  {
+    auto & conv = conversion_map[HEX27];
+    conv.node_map = &hex27_node_map;
+    conv.inverse_node_map = &hex27_inverse_node_map;
+    conv.side_map = &hex_face_map;
+    conv.inverse_side_map = &hex_inverse_face_map;
+    conv.canonical_type = HEX27;
+    conv.exodus_type = "HEX27";
+  }
+  {
+    auto & conv = conversion_map[TET4];
+    conv.side_map = &tet_face_map;
+    conv.inverse_side_map = &tet_inverse_face_map;
+    conv.canonical_type = TET4;
+    conv.exodus_type = "TETRA4";
+  }
+  {
+    auto & conv = conversion_map[TET10];
+    conv.side_map = &tet_face_map;
+    conv.inverse_side_map = &tet_inverse_face_map;
+    conv.canonical_type = TET10;
+    conv.exodus_type = "TETRA10";
+  }
+  {
+    auto & conv = conversion_map[PRISM6];
+    conv.side_map = &prism_face_map;
+    conv.inverse_side_map = &prism_inverse_face_map;
+    conv.canonical_type = PRISM6;
+    conv.exodus_type = "WEDGE";
+  }
+  {
+    auto & conv = conversion_map[PRISM15];
+    conv.side_map = &prism_face_map;
+    conv.inverse_side_map = &prism_inverse_face_map;
+    conv.canonical_type = PRISM15;
+    conv.exodus_type = "WEDGE15";
+  }
+  {
+    auto & conv = conversion_map[PRISM18];
+    conv.side_map = &prism_face_map;
+    conv.inverse_side_map = &prism_inverse_face_map;
+    conv.canonical_type = PRISM18;
+    conv.exodus_type = "WEDGE18";
+  }
+  {
+    auto & conv = conversion_map[PYRAMID5];
+    conv.canonical_type = PYRAMID5;
+    conv.exodus_type = "PYRAMID5";
+  }
+  {
+    auto & conv = conversion_map[PYRAMID13];
+    conv.canonical_type = PYRAMID13;
+    conv.exodus_type = "PYRAMID13";
+  }
+  {
+    auto & conv = conversion_map[PYRAMID14];
+    conv.canonical_type = PYRAMID14;
+    conv.exodus_type = "PYRAMID14";
+  }
+}
+
+
+
+// This function initializes the element_equivalence_map the first time it
+// is called, and returns early all other times.
+void ExodusII_IO_Helper::init_element_equivalence_map()
+{
+  // We use an ExodusII SPHERE element to represent a NodeElem
+  element_equivalence_map["SPHERE"] = NODEELEM;
+
+  // EDGE2 equivalences
+  element_equivalence_map["EDGE"]   = EDGE2;
+  element_equivalence_map["EDGE2"]  = EDGE2;
+  element_equivalence_map["TRUSS"]  = EDGE2;
+  element_equivalence_map["BEAM"]   = EDGE2;
+  element_equivalence_map["BAR"]    = EDGE2;
+  element_equivalence_map["TRUSS2"] = EDGE2;
+  element_equivalence_map["BEAM2"]  = EDGE2;
+  element_equivalence_map["BAR2"]   = EDGE2;
+
+  // EDGE3 equivalences
+  element_equivalence_map["EDGE3"]  = EDGE3;
+  element_equivalence_map["TRUSS3"] = EDGE3;
+  element_equivalence_map["BEAM3"]  = EDGE3;
+  element_equivalence_map["BAR3"]   = EDGE3;
+
+  // QUAD4 equivalences
+  element_equivalence_map["QUAD"]   = QUAD4;
+  element_equivalence_map["QUAD4"]  = QUAD4;
+
+  // QUADSHELL4 equivalences
+  element_equivalence_map["SHELL"]  = QUADSHELL4;
+  element_equivalence_map["SHELL4"] = QUADSHELL4;
+
+  // QUAD8 equivalences
+  element_equivalence_map["QUAD8"]  = QUAD8;
+
+  // QUADSHELL8 equivalences
+  element_equivalence_map["SHELL8"] = QUADSHELL8;
+
+  // QUAD9 equivalences
+  element_equivalence_map["QUAD9"]  = QUAD9;
+  // element_equivalence_map["SHELL9"] = QUAD9;
+
+  // TRI3 equivalences
+  element_equivalence_map["TRI"]       = TRI3;
+  element_equivalence_map["TRI3"]      = TRI3;
+  element_equivalence_map["TRIANGLE"]  = TRI3;
+
+  // TRISHELL3 equivalences
+  element_equivalence_map["TRISHELL"]  = TRISHELL3;
+  element_equivalence_map["TRISHELL3"] = TRISHELL3;
+
+  // TRI6 equivalences
+  element_equivalence_map["TRI6"]      = TRI6;
+  // element_equivalence_map["TRISHELL6"] = TRI6;
+
+  // HEX8 equivalences
+  element_equivalence_map["HEX"]  = HEX8;
+  element_equivalence_map["HEX8"] = HEX8;
+
+  // HEX20 equivalences
+  element_equivalence_map["HEX20"] = HEX20;
+
+  // HEX27 equivalences
+  element_equivalence_map["HEX27"] = HEX27;
+
+  // TET4 equivalences
+  element_equivalence_map["TETRA"]  = TET4;
+  element_equivalence_map["TETRA4"] = TET4;
+
+  // TET10 equivalences
+  element_equivalence_map["TETRA10"] = TET10;
+
+  // PRISM6 equivalences
+  element_equivalence_map["WEDGE"] = PRISM6;
+
+  // PRISM15 equivalences
+  element_equivalence_map["WEDGE15"] = PRISM15;
+
+  // PRISM18 equivalences
+  element_equivalence_map["WEDGE18"] = PRISM18;
+
+  // PYRAMID5 equivalences
+  element_equivalence_map["PYRAMID"]  = PYRAMID5;
+  element_equivalence_map["PYRAMID5"] = PYRAMID5;
+
+  // PYRAMID13 equivalences
+  element_equivalence_map["PYRAMID13"] = PYRAMID13;
+
+  // PYRAMID14 equivalences
+  element_equivalence_map["PYRAMID14"] = PYRAMID14;
+}
+
+ExodusII_IO_Helper::Conversion
+ExodusII_IO_Helper::assign_conversion(const ElemType type)
+{
+  return libmesh_map_find(conversion_map, type);
+}
+
+ExodusII_IO_Helper::Conversion
+ExodusII_IO_Helper::assign_conversion(std::string type_str)
+{
+  // Do only upper-case comparisons
+  std::transform(type_str.begin(), type_str.end(), type_str.begin(), ::toupper);
+  return assign_conversion (libmesh_map_find(element_equivalence_map, type_str));
+}
 
 const char * ExodusII_IO_Helper::get_elem_type() const
 {
@@ -1551,9 +1700,8 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       // Use the first element in this block to get representative information.
       // Note that Exodus assumes all elements in a block are of the same type!
       // We are using that same assumption here!
-      ExodusII_IO_Helper::ElementMaps em;
       const ExodusII_IO_Helper::Conversion conv =
-        em.assign_conversion(mesh.elem_ref(tmp_vec[0]).type());
+        assign_conversion(mesh.elem_ref(tmp_vec[0]).type());
       num_nodes_per_elem = mesh.elem_ref(tmp_vec[0]).n_nodes();
 
       elem_blk_id.push_back(pr.first);
@@ -1615,12 +1763,11 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       // Get a reference to a vector of element IDs for this subdomain.
       subdomain_map_type::mapped_type & tmp_vec = pr.second;
 
-      //Use the first element in this block to get representative information.
-      //Note that Exodus assumes all elements in a block are of the same type!
-      //We are using that same assumption here!
-      ExodusII_IO_Helper::ElementMaps em;
+      // Use the first element in this block to get representative information.
+      // Note that Exodus assumes all elements in a block are of the same type!
+      // We are using that same assumption here!
       const ExodusII_IO_Helper::Conversion conv =
-        em.assign_conversion(mesh.elem_ref(tmp_vec[0]).type());
+        assign_conversion(mesh.elem_ref(tmp_vec[0]).type());
       num_nodes_per_elem = mesh.elem_ref(tmp_vec[0]).n_nodes();
 
       connect.resize(tmp_vec.size()*num_nodes_per_elem);
@@ -1719,8 +1866,6 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
   if ((_run_only_on_proc0) && (this->processor_id() != 0))
     return;
 
-  ExodusII_IO_Helper::ElementMaps em;
-
   // Maps from sideset id to the element and sides
   std::map<int, std::vector<int>> elem;
   std::map<int, std::vector<int>> side;
@@ -1745,7 +1890,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
         for (const auto & f : family)
           {
             const ExodusII_IO_Helper::Conversion conv =
-              em.assign_conversion(mesh.elem_ptr(f->id())->type());
+              assign_conversion(mesh.elem_ptr(f->id())->type());
 
             // Use the libmesh to exodus data structure map to get the proper sideset IDs
             // The data structure contains the "collapsed" contiguous ids
@@ -1777,7 +1922,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
         for (const auto & f : family)
           {
             const ExodusII_IO_Helper::Conversion conv =
-              em.assign_conversion(mesh.elem_ptr(f->id())->type());
+              assign_conversion(mesh.elem_ptr(f->id())->type());
 
             // Use the libmesh to exodus data structure map to get the proper sideset IDs
             // The data structure contains the "collapsed" contiguous ids
@@ -2120,9 +2265,6 @@ write_sideset_data(const MeshBase & mesh,
   // Debugging:
   // libMesh::out << "File has " << num_side_sets << " side sets." << std::endl;
 
-  // We'll use this object to map Exodus side ids to libmesh side ids.
-  ExodusII_IO_Helper::ElementMaps em;
-
   // Write "truth" table for sideset variables.  The function
   // exII::ex_put_var_param() must be called before
   // exII::ex_put_sset_var_tab(). For us, this happens during the call
@@ -2193,7 +2335,7 @@ write_sideset_data(const MeshBase & mesh,
 
               // Map from Exodus side ids to libmesh side ids.
               ExodusII_IO_Helper::Conversion conv =
-                em.assign_conversion(mesh.elem_ptr(elem_id)->type());
+                assign_conversion(mesh.elem_ptr(elem_id)->type());
 
               // Map from Exodus side ids to libmesh side ids.
               unsigned int converted_side_id = conv.get_side_map(side_id);
@@ -2252,9 +2394,6 @@ read_sideset_data(const MeshBase & mesh,
                   std::vector<std::set<boundary_id_type>> & side_ids,
                   std::vector<std::map<BoundaryInfo::BCTuple, Real>> & bc_vals)
 {
-  // We'll use this object to map Exodus side ids to libmesh side ids.
-  ExodusII_IO_Helper::ElementMaps em;
-
   // This reads the sideset variable names into the local
   // sideset_var_names data structure.
   this->read_var_names(SIDESET);
@@ -2333,7 +2472,7 @@ read_sideset_data(const MeshBase & mesh,
                       // Map Exodus side id to libmesh side id.
                       // Map from Exodus side ids to libmesh side ids.
                       ExodusII_IO_Helper::Conversion conv =
-                        em.assign_conversion(mesh.elem_ptr(converted_elem_id)->type());
+                        assign_conversion(mesh.elem_ptr(converted_elem_id)->type());
 
                       // Map from Exodus side id to libmesh side id.
                       // Note: the mapping is defined on 0-based indices, so subtract
@@ -2742,197 +2881,6 @@ std::vector<std::set<subdomain_id_type>> ExodusII_IO_Helper::get_complex_vars_ac
     }
 
   return complex_vars_active_subdomains;
-}
-
-
-
-// ------------------------------------------------------------
-// ExodusII_IO_Helper::Conversion class members
-ExodusII_IO_Helper::Conversion
-ExodusII_IO_Helper::ElementMaps::assign_conversion(std::string type_str)
-{
-  init_element_equivalence_map();
-
-  // Do only upper-case comparisons
-  std::transform(type_str.begin(), type_str.end(), type_str.begin(), ::toupper);
-  return assign_conversion (libmesh_map_find(element_equivalence_map, type_str));
-}
-
-
-
-ExodusII_IO_Helper::Conversion
-ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
-{
-  Conversion conv;
-
-  switch (type)
-    {
-    case NODEELEM:
-      {
-        conv.canonical_type = NODEELEM;
-        conv.exodus_type = "SPHERE";
-        return conv;
-      }
-    case EDGE2:
-      {
-        conv.canonical_type = EDGE2;
-        conv.exodus_type = "EDGE2";
-        return conv;
-      }
-    case EDGE3:
-      {
-        conv.canonical_type = EDGE3;
-        conv.exodus_type = "EDGE3";
-        return conv;
-      }
-    case QUAD4:
-      {
-        conv.canonical_type = QUAD4;
-        conv.exodus_type = "QUAD4";
-        return conv;
-      }
-    case QUADSHELL4:
-      {
-        conv.inverse_side_map = &quadshell4_inverse_edge_map;
-        conv.shellface_index_offset = 2;
-        conv.canonical_type = QUADSHELL4;
-        conv.exodus_type = "SHELL4";
-        return conv;
-      }
-    case QUAD8:
-      {
-        conv.canonical_type = QUAD8;
-        conv.exodus_type = "QUAD8";
-        return conv;
-      }
-    case QUADSHELL8:
-      {
-        conv.inverse_side_map = &quadshell4_inverse_edge_map;
-        conv.shellface_index_offset = 2;
-        conv.canonical_type = QUADSHELL8;
-        conv.exodus_type = "SHELL8";
-        return conv;
-      }
-    case QUAD9:
-      {
-        conv.canonical_type = QUAD9;
-        conv.exodus_type = "QUAD9";
-        return conv;
-      }
-    case TRI3:
-      {
-        conv.canonical_type = TRI3;
-        conv.exodus_type = "TRI3";
-        return conv;
-      }
-    case TRISHELL3:
-      {
-        conv.inverse_side_map = &trishell3_inverse_edge_map;
-        conv.shellface_index_offset = 2;
-        conv.canonical_type = TRISHELL3;
-        conv.exodus_type = "TRISHELL3";
-        return conv;
-      }
-    case TRI3SUBDIVISION:
-      {
-        conv.canonical_type = TRI3SUBDIVISION;
-        conv.exodus_type = "TRI3";
-        return conv;
-      }
-    case TRI6:
-      {
-        conv.canonical_type = TRI6;
-        conv.exodus_type = "TRI6";
-        return conv;
-      }
-    case HEX8:
-      {
-        conv.side_map = &hex_face_map;
-        conv.inverse_side_map = &hex_inverse_face_map;
-        conv.canonical_type = HEX8;
-        conv.exodus_type = "HEX8";
-        return conv;
-      }
-    case HEX20:
-      {
-        conv.side_map = &hex_face_map;
-        conv.inverse_side_map = &hex_inverse_face_map;
-        conv.canonical_type = HEX20;
-        conv.exodus_type = "HEX20";
-        return conv;
-      }
-    case HEX27:
-      {
-        conv.node_map = &hex27_node_map;
-        conv.inverse_node_map = &hex27_inverse_node_map;
-        conv.side_map = &hex_face_map;
-        conv.inverse_side_map = &hex_inverse_face_map;
-        conv.canonical_type = HEX27;
-        conv.exodus_type = "HEX27";
-        return conv;
-      }
-    case TET4:
-      {
-        conv.side_map = &tet_face_map;
-        conv.inverse_side_map = &tet_inverse_face_map;
-        conv.canonical_type = TET4;
-        conv.exodus_type = "TETRA4";
-        return conv;
-    }
-    case TET10:
-      {
-        conv.side_map = &tet_face_map;
-        conv.inverse_side_map = &tet_inverse_face_map;
-        conv.canonical_type = TET10;
-        conv.exodus_type = "TETRA10";
-        return conv;
-    }
-    case PRISM6:
-      {
-        conv.side_map = &prism_face_map;
-        conv.inverse_side_map = &prism_inverse_face_map;
-        conv.canonical_type = PRISM6;
-        conv.exodus_type = "WEDGE";
-        return conv;
-      }
-    case PRISM15:
-      {
-        conv.side_map = &prism_face_map;
-        conv.inverse_side_map = &prism_inverse_face_map;
-        conv.canonical_type = PRISM15;
-        conv.exodus_type = "WEDGE15";
-        return conv;
-      }
-    case PRISM18:
-      {
-        conv.side_map = &prism_face_map;
-        conv.inverse_side_map = &prism_inverse_face_map;
-        conv.canonical_type = PRISM18;
-        conv.exodus_type = "WEDGE18";
-        return conv;
-      }
-    case PYRAMID5:
-      {
-        conv.canonical_type = PYRAMID5;
-        conv.exodus_type = "PYRAMID5";
-        return conv;
-      }
-    case PYRAMID13:
-      {
-        conv.canonical_type = PYRAMID13;
-        conv.exodus_type = "PYRAMID13";
-        return conv;
-      }
-    case PYRAMID14:
-      {
-        conv.canonical_type = PYRAMID14;
-        conv.exodus_type = "PYRAMID14";
-        return conv;
-      }
-
-    default:
-      libmesh_error_msg("Unsupported element type: " << type);
-    }
 }
 
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -40,11 +40,6 @@
 #include "libmesh/mesh_tools.h"  // for elem_types warning
 #endif
 
-// This macro returns the length of the array a.  Don't
-// try using it on empty arrays, since it accesses the
-// zero'th element.
-#define ARRAY_LENGTH(a) (sizeof((a))/sizeof((a)[0]))
-
 // Anonymous namespace for file local data
 namespace
 {

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -2813,7 +2813,8 @@ std::vector<std::set<subdomain_id_type>> ExodusII_IO_Helper::get_complex_vars_ac
 
 // ------------------------------------------------------------
 // ExodusII_IO_Helper::Conversion class members
-ExodusII_IO_Helper::Conversion ExodusII_IO_Helper::ElementMaps::assign_conversion(std::string type_str)
+ExodusII_IO_Helper::Conversion
+ExodusII_IO_Helper::ElementMaps::assign_conversion(std::string type_str)
 {
   init_element_equivalence_map();
 
@@ -2824,222 +2825,249 @@ ExodusII_IO_Helper::Conversion ExodusII_IO_Helper::ElementMaps::assign_conversio
 
 
 
-ExodusII_IO_Helper::Conversion ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
+ExodusII_IO_Helper::Conversion
+ExodusII_IO_Helper::ElementMaps::assign_conversion(const ElemType type)
 {
+  Conversion conv;
+
   switch (type)
     {
     case NODEELEM:
       {
-        return Conversion(&nodeelem_node_map,
-                          &nodeelem_node_map, // inverse node map same as forward node map
-                          nullptr, // NODELEM doesn't have any edges
-                          nullptr, // We also don't inverse map NODEELEM edges
-                          NODEELEM, "SPHERE");
+        conv.node_map = &nodeelem_node_map;
+        conv.inverse_node_map = &nodeelem_node_map;
+        conv.canonical_type = NODEELEM;
+        conv.exodus_type = "SPHERE";
+        return conv;
       }
-
     case EDGE2:
       {
-        return Conversion(&edge2_node_map,
-                          &edge2_node_map, // inverse node map same as forward node map
-                          &edge_edge_map,
-                          &edge_inverse_edge_map,
-                          EDGE2, "EDGE2");
+        conv.node_map = &edge2_node_map;
+        conv.inverse_node_map = &edge2_node_map;
+        conv.side_map = &edge_edge_map;
+        conv.inverse_side_map = &edge_edge_map;
+        conv.canonical_type = EDGE2;
+        conv.exodus_type = "EDGE2";
+        return conv;
       }
     case EDGE3:
       {
-        return Conversion(&edge3_node_map,
-                          &edge3_node_map, // inverse node map same as forward node map
-                          &edge_edge_map,
-                          &edge_inverse_edge_map,
-                          EDGE3, "EDGE3");
+        conv.node_map = &edge3_node_map;
+        conv.inverse_node_map = &edge3_node_map;
+        conv.side_map = &edge_edge_map;
+        conv.inverse_side_map = &edge_edge_map;
+        conv.canonical_type = EDGE3;
+        conv.exodus_type = "EDGE3";
+        return conv;
       }
     case QUAD4:
       {
-        return Conversion(&quad4_node_map,
-                          &quad4_node_map, // inverse node map same as forward node map
-                          &quad_edge_map,
-                          &quad_inverse_edge_map,
-                          QUAD4, "QUAD4");
+        conv.node_map = &quad4_node_map;
+        conv.inverse_node_map = &quad4_node_map;
+        conv.side_map = &quad_edge_map;
+        conv.inverse_side_map = &quad_inverse_edge_map;
+        conv.canonical_type = QUAD4;
+        conv.exodus_type = "QUAD4";
+        return conv;
       }
-
     case QUADSHELL4:
       {
-        return Conversion(&quad4_node_map, // node mapping is the same as for quad4
-                          &quad4_node_map,
-                          &quadshell4_edge_map,
-                          &quadshell4_inverse_edge_map,
-                          &quadshell4_shellface_map,
-                          &quadshell4_inverse_shellface_map,
-                          2, // the side index offset for QUADSHELL4 is 2
-                          QUADSHELL4, "SHELL4");
+        conv.node_map = &quad4_node_map;
+        conv.inverse_node_map = &quad4_node_map;
+        conv.side_map = &quadshell4_edge_map;
+        conv.inverse_side_map = &quadshell4_inverse_edge_map;
+        conv.shellface_map = &quadshell4_shellface_map;
+        conv.inverse_shellface_map = &quadshell4_inverse_shellface_map;
+        conv.shellface_index_offset = 2;
+        conv.canonical_type = QUADSHELL4;
+        conv.exodus_type = "SHELL4";
+        return conv;
       }
-
     case QUAD8:
       {
-        return Conversion(&quad8_node_map,
-                          &quad8_node_map, // inverse node map same as forward node map
-                          &quad_edge_map,
-                          &quad_inverse_edge_map,
-                          QUAD8, "QUAD8");
+        conv.node_map = &quad8_node_map;
+        conv.inverse_node_map = &quad8_node_map;
+        conv.side_map = &quad_edge_map;
+        conv.inverse_side_map = &quad_inverse_edge_map;
+        conv.canonical_type = QUAD8;
+        conv.exodus_type = "QUAD8";
+        return conv;
       }
-
     case QUADSHELL8:
       {
-        return Conversion(&quad8_node_map, // node mapping is the same as for quad8
-                          &quad8_node_map,
-                          &quadshell4_edge_map,
-                          &quadshell4_inverse_edge_map,
-                          &quadshell4_shellface_map,
-                          &quadshell4_inverse_shellface_map,
-                          2, // the side index offset for QUADSHELL8 is 2
-                          QUADSHELL8, "SHELL8");
+        conv.node_map = &quad8_node_map;
+        conv.inverse_node_map = &quad8_node_map;
+        conv.side_map = &quadshell4_edge_map;
+        conv.inverse_side_map = &quadshell4_inverse_edge_map;
+        conv.shellface_map = &quadshell4_shellface_map;
+        conv.inverse_shellface_map = &quadshell4_inverse_shellface_map;
+        conv.shellface_index_offset = 2;
+        conv.canonical_type = QUADSHELL8;
+        conv.exodus_type = "SHELL8";
+        return conv;
       }
-
     case QUAD9:
       {
-        return Conversion(&quad9_node_map,
-                          &quad9_node_map, // inverse node map same as forward node map
-                          &quad_edge_map,
-                          &quad_inverse_edge_map,
-                          QUAD9, "QUAD9");
+        conv.node_map = &quad9_node_map;
+        conv.inverse_node_map = &quad9_node_map;
+        conv.side_map = &quad_edge_map;
+        conv.inverse_side_map = &quad_inverse_edge_map;
+        conv.canonical_type = QUAD9;
+        conv.exodus_type = "QUAD9";
+        return conv;
       }
-
     case TRI3:
       {
-        return Conversion(&tri3_node_map,
-                          &tri3_node_map, // inverse node map same as forward node map
-                          &tri_edge_map,
-                          &tri_inverse_edge_map,
-                          TRI3, "TRI3");
+        conv.node_map = &tri3_node_map;
+        conv.inverse_node_map = &tri3_node_map;
+        conv.side_map = &tri_edge_map;
+        conv.inverse_side_map = &tri_inverse_edge_map;
+        conv.canonical_type = TRI3;
+        conv.exodus_type = "TRI3";
+        return conv;
       }
-
     case TRISHELL3:
       {
-        return Conversion(&tri3_node_map, // node mapping is the same as for tri3
-                          &tri3_node_map,
-                          &trishell3_edge_map,
-                          &trishell3_inverse_edge_map,
-                          &trishell3_shellface_map,
-                          &trishell3_inverse_shellface_map,
-                          2, // the side index offset for TRISHELL4 is 2
-                          TRISHELL3, "TRISHELL3");
+        conv.node_map = &tri3_node_map;
+        conv.inverse_node_map = &tri3_node_map;
+        conv.side_map = &trishell3_edge_map;
+        conv.inverse_side_map = &trishell3_inverse_edge_map;
+        conv.shellface_map = &trishell3_shellface_map;
+        conv.inverse_shellface_map = &trishell3_inverse_shellface_map;
+        conv.shellface_index_offset = 2;
+        conv.canonical_type = TRISHELL3;
+        conv.exodus_type = "TRISHELL3";
+        return conv;
       }
-
     case TRI3SUBDIVISION:
       {
-        return Conversion(&tri3_node_map,
-                          &tri3_node_map, // inverse node map same as forward node map
-                          &tri_edge_map,
-                          &tri_inverse_edge_map,
-                          TRI3SUBDIVISION, "TRI3");
+        conv.node_map = &tri3_node_map;
+        conv.inverse_node_map = &tri3_node_map;
+        conv.side_map = &tri_edge_map;
+        conv.inverse_side_map = &tri_inverse_edge_map;
+        conv.canonical_type = TRI3SUBDIVISION;
+        conv.exodus_type = "TRI3";
+        return conv;
       }
-
     case TRI6:
       {
-        return Conversion(&tri6_node_map,
-                          &tri6_node_map, // inverse node map same as forward node map
-                          &tri_edge_map,
-                          &tri_inverse_edge_map,
-                          TRI6, "TRI6");
+        conv.node_map = &tri6_node_map;
+        conv.inverse_node_map = &tri6_node_map;
+        conv.side_map = &tri_edge_map;
+        conv.inverse_side_map = &tri_inverse_edge_map;
+        conv.canonical_type = TRI6;
+        conv.exodus_type = "TRI6";
+        return conv;
       }
-
     case HEX8:
       {
-        return Conversion(&hex8_node_map,
-                          &hex8_node_map, // inverse node map same as forward node map
-                          &hex_face_map,
-                          &hex_inverse_face_map,
-                          HEX8, "HEX8");
+        conv.node_map = &hex8_node_map;
+        conv.inverse_node_map = &hex8_node_map;
+        conv.side_map = &hex_face_map;
+        conv.inverse_side_map = &hex_inverse_face_map;
+        conv.canonical_type = HEX8;
+        conv.exodus_type = "HEX8";
+        return conv;
       }
-
     case HEX20:
       {
-        return Conversion(&hex20_node_map,
-                          &hex20_node_map, // inverse node map same as forward node map
-                          &hex_face_map,
-                          &hex_inverse_face_map,
-                          HEX20, "HEX20");
+        conv.node_map = &hex20_node_map;
+        conv.inverse_node_map = &hex20_node_map;
+        conv.side_map = &hex_face_map;
+        conv.inverse_side_map = &hex_inverse_face_map;
+        conv.canonical_type = HEX20;
+        conv.exodus_type = "HEX20";
+        return conv;
       }
-
     case HEX27:
       {
-        return Conversion(&hex27_node_map,
-                          &hex27_inverse_node_map, // different inverse node map for Hex27!
-                          &hex27_face_map,
-                          &hex27_inverse_face_map,
-                          HEX27, "HEX27");
+        conv.node_map = &hex27_node_map;
+        conv.inverse_node_map = &hex27_inverse_node_map;
+        conv.side_map = &hex27_face_map;
+        conv.inverse_side_map = &hex27_inverse_face_map;
+        conv.canonical_type = HEX27;
+        conv.exodus_type = "HEX27";
+        return conv;
       }
-
     case TET4:
       {
-        return Conversion(&tet4_node_map,
-                          &tet4_node_map, // inverse node map same as forward node map
-                          &tet_face_map,
-                          &tet_inverse_face_map,
-                          TET4, "TETRA4");
-      }
-
+        conv.node_map = &tet4_node_map;
+        conv.inverse_node_map = &tet4_node_map;
+        conv.side_map = &tet_face_map;
+        conv.inverse_side_map = &tet_inverse_face_map;
+        conv.canonical_type = TET4;
+        conv.exodus_type = "TETRA4";
+        return conv;
+    }
     case TET10:
       {
-        return Conversion(&tet10_node_map,
-                          &tet10_node_map, // inverse node map same as forward node map
-                          &tet_face_map,
-                          &tet_inverse_face_map,
-                          TET10, "TETRA10");
-      }
-
+        conv.node_map = &tet10_node_map;
+        conv.inverse_node_map = &tet10_node_map;
+        conv.side_map = &tet_face_map;
+        conv.inverse_side_map = &tet_inverse_face_map;
+        conv.canonical_type = TET10;
+        conv.exodus_type = "TETRA10";
+        return conv;
+    }
     case PRISM6:
       {
-        return Conversion(&prism6_node_map,
-                          &prism6_node_map, // inverse node map same as forward node map
-                          &prism_face_map,
-                          &prism_inverse_face_map,
-                          PRISM6, "WEDGE");
+        conv.node_map = &prism6_node_map;
+        conv.inverse_node_map = &prism6_node_map;
+        conv.side_map = &prism_face_map;
+        conv.inverse_side_map = &prism_inverse_face_map;
+        conv.canonical_type = PRISM6;
+        conv.exodus_type = "WEDGE";
+        return conv;
       }
-
     case PRISM15:
       {
-        return Conversion(&prism15_node_map,
-                          &prism15_node_map, // inverse node map same as forward node map
-                          &prism_face_map,
-                          &prism_inverse_face_map,
-                          PRISM15, "WEDGE15");
+        conv.node_map = &prism15_node_map;
+        conv.inverse_node_map = &prism15_node_map;
+        conv.side_map = &prism_face_map;
+        conv.inverse_side_map = &prism_inverse_face_map;
+        conv.canonical_type = PRISM15;
+        conv.exodus_type = "WEDGE15";
+        return conv;
       }
-
     case PRISM18:
       {
-        return Conversion(&prism18_node_map,
-                          &prism18_node_map, // inverse node map same as forward node map
-                          &prism_face_map,
-                          &prism_inverse_face_map,
-                          PRISM18, "WEDGE18");
+        conv.node_map = &prism18_node_map;
+        conv.inverse_node_map = &prism18_node_map;
+        conv.side_map = &prism_face_map;
+        conv.inverse_side_map = &prism_inverse_face_map;
+        conv.canonical_type = PRISM18;
+        conv.exodus_type = "WEDGE18";
+        return conv;
       }
-
     case PYRAMID5:
       {
-        return Conversion(&pyramid5_node_map,
-                          &pyramid5_node_map, // inverse node map same as forward node map
-                          &pyramid_face_map,
-                          &pyramid_inverse_face_map,
-                          PYRAMID5, "PYRAMID5");
+        conv.node_map = &pyramid5_node_map;
+        conv.inverse_node_map = &pyramid5_node_map;
+        conv.side_map = &pyramid_face_map;
+        conv.inverse_side_map = &pyramid_inverse_face_map;
+        conv.canonical_type = PYRAMID5;
+        conv.exodus_type = "PYRAMID5";
+        return conv;
       }
-
     case PYRAMID13:
       {
-        return Conversion(&pyramid13_node_map,
-                          &pyramid13_node_map, // inverse node map same as forward node map
-                          &pyramid_face_map,
-                          &pyramid_inverse_face_map,
-                          PYRAMID13, "PYRAMID13");
+        conv.node_map = &pyramid13_node_map;
+        conv.inverse_node_map = &pyramid13_node_map;
+        conv.side_map = &pyramid_face_map;
+        conv.inverse_side_map = &pyramid_inverse_face_map;
+        conv.canonical_type = PYRAMID13;
+        conv.exodus_type = "PYRAMID13";
+        return conv;
       }
-
     case PYRAMID14:
       {
-        return Conversion(&pyramid14_node_map,
-                          &pyramid14_node_map, // inverse node map same as forward node map
-                          &pyramid_face_map,
-                          &pyramid_inverse_face_map,
-                          PYRAMID14, "PYRAMID14");
+        conv.node_map = &pyramid14_node_map;
+        conv.inverse_node_map = &pyramid14_node_map;
+        conv.side_map = &pyramid_face_map;
+        conv.inverse_side_map = &pyramid_inverse_face_map;
+        conv.canonical_type = PYRAMID14;
+        conv.exodus_type = "PYRAMID14";
+        return conv;
       }
 
     default:
@@ -3049,8 +3077,28 @@ ExodusII_IO_Helper::Conversion ExodusII_IO_Helper::ElementMaps::assign_conversio
 
 
 
+int ExodusII_IO_Helper::Conversion::get_node_map(int i) const
+{
+  libmesh_assert(node_map);
+  libmesh_assert_less (i, node_map->size());
+  return (*node_map)[i];
+}
+
+
+
+int ExodusII_IO_Helper::Conversion::get_inverse_node_map(int i) const
+{
+  libmesh_assert(inverse_node_map);
+  libmesh_assert_less (i, inverse_node_map->size());
+  return (*inverse_node_map)[i];
+}
+
+
+
 int ExodusII_IO_Helper::Conversion::get_side_map(int i) const
 {
+  libmesh_assert(side_map);
+
   // If we asked for a side that doesn't exist, return an invalid_id
   // and allow higher-level code to handle it.
   if (static_cast<size_t>(i) >= side_map->size())
@@ -3060,6 +3108,59 @@ int ExodusII_IO_Helper::Conversion::get_side_map(int i) const
 }
 
 
+
+int ExodusII_IO_Helper::Conversion::get_inverse_side_map(int i) const
+{
+  libmesh_assert(inverse_side_map);
+  libmesh_assert_less (i, inverse_side_map->size());
+  return (*inverse_side_map)[i];
+}
+
+
+
+/**
+ * \returns The ith component of the shellface map for this element.
+ * \note Nothing is currently using this.
+ */
+int ExodusII_IO_Helper::Conversion::get_shellface_map(int i) const
+{
+  libmesh_assert(shellface_map);
+  libmesh_assert_less (i, shellface_map->size());
+  return (*shellface_map)[i];
+}
+
+
+
+int ExodusII_IO_Helper::Conversion::get_inverse_shellface_map(int i) const
+{
+  libmesh_assert(inverse_shellface_map);
+  libmesh_assert_less (i, inverse_shellface_map->size());
+  return (*inverse_shellface_map)[i];
+}
+
+
+
+ElemType ExodusII_IO_Helper::Conversion::get_canonical_type() const
+{
+  return canonical_type;
+}
+
+
+
+std::string ExodusII_IO_Helper::Conversion::exodus_elem_type() const
+{
+  return exodus_type;
+}
+
+
+
+/**
+ * \returns The shellface index offset.
+ */
+std::size_t ExodusII_IO_Helper::Conversion::get_shellface_index_offset() const
+{
+  return shellface_index_offset;
+}
 
 ExodusII_IO_Helper::NamesData::NamesData(size_t n_strings, size_t string_length) :
   data_table(n_strings),

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -22,7 +22,6 @@
 #ifdef LIBMESH_HAVE_EXODUS_API
 
 #include <algorithm>
-#include <functional>
 #include <sstream>
 #include <cstdlib> // std::strtol
 
@@ -145,82 +144,82 @@ void ExodusII_IO_Helper::init_conversion_map()
 {
   {
     auto & conv = conversion_map[NODEELEM];
-    conv.canonical_type = NODEELEM;
+    conv.libmesh_type = NODEELEM;
     conv.exodus_type = "SPHERE";
   }
   {
     auto & conv = conversion_map[EDGE2];
-    conv.canonical_type = EDGE2;
+    conv.libmesh_type = EDGE2;
     conv.exodus_type = "EDGE2";
   }
   {
     auto & conv = conversion_map[EDGE3];
-    conv.canonical_type = EDGE3;
+    conv.libmesh_type = EDGE3;
     conv.exodus_type = "EDGE3";
   }
   {
     auto & conv = conversion_map[QUAD4];
-    conv.canonical_type = QUAD4;
+    conv.libmesh_type = QUAD4;
     conv.exodus_type = "QUAD4";
   }
   {
     auto & conv = conversion_map[QUADSHELL4];
     conv.inverse_side_map = &quadshell4_inverse_edge_map;
     conv.shellface_index_offset = 2;
-    conv.canonical_type = QUADSHELL4;
+    conv.libmesh_type = QUADSHELL4;
     conv.exodus_type = "SHELL4";
   }
   {
     auto & conv = conversion_map[QUAD8];
-    conv.canonical_type = QUAD8;
+    conv.libmesh_type = QUAD8;
     conv.exodus_type = "QUAD8";
   }
   {
     auto & conv = conversion_map[QUADSHELL8];
     conv.inverse_side_map = &quadshell4_inverse_edge_map;
     conv.shellface_index_offset = 2;
-    conv.canonical_type = QUADSHELL8;
+    conv.libmesh_type = QUADSHELL8;
     conv.exodus_type = "SHELL8";
   }
   {
     auto & conv = conversion_map[QUAD9];
-    conv.canonical_type = QUAD9;
+    conv.libmesh_type = QUAD9;
     conv.exodus_type = "QUAD9";
   }
   {
     auto & conv = conversion_map[TRI3];
-    conv.canonical_type = TRI3;
+    conv.libmesh_type = TRI3;
     conv.exodus_type = "TRI3";
   }
   {
     auto & conv = conversion_map[TRISHELL3];
     conv.inverse_side_map = &trishell3_inverse_edge_map;
     conv.shellface_index_offset = 2;
-    conv.canonical_type = TRISHELL3;
+    conv.libmesh_type = TRISHELL3;
     conv.exodus_type = "TRISHELL3";
   }
   {
     auto & conv = conversion_map[TRI3SUBDIVISION];
-    conv.canonical_type = TRI3SUBDIVISION;
+    conv.libmesh_type = TRI3SUBDIVISION;
     conv.exodus_type = "TRI3";
   }
   {
     auto & conv = conversion_map[TRI6];
-    conv.canonical_type = TRI6;
+    conv.libmesh_type = TRI6;
     conv.exodus_type = "TRI6";
   }
   {
     auto & conv = conversion_map[HEX8];
     conv.side_map = &hex_face_map;
     conv.inverse_side_map = &hex_inverse_face_map;
-    conv.canonical_type = HEX8;
+    conv.libmesh_type = HEX8;
     conv.exodus_type = "HEX8";
   }
   {
     auto & conv = conversion_map[HEX20];
     conv.side_map = &hex_face_map;
     conv.inverse_side_map = &hex_inverse_face_map;
-    conv.canonical_type = HEX20;
+    conv.libmesh_type = HEX20;
     conv.exodus_type = "HEX20";
   }
   {
@@ -229,57 +228,57 @@ void ExodusII_IO_Helper::init_conversion_map()
     conv.inverse_node_map = &hex27_inverse_node_map;
     conv.side_map = &hex_face_map;
     conv.inverse_side_map = &hex_inverse_face_map;
-    conv.canonical_type = HEX27;
+    conv.libmesh_type = HEX27;
     conv.exodus_type = "HEX27";
   }
   {
     auto & conv = conversion_map[TET4];
     conv.side_map = &tet_face_map;
     conv.inverse_side_map = &tet_inverse_face_map;
-    conv.canonical_type = TET4;
+    conv.libmesh_type = TET4;
     conv.exodus_type = "TETRA4";
   }
   {
     auto & conv = conversion_map[TET10];
     conv.side_map = &tet_face_map;
     conv.inverse_side_map = &tet_inverse_face_map;
-    conv.canonical_type = TET10;
+    conv.libmesh_type = TET10;
     conv.exodus_type = "TETRA10";
   }
   {
     auto & conv = conversion_map[PRISM6];
     conv.side_map = &prism_face_map;
     conv.inverse_side_map = &prism_inverse_face_map;
-    conv.canonical_type = PRISM6;
+    conv.libmesh_type = PRISM6;
     conv.exodus_type = "WEDGE";
   }
   {
     auto & conv = conversion_map[PRISM15];
     conv.side_map = &prism_face_map;
     conv.inverse_side_map = &prism_inverse_face_map;
-    conv.canonical_type = PRISM15;
+    conv.libmesh_type = PRISM15;
     conv.exodus_type = "WEDGE15";
   }
   {
     auto & conv = conversion_map[PRISM18];
     conv.side_map = &prism_face_map;
     conv.inverse_side_map = &prism_inverse_face_map;
-    conv.canonical_type = PRISM18;
+    conv.libmesh_type = PRISM18;
     conv.exodus_type = "WEDGE18";
   }
   {
     auto & conv = conversion_map[PYRAMID5];
-    conv.canonical_type = PYRAMID5;
+    conv.libmesh_type = PYRAMID5;
     conv.exodus_type = "PYRAMID5";
   }
   {
     auto & conv = conversion_map[PYRAMID13];
-    conv.canonical_type = PYRAMID13;
+    conv.libmesh_type = PYRAMID13;
     conv.exodus_type = "PYRAMID13";
   }
   {
     auto & conv = conversion_map[PYRAMID14];
-    conv.canonical_type = PYRAMID14;
+    conv.libmesh_type = PYRAMID14;
     conv.exodus_type = "PYRAMID14";
   }
 }
@@ -377,18 +376,18 @@ void ExodusII_IO_Helper::init_element_equivalence_map()
   element_equivalence_map["PYRAMID14"] = PYRAMID14;
 }
 
-ExodusII_IO_Helper::Conversion
-ExodusII_IO_Helper::assign_conversion(const ElemType type)
+const ExodusII_IO_Helper::Conversion &
+ExodusII_IO_Helper::get_conversion(const ElemType type) const
 {
   return libmesh_map_find(conversion_map, type);
 }
 
-ExodusII_IO_Helper::Conversion
-ExodusII_IO_Helper::assign_conversion(std::string type_str)
+const ExodusII_IO_Helper::Conversion &
+ExodusII_IO_Helper::get_conversion(std::string type_str) const
 {
   // Do only upper-case comparisons
   std::transform(type_str.begin(), type_str.end(), type_str.begin(), ::toupper);
-  return assign_conversion (libmesh_map_find(element_equivalence_map, type_str));
+  return get_conversion (libmesh_map_find(element_equivalence_map, type_str));
 }
 
 const char * ExodusII_IO_Helper::get_elem_type() const
@@ -1700,8 +1699,7 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       // Use the first element in this block to get representative information.
       // Note that Exodus assumes all elements in a block are of the same type!
       // We are using that same assumption here!
-      const ExodusII_IO_Helper::Conversion conv =
-        assign_conversion(mesh.elem_ref(tmp_vec[0]).type());
+      const auto & conv = get_conversion(mesh.elem_ref(tmp_vec[0]).type());
       num_nodes_per_elem = mesh.elem_ref(tmp_vec[0]).n_nodes();
 
       elem_blk_id.push_back(pr.first);
@@ -1766,8 +1764,7 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       // Use the first element in this block to get representative information.
       // Note that Exodus assumes all elements in a block are of the same type!
       // We are using that same assumption here!
-      const ExodusII_IO_Helper::Conversion conv =
-        assign_conversion(mesh.elem_ref(tmp_vec[0]).type());
+      const auto & conv = get_conversion(mesh.elem_ref(tmp_vec[0]).type());
       num_nodes_per_elem = mesh.elem_ref(tmp_vec[0]).n_nodes();
 
       connect.resize(tmp_vec.size()*num_nodes_per_elem);
@@ -1789,12 +1786,12 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
           // This needs to be more than an assert so we don't fail
           // with a mysterious segfault while trying to write mixed
           // element meshes in optimized mode.
-          if (elem.type() != conv.get_canonical_type())
+          if (elem.type() != conv.libmesh_elem_type())
             libmesh_error_msg("Error: Exodus requires all elements with a given subdomain ID to be the same type.\n" \
                               << "Can't write both "                  \
                               << Utility::enum_to_string(elem.type()) \
                               << " and "                              \
-                              << Utility::enum_to_string(conv.get_canonical_type()) \
+                              << Utility::enum_to_string(conv.libmesh_elem_type()) \
                               << " in the same block!");
 
 
@@ -1889,8 +1886,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
 
         for (const auto & f : family)
           {
-            const ExodusII_IO_Helper::Conversion conv =
-              assign_conversion(mesh.elem_ptr(f->id())->type());
+            const auto & conv = get_conversion(mesh.elem_ptr(f->id())->type());
 
             // Use the libmesh to exodus data structure map to get the proper sideset IDs
             // The data structure contains the "collapsed" contiguous ids
@@ -1921,8 +1917,7 @@ void ExodusII_IO_Helper::write_sidesets(const MeshBase & mesh)
 
         for (const auto & f : family)
           {
-            const ExodusII_IO_Helper::Conversion conv =
-              assign_conversion(mesh.elem_ptr(f->id())->type());
+            const auto & conv = get_conversion(mesh.elem_ptr(f->id())->type());
 
             // Use the libmesh to exodus data structure map to get the proper sideset IDs
             // The data structure contains the "collapsed" contiguous ids
@@ -2334,8 +2329,7 @@ write_sideset_data(const MeshBase & mesh,
                 libmesh_error_msg("Error mapping Exodus elem id to libmesh elem id.");
 
               // Map from Exodus side ids to libmesh side ids.
-              ExodusII_IO_Helper::Conversion conv =
-                assign_conversion(mesh.elem_ptr(elem_id)->type());
+              const auto & conv = get_conversion(mesh.elem_ptr(elem_id)->type());
 
               // Map from Exodus side ids to libmesh side ids.
               unsigned int converted_side_id = conv.get_side_map(side_id);
@@ -2471,8 +2465,7 @@ read_sideset_data(const MeshBase & mesh,
 
                       // Map Exodus side id to libmesh side id.
                       // Map from Exodus side ids to libmesh side ids.
-                      ExodusII_IO_Helper::Conversion conv =
-                        assign_conversion(mesh.elem_ptr(converted_elem_id)->type());
+                      const auto & conv = get_conversion(mesh.elem_ptr(converted_elem_id)->type());
 
                       // Map from Exodus side id to libmesh side id.
                       // Note: the mapping is defined on 0-based indices, so subtract
@@ -2960,9 +2953,9 @@ int ExodusII_IO_Helper::Conversion::get_inverse_shellface_map(int i) const
 
 
 
-ElemType ExodusII_IO_Helper::Conversion::get_canonical_type() const
+ElemType ExodusII_IO_Helper::Conversion::libmesh_elem_type() const
 {
-  return canonical_type;
+  return libmesh_type;
 }
 
 

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -830,8 +830,7 @@ void Nemesis_IO::read (const std::string & base_filename)
       const std::string type_str ( nemhelper->elem_type.data() );
 
       // Set any relevant node/edge maps for this element
-      const ExodusII_IO_Helper::Conversion conv =
-        nemhelper->assign_conversion(type_str);
+      const auto & conv = nemhelper->get_conversion(type_str);
 
       if (_verbose)
         libMesh::out << "Reading a block of " << type_str << " elements." << std::endl;
@@ -839,7 +838,7 @@ void Nemesis_IO::read (const std::string & base_filename)
       // Loop over all the elements in this block
       for (unsigned int j=0; j<to_uint(nemhelper->num_elem_this_blk); j++)
         {
-          Elem * elem = Elem::build (conv.get_canonical_type()).release();
+          Elem * elem = Elem::build (conv.libmesh_elem_type()).release();
           libmesh_assert (elem);
 
           // Assign subdomain and processor ID to the newly-created Elem.
@@ -1043,8 +1042,7 @@ void Nemesis_IO::read (const std::string & base_filename)
       // The side numberings in libmesh and exodus are not 1:1, so we need to map
       // whatever side number is stored in Exodus into a libmesh side number using
       // a conv object...
-      const ExodusII_IO_Helper::Conversion conv =
-        nemhelper->assign_conversion(elem->type());
+      const auto & conv = nemhelper->get_conversion(elem->type());
 
       // Finally, we are ready to add the element and its side to the BoundaryInfo object.
       // Call the version of add_side which takes a pointer, since we have already gone to

--- a/src/mesh/nemesis_io.C
+++ b/src/mesh/nemesis_io.C
@@ -806,10 +806,6 @@ void Nemesis_IO::read (const std::string & base_filename)
   // local element number i.
   nemhelper->read_elem_num_map();
 
-  // Instantiate the ElementMaps interface.  This is what translates LibMesh's
-  // element numbering scheme to Exodus's.
-  ExodusII_IO_Helper::ElementMaps em;
-
   // Read in the element connectivity for each block by
   // looping over all the blocks.
   for (unsigned int i=0; i<to_uint(nemhelper->num_elem_blk); i++)
@@ -834,7 +830,8 @@ void Nemesis_IO::read (const std::string & base_filename)
       const std::string type_str ( nemhelper->elem_type.data() );
 
       // Set any relevant node/edge maps for this element
-      const ExodusII_IO_Helper::Conversion conv = em.assign_conversion(type_str);
+      const ExodusII_IO_Helper::Conversion conv =
+        nemhelper->assign_conversion(type_str);
 
       if (_verbose)
         libMesh::out << "Reading a block of " << type_str << " elements." << std::endl;
@@ -1047,7 +1044,7 @@ void Nemesis_IO::read (const std::string & base_filename)
       // whatever side number is stored in Exodus into a libmesh side number using
       // a conv object...
       const ExodusII_IO_Helper::Conversion conv =
-        em.assign_conversion(elem->type());
+        nemhelper->assign_conversion(elem->type());
 
       // Finally, we are ready to add the element and its side to the BoundaryInfo object.
       // Call the version of add_side which takes a pointer, since we have already gone to

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1232,10 +1232,6 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
   // element communication maps in Exodus.
   std::set<unsigned> neighboring_processor_ids;
 
-  // Will be used to create conversion objects capable of mapping libmesh
-  // element numberings into Nemesis numberings.
-  ExodusII_IO_Helper::ElementMaps element_mapper;
-
   for (const auto & elem : pmesh.active_local_element_ptr_range())
     {
       // Add this Elem's ID to all_elem_ids, later we will take the difference
@@ -1248,7 +1244,8 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
 
       // Construct a conversion object for this Element.  This will help us map
       // Libmesh numberings into Nemesis numberings for sides.
-      ExodusII_IO_Helper::Conversion conv = element_mapper.assign_conversion(elem->type());
+      ExodusII_IO_Helper::Conversion conv =
+        assign_conversion(elem->type());
 
       // Add all this element's node IDs to the set of all node IDs.
       // The set of internal_node_ids will be the set difference between
@@ -1762,12 +1759,10 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
       if (elem_ids_this_subdomain.size() == 0)
         libmesh_error_msg("Error, no element IDs found in subdomain " << pr.first);
 
-      ExodusII_IO_Helper::ElementMaps em;
-
       // Use the first element in this block to get representative information.
       // Note that Exodus assumes all elements in a block are of the same type!
       // We are using that same assumption here!
-      const ExodusII_IO_Helper::Conversion conv = em.assign_conversion
+      const ExodusII_IO_Helper::Conversion conv = assign_conversion
         (pmesh.elem_ref(elem_ids_this_subdomain[0]).type());
       this->num_nodes_per_elem =
         pmesh.elem_ref(elem_ids_this_subdomain[0]).n_nodes();
@@ -2098,8 +2093,6 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
   std::map<boundary_id_type, std::vector<int>> local_elem_boundary_id_lists;
   std::map<boundary_id_type, std::vector<int>> local_elem_boundary_id_side_lists;
 
-  ExodusII_IO_Helper::ElementMaps em;
-
   // FIXME: We already built this list once, we should reuse that information!
   std::vector<std::tuple<dof_id_type, unsigned short int, boundary_id_type>> bndry_elem_side_id_list =
     mesh.get_boundary_info().build_side_list();
@@ -2132,7 +2125,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
           // If element is local, process it
           if (f.processor_id() == this->processor_id())
             {
-              const ExodusII_IO_Helper::Conversion conv = em.assign_conversion(f.type());
+              const ExodusII_IO_Helper::Conversion conv = assign_conversion(f.type());
 
               // Use the libmesh to exodus data structure map to get the proper sideset IDs
               // The data structure contains the "collapsed" contiguous ids.
@@ -2336,13 +2329,11 @@ void Nemesis_IO_Helper::write_elements(const MeshBase & mesh, bool /*use_discont
               std::vector<int> & this_block_connectivity = it->second;
               std::vector<dof_id_type> & elements_in_this_block = subdomain_map[block];
 
-              ExodusII_IO_Helper::ElementMaps em;
-
               //Use the first element in this block to get representative information.
               //Note that Exodus assumes all elements in a block are of the same type!
               //We are using that same assumption here!
               const ExodusII_IO_Helper::Conversion conv =
-                em.assign_conversion(mesh.elem_ref(elements_in_this_block[0]).type());
+                assign_conversion(mesh.elem_ref(elements_in_this_block[0]).type());
 
               this->num_nodes_per_elem =
                 mesh.elem_ref(elements_in_this_block[0]).n_nodes();

--- a/src/mesh/nemesis_io_helper.C
+++ b/src/mesh/nemesis_io_helper.C
@@ -1244,8 +1244,7 @@ Nemesis_IO_Helper::compute_internal_and_border_elems_and_internal_nodes(const Me
 
       // Construct a conversion object for this Element.  This will help us map
       // Libmesh numberings into Nemesis numberings for sides.
-      ExodusII_IO_Helper::Conversion conv =
-        assign_conversion(elem->type());
+      const auto & conv = get_conversion(elem->type());
 
       // Add all this element's node IDs to the set of all node IDs.
       // The set of internal_node_ids will be the set difference between
@@ -1762,7 +1761,7 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
       // Use the first element in this block to get representative information.
       // Note that Exodus assumes all elements in a block are of the same type!
       // We are using that same assumption here!
-      const ExodusII_IO_Helper::Conversion conv = assign_conversion
+      const auto & conv = get_conversion
         (pmesh.elem_ref(elem_ids_this_subdomain[0]).type());
       this->num_nodes_per_elem =
         pmesh.elem_ref(elem_ids_this_subdomain[0]).n_nodes();
@@ -1787,11 +1786,11 @@ void Nemesis_IO_Helper::build_element_and_node_maps(const MeshBase & pmesh)
           const Elem & elem = pmesh.elem_ref(elem_id);
 
           // Exodus/Nemesis want every block to have the same element type
-          // libmesh_assert_equal_to (elem->type(), conv.get_canonical_type());
+          // libmesh_assert_equal_to (elem->type(), conv.libmesh_elem_type());
 
           // But we can get away with writing e.g. HEX8 and INFHEX8 in
           // the same block...
-          libmesh_assert_equal_to (elem.n_nodes(), Elem::build(conv.get_canonical_type(), nullptr)->n_nodes());
+          libmesh_assert_equal_to (elem.n_nodes(), Elem::build(conv.libmesh_elem_type(), nullptr)->n_nodes());
 
           for (auto j : IntRange<int>(0, this->num_nodes_per_elem))
             {
@@ -2125,7 +2124,7 @@ void Nemesis_IO_Helper::write_sidesets(const MeshBase & mesh)
           // If element is local, process it
           if (f.processor_id() == this->processor_id())
             {
-              const ExodusII_IO_Helper::Conversion conv = assign_conversion(f.type());
+              const auto & conv = get_conversion(f.type());
 
               // Use the libmesh to exodus data structure map to get the proper sideset IDs
               // The data structure contains the "collapsed" contiguous ids.
@@ -2329,11 +2328,11 @@ void Nemesis_IO_Helper::write_elements(const MeshBase & mesh, bool /*use_discont
               std::vector<int> & this_block_connectivity = it->second;
               std::vector<dof_id_type> & elements_in_this_block = subdomain_map[block];
 
-              //Use the first element in this block to get representative information.
-              //Note that Exodus assumes all elements in a block are of the same type!
-              //We are using that same assumption here!
-              const ExodusII_IO_Helper::Conversion conv =
-                assign_conversion(mesh.elem_ref(elements_in_this_block[0]).type());
+              // Use the first element in this block to get representative information.
+              // Note that Exodus assumes all elements in a block are of the same type!
+              // We are using that same assumption here!
+              const auto & conv =
+                get_conversion(mesh.elem_ref(elements_in_this_block[0]).type());
 
               this->num_nodes_per_elem =
                 mesh.elem_ref(elements_in_this_block[0]).n_nodes();


### PR DESCRIPTION
It think I will need to add a bunch more mappings to this class to go from libmesh edge numberings to Exodus edge numberings, so I refactored and simplified the existing implementation quite a bit in preparation for that.