### PR TITLE
Additional options for adding extra integers+data

### DIFF
--- a/include/mesh/mesh_base.h
+++ b/include/mesh/mesh_base.h
@@ -1796,6 +1796,15 @@ protected:
   void size_node_extra_integers();
 
   /**
+   * Merge extra-integer arrays from an \p other mesh.  Returns two
+   * mappings from index values in \p other to (possibly newly created)
+   * index values with the same string name in \p this mesh, the first
+   * for element integers and the second for node integers.
+   */
+  std::pair<std::vector<unsigned int>, std::vector<unsigned int>>
+    merge_extra_integer_names(const MeshBase & other);
+
+  /**
    * The default geometric GhostingFunctor, used to implement standard
    * libMesh element ghosting behavior.  We use a base class pointer
    * here to avoid dragging in more header dependencies.

--- a/include/mesh/unstructured_mesh.h
+++ b/include/mesh/unstructured_mesh.h
@@ -152,8 +152,15 @@ public:
 
 
   /**
-   * Deep copy of another unstructured mesh class (used by subclass
-   * copy constructors)
+   * Deep copy of nodes and elements from another unstructured mesh
+   * class (used by subclass copy constructors and by mesh merging
+   * operations)
+   *
+   * This will not copy most "high level" data in the mesh; that is
+   * done separately by constructors.  An exception is that, if the
+   * \p other_mesh has element or node extra_integer data, any names
+   * for that data which do not already exist on \p this mesh are
+   * added so that all such data can be copied.
    */
   virtual void copy_nodes_and_elements (const UnstructuredMesh & other_mesh,
                                         const bool skip_find_neighbors = false,

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -939,4 +939,14 @@ void MeshBase::size_node_extra_integers()
 }
 
 
+std::pair<std::vector<unsigned int>, std::vector<unsigned int>>
+MeshBase::merge_extra_integer_names(const MeshBase & other)
+{
+  std::pair<std::vector<unsigned int>, std::vector<unsigned int>> returnval;
+  returnval.first = this->add_elem_integers(other._elem_integer_names);
+  returnval.second = this->add_node_integers(other._node_integer_names);
+  return returnval;
+}
+
+
 } // namespace libMesh

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -172,14 +172,50 @@ void MeshBase::set_spatial_dimension(unsigned char d)
 
 
 
-unsigned int MeshBase::add_elem_integer(const std::string & name)
+unsigned int MeshBase::add_elem_integer(const std::string & name,
+                                        bool allocate_data)
 {
   for (auto i : index_range(_elem_integer_names))
     if (_elem_integer_names[i] == name)
       return i;
 
   _elem_integer_names.push_back(name);
+  if (allocate_data)
+    this->size_elem_extra_integers();
   return _elem_integer_names.size()-1;
+}
+
+
+
+std::vector<unsigned int> MeshBase::add_elem_integers(const std::vector<std::string> & names,
+                                                      bool allocate_data)
+{
+  std::unordered_map<std::string, std::size_t> name_indices;
+  for (auto i : index_range(_elem_integer_names))
+    name_indices[_elem_integer_names[i]] = i;
+
+  std::vector<unsigned int> returnval(names.size());
+
+  bool added_an_integer = false;
+  for (auto i : index_range(names))
+    {
+      const std::string & name = names[i];
+      auto it = name_indices.find(name);
+      if (it != name_indices.end())
+        returnval[i] = it->second;
+      else
+        {
+          returnval[i] = _elem_integer_names.size();
+          name_indices[name] = returnval[i];
+          _elem_integer_names.push_back(name);
+          added_an_integer = true;
+        }
+    }
+
+  if (allocate_data && added_an_integer)
+    this->size_elem_extra_integers();
+
+  return returnval;
 }
 
 
@@ -207,14 +243,50 @@ bool MeshBase::has_elem_integer(const std::string & name) const
 
 
 
