### PR TITLE
Sync nodes after all_second_order if not replicated

### DIFF
--- a/src/mesh/unstructured_mesh.C
+++ b/src/mesh/unstructured_mesh.C
@@ -1306,7 +1306,7 @@ void UnstructuredMesh::all_second_order (const bool full_ordered)
   // partitioning of new nodes may not be well balanced.
   //
   // make_nodes_parallel_consistent() will fix all this.
-  if (!this->is_serial())
+  if (!this->is_replicated())
     MeshCommunication().make_nodes_parallel_consistent (*this);
 
   // renumber nodes, elements etc


### PR DESCRIPTION
Previously we only synced if we were not serial. However,
even if we haven't deleted remote elements in our distributed mesh
we still need to sync the nodes because even if we are adding
nodes on all procs they are getting temporary out-of-sync ids.
If we don't do this sync, then I get failed assertions
in libmesh_assert_valid_parallel_ids. Explicitly, even for the very
first new node, I can fail `(min_proc_id == this->processor_id() && obj)`
because the non-owning proc may have assigned the node
ID 14 while the owning proc assigned it ID 17 or whatever. Then
the owning proc will fail the assertion when `i == 14` because
the LHS will be true while `obj` is `nullptr`