### PR TITLE
Specify override to avoid clang compiler warning

### DIFF
--- a/include/mesh/nemesis_io.h
+++ b/include/mesh/nemesis_io.h
@@ -110,7 +110,7 @@ public:
    */
   virtual void write_nodal_data (const std::string & fname,
                                  const EquationSystems & es,
-                                 const std::set<std::string> * system_names);
+                                 const std::set<std::string> * system_names) override;
 
   /**
    * Output a nodal solution in parallel, without localizing the soln vector.


### PR DESCRIPTION
I've added the MOOSE Mac Test recipe, which as we know from idaholab/moose#14464 will fail run-time testing, but hopefully with this change we can at least build the framework (see https://civet.inl.gov/job/439270/)