### PR TITLE
Add missing PYRAMID cases to l2_lagrange_n_dofs()

### DIFF
--- a/src/fe/fe_l2_lagrange.C
+++ b/src/fe/fe_l2_lagrange.C
@@ -381,6 +381,12 @@ unsigned int l2_lagrange_n_dofs(const ElemType t, const Order o)
           case PRISM18:
             return 18;
 
+          case PYRAMID13:
+            return 13;
+
+          case PYRAMID14:
+            return 14;
+
           case INVALID_ELEM:
             return 0;
 


### PR DESCRIPTION
There is a bunch of duplicated code between the `l2_lagrange_n_dofs()` and `lagrange_n_dofs()` functions, so it would be good if we could actually combine them, similarly to what was done for `shape()`, `shape_deriv()`, and `shape_second_deriv()`. 

At the moment these functions are identical, but one thing to note is that it should in theory be possible to also support higher-order FEs on lower-order geometric elements for L2-Lagrange, something that is not allowed for normal Lagrange elements... so this would be a point in favor of not combining the implementations.

https://github.com/libMesh/libmesh/blob/d0eee22f17e3bf53908246497288ff6abfc8214b/src/fe/fe_l2_lagrange.C#L288-L291