### PR TITLE
ignore_warnings.h before tetgen.h

### DIFF
--- a/include/mesh/mesh_tetgen_wrapper.h
+++ b/include/mesh/mesh_tetgen_wrapper.h
@@ -22,7 +22,10 @@
 #ifdef LIBMESH_HAVE_TETGEN
 
 // TetGen include file
+// tetgen.h triggers -Werror=switch-default
+#include "libmesh/ignore_warnings.h"
 #include "tetgen.h"  // Defines REAL and other Tetgen types
+#include "libmesh/restore_warnings.h"
 
 // C++ includes
 #include <string>


### PR DESCRIPTION
Otherwise I can't use --enable-werror --enable-paranoid-warnings without
hitting -Werror=switch-default

Oddly I'm not sure what's changed here; I caught this with a gcc 8 build; it's not a new gcc 9 warning.