### PR TITLE
Optimize Xdr I/O loops

### DIFF
--- a/src/mesh/xdr_io.C
+++ b/src/mesh/xdr_io.C
@@ -1898,8 +1898,8 @@ void XdrIO::read_serialized_bcs_helper (Xdr & io, T, const std::string bc_type)
       dof_bc_data.reserve (input_buffer.size()/3);
 
       // Look for BCs in this block for all the level-0 elements we have
-      // (not just local ones).  Do this by finding all the entries
-      // in dof_bc_data whose elem_id match the ID of the current element.
+      // (not just local ones).  Do this by checking all entries for
+      // IDs matching an element we can query.
       // We cannot rely on nullptr neighbors at this point since the neighbor
       // data structure has not been initialized.
       for (std::size_t idx=0; idx<input_buffer.size(); idx+=3)
@@ -2017,8 +2017,8 @@ void XdrIO::read_serialized_nodesets (Xdr & io, T)
       node_bc_data.reserve (input_buffer.size()/2);
 
       // Look for BCs in this block for all nodes we have (not just
-      // local ones).  Do this by finding all entries whose
-      // dof_id (node_id) match the ID of a node we can query.
+      // local ones).  Do this by checking all entries for
+      // IDs matching a node we can query.
       for (std::size_t idx=0; idx<input_buffer.size(); idx+=2)
         {
           const dof_id_type dof_id =


### PR DESCRIPTION
Fixes #2290

This should be asymptotically faster on large problems, I got to delete twice as much code as I wrote, and the new code is mostly much simpler than the old.  I can't believe it was this easy and now I'm just waiting for Civet to tell me how badly this change breaks everything.

This does *not* increase XdrIO::io_blksize, however - I agree with @friedmud that our current value is a decade out of date and probably way too low, but I don't want to play with it blindly until/unless we set up a benchmark to say what the exact effects on performance are.  Hopefully changing O(N^2) to O(N) will be such an improvement that we won't even care about O(C_1*N) vs O(C_2*N).