### PR TITLE
Use ReplicatedMesh in new edgeset unit test

### DIFF
--- a/tests/mesh/write_edgeset_data.C
+++ b/tests/mesh/write_edgeset_data.C
@@ -1,7 +1,7 @@
 // Basic include files
 #include "libmesh/equation_systems.h"
 #include "libmesh/exodusII_io.h"
-#include "libmesh/mesh.h"
+#include "libmesh/replicated_mesh.h"
 #include "libmesh/mesh_generation.h"
 #include "libmesh/parallel.h" // set_union
 #include "libmesh/string_to_enum.h"
@@ -30,7 +30,7 @@ public:
 
   void testWrite()
   {
-    Mesh mesh(*TestCommWorld);
+    ReplicatedMesh mesh(*TestCommWorld);
 
     MeshTools::Generation::build_cube (mesh,
                                        5, 5, 5,
@@ -79,7 +79,7 @@ public:
     TestCommWorld->barrier();
 
     // Now read it back in
-    Mesh read_mesh(*TestCommWorld);
+    ReplicatedMesh read_mesh(*TestCommWorld);
     ExodusII_IO reader(read_mesh);
     reader.read("write_edgeset_data.e");
 


### PR DESCRIPTION
Otherwise we get a failure from --enable-parmesh builds, because
something about either this test (added in #2298) or the underlying
code isn't liking DistributedMesh.

This is a short-term workaround so that I don't again run into what
turned out to be an astonishingly hard bug to track down.

As a medium-term fix I'm hoping @jwpeterson can figure out that "isn't
liking DistributedMesh" problem and then we can revert this.

As a long-term improvement, see #1307.  We need something better than
CppUnit for parallel tests, to avoid future "astonishingly hard bug to
track down" issues.  This was another #1008 case, and because I was
working in a branch I had to bisect with --re just to determine that it
really was a new test failing rather than a bug in my branch.