### PR TITLE
RBConstruction: Add post processing callbacks.

### DIFF
--- a/include/reduced_basis/rb_construction.h
+++ b/include/reduced_basis/rb_construction.h
@@ -628,6 +628,27 @@ protected:
                                     bool apply_dof_constraints=true);
 
   /**
+   * This function is called from add_scaled_matrix_and_vector()
+   * before each element matrix and vector are assembled into their
+   * global counterparts. By default it is a no-op, but it could be
+   * used to apply any user-defined transformations immediately prior
+   * to assembly. We use DGFEMContext since it allows for both DG and
+   * continuous Galerkin formulations.
+   */
+  virtual void post_process_elem_matrix_and_vector
+  (DGFEMContext & /*context*/) {}
+
+  /**
+   * Similarly, provide an opportunity to post-process the truth
+   * solution after the solve is complete. By default this is a no-op,
+   * but it could be used to apply any required user-defined post
+   * processing to the solution vector. Note: the truth solution is
+   * stored in the "solution" member of this class, which is inherited
+   * from the parent System class several levels up.
+   */
+  virtual void post_process_truth_solution() {}
+
+  /**
    * Set current_local_solution = vec so that we can access vec
    * from FEMContext during assembly. Override in subclasses if
    * different behavior is required.


### PR DESCRIPTION
* The post_process_elem_matrix_and_vector() callback allows
  modifications to the element matrices/vectors during assembly, for
  example to apply dof rotations. The API uses a DGFEMContext since
  that is what's used internally and it allows for the most general
  type of assembly.
* The post_process_truth_solution() callback allows the user to modify
  the truth solution after a truth solve, for example to "undo" dof
  rotations.
* Call postprocessing callbacks from
  RBConstruction::enrich_basis_from_rhs_terms() and
  RBConstruction::truth_solve(), since these are the places where
  solve_for_matrix_and_rhs() is called.
* Skip post processing (applying rotations) when not applying dof
  constraints.  This prevents rotations from being applied "twice"
  (which would give the wrong answer) and is similar to the way that
  internal constraints are handled.