-unsigned int MeshBase::add_node_integer(const std::string & name)
+unsigned int MeshBase::add_node_integer(const std::string & name,
+                                        bool allocate_data)
 {
   for (auto i : index_range(_node_integer_names))
     if (_node_integer_names[i] == name)
       return i;
 
   _node_integer_names.push_back(name);
+  if (allocate_data)
+    this->size_node_extra_integers();
   return _node_integer_names.size()-1;
+}
+
+
+
+std::vector<unsigned int> MeshBase::add_node_integers(const std::vector<std::string> & names,
+                                                      bool allocate_data)
+{
+  std::unordered_map<std::string, std::size_t> name_indices;
+  for (auto i : index_range(_node_integer_names))
+    name_indices[_node_integer_names[i]] = i;
+
+  std::vector<unsigned int> returnval(names.size());
+
+  bool added_an_integer = false;
+  for (auto i : index_range(names))
+    {
+      const std::string & name = names[i];
+      auto it = name_indices.find(name);
+      if (it != name_indices.end())
+        returnval[i] = it->second;
+      else
+        {
+          returnval[i] = _node_integer_names.size();
+          name_indices[name] = returnval[i];
+          _node_integer_names.push_back(name);
+          added_an_integer = true;
+        }
+    }
+
+  if (allocate_data && added_an_integer)
+    this->size_node_extra_integers();
+
+  return returnval;
 }
 
 
@@ -846,6 +918,24 @@ void MeshBase::set_point_locator_close_to_point_tol(Real val)
 Real MeshBase::get_point_locator_close_to_point_tol() const
 {
   return _point_locator_close_to_point_tol;
+}
+
+
+
+void MeshBase::size_elem_extra_integers()
+{
+  const std::size_t new_size = _elem_integer_names.size();
+  for (auto elem : this->element_ptr_range())
+    elem->add_extra_integers(new_size);
+}
+
+
+
+void MeshBase::size_node_extra_integers()
+{
+  const std::size_t new_size = _node_integer_names.size();
+  for (auto node : this->node_ptr_range())
+    node->add_extra_integers(new_size);
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -57,6 +57,7 @@ unit_tests_sources = \
   mesh/extra_integers.C \
   mesh/mesh_input.C \
   mesh/mesh_function.C \
+  mesh/mesh_stitch.C \
   mesh/mixed_dim_mesh_test.C \
   mesh/nodal_neighbors.C \
   mesh/mesh_extruder.C \

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -199,9 +199,10 @@ am__unit_tests_dbg_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
-	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
+	mesh/mesh_function.C mesh/mesh_stitch.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
 	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
@@ -268,6 +269,7 @@ am__objects_2 = unit_tests_dbg-driver.$(OBJEXT) \
 	mesh/unit_tests_dbg-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_function.$(OBJEXT) \
+	mesh/unit_tests_dbg-mesh_stitch.$(OBJEXT) \
 	mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_dbg-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_dbg-mesh_extruder.$(OBJEXT) \
@@ -337,9 +339,10 @@ am__unit_tests_devel_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
-	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
+	mesh/mesh_function.C mesh/mesh_stitch.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
 	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
@@ -405,6 +408,7 @@ am__objects_4 = unit_tests_devel-driver.$(OBJEXT) \
 	mesh/unit_tests_devel-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_function.$(OBJEXT) \
+	mesh/unit_tests_devel-mesh_stitch.$(OBJEXT) \
 	mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_devel-mesh_extruder.$(OBJEXT) \
@@ -471,9 +475,10 @@ am__unit_tests_oprof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
-	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
+	mesh/mesh_function.C mesh/mesh_stitch.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
 	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
@@ -539,6 +544,7 @@ am__objects_6 = unit_tests_oprof-driver.$(OBJEXT) \
 	mesh/unit_tests_oprof-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_function.$(OBJEXT) \
+	mesh/unit_tests_oprof-mesh_stitch.$(OBJEXT) \
 	mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_oprof-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_oprof-mesh_extruder.$(OBJEXT) \
@@ -605,9 +611,10 @@ am__unit_tests_opt_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
-	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
+	mesh/mesh_function.C mesh/mesh_stitch.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
 	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
@@ -673,6 +680,7 @@ am__objects_8 = unit_tests_opt-driver.$(OBJEXT) \
 	mesh/unit_tests_opt-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_function.$(OBJEXT) \
+	mesh/unit_tests_opt-mesh_stitch.$(OBJEXT) \
 	mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_opt-mesh_extruder.$(OBJEXT) \
@@ -738,9 +746,10 @@ am__unit_tests_prof_SOURCES_DIST = driver.C libmesh_cppunit.h \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
-	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
+	mesh/mesh_function.C mesh/mesh_stitch.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
 	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
@@ -806,6 +815,7 @@ am__objects_10 = unit_tests_prof-driver.$(OBJEXT) \
 	mesh/unit_tests_prof-extra_integers.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_input.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_function.$(OBJEXT) \
+	mesh/unit_tests_prof-mesh_stitch.$(OBJEXT) \
 	mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT) \
 	mesh/unit_tests_prof-nodal_neighbors.$(OBJEXT) \
 	mesh/unit_tests_prof-mesh_extruder.$(OBJEXT) \
