### PR TITLE
Allow MPI_PROC_NULL in broadcast

### DIFF
--- a/contrib/timpi/src/parallel/include/timpi/communicator.h
+++ b/contrib/timpi/src/parallel/include/timpi/communicator.h
@@ -956,6 +956,12 @@ public:
    * Take a local value and broadcast it to all processors.
    * Optionally takes the \p root_id processor, which specifies
    * the processor initiating the broadcast.
+   *
+   * \p root_id can be set to MPI_PROC_NULL for processors receiving
+   * the broadcast and MPI_ROOT for the processor initiating the
+   * broadcast, which eliminates the need to communicate a root
+   * processor before the broadcast.
+   *
    * If \p data is a vector, the user is responsible for resizing it
    * on all processors, except in the case when \p data is a vector
    * of strings.

--- a/contrib/timpi/src/parallel/include/timpi/parallel_implementation.h
+++ b/contrib/timpi/src/parallel/include/timpi/parallel_implementation.h
@@ -1495,15 +1495,15 @@ inline void Communicator::broadcast (bool & data, const unsigned int root_id) co
       return;
     }
 
-  timpi_assert_less (root_id, this->size());
+  timpi_assert (root_id < this->size() ||
+                root_id == (unsigned int)MPI_PROC_NULL ||
+                root_id == (unsigned int)MPI_ROOT);
 
   TIMPI_LOG_SCOPE("broadcast()", "Parallel");
 
   // We don't want to depend on MPI-2 or C++ MPI, so we don't have
   // MPI::BOOL available
   char char_data = data;
-
-  timpi_assert_less(root_id, this->size());
 
   // Spread data to remote processors.
   timpi_call_mpi
@@ -1525,7 +1525,9 @@ inline void Communicator::broadcast (std::basic_string<T> & data,
       return;
     }
 
-  timpi_assert_less (root_id, this->size());
+  timpi_assert (root_id < this->size() ||
+                root_id == (unsigned int)MPI_PROC_NULL ||
+                root_id == (unsigned int)MPI_ROOT);
 
   TIMPI_LOG_SCOPE("broadcast()", "Parallel");
 
@@ -1564,15 +1566,15 @@ inline void Communicator::broadcast (std::vector<T,A> & data,
       return;
     }
 
-  timpi_assert_less (root_id, this->size());
+  timpi_assert (root_id < this->size() ||
+                root_id == (unsigned int)MPI_PROC_NULL ||
+                root_id == (unsigned int)MPI_ROOT);
 
   TIMPI_LOG_SCOPE("broadcast()", "Parallel");
 
   // and get the data from the remote processors.
   // Pass nullptr if our vector is empty.
   T * data_ptr = data.empty() ? nullptr : data.data();
-
-  timpi_assert_less(root_id, this->size());
 
   timpi_call_mpi
     (MPI_Bcast (data_ptr, cast_int<int>(data.size()),
@@ -1591,7 +1593,9 @@ inline void Communicator::broadcast (std::vector<std::basic_string<T>,A> & data,
       return;
     }
 
-  timpi_assert_less (root_id, this->size());
+  timpi_assert (root_id < this->size() ||
+                root_id == (unsigned int)MPI_PROC_NULL ||
+                root_id == (unsigned int)MPI_ROOT);
 
   TIMPI_LOG_SCOPE("broadcast()", "Parallel");
 
@@ -1653,7 +1657,9 @@ inline void Communicator::broadcast (std::set<T,C,A> & data,
       return;
     }
 
-  timpi_assert_less (root_id, this->size());
+  timpi_assert (root_id < this->size() ||
+                root_id == (unsigned int)MPI_PROC_NULL ||
+                root_id == (unsigned int)MPI_ROOT);
 
   TIMPI_LOG_SCOPE("broadcast()", "Parallel");
 
@@ -1687,7 +1693,9 @@ inline void Communicator::broadcast(std::map<T1,T2,C,A> & data,
       return;
     }
 
-  timpi_assert_less (root_id, this->size());
+  timpi_assert (root_id < this->size() ||
+                root_id == (unsigned int)MPI_PROC_NULL ||
+                root_id == (unsigned int)MPI_ROOT);
 
   TIMPI_LOG_SCOPE("broadcast()", "Parallel");
 

--- a/contrib/timpi/test/parallel_unit.C
+++ b/contrib/timpi/test/parallel_unit.C
@@ -112,7 +112,7 @@ std::vector<std::string> pt_number;
 
 
 
-  void testBroadcast()
+  void testBroadcast(const bool use_proc_null)
   {
     std::vector<unsigned int> src(3), dest(3);
 
@@ -123,7 +123,13 @@ std::vector<std::string> pt_number;
     if (TestCommWorld->rank() == 0)
       dest = src;
 
-    TestCommWorld->broadcast(dest);
+    unsigned int root_id = 0;
+#ifdef LIBMESH_HAVE_MPI
+    if (use_proc_null)
+      root_id = (unsigned int)(TestCommWorld->rank() == 0 ? MPI_ROOT : MPI_PROC_NULL);
+#endif
+
+    TestCommWorld->broadcast(dest, root_id);
 
     for (std::size_t i=0; i<src.size(); i++)
       TIMPI_UNIT_ASSERT( src[i]  == dest[i] );
@@ -131,7 +137,7 @@ std::vector<std::string> pt_number;
 
 
 
-  void testBroadcastNestedType()
+  void testBroadcastNestedType(const bool use_proc_null)
   {
     using std::pair;
     typedef pair<pair<pair<pair<int, int>, int>, int>, int> pppp;
@@ -153,7 +159,13 @@ std::vector<std::string> pt_number;
     if (TestCommWorld->rank() == 0)
       dest = src;
 
-    TestCommWorld->broadcast(dest);
+    unsigned int root_id = 0;
+  #ifdef LIBMESH_HAVE_MPI
+      if (use_proc_null)
+        root_id = (unsigned int)(TestCommWorld->rank() == 0 ? MPI_ROOT : MPI_PROC_NULL);
+  #endif
+
+    TestCommWorld->broadcast(dest, root_id);
 
     for (std::size_t i=0; i<src.size(); i++)
       {
@@ -679,8 +691,10 @@ int main(int argc, const char * const * argv)
   testAllGatherVectorString();
   testAllGatherEmptyVectorString();
   testAllGatherHalfEmptyVectorString();
-  testBroadcast();
-  testBroadcastNestedType();
+  testBroadcast(/* use_proc_null = */ false);
+  testBroadcast(/* use_proc_null = */ true);
+  testBroadcastNestedType(/* use_proc_null = */ false);
+  testBroadcastNestedType(/* use_proc_null = */ true);
   testScatter();
   testBarrier();
   testMin();


### PR DESCRIPTION
Closes #2353 

There's a check for `LIBMESH_HAVE_MPI` hanging around in parallel_unit. I moved it over to `TIMPI_HAVE_MPI`. Should this `#ifdef` just come out?