### PR TITLE
Read/write edge boundary conditions in Exodus files

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -847,6 +847,16 @@ public:
   std::string & nodeset_name(boundary_id_type id);
 
   /**
+   * \returns A const reference to an optional edgeset name.
+   */
+  const std::string & get_edgeset_name(boundary_id_type id) const;
+
+  /**
+   * \returns A writable reference to an optional edgeset name.
+   */
+  std::string & edgeset_name(boundary_id_type id);
+
+  /**
    * \returns The id of the named boundary if it exists, \p invalid_id
    * otherwise.
    */
@@ -867,6 +877,14 @@ public:
   { return _ns_id_to_name; }
   const std::map<boundary_id_type, std::string> & get_nodeset_name_map () const
   { return _ns_id_to_name; }
+
+  /**
+   * \returns Writable/const reference to the edgeset name map.
+   */
+  std::map<boundary_id_type, std::string> & set_edgeset_name_map ()
+  { return _es_id_to_name; }
+  const std::map<boundary_id_type, std::string> & get_edgeset_name_map () const
+  { return _es_id_to_name; }
 
   /**
    * Number used for internal use. This is the return value
@@ -984,6 +1002,13 @@ private:
    * this is only implemented for ExodusII
    */
   std::map<boundary_id_type, std::string> _ns_id_to_name;
+
+  /**
+   * This structure maintains the mapping of named edge sets
+   * for file formats that support named blocks.  Currently
+   * this is only implemented for ExodusII
+   */
+  std::map<boundary_id_type, std::string> _es_id_to_name;
 };
 
 } // namespace libMesh

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -200,6 +200,11 @@ public:
   void read_elem_in_block(int block);
 
   /**
+   * Read in edge blocks, storing information in the BoundaryInfo object.
+   */
+  void read_edge_blocks();
+
+  /**
    * Reads the optional \p node_num_map from the \p ExodusII mesh
    * file.
    */

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -644,6 +644,7 @@ public:
 
   // Maps of Ids to named entities
   std::map<int, std::string> id_to_block_names;
+  std::map<int, std::string> id_to_edge_block_names;
   std::map<int, std::string> id_to_ss_names;
   std::map<int, std::string> id_to_ns_names;
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -496,6 +496,13 @@ public:
   // Total number of element blocks
   int num_elem_blk;
 
+  // Total number of edges
+  int num_edge;
+
+  // Total number of edge blocks. The sum of the number of edges in
+  // each block must equal num_edge.
+  int num_edge_blk;
+
   // Total number of node sets
   int num_node_sets;
 

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -521,8 +521,11 @@ public:
   // Total number of elements in all side sets
   int num_elem_all_sidesets;
 
-  // Vector of the block identification numbers
+  // Vector of element block identification numbers
   std::vector<int> block_ids;
+
+  // Vector of edge block identification numbers
+  std::vector<int> edge_block_ids;
 
   // Vector of nodes in an element
   std::vector<int> connect;

--- a/include/mesh/exodusII_io_helper.h
+++ b/include/mesh/exodusII_io_helper.h
@@ -202,7 +202,7 @@ public:
   /**
    * Read in edge blocks, storing information in the BoundaryInfo object.
    */
-  void read_edge_blocks();
+  void read_edge_blocks(MeshBase & mesh);
 
   /**
    * Reads the optional \p node_num_map from the \p ExodusII mesh

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -22,7 +22,6 @@
 
 // Local includes
 #include "libmesh/libmesh_config.h"
-
 #include "libmesh/boundary_info.h"
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/elem.h"

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1518,6 +1518,7 @@ void BoundaryInfo::remove_id (boundary_id_type id)
   _node_boundary_ids.erase(id);
   _ss_id_to_name.erase(id);
   _ns_id_to_name.erase(id);
+  _es_id_to_name.erase(id);
 
   // Erase pointers to geometric entities with this id.
   for (auto it = _boundary_node_id.begin(); it != _boundary_node_id.end(); /*below*/)