@@ -1014,6 +1024,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Po \
+	mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po \
@@ -1033,6 +1044,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po \
+	mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po \
@@ -1052,6 +1064,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Po \
+	mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po \
@@ -1071,6 +1084,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po \
+	mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po \
@@ -1090,6 +1104,7 @@ am__depfiles_remade = ./$(DEPDIR)/unit_tests_dbg-driver.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po \
+	mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po \
 	mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po \
@@ -1690,9 +1705,10 @@ unit_tests_sources = driver.C libmesh_cppunit.h stream_redirector.h \
 	mesh/all_tri.C mesh/distort.C mesh/boundary_mesh.C \
 	mesh/boundary_info.C mesh/boundary_points.C mesh/checkpoint.C \
 	mesh/contains_point.C mesh/extra_integers.C mesh/mesh_input.C \
-	mesh/mesh_function.C mesh/mixed_dim_mesh_test.C \
-	mesh/nodal_neighbors.C mesh/mesh_extruder.C \
-	mesh/slit_mesh_test.C mesh/spatial_dimension_test.C \
+	mesh/mesh_function.C mesh/mesh_stitch.C \
+	mesh/mixed_dim_mesh_test.C mesh/nodal_neighbors.C \
+	mesh/mesh_extruder.C mesh/slit_mesh_test.C \
+	mesh/spatial_dimension_test.C \
 	mesh/mapped_subdomain_partitioner_test.C \
 	mesh/mesh_function_dfem.C mesh/write_sideset_data.C \
 	mesh/write_vec_and_scalar.C numerics/composite_function_test.C \
@@ -1894,6 +1910,8 @@ mesh/unit_tests_dbg-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_dbg-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_dbg-mesh_stitch.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_dbg-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2109,6 +2127,8 @@ mesh/unit_tests_devel-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_devel-mesh_stitch.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_devel-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2274,6 +2294,8 @@ mesh/unit_tests_oprof-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_oprof-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_oprof-mesh_stitch.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_oprof-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2441,6 +2463,8 @@ mesh/unit_tests_opt-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_opt-mesh_stitch.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_opt-nodal_neighbors.$(OBJEXT): mesh/$(am__dirstamp) \
@@ -2606,6 +2630,8 @@ mesh/unit_tests_prof-extra_integers.$(OBJEXT): mesh/$(am__dirstamp) \
 mesh/unit_tests_prof-mesh_input.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mesh_function.$(OBJEXT): mesh/$(am__dirstamp) \
+	mesh/$(DEPDIR)/$(am__dirstamp)
+mesh/unit_tests_prof-mesh_stitch.$(OBJEXT): mesh/$(am__dirstamp) \
 	mesh/$(DEPDIR)/$(am__dirstamp)
 mesh/unit_tests_prof-mixed_dim_mesh_test.$(OBJEXT):  \
 	mesh/$(am__dirstamp) mesh/$(DEPDIR)/$(am__dirstamp)
