### PR TITLE
Cpflags fix

### DIFF
--- a/configure
+++ b/configure
@@ -46286,23 +46286,23 @@ $as_echo
 for method in ${METHODS}; do
      case "${method}" in #(
   opt) :
-    $as_echo "CPPFLAGS...(opt)................... : $CPPFLAGS_OPT $CPFLAGS"
+    $as_echo "CPPFLAGS...(opt)................... : $CPPFLAGS_OPT $CPPFLAGS"
                        $as_echo "CXXFLAGS...(opt)................... : $CXXFLAGS_OPT $CXXFLAGS"
                        $as_echo "CFLAGS.....(opt)................... : $CFLAGS_OPT $CFLAGS" ;; #(
   devel) :
-    $as_echo "CPPFLAGS...(devel)................. : $CPPFLAGS_DEVEL $CPFLAGS"
+    $as_echo "CPPFLAGS...(devel)................. : $CPPFLAGS_DEVEL $CPPFLAGS"
                        $as_echo "CXXFLAGS...(devel)................. : $CXXFLAGS_DEVEL $CXXFLAGS"
                        $as_echo "CFLAGS.....(devel)................. : $CFLAGS_DEVEL $CFLAGS" ;; #(
   dbg) :
-    $as_echo "CPPFLAGS...(dbg)................... : $CPPFLAGS_DBG $CPFLAGS"
+    $as_echo "CPPFLAGS...(dbg)................... : $CPPFLAGS_DBG $CPPFLAGS"
                        $as_echo "CXXFLAGS...(dbg)................... : $CXXFLAGS_DBG $CXXFLAGS"
                        $as_echo "CFLAGS.....(dbg)................... : $CFLAGS_DBG $CFLAGS" ;; #(
   prof) :
-    $as_echo "CPPFLAGS...(prof).................. : $CPPFLAGS_PROF $CPFLAGS"
+    $as_echo "CPPFLAGS...(prof).................. : $CPPFLAGS_PROF $CPPFLAGS"
                        $as_echo "CXXFLAGS...(prof).................. : $CXXFLAGS_PROF $CXXFLAGS"
                        $as_echo "CFLAGS.....(prof).................. : $CFLAGS_PROF $CFLAGS" ;; #(
   oprof) :
-    $as_echo "CPPFLAGS...(oprof)................. : $CPPFLAGS_OPROF $CPFLAGS"
+    $as_echo "CPPFLAGS...(oprof)................. : $CPPFLAGS_OPROF $CPPFLAGS"
                        $as_echo "CXXFLAGS...(oprof)................. : $CXXFLAGS_OPROF $CXXFLAGS"
                        $as_echo "CFLAGS.....(oprof)................. : $CFLAGS_OPROF $CFLAGS" ;; #(
   *) :

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -30,19 +30,19 @@ AS_ECHO(["Build Methods...................... : $METHODS"])
 AS_ECHO([])
 for method in ${METHODS}; do
      AS_CASE("${method}",
-             [opt],   [AS_ECHO(["CPPFLAGS...(opt)................... : $CPPFLAGS_OPT $CPFLAGS"])
+             [opt],   [AS_ECHO(["CPPFLAGS...(opt)................... : $CPPFLAGS_OPT $CPPFLAGS"])
                        AS_ECHO(["CXXFLAGS...(opt)................... : $CXXFLAGS_OPT $CXXFLAGS"])
                        AS_ECHO(["CFLAGS.....(opt)................... : $CFLAGS_OPT $CFLAGS"])],
-             [devel], [AS_ECHO(["CPPFLAGS...(devel)................. : $CPPFLAGS_DEVEL $CPFLAGS"])
+             [devel], [AS_ECHO(["CPPFLAGS...(devel)................. : $CPPFLAGS_DEVEL $CPPFLAGS"])
                        AS_ECHO(["CXXFLAGS...(devel)................. : $CXXFLAGS_DEVEL $CXXFLAGS"])
                        AS_ECHO(["CFLAGS.....(devel)................. : $CFLAGS_DEVEL $CFLAGS"])],
-             [dbg],   [AS_ECHO(["CPPFLAGS...(dbg)................... : $CPPFLAGS_DBG $CPFLAGS"])
+             [dbg],   [AS_ECHO(["CPPFLAGS...(dbg)................... : $CPPFLAGS_DBG $CPPFLAGS"])
                        AS_ECHO(["CXXFLAGS...(dbg)................... : $CXXFLAGS_DBG $CXXFLAGS"])
                        AS_ECHO(["CFLAGS.....(dbg)................... : $CFLAGS_DBG $CFLAGS"])],
-             [prof],  [AS_ECHO(["CPPFLAGS...(prof).................. : $CPPFLAGS_PROF $CPFLAGS"])
+             [prof],  [AS_ECHO(["CPPFLAGS...(prof).................. : $CPPFLAGS_PROF $CPPFLAGS"])
                        AS_ECHO(["CXXFLAGS...(prof).................. : $CXXFLAGS_PROF $CXXFLAGS"])
                        AS_ECHO(["CFLAGS.....(prof).................. : $CFLAGS_PROF $CFLAGS"])],
-             [oprof], [AS_ECHO(["CPPFLAGS...(oprof)................. : $CPPFLAGS_OPROF $CPFLAGS"])
+             [oprof], [AS_ECHO(["CPPFLAGS...(oprof)................. : $CPPFLAGS_OPROF $CPPFLAGS"])
                        AS_ECHO(["CXXFLAGS...(oprof)................. : $CXXFLAGS_OPROF $CXXFLAGS"])
                        AS_ECHO(["CFLAGS.....(oprof)................. : $CFLAGS_OPROF $CFLAGS"])])
 


### PR DESCRIPTION
Just noticed this bug, dating back to 2013, while fiddling around with autoconf for the new MPI subpackage.