@@ -2390,6 +2391,23 @@ std::string & BoundaryInfo::nodeset_name(boundary_id_type id)
   return _ns_id_to_name[id];
 }
 
+const std::string & BoundaryInfo::get_edgeset_name(boundary_id_type id) const
+{
+  static const std::string empty_string;
+  std::map<boundary_id_type, std::string>::const_iterator it =
+    _es_id_to_name.find(id);
+  if (it == _es_id_to_name.end())
+    return empty_string;
+  else
+    return it->second;
+}
+
+
+std::string & BoundaryInfo::edgeset_name(boundary_id_type id)
+{
+  return _es_id_to_name[id];
+}
+
 boundary_id_type BoundaryInfo::get_id_by_name(const std::string & name) const
 {
   // Search sidesets
@@ -2402,8 +2420,13 @@ boundary_id_type BoundaryInfo::get_id_by_name(const std::string & name) const
     if (pr.second == name)
       return pr.first;
 
-  // If we made it here without returning, we don't have a sideset or
-  // nodeset by the requested name, so return invalid_id
+  // Search edgesets
+  for (const auto & pr : _es_id_to_name)
+    if (pr.second == name)
+      return pr.first;
+
+  // If we made it here without returning, we don't have a sideset,
+  // nodeset, or edgeset by the requested name, so return invalid_id
   return invalid_id;
 }
 

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -289,7 +289,7 @@ void ExodusII_IO::read (const std::string & fname)
 
   // Read in edge blocks, storing information in the BoundaryInfo object.
   // Edge blocks are treated as BCs.
-  exio_helper->read_edge_blocks();
+  exio_helper->read_edge_blocks(mesh);
 
   // Set the mesh dimension to the largest encountered for an element
   for (unsigned char i=0; i!=4; ++i)

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -198,7 +198,7 @@ void ExodusII_IO::read (const std::string & fname)
   // sequentially starting from 1 in the Exodus file.
   // libmesh_assert_equal_to (static_cast<unsigned int>(exio_helper->num_nodes), mesh.n_nodes());
 
-  // Get information about all the blocks
+  // Get information about all the element and edge blocks
   exio_helper->read_block_info();
 
   // Reserve space for the elements

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -213,7 +213,7 @@ void ExodusII_IO::read (const std::string & fname)
   // Read in the element connectivity for each block.
   int nelem_last_block = 0;
 
-  // Loop over all the blocks
+  // Loop over all the element blocks
   for (int i=0; i<exio_helper->num_elem_blk; i++)
     {
       // Read the information for block i
@@ -287,12 +287,9 @@ void ExodusII_IO::read (const std::string & fname)
       nelem_last_block += exio_helper->num_elem_this_blk;
     }
 
-  // This assert isn't valid if the Exodus file's numbering doesn't
-  // start with 1!  For example, if Exodus's elem_num_map is 21, 22,
-  // 23, 24, 25, 26, 27, 28, 29, 30, ... 84, then by the time you are
-  // done with the loop above, mesh.n_elem() will report 84 and
-  // nelem_last_block will be 64.
-  // libmesh_assert_equal_to (static_cast<unsigned>(nelem_last_block), mesh.n_elem());
+  // Read in edge blocks, storing information in the BoundaryInfo object.
+  // Edge blocks are treated as BCs.
+  exio_helper->read_edge_blocks();
 
   // Set the mesh dimension to the largest encountered for an element
   for (unsigned char i=0; i!=4; ++i)

--- a/src/mesh/exodusII_io.C
+++ b/src/mesh/exodusII_io.C
@@ -1430,10 +1430,6 @@ void ExodusII_IO::write_nodal_data_common(std::string fname,
           exio_helper->write_sidesets(mesh);
           exio_helper->write_nodesets(mesh);
 
-          if ((mesh.get_boundary_info().n_edge_conds() > 0) && _verbose)
-            libmesh_warning("Warning: Mesh contains edge boundary IDs, but these "
-                            "are not supported by the ExodusII format.");
-
           exio_helper->initialize_nodal_variables(names);
         }
     }

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -847,6 +847,43 @@ void ExodusII_IO_Helper::read_elem_in_block(int block)
 
 
 
