### PR TITLE
In Elem::level check interior_parent->level()

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -2484,7 +2484,12 @@ unsigned int Elem::level() const
   // or by the user, so I am a
   // level-0 element
   if (this->parent() == nullptr)
-    return 0;
+  {
+    if (this->interior_parent() == nullptr)
+      return 0;
+    else
+      return interior_parent()->level();
+  }
 
   // if the parent and this element are of different
   // dimensionality we are at the same level as


### PR DESCRIPTION
In MOOSE mortar when building the mortar segment mesh,
we set the interior_parent for the mortar segments, but
we do not set the parent, because parent implies the child
was formed through adaptivity. However, when a mesh has been
refined and the interior_parent has been refined, then there
are failed assertions in debug mode during prepare_for_use
because the interior_parent level != 0 while previously if the
parent was nullptr the mortar segment would report as being level 0.
Hence I think it makes sense to check the interior_parent level
if the parent is nullptr.

We'll see if this breaks things...