### PR TITLE
Add a missing header inclusion.

### DIFF
--- a/src/fe/fe_xyz_map.C
+++ b/src/fe/fe_xyz_map.C
@@ -17,6 +17,7 @@
 
 #include "libmesh/fe_xyz_map.h"
 #include "libmesh/elem.h"
+#include "libmesh/libmesh_logging.h"
 
 namespace libMesh
 {

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -22,6 +22,7 @@
 
 // Local includes
 #include "libmesh/libmesh_config.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/boundary_info.h"
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/elem.h"

--- a/src/mesh/mesh_base.C
+++ b/src/mesh/mesh_base.C
@@ -28,6 +28,7 @@
 
 // Local includes
 #include "libmesh/boundary_info.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/elem.h"
 #include "libmesh/ghost_point_neighbors.h"
 #include "libmesh/mesh_base.h"

--- a/src/mesh/mesh_output.C
+++ b/src/mesh/mesh_output.C
@@ -19,6 +19,7 @@
 // Local includes
 #include "libmesh/distributed_mesh.h"
 #include "libmesh/equation_systems.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_output.h"
 #include "libmesh/unstructured_mesh.h"
 #include "libmesh/numeric_vector.h"

--- a/src/mesh/mesh_tools.C
+++ b/src/mesh/mesh_tools.C
@@ -20,6 +20,7 @@
 // Local includes
 #include "libmesh/elem.h"
 #include "libmesh/elem_range.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/mesh_communication.h"
 #include "libmesh/mesh_tools.h"

--- a/src/solvers/nlopt_optimization_solver.C
+++ b/src/solvers/nlopt_optimization_solver.C
@@ -24,6 +24,7 @@
 
 // Local Includes
 #include "libmesh/dof_map.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/numeric_vector.h"
 #include "libmesh/nlopt_optimization_solver.h"
 #include "libmesh/sparse_matrix.h"

--- a/src/solvers/petsc_dm_wrapper.C
+++ b/src/solvers/petsc_dm_wrapper.C
@@ -31,6 +31,7 @@
 #include "libmesh/restore_warnings.h"
 
 #include "libmesh/petsc_dm_wrapper.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/system.h"
 #include "libmesh/mesh.h"
 #include "libmesh/mesh_base.h"

--- a/src/utils/location_maps.C
+++ b/src/utils/location_maps.C
@@ -19,6 +19,7 @@
 
 // Local Includes
 #include "libmesh/elem.h"
+#include "libmesh/libmesh_logging.h"
 #include "libmesh/location_maps.h"
 #include "libmesh/mesh_base.h"
 #include "libmesh/node.h"


### PR DESCRIPTION
We use START_LOG below, which is a macro defined in `libmesh_logging.h`.

I cannot compile 1.5.0 without this patch. I am not sure why but I *can* compile master without this patch. I don't know what y'all normally do for releases; would it help if I put up a second PR for this onto `v1.5.1_branch`?

Edit: Clarification: I was able to compile master without this patch at about the time 1.5.0 was released. I need this patch to compile master right now (i.e., as of November 21st).