### PR TITLE
Fix gcc9 warnings

### DIFF
--- a/include/utils/mapvector.h
+++ b/include/utils/mapvector.h
@@ -57,8 +57,7 @@ public:
     veclike_iterator(const typename maptype::iterator & i)
       : it(i) {}
 
-    veclike_iterator(const veclike_iterator & i)
-      : it(i.it) {}
+    veclike_iterator(const veclike_iterator & i) = default;
 
     Val & operator*() const { return it->second; }
 

--- a/src/numerics/trilinos_epetra_vector.C
+++ b/src/numerics/trilinos_epetra_vector.C
@@ -875,6 +875,7 @@ int EpetraVector<T>::GlobalAssemble(Epetra_CombineMode mode)
   return(0);
 }
 
+#include <libmesh/ignore_warnings.h> // deprecated-copy in Epetra_Vector
 
 //----------------------------------------------------------------------------
 template <typename T>
@@ -902,6 +903,7 @@ void EpetraVector<T>::FEoperatorequals(const EpetraVector & source)
   }
 }
 
+#include <libmesh/restore_warnings.h>
 
 //----------------------------------------------------------------------------
 template <typename T>

--- a/src/solvers/trilinos_nox_nonlinear_solver.C
+++ b/src/solvers/trilinos_nox_nonlinear_solver.C
@@ -288,6 +288,8 @@ void NoxNonlinearSolver<T>::init (const char * /*name*/)
 
 
 
+#include <libmesh/ignore_warnings.h> // deprecated-copy in Epetra_Vector
+
 template <typename T>
 std::pair<unsigned int, Real>
 NoxNonlinearSolver<T>::solve (SparseMatrix<T> &  /* jac_in */,  // System Jacobian Matrix
@@ -422,6 +424,8 @@ NoxNonlinearSolver<T>::solve (SparseMatrix<T> &  /* jac_in */,  // System Jacobi
 
   return std::make_pair(total_iters, residual_norm);
 }
+
+#include <libmesh/restore_warnings.h>
 
 
 


### PR DESCRIPTION
Looks like there's only a few of these that we hadn't already fixed; I can compile with --enable-werror --enable-paranoid-warnings with gcc 9.2 after this PR.