### PR TITLE
Add BoundaryInfo::remove_node(node, id).

### DIFF
--- a/include/mesh/boundary_info.h
+++ b/include/mesh/boundary_info.h
@@ -290,6 +290,12 @@ public:
   void remove (const Elem * elem);
 
   /**
+   * Removes boundary id \p id from node \p node, if it exists.
+   */
+  void remove_node (const Node * node,
+                    const boundary_id_type id);
+
+  /**
    * Removes all boundary conditions associated with edge \p edge of
    * element \p elem, if any exist.
    */

--- a/src/mesh/boundary_info.C
+++ b/src/mesh/boundary_info.C
@@ -1328,6 +1328,30 @@ void BoundaryInfo::remove (const Node * node)
 
 
 
+void BoundaryInfo::remove_node (const Node * node,
+                                const boundary_id_type id)
+{
+  libmesh_assert(node);
+
+  auto rng = _boundary_node_id.equal_range(node);
+
+  // Check each entry in the range, if its boundary matches the
+  // specified id, remove it from the map. Note: in C++20, there will
+  // be a specialization of std::erase_if for std::multimaps, which is
+  // exactly what we need here.
+  auto it = rng.first;
+
+  while (it != rng.second)
+    {
+      if (it->second == id)
+        it = _boundary_node_id.erase(it);
+      else
+        ++it;
+    }
+}
+
+
+
 void BoundaryInfo::remove (const Elem * elem)
 {
   libmesh_assert(elem);


### PR DESCRIPTION
We already have an equivalent functionality for sides, i.e. you can
remove certain boundary ids from a side while retaining others, so
this adds the same capability for Nodes.