### PR TITLE
Move forward declaration into its proper namespace

### DIFF
--- a/include/error_estimation/adjoint_refinement_estimator.h
+++ b/include/error_estimation/adjoint_refinement_estimator.h
@@ -29,13 +29,13 @@
 #include <cstddef>
 #include <vector>
 
-// Forward declarations
-class DifferentiablePhysics;
-
 #ifdef LIBMESH_ENABLE_AMR
 
 namespace libMesh
 {
+
+// Forward declarations
+class DifferentiablePhysics;
 
 /**
  * This class implements a "brute force" goal-oriented error


### PR DESCRIPTION
Not sure why most compilers weren't screaming at us about this long ago,
but @vikramvgarg has a branch which got his compiler to error out when
it couldn't resolve the ambiguity.