### PR TITLE
Copy point locator tolerance in MeshFunction::clone().

### DIFF
--- a/include/utils/point_locator_base.h
+++ b/include/utils/point_locator_base.h
@@ -156,6 +156,11 @@ public:
   virtual void disable_out_of_mesh_mode () = 0;
 
   /**
+   * Get the close-to-point tolerance.
+   */
+  Real get_close_to_point_tol() const;
+
+  /**
    * Set a tolerance to use when determining
    * if a point is contained within the mesh.
    */

--- a/src/mesh/mesh_function.C
+++ b/src/mesh/mesh_function.C
@@ -133,11 +133,13 @@ MeshFunction::clear ()
 
 std::unique_ptr<FunctionBase<Number>> MeshFunction::clone () const
 {
-  FunctionBase<Number> * mf_clone =
+  MeshFunction * mf_clone =
     new MeshFunction(_eqn_systems, _vector, _dof_map, _system_vars, this);
 
   if (this->initialized())
     mf_clone->init();
+  mf_clone->set_point_locator_tolerance(
+    this->get_point_locator().get_close_to_point_tol());
 
   return std::unique_ptr<FunctionBase<Number>>(mf_clone);
 }

--- a/src/utils/point_locator_base.C
+++ b/src/utils/point_locator_base.C
@@ -83,6 +83,12 @@ std::unique_ptr<PointLocatorBase> PointLocatorBase::build (PointLocatorType t,
     }
 }
 
+Real PointLocatorBase::get_close_to_point_tol () const
+{
+  return _close_to_point_tol;
+}
+
+
 void PointLocatorBase::set_close_to_point_tol (Real close_to_point_tol)
 {
   _use_close_to_point_tol = true;


### PR DESCRIPTION
This fixes a bug that was uncovered by d19c236ac6565a77c2839db306f11b0bafbe26cb: we were not copying the point locator tolerance when cloning a `MeshFunction`. Since d19c236ac6565a77c2839db306f11b0bafbe26cb is being backported to v1.5.1, we'll want to backport this one as well.
