### PR TITLE
Adding "tellp" to ostream_proxy class

### DIFF
--- a/include/utils/ostream_proxy.h
+++ b/include/utils/ostream_proxy.h
@@ -222,6 +222,11 @@ public:
     return _target;
   }
 
+  /**
+   * Returns the position of the character in the current stream.
+   */
+  std::streampos tellp() { return _target->tellp(); }
+
 private:
   /**
    * The pointer to the "real" ostream we send everything to.


### PR DESCRIPTION
We'd like to be able to use libMesh::out (Moose::out) in our TimedPrint
class. For formatting purposes we need this method.