### PR TITLE
Add a couple DistributedMesh ghosted_elem APIs

### DIFF
--- a/include/mesh/distributed_mesh.h
+++ b/include/mesh/distributed_mesh.h
@@ -215,6 +215,16 @@ public:
    */
   virtual void clear_extra_ghost_elems() { _extra_ghost_elems.clear(); }
 
+  /**
+   * Clears specified extra ghost elements
+   */
+  virtual void clear_extra_ghost_elems(const std::set<Elem *> & extra_ghost_elems);
+
+  /**
+   * Const accessor to the ghosted elements
+   */
+  const std::set<Elem *> & extra_ghost_elems() const { return _extra_ghost_elems; }
+
   // Cached methods that can be called in serial
   virtual dof_id_type n_nodes () const override { return _n_nodes; }
   virtual dof_id_type max_node_id () const override { return _max_node_id; }

--- a/src/mesh/distributed_mesh.C
+++ b/src/mesh/distributed_mesh.C
@@ -1482,6 +1482,15 @@ void DistributedMesh::add_extra_ghost_elem(Elem * e)
   _extra_ghost_elems.insert(e);
 }
 
+void
+DistributedMesh::clear_extra_ghost_elems(const std::set<Elem *> & extra_ghost_elems)
+{
+  std::set<Elem *> tmp;
+  std::set_difference(_extra_ghost_elems.begin(), _extra_ghost_elems.end(),
+                      extra_ghost_elems.begin(), extra_ghost_elems.end(),
+                      std::inserter(tmp, tmp.begin()));
+  _extra_ghost_elems = tmp;
+}
 
 void DistributedMesh::allgather()
 {


### PR DESCRIPTION
In idaholab/moose#14167 I have a test where I am performing
grid sequencing at every time step for a problem in which
a block is moving continuously, demanding continuous update
of geometric searches. In CIVET testing, I ran into a case
where with enough procs I was getting EXEC_BAD_ACCESS
segmentation faults. I'll attach a stack trace, but this
was coming from bad access through parent() pointers. My
hypothesis for this is that we were holding pointers to
parents that had been deleted by previous mesh coarsening/refinement.
So if I clear the extra ghosted elements from previous calls
everything seems to work out; see https://github.com/idaholab/moose/pull/14167/commits/14adebda52e17c619a30ed166c0b881e820f4a6c. The code surrounding that
commit comes from @roystgnr (see [this commit](https://github.com/idaholab/moose/pull/8715/commits/fab79ef63ba264d0bc27cce9bc9b27c65af5b37a))