### PR TITLE
Remove expliciting instantiation

### DIFF
--- a/include/fe/fe_macro.h
+++ b/include/fe/fe_macro.h
@@ -78,20 +78,6 @@
   template class FE< (_dim), NEDELEC_ONE>;                              \
   template class FE< (_dim), MONOMIAL_VEC>
 
-#define INSTANTIATE_ALL_MAPS(_dim)              \
-  INSTANTIATE_MAPS(_dim,CLOUGH);                \
-  INSTANTIATE_MAPS(_dim,HERMITE);               \
-  INSTANTIATE_MAPS(_dim,HIERARCHIC);            \
-  INSTANTIATE_MAPS(_dim,L2_HIERARCHIC);         \
-  INSTANTIATE_MAPS(_dim,LAGRANGE);              \
-  INSTANTIATE_MAPS(_dim,LAGRANGE_VEC);          \
-  INSTANTIATE_MAPS(_dim,L2_LAGRANGE);           \
-  INSTANTIATE_MAPS(_dim,MONOMIAL);              \
-  INSTANTIATE_MAPS(_dim,SCALAR);                \
-  INSTANTIATE_MAPS(_dim,XYZ);                   \
-  INSTANTIATE_MAPS(_dim,NEDELEC_ONE);           \
-  INSTANTIATE_MAPS(_dim,MONOMIAL_VEC)
-
 #else //LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
 
 #define INSTANTIATE_FE(_dim)   template class FE< (_dim), CLOUGH>;      \
@@ -109,23 +95,6 @@
   template class FE< (_dim), RATIONAL_BERNSTEIN>;                       \
   template class FE< (_dim), NEDELEC_ONE>;                              \
   template class FE< (_dim), MONOMIAL_VEC>
-
-#define INSTANTIATE_ALL_MAPS(_dim)              \
-  INSTANTIATE_MAPS(_dim,CLOUGH);                \
-  INSTANTIATE_MAPS(_dim,HERMITE);               \
-  INSTANTIATE_MAPS(_dim,HIERARCHIC);            \
-  INSTANTIATE_MAPS(_dim,L2_HIERARCHIC);         \
-  INSTANTIATE_MAPS(_dim,LAGRANGE);              \
-  INSTANTIATE_MAPS(_dim,LAGRANGE_VEC);          \
-  INSTANTIATE_MAPS(_dim,L2_LAGRANGE);           \
-  INSTANTIATE_MAPS(_dim,MONOMIAL);              \
-  INSTANTIATE_MAPS(_dim,SCALAR);                \
-  INSTANTIATE_MAPS(_dim,BERNSTEIN);             \
-  INSTANTIATE_MAPS(_dim,SZABAB);                \
-  INSTANTIATE_MAPS(_dim,XYZ);                   \
-  INSTANTIATE_MAPS(_dim,RATIONAL_BERNSTEIN);    \
-  INSTANTIATE_MAPS(_dim,NEDELEC_ONE);           \
-  INSTANTIATE_MAPS(_dim,MONOMIAL_VEC)
 
 #endif //LIBMESH_ENABLE_HIGHER_ORDER_SHAPES
 

--- a/src/fe/fe_map.C
+++ b/src/fe/fe_map.C
@@ -2103,13 +2103,6 @@ template void FEMap::init_reference_to_physical_map<1>( const std::vector<Point>
 template void FEMap::init_reference_to_physical_map<2>( const std::vector<Point> &, const Elem *);
 template void FEMap::init_reference_to_physical_map<3>( const std::vector<Point> &, const Elem *);
 
-//--------------------------------------------------------------
-// Explicit instantiations using the macro from fe_macro.h
-INSTANTIATE_ALL_MAPS(0);
-INSTANTIATE_ALL_MAPS(1);
-INSTANTIATE_ALL_MAPS(2);
-INSTANTIATE_ALL_MAPS(3);
-
 // subdivision elements are implemented only for 2D meshes & reimplement
 // the inverse_maps method separately
 INSTANTIATE_SUBDIVISION_MAPS;


### PR DESCRIPTION
Due to the FEMap refactor, we are actually getting duplicate symbols now in the "fe" and "fe_map" objects. This is always a little bit difficult to test so I'm going to turn on several MOOSE targets and see what happens. I did verify on my build system that we had 360 duplicate symbols (4*6*15), which seems to work out right for the explicit instantiation here. 

The bigger mystery is why nobody else is seeing this. None of our Linux boxes are complaining, none of our Clang compilers on Macs are complaining, and newer GCC compilers on Macs aren't complaining. The only combination that I've discovered that is complaining right now is GCC 7.3.1 on OS X. Even more oddly, this configuration was working just a few days ago but started complaining after we did some messing around with the package... Nevertheless, I did verify for sure that this error started occurring on the merge of #2234.