### PR TITLE
Sparsity pattern optimization for "spider" nodes

### DIFF
--- a/include/base/sparsity_pattern.h
+++ b/include/base/sparsity_pattern.h
@@ -26,6 +26,7 @@
 
 // C++ includes
 #include <vector>
+#include <unordered_set>
 
 namespace libMesh
 {
@@ -86,6 +87,17 @@ private:
   const std::set<GhostingFunctor *> & coupling_functors;
   const bool implicit_neighbor_dofs;
   const bool need_full_sparsity_pattern;
+
+  // If there are "spider" nodes in the mesh (i.e. a single node which
+  // is connected to many 1D elements) and Constraints, we can end up
+  // sorting the same set of DOFs multiple times in handle_vi_vj(),
+  // only to find that it has no net effect on the final sparsity. In
+  // such cases it is much faster to keep track of (element_dofs_i,
+  // element_dofs_j) pairs which have already been handled and not
+  // repeat the computation. We use this data structure to keep track
+  // of hashes of sets of dofs we have already seen, thus avoiding
+  // unnecessary caluclations.
+  std::unordered_set<dof_id_type> hashed_dof_sets;
 
   void handle_vi_vj(const std::vector<dof_id_type> & element_dofs_i,
                     const std::vector<dof_id_type> & element_dofs_j);

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -65,6 +65,7 @@ Build::Build (Build & other, Threads::split) :
   coupling_functors(other.coupling_functors),
   implicit_neighbor_dofs(other.implicit_neighbor_dofs),
   need_full_sparsity_pattern(other.need_full_sparsity_pattern),
+  hashed_dof_sets(other.hashed_dof_sets),
   sparsity_pattern(),
   nonlocal_pattern(),
   n_nz(),
@@ -455,6 +456,10 @@ void Build::join (const SparsityPattern::Build & other)
           my_row.erase(std::unique (my_row.begin(), my_row.end()), my_row.end());
         }
     }
+
+  // Combine the other thread's hashed_dof_sets with ours.
+  hashed_dof_sets.insert(other.hashed_dof_sets.begin(),
+                         other.hashed_dof_sets.end());
 }
 
 

--- a/src/base/sparsity_pattern.C
+++ b/src/base/sparsity_pattern.C
@@ -26,7 +26,7 @@
 #include "libmesh/communicator.h"
 #include "libmesh/parallel_algebra.h"
 #include "libmesh/parallel.h"
-
+#include "libmesh/hashword.h"
 
 namespace libMesh
 {
@@ -112,10 +112,28 @@ void Build::handle_vi_vj(const std::vector<dof_id_type> & element_dofs_i,
   const unsigned int n_dofs_on_element_j =
     cast_int<unsigned int>(element_dofs_j.size());
 
+  // It only makes sense to compute hashes and see if we can skip
+  // doing work when there are a "large" amount of DOFs for a given
+  // element. The cutoff for "large" is somewhat arbitrarily chosen
+  // based on a test case with a spider node that resulted in O(10^3)
+  // entries in element_dofs_i for O(10^3) elements. Making this
+  // number larger will disable the hashing optimization in more
+  // cases.
+  bool dofs_seen = false;
+  if (n_dofs_on_element_j > 0 && n_dofs_on_element_i > 256)
+    {
+      auto hash_i = Utility::hashword(element_dofs_i);
+      auto hash_j = Utility::hashword(element_dofs_j);
+      auto final_hash = Utility::hashword2(hash_i, hash_j);
+      auto result = hashed_dof_sets.insert(final_hash);
+      // if insert failed, we have already seen these dofs
+      dofs_seen = !result.second;
+    }
+
   // there might be 0 dofs for the other variable on the same element
   // (when subdomain variables do not overlap) and that's when we do
   // not do anything
-  if (n_dofs_on_element_j > 0)
+  if (n_dofs_on_element_j > 0 && !dofs_seen)
     {
       for (unsigned int i=0; i<n_dofs_on_element_i; i++)
         {


### PR DESCRIPTION
We have often noticed that building the sparsity pattern for meshes with "spider" nodes (a single node which is connected to hundreds or thousands of 1D elements) when Constraints are active on those nodes seems to take longer than it should, and quickly becomes intractable as the number of connected Elems increases. For example, in a relatively small mesh (n_nodes()=4735, n_elem()=3359), `build_sparsity()` took almost 10 seconds:
```
 --------------------------------------------------------------------------------------------------------------------------------
| libMesh Performance: Alive time=17.3783, Active time=17.3716                                                                   |
 --------------------------------------------------------------------------------------------------------------------------------
| Event                                             nCalls     Total Time  Avg Time    Total Time  Avg Time    % of Active Time  |
|                                                              w/o Sub     w/o Sub     With Sub    With Sub    w/o S    With S   |
|--------------------------------------------------------------------------------------------------------------------------------|
|                                                                                                                                |
| DofMap                                                                                                                         |
|   add_neighbors_to_send_list()                    2          0.0009      0.000459    0.0100      0.005004    0.01     0.06     |
|   build_constraint_matrix_and_vector()            3765       0.3753      0.000100    0.3753      0.000100    2.16     2.16     |
|   build_sparsity()                                1          9.3444      9.344351    9.3562      9.356176    53.79    53.86    |
```


After digging into it, we realized that much of the time was being spent doing repeated in-place merge sorts of the same sets of dofs, so that the end result was you would do a bunch of work but it would have no effect on the resulting sparsity. We found that hashing "large" sets of dofs and skipping sorting them on subsequent encounters sped things up quite a bit:
```
 --------------------------------------------------------------------------------------------------------------------------------
| libMesh Performance: Alive time=8.2667, Active time=8.25377                                                                    |
 --------------------------------------------------------------------------------------------------------------------------------
| Event                                             nCalls     Total Time  Avg Time    Total Time  Avg Time    % of Active Time  |
|                                                              w/o Sub     w/o Sub     With Sub    With Sub    w/o S    With S   |
|--------------------------------------------------------------------------------------------------------------------------------|
|                                                                                                                                |
| DofMap                                                                                                                         |
|   add_neighbors_to_send_list()                    6          0.0019      0.000325    0.0239      0.003989    0.02     0.29     |
|   build_constraint_matrix_and_vector()            4354       0.2548      0.000059    0.2548      0.000059    3.09     3.09     |
|   build_sparsity()                                1          0.7280      0.728025    0.7351      0.735086    8.82     8.91     |
```
Obviously, the time spent computing hashes is wasted unless there are lots of duplicate sets of dofs. In our testing we did find that hashing all the time was more expensive on problems without spider nodes, but not prohibitively so relative to the time it saved on problems with them. At the moment, the optimization is currently only enabled if there over 256 connected dofs for a given Elem, but this is a fairly arbitrarily-selected value. We could also consider making the optimization disableable at configure time if necessary.
