### PR TITLE
Fix adjoints ex1 QoIs for multithreaded runs

### DIFF
--- a/examples/adjoints/adjoints_ex1/element_postprocess.C
+++ b/examples/adjoints/adjoints_ex1/element_postprocess.C
@@ -50,6 +50,11 @@ void LaplaceSystem::element_postprocess (DiffContext & context)
         }
     }
 
-  // Update the computed value of the global functional R, by adding the contribution from this element
-  computed_QoI[0] = computed_QoI[0] + dQoI_0;
+  // Update the computed value of the global functional R, by adding
+  // the contribution from this element.
+  {
+    // Keep this thread-safe.
+    Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+    computed_QoI[0] = computed_QoI[0] + dQoI_0;
+  }
 }

--- a/examples/adjoints/adjoints_ex1/side_postprocess.C
+++ b/examples/adjoints/adjoints_ex1/side_postprocess.C
@@ -55,5 +55,9 @@ void LaplaceSystem::side_postprocess(DiffContext & context)
 
     } // end of the quadrature point qp-loop
 
-  computed_QoI[1] = computed_QoI[1] + dQoI_1;
+  {
+    // Keep this thread-safe.
+    Threads::spin_mutex::scoped_lock lock(Threads::spin_mtx);
+    computed_QoI[1] = computed_QoI[1] + dQoI_1;
+  }
 }


### PR DESCRIPTION
This along with the changes in #2335 lets me get a ```--disable-strict-lgpl --enable-everything``` build through
```
LIBMESH_RUN='mpirun -np 4' LIBMESH_OPTIONS='--n_threads=2' make -j 4 check
```
without error.  Before, the QoIs in adjoints ex1 were being intermittently miscalculated with multiple threads.