+void ExodusII_IO_Helper::read_edge_blocks()
+{
+  for (const auto & edge_block_id : edge_block_ids)
+    {
+      // exII::ex_get_block() output parameters.  Unlike the other
+      // "extended" APIs, exII::ex_get_block() does not use a
+      // parameter struct.
+      int num_edge_this_blk = 0;
+      int num_nodes_per_edge = 0;
+      int num_edges_per_edge = 0;
+      int num_faces_per_edge = 0;
+      int num_attr_per_edge = 0;
+      ex_err = exII::ex_get_block(ex_id,
+                                  exII::EX_EDGE_BLOCK,
+                                  edge_block_id,
+                                  elem_type.data(),
+                                  &num_edge_this_blk,
+                                  &num_nodes_per_edge,
+                                  &num_edges_per_edge, // 0 or -1 for edge blocks
+                                  &num_faces_per_edge, // 0 or -1 for edge blocks
+                                  &num_attr_per_edge);
+
+      EX_CHECK_ERR(ex_err, "Error getting edge block info.");
+      message("Info retrieved successfully for block: ", edge_block_id);
+
+      // Debugging:
+      libMesh::out << "edge_block_id = " << edge_block_id << std::endl;
+      libMesh::out << "elem_type = " << elem_type.data() << std::endl;
+      libMesh::out << "num_edge_this_blk = " << num_edge_this_blk << std::endl;
+      libMesh::out << "num_nodes_per_edge = " << num_nodes_per_edge << std::endl;
+      libMesh::out << "num_edges_per_edge = " << num_edges_per_edge << std::endl;
+      libMesh::out << "num_faces_per_edge = " << num_faces_per_edge << std::endl;
+      libMesh::out << "num_attr_per_edge = " << num_attr_per_edge << std::endl;
+    }
+}
+
+
 
 void ExodusII_IO_Helper::read_elem_num_map ()
 {

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -880,7 +880,31 @@ void ExodusII_IO_Helper::read_edge_blocks()
       libMesh::out << "num_edges_per_edge = " << num_edges_per_edge << std::endl;
       libMesh::out << "num_faces_per_edge = " << num_faces_per_edge << std::endl;
       libMesh::out << "num_attr_per_edge = " << num_attr_per_edge << std::endl;
-    }
+
+      // Read in the connectivity of the edges of this block,
+      // watching out for the case where we actually have no
+      // elements in this block (possible with parallel files)
+      connect.resize(num_nodes_per_edge * num_edge_this_blk);
+
+      if (!connect.empty())
+        {
+          ex_err = exII::ex_get_conn(ex_id,
+                                     exII::EX_EDGE_BLOCK,
+                                     edge_block_id,
+                                     connect.data(), // node_conn
+                                     nullptr,        // elem_edge_conn (unused)
+                                     nullptr);       // elem_face_conn (unused)
+
+          EX_CHECK_ERR(ex_err, "Error reading block connectivity.");
+          message("Connectivity retrieved successfully for block: ", edge_block_id);
+
+          // Debugging:
+          libMesh::out << "connect.size() = " << connect.size() << std::endl;
+          for (const auto & exodus_node_id : connect)
+            libMesh::out << exodus_node_id << " ";
+          libMesh::out << std::endl;
+        }
+    } // end for edge_block_id : edge_block_ids)
 }
 
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -728,11 +728,29 @@ void ExodusII_IO_Helper::read_block_info()
       EX_CHECK_ERR(ex_err, "Error getting edge block IDs.");
       message("All edge block IDs retrieved successfully.");
 
+      // Read in edge block names
+      char name_buffer[MAX_STR_LENGTH+1];
+      for (int i=0; i<num_edge_blk; ++i)
+        {
+          ex_err = exII::ex_get_name(ex_id, exII::EX_EDGE_BLOCK,
+                                     edge_block_ids[i], name_buffer);
+          EX_CHECK_ERR(ex_err, "Error getting block name.");
+          id_to_edge_block_names[edge_block_ids[i]] = name_buffer;
+        }
+      message("All edge block names retrieved successfully.");
+
       // Debugging:
