### PR TITLE
RB change to help debugging

### DIFF
--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -219,6 +219,12 @@ public:
   virtual void load_rb_solution();
 
   /**
+   * The slow (but simple, non-error prone) way to compute the residual dual norm.
+   * Useful for error checking.
+   */
+  Real compute_residual_dual_norm_slow(const unsigned int N);
+
+  /**
    * Get a pointer to inner_product_matrix. Accessing via this
    * function, rather than directly through the class member allows
    * us to do error checking (e.g. inner_product_matrix is not


### PR DESCRIPTION
Uncommented and corrected RBConstruction::compute_residual_dual_norm_slow() since it's useful for debugging. This function isn't used anywhere at the moment so this change should not have any effect, but it's useful to be able to use it (e.g. by calling it inside  `RBConstruction::get_RB_error_bound()`) when checking that the error bound is working properly.