### PR TITLE
Fixes subDM propagation for PETSc 3.12 and above.

### DIFF
--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -129,7 +129,7 @@ namespace libMesh
             }
 #else
           PetscErrorCode (*interp)(DM,DM,Mat*,Vec*) = nullptr;
-          ierr = DMShellGetCreateInterpolation(*subdm, &interp);
+          ierr = DMShellGetCreateInterpolation(dm, &interp);
           CHKERRQ(ierr);
           if (interp)
             {
@@ -147,7 +147,7 @@ namespace libMesh
             }
 #else
           PetscErrorCode (*createrestriction)(DM,DM,Mat*) = nullptr;
-          ierr = DMShellGetCreateRestriction(*subdm, &createrestriction);
+          ierr = DMShellGetCreateRestriction(dm, &createrestriction);
           CHKERRQ(ierr);
           if (createrestriction)
             {
@@ -165,7 +165,7 @@ namespace libMesh
             }
 #else
           PetscErrorCode (*createsubdm)(DM,PetscInt,const PetscInt[],IS*,DM*) = nullptr;
-          ierr = DMShellGetCreateSubDM(*subdm, &createsubdm);
+          ierr = DMShellGetCreateSubDM(dm, &createsubdm);
           CHKERRQ(ierr);
           if (createsubdm)
             {


### PR DESCRIPTION
We should grab the function pointers to set for the subDM from the
global DM as opposed to pulling from the then-empty subDM.

Closes #2295.