-      libMesh::out << "edge_block_ids=" << std::endl;
-      for (const auto & id : edge_block_ids)
-        libMesh::out << id << " ";
-      libMesh::out << std::endl;
+      // libMesh::out << "edge_block_ids=" << std::endl;
+      // for (const auto & id : edge_block_ids)
+      //   libMesh::out << id << " ";
+      // libMesh::out << std::endl;
+
+      // Debugging:
+      libMesh::out << "edge block names=" << std::endl;
+      for (const auto & pr : id_to_edge_block_names)
+        libMesh::out << "Block id = " << pr.first
+                     << ", name = " << pr.second
+                     << std::endl;
     }
 }
 

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -1975,12 +1975,8 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
   // Note: We are going to use the edge **boundary** ids as **block** ids.
   for (const auto & pr : edge_id_to_conn)
     {
+      // Store the edge block id in the array to be passed to Exodus.
       boundary_id_type id = pr.first;
-
-      // FIXME: Instead of hard coding 2, divide by the number of
-      // nodes on an actual Edge.
-      std::size_t count = pr.second.size() / 2;
-
       edge_blk_id.push_back(id);
 
       // Set Exodus element type and number of nodes for this edge block.
@@ -1989,8 +1985,9 @@ void ExodusII_IO_Helper::write_elements(const MeshBase & mesh, bool use_disconti
       edge_type_table.push_back_entry(conv.exodus_type.c_str());
       num_nodes_per_edge_vec.push_back(elem_type_node_count.second);
 
-      // The count that we determined earlier.
-      num_edge_this_blk_vec.push_back(count);
+      // The number of edges is the number of entries in the connectivity
+      // array divided by the number of nodes per edge.
+      num_edge_this_blk_vec.push_back(pr.second.size() / elem_type_node_count.second);
 
       // We don't store any attributes currently
       num_attr_edge_vec.push_back(0);

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -949,7 +949,7 @@ void ExodusII_IO_Helper::read_edge_blocks(MeshBase & mesh)
           for (unsigned int i=0; i<connect.size(); i+=num_nodes_per_edge)
             {
               auto edge = Elem::build(conv.libmesh_elem_type());
-              for (unsigned int n=0; n<num_nodes_per_edge; ++n)
+              for (int n=0; n<num_nodes_per_edge; ++n)
                 {
                   int exodus_node_id = connect[i+n];
                   int exodus_node_id_zero_based = exodus_node_id - 1;
@@ -961,6 +961,21 @@ void ExodusII_IO_Helper::read_edge_blocks(MeshBase & mesh)
               // Compute key for the edge Elem we just built.
               dof_id_type edge_key = edge->key();
               libMesh::out << "edge_key = " << edge_key << std::endl;
+
+              // If this key is not found in the edge_map, which is
+              // supposed to include every edge in the Mesh, then we
+              // need to throw an error.
+              auto & elem_edge_pair_vec =
+                libmesh_map_find(edge_map, edge_key);
+
+              // Debugging: print potential elem/edge pairs which have
+              // the same key.
+              for (const auto & elem_edge_pair : elem_edge_pair_vec)
+                {
+                  libMesh::out << "Elem " << elem_edge_pair.first
+                               << ", Edge " << elem_edge_pair.second
+                               << std::endl;
+                }
             } // end loop over connectivity array
         }
     } // end for edge_block_id : edge_block_ids)

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -552,10 +552,6 @@ void ExodusII_IO_Helper::read_header()
   num_edge_blk = params.num_edge_blk;
   num_edge = params.num_edge;
 
-  // Debugging: make sure that the edge block information is there to be read.
-  libMesh::out << "num_edge_blk = " << num_edge_blk << std::endl;
-  libMesh::out << "num_edge = " << num_edge << std::endl;
-
   this->read_num_time_steps();
 
   ex_err = exII::ex_get_var_param(ex_id, "n", &num_nodal_vars);
@@ -738,19 +734,6 @@ void ExodusII_IO_Helper::read_block_info()
           id_to_edge_block_names[edge_block_ids[i]] = name_buffer;
         }
       message("All edge block names retrieved successfully.");