@@ -2867,6 +2893,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po@am__quote@ # am--include-marker
@@ -2886,6 +2913,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po@am__quote@ # am--include-marker
@@ -2905,6 +2933,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po@am__quote@ # am--include-marker
@@ -2924,6 +2953,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po@am__quote@ # am--include-marker
@@ -2943,6 +2973,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po@am__quote@ # am--include-marker
@@ -3634,6 +3665,20 @@ mesh/unit_tests_dbg-mesh_function.obj: mesh/mesh_function.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function.C' object='mesh/unit_tests_dbg-mesh_function.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_function.obj `if test -f 'mesh/mesh_function.C'; then $(CYGPATH_W) 'mesh/mesh_function.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function.C'; fi`
+
+mesh/unit_tests_dbg-mesh_stitch.o: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_stitch.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Tpo -c -o mesh/unit_tests_dbg-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_dbg-mesh_stitch.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+
+mesh/unit_tests_dbg-mesh_stitch.obj: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mesh_stitch.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Tpo -c -o mesh/unit_tests_dbg-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_dbg-mesh_stitch.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_dbg-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
 
 mesh/unit_tests_dbg-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_dbg_CPPFLAGS) $(CPPFLAGS) $(unit_tests_dbg_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_dbg-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_dbg-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
@@ -4727,6 +4772,20 @@ mesh/unit_tests_devel-mesh_function.obj: mesh/mesh_function.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_function.obj `if test -f 'mesh/mesh_function.C'; then $(CYGPATH_W) 'mesh/mesh_function.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function.C'; fi`
 
+mesh/unit_tests_devel-mesh_stitch.o: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_stitch.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Tpo -c -o mesh/unit_tests_devel-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_devel-mesh_stitch.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+
+mesh/unit_tests_devel-mesh_stitch.obj: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mesh_stitch.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Tpo -c -o mesh/unit_tests_devel-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_devel-mesh_stitch.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_devel-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
+
 mesh/unit_tests_devel-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_devel_CPPFLAGS) $(CPPFLAGS) $(unit_tests_devel_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_devel-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_devel-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
@@ -5818,6 +5877,20 @@ mesh/unit_tests_oprof-mesh_function.obj: mesh/mesh_function.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_function.C' object='mesh/unit_tests_oprof-mesh_function.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_function.obj `if test -f 'mesh/mesh_function.C'; then $(CYGPATH_W) 'mesh/mesh_function.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function.C'; fi`
+
+mesh/unit_tests_oprof-mesh_stitch.o: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_stitch.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Tpo -c -o mesh/unit_tests_oprof-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_oprof-mesh_stitch.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+
+mesh/unit_tests_oprof-mesh_stitch.obj: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mesh_stitch.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Tpo -c -o mesh/unit_tests_oprof-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_oprof-mesh_stitch.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_oprof-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
 
 mesh/unit_tests_oprof-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_oprof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_oprof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_oprof-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_oprof-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
@@ -6911,6 +6984,20 @@ mesh/unit_tests_opt-mesh_function.obj: mesh/mesh_function.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_function.obj `if test -f 'mesh/mesh_function.C'; then $(CYGPATH_W) 'mesh/mesh_function.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function.C'; fi`
 
+mesh/unit_tests_opt-mesh_stitch.o: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_stitch.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Tpo -c -o mesh/unit_tests_opt-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_opt-mesh_stitch.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+
+mesh/unit_tests_opt-mesh_stitch.obj: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mesh_stitch.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Tpo -c -o mesh/unit_tests_opt-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_opt-mesh_stitch.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_opt-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
+
 mesh/unit_tests_opt-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_opt_CPPFLAGS) $(CPPFLAGS) $(unit_tests_opt_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_opt-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_opt-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
@@ -8003,6 +8090,20 @@ mesh/unit_tests_prof-mesh_function.obj: mesh/mesh_function.C
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_function.obj `if test -f 'mesh/mesh_function.C'; then $(CYGPATH_W) 'mesh/mesh_function.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_function.C'; fi`
 
+mesh/unit_tests_prof-mesh_stitch.o: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_stitch.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Tpo -c -o mesh/unit_tests_prof-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_prof-mesh_stitch.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_stitch.o `test -f 'mesh/mesh_stitch.C' || echo '$(srcdir)/'`mesh/mesh_stitch.C
+
+mesh/unit_tests_prof-mesh_stitch.obj: mesh/mesh_stitch.C
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mesh_stitch.obj -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Tpo -c -o mesh/unit_tests_prof-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Tpo mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='mesh/mesh_stitch.C' object='mesh/unit_tests_prof-mesh_stitch.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -c -o mesh/unit_tests_prof-mesh_stitch.obj `if test -f 'mesh/mesh_stitch.C'; then $(CYGPATH_W) 'mesh/mesh_stitch.C'; else $(CYGPATH_W) '$(srcdir)/mesh/mesh_stitch.C'; fi`
+
 mesh/unit_tests_prof-mixed_dim_mesh_test.o: mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(unit_tests_prof_CPPFLAGS) $(CPPFLAGS) $(unit_tests_prof_CXXFLAGS) $(CXXFLAGS) -MT mesh/unit_tests_prof-mixed_dim_mesh_test.o -MD -MP -MF mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Tpo -c -o mesh/unit_tests_prof-mixed_dim_mesh_test.o `test -f 'mesh/mixed_dim_mesh_test.C' || echo '$(srcdir)/'`mesh/mixed_dim_mesh_test.C
 @am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Tpo mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po
@@ -9002,6 +9103,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
@@ -9021,6 +9123,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
@@ -9040,6 +9143,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
@@ -9059,6 +9163,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
@@ -9078,6 +9183,7 @@ distclean: distclean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po
@@ -9437,6 +9543,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_dbg-slit_mesh_test.Po
@@ -9456,6 +9563,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_devel-slit_mesh_test.Po
@@ -9475,6 +9583,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_oprof-slit_mesh_test.Po
@@ -9494,6 +9603,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_opt-slit_mesh_test.Po
@@ -9513,6 +9623,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_function_dfem.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_input.Po
+	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mesh_stitch.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-mixed_dim_mesh_test.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-nodal_neighbors.Po
 	-rm -f mesh/$(DEPDIR)/unit_tests_prof-slit_mesh_test.Po

--- a/tests/mesh/mesh_stitch.C
+++ b/tests/mesh/mesh_stitch.C
@@ -1,0 +1,125 @@
+#include <libmesh/elem.h>
+#include <libmesh/mesh_generation.h>
+#include <libmesh/node.h>
+#include <libmesh/replicated_mesh.h>
+
+#include "test_comm.h"
+#include "libmesh_cppunit.h"
+
+
+using namespace libMesh;
+
+
+class MeshStitchTest : public CppUnit::TestCase {
+public:
+  CPPUNIT_TEST_SUITE( MeshStitchTest );
+
+#if LIBMESH_DIM > 2
+  CPPUNIT_TEST( testMeshStitch );
+#endif // LIBMESH_DIM > 2
+
+  CPPUNIT_TEST_SUITE_END();
+
+private:
+
+public:
+  void setUp()
+  {}
+
+  void tearDown()
+  {}
+
+  void testMeshStitch ()
+  {
+    // Generate four meshes to be stitched together
+    ReplicatedMesh mesh0(*TestCommWorld),
+                   mesh1(*TestCommWorld),
+                   mesh2(*TestCommWorld),
+                   mesh3(*TestCommWorld);
+
+    // Give the meshes different extra integers to make sure those
+    // merge.  Reuse names between nodes and elements to make sure
+    // those don't mix.  Add some integers before and others after
+    // generation to test flexibility there.
+
+    std::vector<std::string> names2 {"bar", "baz"};
+    mesh2.add_elem_integers(names2);
+
+    std::vector<std::string> names3 {"bar", "foo"};
+    mesh3.add_elem_integers(names3);
+
+    int ps = 2;
+    MeshTools::Generation::build_cube (mesh0, ps, ps, ps, -1,    0,    0,  1,  0, 1, HEX27);
+    MeshTools::Generation::build_cube (mesh1, ps, ps, ps,    0,  1,    0,  1,  0, 1, HEX27);
+    MeshTools::Generation::build_cube (mesh2, ps, ps, ps, -1,    0, -1,    0,  0, 1, HEX27);
+    MeshTools::Generation::build_cube (mesh3, ps, ps, ps,    0,  1, -1,    0,  0, 1, HEX27);
+
+    struct trivially_copyable_pair // std::pair triggers -Wclass-memaccess
+    {
+      dof_id_type first, second;
+    };
+
+    mesh0.add_node_integer("baz");
+    unsigned int foo1e_idx = mesh1.add_elem_integer("foo");
+    mesh2.add_elem_datum<trivially_copyable_pair>("qux");
+    unsigned int qux2n_idx = mesh2.add_node_datum<trivially_copyable_pair>("qux");
+    mesh3.add_node_integers(names3);
+
+    for (const auto & elem : mesh1.element_ptr_range())
+      elem->set_extra_integer(foo1e_idx, 2);
+
+    for (const auto & node : mesh2.node_ptr_range())
+      node->set_extra_datum<trivially_copyable_pair>
+        (qux2n_idx, {3, 4});
+
+    // We stitch the meshes in a hierarchical way.
+    mesh0.stitch_meshes(mesh1, 2, 4, TOLERANCE, true, true, false, false);
+    mesh2.stitch_meshes(mesh3, 2, 4, TOLERANCE, true, true, false, false);
+    mesh0.stitch_meshes(mesh2, 1, 3, TOLERANCE, true, true, false, false);
+
+    CPPUNIT_ASSERT_EQUAL(mesh0.n_elem(), dof_id_type(32));
+    CPPUNIT_ASSERT_EQUAL(mesh0.n_nodes(), dof_id_type(405));
+    CPPUNIT_ASSERT_EQUAL(mesh0.n_elem_integers(), 5u); // that pair counts 2x
+    CPPUNIT_ASSERT_EQUAL(mesh0.n_node_integers(), 5u);
+    std::vector<std::string> all_names {"foo", "bar", "baz", "qux"};
+    std::vector<unsigned int> node_name_indices {4, 3, 0, 1};
+    for (unsigned int i=0; i != 4; ++i)
+      {
+        CPPUNIT_ASSERT(mesh0.has_elem_integer(all_names[i]));
+        CPPUNIT_ASSERT_EQUAL(mesh0.get_elem_integer_index(all_names[i]), i);
+        CPPUNIT_ASSERT(mesh0.has_node_integer(all_names[i]));
+        CPPUNIT_ASSERT_EQUAL(mesh0.get_node_integer_index(all_names[i]), node_name_indices[i]);
+      }
+
+    unsigned int foo0e_idx = mesh0.get_elem_integer_index("foo");
+    for (const auto & elem : mesh0.element_ptr_range())
+      {
+        CPPUNIT_ASSERT_EQUAL(elem->n_extra_integers(), 5u);
+        const Point c = elem->centroid();
+        if (c(0) > 0 && c(1) > 0) // this came from mesh1
+          CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(foo0e_idx), dof_id_type(2));
+        else
+          CPPUNIT_ASSERT_EQUAL(elem->get_extra_integer(foo0e_idx), DofObject::invalid_id);
+      }
+
+    unsigned int qux0n_idx = mesh0.get_node_integer_index("qux");
+    for (const auto & node : mesh0.node_ptr_range())
+      {
+        CPPUNIT_ASSERT_EQUAL(node->n_extra_integers(), 5u);
+        trivially_copyable_pair datum =
+          node->get_extra_datum<trivially_copyable_pair>(qux0n_idx);
+        if ((*node)(0) <= 0 && (*node)(1) < 0) // this came from mesh2
+          {
+            CPPUNIT_ASSERT_EQUAL(datum.first, dof_id_type(3));
+            CPPUNIT_ASSERT_EQUAL(datum.second, dof_id_type(4));
+          }
+        else
+          {
+            CPPUNIT_ASSERT_EQUAL(datum.first, DofObject::invalid_id);
+            CPPUNIT_ASSERT_EQUAL(datum.second, DofObject::invalid_id);
+          }
+      }
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION( MeshStitchTest );


### PR DESCRIPTION
We now go back and allocate space on nodes and elements in a non-empty
mesh by default.  So that we don't do this O(N) times when adding N
integers, this feature can be manually disabled, or it can be used in
O(1) fashion by using the new vectorized APIs.

Ideally this ought to have unit tests added before merge, but I'm putting it up ASAP for @friedmud and @YaqiWang to look over the API.