### PR TITLE
test for mpi version

### DIFF
--- a/configure
+++ b/configure
@@ -33969,6 +33969,48 @@ fi
 
 
 
+  if test "x$enablempi" != xno; then :
+
+                                cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <mpi.h>
+int
+main ()
+{
+
+                                        const int i=1;
+                                        int position, j, a2;
+                                        int myrank;
+                                        char buff[ 10];
+                                        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+                                        MPI_Pack(&i, 1, MPI_INT, buff, 10, &position, MPI_COMM_WORLD)
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+
+
+$as_echo "#define HAVE_MPI 1" >>confdefs.h
+
+
+else
+
+                       { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&5
+$as_echo "$as_me: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&2;}
+                       enablempi=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+fi
+
+
+
+
+
 
 
 
@@ -34671,6 +34713,48 @@ fi
 
 
 
+  if test "x$enablempi" != xno; then :
+
+                                cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <mpi.h>
+int
+main ()
+{
+
+                                        const int i=1;
+                                        int position, j, a2;
+                                        int myrank;
+                                        char buff[ 10];
+                                        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+                                        MPI_Pack(&i, 1, MPI_INT, buff, 10, &position, MPI_COMM_WORLD)
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+
+
+$as_echo "#define HAVE_MPI 1" >>confdefs.h
+
+
+else
+
+                       { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&5
+$as_echo "$as_me: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&2;}
+                       enablempi=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+fi
+
+
+
+
+
 
 
 
@@ -35187,6 +35271,48 @@ fi
 
 
 
+  if test "x$enablempi" != xno; then :
+
+                                cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <mpi.h>
+int
+main ()
+{
+
+                                        const int i=1;
+                                        int position, j, a2;
+                                        int myrank;
+                                        char buff[ 10];
+                                        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+                                        MPI_Pack(&i, 1, MPI_INT, buff, 10, &position, MPI_COMM_WORLD)
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+
+
+$as_echo "#define HAVE_MPI 1" >>confdefs.h
+
+
+else
+
+                       { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&5
+$as_echo "$as_me: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&2;}
+                       enablempi=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+fi
+
+
+
+
+
 
 
 
@@ -35702,6 +35828,48 @@ fi
 
 
 
+  if test "x$enablempi" != xno; then :
+
+                                cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <mpi.h>
+int
+main ()
+{
+
+                                        const int i=1;
+                                        int position, j, a2;
+                                        int myrank;
+                                        char buff[ 10];
+                                        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+                                        MPI_Pack(&i, 1, MPI_INT, buff, 10, &position, MPI_COMM_WORLD)
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+
+
+$as_echo "#define HAVE_MPI 1" >>confdefs.h
+
+
+else
+
+                       { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&5
+$as_echo "$as_me: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&2;}
+                       enablempi=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+fi
+
+
+
+
+
 
 
 
@@ -35810,25 +35978,72 @@ fi
 
 
 
-          if test "x$PETSC_MPI" != x; then :
+                    if test "x$PETSC_MPI" != x; then :
+
+
+
+  if test "x$enablempi" != xno; then :
+
+                                cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <mpi.h>
+int
+main ()
+{
+
+                                        const int i=1;
+                                        int position, j, a2;
+                                        int myrank;
+                                        char buff[ 10];
+                                        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+                                        MPI_Pack(&i, 1, MPI_INT, buff, 10, &position, MPI_COMM_WORLD)
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+
 
 $as_echo "#define HAVE_MPI 1" >>confdefs.h
 
+
+else
+
+                       { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&5
+$as_echo "$as_me: WARNING: \"MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now...\"" >&2;}
+                       enablempi=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
 fi
 
-          if test $petsc_have_hypre -gt 0; then :
+                                if test "x$enablempi" = xno; then :
+
+                      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: MPI is disabled. Disable PETSc as well." >&5
+$as_echo "$as_me: WARNING: MPI is disabled. Disable PETSc as well." >&2;}
+                      enablepetsc=no
+fi
+
+fi
+
+         if test "x$enablepetsc" != xno; then :
+
+                if test $petsc_have_hypre -gt 0; then :
 
 $as_echo "#define HAVE_PETSC_HYPRE 1" >>confdefs.h
 
 fi
 
-
 $as_echo "#define HAVE_PETSC 1" >>confdefs.h
 
-
-          if test $petsc_have_tao != no; then :
+                if test $petsc_have_tao != no; then :
 
 $as_echo "#define HAVE_PETSC_TAO 1" >>confdefs.h
+
+fi
 
 fi
 

--- a/m4/mpi.m4
+++ b/m4/mpi.m4
@@ -189,6 +189,9 @@ AS_IF([test "x$MPI_IMPL" != x],
                     [AC_MSG_RESULT([$CXX Compiler Does NOT Support MPI...]); enablempi=no])
       ])
 
+dnl check that we are using the correct version of MPI:
+VERSION_MPI
+
 dnl Save variables...
 AC_SUBST(MPI)
 AC_SUBST(MPI_IMPL)
@@ -197,4 +200,34 @@ AC_SUBST(MPI_LIBS_PATH)
 AC_SUBST(MPI_LIBS_PATHS)
 AC_SUBST(MPI_INCLUDES_PATH)
 AC_SUBST(MPI_INCLUDES_PATHS)
+
+])
+
+
+
+AC_DEFUN([VERSION_MPI], [
+
+  AS_IF([test "x$enablempi" != xno],
+  [
+        dnl AC_MSG_RESULT([Checking Version of MPI now:]) dnl TODO: should be not a 'result'!?
+        dnl check the version of available MPI via the API:
+        dnl with the *const* int i, only MPI > 2 will compile.
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([@%:@include <mpi.h>],
+                                        [
+                                        const int i=1;
+                                        int position, j, a[2];
+                                        int myrank;
+                                        char buff@<:@ 10@:>@;
+                                        MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+                                        MPI_Pack(&i, 1, MPI_INT, buff, 10, &position, MPI_COMM_WORLD)
+                                        ])],
+                       [
+                       AC_DEFINE(HAVE_MPI, 1, [Flag indicating whether or not MPI is available])
+                       dnl AC_MSG_RESULT([Have compatible MPI-version.])
+                       ],
+                       [
+                       AC_MSG_WARN(["MPI-version seems to be too low: Need MPI 3.X or compatible. Disable MPI now..."])
+                       enablempi=no
+                       ])
+  ])
 ])

--- a/m4/petsc.m4
+++ b/m4/petsc.m4
@@ -397,16 +397,25 @@ AC_DEFUN([CONFIGURE_PETSC],
           AC_SUBST(PETSC_FC_INCLUDES)
           AC_SUBST(MPI_IMPL)
 
+          dnl if we are going to use MPI as used by PETSc, check that it has a suitable version:
           AS_IF([test "x$PETSC_MPI" != x],
-                [AC_DEFINE(HAVE_MPI, 1, [Flag indicating whether or not MPI is available])])
+                [
+                VERSION_MPI
+                dnl: see if we disabled mpi due to incompatible version:
+                AS_IF([test "x$enablempi" = xno],
+                      [
+                      AC_MSG_WARN([MPI is disabled. Disable PETSc as well.])
+                      enablepetsc=no])
+               ])
 
-          AS_IF([test $petsc_have_hypre -gt 0],
-                [AC_DEFINE(HAVE_PETSC_HYPRE, 1, [Flag indicating whether or not PETSc was compiled with Hypre support])])
-
-          AC_DEFINE(HAVE_PETSC, 1, [Flag indicating whether or not PETSc is available])
-
-          AS_IF([test $petsc_have_tao != no],
-                [AC_DEFINE(HAVE_PETSC_TAO, 1, [Flag indicating whether or not the Toolkit for Advanced Optimization (TAO) is available via PETSc])])
+         AS_IF([test "x$enablepetsc" != xno],
+               [
+                AS_IF([test $petsc_have_hypre -gt 0],
+                      [AC_DEFINE(HAVE_PETSC_HYPRE, 1, [Flag indicating whether or not PETSc was compiled with Hypre support])])
+                AC_DEFINE(HAVE_PETSC, 1, [Flag indicating whether or not PETSc is available])
+                AS_IF([test $petsc_have_tao != no],
+                      [AC_DEFINE(HAVE_PETSC_TAO, 1, [Flag indicating whether or not the Toolkit for Advanced Optimization (TAO) is available via PETSc])])
+               ])
         ])
 
   # If PETSc is not enabled, but it *was* required, error out now


### PR DESCRIPTION
after the unsuccessfull approach in #1920, I'd suggest to test the MPI-version via the APIs itself:
  * we don't rely on ``MPI_VERSION`` strings
  * in case of incomplete implementation of standards, this test still holds
  * is easily extensible to further functions that may or may not be implemented.

I hope, it behaves as expected for other configurations as well...