-
-      // Debugging:
-      // libMesh::out << "edge_block_ids=" << std::endl;
-      // for (const auto & id : edge_block_ids)
-      //   libMesh::out << id << " ";
-      // libMesh::out << std::endl;
-
-      // Debugging:
-      libMesh::out << "edge block names=" << std::endl;
-      for (const auto & pr : id_to_edge_block_names)
-        libMesh::out << "Block id = " << pr.first
-                     << ", name = " << pr.second
-                     << std::endl;
     }
 }
 
@@ -1001,6 +984,9 @@ void ExodusII_IO_Helper::read_edge_blocks(MeshBase & mesh)
                     }
                 } // end loop over elem_edge_pairs
             } // end loop over connectivity array
+
+          // Set edgeset name in the BoundaryInfo object.
+          bi.edgeset_name(edge_block_id) = id_to_edge_block_names[edge_block_id];
         } // end if !connect.empty()
     } // end for edge_block_id : edge_block_ids
 }

--- a/src/mesh/exodusII_io_helper.C
+++ b/src/mesh/exodusII_io_helper.C
@@ -548,6 +548,12 @@ void ExodusII_IO_Helper::read_header()
   num_elem_blk = params.num_elem_blk;
   num_node_sets = params.num_node_sets;
   num_side_sets = params.num_side_sets;
+  num_edge_blk = params.num_edge_blk;
+  num_edge = params.num_edge;
+
+  // Debugging: make sure that the edge block information is there to be read.
+  libMesh::out << "num_edge_blk = " << num_edge_blk << std::endl;
+  libMesh::out << "num_edge = " << num_edge << std::endl;
 
   this->read_num_time_steps();
 
@@ -708,6 +714,24 @@ void ExodusII_IO_Helper::read_block_info()
           id_to_block_names[block_ids[i]] = name_buffer;
         }
       message("All block names retrieved successfully.");
+    }
+
+  if (num_edge_blk)
+    {
+      // Read all edge block IDs.
+      edge_block_ids.resize(num_edge_blk);
+      ex_err = exII::ex_get_ids(ex_id,
+                                exII::EX_EDGE_BLOCK,
+                                edge_block_ids.data());
+
+      EX_CHECK_ERR(ex_err, "Error getting edge block IDs.");
+      message("All edge block IDs retrieved successfully.");
+
+      // Debugging:
+      libMesh::out << "edge_block_ids=" << std::endl;
+      for (const auto & id : edge_block_ids)
+        libMesh::out << id << " ";
+      libMesh::out << std::endl;
     }
 }
 


### PR DESCRIPTION
It was previously possible to store "edgesets" in Exodus files using blocks of "fake" 1D elements, but this wasn't supported directly through the `BoundaryInfo` object, and it was a bit inconvenient for other reasons as well. This PR adds the ability to automatically read/write edge *blocks* to Exodus files based on the edge boundary conditions that are stored in the `BoundaryInfo` object. 

Note that we write edge *blocks* (similar to element blocks) and not "edgesets". This is because the concepts of sidesets and edgesets are slightly different in Exodus. Sidesets allow one to refer to specific sides of elements which live in a separate block, while "edgesets" in Exodus merely allow one to refer to a collection of edges in a separate edge block. This is mainly due to the fact that support for writing edges (and faces, which are different from sides!) was added to Exodus sometime after the initial APIs were published. We therefore treat the *boundary id* of the edgesets stored within libmesh as *block ids* in the Exodus file, and the Exodus reader handles the conversion to/from the `BoundaryInfo` object. 

I also have a rough draft of a unit test that I will push to this PR momentarily. 

