### PR TITLE
Communicate make_links_to_me_local neighbor_side

### DIFF
--- a/include/geom/elem.h
+++ b/include/geom/elem.h
@@ -521,12 +521,12 @@ public:
   void make_links_to_me_remote ();
 
   /**
-   * Resets the appropriate neighbor pointers of our nth neighbor (and
+   * Resets the \p neighbor_side pointers of our nth neighbor (and
    * its descendants, if appropriate) to point to this Elem instead of
    * to the global remote_elem.  Used by the library when a formerly
    * remote element is being added to the local processor.
    */
-  void make_links_to_me_local (unsigned int n);
+  void make_links_to_me_local (unsigned int n, unsigned int neighbor_side);
 
   /**
    * \returns \p true if this element is remote, false otherwise.

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -996,7 +996,7 @@ void Elem::libmesh_assert_valid_neighbors() const
 
 
 
-void Elem::make_links_to_me_local(unsigned int n)
+void Elem::make_links_to_me_local(unsigned int n, unsigned int nn)
 {
   Elem * neigh = this->neighbor_ptr(n);
 
@@ -1023,19 +1023,15 @@ void Elem::make_links_to_me_local(unsigned int n)
   if (neigh->level() != this->level())
     return;
 
-  // What side of neigh are we on?  We can't use the usual Elem
-  // method because we're in the middle of restoring topology
-  const std::unique_ptr<Elem> my_side = this->side_ptr(n);
-  unsigned int nn = 0;
-  for (; nn != neigh->n_sides(); ++nn)
-    {
-      const std::unique_ptr<Elem> neigh_side = neigh->side_ptr(nn);
-      if (*my_side == *neigh_side)
-        break;
-    }
-
-  // we had better be on *some* side of neigh
-  libmesh_assert_less (nn, neigh->n_sides());
+  // What side of neigh are we on?  nn.
+  //
+  // We can't use the usual Elem method because we're in the middle of
+  // restoring topology.  We can't compare side_ptr nodes because
+  // users want to abuse neighbor_ptr to point to
+  // not-technically-neighbors across mesh slits.  We can't compare
+  // node locations because users want to move those
+  // not-technically-neighbors until they're
+  // not-even-geometrically-neighbors.
 
   // Find any elements that ought to point to elem
   std::vector<Elem *> neigh_family;

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1038,8 +1038,7 @@ void Elem::make_links_to_me_local(unsigned int n, unsigned int nn)
 #ifdef LIBMESH_ENABLE_AMR
   if (this->active())
     neigh->family_tree_by_side(neigh_family, nn);
-  else if (neigh->subactive() ||
-           neigh->ancestor())
+  else
 #endif
     neigh_family.push_back(neigh);
 

--- a/src/geom/elem.C
+++ b/src/geom/elem.C
@@ -1038,7 +1038,8 @@ void Elem::make_links_to_me_local(unsigned int n, unsigned int nn)
 #ifdef LIBMESH_ENABLE_AMR
   if (this->active())
     neigh->family_tree_by_side(neigh_family, nn);
-  else if (neigh->subactive())
+  else if (neigh->subactive() ||
+           neigh->ancestor())
 #endif
     neigh_family.push_back(neigh);
 


### PR DESCRIPTION
With user code playing tricks with neighbor topology while disconnecting
neighbor geometry, there's really no other way to make sure we don't
accidentally break that topology.

Like #2362 this fixes the test case in idaholab/moose#14456 for me; unlike #2362 those problems should *stay* fixed even if the geometry of the non-neighbor "neighbors" gets displaced out of alignment.

@arovinelli, could you confirm that the fix here works for you too?