### PR TITLE
Use DirichletBoundary in example

### DIFF
--- a/examples/adaptivity/adaptivity_ex3/lshaped.xda
+++ b/examples/adaptivity/adaptivity_ex3/lshaped.xda
@@ -1,7 +1,7 @@
 libMesh-0.9.6+
 3	 # number of elements
 8	 # number of nodes
-n/a	 # boundary condition specification file
+.  	 # boundary condition specification file
 .	 # subdomain id specification file
 n/a	 # processor id specification file
 n/a	 # p-level specification file
@@ -28,6 +28,14 @@ n/a	 # p-level specification file
 0.0000000000000000e+00 -1.0000000000000000e+00 0.0000000000000000e+00
 0	 # presence of unique ids
 0	 # sideset id to name map
-0	 # number of boundary conditions
+8	 # number of boundary conditions
+0 2 0
+0 3 0
+1 0 0
+1 1 0
+1 2 0
+2 0 0
+2 1 0
+2 3 0
 0	 # nodeset id to name map
 0	 # number of nodesets

--- a/examples/adaptivity/adaptivity_ex3/lshaped3D.xda
+++ b/examples/adaptivity/adaptivity_ex3/lshaped3D.xda
@@ -1,7 +1,7 @@
 libMesh-0.9.6+
 3	 # number of elements
 16	 # number of nodes
-n/a	 # boundary condition specification file
+.  	 # boundary condition specification file
 .	 # subdomain id specification file
 n/a	 # processor id specification file
 n/a	 # p-level specification file
@@ -36,6 +36,20 @@ n/a	 # p-level specification file
 0.0000000000000000e+00 -1.0000000000000000e+00 1.0000000000000000e+00
 0	 # presence of unique ids
 0	 # sideset id to name map
-0	 # number of boundary conditions
+14	 # number of boundary conditions
+0 0 0
+0 3 0
+0 4 0
+0 5 0
+1 0 0
+1 1 0
+1 2 0
+1 3 0
+1 5 0
+2 0 0
+2 1 0
+2 2 0
+2 4 0
+2 5 0
 0	 # nodeset id to name map
 0	 # number of nodesets


### PR DESCRIPTION
I left some examples using penalty conditions, way back when, to
demonstrate that alternative, but we've got more penalty formulations
than we need in the vector examples these days.  Let's make this one
more "normal", both to get better exercise of boundary projections and
to make it more useful for benchmarking.

(In reality I made this change to explore a solver convergence issue
at high p, and that turned out to be a red herring, but I still think
this is an improvement)